### PR TITLE
Only synthesize a 'viewBox' in `<img>` for the document element `<svg>`

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -10445,6 +10445,7 @@
         "web-platform-tests/svg/coordinate-systems/support/viewBox-scaling-text-001-ref.html",
         "web-platform-tests/svg/coordinate-systems/support/views.svg",
         "web-platform-tests/svg/crashtests/support/used.svg",
+        "web-platform-tests/svg/embedded/reference/green-rect-100x100.svg",
         "web-platform-tests/svg/geometry/reftests/circle-ref.svg",
         "web-platform-tests/svg/geometry/reftests/ellipse-ref.svg",
         "web-platform-tests/svg/geometry/reftests/percentage-ref.svg",

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/embedded/image-embedding-svg-nested-svg-in-foreignobject-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/embedded/image-embedding-svg-nested-svg-in-foreignobject-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/embedded/image-embedding-svg-nested-svg-in-foreignobject.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/embedded/image-embedding-svg-nested-svg-in-foreignobject.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<title>Only synthesize a 'viewBox' for the outermost SVG root in image contexts</title>
+<link rel="help" href="https://crbug.com/1313530">
+<link rel="match" href="../struct/reftests/reference/green-100x100.html">
+<img width="100" height="100" src="data:image/svg+xml,
+  <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' width='100' id='svg'>
+    <rect width='200' height='200' fill='red'/>
+    <foreignObject width='200' height='200'>
+      <div xmlns='http://www.w3.org/1999/xhtml' style='height: 100px; width: 100px'>
+        <svg xmlns='http://www.w3.org/2000/svg' style='width: 100%; height: 100%; overflow: visible' width='200' height='200'>
+          <rect width='200' height='200' fill='green'/>
+        </svg>
+      </div>
+    </foreignObject>
+  </svg>
+">

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/embedded/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/embedded/w3c-import.log
@@ -14,6 +14,8 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/svg/embedded/image-embedding-svg-nested-svg-in-foreignobject-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/svg/embedded/image-embedding-svg-nested-svg-in-foreignobject.html
 /LayoutTests/imported/w3c/web-platform-tests/svg/embedded/image-embedding-svg-viewref-with-viewbox.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/embedded/image-embedding-svg-with-viewport-units-inline-style.svg
 /LayoutTests/imported/w3c/web-platform-tests/svg/embedded/image-embedding-svg-with-viewport-units.svg

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2004, 2005, 2006, 2019 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2010 Rob Buis <buis@kde.org>
  * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
- * Copyright (C) 2015 Google Inc. All rights reserved.
+ * Copyright (C) 2015-2022 Google Inc. All rights reserved.
  * Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -587,7 +587,11 @@ FloatRect SVGSVGElement::currentViewBoxRect() const
     if (!viewBox.isEmpty())
         return viewBox;
 
-    auto isEmbeddedThroughSVGImage = [](const RenderElement* renderer) -> bool {
+    auto isEmbeddedThroughSVGImage = [this](const RenderElement* renderer) -> bool {
+        auto isDocumentElement = document().documentElement() == this;
+        if (!isDocumentElement)
+            return false;
+
         if (!renderer)
             return false;
 


### PR DESCRIPTION
#### 257fce338020bac6c216a203f092b909cabb9bf9
<pre>
Only synthesize a &apos;viewBox&apos; in `&lt;img&gt;` for the document element `&lt;svg&gt;`

<a href="https://bugs.webkit.org/show_bug.cgi?id=284938">https://bugs.webkit.org/show_bug.cgi?id=284938</a>
<a href="https://rdar.apple.com/141733733">rdar://141733733</a>

Reviewed by Darin Adler.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src/+/b895b95cbe1718e0492cec48a398e90d26049ed3">https://chromium.googlesource.com/chromium/src/+/b895b95cbe1718e0492cec48a398e90d26049ed3</a>

SVGSVGElement::currentViewBoxRect() needs to check that it is the
document element as well in the lambda function so it can accordingly
synthesize a `viewBox` in `&lt;img&gt;`.

Upstream Commit (Test Sync): <a href="https://github.com/web-platform-tests/wpt/commit/56a3a0687521ab33b98a25ce20f94662671098d8">https://github.com/web-platform-tests/wpt/commit/56a3a0687521ab33b98a25ce20f94662671098d8</a>

* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::currentViewBoxRect const):
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/svg/embedded/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/svg/embedded/image-embedding-svg-nested-svg-in-foreignobject-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/embedded/image-embedding-svg-nested-svg-in-foreignobject.html:

Canonical link: <a href="https://commits.webkit.org/288134@main">https://commits.webkit.org/288134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f6b821d8e1defb4eb399c8a7fde82ff7a62ade0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86385 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32833 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63817 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21551 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44103 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/919 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28644 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31286 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72284 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87821 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72174 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71405 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17824 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15498 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14419 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/442 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9028 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14560 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8869 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12392 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10677 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->