### PR TITLE
[JSC] `StringValueOf` node should not be converted to `ToString` node when `this` value is not string

### DIFF
--- a/JSTests/stress/string-prototype-toString-no-string-this
+++ b/JSTests/stress/string-prototype-toString-no-string-this
@@ -1,0 +1,22 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+let runs = 1e5;
+let called = 0;
+function test() {
+  const toString = String.prototype.toString;
+  try {
+    toString();
+  } catch {
+    called++;
+  }
+}
+noInline(test);
+
+for (let i = 0; i < runs; i++) {
+  test();
+}
+
+shouldBe(called, runs);

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3947,14 +3947,6 @@ private:
             return;
         }
 
-        if (node->child1()->shouldSpeculateStringOrOther()) {
-            fixEdge<StringOrOtherUse>(node->child1());
-            node->convertToToString();
-            // It does not need to look up a toString property for the StringObject case. So we can clear NodeMustGenerate.
-            node->clearFlags(NodeMustGenerate);
-            return;
-        }
-
         if (node->child1()->shouldSpeculateStringObject()) {
             fixEdge<StringObjectUse>(node->child1());
             node->convertToToString();


### PR DESCRIPTION
#### d496afe37c9dfce7ce4df4ae0165a61ce42649fc
<pre>
[JSC] `StringValueOf` node should not be converted to `ToString` node when `this` value is not string
<a href="https://bugs.webkit.org/show_bug.cgi?id=284614">https://bugs.webkit.org/show_bug.cgi?id=284614</a>

Reviewed by NOBODY (OOPS!).

The `ToString` node converts `undefined` into the string `&quot;undefined&quot;`.
However, `String.prototype.toString` and `String.prototype.valueOf`
throw a `TypeError` if the `this` value is not a string[1].

Therefore, converting a `StringValueOf` node into a `ToString` node is
incorrect.

This patch updates `DFGFixupPhase` to prevent the `StringValueOf` node
from being converted into a `ToString` node.

Also, there are no performance regressions in the benchmark added by
the patch that introduced the removed branch[2]:

                             TipOfTree                  Patched

string-or-other-add       88.0114+-0.7678           87.7158+-0.8438

[1]: <a href="https://tc39.es/ecma262/#sec-string.prototype.tostring">https://tc39.es/ecma262/#sec-string.prototype.tostring</a>
[2]: <a href="https://commits.webkit.org/275280@main">https://commits.webkit.org/275280@main</a>

* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupStringValueOf):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d496afe37c9dfce7ce4df4ae0165a61ce42649fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1346 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35774 "Hash d496afe3 for PR 38188 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86368 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32816 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63806 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21536 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1010 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/35774 "Hash d496afe3 for PR 38188 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44092 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/909 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/35774 "Hash d496afe3 for PR 38188 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31269 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74800 "Found 1 new JSC stress test failure: stress/scoped-arguments-table-should-be-tolerant-for-oom.js.dfg-eager-no-cjit-validate (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72277 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/35774 "Hash d496afe3 for PR 38188 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87803 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80874 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9060 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72157 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9245 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/35774 "Hash d496afe3 for PR 38188 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71389 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15486 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/35774 "Hash d496afe3 for PR 38188 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103286 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9011 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14543 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25075 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8852 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12375 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10660 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->