### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/dom

### DIFF
--- a/Source/WebCore/dom/DOMException.cpp
+++ b/Source/WebCore/dom/DOMException.cpp
@@ -31,45 +31,43 @@
 
 #include "Exception.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 // This array needs to be kept in sync with the ExceptionCode enumeration.
 // http://heycam.github.io/webidl/#idl-DOMException-error-names
-static const DOMException::Description descriptions[] = {
-    { "IndexSizeError"_s, "The index is not in the allowed range."_s, 1 },
-    { "HierarchyRequestError"_s, "The operation would yield an incorrect node tree."_s, 3 },
-    { "WrongDocumentError"_s, "The object is in the wrong document."_s, 4 },
-    { "InvalidCharacterError"_s, "The string contains invalid characters."_s, 5 },
-    { "NoModificationAllowedError"_s, "The object can not be modified."_s, 7 },
-    { "NotFoundError"_s, "The object can not be found here."_s, 8 },
-    { "NotSupportedError"_s, "The operation is not supported."_s, 9 },
-    { "InUseAttributeError"_s, "The attribute is in use."_s, 10 },
-    { "InvalidStateError"_s, "The object is in an invalid state."_s, 11 },
-    { "SyntaxError"_s, "The string did not match the expected pattern."_s, 12 },
-    { "InvalidModificationError"_s, " The object can not be modified in this way."_s, 13 },
-    { "NamespaceError"_s, "The operation is not allowed by Namespaces in XML."_s, 14 },
-    { "InvalidAccessError"_s, "The object does not support the operation or argument."_s, 15 },
-    { "TypeMismatchError"_s, "The type of an object was incompatible with the expected type of the parameter associated to the object."_s, 17 },
-    { "SecurityError"_s, "The operation is insecure."_s, 18 },
-    { "NetworkError"_s, " A network error occurred."_s, 19 },
-    { "AbortError"_s, "The operation was aborted."_s, 20 },
-    { "URLMismatchError"_s, "The given URL does not match another URL."_s, 21 },
-    { "QuotaExceededError"_s, "The quota has been exceeded."_s, 22 },
-    { "TimeoutError"_s, "The operation timed out."_s, 23 },
-    { "InvalidNodeTypeError"_s, "The supplied node is incorrect or has an incorrect ancestor for this operation."_s, 24 },
-    { "DataCloneError"_s, "The object can not be cloned."_s, 25 },
-    { "EncodingError"_s, "The encoding operation (either encoded or decoding) failed."_s, 0 },
-    { "NotReadableError"_s, "The I/O read operation failed."_s, 0 },
-    { "UnknownError"_s, "The operation failed for an unknown transient reason (e.g. out of memory)."_s, 0 },
-    { "ConstraintError"_s, "A mutation operation in a transaction failed because a constraint was not satisfied."_s, 0 },
-    { "DataError"_s, "Provided data is inadequate."_s, 0 },
-    { "TransactionInactiveError"_s, "A request was placed against a transaction which is currently not active, or which is finished."_s, 0 },
-    { "ReadOnlyError"_s, "The mutating operation was attempted in a \"readonly\" transaction."_s, 0 },
-    { "VersionError"_s, "An attempt was made to open a database using a lower version than the existing version."_s, 0 },
-    { "OperationError"_s, "The operation failed for an operation-specific reason."_s, 0 },
-    { "NotAllowedError"_s, "The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission."_s, 0 }
+static constexpr std::array descriptions {
+    DOMException::Description { "IndexSizeError"_s, "The index is not in the allowed range."_s, 1 },
+    DOMException::Description { "HierarchyRequestError"_s, "The operation would yield an incorrect node tree."_s, 3 },
+    DOMException::Description { "WrongDocumentError"_s, "The object is in the wrong document."_s, 4 },
+    DOMException::Description { "InvalidCharacterError"_s, "The string contains invalid characters."_s, 5 },
+    DOMException::Description { "NoModificationAllowedError"_s, "The object can not be modified."_s, 7 },
+    DOMException::Description { "NotFoundError"_s, "The object can not be found here."_s, 8 },
+    DOMException::Description { "NotSupportedError"_s, "The operation is not supported."_s, 9 },
+    DOMException::Description { "InUseAttributeError"_s, "The attribute is in use."_s, 10 },
+    DOMException::Description { "InvalidStateError"_s, "The object is in an invalid state."_s, 11 },
+    DOMException::Description { "SyntaxError"_s, "The string did not match the expected pattern."_s, 12 },
+    DOMException::Description { "InvalidModificationError"_s, " The object can not be modified in this way."_s, 13 },
+    DOMException::Description { "NamespaceError"_s, "The operation is not allowed by Namespaces in XML."_s, 14 },
+    DOMException::Description { "InvalidAccessError"_s, "The object does not support the operation or argument."_s, 15 },
+    DOMException::Description { "TypeMismatchError"_s, "The type of an object was incompatible with the expected type of the parameter associated to the object."_s, 17 },
+    DOMException::Description { "SecurityError"_s, "The operation is insecure."_s, 18 },
+    DOMException::Description { "NetworkError"_s, " A network error occurred."_s, 19 },
+    DOMException::Description { "AbortError"_s, "The operation was aborted."_s, 20 },
+    DOMException::Description { "URLMismatchError"_s, "The given URL does not match another URL."_s, 21 },
+    DOMException::Description { "QuotaExceededError"_s, "The quota has been exceeded."_s, 22 },
+    DOMException::Description { "TimeoutError"_s, "The operation timed out."_s, 23 },
+    DOMException::Description { "InvalidNodeTypeError"_s, "The supplied node is incorrect or has an incorrect ancestor for this operation."_s, 24 },
+    DOMException::Description { "DataCloneError"_s, "The object can not be cloned."_s, 25 },
+    DOMException::Description { "EncodingError"_s, "The encoding operation (either encoded or decoding) failed."_s, 0 },
+    DOMException::Description { "NotReadableError"_s, "The I/O read operation failed."_s, 0 },
+    DOMException::Description { "UnknownError"_s, "The operation failed for an unknown transient reason (e.g. out of memory)."_s, 0 },
+    DOMException::Description { "ConstraintError"_s, "A mutation operation in a transaction failed because a constraint was not satisfied."_s, 0 },
+    DOMException::Description { "DataError"_s, "Provided data is inadequate."_s, 0 },
+    DOMException::Description { "TransactionInactiveError"_s, "A request was placed against a transaction which is currently not active, or which is finished."_s, 0 },
+    DOMException::Description { "ReadOnlyError"_s, "The mutating operation was attempted in a \"readonly\" transaction."_s, 0 },
+    DOMException::Description { "VersionError"_s, "An attempt was made to open a database using a lower version than the existing version."_s, 0 },
+    DOMException::Description { "OperationError"_s, "The operation failed for an operation-specific reason."_s, 0 },
+    DOMException::Description { "NotAllowedError"_s, "The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission."_s, 0 }
 };
 static_assert(!static_cast<bool>(ExceptionCode::IndexSizeError), "This table needs to be kept in sync with DOMException names in ExceptionCode enumeration");
 static_assert(static_cast<std::size_t>(ExceptionCode::NotAllowedError) == std::size(descriptions) - 1, "This table needs to be kept in sync with DOMException names in ExceptionCode enumeration");
@@ -117,5 +115,3 @@ DOMException::DOMException(LegacyCode legacyCode, const String& name, const Stri
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -103,8 +103,6 @@
 #include "ContentChangeObserver.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(Node);
@@ -1816,7 +1814,7 @@ ExceptionOr<void> Node::setTextContent(String&& text)
 static SHA1::Digest hashPointer(const void* pointer)
 {
     SHA1 sha1;
-    sha1.addBytes(std::span { reinterpret_cast<const uint8_t*>(&pointer), sizeof(pointer) });
+    sha1.addBytes(asByteSpan(pointer));
     SHA1::Digest digest;
     sha1.computeHash(digest);
     return digest;
@@ -3104,8 +3102,6 @@ TextStream& operator<<(TextStream& ts, const Node& node)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #if ENABLE(TREE_DEBUGGING)
 


### PR DESCRIPTION
#### 69b2bdf789b1045700861f55841b60d0db5caab4
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/dom
<a href="https://bugs.webkit.org/show_bug.cgi?id=284931">https://bugs.webkit.org/show_bug.cgi?id=284931</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/DOMException.cpp:
* Source/WebCore/dom/ElementData.cpp:
(WebCore::ShareableElementData::ShareableElementData):
(WebCore::ShareableElementData::~ShareableElementData):
* Source/WebCore/dom/ElementData.h:
(WebCore::ElementData::attributeSpan const):
(WebCore::ShareableElementData::span):
(WebCore::ElementData::findAttributeIndexByName const):
(WebCore::ElementData::findAttributeByName const):
(WebCore::ElementData::attributeAt const):
* Source/WebCore/dom/Node.cpp:
(WebCore::hashPointer):
* Source/WebCore/dom/SpaceSplitString.cpp:
(WebCore::TokenAtomStringInitializer::TokenAtomStringInitializer):
(WebCore::TokenAtomStringInitializer::processToken):
(WebCore::TokenAtomStringInitializer::nextMemoryBucket const):
(WebCore::SpaceSplitStringData::create):
(WebCore::SpaceSplitStringData::destroy):
* Source/WebCore/dom/SpaceSplitString.h:
(WebCore::SpaceSplitStringData::begin const):
(WebCore::SpaceSplitStringData::end const):
(WebCore::SpaceSplitStringData::begin):
(WebCore::SpaceSplitStringData::end):
(WebCore::SpaceSplitStringData::contains):
(WebCore::SpaceSplitStringData::operator[]):
(WebCore::SpaceSplitStringData::tokenArray):
(WebCore::SpaceSplitStringData::tokenArray const):
(WebCore::SpaceSplitString::begin const):
(WebCore::SpaceSplitString::end const):
(WebCore::SpaceSplitString::begin):
(WebCore::SpaceSplitString::end):
(WebCore::SpaceSplitStringData::tokenArrayStart): Deleted.
(WebCore::SpaceSplitStringData::tokenArrayStart const): Deleted.

Canonical link: <a href="https://commits.webkit.org/288162@main">https://commits.webkit.org/288162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02ff82e0089cb3291f7e5d56668cef9be011f968

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86430 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32880 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63862 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21591 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44145 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/958 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28687 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31325 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72309 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29299 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87860 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6498 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72221 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71443 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15536 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14458 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/492 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12714 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9067 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14605 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8908 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12431 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10716 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->