### PR TITLE
Avoid text cursor from being applied if `-webkit-user-select: none` is set

### DIFF
--- a/LayoutTests/editing/selection/user-select-none-02-expected.txt
+++ b/LayoutTests/editing/selection/user-select-none-02-expected.txt
@@ -1,0 +1,6 @@
+You should not be able of select this text.
+PASS selection.toString() is ""
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/user-select-none-02.html
+++ b/LayoutTests/editing/selection/user-select-none-02.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+<title>Test user-select: none Test</title>
+<style>
+#test-element {
+   background-color: lightblue;
+   padding: 10px;
+   font-size: 16px;
+   text-align: center;
+   border: 1px solid #000;
+   -webkit-user-select: none;
+}
+</style>
+</head>
+<script src="../../resources/js-test.js"></script>
+<body>
+<div id="test-element">
+You should not be able of select this text.
+</div>
+<div id="console"></div>
+<script>
+   const testElement = document.getElementById('test-element');
+   const range = document.createRange();
+   range.selectNodeContents(testElement);
+   const selection = window.getSelection();
+   selection.removeAllRanges();
+   selection.addRange(range);
+   shouldBeEqualToString("selection.toString()" , '');
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1721,10 +1721,10 @@ std::optional<Cursor> EventHandler::selectCursor(const HitTestResult& result, bo
             && !m_mouseDownMayStartDrag
 #endif
             && frame->selection().isCaretOrRange()
-            && !m_capturingMouseEventsElement)
+            && !m_capturingMouseEventsElement && renderer && renderer->style().usedUserSelect() != UserSelect::None)
                 return iBeam;
 
-        if ((editable || (renderer && renderer->isRenderText() && node->canStartSelection())) && !inResizer && !result.scrollbar())
+        if ((editable || (renderer && renderer->isRenderText() && node->canStartSelection() && renderer->style().usedUserSelect() != UserSelect::None)) && !inResizer && !result.scrollbar())
             return iBeam;
         return pointerCursor();
     }


### PR DESCRIPTION
#### 4264524b4c6097fea9b173afec3f4c00cd57b213
<pre>
Avoid text cursor from being applied if `-webkit-user-select: none` is set
<a href="https://bugs.webkit.org/show_bug.cgi?id=244944">https://bugs.webkit.org/show_bug.cgi?id=244944</a>

Reviewed by Tim Nguyen.

The cursor was incorrectly changing to a text pointer even when `-webkit-user-select: none` was applied.
This is fixed by verifying the `-webkit-user-select` in the event handler and preventing the text pointer from being selected when `-webkit-user-select: none` is set.

* Source/WebCore/css/CSSProperties.json:
* LayoutTests/editing/selection/user-select-none-02-expected.txt: Added.
* LayoutTests/editing/selection/user-select-none-02.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::selectCursor):

Canonical link: <a href="https://commits.webkit.org/289793@main">https://commits.webkit.org/289793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f42edc1505a4fc2c2a6fbe445400e42f06a8d502

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92875 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38722 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67905 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25647 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6034 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79592 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48274 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/34000 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37829 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76209 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94739 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15140 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11162 "Found 1 new test failure: ipc/decode-object-array-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76760 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75998 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18697 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20391 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18807 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8144 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15158 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20459 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14900 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18345 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->