### PR TITLE
[WebGPU] Large indirect draw calls should trigger device lost

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-284937-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-284937-expected.txt
@@ -1,0 +1,62 @@
+CONSOLE MESSAGE: promises created
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: Unhandled Promise Rejection: GPUPipelineError
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: the end
+CONSOLE MESSAGE: the end
+CONSOLE MESSAGE: repro_284937.html
+CONSOLE MESSAGE: notify done
+layer at (0,0) size 785x4861
+  RenderView at (0,0) size 785x600
+layer at (0,0) size 785x4861
+  RenderBlock {HTML} at (0,0) size 785x4861 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x4845
+      RenderHTMLCanvas {CANVAS} at (0,4395) size 300x150
+      RenderImage {IMG} at (300,4543) size 26x2
+      RenderImage {IMG} at (300,4694) size 5x1
+      RenderImage {IMG} at (605,4638) size 32x57
+      RenderImage {IMG} at (637,4654) size 76x41
+      RenderImage {IMG} at (713,4682) size 38x13
+      RenderImage {IMG} at (0,4828) size 54x17
+      RenderImage {IMG} at (54,4794) size 189x51
+      RenderImage {IMG} at (243,4830) size 1x15
+      RenderImage {IMG} at (244,4838) size 20x7
+      RenderImage {IMG} at (264,4725) size 15x120
+layer at (334,8) size 396x4545
+  RenderHTMLCanvas {CANVAS} at (326,0) size 396x4545
+layer at (8,4553) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,4545) size 300x150
+layer at (313,4553) size 300x150
+  RenderHTMLCanvas {CANVAS} at (305,4545) size 300x150
+layer at (287,4703) size 300x150
+  RenderHTMLCanvas {CANVAS} at (279,4695) size 300x150

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-284937.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-284937.html
@@ -1,0 +1,27872 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+    // START
+    var videoFrame0;
+    var videoFrame1;
+    var videoFrame3;
+    var videoFrame4;
+    var videoFrame6;
+    var videoFrame7;
+    var videoFrame8;
+    var videoFrame9;
+    var videoFrame11;
+    var videoFrame13;
+    var videoFrame14;
+    var videoFrame15;
+    var videoFrame17;
+    var videoFrame18;
+    var videoFrame19;
+    var videoFrame20;
+    var videoFrame22;
+    var videoFrame24;
+    var videoFrame26;
+    var videoFrame29;
+    var videoFrame30;
+    var videoFrame32;
+    var videoFrame33;
+    var videoFrame34;
+    var videoFrame37;
+    var videoFrame38;
+    var videoFrame40;
+    var videoFrame41;
+    var videoFrame42;
+    var videoFrame44;
+    var videoFrame45;
+    var videoFrame48;
+    var videoFrame49;
+    var videoFrame50;
+    var videoFrame51;
+    var videoFrame52;
+    var videoFrame53;
+    var videoFrame54;
+    var videoFrame55;
+    var videoFrame56;
+    var videoFrame57;
+    var videoFrame58;
+    var videoFrame59;
+try {
+    let adapter0 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let device0 = await adapter0.requestDevice({
+  defaultQueue: {},
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 32,
+    maxVertexAttributes: 16,
+    maxVertexBufferArrayStride: 2048,
+    maxBindGroupsPlusVertexBuffers: 24,
+    minStorageBufferOffsetAlignment: 256,
+    maxUniformBufferBindingSize: 29597045,
+    maxStorageBufferBindingSize: 144304191,
+  },
+});
+let commandEncoder0 = device0.createCommandEncoder({});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder1 = device0.createCommandEncoder({});
+let computePassEncoder0 = commandEncoder1.beginComputePass();
+let sampler0 = device0.createSampler({addressModeU: 'repeat', magFilter: 'linear', compare: 'always'});
+let commandEncoder2 = device0.createCommandEncoder({});
+let texture0 = device0.createTexture({
+  size: [97, 60, 68],
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder1 = commandEncoder0.beginComputePass({});
+let sampler1 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 74.97,
+  maxAnisotropy: 10,
+});
+let veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 85, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let computePassEncoder2 = commandEncoder2.beginComputePass({});
+let sampler2 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', minFilter: 'linear', lodMaxClamp: 88.80});
+let buffer0 = device0.createBuffer({size: 15609, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let commandEncoder3 = device0.createCommandEncoder({});
+let computePassEncoder3 = commandEncoder3.beginComputePass({});
+let promise0 = device0.queue.onSubmittedWorkDone();
+let veryExplicitBindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 85, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout1]});
+try {
+device0.label = '\u041e\u{1fbcf}\uc7ac\u8548\u{1ff1b}';
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let texture1 = device0.createTexture({
+  size: [60, 1, 133],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let buffer1 = device0.createBuffer({
+  size: 3027,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let texture2 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 798},
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView0 = texture2.createView({baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 1091});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(14_041).fill(5), /* required buffer size: 14_041 */
+{offset: 171, bytesPerRow: 111, rowsPerImage: 119}, {width: 53, height: 6, depthOrArrayLayers: 2});
+} catch {}
+let veryExplicitBindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 85, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let buffer2 = device0.createBuffer({
+  size: 11970,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let renderBundle0 = renderBundleEncoder0.finish({});
+let textureView1 = texture2.createView({});
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let buffer3 = device0.createBuffer({size: 3733, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder4 = device0.createCommandEncoder({});
+let textureView2 = texture0.createView({baseArrayLayer: 0});
+let sampler3 = device0.createSampler({
+  label: '\u{1fcc9}\u{1fa89}\u475e\u5c50\u89b4\u3257\u08a3\u02c8\u050b\u0007\u718b',
+  mipmapFilter: 'nearest',
+});
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 13},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 276},
+  aspect: 'all',
+},
+{width: 0, height: 5, depthOrArrayLayers: 15});
+} catch {}
+try {
+computePassEncoder1.insertDebugMarker('\u{1f821}');
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let commandEncoder5 = device0.createCommandEncoder({});
+let texture3 = device0.createTexture({
+  size: [390, 240, 50],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder4.copyBufferToBuffer(buffer1, 148, buffer3, 120, 768);
+} catch {}
+try {
+commandEncoder4.resolveQuerySet(querySet0, 158, 89, buffer1, 256);
+} catch {}
+let commandEncoder6 = device0.createCommandEncoder();
+let computePassEncoder4 = commandEncoder5.beginComputePass({});
+let sampler4 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 93.49,
+});
+let buffer4 = device0.createBuffer({
+  size: 16802,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 11, y: 5, z: 1},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder({});
+let sampler5 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.73,
+  compare: 'not-equal',
+});
+let computePassEncoder5 = commandEncoder7.beginComputePass({});
+try {
+device0.queue.writeBuffer(buffer3, 608, new Float32Array(6754), 1237, 120);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData0 = new ImageData(12, 104);
+try {
+adapter0.label = '\u6248\u{1f793}';
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({});
+let textureView3 = texture3.createView({});
+let renderPassEncoder0 = commandEncoder4.beginRenderPass({
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 40,
+  clearValue: { r: 896.9, g: -616.9, b: -928.7, a: -967.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 60388498,
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder0.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer2);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let bindGroup0 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 85, resource: {buffer: buffer4, offset: 256, size: 2912}}],
+});
+let commandEncoder9 = device0.createCommandEncoder({});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup0, new Uint32Array(578), 126, 0);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer1, 'uint16', 166, 48);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(6, buffer2, 4_268);
+} catch {}
+try {
+renderBundleEncoder1.insertDebugMarker('\u5dbe');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 2, y: 9, z: 14},
+  aspect: 'all',
+}, new Uint8Array(1_685).fill(160), /* required buffer size: 1_685 */
+{offset: 106, bytesPerRow: 73, rowsPerImage: 4}, {width: 23, height: 2, depthOrArrayLayers: 6});
+} catch {}
+try {
+  await promise1;
+} catch {}
+let texture4 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 327},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView4 = texture0.createView({});
+let renderPassEncoder1 = commandEncoder6.beginRenderPass({
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 45,
+  clearValue: { r: -774.6, g: -442.5, b: -363.6, a: -527.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 852751095,
+});
+let renderBundle1 = renderBundleEncoder1.finish();
+try {
+computePassEncoder1.setBindGroup(0, bindGroup0, new Uint32Array(257), 2, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup0, new Uint32Array(585), 108, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(169.86221538057632, 73.68003529777168, 199.92668028601145, 6.340887775065736, 0.6764635586834978, 0.8856763821201888);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint32', 580, 350);
+} catch {}
+try {
+commandEncoder9.copyBufferToBuffer(buffer0, 8844, buffer4, 3764, 136);
+} catch {}
+let commandEncoder10 = device0.createCommandEncoder({});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 615});
+let textureView5 = texture3.createView({aspect: 'all'});
+let computePassEncoder6 = commandEncoder10.beginComputePass({});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(128, 17, 2, 12);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer0, 0, 1_127);
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder({});
+let renderPassEncoder2 = commandEncoder11.beginRenderPass({
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 15,
+  clearValue: { r: 318.0, g: 878.2, b: -479.7, a: -915.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 13319575,
+});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer0, 6176, buffer4, 5608, 1304);
+} catch {}
+let sampler6 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 74.23,
+  compare: 'not-equal',
+  maxAnisotropy: 1,
+});
+let texture5 = device0.createTexture({
+  size: [390, 240, 1],
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView6 = texture2.createView({dimension: '3d', aspect: 'all'});
+let computePassEncoder7 = commandEncoder9.beginComputePass({});
+let sampler7 = device0.createSampler({addressModeU: 'mirror-repeat', lodMaxClamp: 71.17});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(13);
+} catch {}
+try {
+adapter0.label = '\ud443\u0102\u{1ffab}\u{1ff07}\u4a1f';
+} catch {}
+let veryExplicitBindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 85, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let buffer5 = device0.createBuffer({size: 7557, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView7 = texture4.createView({arrayLayerCount: 1});
+let renderPassEncoder3 = commandEncoder8.beginRenderPass({
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 32,
+  clearValue: { r: -572.4, g: 372.6, b: -873.2, a: -981.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 28254937,
+});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup0, new Uint32Array(3639), 41, 0);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(0, buffer4, 4_220, 112);
+} catch {}
+let texture6 = device0.createTexture({
+  size: [97],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle0, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer4);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let texture7 = device0.createTexture({
+  size: [60, 1, 240],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView8 = texture4.createView({});
+let renderPassEncoder4 = commandEncoder5.beginRenderPass({
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 11,
+  clearValue: { r: 106.6, g: -717.3, b: 492.2, a: 538.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 220489908,
+});
+let sampler8 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 84.48});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(3, bindGroup0, new Uint32Array(2936), 501, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 130},
+  aspect: 'all',
+}, new Uint8Array(21_701).fill(145), /* required buffer size: 21_701 */
+{offset: 101, bytesPerRow: 10, rowsPerImage: 27}, {width: 4, height: 0, depthOrArrayLayers: 81});
+} catch {}
+let imageData1 = new ImageData(96, 20);
+let veryExplicitBindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 113,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 206,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup0, new Uint32Array(33), 6, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup0, new Uint32Array(1488), 129, 0);
+} catch {}
+let bindGroup1 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 85, resource: {buffer: buffer2, offset: 0, size: 3632}}],
+});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup1, new Uint32Array(2398), 230, 0);
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 85, resource: {buffer: buffer4, offset: 4864, size: 1560}}],
+});
+let buffer6 = device0.createBuffer({size: 1711, usage: GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder12 = device0.createCommandEncoder({});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup0, new Uint32Array(47), 7, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer1, 'uint32', 316, 238);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let buffer7 = device0.createBuffer({size: 14659, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let textureView9 = texture7.createView({aspect: 'all', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder8 = commandEncoder12.beginComputePass({});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(85, 4, 16, 11);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer4, 'uint32', 2_008, 865);
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 85, resource: {buffer: buffer2, offset: 2816, size: 6280}}],
+});
+let sampler9 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 76.42,
+  maxAnisotropy: 8,
+});
+let texture8 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 43},
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup1, new Uint32Array(1517), 179, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle1, renderBundle1, renderBundle0]);
+} catch {}
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], stencilReadOnly: true});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint32', 1_264, 238);
+} catch {}
+let buffer8 = device0.createBuffer({size: 21763, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder13 = device0.createCommandEncoder({});
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 743});
+let computePassEncoder9 = commandEncoder13.beginComputePass({});
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer1, 'uint16', 392, 66);
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder({});
+let computePassEncoder10 = commandEncoder14.beginComputePass({});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup3, new Uint32Array(963), 598, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup0, new Uint32Array(3068), 99, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer4, 0);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer1, 'uint32', 108, 120);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(6, buffer0, 0, 4_544);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 273});
+let textureView10 = texture4.createView({});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup2, new Uint32Array(620), 66, 0);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup3, new Uint32Array(23), 0, 0);
+} catch {}
+try {
+buffer1.label = '\u{1fd56}\uace2\u01a8\u958c\u{1fdcc}\u0562\u28f3\u518a\ufe75';
+} catch {}
+let texture9 = device0.createTexture({
+  size: [780, 480, 1],
+  mipLevelCount: 3,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle2 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(1, bindGroup0, new Uint32Array(637), 72, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(130.11242954122966, 132.88755579448238, 58.89560037084198, 12.859388381904163, 0.5865818712441482, 0.8837613749320041);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint32', 572, 99);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 85, resource: {buffer: buffer4, offset: 0, size: 2176}}],
+});
+let commandEncoder15 = device0.createCommandEncoder();
+let texture10 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 1},
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture11 = device0.createTexture({
+  size: [97, 60, 1],
+  mipLevelCount: 3,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView11 = texture3.createView({});
+let renderPassEncoder5 = commandEncoder15.beginRenderPass({
+  colorAttachments: [{
+  view: textureView5,
+  depthSlice: 2,
+  clearValue: { r: 440.6, g: 262.6, b: -633.4, a: -274.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint32', 48, 1_430);
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\u{1fe8c}');
+} catch {}
+let textureView12 = texture10.createView({dimension: '2d', baseMipLevel: 0, arrayLayerCount: 1});
+try {
+renderPassEncoder5.setBlendConstant({ r: -140.2, g: 839.2, b: -27.59, a: -449.9, });
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint16', 356, 283);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 1376, new Float32Array(7418), 2210, 188);
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 85, resource: {buffer: buffer2, offset: 1024, size: 7724}}],
+});
+let buffer9 = device0.createBuffer({
+  size: 3988,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup0, new Uint32Array(3339), 518, 0);
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 113, resource: sampler2}, {binding: 206, resource: {buffer: buffer9, offset: 1536}}],
+});
+let commandEncoder16 = device0.createCommandEncoder();
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint32', 456, 317);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 17, y: 21, z: 1},
+  aspect: 'all',
+}, new Uint8Array(50_813).fill(231), /* required buffer size: 50_813 */
+{offset: 46, bytesPerRow: 85, rowsPerImage: 59}, {width: 11, height: 8, depthOrArrayLayers: 11});
+} catch {}
+let computePassEncoder11 = commandEncoder16.beginComputePass({});
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup2, new Uint32Array(1073), 133, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer0, 2_448);
+} catch {}
+await gc();
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 805});
+let textureView13 = texture10.createView({});
+let texture12 = device0.createTexture({size: [480, 1, 30], format: 'rg8unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup0, new Uint32Array(1775), 747, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup0, new Uint32Array(2512), 223, 0);
+} catch {}
+try {
+  await promise0;
+} catch {}
+let bindGroup7 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 85, resource: {buffer: buffer9, offset: 0}}],
+});
+let texture13 = device0.createTexture({
+  size: {width: 16},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView14 = texture0.createView({label: '\u39bb\u{1f6d7}\u{1face}\u{1f954}', aspect: 'all'});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup5);
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 85, resource: {buffer: buffer9, offset: 0}}],
+});
+let commandEncoder17 = device0.createCommandEncoder({});
+let computePassEncoder12 = commandEncoder17.beginComputePass({});
+let renderBundle3 = renderBundleEncoder3.finish({});
+let sampler10 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.85,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer4, 'uint32', 980, 1_189);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 50}
+*/
+{
+  source: imageData1,
+  origin: { x: 19, y: 0 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 45, y: 7, z: 13},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData2 = new ImageData(76, 164);
+let commandEncoder18 = device0.createCommandEncoder({});
+let computePassEncoder13 = commandEncoder18.beginComputePass({});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup2, new Uint32Array(2544), 17, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle1, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint16', 922, 321);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 39, y: 2 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 15, y: 17, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], sampleCount: 1, stencilReadOnly: true});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup2, new Uint32Array(909), 148, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup0, []);
+} catch {}
+let texture14 = device0.createTexture({size: [480, 1, 16], dimension: '3d', format: 'rg8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView15 = texture9.createView({format: 'rg8unorm', mipLevelCount: 1});
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer0, 0, 932);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer1, 'uint16', 858, 643);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(3, buffer2);
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\uf143');
+} catch {}
+let imageData3 = new ImageData(20, 56);
+let bindGroup9 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 85, resource: {buffer: buffer9, offset: 768}}],
+});
+let commandEncoder19 = device0.createCommandEncoder();
+let texture15 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 65},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView16 = texture15.createView({dimension: '2d-array', baseArrayLayer: 9, arrayLayerCount: 12});
+try {
+renderPassEncoder3.executeBundles([renderBundle0, renderBundle1, renderBundle0, renderBundle3, renderBundle3, renderBundle3]);
+} catch {}
+try {
+adapter0.label = '\uc618\u429a';
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 85, resource: {buffer: buffer4, offset: 256, size: 5976}}],
+});
+let buffer10 = device0.createBuffer({
+  size: 9256,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder20 = device0.createCommandEncoder({});
+let texture16 = device0.createTexture({
+  size: {width: 16},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler11 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 12.69,
+});
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint16', 230, 368);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(0, buffer0, 1_712);
+} catch {}
+let textureView17 = texture9.createView({mipLevelCount: 1});
+let renderBundle4 = renderBundleEncoder5.finish({});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(3, bindGroup4, new Uint32Array(11), 0, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup0, new Uint32Array(773), 14, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer1, 'uint32', 232, 385);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer10, 104, buffer8, 388, 932);
+} catch {}
+try {
+adapter0.label = '\u{1f70d}\u0d49\u0f44\uf32b\u0807\u0a5b\u6fc0\u64c7\u0427\uae48\u0f3c';
+} catch {}
+let texture17 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 22},
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture18 = device0.createTexture({
+  size: [120],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup1, new Uint32Array(571), 114, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle3]);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 6562 */
+  offset: 6562,
+  bytesPerRow: 22784,
+  buffer: buffer0,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 20, y: 8, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 50, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 400,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture19 = device0.createTexture({size: [480, 1, 1], format: 'r16sint', usage: GPUTextureUsage.TEXTURE_BINDING, viewFormats: []});
+let textureView18 = texture17.createView({baseMipLevel: 0, arrayLayerCount: 13});
+let computePassEncoder14 = commandEncoder19.beginComputePass({});
+try {
+renderPassEncoder5.setVertexBuffer(3, undefined, 881_557_176);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+await gc();
+let textureView19 = texture17.createView({dimension: 'cube'});
+let textureView20 = texture12.createView({dimension: '2d', baseArrayLayer: 0});
+let sampler12 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 40.71});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup8, new Uint32Array(3063), 637, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint16', 1_058, 87);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(3, buffer2, 2_084, 1_085);
+} catch {}
+let texture20 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture21 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView21 = texture15.createView({dimension: '2d', baseArrayLayer: 17});
+let computePassEncoder15 = commandEncoder20.beginComputePass({});
+try {
+renderPassEncoder5.executeBundles([renderBundle0, renderBundle4]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 18, y: 19, z: 0},
+  aspect: 'all',
+}, new Uint8Array(9).fill(115), /* required buffer size: 9 */
+{offset: 9, bytesPerRow: 32}, {width: 15, height: 53, depthOrArrayLayers: 0});
+} catch {}
+let texture22 = device0.createTexture({
+  size: [780],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture23 = device0.createTexture({
+  size: [240, 1, 34],
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup7, []);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(6, buffer0, 0, 927);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder({});
+let texture24 = device0.createTexture({
+  size: [120, 1, 233],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder16 = commandEncoder21.beginComputePass({});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup8, new Uint32Array(1697), 56, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer1, 'uint16', 426, 123);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup2, new Uint32Array(5879), 300, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 2052, new Int16Array(8675), 1002, 1392);
+} catch {}
+let textureView22 = texture24.createView({dimension: '2d-array', baseArrayLayer: 29, arrayLayerCount: 19});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle0, renderBundle1]);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer10, 'uint32', 1_320, 697);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(2, buffer0, 0, 1_454);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u77ae');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 50}
+*/
+{
+  source: imageData0,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 47, y: 61, z: 11},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 51, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder({});
+let texture25 = device0.createTexture({
+  size: {width: 480},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture26 = device0.createTexture({size: [60, 1, 7], dimension: '3d', format: 'rg8unorm', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder17 = commandEncoder22.beginComputePass();
+try {
+buffer5.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(57).fill(53), /* required buffer size: 57 */
+{offset: 57}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup11 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 85, resource: {buffer: buffer4, offset: 2048, size: 1260}}],
+});
+let textureView23 = texture16.createView({});
+let texture27 = device0.createTexture({
+  size: {width: 60, height: 1, depthOrArrayLayers: 82},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle5 = renderBundleEncoder4.finish({});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup5);
+} catch {}
+let buffer11 = device0.createBuffer({
+  size: 14264,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true,
+});
+let texture28 = device0.createTexture({
+  size: {width: 480, height: 1, depthOrArrayLayers: 38},
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler13 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', minFilter: 'linear'});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder();
+let textureView24 = texture25.createView({aspect: 'all', mipLevelCount: 1});
+let textureView25 = texture25.createView({});
+let renderPassEncoder6 = commandEncoder23.beginRenderPass({
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 38,
+  clearValue: { r: 807.6, g: 83.55, b: 285.4, a: 341.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet4,
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle6 = renderBundleEncoder6.finish();
+let sampler14 = device0.createSampler({addressModeV: 'repeat', magFilter: 'nearest', minFilter: 'linear', lodMaxClamp: 44.77});
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer10);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 16, y: 1 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 202, y: 55, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 24, height: 2, depthOrArrayLayers: 0});
+} catch {}
+videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'film', transfer: 'log'} });
+let commandEncoder24 = device0.createCommandEncoder({});
+let texture29 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 26},
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView26 = texture23.createView({dimension: '2d', baseArrayLayer: 5});
+let renderPassEncoder7 = commandEncoder24.beginRenderPass({
+  label: '\u{1ff08}\u349b',
+  colorAttachments: [{
+  view: textureView5,
+  depthSlice: 47,
+  clearValue: { r: -707.5, g: -660.1, b: 853.0, a: 243.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet3,
+});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup2, []);
+} catch {}
+try {
+computePassEncoder15.setBindGroup(1, bindGroup2, new Uint32Array(255), 38, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(1, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 812, new Int16Array(16157), 2064, 596);
+} catch {}
+let commandEncoder25 = device0.createCommandEncoder({});
+let textureView27 = texture20.createView({baseMipLevel: 0, baseArrayLayer: 0});
+let renderPassEncoder8 = commandEncoder25.beginRenderPass({
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: 144.7, g: -125.2, b: -711.1, a: 525.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 82951185,
+});
+try {
+renderPassEncoder5.setViewport(58.93251905856119, 44.59234884759438, 317.49558799864263, 89.3337705721996, 0.3978468562979425, 0.4336160272719379);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer11, 'uint32', 528, 238);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder({});
+let textureView28 = texture24.createView({dimension: '2d', baseArrayLayer: 17, arrayLayerCount: 1});
+let computePassEncoder18 = commandEncoder26.beginComputePass({});
+let sampler15 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat'});
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup3, new Uint32Array(1283), 330, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer10, 'uint32', 872, 329);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer2, 0, 2_854);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 97, height: 60, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 22 },
+  flipY: false,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 62, y: 8, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let imageData4 = new ImageData(228, 32);
+let veryExplicitBindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 50, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 400,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder27 = device0.createCommandEncoder({});
+let texture30 = device0.createTexture({
+  size: [240, 1, 14],
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture31 = device0.createTexture({
+  size: [16, 16, 68],
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView29 = texture6.createView({mipLevelCount: 1});
+let computePassEncoder19 = commandEncoder27.beginComputePass({});
+try {
+renderPassEncoder5.setBlendConstant({ r: -770.0, g: 84.20, b: -722.4, a: -394.0, });
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'smpteRp431', transfer: 'bt2020_12bit'} });
+let texture32 = device0.createTexture({
+  size: [120, 1, 31],
+  mipLevelCount: 4,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture33 = device0.createTexture({size: [97, 60, 1], mipLevelCount: 2, format: 'depth32float', usage: GPUTextureUsage.TEXTURE_BINDING});
+let sampler16 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 97.71,
+});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup2, new Uint32Array(1158), 97, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer11, 'uint32', 888, 409);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer10, 1_344, 345);
+} catch {}
+let img0 = await imageWithData(5, 1, '#10101010', '#20202020');
+let commandEncoder28 = device0.createCommandEncoder({});
+let textureView30 = texture33.createView({mipLevelCount: 1});
+let computePassEncoder20 = commandEncoder28.beginComputePass({});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup5, []);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup0, new Uint32Array(3424), 2_070, 0);
+} catch {}
+await gc();
+let buffer12 = device0.createBuffer({size: 8129, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder29 = device0.createCommandEncoder({});
+let texture34 = device0.createTexture({
+  size: [390, 240, 1],
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView31 = texture24.createView({label: '\u16a6\u1725\u250b\u0ef8', baseMipLevel: 0, baseArrayLayer: 12, arrayLayerCount: 61});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup3, new Uint32Array(8188), 1_744, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer11, 'uint32', 5_252, 3_954);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer0, 0, 191);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 195, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 16, y: 11, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+try {
+adapter0.label = '\u9f0c\ub55a\u{1f8cf}\u01a8\u{1f98e}\uc92f\uc795\u0244';
+} catch {}
+let texture35 = device0.createTexture({
+  size: [16, 16, 7],
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView32 = texture6.createView({arrayLayerCount: 1});
+let computePassEncoder21 = commandEncoder29.beginComputePass();
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint16', 1_784, 433);
+} catch {}
+let textureView33 = texture35.createView({});
+document.body.append(img0);
+let texture36 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 377},
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup0, new Uint32Array(2601), 608, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup5, new Uint32Array(487), 31, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer11, 'uint16', 1_054, 6_013);
+} catch {}
+try {
+computePassEncoder9.pushDebugGroup('\u9069');
+} catch {}
+let buffer13 = device0.createBuffer({size: 37754, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+let commandEncoder30 = device0.createCommandEncoder({});
+let texture37 = device0.createTexture({
+  size: [97, 60, 1],
+  dimension: '2d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture38 = device0.createTexture({
+  size: {width: 60, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder22 = commandEncoder30.beginComputePass();
+try {
+renderPassEncoder8.executeBundles([renderBundle0]);
+} catch {}
+document.body.prepend(img0);
+let veryExplicitBindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 12,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 49,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 58, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 70,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 72,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 88,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 95,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 349,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 615,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder31 = device0.createCommandEncoder({});
+let textureView34 = texture18.createView({});
+let sampler17 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', minFilter: 'nearest'});
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup3, new Uint32Array(21), 3, 0);
+} catch {}
+try {
+commandEncoder31.copyBufferToBuffer(buffer13, 3292, buffer4, 1604, 160);
+} catch {}
+try {
+commandEncoder31.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1306 */
+  offset: 1306,
+  bytesPerRow: 7680,
+  buffer: buffer1,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder31.insertDebugMarker('\u03ff');
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 206, resource: {buffer: buffer10, offset: 3328}}, {binding: 113, resource: sampler4}],
+});
+let textureView35 = texture30.createView({dimension: '3d'});
+let renderPassEncoder9 = commandEncoder31.beginRenderPass({
+  colorAttachments: [{view: textureView3, depthSlice: 20, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet2,
+});
+let sampler18 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 81.05});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup5, new Uint32Array(2634), 305, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer0, 0);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+document.body.append(img0);
+let texture39 = device0.createTexture({
+  size: {width: 480, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture40 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 22},
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 9},
+  aspect: 'all',
+}, new Uint8Array(80_647).fill(154), /* required buffer size: 80_647 */
+{offset: 52, bytesPerRow: 199, rowsPerImage: 81}, {width: 84, height: 0, depthOrArrayLayers: 6});
+} catch {}
+let veryExplicitBindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 85, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let buffer14 = device0.createBuffer({size: 9664, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView36 = texture20.createView({dimension: '2d-array'});
+let sampler19 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 81.72,
+  compare: 'not-equal',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer11, 'uint16', 3_128, 1_668);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(1, buffer10, 188);
+} catch {}
+try {
+computePassEncoder15.insertDebugMarker('\u04d3');
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [{binding: 85, resource: {buffer: buffer2, offset: 4864, size: 2240}}],
+});
+let textureView37 = texture37.createView({aspect: 'all'});
+let texture41 = device0.createTexture({
+  size: [240, 1, 35],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView38 = texture11.createView({mipLevelCount: 1});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup0, new Uint32Array(116), 71, 0);
+} catch {}
+try {
+renderPassEncoder5.insertDebugMarker('\u335c');
+} catch {}
+let canvas0 = document.createElement('canvas');
+let bindGroup14 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 206, resource: {buffer: buffer4, offset: 2304, size: 2020}},
+    {binding: 113, resource: sampler11},
+  ],
+});
+let buffer15 = device0.createBuffer({size: 4466, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup0, new Uint32Array(766), 25, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder6.setViewport(368.71237217352433, 211.36330624180576, 11.875753023123584, 22.864471689102107, 0.5905747860678446, 0.617411546147543);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer1, 'uint32', 444, 130);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer0, 420, 801);
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 85, resource: {buffer: buffer2, offset: 1024, size: 2012}}],
+});
+let buffer16 = device0.createBuffer({size: 6637, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder32 = device0.createCommandEncoder();
+let texture42 = device0.createTexture({
+  size: {width: 240},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView39 = texture4.createView({label: '\ub89d\u{1f83d}\u0d11\u{1fe53}\ucbdd\u0bdb\u0928\ue4ca', dimension: '3d'});
+let renderPassEncoder10 = commandEncoder32.beginRenderPass({
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 42,
+  clearValue: { r: 912.5, g: -416.7, b: -123.6, a: -864.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup8, new Uint32Array(2407), 57, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 3,
+  origin: {x: 23, y: 8, z: 0},
+  aspect: 'all',
+}, new Uint8Array(81).fill(111), /* required buffer size: 81 */
+{offset: 81, bytesPerRow: 103}, {width: 30, height: 11, depthOrArrayLayers: 0});
+} catch {}
+let texture43 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint16', 754, 492);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer0, 0, 3_954);
+} catch {}
+document.body.prepend(img0);
+let bindGroup16 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [{binding: 85, resource: {buffer: buffer4, offset: 1792, size: 8648}}],
+});
+let textureView40 = texture20.createView({});
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer0, 232, 259);
+} catch {}
+let buffer17 = device0.createBuffer({
+  size: 1807,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder33 = device0.createCommandEncoder({});
+let texture44 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView41 = texture3.createView({});
+let renderPassEncoder11 = commandEncoder33.beginRenderPass({colorAttachments: [{view: textureView26, loadOp: 'load', storeOp: 'store'}]});
+let externalTexture1 = device0.importExternalTexture({label: '\u{1f7f9}\ube34\u08bf\u2e50', source: videoFrame1});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer1, 'uint16', 132, 53);
+} catch {}
+document.body.append(canvas0);
+let buffer18 = device0.createBuffer({
+  size: 26994,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView42 = texture33.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup5, new Uint32Array(484), 41, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup3, new Uint32Array(335), 65, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer17, 'uint16', 150, 79);
+} catch {}
+document.body.append(canvas0);
+let bindGroup17 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 85, resource: {buffer: buffer9, offset: 256}}],
+});
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout7]});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup13, new Uint32Array(658), 41, 0);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(183);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer17, 'uint32', 648, 14);
+} catch {}
+let commandEncoder34 = device0.createCommandEncoder({});
+let computePassEncoder23 = commandEncoder34.beginComputePass({});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(3, bindGroup0, new Uint32Array(2462), 764, 0);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -779.9, g: -943.3, b: -662.4, a: -180.9, });
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer17, 'uint16', 374, 555);
+} catch {}
+let imageData5 = new ImageData(12, 80);
+let buffer19 = device0.createBuffer({
+  size: 2508,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder35 = device0.createCommandEncoder({});
+let textureView43 = texture7.createView({aspect: 'all', mipLevelCount: 1});
+let sampler20 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 36.74});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup7, new Uint32Array(240), 110, 0);
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 113, resource: sampler15},
+    {binding: 206, resource: {buffer: buffer4, offset: 2816, size: 1768}},
+  ],
+});
+let commandEncoder36 = device0.createCommandEncoder({});
+let renderPassEncoder12 = commandEncoder35.beginRenderPass({
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: 125.7, g: -813.6, b: 437.3, a: 21.49, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler21 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat'});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup7);
+} catch {}
+let commandEncoder37 = device0.createCommandEncoder({});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 355});
+let textureView44 = texture7.createView({dimension: '3d', mipLevelCount: 1});
+let computePassEncoder24 = commandEncoder36.beginComputePass({});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup2);
+} catch {}
+videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'jedecP22Phosphors', transfer: 'iec6196624'} });
+let bindGroup19 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 85, resource: {buffer: buffer4, offset: 512, size: 1232}}],
+});
+let texture45 = device0.createTexture({
+  size: {width: 16},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder25 = commandEncoder37.beginComputePass({});
+let sampler22 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 62.29,
+  compare: 'less-equal',
+});
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 12, y: 80, z: 4},
+  aspect: 'all',
+}, new Uint8Array(120).fill(77), /* required buffer size: 120 */
+{offset: 120}, {width: 23, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 50}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 208, y: 7, z: 7},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'bt470m', transfer: 'logSqrt'} });
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 560, new BigUint64Array(11264), 985, 80);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup8, new Uint32Array(1569), 575, 0);
+} catch {}
+let texture46 = device0.createTexture({
+  size: {width: 195, height: 120, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder2.setIndexBuffer(buffer17, 'uint16', 50, 117);
+} catch {}
+let arrayBuffer0 = buffer11.getMappedRange();
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(831).fill(210), /* required buffer size: 831 */
+{offset: 831}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture47 = device0.createTexture({
+  size: [60, 1, 126],
+  dimension: '2d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture48 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 22},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup1, []);
+} catch {}
+try {
+computePassEncoder6.setBindGroup(0, bindGroup15, new Uint32Array(104), 0, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup7, new Uint32Array(1341), 103, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 77, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(59).fill(24), /* required buffer size: 59 */
+{offset: 59, rowsPerImage: 21}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img1 = await imageWithData(38, 13, '#10101010', '#20202020');
+try {
+computePassEncoder13.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup19, new Uint32Array(1426), 88, 0);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let buffer20 = device0.createBuffer({size: 9005, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler23 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', magFilter: 'linear', lodMaxClamp: 62.04});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup13);
+} catch {}
+let texture49 = device0.createTexture({
+  size: [16],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView45 = texture18.createView({});
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup15, new Uint32Array(89), 7, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle0, renderBundle2, renderBundle4, renderBundle2, renderBundle4, renderBundle0, renderBundle4]);
+} catch {}
+try {
+computePassEncoder14.pushDebugGroup('\u{1feb0}');
+} catch {}
+videoFrame4 = new VideoFrame(img1, {timestamp: 0});
+let buffer21 = device0.createBuffer({
+  size: 14848,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder38 = device0.createCommandEncoder({});
+let renderPassEncoder13 = commandEncoder38.beginRenderPass({
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 17,
+  clearValue: { r: -740.4, g: 296.2, b: -361.3, a: -316.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler24 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 82.06,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 7},
+  aspect: 'all',
+}, new Uint8Array(13).fill(204), /* required buffer size: 13 */
+{offset: 13}, {width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 240, height: 1, depthOrArrayLayers: 34}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture50 = device0.createTexture({
+  size: {width: 195, height: 120, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder12.setVertexBuffer(6, buffer4, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 684, new Float32Array(23389), 1123, 480);
+} catch {}
+let buffer22 = device0.createBuffer({size: 13777, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder39 = device0.createCommandEncoder({});
+let texture51 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView46 = texture38.createView({});
+let renderBundle7 = renderBundleEncoder7.finish({});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup8, new Uint32Array(1825), 322, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup16, new Uint32Array(888), 11, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer18, 'uint16', 2_072, 808);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 178, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(31_022).fill(32), /* required buffer size: 31_022 */
+{offset: 17, bytesPerRow: 53, rowsPerImage: 117}, {width: 22, height: 0, depthOrArrayLayers: 6});
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder({});
+let texture52 = device0.createTexture({
+  size: [240, 1, 16],
+  sampleCount: 1,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder26 = commandEncoder39.beginComputePass({});
+let renderPassEncoder14 = commandEncoder40.beginRenderPass({
+  colorAttachments: [{view: textureView26, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 46318815,
+});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup5, new Uint32Array(213), 33, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer17, 'uint32', 728, 324);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer18);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 7}
+*/
+{
+  source: imageData4,
+  origin: { x: 0, y: 11 },
+  flipY: true,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 7, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout6]});
+let buffer23 = device0.createBuffer({
+  size: 2624,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView47 = texture10.createView({});
+try {
+renderPassEncoder13.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder13.insertDebugMarker('\u5f34');
+} catch {}
+let veryExplicitBindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let texture53 = device0.createTexture({
+  size: {width: 195, height: 120, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer10, 'uint16', 946, 806);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 4940, new Float32Array(7230), 712, 1920);
+} catch {}
+document.body.prepend(canvas0);
+let veryExplicitBindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 12,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 49,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 58, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 70,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 72,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 88,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 95,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 349,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 615,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let texture54 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 1},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture55 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup5, new Uint32Array(2002), 116, 0);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: 230.7, g: -205.5, b: 45.55, a: -520.5, });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture56 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture57 = device0.createTexture({size: [16], dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup4, new Uint32Array(1057), 235, 0);
+} catch {}
+let texture58 = device0.createTexture({
+  size: [780, 480, 1],
+  mipLevelCount: 5,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder4.setIndexBuffer(buffer11, 'uint16', 504, 2_648);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(56).fill(204), /* required buffer size: 56 */
+{offset: 56, rowsPerImage: 36}, {width: 54, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+await gc();
+let commandEncoder41 = device0.createCommandEncoder();
+let texture59 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 22},
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture60 = device0.createTexture({size: [195, 120, 1], format: 'rg8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let renderPassEncoder15 = commandEncoder41.beginRenderPass({
+  colorAttachments: [{
+  view: textureView41,
+  depthSlice: 12,
+  clearValue: { r: 384.8, g: 893.7, b: 326.5, a: 232.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle0, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer23, 124, 351);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 50, resource: sampler23},
+    {binding: 21, resource: textureView13},
+    {binding: 400, resource: {buffer: buffer4, offset: 4864, size: 420}},
+  ],
+});
+let buffer24 = device0.createBuffer({
+  size: 7446,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView48 = texture59.createView({dimension: 'cube-array', baseArrayLayer: 4, arrayLayerCount: 6});
+let textureView49 = texture48.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 6});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer24);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 5540, new BigUint64Array(11832), 4058, 24);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise2;
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({});
+let texture61 = device0.createTexture({
+  size: [390, 240, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView50 = texture4.createView({arrayLayerCount: 1});
+let computePassEncoder27 = commandEncoder42.beginComputePass({});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(3, bindGroup8, new Uint32Array(2617), 17, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer11, 'uint16', 86, 3_608);
+} catch {}
+try {
+computePassEncoder9.popDebugGroup();
+} catch {}
+document.body.append(canvas0);
+let commandEncoder43 = device0.createCommandEncoder({});
+let texture62 = device0.createTexture({
+  size: [97, 60, 98],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder28 = commandEncoder43.beginComputePass({});
+try {
+renderPassEncoder15.setVertexBuffer(6, buffer16, 272, 130);
+} catch {}
+document.body.prepend(img1);
+let texture63 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup2, new Uint32Array(354), 81, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup19, new Uint32Array(2135), 110, 0);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let imageData6 = new ImageData(152, 36);
+let buffer25 = device0.createBuffer({size: 14677, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let textureView51 = texture2.createView({dimension: '3d', format: 'rg8unorm', arrayLayerCount: 1});
+try {
+renderPassEncoder5.executeBundles([renderBundle4, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(4, buffer0, 404);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise3;
+} catch {}
+let imageBitmap0 = await createImageBitmap(imageData2);
+let buffer26 = device0.createBuffer({
+  size: 20692,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture64 = device0.createTexture({
+  size: [60, 1, 1],
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup14, new Uint32Array(1081), 8, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup21 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 85, resource: {buffer: buffer2, offset: 2304, size: 4884}}],
+});
+try {
+renderPassEncoder7.setIndexBuffer(buffer1, 'uint16', 20, 593);
+} catch {}
+let imageData7 = new ImageData(164, 56);
+let textureView52 = texture5.createView({mipLevelCount: 1});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle0, renderBundle4, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer18, 'uint16', 11_322, 1_340);
+} catch {}
+await gc();
+let buffer27 = device0.createBuffer({size: 16069, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let textureView53 = texture23.createView({baseArrayLayer: 2, arrayLayerCount: 4});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup1, new Uint32Array(1620), 110, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer18, 'uint16', 11_994, 2_123);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(2, buffer25);
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout7,
+  entries: [
+    {binding: 95, resource: textureView28},
+    {binding: 72, resource: {buffer: buffer9, offset: 768}},
+    {binding: 70, resource: textureView36},
+    {binding: 58, resource: externalTexture3},
+    {binding: 615, resource: textureView35},
+    {binding: 88, resource: textureView19},
+    {binding: 349, resource: {buffer: buffer23, offset: 768}},
+    {binding: 12, resource: {buffer: buffer9, offset: 0, size: 576}},
+    {binding: 49, resource: textureView27},
+    {binding: 22, resource: textureView24},
+  ],
+});
+let texture65 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm']});
+let sampler25 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  lodMaxClamp: 89.99,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder13.executeBundles([renderBundle2, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer18, 'uint16', 8_862, 719);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer18, 'uint16', 4_996, 3_035);
+} catch {}
+try {
+globalThis.someLabel = externalTexture4.label;
+} catch {}
+let bindGroup23 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 206, resource: {buffer: buffer2, offset: 768, size: 392}},
+    {binding: 113, resource: sampler3},
+  ],
+});
+let commandEncoder44 = device0.createCommandEncoder({});
+let texture66 = device0.createTexture({
+  size: [97, 60, 1],
+  dimension: '2d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView54 = texture5.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder29 = commandEncoder44.beginComputePass({});
+let sampler26 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'greater-equal',
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup2, new Uint32Array(310), 42, 0);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -333.8, g: -935.0, b: -0.5089, a: -673.9, });
+} catch {}
+try {
+renderPassEncoder2.setViewport(24.588790162430026, 23.700444777235205, 214.53700309959552, 189.208304990673, 0.39797303049596244, 0.853903164323398);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer17, 'uint16', 272, 384);
+} catch {}
+let buffer28 = device0.createBuffer({
+  size: 8930,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder45 = device0.createCommandEncoder({});
+let computePassEncoder30 = commandEncoder45.beginComputePass({});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup4, new Uint32Array(1040), 423, 0);
+} catch {}
+try {
+renderPassEncoder6.setViewport(29.022504209018418, 145.2860607444422, 156.47966427769367, 52.30412512707406, 0.5672515525738752, 0.8620822501938202);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer19, 'uint16', 154, 80);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 157, y: 28, z: 0},
+  aspect: 'all',
+}, new Uint8Array(232).fill(219), /* required buffer size: 232 */
+{offset: 232, bytesPerRow: 230}, {width: 47, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 97, height: 60, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData3,
+  origin: { x: 1, y: 3 },
+  flipY: false,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 3, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder25.setBindGroup(2, bindGroup14, new Uint32Array(43), 18, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer16, 'uint32', 1_236, 642);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(0, buffer21, 0, 3_595);
+} catch {}
+let veryExplicitBindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 50, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 400,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup24 = device0.createBindGroup({
+  label: '\u{1fb0c}\ud95f\ub6fe\u2c17\uf82f',
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 206, resource: {buffer: buffer4, offset: 1536, size: 8860}},
+    {binding: 113, resource: sampler7},
+  ],
+});
+let texture67 = device0.createTexture({size: [16], mipLevelCount: 1, dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.COPY_DST});
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'unspecified', transfer: 'bt709'} });
+try {
+adapter0.label = '\u{1f8da}\u2471\u{1fffd}\u0b1f\uf6f3\u0dcb\u0601\u0e58\u0d0a\u{1fca4}\u41e6';
+} catch {}
+let bindGroup25 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 70, resource: textureView36},
+    {binding: 22, resource: textureView25},
+    {binding: 95, resource: textureView28},
+    {binding: 72, resource: {buffer: buffer17, offset: 256, size: 408}},
+    {binding: 615, resource: textureView35},
+    {binding: 88, resource: textureView19},
+    {binding: 58, resource: externalTexture5},
+    {binding: 349, resource: {buffer: buffer23, offset: 0}},
+    {binding: 12, resource: {buffer: buffer17, offset: 0, size: 1192}},
+    {binding: 49, resource: textureView40},
+  ],
+});
+try {
+renderPassEncoder8.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer17, 'uint32', 124, 422);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer25);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup21, new Uint32Array(1255), 79, 0);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer11, 'uint32', 400, 24);
+} catch {}
+try {
+  await buffer15.mapAsync(GPUMapMode.READ, 0, 1728);
+} catch {}
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let textureView55 = texture48.createView({dimension: '2d', baseArrayLayer: 10});
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup19, new Uint32Array(173), 12, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer11, 'uint16', 274, 1_007);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer1, 'uint16', 80, 30);
+} catch {}
+let bindGroup26 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout11,
+  entries: [
+    {binding: 400, resource: {buffer: buffer17, offset: 0, size: 332}},
+    {binding: 21, resource: textureView12},
+    {binding: 50, resource: sampler18},
+  ],
+});
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 126});
+let texture68 = device0.createTexture({
+  size: {width: 60, height: 1, depthOrArrayLayers: 23},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(2, buffer17);
+} catch {}
+try {
+renderPassEncoder13.insertDebugMarker('\u64d6');
+} catch {}
+document.body.append(img0);
+await gc();
+let imageData8 = new ImageData(80, 16);
+let buffer29 = device0.createBuffer({
+  size: 5834,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle4, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer10, 'uint16', 3_116, 1_312);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(0, buffer21, 1_764, 286);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer17, 'uint16', 310, 37);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup27 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [{binding: 0, resource: {buffer: buffer21, offset: 1792}}],
+});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup5, new Uint32Array(283), 29, 0);
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(643);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(2, buffer23, 308);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(1, bindGroup2, new Uint32Array(133), 18, 0);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(4, undefined, 34_731_087);
+} catch {}
+let bindGroup28 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout7,
+  entries: [
+    {binding: 49, resource: textureView40},
+    {binding: 70, resource: textureView36},
+    {binding: 88, resource: textureView19},
+    {binding: 615, resource: textureView35},
+    {binding: 72, resource: {buffer: buffer29, offset: 0, size: 628}},
+    {binding: 95, resource: textureView28},
+    {binding: 58, resource: externalTexture4},
+    {binding: 22, resource: textureView24},
+    {binding: 12, resource: {buffer: buffer17, offset: 0, size: 320}},
+    {binding: 349, resource: {buffer: buffer25, offset: 3584, size: 1559}},
+  ],
+});
+let sampler27 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 94.21,
+});
+try {
+renderPassEncoder10.setIndexBuffer(buffer1, 'uint16', 230, 132);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(7, buffer10);
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder();
+let texture69 = device0.createTexture({
+  size: [480, 1, 33],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder16 = commandEncoder46.beginRenderPass({
+  colorAttachments: [{
+  view: textureView15,
+  clearValue: { r: 412.7, g: 305.5, b: 467.0, a: -691.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler28 = device0.createSampler({addressModeU: 'repeat', lodMaxClamp: 92.88});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer16, 'uint32', 128, 587);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 11, y: 1 },
+  flipY: false,
+}, {
+  texture: texture55,
+  mipLevel: 1,
+  origin: {x: 53, y: 50, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 155, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture70 = device0.createTexture({
+  size: [240, 1, 44],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView56 = texture58.createView({aspect: 'stencil-only', mipLevelCount: 1, baseArrayLayer: 0});
+let renderBundle8 = renderBundleEncoder8.finish();
+try {
+computePassEncoder29.setBindGroup(1, bindGroup14, new Uint32Array(9318), 559, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle0, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(354, 8, 116, 66);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer19, 'uint16', 236, 89);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(0, buffer16, 1_008, 3_036);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 780, height: 480, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 0, y: 3 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 29, y: 85, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 228, height: 0, depthOrArrayLayers: 0});
+} catch {}
+videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'smpte240m', transfer: 'hlg'} });
+let shaderModule0 = device0.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+struct T0 {
+  f0: vec4u,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct VertexOutput0 {
+  @location(6) @interpolate(flat, sample) f0: i32,
+  @invariant @builtin(position) f1: vec4f,
+  @location(10) @interpolate(flat, sample) f2: u32,
+  @location(8) f3: vec2u,
+  @location(15) f4: vec2f,
+  @location(14) @interpolate(flat) f5: vec2i,
+  @location(3) @interpolate(flat, center) f6: vec4u,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn fn2(a0: ptr<storage, array<array<array<atomic<i32>, 1>, 1>>, read_write>, a1: ptr<workgroup, mat3x3h>) -> T0 {
+  var out: T0;
+  out = T0(vec4u(u32(atomicLoad(&(*a0)[u32(unconst_u32(32))][0][0]))));
+  fn0();
+  atomicSub(&(*a0)[u32(unconst_u32(46))][u32(unconst_u32(191))][u32(unconst_u32(59))], i32(unconst_i32(45)));
+  fn0();
+  let ptr2: ptr<workgroup, mat3x3h> = &(*a1);
+  let ptr3: ptr<workgroup, mat3x3h> = &(*a1);
+  var vf16 = fn0();
+  let ptr4: ptr<storage, atomic<i32>, read_write> = &(*a0)[u32(unconst_u32(20))][u32(unconst_u32(40))][u32(unconst_u32(87))];
+  (*a1) += mat3x3h(f16(atomicLoad(&(*a0)[arrayLength(&(*a0))][u32(unconst_u32(326))][0])), f16(atomicLoad(&(*a0)[arrayLength(&(*a0))][u32(unconst_u32(326))][0])), f16(atomicLoad(&(*a0)[arrayLength(&(*a0))][u32(unconst_u32(326))][0])), f16(atomicLoad(&(*a0)[arrayLength(&(*a0))][u32(unconst_u32(326))][0])), f16(atomicLoad(&(*a0)[arrayLength(&(*a0))][u32(unconst_u32(326))][0])), f16(atomicLoad(&(*a0)[arrayLength(&(*a0))][u32(unconst_u32(326))][0])), f16(atomicLoad(&(*a0)[arrayLength(&(*a0))][u32(unconst_u32(326))][0])), f16(atomicLoad(&(*a0)[arrayLength(&(*a0))][u32(unconst_u32(326))][0])), f16(atomicLoad(&(*a0)[arrayLength(&(*a0))][u32(unconst_u32(326))][0])));
+  fn0();
+  let vf17: i32 = atomicLoad(&(*a0)[arrayLength(&(*a0))][u32(unconst_u32(39))][0]);
+  out.f0 *= vec4u(u32((*ptr3)[u32(unconst_u32(167))][u32(unconst_u32(129))]));
+  return out;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(0) var<uniform> buffer30: vec4u;
+
+fn fn0() -> vec2u {
+  var out: vec2u;
+  out = bitcast<vec2u>(tanh(vec4h(unconst_f16(15626.9), unconst_f16(5571.9), unconst_f16(4575.8), unconst_f16(-12285.8))));
+  out = bitcast<vec2u>(refract(vec3f(unconst_f32(0.00926), unconst_f32(0.00348), unconst_f32(0.1215)), vec3f(unconst_f32(0.06386), unconst_f32(0.1382), unconst_f32(-0.2289)), f32(unconst_f32(0.2251))).yz);
+  var vf0: u32 = insertBits(u32(unconst_u32(109)), u32(unconst_u32(108)), u32(unconst_u32(169)), u32(unconst_u32(158)));
+  var vf1: vec4h = sign(vec4h(unconst_f16(37399.5), unconst_f16(1094.6), unconst_f16(12856.2), unconst_f16(8892.8)));
+  let vf2: vec4f = quantizeToF16(vec4f(unconst_f32(-0.1117), unconst_f32(0.2260), unconst_f32(0.09369), unconst_f32(0.1034)));
+  vf0 -= u32(sign(vec4h(unconst_f16(17265.7), unconst_f16(16960.3), unconst_f16(520.4), unconst_f16(15505.9))).x);
+  var vf3: f16 = asin(f16(unconst_f16(12315.5)));
+  vf0 = pack4x8unorm(quantizeToF16(vec4f(tanh(vec4h(unconst_f16(28060.9), unconst_f16(9942.7), unconst_f16(5988.6), unconst_f16(3407.7))))));
+  var vf4: f16 = vf1[u32(unconst_u32(87))];
+  let vf5: u32 = pack4xU8(vec4u(unconst_u32(38), unconst_u32(315), unconst_u32(68), unconst_u32(80)));
+  var vf6: u32 = pack4xU8(vec4u(unconst_u32(327), unconst_u32(350), unconst_u32(165), unconst_u32(4)));
+  out &= vec2u(pack4xU8(vec4u(unconst_u32(59), unconst_u32(101), unconst_u32(31), unconst_u32(8))));
+  vf6 = pack4xU8Clamp(vec4u(sign(vec4h(f16(vf2[u32(unconst_u32(121))])))));
+  vf4 += vf1.b;
+  var vf7: vec4h = sign(vec4h(unconst_f16(2179.4), unconst_f16(16490.4), unconst_f16(-2801.1), unconst_f16(3111.5)));
+  var vf8: f16 = vf1[u32(unconst_u32(68))];
+  let ptr0: ptr<function, f16> = &vf8;
+  vf0 &= u32(vf8);
+  vf1 = vec4h(f16(vf5));
+  vf1 = vec4h(refract(vec3f(unconst_f32(0.04859), unconst_f32(0.00078), unconst_f32(0.2034)), vec3f(unconst_f32(-0.2365), unconst_f32(0.04194), unconst_f32(-0.4320)), unpack2x16float(u32(unconst_u32(38))).g).xzyx);
+  vf7 += vec4h(f16(vf5));
+  let ptr1: ptr<function, u32> = &vf6;
+  return out;
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn fn1() -> u32 {
+  var out: u32;
+  let vf9: vec4f = abs(vec4f(unconst_f32(0.2258), unconst_f32(0.04053), unconst_f32(0.05864), unconst_f32(0.2590)));
+  out |= u32(pow(f16(unconst_f16(1209.4)), f16(unpack4xU8(u32(unconst_u32(4))).a)));
+  var vf10: u32 = pack4xI8(vec4i(unconst_i32(-93), unconst_i32(134), unconst_i32(45), unconst_i32(160)));
+  vf10 ^= bitcast<u32>(insertBits(i32(unconst_i32(-95)), i32(unconst_i32(234)), pack4xI8(vec4i(unconst_i32(128), unconst_i32(484), unconst_i32(339), unconst_i32(138))), u32(unconst_u32(178))));
+  let vf11: u32 = pack4xU8Clamp(vec4u(unconst_u32(17), unconst_u32(198), unconst_u32(53), unconst_u32(260)));
+  out = u32(sinh(vec4h(unconst_f16(27849.8), unconst_f16(972.7), unconst_f16(1005.7), unconst_f16(18688.0)))[1]);
+  vf10 &= vf10;
+  var vf12: vec4f = acos(vec4f(unconst_f32(0.04008), unconst_f32(0.8507), unconst_f32(0.02285), unconst_f32(0.2873)));
+  vf10 &= pack4xI8(vec4i(unconst_i32(236), unconst_i32(365), unconst_i32(154), unconst_i32(459)));
+  vf10 -= pack4xU8Clamp(unpack4xU8(u32(unconst_u32(16))));
+  var vf13: i32 = countLeadingZeros(i32(unconst_i32(215)));
+  let vf14: vec4h = sinh(vec4h(unconst_f16(-17327.4), unconst_f16(14988.6), unconst_f16(10665.0), unconst_f16(7214.5)));
+  let vf15: f16 = vf14[u32(unconst_u32(47))];
+  return out;
+}
+
+alias vec3b = vec3<bool>;
+
+@vertex
+fn vertex0(@location(6) @interpolate(flat) a0: vec4u) -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f5 = vec2i(i32(step(f16(unconst_f16(1660.3)), f16(unconst_f16(35518.2)))));
+  var vf18: f16 = trunc(f16(unconst_f16(33236.2)));
+  out.f3 = vec2u(round(vec3h(unconst_f16(27096.6), unconst_f16(19471.5), unconst_f16(17492.5))).rb);
+  out.f6 ^= vec4u(unpack4x8unorm(pack2x16float(mix(bitcast<vec2f>(abs(vec2u(unconst_u32(102), unconst_u32(110)))), vec2f(unconst_f32(0.02464), unconst_f32(0.1266)), f32(unconst_f32(0.08453))))));
+  var vf19: vec2u = abs(vec2u(unconst_u32(277), unconst_u32(4)));
+  var vf20: vec4f = unpack4x8snorm(pack4x8unorm(clamp(vec4f(unconst_f32(0.04675), unconst_f32(1.000), unconst_f32(0.3707), unconst_f32(0.1054)), vec4f(unconst_f32(0.3620), unconst_f32(0.02876), unconst_f32(-0.02319), unconst_f32(0.05429)), vec4f(unconst_f32(-0.02385), unconst_f32(0.3212), unconst_f32(-0.09238), unconst_f32(-0.03045)))));
+  fn0();
+  let vf21: f32 = min(f32(unconst_f32(0.2451)), f32(unconst_f32(0.3586)));
+  vf19 += vec2u(clamp(vec4f(unconst_f32(0.1737), unconst_f32(0.2256), unconst_f32(0.6275), unconst_f32(0.3540)), vec4f(clamp(f32(unconst_f32(0.3300)), f32(unconst_f32(0.4174)), f32(unconst_f32(0.4679)))), vec4f(unconst_f32(0.2570), unconst_f32(0.06434), unconst_f32(0.2812), unconst_f32(0.04848))).xz);
+  out.f4 *= vec2f(degrees(vec3h(unconst_f16(20334.7), unconst_f16(671.1), unconst_f16(663.0))).gb);
+  vf18 = step(f16(unconst_f16(1924.9)), f16(unconst_f16(-36047.2)));
+  let vf22: vec3h = degrees(vec3h(unconst_f16(5198.0), unconst_f16(3104.6), unconst_f16(1045.0)));
+  let ptr5: ptr<function, vec4f> = &vf20;
+  fn0();
+  out.f3 -= vec2u(degrees(vec3h(unconst_f16(9851.3), unconst_f16(9310.1), unconst_f16(662.3))).zy);
+  var vf23: vec4f = unpack4x8snorm(u32(unconst_u32(191)));
+  vf18 *= f16(mix(vec2f(unconst_f32(0.02530), unconst_f32(0.01993)), vec2f(unconst_f32(0.02279), unconst_f32(-0.2785)), f32(unconst_f32(0.04760))).x);
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  var vf24: vec4f = reflect(vec4f(unconst_f32(0.5675), unconst_f32(0.00589), unconst_f32(0.1121), unconst_f32(0.06459)), vec4f(unconst_f32(0.1071), unconst_f32(0.05607), unconst_f32(0.2285), unconst_f32(0.00158)));
+  vf24 -= bitcast<vec4f>(unpack4xU8(u32(unconst_u32(150))));
+  fn0();
+  let vf25: vec4h = saturate(vec4h(unconst_f16(4657.3), unconst_f16(10113.7), unconst_f16(1940.7), unconst_f16(1655.4)));
+  vf24 = vec4f(bitcast<f32>((*&buffer30)[u32(unconst_u32(41))]));
+  fn0();
+  var vf26: f32 = exp2(f32(unconst_f32(0.2791)));
+  vf24 = vec4f(bitcast<f32>((*&buffer30)[u32(unconst_u32(129))]));
+  let ptr6: ptr<uniform, vec4u> = &(*&buffer30);
+  var vf27 = fn0();
+  var vf28 = fn0();
+  let vf29: u32 = buffer30[u32(unconst_u32(66))];
+  vf26 += bitcast<f32>(dot(vec2i(i32(pow(f16(unconst_f16(5518.1)), f16(unconst_f16(15276.9))))), vec2i(unconst_i32(22), unconst_i32(74))));
+  _ = buffer30;
+}`,
+});
+let bindGroup29 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [{binding: 0, resource: {buffer: buffer17, offset: 0, size: 913}}],
+});
+let buffer31 = device0.createBuffer({size: 9176, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let textureView57 = texture1.createView({mipLevelCount: 1});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup26, new Uint32Array(2724), 396, 0);
+} catch {}
+let arrayBuffer1 = buffer15.getMappedRange(328, 1304);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 7}
+*/
+{
+  source: imageData7,
+  origin: { x: 1, y: 5 },
+  flipY: false,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+document.body.prepend(img1);
+let bindGroup30 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 85, resource: {buffer: buffer17, offset: 0, size: 1348}}],
+});
+let commandEncoder47 = device0.createCommandEncoder({});
+let texture71 = device0.createTexture({size: {width: 195}, dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder31 = commandEncoder47.beginComputePass({});
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup3, new Uint32Array(1899), 690, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle7, renderBundle6, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder7.setViewport(15.429217263652909, 221.2545858525574, 102.82605183995653, 10.06793545121205, 0.6683393069109161, 0.984131985674513);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer11, 'uint16', 1_234, 1_554);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(7, buffer25);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 17, z: 0},
+  aspect: 'all',
+}, new Uint8Array(174).fill(185), /* required buffer size: 174 */
+{offset: 174, bytesPerRow: 89}, {width: 10, height: 14, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({});
+let computePassEncoder32 = commandEncoder48.beginComputePass();
+try {
+computePassEncoder30.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(3, bindGroup16, new Uint32Array(778), 130, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup26, new Uint32Array(2279), 23, 0);
+} catch {}
+let arrayBuffer2 = buffer15.getMappedRange(192, 32);
+try {
+computePassEncoder14.popDebugGroup();
+} catch {}
+let commandEncoder49 = device0.createCommandEncoder({});
+let renderPassEncoder17 = commandEncoder49.beginRenderPass({
+  colorAttachments: [{view: textureView5, depthSlice: 8, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet5,
+});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup20, new Uint32Array(2043), 447, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer18, 'uint32', 24_436, 643);
+} catch {}
+let commandEncoder50 = device0.createCommandEncoder({});
+let texture72 = device0.createTexture({
+  size: [480, 1, 7],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView58 = texture46.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup26);
+} catch {}
+let promise4 = shaderModule0.getCompilationInfo();
+let veryExplicitBindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 113,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 206,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView59 = texture67.createView({});
+let computePassEncoder33 = commandEncoder50.beginComputePass({});
+let sampler29 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', minFilter: 'linear', mipmapFilter: 'linear'});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle4, renderBundle6]);
+} catch {}
+canvas0.height = 4545;
+let bindGroup31 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 349, resource: {buffer: buffer23, offset: 512}},
+    {binding: 615, resource: textureView35},
+    {binding: 70, resource: textureView36},
+    {binding: 88, resource: textureView19},
+    {binding: 12, resource: {buffer: buffer17, offset: 256, size: 424}},
+    {binding: 72, resource: {buffer: buffer2, offset: 3328, size: 1604}},
+    {binding: 49, resource: textureView27},
+    {binding: 95, resource: textureView28},
+    {binding: 58, resource: externalTexture2},
+    {binding: 22, resource: textureView25},
+  ],
+});
+let texture73 = device0.createTexture({
+  size: [390, 240, 1],
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler30 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMaxClamp: 83.48});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup11, new Uint32Array(143), 17, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer4, 'uint16', 1_876, 767);
+} catch {}
+let imageData9 = new ImageData(52, 12);
+let bindGroup32 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 85, resource: {buffer: buffer18, offset: 5120, size: 1868}}],
+});
+let buffer32 = device0.createBuffer({
+  size: 1933,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture74 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 22},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView60 = texture35.createView({});
+try {
+renderPassEncoder16.setVertexBuffer(2, buffer24, 0, 434);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 1026});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup25);
+} catch {}
+let bindGroup33 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 85, resource: {buffer: buffer18, offset: 4096, size: 5200}}],
+});
+let buffer33 = device0.createBuffer({
+  size: 459,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder51 = device0.createCommandEncoder({});
+let sampler31 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat', minFilter: 'linear'});
+let externalTexture6 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup21, new Uint32Array(1051), 192, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup4, new Uint32Array(593), 126, 0);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer33, 'uint32', 156, 3);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer24, 1_664, 556);
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer13, 4304, buffer29, 900, 20);
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture61,
+  mipLevel: 0,
+  origin: {x: 134, y: 27, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 23},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 195, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 72, y: 11, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder34 = commandEncoder51.beginComputePass({});
+let sampler32 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 79.93,
+  lodMaxClamp: 97.30,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup19, new Uint32Array(1065), 156, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let commandEncoder52 = device0.createCommandEncoder({});
+let sampler33 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 55.32,
+});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup8, new Uint32Array(3006), 179, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer18, 'uint16', 8_766, 515);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer2);
+} catch {}
+let arrayBuffer3 = buffer15.getMappedRange(8, 40);
+let promise5 = device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule0, constants: {}}});
+let bindGroup34 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 85, resource: {buffer: buffer4, offset: 2304, size: 1956}}],
+});
+let textureView61 = texture38.createView({mipLevelCount: 1});
+let texture75 = device0.createTexture({size: [780, 480, 1], mipLevelCount: 4, format: 'rg8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let textureView62 = texture27.createView({baseArrayLayer: 7, arrayLayerCount: 3});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(202, 18, 158, 150);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(622);
+} catch {}
+let arrayBuffer4 = buffer15.getMappedRange(0, 0);
+try {
+device0.queue.writeBuffer(buffer31, 1652, new Int16Array(22579), 1231, 1324);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let commandEncoder53 = device0.createCommandEncoder();
+let textureView63 = texture45.createView({});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle0, renderBundle1, renderBundle6]);
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 716, new DataView(new ArrayBuffer(7251)), 72, 44);
+} catch {}
+let commandEncoder54 = device0.createCommandEncoder({});
+let textureView64 = texture31.createView({arrayLayerCount: 1});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup10, new Uint32Array(1839), 883, 0);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer5, 324, buffer2, 5884, 1504);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup35 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 85, resource: {buffer: buffer9, offset: 256}}],
+});
+let texture76 = device0.createTexture({size: [780, 480, 1], format: 'rg8unorm', usage: GPUTextureUsage.TEXTURE_BINDING, viewFormats: []});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup1, new Uint32Array(326), 70, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer33, 'uint32', 28, 41);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer29);
+} catch {}
+try {
+commandEncoder54.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 43, y: 252, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 46 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 892 */
+  offset: 892,
+  bytesPerRow: 1792,
+  buffer: buffer9,
+}, {width: 23, height: 71, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder18.setBindGroup(3, bindGroup16, []);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer32, 'uint16', 184, 672);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 195, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData5,
+  origin: { x: 0, y: 8 },
+  flipY: true,
+}, {
+  texture: texture73,
+  mipLevel: 1,
+  origin: {x: 4, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture77 = device0.createTexture({
+  size: {width: 60, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder35 = commandEncoder54.beginComputePass({});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup28, []);
+} catch {}
+let bindGroup36 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 21, resource: textureView56},
+    {binding: 400, resource: {buffer: buffer18, offset: 2304, size: 1928}},
+    {binding: 50, resource: sampler8},
+  ],
+});
+let textureView65 = texture77.createView({format: 'rgba16sint'});
+let renderPassEncoder18 = commandEncoder53.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -233.5, g: 368.1, b: 59.63, a: 375.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 153046712,
+});
+let sampler34 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.43,
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup21, new Uint32Array(592), 32, 0);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 650.4, g: 274.0, b: -142.1, a: 849.5, });
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(802);
+} catch {}
+let arrayBuffer5 = buffer15.getMappedRange(224, 56);
+let veryExplicitBindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 140,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let renderPassEncoder19 = commandEncoder52.beginRenderPass({
+  colorAttachments: [{
+  view: textureView17,
+  clearValue: { r: 543.3, g: -680.3, b: 442.4, a: 988.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 264099804,
+});
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer33, 'uint16', 36, 56);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+videoFrame7 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let bindGroup37 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 400, resource: {buffer: buffer10, offset: 512}},
+    {binding: 21, resource: textureView56},
+    {binding: 50, resource: sampler33},
+  ],
+});
+let buffer34 = device0.createBuffer({
+  size: 1554,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder55 = device0.createCommandEncoder({});
+let computePassEncoder36 = commandEncoder55.beginComputePass({});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup4, new Uint32Array(665), 28, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer17, 'uint16', 130, 209);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(126).fill(67), /* required buffer size: 126 */
+{offset: 126, bytesPerRow: 12, rowsPerImage: 83}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder({});
+let texture78 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView66 = texture16.createView({});
+let computePassEncoder37 = commandEncoder56.beginComputePass({});
+try {
+computePassEncoder3.setBindGroup(0, bindGroup29, new Uint32Array(3785), 804, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup19, new Uint32Array(233), 10, 0);
+} catch {}
+let pipeline0 = await promise5;
+let imageData10 = new ImageData(4, 76);
+let buffer35 = device0.createBuffer({size: 4561, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder57 = device0.createCommandEncoder({});
+let texture79 = device0.createTexture({size: {width: 780}, dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView67 = texture0.createView({format: 'rg8unorm'});
+let renderPassEncoder20 = commandEncoder57.beginRenderPass({
+  colorAttachments: [{
+  view: textureView3,
+  depthSlice: 26,
+  clearValue: { r: -720.2, g: 539.6, b: -991.6, a: 101.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  depthReadOnly: false,
+});
+let sampler35 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 82.23,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder19.beginOcclusionQuery(198);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup13, new Uint32Array(2641), 1_384, 0);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer32, 'uint16', 586, 677);
+} catch {}
+let buffer36 = device0.createBuffer({
+  size: 1137,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup4, new Uint32Array(1145), 15, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle3, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer0, 7_408);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer32, 72);
+} catch {}
+let textureView68 = texture9.createView({format: 'rg8unorm', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(3, bindGroup33, new Uint32Array(1360), 158, 0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup24, new Uint32Array(5695), 47, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer24, 1_468, 55);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let buffer37 = device0.createBuffer({
+  size: 30233,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let texture80 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler36 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 66.33});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup8, new Uint32Array(2765), 63, 0);
+} catch {}
+try {
+renderPassEncoder6.setViewport(222.54919132258377, 40.13645607822892, 74.52235747796581, 139.41011752659514, 0.23223031740574718, 0.858681543974497);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer24, 316);
+} catch {}
+try {
+buffer27.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 756, new Float32Array(10558), 2489, 1524);
+} catch {}
+videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'jedecP22Phosphors', transfer: 'bt2020_10bit'} });
+let autogeneratedBindGroupLayout0 = pipeline0.getBindGroupLayout(0);
+let texture81 = device0.createTexture({
+  size: {width: 120, height: 1, depthOrArrayLayers: 22},
+  mipLevelCount: 2,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView69 = texture10.createView({dimension: '2d-array'});
+let renderBundle9 = renderBundleEncoder9.finish({});
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup3, new Uint32Array(2306), 1_026, 0);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle8]);
+} catch {}
+let sampler37 = device0.createSampler({addressModeW: 'repeat', mipmapFilter: 'linear', lodMaxClamp: 97.35});
+try {
+renderPassEncoder16.setIndexBuffer(buffer10, 'uint32', 20, 2_961);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let bindGroup38 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout11,
+  entries: [
+    {binding: 400, resource: {buffer: buffer33, offset: 0, size: 16}},
+    {binding: 21, resource: textureView47},
+    {binding: 50, resource: sampler8},
+  ],
+});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true});
+let renderBundle10 = renderBundleEncoder10.finish({});
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer33, 'uint16', 158, 7);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder58 = device0.createCommandEncoder({});
+let texture82 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder21 = commandEncoder58.beginRenderPass({
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 17,
+  clearValue: { r: 133.2, g: 719.2, b: -244.0, a: -501.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler38 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 84.48,
+});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 50}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 4, y: 1 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 37, y: 51, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 11, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let sampler39 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(1, buffer32);
+} catch {}
+let texture83 = device0.createTexture({
+  size: [390],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView70 = texture2.createView({baseArrayLayer: 0});
+let sampler40 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.13,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup19, new Uint32Array(1344), 363, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer34, 'uint32', 352, 19);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(0, buffer24, 0, 35);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let bindGroup39 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout7,
+  entries: [
+    {binding: 12, resource: {buffer: buffer32, offset: 0, size: 272}},
+    {binding: 22, resource: textureView24},
+    {binding: 72, resource: {buffer: buffer29, offset: 0, size: 1564}},
+    {binding: 95, resource: textureView28},
+    {binding: 349, resource: {buffer: buffer16, offset: 768, size: 2386}},
+    {binding: 615, resource: textureView35},
+    {binding: 88, resource: textureView19},
+    {binding: 58, resource: externalTexture5},
+    {binding: 70, resource: textureView36},
+    {binding: 49, resource: textureView40},
+  ],
+});
+let commandEncoder59 = device0.createCommandEncoder({label: '\u{1f7e6}\uef64'});
+let renderPassEncoder22 = commandEncoder59.beginRenderPass({
+  colorAttachments: [{
+  view: textureView26,
+  clearValue: { r: 498.9, g: -946.3, b: 605.3, a: -566.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup38, new Uint32Array(1467), 170, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer1, 'uint16', 322, 586);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer27, 2_776);
+} catch {}
+let autogeneratedBindGroupLayout1 = pipeline0.getBindGroupLayout(0);
+let texture84 = device0.createTexture({
+  size: [16, 16, 32],
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture85 = device0.createTexture({
+  size: [97, 60, 101],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView71 = texture15.createView({dimension: '2d', baseArrayLayer: 1});
+try {
+renderPassEncoder9.executeBundles([renderBundle7, renderBundle8, renderBundle0, renderBundle2, renderBundle0]);
+} catch {}
+try {
+  await promise4;
+} catch {}
+let imageBitmap1 = await createImageBitmap(canvas0);
+let commandEncoder60 = device0.createCommandEncoder({});
+let textureView72 = texture11.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderPassEncoder23 = commandEncoder60.beginRenderPass({
+  colorAttachments: [{
+  view: textureView72,
+  clearValue: { r: 25.62, g: -11.29, b: -781.1, a: -728.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 136438037,
+});
+try {
+computePassEncoder13.setBindGroup(3, bindGroup36);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(2, bindGroup2, new Uint32Array(62), 46, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer11, 'uint16', 1_184, 2_618);
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup40 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [{binding: 0, resource: {buffer: buffer21, offset: 1280, size: 5184}}],
+});
+let commandEncoder61 = device0.createCommandEncoder({});
+let computePassEncoder38 = commandEncoder61.beginComputePass({});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup10, new Uint32Array(628), 61, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer17, 'uint32', 488, 174);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder15.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup28, new Uint32Array(205), 5, 0);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(5, buffer21, 0);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let buffer38 = device0.createBuffer({
+  size: 17750,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer16, 'uint16', 650, 630);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+await gc();
+let textureView73 = texture58.createView({dimension: '2d', aspect: 'stencil-only', mipLevelCount: 1});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup21, new Uint32Array(506), 1, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup7, new Uint32Array(2209), 8, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3, renderBundle1, renderBundle0]);
+} catch {}
+let imageData11 = new ImageData(52, 32);
+let textureView74 = texture34.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+renderPassEncoder1.setIndexBuffer(buffer16, 'uint16', 182, 1_642);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let buffer39 = device0.createBuffer({size: 13548, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let texture86 = device0.createTexture({
+  label: '\u4de6\u384c\u8744\u{1f70a}\ub4f5\u{1f6e1}\u311b',
+  size: [390, 240, 1],
+  sampleCount: 4,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, buffer29);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(27_258).fill(180), /* required buffer size: 27_258 */
+{offset: 104, bytesPerRow: 46, rowsPerImage: 59}, {width: 7, height: 1, depthOrArrayLayers: 11});
+} catch {}
+let veryExplicitBindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 13,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 51,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 82,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+    {binding: 88, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 93,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 95,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 104,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {binding: 153, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 183,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 203,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer40 = device0.createBuffer({
+  size: 3800,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder62 = device0.createCommandEncoder({});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder36.setBindGroup(3, bindGroup26, new Uint32Array(791), 32, 0);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer18, 'uint16', 2_320, 2_515);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 50}
+*/
+{
+  source: imageData7,
+  origin: { x: 5, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 24, y: 1, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 51, height: 4, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let autogeneratedBindGroupLayout2 = pipeline0.getBindGroupLayout(0);
+let texture87 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer16, 'uint16', 770, 1_594);
+} catch {}
+let pipeline1 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0}});
+let textureView75 = texture87.createView({});
+try {
+computePassEncoder36.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer33, 'uint16', 0, 17);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(4, buffer18, 1_108);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 2544, new Float32Array(45264), 2982, 1648);
+} catch {}
+let autogeneratedBindGroupLayout3 = pipeline1.getBindGroupLayout(0);
+let bindGroup41 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout7,
+  entries: [
+    {binding: 349, resource: {buffer: buffer37, offset: 7936, size: 12266}},
+    {binding: 22, resource: textureView24},
+    {binding: 49, resource: textureView40},
+    {binding: 70, resource: textureView36},
+    {binding: 88, resource: textureView19},
+    {binding: 12, resource: {buffer: buffer34, offset: 0, size: 592}},
+    {binding: 95, resource: textureView28},
+    {binding: 58, resource: externalTexture1},
+    {binding: 72, resource: {buffer: buffer18, offset: 15360, size: 5528}},
+    {binding: 615, resource: textureView35},
+  ],
+});
+let buffer41 = device0.createBuffer({
+  size: 2601,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView76 = texture48.createView({dimension: 'cube', format: 'rg8unorm', baseArrayLayer: 1});
+let texture88 = device0.createTexture({
+  size: [60],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder24 = commandEncoder62.beginRenderPass({
+  colorAttachments: [{
+  view: textureView72,
+  clearValue: { r: 596.0, g: -790.7, b: 893.1, a: 248.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 88131916,
+});
+try {
+computePassEncoder3.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle10]);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+adapter0.label = '\u{1facc}\ua1bc\u9b44\uc9ed\u0505\u{1f60a}\u0dd8\uc9ef\u8186\ucf28\u{1f778}';
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer36, 164, 323);
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(90, 76);
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout0]});
+let texture89 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(1, bindGroup5, new Uint32Array(2099), 142, 0);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup26, new Uint32Array(1172), 50, 0);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer17, 'uint16', 598, 54);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(0, buffer2);
+} catch {}
+try {
+  await buffer12.mapAsync(GPUMapMode.WRITE, 1176, 616);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 7}
+*/
+{
+  source: imageData9,
+  origin: { x: 21, y: 2 },
+  flipY: false,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData12 = new ImageData(20, 8);
+let texture90 = device0.createTexture({
+  size: {width: 120, height: 1, depthOrArrayLayers: 15},
+  dimension: '2d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup30, new Uint32Array(1601), 96, 0);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+let arrayBuffer6 = buffer15.getMappedRange(48, 40);
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(616).fill(8), /* required buffer size: 616 */
+{offset: 616}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline2 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+try {
+  await promise7;
+} catch {}
+let autogeneratedBindGroupLayout4 = pipeline1.getBindGroupLayout(0);
+let buffer42 = device0.createBuffer({
+  size: 9974,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView77 = texture80.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler41 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 98.16,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder35.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(49, 36, 10, 9);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise8;
+} catch {}
+let commandEncoder63 = device0.createCommandEncoder();
+let textureView78 = texture19.createView({});
+let computePassEncoder39 = commandEncoder63.beginComputePass({});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup5, new Uint32Array(754), 35, 0);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext1 = offscreenCanvas0.getContext('webgpu');
+let bindGroup42 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout4,
+  entries: [{binding: 0, resource: {buffer: buffer42, offset: 256, size: 379}}],
+});
+let commandEncoder64 = device0.createCommandEncoder({});
+let texture91 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder40 = commandEncoder64.beginComputePass();
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup1, new Uint32Array(2014), 92, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer33, 'uint16', 38, 26);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let veryExplicitBindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [{binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: true }}],
+});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup42, new Uint32Array(3037), 619, 0);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(10, 1, 8, 27);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer32, 'uint16', 102, 623);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 1992, new Int16Array(328));
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 0, resource: {buffer: buffer36, offset: 256, size: 287}}],
+});
+let commandEncoder65 = device0.createCommandEncoder({});
+let texture92 = device0.createTexture({
+  size: [97, 60, 1],
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView79 = texture75.createView({mipLevelCount: 1});
+let computePassEncoder41 = commandEncoder65.beginComputePass({});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup10, new Uint32Array(1226), 114, 0);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup13, new Uint32Array(57), 5, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer25, 2_728);
+} catch {}
+let textureView80 = texture84.createView({arrayLayerCount: 1});
+let textureView81 = texture18.createView({aspect: 'all', mipLevelCount: 1, baseArrayLayer: 0});
+let sampler42 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 64.01,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+computePassEncoder35.setBindGroup(0, bindGroup18, new Uint32Array(2579), 1_105, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(139).fill(141), /* required buffer size: 139 */
+{offset: 139}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise9;
+} catch {}
+let texture93 = device0.createTexture({
+  size: [390, 240, 17],
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView82 = texture85.createView({mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup20, new Uint32Array(467), 95, 0);
+} catch {}
+let autogeneratedBindGroupLayout5 = pipeline0.getBindGroupLayout(0);
+let bindGroup44 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout11,
+  entries: [
+    {binding: 50, resource: sampler16},
+    {binding: 400, resource: {buffer: buffer18, offset: 256, size: 1900}},
+    {binding: 21, resource: textureView47},
+  ],
+});
+let buffer43 = device0.createBuffer({size: 2837, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX, mappedAtCreation: false});
+let commandEncoder66 = device0.createCommandEncoder();
+let textureView83 = texture1.createView({mipLevelCount: 1});
+let computePassEncoder42 = commandEncoder66.beginComputePass({});
+try {
+renderPassEncoder16.executeBundles([renderBundle4, renderBundle1, renderBundle10, renderBundle6, renderBundle1, renderBundle0]);
+} catch {}
+document.body.prepend(canvas0);
+let textureView84 = texture72.createView({mipLevelCount: 1});
+let sampler43 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', compare: 'less-equal'});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame7});
+try {
+computePassEncoder41.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle3, renderBundle3, renderBundle5, renderBundle0, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer38, 'uint16', 7_692, 1_335);
+} catch {}
+let bindGroup45 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout11,
+  entries: [
+    {binding: 50, resource: sampler29},
+    {binding: 400, resource: {buffer: buffer10, offset: 1536}},
+    {binding: 21, resource: textureView13},
+  ],
+});
+let textureView85 = texture73.createView({mipLevelCount: 1});
+let texture94 = device0.createTexture({
+  size: [16, 16, 455],
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup40, new Uint32Array(2050), 46, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup46 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 21, resource: textureView47},
+    {binding: 400, resource: {buffer: buffer9, offset: 0}},
+    {binding: 50, resource: sampler42},
+  ],
+});
+let buffer44 = device0.createBuffer({
+  size: 1148,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder67 = device0.createCommandEncoder();
+try {
+computePassEncoder33.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle10, renderBundle5, renderBundle5, renderBundle7, renderBundle5, renderBundle5, renderBundle1]);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let pipeline3 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0}});
+let texture95 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 1},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true});
+try {
+computePassEncoder20.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup39, new Uint32Array(2038), 166, 0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(3, buffer26, 8_608);
+} catch {}
+let pipeline4 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0, constants: {}}});
+let commandEncoder68 = device0.createCommandEncoder({});
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 1829});
+let computePassEncoder43 = commandEncoder67.beginComputePass({});
+try {
+computePassEncoder24.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup40, new Uint32Array(381), 3, 0);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(3, undefined, 618_756_032, 825_674_726);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4, buffer25);
+} catch {}
+let veryExplicitBindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 13,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 51,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 82,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+    {binding: 88, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 93,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 95,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 104,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {binding: 153, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 183,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 203,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup47 = device0.createBindGroup({layout: veryExplicitBindGroupLayout13, entries: [{binding: 140, resource: textureView66}]});
+let textureView86 = texture95.createView({});
+let sampler44 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', minFilter: 'linear', lodMaxClamp: 84.20});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup29, new Uint32Array(3471), 593, 0);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(1, buffer18);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup18, new Uint32Array(665), 174, 0);
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4102 */
+  offset: 4102,
+  buffer: buffer27,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 16, y: 0, z: 7},
+  aspect: 'all',
+}, new Uint8Array(210).fill(97), /* required buffer size: 210 */
+{offset: 210, bytesPerRow: 36}, {width: 7, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let commandEncoder69 = device0.createCommandEncoder();
+let textureView87 = texture95.createView({dimension: '2d-array', baseArrayLayer: 0});
+let texture96 = device0.createTexture({
+  size: [97, 60, 1],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder25 = commandEncoder69.beginRenderPass({
+  colorAttachments: [{view: textureView17, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet1,
+});
+let renderBundle11 = renderBundleEncoder11.finish({});
+try {
+computePassEncoder32.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle8, renderBundle6, renderBundle7, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer42, 'uint16', 2_838, 700);
+} catch {}
+let commandEncoder70 = device0.createCommandEncoder();
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 393});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+computePassEncoder36.setBindGroup(3, bindGroup29, new Uint32Array(1387), 48, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+adapter0.label = '\ua5a6\u2b98\u03dd\u{1f8a0}\u2820\u005e\u{1fdc8}\u083e\u062b';
+} catch {}
+let bindGroup48 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout14,
+  entries: [
+    {binding: 82, resource: textureView60},
+    {binding: 95, resource: {buffer: buffer2, offset: 2560, size: 9408}},
+    {binding: 183, resource: textureView66},
+    {binding: 6, resource: {buffer: buffer17, offset: 512, size: 72}},
+    {binding: 93, resource: {buffer: buffer34, offset: 0, size: 184}},
+    {binding: 104, resource: textureView65},
+    {binding: 13, resource: sampler28},
+    {binding: 153, resource: externalTexture4},
+    {binding: 88, resource: sampler28},
+    {binding: 203, resource: {buffer: buffer41, offset: 0, size: 2336}},
+    {binding: 51, resource: textureView30},
+  ],
+});
+let buffer45 = device0.createBuffer({size: 16343, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM, mappedAtCreation: false});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup42, new Uint32Array(2226), 61, 0);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle11, renderBundle0, renderBundle10]);
+} catch {}
+let autogeneratedBindGroupLayout6 = pipeline4.getBindGroupLayout(0);
+let buffer46 = device0.createBuffer({
+  size: 9656,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 669});
+let textureView88 = texture28.createView({dimension: '2d', format: 'r32float', baseArrayLayer: 1});
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer33, 'uint16', 352, 4);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer10, 2_824);
+} catch {}
+let textureView89 = texture29.createView({});
+let computePassEncoder44 = commandEncoder68.beginComputePass();
+try {
+computePassEncoder22.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer39, 0, 726);
+} catch {}
+try {
+commandEncoder70.copyBufferToBuffer(buffer17, 360, buffer19, 280, 100);
+} catch {}
+try {
+commandEncoder70.clearBuffer(buffer37, 25196, 92);
+} catch {}
+let autogeneratedBindGroupLayout7 = pipeline2.getBindGroupLayout(0);
+let textureView90 = texture33.createView({baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder45 = commandEncoder70.beginComputePass({});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle12 = renderBundleEncoder12.finish({});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle6, renderBundle7, renderBundle3, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer36, 0, 355);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(6_343).fill(32), /* required buffer size: 6_343 */
+{offset: 7, bytesPerRow: 36, rowsPerImage: 8}, {width: 1, height: 0, depthOrArrayLayers: 23});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let texture97 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView91 = texture44.createView({aspect: 'all'});
+try {
+computePassEncoder31.setBindGroup(3, bindGroup25, new Uint32Array(923), 44, 0);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(117, 166, 68, 30);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(0, buffer21, 12_964, 133);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 144, new Int16Array(25370), 1710, 444);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+await gc();
+let bindGroup49 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 85, resource: {buffer: buffer38, offset: 0, size: 4788}}],
+});
+let commandEncoder71 = device0.createCommandEncoder({});
+let textureView92 = texture88.createView({arrayLayerCount: 1});
+try {
+computePassEncoder33.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup26, new Uint32Array(195), 91, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer43, 'uint16', 824, 51);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(0, buffer17, 64, 316);
+} catch {}
+try {
+commandEncoder15.copyBufferToTexture({
+  /* bytesInLastRow: 195 widthInBlocks: 195 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 76 */
+  offset: 76,
+  bytesPerRow: 7168,
+  buffer: buffer35,
+}, {
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 14, z: 0},
+  aspect: 'stencil-only',
+}, {width: 195, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 2, y: 4, z: 3},
+  aspect: 'all',
+}, new Uint8Array(29_559).fill(42), /* required buffer size: 29_559 */
+{offset: 355, bytesPerRow: 149, rowsPerImage: 28}, {width: 1, height: 0, depthOrArrayLayers: 8});
+} catch {}
+let commandEncoder72 = device0.createCommandEncoder({});
+let textureView93 = texture17.createView({dimension: 'cube-array', arrayLayerCount: 6});
+let textureView94 = texture23.createView({aspect: 'all', baseArrayLayer: 4, arrayLayerCount: 20});
+let computePassEncoder46 = commandEncoder71.beginComputePass({});
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+buffer44.unmap();
+} catch {}
+try {
+commandEncoder72.copyBufferToBuffer(buffer26, 2668, buffer41, 80, 336);
+} catch {}
+try {
+commandEncoder15.resolveQuerySet(querySet10, 7, 7, buffer28, 0);
+} catch {}
+try {
+externalTexture5.label = '\u3a22\uf717\u032b\u271d\u1a2f\u29e5\u{1fa58}\u0a3a\u0b80';
+} catch {}
+let commandEncoder73 = device0.createCommandEncoder({});
+let textureView95 = texture46.createView({baseMipLevel: 0, mipLevelCount: 1});
+try {
+commandEncoder73.copyBufferToTexture({
+  /* bytesInLastRow: 568 widthInBlocks: 71 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 296 */
+  offset: 296,
+  bytesPerRow: 16128,
+  rowsPerImage: 535,
+  buffer: buffer17,
+}, {
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 109, y: 18, z: 0},
+  aspect: 'all',
+}, {width: 71, height: 59, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer0 = commandEncoder72.finish();
+let computePassEncoder47 = commandEncoder15.beginComputePass({});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(7, buffer25, 0, 1_458);
+} catch {}
+videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'smpteRp431', transfer: 'pq'} });
+let bindGroup50 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 21, resource: textureView56},
+    {binding: 50, resource: sampler41},
+    {binding: 400, resource: {buffer: buffer38, offset: 512, size: 8576}},
+  ],
+});
+let commandEncoder74 = device0.createCommandEncoder({});
+let textureView96 = texture81.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder48 = commandEncoder73.beginComputePass({});
+try {
+renderPassEncoder16.setIndexBuffer(buffer43, 'uint16', 428, 190);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+commandEncoder74.copyBufferToTexture({
+  /* bytesInLastRow: 36 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 520 */
+  offset: 520,
+  bytesPerRow: 2304,
+  buffer: buffer17,
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 23, y: 10, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 12, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+document.body.prepend(img0);
+let commandEncoder75 = device0.createCommandEncoder();
+let computePassEncoder49 = commandEncoder75.beginComputePass({label: '\u03fc\uab38\ubbe3\u{1fa57}\u899d\u832a\u0600\u0314\ue963'});
+try {
+renderPassEncoder16.setVertexBuffer(6, buffer31, 0, 1_108);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+commandEncoder74.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 380 */
+  offset: 380,
+  bytesPerRow: 22272,
+  rowsPerImage: 754,
+  buffer: buffer10,
+}, {
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder0.pushDebugGroup('\u{1fc91}');
+} catch {}
+let autogeneratedBindGroupLayout8 = pipeline3.getBindGroupLayout(0);
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout0]});
+let buffer47 = device0.createBuffer({size: 5798, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder76 = device0.createCommandEncoder({});
+let texture98 = device0.createTexture({
+  size: [390, 240, 1],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder35.setBindGroup(3, bindGroup16, new Uint32Array(2864), 438, 0);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder74.clearBuffer(buffer43, 904, 60);
+} catch {}
+try {
+commandEncoder76.insertDebugMarker('\u2cf8');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let autogeneratedBindGroupLayout9 = pipeline1.getBindGroupLayout(0);
+let commandEncoder77 = device0.createCommandEncoder({});
+let textureView97 = texture78.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder50 = commandEncoder74.beginComputePass();
+try {
+computePassEncoder0.setBindGroup(2, bindGroup7, []);
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer39, 'uint32', 2_500, 290);
+} catch {}
+try {
+commandEncoder77.copyBufferToBuffer(buffer37, 5760, buffer2, 840, 2832);
+} catch {}
+let textureView98 = texture42.createView({format: 'rg8unorm', arrayLayerCount: 1});
+let renderPassEncoder26 = commandEncoder77.beginRenderPass({
+  colorAttachments: [{
+  view: textureView38,
+  clearValue: { r: -721.0, g: 581.1, b: 906.7, a: 674.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(1, bindGroup20, new Uint32Array(2691), 121, 0);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup47, new Uint32Array(1147), 246, 0);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer34, 'uint32', 236, 199);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(3, buffer46, 0, 717);
+} catch {}
+try {
+commandEncoder76.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4288 */
+  offset: 4288,
+  bytesPerRow: 6144,
+  rowsPerImage: 497,
+  buffer: buffer25,
+}, {
+  texture: texture41,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(140).fill(6), /* required buffer size: 140 */
+{offset: 140, bytesPerRow: 64}, {width: 16, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder({});
+let computePassEncoder51 = commandEncoder76.beginComputePass({});
+try {
+computePassEncoder43.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer4, 'uint32', 5_564, 876);
+} catch {}
+let pipeline5 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let textureView99 = texture41.createView({baseMipLevel: 0, mipLevelCount: 1});
+try {
+device0.queue.writeBuffer(buffer9, 1176, new Float32Array(4008), 1689, 228);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+let buffer48 = device0.createBuffer({
+  size: 13929,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView100 = texture28.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 2});
+let textureView101 = texture65.createView({});
+let sampler45 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup24, new Uint32Array(2212), 197, 0);
+} catch {}
+videoFrame10 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let autogeneratedBindGroupLayout10 = pipeline2.getBindGroupLayout(0);
+let commandEncoder79 = device0.createCommandEncoder({});
+let texture99 = device0.createTexture({
+  size: {width: 195, height: 120, depthOrArrayLayers: 1},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView102 = texture57.createView({baseMipLevel: 0});
+try {
+computePassEncoder45.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer17, 'uint32', 288, 809);
+} catch {}
+try {
+renderPassEncoder0.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData2,
+  origin: { x: 7, y: 38 },
+  flipY: false,
+}, {
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise10;
+} catch {}
+let autogeneratedBindGroupLayout11 = pipeline5.getBindGroupLayout(0);
+let commandEncoder80 = device0.createCommandEncoder({});
+let textureView103 = texture94.createView({baseMipLevel: 0});
+let textureView104 = texture26.createView({});
+let computePassEncoder52 = commandEncoder80.beginComputePass({});
+try {
+computePassEncoder16.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+commandEncoder78.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 216 */
+  offset: 216,
+  bytesPerRow: 10752,
+  buffer: buffer37,
+}, {
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'smpte170m', transfer: 'gamma22curve'} });
+try {
+adapter0.label = '\ud540\u34b9\u{1ff71}\ude5c\ufbe3\u3169\u{1f979}\u{1fafd}\u836c';
+} catch {}
+try {
+computePassEncoder13.setBindGroup(3, bindGroup49, new Uint32Array(10000), 225, 0);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer16, 'uint32', 100, 1_108);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 240, height: 1, depthOrArrayLayers: 34}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 8, y: 9 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup51 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 50, resource: sampler2},
+    {binding: 21, resource: textureView13},
+    {binding: 400, resource: {buffer: buffer10, offset: 2048}},
+  ],
+});
+let buffer49 = device0.createBuffer({
+  label: '\u0a6a\uf39e\u{1f79c}\uc374\u055a\u19e5\u013e\u186a\u90dc',
+  size: 24251,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture100 = device0.createTexture({
+  size: {width: 480, height: 1, depthOrArrayLayers: 21},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder27 = commandEncoder78.beginRenderPass({
+  colorAttachments: [{
+  view: textureView38,
+  clearValue: { r: 184.4, g: -683.9, b: -572.4, a: 452.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 31756429,
+});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup49, []);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+globalThis.someLabel = externalTexture7.label;
+} catch {}
+let texture101 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 29},
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView105 = texture77.createView({dimension: '2d-array'});
+let computePassEncoder53 = commandEncoder79.beginComputePass({});
+try {
+computePassEncoder40.setBindGroup(2, bindGroup49, new Uint32Array(7743), 2_053, 0);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder2.setViewport(343.60618802766373, 23.213668145281325, 26.343426394079017, 29.406732869338782, 0.15470041832498593, 0.38782200070263895);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(5, undefined);
+} catch {}
+videoFrame12 = videoFrame11.clone();
+let bindGroup52 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout10,
+  entries: [{binding: 0, resource: {buffer: buffer16, offset: 256, size: 1895}}],
+});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 500});
+let textureView106 = texture93.createView({mipLevelCount: 1});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle3]);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup53 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 21, resource: textureView47},
+    {binding: 400, resource: {buffer: buffer42, offset: 1280, size: 1280}},
+    {binding: 50, resource: sampler10},
+  ],
+});
+let buffer50 = device0.createBuffer({size: 2260, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup50);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(3, bindGroup42, new Uint32Array(1283), 186, 0);
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup40, new Uint32Array(374), 65, 0);
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup54 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout9,
+  entries: [{binding: 0, resource: {buffer: buffer40, offset: 1792}}],
+});
+let commandEncoder81 = device0.createCommandEncoder();
+let textureView107 = texture31.createView({arrayLayerCount: 1});
+try {
+computePassEncoder46.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(3, bindGroup19, new Uint32Array(771), 443, 0);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -692.3, g: -826.4, b: -748.4, a: 805.8, });
+} catch {}
+let bindGroup55 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout16,
+  entries: [
+    {binding: 6, resource: {buffer: buffer19, offset: 768}},
+    {binding: 88, resource: sampler7},
+    {binding: 93, resource: {buffer: buffer41, offset: 0, size: 172}},
+    {binding: 183, resource: textureView66},
+    {binding: 203, resource: {buffer: buffer28, offset: 0, size: 2392}},
+    {binding: 104, resource: textureView37},
+    {binding: 153, resource: externalTexture7},
+    {binding: 51, resource: textureView86},
+    {binding: 82, resource: textureView33},
+    {binding: 13, resource: sampler36},
+    {binding: 95, resource: {buffer: buffer24, offset: 512, size: 4292}},
+  ],
+});
+let computePassEncoder54 = commandEncoder81.beginComputePass({});
+try {
+computePassEncoder47.setBindGroup(3, bindGroup23, new Uint32Array(2193), 77, 0);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline4);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder({});
+let texture102 = device0.createTexture({
+  size: [120, 1, 56],
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView108 = texture81.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 3});
+let computePassEncoder55 = commandEncoder82.beginComputePass();
+try {
+computePassEncoder32.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup28, new Uint32Array(1012), 77, 0);
+} catch {}
+try {
+computePassEncoder37.pushDebugGroup('\u{1f7b8}');
+} catch {}
+let veryExplicitBindGroupLayout17 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 140,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let buffer51 = device0.createBuffer({
+  size: 5774,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder83 = device0.createCommandEncoder();
+let computePassEncoder56 = commandEncoder83.beginComputePass({});
+try {
+computePassEncoder40.setBindGroup(2, bindGroup34, new Uint32Array(2603), 305, 0);
+} catch {}
+await gc();
+let bindGroup56 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout2,
+  entries: [{binding: 0, resource: {buffer: buffer21, offset: 4352}}],
+});
+try {
+renderPassEncoder4.executeBundles([renderBundle7, renderBundle5, renderBundle10, renderBundle1, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(0, buffer39, 0);
+} catch {}
+let imageData13 = new ImageData(20, 84);
+let bindGroup57 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout2,
+  entries: [{binding: 0, resource: {buffer: buffer38, offset: 2304, size: 3831}}],
+});
+let texture103 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 82},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let sampler46 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder35.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup19, new Uint32Array(1061), 641, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle4]);
+} catch {}
+let arrayBuffer7 = buffer12.getMappedRange(1176, 92);
+try {
+buffer4.unmap();
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup58 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout12,
+  entries: [{binding: 113, resource: sampler1}, {binding: 206, resource: {buffer: buffer40, offset: 512}}],
+});
+let buffer52 = device0.createBuffer({size: 22661, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView109 = texture25.createView({});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup8, new Uint32Array(1591), 442, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup49);
+} catch {}
+try {
+computePassEncoder37.popDebugGroup();
+} catch {}
+let textureView110 = texture86.createView({aspect: 'depth-only', baseArrayLayer: 0});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup14, []);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder23.insertDebugMarker('\u3984');
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+offscreenCanvas0.height = 1570;
+let commandEncoder84 = device0.createCommandEncoder({});
+let commandBuffer1 = commandEncoder84.finish({});
+let texture104 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+computePassEncoder28.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle1]);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+let img2 = await imageWithData(189, 51, '#10101010', '#20202020');
+let bindGroup59 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 72, resource: {buffer: buffer48, offset: 11008, size: 164}},
+    {binding: 49, resource: textureView27},
+    {binding: 349, resource: {buffer: buffer17, offset: 256, size: 632}},
+    {binding: 95, resource: textureView28},
+    {binding: 70, resource: textureView36},
+    {binding: 88, resource: textureView76},
+    {binding: 12, resource: {buffer: buffer42, offset: 1280, size: 936}},
+    {binding: 615, resource: textureView80},
+    {binding: 58, resource: externalTexture4},
+    {binding: 22, resource: textureView24},
+  ],
+});
+try {
+computePassEncoder38.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup11, new Uint32Array(1932), 20, 0);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer18, 'uint16', 1_658, 2_819);
+} catch {}
+let arrayBuffer8 = buffer12.getMappedRange(1272, 220);
+try {
+device0.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 111, y: 173, z: 0},
+  aspect: 'all',
+}, new Uint8Array(198).fill(134), /* required buffer size: 198 */
+{offset: 198, bytesPerRow: 1124, rowsPerImage: 10}, {width: 245, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup60 = device0.createBindGroup({layout: veryExplicitBindGroupLayout17, entries: [{binding: 140, resource: textureView66}]});
+let buffer53 = device0.createBuffer({
+  size: 2535,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder85 = device0.createCommandEncoder({});
+let computePassEncoder57 = commandEncoder85.beginComputePass({});
+let sampler47 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 97.82});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup57);
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -831.8, g: 542.3, b: -108.2, a: -733.4, });
+} catch {}
+let autogeneratedBindGroupLayout12 = pipeline2.getBindGroupLayout(0);
+let texture105 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 167},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup60);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup59, new Uint32Array(4848), 1_794, 0);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle10, renderBundle7, renderBundle10, renderBundle3, renderBundle6, renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer42, 'uint32', 1_260, 126);
+} catch {}
+let arrayBuffer9 = buffer15.getMappedRange(1632, 0);
+let buffer54 = device0.createBuffer({
+  size: 13388,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView111 = texture51.createView({mipLevelCount: 1});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup30, new Uint32Array(1968), 28, 0);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer16, 'uint32', 2_336, 547);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+document.body.prepend(canvas0);
+let autogeneratedBindGroupLayout13 = pipeline2.getBindGroupLayout(0);
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 800});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let renderBundle13 = renderBundleEncoder13.finish({});
+let sampler48 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 95.69});
+try {
+computePassEncoder45.setBindGroup(1, bindGroup14, new Uint32Array(108), 5, 0);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup49, new Uint32Array(1485), 125, 0);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(2, buffer51, 432, 206);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let pipeline6 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0, constants: {}}});
+videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpteSt4281', transfer: 'smpteSt4281'} });
+let commandEncoder86 = device0.createCommandEncoder({});
+let texture106 = device0.createTexture({
+  size: {width: 60, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder58 = commandEncoder86.beginComputePass({});
+try {
+computePassEncoder47.setPipeline(pipeline3);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 23}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 35, y: 206 },
+  flipY: true,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 29, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img3 = await imageWithData(54, 17, '#10101010', '#20202020');
+let bindGroup61 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout12,
+  entries: [{binding: 0, resource: {buffer: buffer28, offset: 2816, size: 3358}}],
+});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup39, new Uint32Array(17), 2, 0);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup57, []);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup7, new Uint32Array(1976), 1_090, 0);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer42, 'uint32', 928, 632);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+  await buffer5.mapAsync(GPUMapMode.WRITE, 168, 6188);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline7 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0, constants: {}}});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer55 = device0.createBuffer({size: 13761, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder87 = device0.createCommandEncoder();
+let texture107 = device0.createTexture({
+  size: [120],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup49);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(0, bindGroup41, new Uint32Array(784), 255, 0);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer33, 'uint32', 28, 35);
+} catch {}
+try {
+commandEncoder87.clearBuffer(buffer13, 8240, 236);
+} catch {}
+let commandEncoder88 = device0.createCommandEncoder({});
+let texture108 = device0.createTexture({
+  size: [16, 16, 254],
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture109 = device0.createTexture({
+  label: '\ub4a2\u0485\u9ba5\u{1ff26}\u0344\u{1fe86}\u0bff\u6fe4\u5b77\u333d\u{1fba9}',
+  size: {width: 480},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView112 = texture9.createView({aspect: 'all', mipLevelCount: 1});
+let computePassEncoder59 = commandEncoder87.beginComputePass({});
+try {
+computePassEncoder59.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup47, new Uint32Array(3106), 708, 0);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(6, buffer32);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder88.copyBufferToTexture({
+  /* bytesInLastRow: 6 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 386 */
+  offset: 386,
+  buffer: buffer28,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder88.resolveQuerySet(querySet10, 27, 21, buffer47, 512);
+} catch {}
+let texture110 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 270},
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler49 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.58,
+});
+try {
+computePassEncoder40.setBindGroup(3, bindGroup53);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 28, y: 85, z: 0},
+  aspect: 'all',
+}, new Uint8Array(53).fill(141), /* required buffer size: 53 */
+{offset: 53, bytesPerRow: 1323}, {width: 304, height: 55, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let computePassEncoder60 = commandEncoder88.beginComputePass({});
+try {
+computePassEncoder27.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup39, []);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle0, renderBundle10, renderBundle0]);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 50}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 41, y: 73, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer56 = device0.createBuffer({
+  size: 2820,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder3.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer39, 0, 1_413);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup14, new Uint32Array(961), 147, 0);
+} catch {}
+videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpte170m', transfer: 'bt709'} });
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 566});
+try {
+computePassEncoder50.setBindGroup(2, bindGroup42);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup59, new Uint32Array(1547), 250, 0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(166.67942111183507, 132.81309703842066, 39.32303494540319, 74.49474350212888, 0.05638657176195705, 0.6551735395090899);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer54, 'uint16', 2_706, 3_254);
+} catch {}
+try {
+  await promise11;
+} catch {}
+canvas0.width = 396;
+let autogeneratedBindGroupLayout14 = pipeline5.getBindGroupLayout(0);
+let buffer57 = device0.createBuffer({size: 2379, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView113 = texture39.createView({dimension: '2d-array'});
+let texture111 = device0.createTexture({size: {width: 120}, dimension: '1d', format: 'rgba8unorm-srgb', usage: GPUTextureUsage.COPY_SRC});
+let textureView114 = texture42.createView({arrayLayerCount: 1});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup59);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup61, new Uint32Array(5068), 201, 0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(5, undefined);
+} catch {}
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 94});
+let textureView115 = texture93.createView({});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup18, new Uint32Array(2396), 265, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer32, 'uint16', 88, 739);
+} catch {}
+try {
+computePassEncoder8.pushDebugGroup('\u07c6');
+} catch {}
+let autogeneratedBindGroupLayout15 = pipeline2.getBindGroupLayout(0);
+let texture112 = device0.createTexture({
+  size: [195],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder53.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise12;
+} catch {}
+videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'jedecP22Phosphors', transfer: 'pq'} });
+let texture113 = device0.createTexture({
+  size: {width: 60, height: 1, depthOrArrayLayers: 1},
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder30.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup23, new Uint32Array(415), 91, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle4, renderBundle8, renderBundle10, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer42, 'uint16', 98, 1_290);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(368).fill(211), /* required buffer size: 368 */
+{offset: 368, rowsPerImage: 70}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView116 = texture38.createView({});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let renderBundle14 = renderBundleEncoder17.finish({});
+try {
+computePassEncoder8.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle6, renderBundle1]);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let autogeneratedBindGroupLayout16 = pipeline6.getBindGroupLayout(0);
+let buffer58 = device0.createBuffer({size: 6900, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 230});
+let texture114 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundle15 = renderBundleEncoder15.finish({});
+let sampler50 = device0.createSampler({mipmapFilter: 'nearest', lodMaxClamp: 78.41});
+try {
+computePassEncoder30.setBindGroup(3, bindGroup32, new Uint32Array(1830), 602, 0);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer19, 'uint16', 660, 974);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer33, 'uint32', 100, 11);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(5, buffer4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 195, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame11,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture73,
+  mipLevel: 1,
+  origin: {x: 100, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer59 = device0.createBuffer({size: 8118, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT});
+let texture115 = device0.createTexture({
+  size: [240, 1, 1],
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle16 = renderBundleEncoder14.finish({});
+try {
+computePassEncoder55.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer10, 'uint16', 2_994, 2_815);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup24, new Uint32Array(106), 17, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+await gc();
+let autogeneratedBindGroupLayout17 = pipeline7.getBindGroupLayout(0);
+let bindGroup62 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 85, resource: {buffer: buffer28, offset: 512, size: 1244}}],
+});
+let buffer60 = device0.createBuffer({
+  size: 5871,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let sampler51 = device0.createSampler({
+  label: '\u05e2\uc6b1\u{1fb13}\u3fc7\u83c5\u05ac\uc8c9\uf45e\uda52\u7415\u{1ffc3}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 59.10,
+});
+try {
+computePassEncoder31.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle4, renderBundle4, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 932.8, g: -757.1, b: -590.6, a: 219.6, });
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(2, buffer42, 0, 4_799);
+} catch {}
+let veryExplicitBindGroupLayout18 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 13,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 51,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 82,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+    {binding: 88, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 93,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 95,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 104,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {binding: 153, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 183,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 203,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout4]});
+let commandEncoder89 = device0.createCommandEncoder({});
+let texture116 = device0.createTexture({
+  size: [97, 60, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture117 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder61 = commandEncoder89.beginComputePass({});
+let renderBundle17 = renderBundleEncoder16.finish({label: '\u{1f7e1}\u1ace\u{1fbb1}\u9ccb\u93e9'});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup16);
+} catch {}
+let imageData14 = new ImageData(28, 8);
+let bindGroup63 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout5,
+  entries: [{binding: 0, resource: {buffer: buffer39, offset: 7680, size: 96}}],
+});
+let commandEncoder90 = device0.createCommandEncoder({});
+let computePassEncoder62 = commandEncoder90.beginComputePass({});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup18, new Uint32Array(2455), 529, 0);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup28, []);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup57, new Uint32Array(5875), 3_465, 0);
+} catch {}
+let textureView117 = texture51.createView({format: 'rgba8uint', mipLevelCount: 1});
+let textureView118 = texture8.createView({aspect: 'all', baseMipLevel: 0});
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup1, new Uint32Array(82), 15, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer11, 'uint32', 356, 297);
+} catch {}
+try {
+computePassEncoder8.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.append(canvas0);
+try {
+adapter0.label = '\uee8f\u{1fd7b}\u{1fd68}\u55c5\u64fa\u28fb\ud645\uc4f8\u8d9c';
+} catch {}
+let texture118 = device0.createTexture({
+  size: [240, 1, 1],
+  mipLevelCount: 3,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup14, new Uint32Array(473), 117, 0);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(336);
+} catch {}
+let arrayBuffer10 = buffer5.getMappedRange(2952, 76);
+let commandEncoder91 = device0.createCommandEncoder({});
+let textureView119 = texture100.createView({aspect: 'all', format: 'rgba16sint', mipLevelCount: 1});
+let textureView120 = texture29.createView({});
+let renderPassEncoder28 = commandEncoder91.beginRenderPass({
+  colorAttachments: [{view: textureView118, depthSlice: 25, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 76619064,
+});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame3, colorSpace: 'srgb'});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup63);
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer10, 'uint16', 4_206, 1_274);
+} catch {}
+try {
+autogeneratedBindGroupLayout14.label = '\u6577\u{1f765}\u06c3\u{1ff4f}\u0eb8';
+} catch {}
+let autogeneratedBindGroupLayout18 = pipeline1.getBindGroupLayout(0);
+let bindGroup64 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout15,
+  entries: [{binding: 0, resource: {buffer: buffer37, offset: 0, size: 174}}],
+});
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 428});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+});
+let renderBundle18 = renderBundleEncoder18.finish({});
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup3, new Uint32Array(195), 44, 0);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 3, y: 16, z: 5},
+  aspect: 'all',
+}, new Uint8Array(7_792).fill(122), /* required buffer size: 7_792 */
+{offset: 230, bytesPerRow: 22, rowsPerImage: 66}, {width: 8, height: 14, depthOrArrayLayers: 6});
+} catch {}
+let autogeneratedBindGroupLayout19 = pipeline2.getBindGroupLayout(0);
+let commandEncoder92 = device0.createCommandEncoder();
+let computePassEncoder63 = commandEncoder92.beginComputePass({});
+let sampler52 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', magFilter: 'nearest', compare: 'equal'});
+try {
+computePassEncoder58.setPipeline(pipeline4);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+let bindGroup65 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout5,
+  entries: [{binding: 0, resource: {buffer: buffer36, offset: 0, size: 479}}],
+});
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 524});
+let textureView121 = texture103.createView({mipLevelCount: 1});
+try {
+computePassEncoder5.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(3, buffer10, 0, 769);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 28, y: 12, z: 1},
+  aspect: 'all',
+}, new Uint8Array(162_150).fill(148), /* required buffer size: 162_150 */
+{offset: 330, bytesPerRow: 45, rowsPerImage: 128}, {width: 0, height: 13, depthOrArrayLayers: 29});
+} catch {}
+try {
+globalThis.someLabel = externalTexture0.label;
+} catch {}
+let bindGroup66 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [{binding: 0, resource: {buffer: buffer25, offset: 5376, size: 399}}],
+});
+let buffer61 = device0.createBuffer({size: 6985, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline7);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup13, []);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer59, 468, new Int16Array(11460), 730, 1952);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData15 = new ImageData(92, 68);
+let commandEncoder93 = device0.createCommandEncoder({});
+try {
+computePassEncoder62.setBindGroup(3, bindGroup28, new Uint32Array(179), 63, 0);
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup60);
+} catch {}
+videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpte432', transfer: 'logSqrt'} });
+let commandEncoder94 = device0.createCommandEncoder({});
+try {
+commandEncoder94.copyBufferToBuffer(buffer17, 20, buffer37, 10248, 116);
+} catch {}
+let img4 = await imageWithData(32, 57, '#10101010', '#20202020');
+let veryExplicitBindGroupLayout19 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 12,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 49,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 58, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 70,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 72,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 88,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 95,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 349,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 615,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout20 = pipeline5.getBindGroupLayout(0);
+let texture119 = device0.createTexture({
+  size: {width: 97},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup10, new Uint32Array(272), 55, 0);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer39, 'uint16', 54, 4_282);
+} catch {}
+let arrayBuffer11 = buffer5.getMappedRange(1256, 628);
+try {
+commandEncoder94.insertDebugMarker('\ud74d');
+} catch {}
+document.body.prepend(img2);
+let bindGroup67 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 113, resource: sampler9},
+    {binding: 206, resource: {buffer: buffer32, offset: 256, size: 604}},
+  ],
+});
+let buffer62 = device0.createBuffer({
+  size: 16969,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+});
+let textureView122 = texture52.createView({dimension: '2d'});
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer46, 608, new BigUint64Array(80));
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture116,
+  mipLevel: 0,
+  origin: {x: 34, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(67).fill(253), /* required buffer size: 67 */
+{offset: 67}, {width: 23, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 780, height: 480, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 134, y: 250, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder95 = device0.createCommandEncoder({});
+let computePassEncoder64 = commandEncoder94.beginComputePass();
+let renderPassEncoder29 = commandEncoder93.beginRenderPass({
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: 649.7, g: 518.7, b: -381.1, a: 189.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet13,
+});
+try {
+computePassEncoder48.end();
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup2);
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(21, 29);
+videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'bt709', transfer: 'iec61966-2-1'} });
+let bindGroup68 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout11,
+  entries: [
+    {binding: 21, resource: textureView111},
+    {binding: 400, resource: {buffer: buffer17, offset: 0, size: 196}},
+    {binding: 50, resource: sampler28},
+  ],
+});
+let commandEncoder96 = device0.createCommandEncoder({});
+let sampler53 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 84.64,
+});
+try {
+renderPassEncoder10.setVertexBuffer(3, buffer61, 0, 1_615);
+} catch {}
+let veryExplicitBindGroupLayout20 = device0.createBindGroupLayout({entries: [{binding: 96, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }}]});
+let autogeneratedBindGroupLayout21 = pipeline0.getBindGroupLayout(0);
+let buffer63 = device0.createBuffer({size: 2932, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup61);
+} catch {}
+try {
+computePassEncoder46.setBindGroup(3, bindGroup64, new Uint32Array(3650), 641, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer60, 'uint16', 300, 540);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 7}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 1, y: 10, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder97 = device0.createCommandEncoder({});
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup63);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer16);
+} catch {}
+try {
+commandEncoder73.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 106 */
+  offset: 106,
+  bytesPerRow: 1280,
+  buffer: buffer46,
+}, {
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer29, 892, new BigUint64Array(10615), 996, 328);
+} catch {}
+let autogeneratedBindGroupLayout22 = pipeline2.getBindGroupLayout(0);
+let commandEncoder98 = device0.createCommandEncoder({});
+let computePassEncoder65 = commandEncoder98.beginComputePass();
+try {
+computePassEncoder11.setBindGroup(3, bindGroup66);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(1, bindGroup30, new Uint32Array(5009), 199, 0);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer16, 'uint32', 1_780, 27);
+} catch {}
+try {
+  await buffer22.mapAsync(GPUMapMode.WRITE, 0, 548);
+} catch {}
+let textureView123 = texture86.createView({aspect: 'all'});
+let sampler54 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 6,
+});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup33, new Uint32Array(378), 88, 0);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(58);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+let commandEncoder99 = device0.createCommandEncoder({});
+let computePassEncoder66 = commandEncoder96.beginComputePass({});
+try {
+computePassEncoder28.setBindGroup(3, bindGroup59, []);
+} catch {}
+try {
+computePassEncoder21.setBindGroup(0, bindGroup1, new Uint32Array(1822), 105, 0);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 97, height: 60, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 3, y: 4, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout23 = pipeline6.getBindGroupLayout(0);
+let buffer64 = device0.createBuffer({size: 898, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture120 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView124 = texture10.createView({baseMipLevel: 0});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame15});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup43, new Uint32Array(1547), 262, 0);
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup21, new Uint32Array(409), 2, 0);
+} catch {}
+try {
+commandEncoder73.copyBufferToBuffer(buffer27, 364, buffer24, 3464, 708);
+} catch {}
+let img5 = await imageWithData(76, 41, '#10101010', '#20202020');
+let imageBitmap2 = await createImageBitmap(imageBitmap1);
+let computePassEncoder67 = commandEncoder97.beginComputePass({});
+try {
+computePassEncoder67.setBindGroup(3, bindGroup21, new Uint32Array(3839), 516, 0);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(0, buffer36);
+} catch {}
+try {
+commandEncoder99.copyBufferToTexture({
+  /* bytesInLastRow: 44 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2038 */
+  offset: 2038,
+  buffer: buffer25,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 3},
+  aspect: 'all',
+}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer65 = device0.createBuffer({
+  size: 3963,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let computePassEncoder68 = commandEncoder99.beginComputePass();
+let renderPassEncoder30 = commandEncoder95.beginRenderPass({
+  label: '\u70e3\uc740\u056d\u0444\u325d\ubc6c\u4e10\u19e1\u382f\u5a03',
+  colorAttachments: [{
+  view: textureView118,
+  depthSlice: 16,
+  clearValue: { r: 154.8, g: -409.7, b: 959.1, a: 229.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder60.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(7, buffer60, 0, 406);
+} catch {}
+try {
+commandEncoder73.copyBufferToTexture({
+  /* bytesInLastRow: 520 widthInBlocks: 65 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 424 */
+  offset: 424,
+  bytesPerRow: 6144,
+  rowsPerImage: 1520,
+  buffer: buffer28,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 65, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline8 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule0, constants: {}}});
+let bindGroup69 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout9,
+  entries: [{binding: 0, resource: {buffer: buffer23, offset: 256}}],
+});
+let texture121 = device0.createTexture({
+  size: [240, 1, 19],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView125 = texture38.createView({format: 'rg8unorm', mipLevelCount: 1});
+let computePassEncoder69 = commandEncoder73.beginComputePass({});
+let sampler55 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 93.85,
+});
+let externalTexture10 = device0.importExternalTexture({source: videoFrame12});
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup14, new Uint32Array(5391), 201, 0);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(3, buffer25, 3_056);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 0, y: 22, z: 0},
+  aspect: 'all',
+}, new Uint8Array(64).fill(247), /* required buffer size: 64 */
+{offset: 64, bytesPerRow: 151}, {width: 10, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 195, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture73,
+  mipLevel: 1,
+  origin: {x: 148, y: 65, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img5);
+try {
+adapter0.label = '\u{1fe15}\ue6ab\u11fa\u{1ffc1}\u096a';
+} catch {}
+let bindGroup70 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout18,
+  entries: [{binding: 0, resource: {buffer: buffer21, offset: 512}}],
+});
+let commandEncoder100 = device0.createCommandEncoder({});
+let texture122 = device0.createTexture({
+  size: {width: 60},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder70 = commandEncoder100.beginComputePass({});
+try {
+computePassEncoder51.setBindGroup(0, bindGroup63);
+} catch {}
+try {
+computePassEncoder29.setBindGroup(3, bindGroup38, new Uint32Array(1377), 334, 0);
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup52);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer61, 'uint16', 356, 2_503);
+} catch {}
+let pipeline9 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule0, constants: {}}});
+document.body.append(canvas0);
+let commandEncoder101 = device0.createCommandEncoder({});
+let computePassEncoder71 = commandEncoder101.beginComputePass();
+try {
+computePassEncoder68.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle5, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(7, buffer23);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 2488, new Float32Array(1902));
+} catch {}
+let imageData16 = new ImageData(24, 28);
+let bindGroup71 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout12,
+  entries: [{binding: 0, resource: {buffer: buffer37, offset: 3072, size: 9503}}],
+});
+let commandEncoder102 = device0.createCommandEncoder();
+let textureView126 = texture34.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder72 = commandEncoder102.beginComputePass({});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup46);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup8);
+} catch {}
+let bindGroup72 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout9,
+  entries: [{binding: 0, resource: {buffer: buffer50, offset: 0}}],
+});
+let buffer66 = device0.createBuffer({
+  size: 11246,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture123 = device0.createTexture({
+  size: {width: 240},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView127 = texture123.createView({});
+let sampler56 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  compare: 'not-equal',
+});
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup29, new Uint32Array(1844), 57, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer43, 'uint16', 222, 401);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(5, buffer31, 336, 461);
+} catch {}
+let commandEncoder103 = device0.createCommandEncoder({});
+let textureView128 = texture103.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 0});
+let sampler57 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', mipmapFilter: 'linear', lodMaxClamp: 95.30});
+try {
+renderPassEncoder3.setIndexBuffer(buffer61, 'uint16', 370, 521);
+} catch {}
+document.body.append(canvas0);
+let computePassEncoder73 = commandEncoder103.beginComputePass({});
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup61, new Uint32Array(5078), 308, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(206.55437795541704, 39.79383281807575, 98.66835859343342, 199.63019339900455, 0.1007635226643171, 0.4632831785949121);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let autogeneratedBindGroupLayout24 = pipeline3.getBindGroupLayout(0);
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 788});
+let texture124 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 50},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView129 = texture24.createView({dimension: '2d'});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup40, new Uint32Array(51), 5, 0);
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle3, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(1, buffer10, 0, 1_855);
+} catch {}
+try {
+buffer65.unmap();
+} catch {}
+let bindGroup73 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 21, resource: textureView73},
+    {binding: 50, resource: sampler44},
+    {binding: 400, resource: {buffer: buffer9, offset: 0}},
+  ],
+});
+let texture125 = device0.createTexture({
+  label: '\u47a6\ufe32\u{1fa8d}\u0de7\u4c6b\u098c\u3114\u0c73\u0fea\u0945',
+  size: [16],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture126 = device0.createTexture({
+  size: [195, 120, 1],
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView130 = texture8.createView({});
+try {
+computePassEncoder45.setBindGroup(2, bindGroup59, new Uint32Array(437), 13, 0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup61);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer46, 'uint32', 1_952, 499);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer29, 704, new BigUint64Array(59), 11, 4);
+} catch {}
+let imageData17 = new ImageData(16, 68);
+let autogeneratedBindGroupLayout25 = pipeline9.getBindGroupLayout(0);
+let texture127 = device0.createTexture({size: [240, 1, 1], format: 'depth24plus', usage: GPUTextureUsage.TEXTURE_BINDING});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let renderBundle19 = renderBundleEncoder19.finish({});
+try {
+computePassEncoder70.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(0, bindGroup65);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer39, 'uint16', 2_678);
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas1.getContext('webgpu');
+let veryExplicitBindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 140,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let bindGroup74 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [{binding: 85, resource: {buffer: buffer65, offset: 256, size: 1328}}],
+});
+let commandEncoder104 = device0.createCommandEncoder({});
+let sampler58 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.76,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder54.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup67);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer46, 'uint16', 1_114, 689);
+} catch {}
+let commandEncoder105 = device0.createCommandEncoder({});
+let textureView131 = texture102.createView({mipLevelCount: 1, baseArrayLayer: 10, arrayLayerCount: 16});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame6});
+try {
+computePassEncoder73.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup52, new Uint32Array(488), 61, 0);
+} catch {}
+try {
+commandEncoder105.resolveQuerySet(querySet3, 4, 6, buffer40, 768);
+} catch {}
+let commandEncoder106 = device0.createCommandEncoder({});
+let sampler59 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.84,
+});
+try {
+computePassEncoder66.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(buffer0, 15608, buffer3, 276, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 17, y: 6, z: 0},
+  aspect: 'all',
+}, new Uint8Array(88_286).fill(105), /* required buffer size: 88_286 */
+{offset: 36, bytesPerRow: 93, rowsPerImage: 52}, {width: 43, height: 13, depthOrArrayLayers: 19});
+} catch {}
+let commandEncoder107 = device0.createCommandEncoder({});
+let texture128 = device0.createTexture({
+  size: [780],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder31 = commandEncoder107.beginRenderPass({
+  colorAttachments: [{
+  view: textureView17,
+  clearValue: { r: -737.0, g: 68.73, b: 11.61, a: -732.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler60 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', magFilter: 'linear', lodMaxClamp: 28.12});
+try {
+computePassEncoder66.setBindGroup(0, bindGroup52, new Uint32Array(761), 220, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup7, new Uint32Array(344), 155, 0);
+} catch {}
+try {
+buffer33.unmap();
+} catch {}
+try {
+commandEncoder104.copyTextureToBuffer({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 17, y: 8, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 108 widthInBlocks: 54 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 0 */
+  offset: 0,
+  bytesPerRow: 512,
+  buffer: buffer40,
+}, {width: 54, height: 24, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder57.insertDebugMarker('\u703d');
+} catch {}
+let autogeneratedBindGroupLayout26 = pipeline9.getBindGroupLayout(0);
+let commandEncoder108 = device0.createCommandEncoder({});
+let texture129 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 22},
+  mipLevelCount: 2,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let sampler61 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMinClamp: 97.92, lodMaxClamp: 98.63});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup67);
+} catch {}
+try {
+computePassEncoder50.setBindGroup(1, bindGroup33, new Uint32Array(698), 166, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer43, 'uint16', 370, 43);
+} catch {}
+try {
+commandEncoder108.copyBufferToTexture({
+  /* bytesInLastRow: 584 widthInBlocks: 73 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 48 */
+  offset: 48,
+  buffer: buffer1,
+}, {
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 73, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder10.pushDebugGroup('\u07ee');
+} catch {}
+let commandEncoder109 = device0.createCommandEncoder();
+let renderPassEncoder32 = commandEncoder109.beginRenderPass({
+  colorAttachments: [{view: textureView72, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet16,
+  maxDrawCount: 16218214,
+});
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup53, new Uint32Array(348), 37, 0);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle6, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer32, 'uint16', 206, 626);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer50, 312, new Float32Array(9438), 257, 48);
+} catch {}
+let sampler62 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  compare: 'equal',
+});
+try {
+computePassEncoder32.setBindGroup(3, bindGroup73, new Uint32Array(2568), 38, 0);
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer10, 'uint32', 1_392, 328);
+} catch {}
+let bindGroup75 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout8,
+  entries: [{binding: 0, resource: {buffer: buffer36, offset: 512, size: 76}}],
+});
+let textureView132 = texture59.createView({dimension: 'cube-array', baseMipLevel: 0, baseArrayLayer: 1, arrayLayerCount: 6});
+let computePassEncoder74 = commandEncoder108.beginComputePass({});
+let sampler63 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 93.53, maxAnisotropy: 1});
+try {
+computePassEncoder74.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup18, new Uint32Array(758), 41, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer11, 'uint32', 2_748, 1_661);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(18_776).fill(118), /* required buffer size: 18_776 */
+{offset: 56, bytesPerRow: 78, rowsPerImage: 60}, {width: 11, height: 0, depthOrArrayLayers: 5});
+} catch {}
+await gc();
+let texture130 = device0.createTexture({
+  size: {width: 16},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler64 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 44.79,
+  lodMaxClamp: 49.83,
+  maxAnisotropy: 6,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 2,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(45).fill(121), /* required buffer size: 45 */
+{offset: 45, bytesPerRow: 100}, {width: 7, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout27 = pipeline3.getBindGroupLayout(0);
+let computePassEncoder75 = commandEncoder104.beginComputePass({});
+try {
+computePassEncoder69.setPipeline(pipeline5);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup19, new Uint32Array(786), 47, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let bindGroup76 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout18,
+  entries: [
+    {binding: 153, resource: externalTexture0},
+    {binding: 51, resource: textureView30},
+    {binding: 95, resource: {buffer: buffer28, offset: 0, size: 484}},
+    {binding: 104, resource: textureView37},
+    {binding: 88, resource: sampler42},
+    {binding: 13, resource: sampler4},
+    {binding: 183, resource: textureView66},
+    {binding: 93, resource: {buffer: buffer33, offset: 0, size: 48}},
+    {binding: 6, resource: {buffer: buffer38, offset: 0, size: 2880}},
+    {binding: 82, resource: textureView60},
+    {binding: 203, resource: {buffer: buffer24, offset: 256, size: 2448}},
+  ],
+});
+let textureView133 = texture83.createView({});
+let texture131 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView134 = texture72.createView({aspect: 'all', mipLevelCount: 1});
+let computePassEncoder76 = commandEncoder105.beginComputePass({});
+try {
+computePassEncoder49.setBindGroup(0, bindGroup52);
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder3.setViewport(93.09454362030716, 11.86765323971053, 271.3171658792423, 188.53737312990862, 0.7696470740040042, 0.8588004472019473);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(6, buffer53, 0, 355);
+} catch {}
+try {
+computePassEncoder10.popDebugGroup();
+} catch {}
+await gc();
+let buffer67 = device0.createBuffer({size: 4370, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder110 = device0.createCommandEncoder({});
+let textureView135 = texture16.createView({});
+let computePassEncoder77 = commandEncoder106.beginComputePass({});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer2, 0);
+} catch {}
+try {
+commandEncoder110.copyBufferToBuffer(buffer56, 140, buffer26, 832, 1600);
+} catch {}
+let commandEncoder111 = device0.createCommandEncoder({});
+let texture132 = device0.createTexture({
+  size: [480, 1, 1],
+  sampleCount: 1,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let computePassEncoder78 = commandEncoder69.beginComputePass();
+try {
+computePassEncoder58.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder78.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup39, new Uint32Array(4972), 136, 0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder110.copyTextureToBuffer({
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2956 */
+  offset: 2956,
+  bytesPerRow: 16640,
+  buffer: buffer49,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+let pipeline10 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0}});
+let buffer68 = device0.createBuffer({size: 11366, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let commandEncoder112 = device0.createCommandEncoder({});
+let textureView136 = texture93.createView({});
+let computePassEncoder79 = commandEncoder111.beginComputePass({});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup67);
+} catch {}
+try {
+computePassEncoder79.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup38, []);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle10, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer43, 'uint16', 52, 543);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer67, 0, 245);
+} catch {}
+await gc();
+let autogeneratedBindGroupLayout28 = pipeline2.getBindGroupLayout(0);
+let computePassEncoder80 = commandEncoder110.beginComputePass();
+let sampler65 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 85.12,
+  maxAnisotropy: 16,
+});
+let externalTexture12 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder80.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup14, new Uint32Array(2533), 34, 0);
+} catch {}
+document.body.prepend(canvas0);
+let buffer69 = device0.createBuffer({
+  size: 20674,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let textureView137 = texture70.createView({aspect: 'all', mipLevelCount: 1, baseArrayLayer: 9, arrayLayerCount: 1});
+let computePassEncoder81 = commandEncoder112.beginComputePass();
+let sampler66 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 54.00,
+});
+try {
+computePassEncoder74.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder81.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup62);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup64, new Uint32Array(111), 13, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle8]);
+} catch {}
+let arrayBuffer12 = buffer5.getMappedRange(3032, 60);
+try {
+device0.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 63, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(580).fill(220), /* required buffer size: 580 */
+{offset: 22, bytesPerRow: 62, rowsPerImage: 9}, {width: 12, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let buffer70 = device0.createBuffer({
+  size: 2272,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder113 = device0.createCommandEncoder();
+let computePassEncoder82 = commandEncoder113.beginComputePass({});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup25, []);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup57);
+} catch {}
+let buffer71 = device0.createBuffer({size: 65536, usage: GPUBufferUsage.INDEX});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup34, new Uint32Array(2681), 56, 0);
+} catch {}
+try {
+computePassEncoder82.setPipeline(pipeline5);
+} catch {}
+let imageData18 = new ImageData(24, 28);
+videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'smpte432', transfer: 'smpte170m'} });
+videoFrame19 = new VideoFrame(img1, {timestamp: 0});
+let autogeneratedBindGroupLayout29 = pipeline8.getBindGroupLayout(0);
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 161});
+let textureView138 = texture113.createView({});
+let sampler67 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 52.42});
+try {
+computePassEncoder71.setBindGroup(1, bindGroup74, new Uint32Array(5267), 287, 0);
+} catch {}
+let buffer72 = device0.createBuffer({size: 1002, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView139 = texture118.createView({label: '\u0397\u{1fc32}\u5f5f\u4ad9\u0100\u05ca\uc36b', format: 'depth24plus', mipLevelCount: 1});
+let sampler68 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 73.16});
+let externalTexture13 = device0.importExternalTexture({source: videoFrame2});
+try {
+computePassEncoder62.setBindGroup(1, bindGroup23, new Uint32Array(4365), 1_948, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup46, new Uint32Array(1212), 148, 0);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(163, 166, 90, 38);
+} catch {}
+try {
+buffer58.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture128,
+  mipLevel: 0,
+  origin: {x: 160, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(242).fill(144), /* required buffer size: 242 */
+{offset: 242}, {width: 215, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler69 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 98.32});
+document.body.append(canvas0);
+let commandEncoder114 = device0.createCommandEncoder({});
+let texture133 = device0.createTexture({
+  size: {width: 60, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder83 = commandEncoder114.beginComputePass({});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['rg32sint', 'rgba16uint', 'rgba8uint'], stencilReadOnly: true});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup48, new Uint32Array(799), 179, 0);
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup38, new Uint32Array(1271), 202, 0);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(7, buffer66, 1_948, 64);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(0, buffer46);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let arrayBuffer13 = buffer22.getMappedRange(32, 20);
+let bindGroup77 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout20,
+  entries: [{binding: 0, resource: {buffer: buffer62, offset: 3328, size: 3092}}],
+});
+let renderBundle20 = renderBundleEncoder20.finish({});
+try {
+renderPassEncoder4.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer16, 28, 1_099);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 82}
+*/
+{
+  source: img1,
+  origin: { x: 10, y: 3 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup78 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout29,
+  entries: [{binding: 0, resource: {buffer: buffer51, offset: 1024, size: 1406}}],
+});
+let buffer73 = device0.createBuffer({size: 548, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let texture134 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 22},
+  mipLevelCount: 1,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder83.setBindGroup(2, bindGroup41, new Uint32Array(1239), 278, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle0, renderBundle6, renderBundle3, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer18, 'uint16', 1_600, 5_488);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+document.body.prepend(canvas0);
+videoFrame20 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let commandEncoder115 = device0.createCommandEncoder({});
+let textureView140 = texture3.createView({});
+let computePassEncoder84 = commandEncoder115.beginComputePass({});
+try {
+computePassEncoder84.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer56, 'uint16', 918, 349);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer61, 1_152, 667);
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: videoFrame19,
+  origin: { x: 1, y: 8 },
+  flipY: false,
+}, {
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer74 = device0.createBuffer({size: 261, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let texture135 = device0.createTexture({
+  size: {width: 195},
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup57);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup29, new Uint32Array(1311), 57, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 10, y: 3, z: 6},
+  aspect: 'all',
+}, new Uint8Array(28_158).fill(254), /* required buffer size: 28_158 */
+{offset: 26, bytesPerRow: 190, rowsPerImage: 69}, {width: 6, height: 11, depthOrArrayLayers: 3});
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+try {
+globalThis.someLabel = renderPassEncoder27.label;
+} catch {}
+let veryExplicitBindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 140,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout30 = pipeline1.getBindGroupLayout(0);
+let textureView141 = texture80.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let sampler70 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 4.056,
+});
+try {
+computePassEncoder30.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup36, new Uint32Array(376), 3, 0);
+} catch {}
+let veryExplicitBindGroupLayout23 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 13,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 51,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 82,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+    {binding: 88, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 93,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 95,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 104,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {binding: 153, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 183,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 203,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer75 = device0.createBuffer({size: 1538, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let texture136 = device0.createTexture({
+  size: [390, 240, 1],
+  mipLevelCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture137 = device0.createTexture({
+  size: [240, 1, 47],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder55.setBindGroup(2, bindGroup32, new Uint32Array(4355), 147, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer39, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup79 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout10,
+  entries: [{binding: 0, resource: {buffer: buffer70, offset: 0}}],
+});
+let texture138 = gpuCanvasContext1.getCurrentTexture();
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup41, new Uint32Array(1261), 94, 0);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(168);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer67, 1_020, 61);
+} catch {}
+try {
+  await promise14;
+} catch {}
+let sampler71 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', magFilter: 'linear', lodMaxClamp: 79.63});
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+let bindGroup80 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout28,
+  entries: [{binding: 0, resource: {buffer: buffer28, offset: 1792, size: 921}}],
+});
+let textureView142 = texture14.createView({});
+let sampler72 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', minFilter: 'nearest', compare: 'always'});
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup80, new Uint32Array(2031), 110, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle2]);
+} catch {}
+let bindGroup81 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 0, resource: {buffer: buffer36, offset: 0, size: 25}}],
+});
+let buffer76 = device0.createBuffer({
+  size: 8847,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder116 = device0.createCommandEncoder({});
+let computePassEncoder85 = commandEncoder116.beginComputePass();
+try {
+computePassEncoder83.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(5, buffer51);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+  await promise13;
+} catch {}
+let autogeneratedBindGroupLayout31 = pipeline5.getBindGroupLayout(0);
+let textureView143 = texture15.createView({dimension: '2d', format: 'rg8unorm', baseArrayLayer: 6});
+try {
+computePassEncoder85.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup39, []);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer32, 'uint32', 276, 432);
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(19) var tex0: texture_depth_2d;
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct VertexOutput1 {
+  @location(0) @interpolate(flat, center) f7: vec2i,
+  @invariant @builtin(position) f8: vec4f,
+}
+
+@group(0) @binding(134) var<uniform> buffer77: array<array<array<mat4x2h, 1>, 2>, 5>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T0 {
+  @size(304) f0: array<vec2h>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(184) var<storage, read_write> buffer78: array<array<array<array<array<array<array<array<array<array<f16, 1>, 19>, 1>, 1>, 1>, 1>, 4>, 2>, 1>, 1>;
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2f,
+  @location(5) @interpolate(linear, center) f1: vec4f,
+}
+
+struct T1 {
+  @align(32) @size(160) f0: atomic<i32>,
+}
+
+@vertex
+fn vertex1(@location(12) a0: vec4h) -> VertexOutput1 {
+  var out: VertexOutput1;
+  let vf30: vec2u = textureDimensions(tex0, i32(unconst_i32(124)));
+  out.f8 = vec4f(buffer77[u32(unconst_u32(99))][1][u32(unconst_u32(133))][unconst_i32(2)].yyyy);
+  let vf31: f16 = (*&buffer77)[4][1][u32((*&buffer77)[4][1][u32(unconst_u32(101))][u32(unconst_u32(159))][u32(unconst_u32(305))])][u32(unconst_u32(33))][u32(unconst_u32(45))];
+  let vf32: vec2u = countOneBits(vec2u(unconst_u32(258), unconst_u32(65)));
+  out.f7 *= unpack4xI8(u32(unconst_u32(94))).yx;
+  let vf33: vec4i = unpack4xI8(u32(unconst_u32(1)));
+  return out;
+  _ = buffer77;
+  _ = tex0;
+}
+
+@fragment
+fn fragment0(@location(0) a0: vec2i, @builtin(position) a1: vec4f) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  let ptr7: ptr<storage, array<array<f16, 1>, 19>, read_write> = &(*&buffer78)[0][u32(unconst_u32(176))][u32(unconst_u32(194))][3][u32(unconst_u32(17))][0][u32(unconst_u32(42))][0];
+  let ptr8: ptr<storage, f16, read_write> = &(*&buffer78)[0][u32(unconst_u32(15))][u32(unconst_u32(3))][3][0][u32(unconst_u32(132))][0][u32((*&buffer78)[0][u32(unconst_u32(168))][u32(unconst_u32(105))][3][0][0][0][u32(unconst_u32(142))][u32(unconst_u32(202))][u32(unconst_u32(307))])][u32(unconst_u32(176))][0];
+  out.f0 = vec2f(f32((*&buffer78)[0][0][1][u32(buffer78[u32(buffer78[u32(unconst_u32(519))][u32(unconst_u32(193))][1][u32(unconst_u32(110))][u32(unconst_u32(96))][0][u32(unconst_u32(3))][0][18][0])][u32(unconst_u32(186))][u32(unconst_u32(443))][3][0][u32(unconst_u32(101))][0][0][u32(unconst_u32(120))][u32(unconst_u32(506))])][0][0][u32(unconst_u32(48))][u32(unconst_u32(1))][u32(unconst_u32(205))][0]));
+  let ptr9: ptr<storage, array<f16, 1>, read_write> = &(*&buffer78)[0][u32(unconst_u32(133))][u32(unconst_u32(79))][3][u32(unconst_u32(328))][0][u32(unconst_u32(45))][u32(unconst_u32(220))][u32(unconst_u32(299))];
+  out = FragmentOutput0(vec2f(f32((*&buffer78)[0][0][u32(unconst_u32(94))][3][u32(unconst_u32(51))][u32(unconst_u32(183))][0][0][u32(unconst_u32(20))][u32(unconst_u32(79))])), vec4f(f32((*&buffer78)[0][0][u32(unconst_u32(94))][3][u32(unconst_u32(51))][u32(unconst_u32(183))][0][0][u32(unconst_u32(20))][u32(unconst_u32(79))])));
+  let ptr10: ptr<uniform, mat4x2h> = &(*&buffer77)[4][u32(unconst_u32(125))][u32(unconst_u32(25))];
+  out.f0 = vec2f(f32((*&buffer78)[0][u32(unconst_u32(601))][1][3][u32(unconst_u32(143))][u32(unconst_u32(134))][u32(unconst_u32(117))][0][18][0]));
+  let ptr11: ptr<storage, f16, read_write> = &(*&buffer78)[u32(unconst_u32(37))][u32((*&buffer78)[u32(unconst_u32(40))][0][1][3][0][0][0][u32((*&buffer78)[0][u32(unconst_u32(17))][u32(unconst_u32(50))][u32(unconst_u32(14))][0][0][0][0][u32(unconst_u32(158))][0])][u32(unconst_u32(14))][u32(unconst_u32(105))])][1][3][u32(unconst_u32(135))][0][0][u32(buffer78[0][0][u32(unconst_u32(38))][u32(unconst_u32(88))][0][0][u32(unconst_u32(100))][u32(unconst_u32(58))][18][u32(unconst_u32(91))])][u32(unconst_u32(199))][0];
+  out.f0 = vec2f(f32(buffer78[u32(buffer78[0][u32(unconst_u32(176))][1][u32(unconst_u32(19))][u32(unconst_u32(555))][u32(unconst_u32(141))][u32(unconst_u32(424))][0][18][0])][u32(unconst_u32(154))][1][u32(unconst_u32(716))][u32(unconst_u32(301))][u32(unconst_u32(70))][0][0][18][0]));
+  out = FragmentOutput0(vec2f(f32(buffer78[0][0][u32(unconst_u32(357))][3][0][0][u32(unconst_u32(34))][0][18][0])), vec4f(f32(buffer78[0][0][u32(unconst_u32(357))][3][0][0][u32(unconst_u32(34))][0][18][0])));
+  out.f1 *= vec4f(f32(buffer78[u32(unconst_u32(78))][u32(unconst_u32(663))][u32(unconst_u32(156))][u32(unconst_u32(586))][u32(unconst_u32(392))][0][0][u32(buffer78[u32(unconst_u32(563))][0][u32(buffer78[u32(unconst_u32(269))][0][u32(unconst_u32(49))][3][0][0][0][u32(unconst_u32(6))][u32(unconst_u32(53))][0])][u32(buffer78[u32(buffer78[u32((*&buffer78)[0][u32(unconst_u32(155))][1][u32(unconst_u32(25))][u32(unconst_u32(40))][0][0][0][u32(unconst_u32(81))][u32(unconst_u32(11))])][0][u32(unconst_u32(13))][3][u32(unconst_u32(117))][0][0][u32(unconst_u32(270))][18][0])][0][1][u32(unconst_u32(408))][u32(unconst_u32(133))][0][0][0][18][0])][u32(unconst_u32(131))][0][0][u32(unconst_u32(66))][18][0])][18][u32(buffer78[u32(unconst_u32(259))][u32(buffer78[0][u32(unconst_u32(54))][u32(unconst_u32(2))][u32(unconst_u32(238))][0][u32(unconst_u32(284))][u32(unconst_u32(73))][u32(unconst_u32(59))][18][u32(unconst_u32(83))])][1][3][u32(unconst_u32(156))][0][u32(unconst_u32(65))][0][18][0])]));
+  let ptr12: ptr<storage, array<f16, 1>, read_write> = &(*&buffer78)[u32(unconst_u32(165))][0][u32(unconst_u32(159))][3][0][0][0][0][u32(unconst_u32(60))];
+  let ptr13: ptr<storage, f16, read_write> = &buffer78[0][u32(unconst_u32(630))][1][3][u32(unconst_u32(687))][0][u32(unconst_u32(132))][u32(unconst_u32(225))][u32(unconst_u32(541))][u32((*&buffer78)[0][0][u32(unconst_u32(72))][u32(unconst_u32(93))][u32(unconst_u32(170))][u32((*&buffer78)[0][u32(unconst_u32(15))][1][3][u32(unconst_u32(258))][0][0][u32(unconst_u32(108))][u32(unconst_u32(466))][0])][u32(unconst_u32(170))][0][18][0])];
+  let ptr14: ptr<storage, f16, read_write> = &buffer78[0][u32(unconst_u32(31))][1][3][u32(unconst_u32(19))][0][0][u32(unconst_u32(98))][18][0];
+  let ptr15: ptr<storage, f16, read_write> = &(*&buffer78)[0][u32(unconst_u32(117))][u32(buffer78[0][0][1][u32(unconst_u32(322))][u32(unconst_u32(191))][u32(unconst_u32(512))][0][u32(unconst_u32(364))][18][u32(unconst_u32(36))])][u32(unconst_u32(241))][0][u32(unconst_u32(218))][u32(unconst_u32(278))][0][u32(unconst_u32(76))][u32(unconst_u32(186))];
+  let ptr16: ptr<storage, array<f16, 1>, read_write> = &(*&buffer78)[0][0][1][u32(unconst_u32(0))][u32(unconst_u32(397))][u32(unconst_u32(133))][0][0][u32((*&buffer78)[0][0][1][3][0][u32(unconst_u32(119))][0][u32((*&buffer78)[u32(unconst_u32(4))][u32(unconst_u32(414))][u32(unconst_u32(134))][u32(unconst_u32(309))][u32(unconst_u32(177))][0][0][0][u32(unconst_u32(171))][u32(unconst_u32(64))])][u32(unconst_u32(128))][0])];
+  let ptr17: ptr<storage, array<f16, 1>, read_write> = &buffer78[0][u32(unconst_u32(60))][1][3][u32(buffer78[0][0][u32(unconst_u32(2))][u32((*&buffer78)[0][u32(unconst_u32(132))][u32(unconst_u32(186))][3][0][0][u32(unconst_u32(316))][0][18][0])][0][u32(unconst_u32(77))][0][0][18][0])][u32(unconst_u32(129))][u32(unconst_u32(389))][0][u32(unconst_u32(139))];
+  let ptr18: ptr<storage, array<array<f16, 1>, 19>, read_write> = &buffer78[u32(unconst_u32(28))][0][u32(unconst_u32(488))][u32(unconst_u32(277))][u32(unconst_u32(390))][0][u32(unconst_u32(152))][0];
+  let ptr19: ptr<storage, array<f16, 1>, read_write> = &(*&buffer78)[0][0][u32(unconst_u32(104))][3][u32(unconst_u32(75))][0][0][0][u32(unconst_u32(57))];
+  out.f0 = vec2f(f32((*&buffer78)[0][u32(unconst_u32(248))][1][3][u32(unconst_u32(10))][0][u32(unconst_u32(68))][u32(unconst_u32(38))][u32(unconst_u32(296))][u32(unconst_u32(26))]));
+  discard;
+  let ptr20: ptr<storage, f16, read_write> = &(*&buffer78)[0][0][1][u32(unconst_u32(163))][u32((*&buffer78)[u32(buffer78[u32(unconst_u32(211))][u32(unconst_u32(119))][1][3][u32(unconst_u32(28))][u32(unconst_u32(187))][0][0][u32(unconst_u32(516))][0])][u32(unconst_u32(36))][1][3][u32(unconst_u32(153))][0][0][0][18][0])][0][u32(unconst_u32(39))][u32(unconst_u32(171))][18][0];
+  out.f0 = vec2f(f32(buffer78[u32(unconst_u32(23))][0][1][u32(unconst_u32(21))][0][0][0][0][18][0]));
+  return out;
+  _ = buffer77;
+  _ = buffer78;
+}
+
+@compute @workgroup_size(1, 1, 3)
+fn compute1() {
+  var vf34: vec2h = tan(vec2h(unconst_f16(12482.9), unconst_f16(3564.4)));
+  var vf35: vec3u = max(vec3u(unconst_u32(132), unconst_u32(1), unconst_u32(514)), vec3u(unconst_u32(23), unconst_u32(163), unconst_u32(187)));
+}`,
+});
+let buffer79 = device0.createBuffer({size: 3906, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture139 = device0.createTexture({
+  size: {width: 480, height: 1, depthOrArrayLayers: 172},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture140 = gpuCanvasContext0.getCurrentTexture();
+let sampler73 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 69.86,
+  lodMaxClamp: 71.11,
+});
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup2, new Uint32Array(4850), 1_063, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer32, 0, 607);
+} catch {}
+let veryExplicitBindGroupLayout24 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 12,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 49,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 58, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 70,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 72,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 88,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 95,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d' },
+    },
+    {
+      binding: 349,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 615,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let bindGroup82 = device0.createBindGroup({layout: veryExplicitBindGroupLayout21, entries: [{binding: 140, resource: textureView23}]});
+let textureView144 = texture54.createView({dimension: '2d-array'});
+let textureView145 = texture69.createView({mipLevelCount: 1, baseArrayLayer: 6, arrayLayerCount: 10});
+let sampler74 = device0.createSampler({addressModeU: 'mirror-repeat', lodMaxClamp: 88.66, compare: 'never'});
+try {
+renderPassEncoder22.setVertexBuffer(7, buffer4, 0, 2_470);
+} catch {}
+let arrayBuffer14 = buffer22.getMappedRange(0, 0);
+let bindGroup83 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout4,
+  entries: [{binding: 0, resource: {buffer: buffer38, offset: 768, size: 1586}}],
+});
+let buffer80 = device0.createBuffer({size: 355, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX});
+let commandEncoder117 = device0.createCommandEncoder({});
+let computePassEncoder86 = commandEncoder117.beginComputePass({});
+try {
+computePassEncoder85.setBindGroup(1, bindGroup48);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(152).fill(111), /* required buffer size: 152 */
+{offset: 152}, {width: 62, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let bindGroup84 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout15,
+  entries: [{binding: 0, resource: {buffer: buffer23, offset: 0, size: 511}}],
+});
+let buffer81 = device0.createBuffer({size: 1157, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 99});
+let sampler75 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.21,
+  compare: 'greater',
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder22.setIndexBuffer(buffer38, 'uint32', 3_504, 4_036);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer49, 0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let texture141 = device0.createTexture({size: [780], dimension: '1d', format: 'rgba8unorm-srgb', usage: GPUTextureUsage.TEXTURE_BINDING});
+let sampler76 = device0.createSampler({addressModeV: 'mirror-repeat', minFilter: 'nearest', lodMaxClamp: 95.90, compare: 'equal'});
+try {
+computePassEncoder77.setBindGroup(0, bindGroup10);
+} catch {}
+let pipeline11 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {mask: 0x9584adf},
+  fragment: {
+  module: shaderModule1,
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex1',
+    buffers: [{arrayStride: 40, attributes: [{format: 'snorm16x4', offset: 4, shaderLocation: 12}]}],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw'},
+});
+let autogeneratedBindGroupLayout32 = pipeline4.getBindGroupLayout(0);
+let commandEncoder118 = device0.createCommandEncoder();
+let renderPassEncoder33 = commandEncoder118.beginRenderPass({
+  colorAttachments: [{
+  view: textureView79,
+  clearValue: { r: 750.2, g: -471.4, b: 576.4, a: 721.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder7.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(3, buffer74, 36, 51);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 92, new BigUint64Array(1181), 322, 88);
+} catch {}
+document.body.append(canvas0);
+let imageData19 = new ImageData(28, 12);
+let bindGroup85 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout5,
+  entries: [{binding: 0, resource: {buffer: buffer76, offset: 2816, size: 99}}],
+});
+let texture142 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder54.setBindGroup(0, bindGroup49);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer70, 'uint32', 460, 210);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 41, y: 32, z: 0},
+  aspect: 'all',
+}, new Uint8Array(2).fill(209), /* required buffer size: 2 */
+{offset: 2, bytesPerRow: 519}, {width: 124, height: 36, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup86 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout2,
+  entries: [{binding: 0, resource: {buffer: buffer38, offset: 0, size: 926}}],
+});
+let buffer82 = device0.createBuffer({size: 5291, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder119 = device0.createCommandEncoder({});
+let texture143 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16sint'],
+});
+try {
+renderPassEncoder8.setPipeline(pipeline11);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let veryExplicitBindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 113,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 206,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer83 = device0.createBuffer({size: 2462, usage: GPUBufferUsage.INDIRECT});
+let computePassEncoder87 = commandEncoder119.beginComputePass({});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(3, buffer60, 0, 583);
+} catch {}
+let commandEncoder120 = device0.createCommandEncoder({});
+let texture144 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup64, []);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle3, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(6, buffer46, 876, 4_314);
+} catch {}
+let bindGroup87 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout2,
+  entries: [{binding: 0, resource: {buffer: buffer13, offset: 1792, size: 5170}}],
+});
+let buffer84 = device0.createBuffer({size: 14194, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: false});
+let texture145 = device0.createTexture({
+  size: [390, 240, 1],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture14 = device0.importExternalTexture({
+  label: '\u{1f886}\ubb67\u42e7\uc81c\uf56f\u{1f900}\u2454\uddb5\ua621\u0c3b\u0628',
+  source: videoFrame8,
+});
+try {
+renderPassEncoder2.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(5, buffer46, 0, 675);
+} catch {}
+document.body.prepend(canvas0);
+let autogeneratedBindGroupLayout33 = pipeline3.getBindGroupLayout(0);
+let commandEncoder121 = device0.createCommandEncoder({});
+let textureView146 = texture125.createView({});
+let renderPassEncoder34 = commandEncoder121.beginRenderPass({
+  colorAttachments: [{
+  view: textureView97,
+  clearValue: { r: 724.4, g: 322.4, b: 467.4, a: -833.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 407317978,
+});
+let externalTexture15 = device0.importExternalTexture({source: videoFrame15});
+try {
+computePassEncoder87.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(6, buffer53, 340, 135);
+} catch {}
+try {
+commandEncoder120.resolveQuerySet(querySet2, 68, 75, buffer21, 2560);
+} catch {}
+try {
+computePassEncoder78.insertDebugMarker('\u{1fead}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 50}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 2, y: 1 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 34, y: 11, z: 7},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder122 = device0.createCommandEncoder({});
+let textureView147 = texture81.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 4});
+let computePassEncoder88 = commandEncoder120.beginComputePass();
+try {
+computePassEncoder45.setBindGroup(3, bindGroup85);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(0, bindGroup61, new Uint32Array(2781), 105, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup86);
+} catch {}
+try {
+commandEncoder122.copyBufferToBuffer(buffer22, 3536, buffer46, 464, 1064);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 780, height: 480, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+}, {
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 29, y: 14, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 28, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let imageData20 = new ImageData(4, 44);
+let buffer85 = device0.createBuffer({
+  label: '\u0fab\u20ab\u4edd\uf3c7\u{1f683}\u{1fa10}',
+  size: 13297,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let textureView148 = texture63.createView({});
+try {
+computePassEncoder43.setBindGroup(2, bindGroup83, new Uint32Array(411), 8, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup72, new Uint32Array(326), 35, 0);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(99);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(7, buffer51, 892);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer43, 548, new Int16Array(10871), 1333, 44);
+} catch {}
+try {
+globalThis.someLabel = sampler62.label;
+} catch {}
+let bindGroup88 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout14,
+  entries: [
+    {binding: 6, resource: {buffer: buffer70, offset: 0}},
+    {binding: 153, resource: externalTexture15},
+    {binding: 93, resource: {buffer: buffer69, offset: 1792, size: 2352}},
+    {binding: 203, resource: {buffer: buffer4, offset: 1536, size: 5552}},
+    {binding: 13, resource: sampler15},
+    {binding: 82, resource: textureView33},
+    {binding: 51, resource: textureView90},
+    {binding: 88, resource: sampler49},
+    {binding: 183, resource: textureView23},
+    {binding: 95, resource: {buffer: buffer4, offset: 9472, size: 3112}},
+    {binding: 104, resource: textureView37},
+  ],
+});
+let texture146 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView149 = texture100.createView({mipLevelCount: 1});
+let computePassEncoder89 = commandEncoder122.beginComputePass({});
+try {
+computePassEncoder89.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline11);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer86 = device0.createBuffer({
+  size: 8958,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let texture147 = device0.createTexture({
+  size: {width: 120},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder50.setBindGroup(3, bindGroup68);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline11);
+} catch {}
+let commandEncoder123 = device0.createCommandEncoder();
+let computePassEncoder90 = commandEncoder123.beginComputePass({});
+let externalTexture16 = device0.importExternalTexture({source: videoFrame20});
+try {
+computePassEncoder90.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline11);
+} catch {}
+try {
+buffer74.unmap();
+} catch {}
+await gc();
+let bindGroup89 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 0, resource: {buffer: buffer70, offset: 0}}],
+});
+let texture148 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 7},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView150 = texture98.createView({dimension: '2d-array', aspect: 'depth-only'});
+let sampler77 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 88.11,
+  maxAnisotropy: 15,
+});
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup11);
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+let pipeline12 = device0.createRenderPipeline({
+  layout: 'auto',
+  multisample: {mask: 0x7c22bf0},
+  fragment: {
+  module: shaderModule1,
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'dst'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    buffers: [{arrayStride: 252, attributes: [{format: 'float16x4', offset: 24, shaderLocation: 12}]}],
+  },
+  primitive: {cullMode: 'back'},
+});
+let commandEncoder124 = device0.createCommandEncoder({});
+try {
+computePassEncoder54.setBindGroup(1, bindGroup3, new Uint32Array(665), 9, 0);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle1, renderBundle1, renderBundle7, renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer16, 'uint16', 906, 2_628);
+} catch {}
+let arrayBuffer15 = buffer5.getMappedRange(168, 120);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer87 = device0.createBuffer({
+  size: 5263,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup78);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let autogeneratedBindGroupLayout34 = pipeline2.getBindGroupLayout(0);
+let bindGroup90 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout14,
+  entries: [
+    {binding: 95, resource: {buffer: buffer73, offset: 0, size: 20}},
+    {binding: 104, resource: textureView37},
+    {binding: 93, resource: {buffer: buffer40, offset: 3072}},
+    {binding: 13, resource: sampler21},
+    {binding: 82, resource: textureView33},
+    {binding: 88, resource: sampler53},
+    {binding: 203, resource: {buffer: buffer67, offset: 256, size: 2748}},
+    {binding: 183, resource: textureView23},
+    {binding: 51, resource: textureView30},
+    {binding: 153, resource: externalTexture14},
+    {binding: 6, resource: {buffer: buffer26, offset: 256}},
+  ],
+});
+let commandEncoder125 = device0.createCommandEncoder({});
+let textureView151 = texture75.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder91 = commandEncoder124.beginComputePass();
+try {
+renderPassEncoder34.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder125.copyTextureToBuffer({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 160 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 672 */
+  offset: 672,
+  buffer: buffer65,
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise15;
+} catch {}
+let buffer88 = device0.createBuffer({size: 15149, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let computePassEncoder92 = commandEncoder125.beginComputePass({});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup85);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer10, 'uint16', 1_422, 1_972);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture144,
+  mipLevel: 0,
+  origin: {x: 83, y: 21, z: 0},
+  aspect: 'all',
+}, new Uint8Array(152).fill(242), /* required buffer size: 152 */
+{offset: 152, bytesPerRow: 145}, {width: 17, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder126 = device0.createCommandEncoder({});
+let computePassEncoder93 = commandEncoder126.beginComputePass({});
+try {
+computePassEncoder92.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup64, new Uint32Array(1362), 42, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer36, 'uint16', 370, 183);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55); };
+} catch {}
+videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'smpteSt4281', transfer: 'bt709'} });
+let texture149 = device0.createTexture({
+  size: [240, 1, 1],
+  sampleCount: 4,
+  dimension: '2d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder39.setBindGroup(2, bindGroup26, new Uint32Array(1918), 487, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+  await promise16;
+} catch {}
+let buffer89 = device0.createBuffer({size: 12449, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder127 = device0.createCommandEncoder({});
+let textureView152 = texture149.createView({});
+let textureView153 = texture93.createView({dimension: '3d'});
+let computePassEncoder94 = commandEncoder127.beginComputePass({});
+let sampler78 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 88.65,
+});
+try {
+computePassEncoder28.setBindGroup(3, bindGroup80);
+} catch {}
+try {
+computePassEncoder73.setBindGroup(0, bindGroup42, new Uint32Array(34), 1, 0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer48, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+document.body.append(img4);
+videoFrame22 = new VideoFrame(videoFrame3, {timestamp: 0});
+let buffer90 = device0.createBuffer({size: 6220, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder128 = device0.createCommandEncoder({});
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 959});
+let textureView154 = texture107.createView({mipLevelCount: 1});
+let texture150 = device0.createTexture({
+  size: [195],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16sint'],
+});
+let computePassEncoder95 = commandEncoder128.beginComputePass({});
+try {
+computePassEncoder72.setBindGroup(2, bindGroup85);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(98).fill(239), /* required buffer size: 98 */
+{offset: 98, rowsPerImage: 98}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder129 = device0.createCommandEncoder();
+let texture151 = device0.createTexture({
+  size: [480, 1, 6],
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture17 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder92.setBindGroup(2, bindGroup74, new Uint32Array(1298), 380, 0);
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup64);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer60, 0, 905);
+} catch {}
+let commandEncoder130 = device0.createCommandEncoder({});
+let texture152 = device0.createTexture({
+  size: [97, 60, 1],
+  sampleCount: 1,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder96 = commandEncoder130.beginComputePass();
+try {
+computePassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle7, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline12);
+} catch {}
+try {
+globalThis.someLabel = externalTexture0.label;
+} catch {}
+let autogeneratedBindGroupLayout35 = pipeline1.getBindGroupLayout(0);
+let commandEncoder131 = device0.createCommandEncoder({});
+let computePassEncoder97 = commandEncoder129.beginComputePass({});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle21 = renderBundleEncoder21.finish({});
+try {
+computePassEncoder94.setBindGroup(3, bindGroup0, new Uint32Array(113), 4, 0);
+} catch {}
+try {
+computePassEncoder95.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup66);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder131.copyBufferToBuffer(buffer52, 816, buffer36, 116, 140);
+} catch {}
+try {
+commandEncoder131.copyTextureToTexture({
+  texture: texture50,
+  mipLevel: 2,
+  origin: {x: 8, y: 2, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 3,
+  origin: {x: 6, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout36 = pipeline12.getBindGroupLayout(0);
+let commandEncoder132 = device0.createCommandEncoder({});
+try {
+computePassEncoder69.setBindGroup(3, bindGroup0, []);
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder131.copyBufferToTexture({
+  /* bytesInLastRow: 46 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1616 */
+  offset: 1616,
+  buffer: buffer41,
+}, {
+  texture: texture41,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer31, 496, new Float32Array(5));
+} catch {}
+let textureView155 = texture142.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder98 = commandEncoder132.beginComputePass({});
+let renderPassEncoder35 = commandEncoder131.beginRenderPass({
+  colorAttachments: [{
+  view: textureView68,
+  clearValue: { r: -226.4, g: 704.5, b: -174.7, a: -141.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet9,
+});
+let sampler79 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 36.46,
+  lodMaxClamp: 61.85,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder96.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(6, buffer42, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 93, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(41).fill(120), /* required buffer size: 41 */
+{offset: 41, bytesPerRow: 144}, {width: 58, height: 102, depthOrArrayLayers: 0});
+} catch {}
+let texture153 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 311},
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView156 = texture28.createView({baseArrayLayer: 4, arrayLayerCount: 1});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup65);
+} catch {}
+try {
+computePassEncoder26.setBindGroup(3, bindGroup49, new Uint32Array(773), 28, 0);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer60, 'uint16', 1_020, 1_665);
+} catch {}
+let bindGroup91 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout27,
+  entries: [{binding: 0, resource: {buffer: buffer81, offset: 0, size: 99}}],
+});
+let textureView157 = texture130.createView({});
+try {
+computePassEncoder97.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup71, new Uint32Array(2638), 164, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView158 = texture127.createView({dimension: '2d-array', format: 'depth24plus', baseMipLevel: 0});
+let sampler80 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  compare: 'equal',
+  maxAnisotropy: 1,
+});
+let textureView159 = texture125.createView({dimension: '1d', arrayLayerCount: 1});
+let textureView160 = texture107.createView({});
+try {
+renderPassEncoder29.setVertexBuffer(5, buffer21, 144);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 18244, new DataView(new ArrayBuffer(4290)), 980, 16);
+} catch {}
+let commandEncoder133 = device0.createCommandEncoder({});
+let texture154 = device0.createTexture({
+  size: [390, 240, 1],
+  sampleCount: 4,
+  dimension: '2d',
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder91.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer34, 'uint32', 660, 268);
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+document.body.append(img0);
+let commandEncoder134 = device0.createCommandEncoder({});
+let computePassEncoder99 = commandEncoder133.beginComputePass({});
+let externalTexture18 = device0.importExternalTexture({source: videoFrame22});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup10, new Uint32Array(1264), 173, 0);
+} catch {}
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer71, 'uint32', 28_660, 3_889);
+} catch {}
+try {
+commandEncoder134.copyBufferToBuffer(buffer22, 1988, buffer57, 124, 52);
+} catch {}
+videoFrame23 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'film', transfer: 'log'} });
+try {
+adapter0.label = '\u608b\u{1fb3d}\u0c4a\u179f\u05c2\ue4ee\u9ac5\u{1fa28}';
+} catch {}
+let bindGroup92 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout30,
+  entries: [{binding: 0, resource: {buffer: buffer50, offset: 0}}],
+});
+let buffer91 = device0.createBuffer({
+  size: 14292,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder135 = device0.createCommandEncoder({});
+let computePassEncoder100 = commandEncoder35.beginComputePass({});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup84);
+} catch {}
+try {
+computePassEncoder60.setBindGroup(0, bindGroup21, new Uint32Array(283), 3, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup23, new Uint32Array(885), 94, 0);
+} catch {}
+try {
+renderPassEncoder29.beginOcclusionQuery(22);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle1]);
+} catch {}
+videoFrame24 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+let buffer92 = device0.createBuffer({size: 10292, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let querySet22 = device0.createQuerySet({type: 'occlusion', count: 1813});
+let textureView161 = texture122.createView({arrayLayerCount: 1});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup25, new Uint32Array(3097), 229, 0);
+} catch {}
+try {
+computePassEncoder100.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup15, new Uint32Array(228), 67, 0);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(59);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img5);
+let bindGroup93 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout18,
+  entries: [
+    {binding: 203, resource: {buffer: buffer38, offset: 768, size: 7288}},
+    {binding: 153, resource: externalTexture9},
+    {binding: 104, resource: textureView65},
+    {binding: 51, resource: textureView90},
+    {binding: 88, resource: sampler51},
+    {binding: 82, resource: textureView33},
+    {binding: 13, resource: sampler50},
+    {binding: 95, resource: {buffer: buffer66, offset: 2304, size: 1136}},
+    {binding: 6, resource: {buffer: buffer18, offset: 6656, size: 5360}},
+    {binding: 183, resource: textureView66},
+    {binding: 93, resource: {buffer: buffer38, offset: 0, size: 3656}},
+  ],
+});
+let commandEncoder136 = device0.createCommandEncoder({});
+let computePassEncoder101 = commandEncoder136.beginComputePass({});
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup40);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer18, 'uint16', 54, 1_359);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, undefined, 0, 1_876_609_840);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+let autogeneratedBindGroupLayout37 = pipeline4.getBindGroupLayout(0);
+let computePassEncoder102 = commandEncoder134.beginComputePass({label: '\u7b5a\ucc43\u061f\u0c1e\ubfdf\ua965\uc7d8\u{1f7fc}\u0545'});
+try {
+computePassEncoder68.setBindGroup(1, bindGroup60, new Uint32Array(500), 18, 0);
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup49, new Uint32Array(510), 0, 0);
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder135.copyBufferToBuffer(buffer56, 388, buffer4, 4908, 100);
+} catch {}
+try {
+commandEncoder135.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2156 */
+  offset: 2156,
+  bytesPerRow: 2560,
+  buffer: buffer25,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 5, y: 5, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline13 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex1',
+    buffers: [
+      {
+        arrayStride: 424,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x2', offset: 94, shaderLocation: 12}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+let autogeneratedBindGroupLayout38 = pipeline8.getBindGroupLayout(0);
+let bindGroup94 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout31,
+  entries: [{binding: 0, resource: {buffer: buffer21, offset: 0}}],
+});
+let buffer93 = device0.createBuffer({size: 3566, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder137 = device0.createCommandEncoder({});
+let texture155 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 22},
+  sampleCount: 1,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler81 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 59.87,
+});
+try {
+computePassEncoder98.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup94);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(1, bindGroup2, new Uint32Array(451), 129, 0);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(0, buffer18, 0);
+} catch {}
+let autogeneratedBindGroupLayout39 = pipeline12.getBindGroupLayout(0);
+let textureView162 = texture49.createView({});
+let sampler82 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', magFilter: 'linear'});
+try {
+computePassEncoder99.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: 895.5, g: -311.2, b: -620.7, a: -109.0, });
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(3, buffer51);
+} catch {}
+let bindGroup95 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout6,
+  entries: [{binding: 0, resource: {buffer: buffer51, offset: 0, size: 325}}],
+});
+let commandEncoder138 = device0.createCommandEncoder({});
+let textureView163 = texture41.createView({mipLevelCount: 1});
+let renderPassEncoder36 = commandEncoder138.beginRenderPass({
+  colorAttachments: [{
+  view: textureView130,
+  depthSlice: 34,
+  clearValue: { r: 668.5, g: 748.6, b: -689.7, a: -477.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let sampler83 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 56.25,
+});
+try {
+renderPassEncoder7.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer11, 'uint32', 2_568, 1_623);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(2, buffer61, 0, 443);
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+let texture156 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder103 = commandEncoder135.beginComputePass({});
+let renderPassEncoder37 = commandEncoder137.beginRenderPass({
+  colorAttachments: [{
+  view: textureView38,
+  clearValue: { r: -862.9, g: 871.5, b: -326.0, a: 351.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup64, []);
+} catch {}
+try {
+computePassEncoder101.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup67, new Uint32Array(2414), 396, 0);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: -304.8, g: -841.2, b: -400.5, a: -731.4, });
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(2, buffer32, 292);
+} catch {}
+try {
+  await promise18;
+} catch {}
+await gc();
+try {
+computePassEncoder68.setBindGroup(2, bindGroup40, new Uint32Array(517), 57, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer33, 'uint16', 52, 64);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer89);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer17, 'uint16', 232, 647);
+} catch {}
+await gc();
+let autogeneratedBindGroupLayout40 = pipeline2.getBindGroupLayout(0);
+let commandEncoder139 = device0.createCommandEncoder({});
+let computePassEncoder104 = commandEncoder139.beginComputePass({});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(3);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+let buffer94 = device0.createBuffer({
+  size: 3529,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView164 = texture51.createView({dimension: '2d-array', format: 'rgba8uint', mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundle22 = renderBundleEncoder22.finish({});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup11);
+} catch {}
+let arrayBuffer16 = buffer22.getMappedRange(8, 20);
+let autogeneratedBindGroupLayout41 = pipeline11.getBindGroupLayout(0);
+try {
+buffer84.unmap();
+} catch {}
+let imageData21 = new ImageData(24, 20);
+let autogeneratedBindGroupLayout42 = pipeline6.getBindGroupLayout(0);
+let commandEncoder140 = device0.createCommandEncoder({});
+let textureView165 = texture3.createView({dimension: '3d'});
+let sampler84 = device0.createSampler({addressModeW: 'repeat', magFilter: 'linear', lodMinClamp: 25.45});
+try {
+computePassEncoder104.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup86, new Uint32Array(773), 106, 0);
+} catch {}
+try {
+renderPassEncoder22.beginOcclusionQuery(510);
+} catch {}
+try {
+commandEncoder140.copyBufferToTexture({
+  /* bytesInLastRow: 258 widthInBlocks: 129 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1376 */
+  offset: 1376,
+  bytesPerRow: 26368,
+  rowsPerImage: 681,
+  buffer: buffer52,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 5, y: 24, z: 0},
+  aspect: 'all',
+}, {width: 129, height: 37, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img1);
+let texture157 = device0.createTexture({
+  size: [390, 240, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder105 = commandEncoder140.beginComputePass({});
+try {
+computePassEncoder84.setBindGroup(3, bindGroup92, new Uint32Array(218), 14, 0);
+} catch {}
+try {
+computePassEncoder103.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(1, buffer17);
+} catch {}
+try {
+renderPassEncoder0.pushDebugGroup('\u0a26');
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\u{1ffaa}');
+} catch {}
+let commandEncoder141 = device0.createCommandEncoder({});
+let sampler85 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat'});
+try {
+computePassEncoder105.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup60, new Uint32Array(2800), 12, 0);
+} catch {}
+try {
+renderPassEncoder22.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(1, buffer10, 8_400, 321);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder141.copyBufferToTexture({
+  /* bytesInLastRow: 1496 widthInBlocks: 374 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 756 */
+  offset: 756,
+  bytesPerRow: 2560,
+  buffer: buffer23,
+}, {
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 93, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 374, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(274, 64);
+let computePassEncoder106 = commandEncoder141.beginComputePass({});
+try {
+computePassEncoder32.setBindGroup(1, bindGroup52);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup47, new Uint32Array(1170), 82, 0);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline12);
+} catch {}
+let commandEncoder142 = device0.createCommandEncoder({});
+let texture158 = device0.createTexture({
+  size: {width: 120, height: 1, depthOrArrayLayers: 60},
+  mipLevelCount: 5,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView166 = texture58.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder107 = commandEncoder142.beginComputePass({});
+try {
+computePassEncoder87.setBindGroup(2, bindGroup72);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(0, buffer74, 0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+  await buffer3.mapAsync(GPUMapMode.READ, 296, 572);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder143 = device0.createCommandEncoder({});
+let computePassEncoder108 = commandEncoder143.beginComputePass();
+try {
+computePassEncoder64.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+computePassEncoder23.setBindGroup(0, bindGroup80, new Uint32Array(1156), 40, 0);
+} catch {}
+try {
+computePassEncoder107.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup7, new Uint32Array(1716), 132, 0);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(7, buffer16, 2_724);
+} catch {}
+try {
+buffer42.unmap();
+} catch {}
+try {
+  await promise19;
+} catch {}
+let buffer95 = device0.createBuffer({size: 4260, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+try {
+renderPassEncoder16.setIndexBuffer(buffer56, 'uint32', 308, 533);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer21);
+} catch {}
+let commandEncoder144 = device0.createCommandEncoder({label: '\u{1f6aa}\u0fce\u21f0\uc661\u04db\u6b14'});
+let texture159 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder109 = commandEncoder144.beginComputePass({});
+let externalTexture19 = device0.importExternalTexture({source: videoFrame13, colorSpace: 'display-p3'});
+try {
+computePassEncoder81.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer46, 'uint16', 3_400, 183);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline11);
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+let texture160 = device0.createTexture({
+  size: [97, 60, 1],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView167 = texture46.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder43.setBindGroup(0, bindGroup74);
+} catch {}
+try {
+computePassEncoder64.setBindGroup(1, bindGroup16, new Uint32Array(1183), 395, 0);
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(2, buffer49);
+} catch {}
+try {
+computePassEncoder37.pushDebugGroup('\u{1faef}');
+} catch {}
+try {
+computePassEncoder37.popDebugGroup();
+} catch {}
+await gc();
+let veryExplicitBindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 191,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let sampler86 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 56.49});
+try {
+device0.queue.writeBuffer(buffer9, 24, new DataView(new ArrayBuffer(18826)), 3074, 368);
+} catch {}
+videoFrame25 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpte240m', transfer: 'iec61966-2-1'} });
+let bindGroup96 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout33,
+  entries: [{binding: 0, resource: {buffer: buffer21, offset: 1024}}],
+});
+try {
+computePassEncoder38.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(1, bindGroup57, new Uint32Array(1733), 580, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup92, new Uint32Array(5531), 168, 0);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline12);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 50}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 84, y: 63, z: 13},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer96 = device0.createBuffer({
+  size: 9653,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder145 = device0.createCommandEncoder({});
+let querySet23 = device0.createQuerySet({type: 'occlusion', count: 1236});
+let computePassEncoder110 = commandEncoder145.beginComputePass({});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let sampler87 = device0.createSampler({minFilter: 'nearest', lodMaxClamp: 98.99});
+try {
+computePassEncoder101.setBindGroup(0, bindGroup48, new Uint32Array(265), 67, 0);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(1, buffer32, 0, 234);
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+let bindGroup97 = device0.createBindGroup({layout: veryExplicitBindGroupLayout22, entries: [{binding: 140, resource: textureView66}]});
+let querySet24 = device0.createQuerySet({type: 'occlusion', count: 1078});
+try {
+computePassEncoder109.setBindGroup(0, bindGroup48, []);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline13);
+} catch {}
+try {
+computePassEncoder49.insertDebugMarker('\u38b3');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer43, 72, new DataView(new ArrayBuffer(9713)), 2204, 620);
+} catch {}
+await gc();
+let imageBitmap3 = await createImageBitmap(videoFrame13);
+let commandEncoder146 = device0.createCommandEncoder({});
+let textureView168 = texture149.createView({mipLevelCount: 1});
+let computePassEncoder111 = commandEncoder146.beginComputePass({});
+try {
+computePassEncoder109.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup44);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup1, []);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext3 = offscreenCanvas2.getContext('webgpu');
+let textureView169 = texture122.createView({});
+try {
+computePassEncoder111.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup71);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(3, bindGroup68, new Uint32Array(802), 123, 0);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(3, buffer26, 0, 4_138);
+} catch {}
+try {
+buffer79.unmap();
+} catch {}
+try {
+  await buffer64.mapAsync(GPUMapMode.READ, 208, 80);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+try {
+computePassEncoder110.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer61, 'uint16', 1_536, 772);
+} catch {}
+try {
+computePassEncoder92.insertDebugMarker('\u0057');
+} catch {}
+let autogeneratedBindGroupLayout43 = pipeline11.getBindGroupLayout(0);
+let buffer97 = device0.createBuffer({size: 8003, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderBundle23 = renderBundleEncoder23.finish({});
+let sampler88 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 90.47,
+});
+try {
+computePassEncoder102.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(1, bindGroup28, new Uint32Array(1445), 64, 0);
+} catch {}
+try {
+computePassEncoder106.setPipeline(pipeline8);
+} catch {}
+try {
+  await promise20;
+} catch {}
+let canvas1 = document.createElement('canvas');
+let imageData22 = new ImageData(12, 44);
+let textureView170 = texture134.createView({dimension: 'cube', format: 'rg32sint', arrayLayerCount: 6});
+let sampler89 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 81.29});
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup67);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer33, 'uint32', 72, 41);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(7, undefined, 412_452_126, 515_992_601);
+} catch {}
+let bindGroup98 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout26,
+  entries: [{binding: 191, resource: {buffer: buffer29, offset: 256, size: 972}}],
+});
+let textureView171 = texture10.createView({});
+try {
+computePassEncoder93.setBindGroup(1, bindGroup85);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle3, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline12);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 50}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 5, y: 1 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 117, y: 52, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 76, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup99 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 0, resource: {buffer: buffer31, offset: 2560}}],
+});
+let texture161 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder92.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+computePassEncoder86.end();
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup29, new Uint32Array(2647), 565, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 23}
+*/
+{
+  source: imageData1,
+  origin: { x: 25, y: 5 },
+  flipY: true,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 44, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout44 = pipeline7.getBindGroupLayout(0);
+let bindGroup100 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout18,
+  entries: [{binding: 0, resource: {buffer: buffer13, offset: 3328, size: 8093}}],
+});
+let commandEncoder147 = device0.createCommandEncoder({});
+let textureView172 = texture153.createView({mipLevelCount: 1});
+let computePassEncoder112 = commandEncoder147.beginComputePass();
+let sampler90 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 85.47,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder105.setBindGroup(1, bindGroup82);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline12);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 16},
+  aspect: 'all',
+}, new Uint8Array(1_198).fill(184), /* required buffer size: 1_198 */
+{offset: 106, bytesPerRow: 16, rowsPerImage: 4}, {width: 2, height: 1, depthOrArrayLayers: 18});
+} catch {}
+let buffer98 = device0.createBuffer({size: 10654, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let texture162 = device0.createTexture({size: [120], dimension: '1d', format: 'rgba16uint', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+let texture163 = gpuCanvasContext2.getCurrentTexture();
+try {
+renderPassEncoder4.setIndexBuffer(buffer11, 'uint16', 3_912, 1_603);
+} catch {}
+try {
+commandEncoder117.copyBufferToBuffer(buffer58, 2948, buffer37, 5940, 176);
+} catch {}
+try {
+renderPassEncoder0.popDebugGroup();
+} catch {}
+let imageData23 = new ImageData(12, 56);
+let autogeneratedBindGroupLayout45 = pipeline0.getBindGroupLayout(0);
+let computePassEncoder113 = commandEncoder117.beginComputePass();
+try {
+computePassEncoder72.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+computePassEncoder89.setBindGroup(3, bindGroup10, new Uint32Array(598), 173, 0);
+} catch {}
+try {
+computePassEncoder112.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle3]);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.prepend(canvas1);
+let querySet25 = device0.createQuerySet({type: 'occlusion', count: 36});
+let textureView173 = texture134.createView({dimension: 'cube', baseMipLevel: 0});
+let texture164 = device0.createTexture({size: [390, 240, 1], format: 'rg8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let texture165 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder15.setBindGroup(2, bindGroup89, new Uint32Array(365), 4, 0);
+} catch {}
+try {
+computePassEncoder113.setPipeline(pipeline4);
+} catch {}
+let textureView174 = texture134.createView({dimension: 'cube', aspect: 'all', baseArrayLayer: 3, arrayLayerCount: 6});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup47, new Uint32Array(46), 8, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer91, 'uint16', 4_844, 2_225);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 59, y: 54, z: 0},
+  aspect: 'all',
+}, new Uint8Array(126).fill(91), /* required buffer size: 126 */
+{offset: 126, bytesPerRow: 125, rowsPerImage: 64}, {width: 59, height: 14, depthOrArrayLayers: 0});
+} catch {}
+let texture166 = device0.createTexture({
+  label: '\u{1ff7f}\u00e4\u9360\uf30c',
+  size: [480, 1, 141],
+  mipLevelCount: 2,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder113.setBindGroup(2, bindGroup38, new Uint32Array(1708), 128, 0);
+} catch {}
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup82, new Uint32Array(1789), 843, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(3, buffer56, 0, 584);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(6_663).fill(99), /* required buffer size: 6_663 */
+{offset: 91, bytesPerRow: 106, rowsPerImage: 62}, {width: 0, height: 0, depthOrArrayLayers: 2});
+} catch {}
+document.body.prepend(img0);
+await gc();
+let autogeneratedBindGroupLayout46 = pipeline5.getBindGroupLayout(0);
+let buffer99 = device0.createBuffer({
+  size: 9234,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup77);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline12);
+} catch {}
+let arrayBuffer17 = buffer5.getMappedRange(664, 188);
+let bindGroup101 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout14,
+  entries: [{binding: 0, resource: {buffer: buffer86, offset: 3840, size: 753}}],
+});
+let buffer100 = device0.createBuffer({
+  size: 3738,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView175 = texture136.createView({mipLevelCount: 1});
+try {
+computePassEncoder17.setBindGroup(2, bindGroup57);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup63);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(4, buffer31, 0, 1_677);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 52, y: 24, z: 0},
+  aspect: 'all',
+}, new Uint8Array(16).fill(188), /* required buffer size: 16 */
+{offset: 16, bytesPerRow: 672}, {width: 83, height: 50, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: ['rg32sint', 'rgba16uint', 'rgba8uint'], depthReadOnly: true});
+let renderBundle24 = renderBundleEncoder24.finish({});
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup0, new Uint32Array(2528), 298, 0);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer18, 'uint16', 102, 3_877);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline11);
+} catch {}
+let pipeline14 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one', dstFactor: 'src'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    buffers: [{arrayStride: 136, attributes: [{format: 'unorm16x4', offset: 0, shaderLocation: 12}]}],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'back'},
+});
+let veryExplicitBindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 140,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup63, new Uint32Array(1741), 136, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let autogeneratedBindGroupLayout47 = pipeline0.getBindGroupLayout(0);
+let bindGroup102 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout23,
+  entries: [
+    {binding: 183, resource: textureView135},
+    {binding: 6, resource: {buffer: buffer73, offset: 0, size: 84}},
+    {binding: 203, resource: {buffer: buffer69, offset: 2560, size: 2492}},
+    {binding: 153, resource: externalTexture12},
+    {binding: 82, resource: textureView33},
+    {binding: 104, resource: textureView65},
+    {binding: 51, resource: textureView90},
+    {binding: 13, resource: sampler41},
+    {binding: 93, resource: {buffer: buffer65, offset: 1024, size: 192}},
+    {binding: 95, resource: {buffer: buffer32, offset: 0, size: 20}},
+    {binding: 88, resource: sampler57},
+  ],
+});
+let commandEncoder148 = device0.createCommandEncoder();
+let texture167 = device0.createTexture({
+  size: [120, 1, 185],
+  mipLevelCount: 2,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView176 = texture81.createView({format: 'rgba8unorm-srgb', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+let renderPassEncoder38 = commandEncoder148.beginRenderPass({
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: -502.7, g: -312.0, b: 593.9, a: 462.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 126982835,
+});
+let sampler91 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.14,
+});
+try {
+renderPassEncoder21.executeBundles([renderBundle22, renderBundle10, renderBundle8, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(7, buffer39, 0, 2_272);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+canvas1.getContext('2d');
+} catch {}
+try {
+computePassEncoder49.setBindGroup(2, bindGroup73, new Uint32Array(2970), 9, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer65, 'uint16', 692, 3_072);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer67);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 195, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData21,
+  origin: { x: 3, y: 0 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 8, y: 26, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 2, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder149 = device0.createCommandEncoder({});
+let computePassEncoder114 = commandEncoder149.beginComputePass({});
+try {
+computePassEncoder114.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder35.setStencilReference(537);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 9},
+  aspect: 'all',
+}, new Uint8Array(25_155).fill(250), /* required buffer size: 25_155 */
+{offset: 71, bytesPerRow: 66, rowsPerImage: 25}, {width: 2, height: 6, depthOrArrayLayers: 16});
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup103 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout21,
+  entries: [{binding: 0, resource: {buffer: buffer44, offset: 256}}],
+});
+let sampler92 = device0.createSampler({addressModeV: 'repeat'});
+try {
+renderPassEncoder33.executeBundles([renderBundle3, renderBundle22, renderBundle22]);
+} catch {}
+try {
+buffer62.unmap();
+} catch {}
+let querySet26 = device0.createQuerySet({type: 'occlusion', count: 1131});
+let texture168 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder107.setBindGroup(1, bindGroup102, new Uint32Array(822), 159, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer11, 'uint16', 1_560, 2_029);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 12, y: 30, z: 0},
+  aspect: 'all',
+}, new Uint8Array(430).fill(19), /* required buffer size: 430 */
+{offset: 430, bytesPerRow: 1189}, {width: 142, height: 38, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let veryExplicitBindGroupLayout28 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 50, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 400,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer101 = device0.createBuffer({
+  size: 29657,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle22]);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant({ r: 392.0, g: -815.0, b: -89.84, a: -489.0, });
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline13);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture129,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(67).fill(232), /* required buffer size: 67 */
+{offset: 67, bytesPerRow: 28}, {width: 0, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer70, 'uint16', 86, 194);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline13);
+} catch {}
+document.body.append(img1);
+let buffer102 = device0.createBuffer({size: 2366, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let commandEncoder150 = device0.createCommandEncoder({});
+let texture169 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder42.setBindGroup(2, bindGroup71, new Uint32Array(1518), 325, 0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup91);
+} catch {}
+try {
+renderPassEncoder1.setViewport(76.77576732754079, 170.52282211288173, 205.27922025782382, 22.235907174100333, 0.6732647992678132, 0.6742248080637997);
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+let bindGroup104 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout9,
+  entries: [{binding: 0, resource: {buffer: buffer16, offset: 256, size: 413}}],
+});
+let commandEncoder151 = device0.createCommandEncoder({});
+let textureView177 = texture156.createView({});
+let renderPassEncoder39 = commandEncoder150.beginRenderPass({
+  colorAttachments: [{
+  view: textureView17,
+  clearValue: { r: -584.8, g: 447.4, b: 825.0, a: 150.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet10,
+  maxDrawCount: 132947530,
+});
+try {
+computePassEncoder47.setBindGroup(1, bindGroup77);
+} catch {}
+try {
+commandEncoder151.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2600 */
+  offset: 2600,
+  buffer: buffer60,
+}, {
+  texture: texture41,
+  mipLevel: 1,
+  origin: {x: 27, y: 0, z: 3},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 3,
+  origin: {x: 30, y: 12, z: 0},
+  aspect: 'all',
+}, new Uint8Array(219).fill(50), /* required buffer size: 219 */
+{offset: 219}, {width: 16, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise17;
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(355, 67);
+let autogeneratedBindGroupLayout48 = pipeline4.getBindGroupLayout(0);
+let buffer103 = device0.createBuffer({size: 399, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder152 = device0.createCommandEncoder({});
+let textureView178 = texture136.createView({format: 'r32uint'});
+let texture170 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 16},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder115 = commandEncoder152.beginComputePass({});
+try {
+computePassEncoder115.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 569.0, g: -640.3, b: 691.6, a: -777.8, });
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline11);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let autogeneratedBindGroupLayout49 = pipeline7.getBindGroupLayout(0);
+let buffer104 = device0.createBuffer({size: 8640, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView179 = texture151.createView({mipLevelCount: 1});
+let texture171 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 8},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView180 = texture23.createView({baseArrayLayer: 6, arrayLayerCount: 4});
+let computePassEncoder116 = commandEncoder151.beginComputePass({});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let sampler93 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 97.90,
+  compare: 'always',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder40.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder116.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer65, 'uint16', 998, 1_318);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(2, bindGroup92, new Uint32Array(1879), 1_879, 0);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer32, 'uint16', 156, 196);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(6, buffer16, 0, 1_611);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture130,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(39).fill(218), /* required buffer size: 39 */
+{offset: 39, bytesPerRow: 32}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+let pipeline15 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0, constants: {}}});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let canvas2 = document.createElement('canvas');
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup87, new Uint32Array(889), 233, 0);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer65, 'uint16', 1_570, 300);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(2, buffer26, 0, 4_652);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer91, 'uint32', 584, 2_028);
+} catch {}
+try {
+  await promise22;
+} catch {}
+let commandEncoder153 = device0.createCommandEncoder({});
+let querySet27 = device0.createQuerySet({type: 'occlusion', count: 27});
+let computePassEncoder117 = commandEncoder153.beginComputePass({});
+let externalTexture20 = device0.importExternalTexture({source: videoFrame9, colorSpace: 'srgb'});
+try {
+computePassEncoder102.setBindGroup(0, bindGroup47);
+} catch {}
+try {
+computePassEncoder117.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(2, bindGroup49, new Uint32Array(2836), 417, 0);
+} catch {}
+try {
+renderPassEncoder30.setViewport(69.12845138370231, 36.67454070821356, 22.179158405658963, 15.088520914306843, 0.14727469296367635, 0.5268664233771176);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer46, 'uint32', 1_960, 230);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(3, buffer91, 6_976, 712);
+} catch {}
+let bindGroup105 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout8,
+  entries: [{binding: 0, resource: {buffer: buffer53, offset: 0, size: 479}}],
+});
+let buffer105 = device0.createBuffer({
+  size: 25702,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView181 = texture124.createView({});
+let sampler94 = device0.createSampler({addressModeW: 'repeat', magFilter: 'nearest', mipmapFilter: 'nearest'});
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup95);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup0, new Uint32Array(2272), 151, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer100, 'uint32', 220, 682);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 0, y: 24, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(27).fill(71), /* required buffer size: 27 */
+{offset: 27, bytesPerRow: 278}, {width: 195, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder154 = device0.createCommandEncoder({});
+try {
+computePassEncoder71.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+computePassEncoder52.setBindGroup(2, bindGroup5, new Uint32Array(2892), 255, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer96, 976);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(3, bindGroup73);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(3, buffer26);
+} catch {}
+try {
+commandEncoder154.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1296 */
+  offset: 1296,
+  buffer: buffer10,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 0, y: 7, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder154.copyTextureToBuffer({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 1, y: 8, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 478 widthInBlocks: 239 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 578 */
+  offset: 578,
+  bytesPerRow: 18688,
+  rowsPerImage: 629,
+  buffer: buffer7,
+}, {width: 239, height: 215, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout50 = pipeline15.getBindGroupLayout(0);
+let commandEncoder155 = device0.createCommandEncoder({});
+let computePassEncoder118 = commandEncoder154.beginComputePass({});
+let renderPassEncoder40 = commandEncoder155.beginRenderPass({
+  colorAttachments: [{
+  view: textureView130,
+  depthSlice: 36,
+  clearValue: { r: -398.7, g: -441.4, b: -337.7, a: 244.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler95 = device0.createSampler({addressModeU: 'mirror-repeat', lodMaxClamp: 97.14});
+try {
+computePassEncoder46.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup105);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(7, buffer49, 2_348, 360);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 7}
+*/
+{
+  source: videoFrame18,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 5, y: 7, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas3.getContext('webgpu');
+try {
+  await promise21;
+} catch {}
+let textureView182 = texture16.createView({});
+try {
+computePassEncoder73.setBindGroup(2, bindGroup2, new Uint32Array(702), 87, 0);
+} catch {}
+try {
+computePassEncoder118.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer71, 'uint16', 10_486, 18_662);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer25, 0, 1_311);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(2, bindGroup57);
+} catch {}
+try {
+buffer44.destroy();
+} catch {}
+let buffer106 = device0.createBuffer({
+  size: 807,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder39.setBindGroup(1, bindGroup59);
+} catch {}
+try {
+computePassEncoder33.setBindGroup(2, bindGroup50, new Uint32Array(628), 153, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup94);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup24, new Uint32Array(215), 17, 0);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer46, 'uint16', 1_308, 343);
+} catch {}
+try {
+buffer47.unmap();
+} catch {}
+let commandEncoder156 = device0.createCommandEncoder({});
+let computePassEncoder119 = commandEncoder156.beginComputePass();
+try {
+computePassEncoder119.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer46, 'uint16', 4_240, 2_265);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup50, new Uint32Array(795), 14, 0);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(0, buffer23);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let gpuCanvasContext5 = canvas2.getContext('webgpu');
+let bindGroup106 = device0.createBindGroup({layout: veryExplicitBindGroupLayout13, entries: [{binding: 140, resource: textureView182}]});
+let buffer107 = device0.createBuffer({size: 9456, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE, mappedAtCreation: false});
+try {
+computePassEncoder82.setBindGroup(0, bindGroup24, new Uint32Array(833), 23, 0);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(152);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(0, bindGroup76, new Uint32Array(109), 4, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 240, height: 1, depthOrArrayLayers: 34}
+*/
+{
+  source: videoFrame25,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 103, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+let autogeneratedBindGroupLayout51 = pipeline7.getBindGroupLayout(0);
+let renderBundle25 = renderBundleEncoder25.finish({});
+let bindGroup107 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout49,
+  entries: [{binding: 0, resource: {buffer: buffer45, offset: 2048, size: 3008}}],
+});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup23, new Uint32Array(1484), 581, 0);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup97);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline11);
+} catch {}
+videoFrame26 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'smpteSt4281', transfer: 'unspecified'} });
+let buffer108 = device0.createBuffer({size: 15233, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let textureView183 = texture151.createView({arrayLayerCount: 1});
+let sampler96 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 63.06,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder100.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup91, new Uint32Array(263), 0, 0);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer89);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer51, 344, new BigUint64Array(2539), 902, 360);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let textureView184 = texture156.createView({});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup59);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup77);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer34, 756, new Float32Array(8285), 1303, 12);
+} catch {}
+let bindGroup108 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [{binding: 0, resource: {buffer: buffer23, offset: 256}}],
+});
+let sampler97 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 75.38,
+});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+computePassEncoder58.setBindGroup(3, bindGroup86, new Uint32Array(1542), 62, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer76, 'uint32', 616, 601);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline12);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55); };
+} catch {}
+try {
+computePassEncoder91.setBindGroup(2, bindGroup101, new Uint32Array(4622), 315, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer65, 'uint32', 684, 315);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(7, buffer49, 1_680);
+} catch {}
+try {
+buffer82.unmap();
+} catch {}
+let autogeneratedBindGroupLayout52 = pipeline9.getBindGroupLayout(0);
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout4]});
+let buffer109 = device0.createBuffer({size: 60066, usage: GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder157 = device0.createCommandEncoder({});
+let texture172 = device0.createTexture({
+  size: {width: 195},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder120 = commandEncoder157.beginComputePass({label: '\u63ba\ufcf6\uebc9\u{1f73b}\u8d46\u08dd\u0d87\u99b5\ubf34\u6d32\ufa2b'});
+try {
+computePassEncoder120.setBindGroup(1, bindGroup94, new Uint32Array(496), 162, 0);
+} catch {}
+try {
+renderPassEncoder18.setViewport(159.17821520091218, 0.5525699112077318, 48.22795887187192, 0.320566282325916, 0.660435662064412, 0.7540548792983619);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer42, 'uint32', 3_624, 3_474);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(0, buffer36, 0, 20);
+} catch {}
+try {
+buffer95.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 780, height: 480, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 39, y: 7 },
+  flipY: true,
+}, {
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 29, y: 36, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 51, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup109 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout25,
+  entries: [
+    {binding: 206, resource: {buffer: buffer28, offset: 1280, size: 1232}},
+    {binding: 113, resource: sampler95},
+  ],
+});
+let textureView185 = texture125.createView({aspect: 'all', mipLevelCount: 1});
+let textureView186 = texture33.createView({aspect: 'depth-only', mipLevelCount: 1});
+try {
+computePassEncoder92.setPipeline(pipeline7);
+} catch {}
+try {
+computePassEncoder120.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup87, []);
+} catch {}
+try {
+renderPassEncoder14.setViewport(138.2407412746286, 0.6402762336912868, 49.147147274181805, 0.3231089075799061, 0.6290208225027683, 0.7849504209236116);
+} catch {}
+document.body.prepend(canvas0);
+let veryExplicitBindGroupLayout29 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 191,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer110 = device0.createBuffer({size: 5597, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup74);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup44, new Uint32Array(282), 26, 0);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer96, 'uint32', 112, 1_235);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer0, 1_712, 576);
+} catch {}
+let buffer111 = device0.createBuffer({size: 13277, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let texture173 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler98 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 85.81,
+});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 50}
+*/
+{
+  source: imageData1,
+  origin: { x: 13, y: 0 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 9, y: 24, z: 16},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 22, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup110 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 85, resource: {buffer: buffer42, offset: 256, size: 2924}}],
+});
+let textureView187 = texture164.createView({});
+try {
+computePassEncoder55.setBindGroup(0, bindGroup100);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup60, new Uint32Array(2625), 622, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0, renderBundle22]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 1500, new Int16Array(4093), 1250, 468);
+} catch {}
+let autogeneratedBindGroupLayout53 = pipeline8.getBindGroupLayout(0);
+let bindGroup111 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout8,
+  entries: [{binding: 0, resource: {buffer: buffer91, offset: 1536, size: 1786}}],
+});
+let sampler99 = device0.createSampler({addressModeV: 'repeat', lodMinClamp: 51.80, lodMaxClamp: 91.38});
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup63, new Uint32Array(1120), 248, 0);
+} catch {}
+let buffer112 = device0.createBuffer({size: 11816, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup79);
+} catch {}
+let arrayBuffer18 = buffer22.getMappedRange(56, 0);
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let buffer113 = device0.createBuffer({
+  size: 8198,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder158 = device0.createCommandEncoder();
+let computePassEncoder121 = commandEncoder158.beginComputePass({});
+try {
+computePassEncoder118.setBindGroup(0, bindGroup15, []);
+} catch {}
+try {
+computePassEncoder103.setBindGroup(3, bindGroup78, new Uint32Array(197), 10, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup33, new Uint32Array(2818), 669, 0);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle22, renderBundle4, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer36, 424);
+} catch {}
+videoFrame27 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'film', transfer: 'smpteSt4281'} });
+let commandEncoder159 = device0.createCommandEncoder();
+let texture174 = device0.createTexture({
+  size: [480],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder122 = commandEncoder159.beginComputePass({});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup104, new Uint32Array(1554), 52, 0);
+} catch {}
+try {
+computePassEncoder121.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(53);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline11);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let bindGroup112 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout12,
+  entries: [
+    {binding: 113, resource: sampler33},
+    {binding: 206, resource: {buffer: buffer106, offset: 0, size: 312}},
+  ],
+});
+let texture175 = device0.createTexture({
+  size: [240, 1, 1],
+  sampleCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder113.setBindGroup(2, bindGroup39);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup49, new Uint32Array(1379), 372, 0);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer60, 'uint16', 1_488, 385);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle6, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer36, 'uint16', 96, 349);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer10);
+} catch {}
+let arrayBuffer19 = buffer64.getMappedRange(240, 0);
+document.body.append(img1);
+let bindGroup113 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 0, resource: {buffer: buffer41, offset: 512, size: 311}}],
+});
+let buffer114 = device0.createBuffer({
+  size: 4157,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder160 = device0.createCommandEncoder();
+let textureView188 = texture5.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder123 = commandEncoder160.beginComputePass();
+try {
+renderPassEncoder21.setBindGroup(0, bindGroup15, new Uint32Array(4853), 1_117, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle3, renderBundle8, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, buffer93);
+} catch {}
+let arrayBuffer20 = buffer22.getMappedRange(64, 4);
+try {
+buffer101.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture176 = device0.createTexture({
+  size: [195],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup113, new Uint32Array(1821), 251, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup34, new Uint32Array(6358), 1_013, 0);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(3, buffer39);
+} catch {}
+try {
+  await buffer90.mapAsync(GPUMapMode.WRITE, 1544, 2252);
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\uc36c');
+} catch {}
+let commandEncoder161 = device0.createCommandEncoder({label: '\uadac\u1376'});
+let textureView189 = texture176.createView({aspect: 'all', baseArrayLayer: 0});
+try {
+computePassEncoder112.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+computePassEncoder122.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle5, renderBundle4, renderBundle7]);
+} catch {}
+let commandEncoder162 = device0.createCommandEncoder({});
+let texture177 = device0.createTexture({
+  size: {width: 16},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup38, new Uint32Array(843), 1, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle6, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer46, 'uint32', 1_348, 866);
+} catch {}
+let arrayBuffer21 = buffer90.getMappedRange(1640, 116);
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55); };
+} catch {}
+let texture178 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder124 = commandEncoder161.beginComputePass({});
+let textureView190 = texture57.createView({});
+let renderPassEncoder41 = commandEncoder162.beginRenderPass({
+  colorAttachments: [{
+  view: textureView85,
+  clearValue: { r: -420.3, g: 158.2, b: 449.1, a: 501.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup61);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(0, bindGroup15, new Uint32Array(3330), 126, 0);
+} catch {}
+try {
+computePassEncoder124.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup57);
+} catch {}
+let autogeneratedBindGroupLayout54 = pipeline14.getBindGroupLayout(0);
+let commandEncoder163 = device0.createCommandEncoder({});
+let texture179 = device0.createTexture({
+  size: [195, 120, 78],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder125 = commandEncoder163.beginComputePass({});
+try {
+computePassEncoder123.setBindGroup(1, bindGroup21, new Uint32Array(3393), 39, 0);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup61, new Uint32Array(2783), 375, 0);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(1, buffer98);
+} catch {}
+try {
+querySet12.destroy();
+} catch {}
+try {
+buffer62.unmap();
+} catch {}
+let pipeline16 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex1',
+    constants: {},
+    buffers: [{arrayStride: 44, attributes: [{format: 'float16x2', offset: 0, shaderLocation: 12}]}],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32'},
+});
+let imageData24 = new ImageData(16, 104);
+let commandEncoder164 = device0.createCommandEncoder({});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup81);
+} catch {}
+try {
+computePassEncoder123.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer39, 'uint16', 3_266, 566);
+} catch {}
+try {
+commandEncoder164.copyBufferToBuffer(buffer40, 16, buffer36, 44, 36);
+} catch {}
+await gc();
+let buffer115 = device0.createBuffer({
+  size: 25538,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture180 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 1},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder126 = commandEncoder164.beginComputePass();
+try {
+computePassEncoder32.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder126.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer16, 'uint16', 638, 638);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline14);
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+let texture181 = device0.createTexture({
+  size: [780, 480, 1],
+  mipLevelCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler100 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 92.64});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup32, []);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer74, 'uint16', 34, 46);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer60);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: img5,
+  origin: { x: 7, y: 8 },
+  flipY: false,
+}, {
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+videoFrame28 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpteRp431', transfer: 'smpte170m'} });
+let autogeneratedBindGroupLayout55 = pipeline9.getBindGroupLayout(0);
+try {
+computePassEncoder15.setBindGroup(2, bindGroup48);
+} catch {}
+try {
+computePassEncoder125.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle6, renderBundle1, renderBundle22, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(3, buffer27);
+} catch {}
+let buffer116 = device0.createBuffer({size: 17465, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let textureView191 = texture176.createView({});
+let texture182 = device0.createTexture({
+  size: [97, 60, 1],
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView192 = texture55.createView({mipLevelCount: 1});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let renderBundle26 = renderBundleEncoder26.finish({});
+let sampler101 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 92.69});
+try {
+computePassEncoder124.setBindGroup(0, bindGroup11, new Uint32Array(187), 3, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer68, 'uint16', 662, 5_432);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer51, 0, 3_112);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(11).fill(226), /* required buffer size: 11 */
+{offset: 11}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let veryExplicitBindGroupLayout30 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 140,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout56 = pipeline15.getBindGroupLayout(0);
+let bindGroup114 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout11,
+  entries: [{binding: 0, resource: {buffer: buffer13, offset: 11520, size: 757}}],
+});
+let sampler102 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMaxClamp: 67.41,
+});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup2, new Uint32Array(1601), 326, 0);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer32, 'uint16', 564, 29);
+} catch {}
+let bindGroup115 = device0.createBindGroup({
+  label: '\u20b7\u0088\u1042\u0d32\u6e64',
+  layout: autogeneratedBindGroupLayout55,
+  entries: [{binding: 0, resource: {buffer: buffer41, offset: 1024, size: 22}}],
+});
+try {
+computePassEncoder45.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup40);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup28, new Uint32Array(3408), 68, 0);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(1, buffer80);
+} catch {}
+try {
+buffer113.unmap();
+} catch {}
+let commandEncoder165 = device0.createCommandEncoder();
+let textureView193 = texture81.createView({format: 'rgba8unorm-srgb', mipLevelCount: 1, baseArrayLayer: 6, arrayLayerCount: 3});
+let renderPassEncoder42 = commandEncoder165.beginRenderPass({
+  colorAttachments: [{view: textureView118, depthSlice: 17, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 134726036,
+});
+try {
+computePassEncoder99.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(2, bindGroup16, new Uint32Array(409), 95, 0);
+} catch {}
+try {
+renderPassEncoder35.beginOcclusionQuery(109);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle6, renderBundle22, renderBundle1, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder30.setBlendConstant({ r: 677.4, g: -277.2, b: -424.5, a: 233.8, });
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(6, buffer21, 0, 3_831);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup23, new Uint32Array(537), 1, 0);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+let pipeline17 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-src-alpha'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 276,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x4', offset: 100, shaderLocation: 12}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list'},
+});
+await gc();
+let veryExplicitBindGroupLayout31 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 10,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {binding: 93, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+  ],
+});
+let bindGroup116 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout28,
+  entries: [{binding: 0, resource: {buffer: buffer86, offset: 1792, size: 910}}],
+});
+let textureView194 = texture64.createView({});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true});
+let sampler103 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.25,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder46.setBindGroup(2, bindGroup93);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup104, new Uint32Array(1042), 6, 0);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle6, renderBundle6, renderBundle1, renderBundle1, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup66);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer43, 'uint32', 276, 433);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData16,
+  origin: { x: 3, y: 0 },
+  flipY: true,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 18},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder166 = device0.createCommandEncoder({});
+let querySet28 = device0.createQuerySet({type: 'occlusion', count: 483});
+let computePassEncoder127 = commandEncoder166.beginComputePass({});
+try {
+computePassEncoder127.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(3, buffer67, 0, 198);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise24 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 240, height: 1, depthOrArrayLayers: 34}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 4, y: 1 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 20},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup117 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 85, resource: {buffer: buffer70, offset: 0, size: 1236}}],
+});
+let buffer117 = device0.createBuffer({size: 2385, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let commandEncoder167 = device0.createCommandEncoder({});
+try {
+computePassEncoder59.setBindGroup(1, bindGroup87);
+} catch {}
+try {
+computePassEncoder71.setBindGroup(3, bindGroup34, new Uint32Array(1058), 27, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup85, new Uint32Array(488), 61, 0);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(7, buffer91, 4_108);
+} catch {}
+await gc();
+videoFrame29 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'smpteRp431', transfer: 'unspecified'} });
+let bindGroup118 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout23,
+  entries: [{binding: 0, resource: {buffer: buffer28, offset: 3072, size: 1601}}],
+});
+let commandEncoder168 = device0.createCommandEncoder({});
+let texture183 = device0.createTexture({
+  size: [780, 480, 1],
+  mipLevelCount: 3,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup97, new Uint32Array(3308), 335, 0);
+} catch {}
+try {
+renderPassEncoder35.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder168.copyBufferToBuffer(buffer84, 1348, buffer28, 1164, 1932);
+} catch {}
+try {
+commandEncoder167.copyBufferToTexture({
+  /* bytesInLastRow: 392 widthInBlocks: 49 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 472 */
+  offset: 472,
+  bytesPerRow: 30208,
+  buffer: buffer101,
+}, {
+  texture: texture183,
+  mipLevel: 2,
+  origin: {x: 10, y: 96, z: 0},
+  aspect: 'all',
+}, {width: 49, height: 13, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder167.resolveQuerySet(querySet9, 32, 5, buffer51, 768);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+try {
+textureView117.label = '\u{1fd6f}\u{1fe88}';
+} catch {}
+let autogeneratedBindGroupLayout57 = pipeline10.getBindGroupLayout(0);
+let commandEncoder169 = device0.createCommandEncoder({});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup94);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle0, renderBundle11, renderBundle3, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup73);
+} catch {}
+try {
+renderBundleEncoder27.setIndexBuffer(buffer34, 'uint16', 250, 361);
+} catch {}
+try {
+commandEncoder168.copyTextureToBuffer({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 568 widthInBlocks: 142 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 904 */
+  offset: 904,
+  buffer: buffer19,
+}, {width: 142, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+let autogeneratedBindGroupLayout58 = pipeline1.getBindGroupLayout(0);
+let bindGroup119 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout54,
+  entries: [
+    {binding: 184, resource: {buffer: buffer9, offset: 0}},
+    {binding: 19, resource: textureView186},
+    {binding: 134, resource: {buffer: buffer87, offset: 256, size: 727}},
+  ],
+});
+let texture184 = device0.createTexture({
+  label: '\u58e1\uc3fa\u67a2\u0620\u2fc9\u4010\u{1ff22}\u7611\u{1fc97}\u{1ff1f}',
+  size: [240, 1, 6],
+  mipLevelCount: 5,
+  format: 'r8snorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder128 = commandEncoder168.beginComputePass({});
+let renderBundle27 = renderBundleEncoder27.finish({});
+let sampler104 = device0.createSampler({addressModeV: 'clamp-to-edge', lodMaxClamp: 13.43});
+try {
+computePassEncoder128.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup118, []);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup44, new Uint32Array(20), 5, 0);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle6]);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await promise24;
+} catch {}
+document.body.append(canvas1);
+let bindGroup120 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout23,
+  entries: [{binding: 0, resource: {buffer: buffer39, offset: 1280}}],
+});
+let commandEncoder170 = device0.createCommandEncoder({});
+let computePassEncoder129 = commandEncoder170.beginComputePass({});
+let renderPassEncoder43 = commandEncoder169.beginRenderPass({
+  colorAttachments: [{
+  view: textureView165,
+  depthSlice: 12,
+  clearValue: { r: -893.8, g: -935.2, b: -743.7, a: 942.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder54.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+computePassEncoder95.setBindGroup(0, bindGroup1, new Uint32Array(1786), 71, 0);
+} catch {}
+try {
+computePassEncoder129.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup115);
+} catch {}
+try {
+renderPassEncoder32.setBlendConstant({ r: 40.35, g: -610.5, b: -534.5, a: -911.0, });
+} catch {}
+try {
+commandEncoder167.copyBufferToBuffer(buffer82, 936, buffer46, 536, 500);
+} catch {}
+try {
+commandEncoder167.resolveQuerySet(querySet16, 79, 100, buffer9, 256);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup121 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout36,
+  entries: [
+    {binding: 184, resource: {buffer: buffer66, offset: 4096, size: 676}},
+    {binding: 19, resource: textureView86},
+    {binding: 134, resource: {buffer: buffer42, offset: 256, size: 2532}},
+  ],
+});
+let buffer118 = device0.createBuffer({
+  size: 604,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture185 = device0.createTexture({
+  label: '\u5304\u020e\u{1fce9}\u019b\ufdb4',
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture186 = device0.createTexture({
+  size: [120],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView195 = texture69.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 10});
+try {
+computePassEncoder107.end();
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup117);
+} catch {}
+let arrayBuffer22 = buffer64.getMappedRange(248, 0);
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let autogeneratedBindGroupLayout59 = pipeline2.getBindGroupLayout(0);
+let bindGroup122 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout15,
+  entries: [{binding: 0, resource: {buffer: buffer13, offset: 1536, size: 488}}],
+});
+let commandEncoder171 = device0.createCommandEncoder();
+let texture187 = gpuCanvasContext3.getCurrentTexture();
+let renderPassEncoder44 = commandEncoder167.beginRenderPass({
+  colorAttachments: [{
+  view: textureView41,
+  depthSlice: 28,
+  clearValue: { r: 704.0, g: -886.1, b: 391.5, a: 480.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler105 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 90.73,
+});
+try {
+computePassEncoder63.setBindGroup(1, bindGroup110);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle0, renderBundle4, renderBundle11, renderBundle10, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer74, 'uint16', 86, 113);
+} catch {}
+try {
+commandEncoder171.copyBufferToBuffer(buffer65, 184, buffer26, 7744, 272);
+} catch {}
+try {
+commandEncoder142.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 64 */
+  offset: 64,
+  bytesPerRow: 13824,
+  buffer: buffer99,
+}, {
+  texture: texture120,
+  mipLevel: 1,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 107, depthOrArrayLayers: 0});
+} catch {}
+let textureView196 = texture154.createView({});
+let texture188 = device0.createTexture({
+  size: [240, 1, 1],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder19.beginOcclusionQuery(112);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData9,
+  origin: { x: 4, y: 1 },
+  flipY: false,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 2, y: 3, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+videoFrame30 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'bt2020', transfer: 'linear'} });
+let bindGroup123 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout12,
+  entries: [{binding: 0, resource: {buffer: buffer66, offset: 2048, size: 791}}],
+});
+let commandBuffer2 = commandEncoder142.finish();
+let textureView197 = texture39.createView({aspect: 'all', baseArrayLayer: 0});
+let renderPassEncoder45 = commandEncoder171.beginRenderPass({
+  label: '\u{1ff6c}\u0c5b',
+  colorAttachments: [{
+  view: textureView5,
+  depthSlice: 30,
+  clearValue: { r: 18.69, g: -281.5, b: 683.6, a: 937.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let promise25 = device0.queue.onSubmittedWorkDone();
+let texture189 = device0.createTexture({
+  size: {width: 120, height: 1, depthOrArrayLayers: 42},
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture21 = device0.importExternalTexture({source: videoFrame16});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup39, new Uint32Array(355), 97, 0);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(200, 3, 157, 39);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline12);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+let pipeline18 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule0}});
+try {
+  await promise23;
+} catch {}
+let textureView198 = texture189.createView({});
+let texture190 = device0.createTexture({
+  size: {width: 480, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler106 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 96.67,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder28.setBindGroup(3, bindGroup67, new Uint32Array(251), 47, 0);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(3, buffer36, 84, 173);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 82}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 29, y: 1 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 41},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline19 = await device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule1, entryPoint: 'compute1'}});
+try {
+renderPassEncoder33.setVertexBuffer(0, buffer51, 0, 2_022);
+} catch {}
+let buffer119 = device0.createBuffer({size: 1690, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandEncoder172 = device0.createCommandEncoder({});
+try {
+computePassEncoder127.setBindGroup(0, bindGroup68);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup72, new Uint32Array(2646), 347, 0);
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline12);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55); };
+} catch {}
+let bindGroup124 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout47,
+  entries: [{binding: 0, resource: {buffer: buffer37, offset: 1536, size: 5997}}],
+});
+let buffer120 = device0.createBuffer({
+  size: 8,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet29 = device0.createQuerySet({type: 'occlusion', count: 805});
+let texture191 = device0.createTexture({size: [195, 120, 1], mipLevelCount: 2, format: 'depth24plus', usage: GPUTextureUsage.COPY_DST});
+let textureView199 = texture74.createView({aspect: 'all', arrayLayerCount: 2});
+let computePassEncoder130 = commandEncoder172.beginComputePass({});
+try {
+computePassEncoder130.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup107);
+} catch {}
+let bindGroup125 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout18,
+  entries: [{binding: 0, resource: {buffer: buffer38, offset: 5376, size: 9761}}],
+});
+let buffer121 = device0.createBuffer({size: 7921, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder173 = device0.createCommandEncoder();
+let computePassEncoder131 = commandEncoder173.beginComputePass({});
+try {
+computePassEncoder131.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup67, new Uint32Array(5000), 1_134, 0);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer118, 'uint32', 12, 109);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(7, buffer21, 0, 5_156);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture166,
+  mipLevel: 0,
+  origin: {x: 166, y: 0, z: 12},
+  aspect: 'all',
+}, new Uint8Array(156_513).fill(62), /* required buffer size: 156_513 */
+{offset: 77, bytesPerRow: 148, rowsPerImage: 151}, {width: 25, height: 0, depthOrArrayLayers: 8});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let textureView200 = texture189.createView({baseMipLevel: 0});
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.append(img3);
+let buffer122 = device0.createBuffer({
+  label: '\u7fe6\u{1f718}\u030f\u05c4\u5054\u37cb\ueb1d\u{1fcde}\u05d2\u644f\u{1ff3e}',
+  size: 7025,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+renderPassEncoder18.insertDebugMarker('\u{1f723}');
+} catch {}
+let promise26 = device0.queue.onSubmittedWorkDone();
+let bindGroup126 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout7,
+  entries: [{binding: 0, resource: {buffer: buffer70, offset: 0}}],
+});
+let texture192 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 274},
+  mipLevelCount: 7,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8unorm'],
+});
+let sampler107 = device0.createSampler({addressModeU: 'mirror-repeat'});
+try {
+computePassEncoder62.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup77);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup75, new Uint32Array(534), 7, 0);
+} catch {}
+try {
+renderPassEncoder22.beginOcclusionQuery(139);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer70, 'uint16', 88, 114);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise27 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let texture193 = device0.createTexture({
+  size: [120, 1, 12],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder34.setVertexBuffer(2, buffer80, 160, 102);
+} catch {}
+try {
+  await promise25;
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+enable f16;
+
+struct T0 {
+  @align(16) @size(16) f0: atomic<i32>,
+}
+
+struct T2 {
+  @align(16) @size(16) f0: array<u32>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<private> vp0: array<vec2i, 1> = array<vec2i, 1>(vec2i(572, 215));
+
+alias vec3b = vec3<bool>;
+
+struct FragmentOutput1 {
+  @location(2) f0: vec4i,
+  @location(1) @interpolate(flat, sample) f1: vec4u,
+  @location(0) f2: vec4f,
+  @builtin(frag_depth) f3: f32,
+  @location(3) @interpolate(flat, center) f4: vec2u,
+}
+
+struct T1 {
+  @align(16) @size(16) f0: array<mat2x2h>,
+}
+
+fn fn0() -> array<array<mat2x2f, 2>, 1> {
+  var out: array<array<mat2x2f, 2>, 1>;
+  out[u32(unconst_u32(44))][u32(unconst_u32(21))] = mat2x2f(bitcast<vec2f>(vp1[0].f1.yy), vec2f(vp1[0].f1.zw));
+  let vf36: f32 = vp1[vp1[0].f4.y].f2[u32(unconst_u32(621))];
+  var vf37: i32 = extractBits(i32(unconst_i32(425)), u32(unconst_u32(310)), u32(unconst_u32(243)));
+  let ptr21: ptr<private, array<vec2i, 1>> = &vp0;
+  vf37 += i32(vp1[u32(unconst_u32(471))].f4.y);
+  let ptr22: ptr<private, vec4f> = &vp1[0].f2;
+  vp1[u32(unconst_u32(341))].f2 -= vp1[0].f2;
+  let ptr23: ptr<private, vec2i> = &vp0[u32(unconst_u32(120))];
+  let ptr24: ptr<private, f32> = &vp1[u32(unconst_u32(105))].f3;
+  let ptr25: ptr<private, vec4u> = &vp1[u32(unconst_u32(17))].f1;
+  return out;
+}
+
+var<private> vp1: array<FragmentOutput1, 1> = array<FragmentOutput1, 1>();
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct FragmentOutput2 {
+  @location(3) @interpolate(flat, sample) f0: u32,
+  @location(0) @interpolate(perspective) f1: vec2f,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn fn1() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  fn0();
+  fn0();
+  var vf38 = fn0();
+  out.f1 -= vec4u(degrees(vec3h(unconst_f16(5656.0), unconst_f16(476.6), unconst_f16(7153.7))).xzyz);
+  out.f1 += vec4u(asin(vec2h(unconst_f16(20815.8), unconst_f16(965.1))).xyxy);
+  fn0();
+  return out;
+}
+
+@vertex
+fn vertex2(@location(13) @interpolate(flat, sample) a0: i32) -> @builtin(position) vec4f {
+  var out: vec4f;
+  var vf39 = fn1();
+  fn1();
+  out = vec4f(vf39.f1);
+  out = vec4f(vp1[u32(unconst_u32(44))].f1);
+  vp1[u32(unconst_u32(316))].f4 = vec2u(saturate(vec3h(unconst_f16(11311.7), unconst_f16(5770.2), unconst_f16(2304.4))).bb);
+  fn0();
+  let vf40: vec2u = abs(vec2u(unconst_u32(52), unconst_u32(153)));
+  vp1[u32(unconst_u32(59))].f4 *= vec2u(bitcast<u32>(vp1[u32(unconst_u32(110))].f3));
+  vf39 = FragmentOutput1(vec4i(bitcast<i32>(vp1[0].f2[u32(unconst_u32(13))])), vec4u(bitcast<u32>(vp1[0].f2[u32(unconst_u32(13))])), vec4f(vp1[0].f2[u32(unconst_u32(13))]), vp1[0].f2[u32(unconst_u32(13))], vec2u(bitcast<u32>(vp1[0].f2[u32(unconst_u32(13))])));
+  return out;
+}
+
+@fragment
+fn fragment1() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  let ptr26: ptr<private, f32> = &vp1[u32(unconst_u32(259))].f3;
+  return out;
+}
+
+@fragment
+fn fragment2() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  let vf41: i32 = vp1[u32(unconst_u32(152))].f0[u32(unconst_u32(20))];
+  var vf42: i32 = vf41;
+  out.f1 -= vec2f(f32(vp0[u32(unconst_u32(172))][u32(vp0[0][u32(unconst_u32(31))])]));
+  vf42 = i32(vp1[u32(unconst_u32(257))].f3);
+  let ptr27: ptr<private, f32> = &vp1[0].f3;
+  out.f0 >>= u32(vp1[0].f3);
+  let ptr28: ptr<private, vec4f> = &vp1[0].f2;
+  var vf43: i32 = vf41;
+  vp0[u32(unconst_u32(602))] = bitcast<vec2i>(vp1[u32(unconst_u32(110))].f4);
+  let vf44: f32 = vp1[u32(unconst_u32(230))].f2[u32(unconst_u32(17))];
+  return out;
+}`,
+});
+let buffer124 = device0.createBuffer({
+  size: 25352,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let commandEncoder174 = device0.createCommandEncoder({});
+let texture194 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 44},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView201 = texture135.createView({aspect: 'all', arrayLayerCount: 1});
+let renderPassEncoder46 = commandEncoder174.beginRenderPass({
+  colorAttachments: [{
+  view: textureView151,
+  clearValue: { r: 770.2, g: 555.9, b: 371.0, a: 100.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 738638719,
+});
+let sampler108 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 94.40});
+try {
+computePassEncoder118.setBindGroup(3, bindGroup72);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle0, renderBundle10, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(5, buffer53, 0, 1_434);
+} catch {}
+document.body.prepend(img0);
+let bindGroup127 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout5,
+  entries: [{binding: 0, resource: {buffer: buffer39, offset: 7168}}],
+});
+let commandEncoder175 = device0.createCommandEncoder({});
+let computePassEncoder132 = commandEncoder175.beginComputePass();
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup33, []);
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(3, 2, 0, 4);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(0, buffer46, 2_904, 257);
+} catch {}
+try {
+  await promise27;
+} catch {}
+let commandEncoder176 = device0.createCommandEncoder({});
+let texture195 = device0.createTexture({
+  size: [16, 16, 64],
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder47 = commandEncoder176.beginRenderPass({
+  colorAttachments: [{
+  view: textureView192,
+  clearValue: { r: -702.8, g: 561.3, b: 932.9, a: 660.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet24,
+});
+let sampler109 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 64.81,
+});
+try {
+computePassEncoder17.setBindGroup(3, bindGroup77, new Uint32Array(2659), 218, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup78, new Uint32Array(16), 1, 0);
+} catch {}
+try {
+renderPassEncoder22.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer76, 'uint32', 632, 1_852);
+} catch {}
+try {
+buffer44.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandEncoder177 = device0.createCommandEncoder({});
+let texture196 = gpuCanvasContext0.getCurrentTexture();
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true});
+let renderBundle28 = renderBundleEncoder28.finish({});
+try {
+computePassEncoder90.end();
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup105);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer43, 'uint16', 1_676, 154);
+} catch {}
+try {
+commandEncoder123.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout60 = pipeline8.getBindGroupLayout(0);
+let computePassEncoder133 = commandEncoder177.beginComputePass({});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let renderBundle29 = renderBundleEncoder29.finish({});
+let sampler110 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.01,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup89);
+} catch {}
+try {
+computePassEncoder133.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder123.copyTextureToTexture({
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture150,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder134 = commandEncoder123.beginComputePass({});
+let sampler111 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 82.63,
+  lodMaxClamp: 96.68,
+});
+try {
+computePassEncoder134.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(1, bindGroup121);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(1, bindGroup67, new Uint32Array(1627), 291, 0);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer113, 'uint32', 776, 2_703);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(7, buffer93);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer76, 296, new Float32Array(1742), 715, 16);
+} catch {}
+let veryExplicitBindGroupLayout32 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 85, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let textureView202 = texture107.createView({format: 'rg32uint'});
+let externalTexture22 = device0.importExternalTexture({source: videoFrame15, colorSpace: 'display-p3'});
+try {
+renderPassEncoder14.setIndexBuffer(buffer100, 'uint32', 228, 1_044);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(2, undefined, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer21.detached) { new Uint8Array(arrayBuffer21).fill(0x55); };
+} catch {}
+let commandEncoder178 = device0.createCommandEncoder({});
+let texture197 = device0.createTexture({
+  label: '\u2a4f\ua885',
+  size: [480, 1, 18],
+  mipLevelCount: 3,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder135 = commandEncoder178.beginComputePass({});
+let sampler112 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.58,
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup125, new Uint32Array(92), 0, 0);
+} catch {}
+try {
+computePassEncoder132.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup123);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer106, 'uint32', 4, 8);
+} catch {}
+try {
+buffer53.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_DST, colorSpace: 'display-p3'});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(106).fill(74), /* required buffer size: 106 */
+{offset: 106, bytesPerRow: 61, rowsPerImage: 127}, {width: 48, height: 30, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise26;
+} catch {}
+let veryExplicitBindGroupLayout33 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 167,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView203 = texture150.createView({aspect: 'all'});
+let sampler113 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 20.71,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder70.setBindGroup(1, bindGroup98, new Uint32Array(197), 17, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup38);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder179 = device0.createCommandEncoder({});
+let textureView204 = texture133.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder136 = commandEncoder179.beginComputePass({});
+try {
+computePassEncoder136.setPipeline(pipeline9);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture160,
+  mipLevel: 0,
+  origin: {x: 8, y: 7, z: 0},
+  aspect: 'all',
+}, new Uint8Array(127).fill(127), /* required buffer size: 127 */
+{offset: 127, bytesPerRow: 104}, {width: 7, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout34 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 17,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup128 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout45,
+  entries: [{binding: 0, resource: {buffer: buffer17, offset: 512, size: 68}}],
+});
+let buffer125 = device0.createBuffer({size: 10241, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder180 = device0.createCommandEncoder({});
+try {
+computePassEncoder71.setBindGroup(2, bindGroup98, new Uint32Array(1497), 70, 0);
+} catch {}
+try {
+computePassEncoder115.end();
+} catch {}
+try {
+renderPassEncoder39.setBlendConstant({ r: -635.5, g: -695.3, b: -244.2, a: -944.4, });
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline13);
+} catch {}
+let veryExplicitBindGroupLayout35 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 357,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 378,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 382,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 395,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let commandEncoder181 = device0.createCommandEncoder({});
+let renderPassEncoder48 = commandEncoder181.beginRenderPass({
+  colorAttachments: [{
+  view: textureView5,
+  depthSlice: 17,
+  clearValue: { r: 449.0, g: -906.3, b: 326.5, a: 256.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet15,
+});
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(6, buffer91);
+} catch {}
+try {
+commandEncoder180.clearBuffer(buffer122, 472, 80);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let commandEncoder182 = device0.createCommandEncoder({label: '\uec89\u948b\u{1f619}\u9041\u1c65\u0baf\u{1fb4e}\ue48f\u028c'});
+let computePassEncoder137 = commandEncoder152.beginComputePass({});
+try {
+computePassEncoder137.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer112, 448, 857);
+} catch {}
+try {
+  await buffer57.mapAsync(GPUMapMode.READ, 0, 304);
+} catch {}
+try {
+commandEncoder182.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 100, y: 9, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 32 */
+  offset: 32,
+  bytesPerRow: 768,
+  buffer: buffer54,
+}, {width: 4, height: 56, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder180.copyTextureToTexture({
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture166,
+  mipLevel: 1,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 41, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder183 = device0.createCommandEncoder({});
+let texture198 = device0.createTexture({size: {width: 780}, dimension: '1d', format: 'rgba16sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView205 = texture75.createView({dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder138 = commandEncoder182.beginComputePass({});
+try {
+renderPassEncoder18.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer61, 'uint32', 392, 2_101);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder183.insertDebugMarker('\u0b1b');
+} catch {}
+let autogeneratedBindGroupLayout61 = pipeline9.getBindGroupLayout(0);
+let commandEncoder184 = device0.createCommandEncoder();
+let texture199 = device0.createTexture({
+  size: [120, 1, 1],
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler114 = device0.createSampler({addressModeV: 'repeat', minFilter: 'linear', lodMinClamp: 99.67, lodMaxClamp: 99.73, compare: 'always'});
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup122, new Uint32Array(470), 72, 1);
+} catch {}
+try {
+renderPassEncoder40.setStencilReference(480);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer96, 'uint16', 3_866, 1_611);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(5, buffer91);
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT, colorSpace: 'srgb'});
+} catch {}
+let buffer126 = device0.createBuffer({
+  size: 12888,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder185 = device0.createCommandEncoder({});
+let texture200 = device0.createTexture({
+  size: [195, 120, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder135.setBindGroup(1, bindGroup118, new Uint32Array(4683), 371, 0);
+} catch {}
+try {
+computePassEncoder138.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup42);
+} catch {}
+try {
+renderPassEncoder33.setScissorRect(66, 130, 94, 1);
+} catch {}
+try {
+commandEncoder185.copyTextureToTexture({
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 43, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer127 = device0.createBuffer({
+  size: 9118,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView206 = texture109.createView({format: 'rgb10a2uint'});
+let computePassEncoder139 = commandEncoder184.beginComputePass({});
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup116, new Uint32Array(2366), 7, 0);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline14);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let promise28 = device0.queue.onSubmittedWorkDone();
+document.body.append(img3);
+let autogeneratedBindGroupLayout62 = pipeline14.getBindGroupLayout(0);
+let bindGroup129 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [
+    {binding: 70, resource: textureView74},
+    {binding: 88, resource: textureView19},
+    {binding: 58, resource: externalTexture20},
+    {binding: 95, resource: textureView100},
+    {binding: 349, resource: {buffer: buffer40, offset: 256}},
+    {binding: 22, resource: textureView25},
+    {binding: 49, resource: textureView126},
+    {binding: 72, resource: {buffer: buffer67, offset: 768, size: 360}},
+    {binding: 615, resource: textureView35},
+    {binding: 12, resource: {buffer: buffer114, offset: 768, size: 348}},
+  ],
+});
+let commandEncoder186 = device0.createCommandEncoder({});
+let texture201 = device0.createTexture({
+  size: [390, 240, 1],
+  mipLevelCount: 3,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder139.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(6, buffer25, 1_652, 1_610);
+} catch {}
+try {
+commandEncoder186.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 16 */
+  offset: 16,
+  rowsPerImage: 14,
+  buffer: buffer91,
+}, {
+  texture: texture180,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise29 = device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {module: shaderModule2, entryPoint: 'fragment2', targets: [{format: 'rg8unorm'}]},
+  vertex: {
+    module: shaderModule0,
+    constants: {},
+    buffers: [{arrayStride: 512, attributes: [{format: 'uint8x2', offset: 152, shaderLocation: 6}]}],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+let buffer128 = device0.createBuffer({size: 5493, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder187 = device0.createCommandEncoder({});
+let computePassEncoder140 = commandEncoder180.beginComputePass({});
+try {
+computePassEncoder135.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer61, 'uint32', 2_692, 315);
+} catch {}
+try {
+commandEncoder185.copyBufferToTexture({
+  /* bytesInLastRow: 288 widthInBlocks: 36 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 448 */
+  offset: 448,
+  buffer: buffer69,
+}, {
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 36, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder186.copyTextureToTexture({
+  texture: texture34,
+  mipLevel: 1,
+  origin: {x: 41, y: 5, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture172,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 101, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView207 = texture116.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder140.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup125, new Uint32Array(2792), 21, 0);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer70, 'uint32', 312, 204);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(4, buffer66, 3_092, 3_577);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(0, bindGroup66, new Uint32Array(388), 67, 0);
+} catch {}
+let imageData25 = new ImageData(168, 72);
+let commandEncoder188 = device0.createCommandEncoder({});
+let computePassEncoder141 = commandEncoder183.beginComputePass({});
+try {
+computePassEncoder141.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup83);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup75, new Uint32Array(839), 45, 0);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer96, 'uint32', 3_628, 1_068);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(4, buffer93, 2_024, 292);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer1, 'uint32', 904, 112);
+} catch {}
+let autogeneratedBindGroupLayout63 = pipeline0.getBindGroupLayout(0);
+let commandEncoder189 = device0.createCommandEncoder();
+let textureView208 = texture78.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder142 = commandEncoder188.beginComputePass({});
+let renderPassEncoder49 = commandEncoder185.beginRenderPass({colorAttachments: [{view: textureView130, depthSlice: 7, loadOp: 'clear', storeOp: 'store'}]});
+let renderBundle30 = renderBundleEncoder30.finish({});
+try {
+computePassEncoder142.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup105);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer10, 'uint32', 2_472, 625);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(1, buffer80, 0, 24);
+} catch {}
+try {
+commandEncoder189.copyBufferToBuffer(buffer113, 724, buffer24, 6680, 92);
+} catch {}
+try {
+computePassEncoder100.setBindGroup(0, bindGroup121);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup68);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup0, new Uint32Array(258), 83, 0);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer19, 'uint16', 322, 320);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(4, buffer10, 1_612, 2_978);
+} catch {}
+try {
+commandEncoder186.copyBufferToBuffer(buffer13, 384, buffer100, 624, 388);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer69, 3204, new Int16Array(5934), 106, 1384);
+} catch {}
+let buffer129 = device0.createBuffer({
+  size: 11453,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView209 = texture170.createView({baseArrayLayer: 1, arrayLayerCount: 5});
+let sampler115 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 67.52,
+  maxAnisotropy: 19,
+});
+let arrayBuffer23 = buffer5.getMappedRange(3504, 148);
+try {
+computePassEncoder7.pushDebugGroup('\u450c');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 1392, new Int16Array(1743), 317, 132);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 195, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame24,
+  origin: { x: 2, y: 1 },
+  flipY: true,
+}, {
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise28;
+} catch {}
+let buffer130 = device0.createBuffer({
+  size: 1962,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder143 = commandEncoder189.beginComputePass();
+try {
+computePassEncoder143.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder186.clearBuffer(buffer20, 548, 2604);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let autogeneratedBindGroupLayout64 = pipeline11.getBindGroupLayout(0);
+let bindGroup130 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout10,
+  entries: [{binding: 0, resource: {buffer: buffer105, offset: 15104, size: 1435}}],
+});
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout16]});
+let texture202 = device0.createTexture({
+  size: [390, 240, 1],
+  dimension: '2d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder144 = commandEncoder186.beginComputePass();
+let renderPassEncoder50 = commandEncoder187.beginRenderPass({
+  colorAttachments: [{
+  view: textureView79,
+  clearValue: { r: -666.3, g: -302.1, b: 856.7, a: 170.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 468771829,
+});
+try {
+computePassEncoder121.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(112, 123, 26, 5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 11, y: 1, z: 7},
+  aspect: 'all',
+}, new Uint8Array(30_759).fill(112), /* required buffer size: 30_759 */
+{offset: 120, bytesPerRow: 125, rowsPerImage: 46}, {width: 7, height: 16, depthOrArrayLayers: 6});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView210 = texture122.createView({});
+let texture203 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder122.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+computePassEncoder144.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 192, new Int16Array(6729), 145, 544);
+} catch {}
+let promise30 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise30;
+} catch {}
+let autogeneratedBindGroupLayout65 = pipeline13.getBindGroupLayout(0);
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true});
+try {
+renderPassEncoder19.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(2, bindGroup44, new Uint32Array(897), 107, 0);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline11);
+} catch {}
+let pipeline20 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule1, entryPoint: 'compute1'}});
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+let veryExplicitBindGroupLayout36 = device0.createBindGroupLayout({
+  label: '\u{1fd22}\u4505',
+  entries: [{binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: true }}],
+});
+let bindGroup131 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout16,
+  entries: [{binding: 0, resource: {buffer: buffer114, offset: 0, size: 4157}}],
+});
+let buffer131 = device0.createBuffer({size: 6765, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler116 = device0.createSampler({lodMaxClamp: 73.52});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup74, new Uint32Array(1599), 184, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer127, 'uint32', 624, 262);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(5, undefined, 0);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(3, bindGroup49);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(1, bindGroup1, new Uint32Array(1114), 277, 0);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer118, 'uint32', 40, 27);
+} catch {}
+try {
+buffer120.unmap();
+} catch {}
+try {
+computePassEncoder7.popDebugGroup();
+} catch {}
+document.body.prepend(canvas2);
+let img6 = await imageWithData(1, 6, '#10101010', '#20202020');
+let commandEncoder190 = device0.createCommandEncoder({});
+let computePassEncoder145 = commandEncoder190.beginComputePass({});
+try {
+computePassEncoder145.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup60);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(0, buffer46, 0, 1_088);
+} catch {}
+await gc();
+let imageData26 = new ImageData(48, 8);
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], sampleCount: 1, stencilReadOnly: true});
+try {
+renderPassEncoder27.setIndexBuffer(buffer67, 'uint16', 362, 719);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(3, bindGroup74, new Uint32Array(96), 7, 0);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer1, 'uint16', 676, 399);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline12);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 195, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 34, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture204 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 32},
+  mipLevelCount: 5,
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle31 = renderBundleEncoder31.finish({label: '\u72e1\u079c\u{1fc62}\u2e11\u{1faff}\u{1fed8}\u{1fa0e}\uff46\ua0c8'});
+let externalTexture23 = device0.importExternalTexture({source: videoFrame21, colorSpace: 'display-p3'});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup76, new Uint32Array(126), 4, 0);
+} catch {}
+let pipeline21 = await promise29;
+let buffer132 = device0.createBuffer({
+  size: 1904,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let renderBundle32 = renderBundleEncoder32.finish();
+try {
+computePassEncoder22.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle31]);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(4, buffer129, 0, 1_938);
+} catch {}
+let arrayBuffer24 = buffer22.getMappedRange(72, 52);
+let commandEncoder191 = device0.createCommandEncoder({});
+let computePassEncoder146 = commandEncoder191.beginComputePass({});
+try {
+computePassEncoder146.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(0, bindGroup81, new Uint32Array(886), 71, 0);
+} catch {}
+let commandEncoder192 = device0.createCommandEncoder({});
+let texture205 = device0.createTexture({
+  size: {width: 480, height: 1, depthOrArrayLayers: 1},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView211 = texture91.createView({dimension: '2d-array'});
+let computePassEncoder147 = commandEncoder192.beginComputePass({});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm']});
+try {
+renderPassEncoder47.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(5, buffer108);
+} catch {}
+let buffer133 = device0.createBuffer({size: 14546, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM, mappedAtCreation: false});
+let commandEncoder193 = device0.createCommandEncoder({});
+let texture206 = device0.createTexture({
+  size: [480],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView212 = texture99.createView({mipLevelCount: 1});
+let renderPassEncoder51 = commandEncoder193.beginRenderPass({
+  colorAttachments: [{
+  view: textureView68,
+  clearValue: { r: -651.7, g: -653.9, b: 888.7, a: -474.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet17,
+});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+computePassEncoder147.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup52);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer71, 'uint16', 1_560, 15_726);
+} catch {}
+let texture207 = device0.createTexture({size: [97, 60, 1], format: 'rgba8unorm-srgb', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+renderPassEncoder9.beginOcclusionQuery(25);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer99, 'uint32', 272, 211);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup115);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup130);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(2, buffer118);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer48, 'uint32', 956, 1_480);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(0, buffer18);
+} catch {}
+let bindGroup132 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout44,
+  entries: [{binding: 0, resource: {buffer: buffer25, offset: 8960, size: 798}}],
+});
+let commandEncoder194 = device0.createCommandEncoder({});
+let textureView213 = texture165.createView({dimension: '2d-array'});
+let renderPassEncoder52 = commandEncoder194.beginRenderPass({
+  colorAttachments: [{
+  view: textureView38,
+  clearValue: { r: 758.6, g: 866.4, b: 95.08, a: -391.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet19,
+  maxDrawCount: 137053278,
+});
+try {
+computePassEncoder81.setBindGroup(2, bindGroup123, new Uint32Array(259), 76, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup67);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(4, buffer93, 524, 32);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup116);
+} catch {}
+try {
+renderBundleEncoder33.drawIndexed(31, 14, 48, 1_058_594_358, 186_752_955);
+} catch {}
+try {
+renderBundleEncoder33.drawIndexedIndirect(buffer18, 3_516);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(0, buffer36, 0, 222);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+  await buffer79.mapAsync(GPUMapMode.WRITE, 0, 104);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder195 = device0.createCommandEncoder({label: '\u4180\uc8b9\u0e93'});
+let querySet30 = device0.createQuerySet({type: 'occlusion', count: 491});
+let computePassEncoder148 = commandEncoder195.beginComputePass({});
+try {
+computePassEncoder130.setBindGroup(1, bindGroup88, new Uint32Array(470), 9, 0);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(1, bindGroup126);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer124, 'uint32', 1_044, 4_793);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(4, buffer56, 0);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(6, buffer108);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+document.body.prepend(img4);
+let textureView214 = texture199.createView({});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup88, new Uint32Array(3008), 1_193, 0);
+} catch {}
+try {
+computePassEncoder148.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder33.drawIndexed(208, 146, 4, -1_539_130_667, 1_205_694_079);
+} catch {}
+try {
+gpuCanvasContext4.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise31 = device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule0, constants: {}}});
+try {
+renderPassEncoder29.beginOcclusionQuery(112);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle4, renderBundle22, renderBundle7, renderBundle28, renderBundle22, renderBundle3, renderBundle32]);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup112, new Uint32Array(275), 20, 0);
+} catch {}
+try {
+renderBundleEncoder33.drawIndexedIndirect(buffer118, 48);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer76, 'uint16', 344, 1_505);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(4, buffer100, 984, 181);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+@id(27508) override override4: bool;
+
+override override1 = 0.05908;
+
+var<workgroup> vw0: array<u32, 4>;
+
+var<private> vp2: mat3x4f = mat3x4f(0.3900, 0.2567, -0.06605, 0.2591, -0.05117, 0.1062, 0.02927, 0.1728, 0.02175, 0.2397, -0.2181, 0.06073);
+
+struct VertexOutput2 {
+  @builtin(position) f9: vec4f,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@id(65470) override override0: f16 = -29161.3;
+
+alias vec3b = vec3<bool>;
+
+struct FragmentOutput3 {
+  @location(2) f0: vec4u,
+  @location(0) @interpolate(flat) f1: vec2i,
+  @location(1) f2: vec4u,
+}
+
+var<private> vp4: VertexOutput2 = VertexOutput2(vec4f(0.1151, 0.02645, -0.1110, 0.1304));
+
+override override3: i32;
+
+@group(1) @binding(39) var tex2: texture_2d<i32>;
+
+fn fn0() -> mat2x3h {
+  var out: mat2x3h;
+  vp2 = vp2;
+  var vf45: vec2h = saturate(vec2h(unconst_f16(537.3), unconst_f16(-59.71)));
+  vp5 -= bitcast<vec4f>(countOneBits(vec4i(unconst_i32(83), unconst_i32(-63), unconst_i32(62), unconst_i32(29))))[2];
+  let vf46: vec3i = clamp(vec3i(unconst_i32(98), unconst_i32(4), unconst_i32(764)), vec3i(unconst_i32(430), unconst_i32(468), unconst_i32(175)), vec3i(unconst_i32(57), unconst_i32(106), unconst_i32(171)));
+  let vf47: vec4i = countOneBits(vec4i(dot4I8Packed(u32(unconst_u32(71)), u32(unconst_u32(19)))));
+  vp5 = f32(vf46[u32(unconst_u32(0))]);
+  var vf48: vec2<bool> = select(vec2<bool>(unconst_bool(true), unconst_bool(true)), vec2<bool>(unconst_bool(true), unconst_bool(true)), bool(unconst_bool(true)));
+  vp2 += mat3x4f(override1, override1, override1, override1, override1, override1, override1, override1, override1, override1, override1, override1);
+  vp2 = mat3x4f(vec4f(saturate(vec2h(unconst_f16(9631.5), unconst_f16(33761.7))).yyyy), vec4f(saturate(vec2h(unconst_f16(9631.5), unconst_f16(33761.7))).yxyy), vec4f(saturate(vec2h(unconst_f16(9631.5), unconst_f16(33761.7))).yyyx));
+  vp4.f9 = vec4f(f32(log(f16(unconst_f16(4126.9)))));
+  vp3 -= vec4u(select(vec2<bool>(unconst_bool(false), unconst_bool(true)), vec2<bool>(unconst_bool(true), unconst_bool(true)), bool(unconst_bool(true))).xxxy);
+  return out;
+  _ = override1;
+}
+
+var<private> vp3: vec4u = vec4u(788, 263, 328, 50);
+
+var<workgroup> vw2: atomic<u32>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(96) var sam0: sampler;
+
+var<private> vp5: f32 = f32(0.1672);
+
+var<workgroup> vw1: atomic<u32>;
+
+struct T0 {
+  f0: array<array<vec2h, 1>, 73>,
+  @size(400) f1: vec4u,
+}
+
+override override2: u32;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+override override5: i32 = 47;
+
+@vertex
+fn vertex3() -> VertexOutput2 {
+  var out: VertexOutput2;
+  let vf49: vec3h = floor(vec3h(unconst_f16(4782.4), unconst_f16(639.8), unconst_f16(-15480.2)));
+  fn0();
+  vp2 = mat3x4f(f32(override4), f32(override4), f32(override4), f32(override4), f32(override4), f32(override4), f32(override4), f32(override4), f32(override4), f32(override4), f32(override4), f32(override4));
+  out.f9 = unpack2x16float(u32(unconst_u32(123))).rgrr;
+  fn0();
+  var vf50 = fn0();
+  out.f9 += bitcast<vec4f>(vp3);
+  fn0();
+  vp2 = mat3x4f(vp5, vp5, vp5, vp5, vp5, vp5, vp5, vp5, vp5, vp5, vp5, vp5);
+  vf50 -= mat2x3h(acosh(vec3h(vp2[u32(unconst_u32(22))].zwx)), acosh(vec3h(vp2[u32(unconst_u32(22))].zwx)));
+  vf50 = mat2x3h(vec3h(vp2[u32(unconst_u32(69))].ywx), vec3h(vp2[u32(unconst_u32(69))].xyx));
+  out.f9 *= vp4.f9;
+  var vf51 = fn0();
+  fn0();
+  vp3 += vec4u(asin(vec2h(unconst_f16(2183.5), unconst_f16(-615.3))).rrrg);
+  out = VertexOutput2(vec4f(countOneBits(vec4i(unconst_i32(216), unconst_i32(12), unconst_i32(-75), unconst_i32(136)))));
+  vp2 = mat3x4f(vec4f(vf50[u32(unconst_u32(24))].bbgg), vec4f(vf50[u32(unconst_u32(24))].xyyz), vec4f(vf50[u32(unconst_u32(24))].yzyx));
+  fn0();
+  return out;
+  _ = override4;
+  _ = override1;
+}
+
+@fragment
+fn fragment3() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  out.f0 -= vec4u(degrees(vec4f(f32(override4))));
+  var vf52 = fn0();
+  vp4 = VertexOutput2(bitcast<vec4f>(vp3));
+  var vf53: f32 = vp2[u32(unconst_u32(45))][u32(unconst_u32(80))];
+  out = FragmentOutput3(bitcast<vec4u>(vp4.f9), vec2i(vp4.f9.aa), vec4u(vp4.f9));
+  var vf54 = fn0();
+  let vf55: f16 = vf52[u32(unconst_u32(169))][u32(unconst_u32(347))];
+  let vf56: vec2h = abs(vec2h(unconst_f16(20429.5), unconst_f16(4286.6)));
+  vf54 = mat2x3h(vec3h(vp4.f9.agr), vec3h(vp4.f9.zzz));
+  var vf57: vec4h = trunc(degrees(vec3h(unconst_f16(2198.4), unconst_f16(13731.2), unconst_f16(6730.4))).zxzx);
+  out.f1 = vec2i(bitcast<i32>(override2));
+  out = FragmentOutput3(vec4u(sign(vec2i(vf54[unconst_i32(1)].rg)).rrgg), sign(vec2i(vf54[unconst_i32(1)].rg)), vec4u(sign(vec2i(vf54[unconst_i32(1)].rg)).xxxy));
+  vp3 &= vec4u(u32(vf56[u32(trunc(vec4h(unconst_f16(535.5), unconst_f16(880.8), unconst_f16(2973.7), unconst_f16(17140.4)))[3])]));
+  var vf58 = fn0();
+  var vf59: vec3i = reverseBits(vec3i(unconst_i32(187), unconst_i32(-451), unconst_i32(83)));
+  vf58 = mat2x3h(vec3h(degrees(vec4f(unconst_f32(0.01681), unconst_f32(0.2392), unconst_f32(0.04475), unconst_f32(0.02673))).xzx), vec3h(degrees(vec4f(unconst_f32(0.01681), unconst_f32(0.2392), unconst_f32(0.04475), unconst_f32(0.02673))).bgg));
+  vf53 = determinant(mat3x3f(unconst_f32(0.00121), unconst_f32(0.1089), unconst_f32(0.1288), unconst_f32(-0.1580), unconst_f32(0.1569), unconst_f32(0.1345), unconst_f32(1.000), unconst_f32(0.06433), unconst_f32(0.1613)));
+  let vf60: vec4f = degrees(vec4f(unconst_f32(-0.1112), unconst_f32(0.1223), unconst_f32(0.3578), unconst_f32(0.4158)));
+  vp3 = unpack4xU8(u32(vf60[u32(unconst_u32(305))]));
+  vf59 &= vec3i(i32(vf53));
+  var vf61 = fn0();
+  var vf62 = fn0();
+  var vf63 = fn0();
+  vf63 = mat2x3h(trunc(vec4h(unconst_f16(10663.8), unconst_f16(4516.4), unconst_f16(7151.3), unconst_f16(9582.3))).xxz, trunc(vec4h(unconst_f16(10663.8), unconst_f16(4516.4), unconst_f16(7151.3), unconst_f16(9582.3))).rrr);
+  out.f2 = unpack4xU8(u32(override3));
+  return out;
+  _ = override3;
+  _ = override2;
+  _ = override4;
+  _ = override1;
+}
+
+@compute @workgroup_size(4, 1, 1)
+fn compute2() {
+  vw0[u32(unconst_u32(312))] |= bitcast<u32>(vp2[u32(unconst_u32(115))][u32(unconst_u32(417))]);
+  atomicAdd(&vw2, u32(unconst_u32(20)));
+  let ptr29: ptr<workgroup, u32> = &(*&vw0)[3];
+  var vf64: vec3f = quantizeToF16(vec3f(unconst_f32(0.05531), unconst_f32(0.1370), unconst_f32(-0.02254)));
+  let vf65: u32 = atomicExchange(&vw2, u32(unconst_u32(237)));
+  let ptr30: ptr<private, mat3x4f> = &vp2;
+  vp3 -= unpack4xU8(u32(override5));
+  vp5 -= vp2[u32(unconst_u32(23))][u32(unconst_u32(162))];
+  vp4.f9 -= vec4f(f32(override3));
+  let ptr31: ptr<workgroup, u32> = &vw0[u32(unconst_u32(293))];
+  vp5 = bitcast<f32>((*ptr29));
+  vp3 <<= vec4u(u32((*ptr30)[u32(unconst_u32(29))][u32(unconst_u32(458))]));
+  let vf66: vec4i = textureGather(260 % 4, tex2, sam0, vec2f(unconst_f32(0.06734), unconst_f32(0.2717)), clamp(vec2i(534, 264), vec2i(-8), vec2i(7)));
+  vp5 = (*ptr30)[u32(unconst_u32(517))][u32(unconst_u32(352))];
+  let ptr32: ptr<workgroup, u32> = &vw0[3];
+  _ = override3;
+  _ = override5;
+  _ = sam0;
+  _ = tex2;
+}`,
+});
+let bindGroup133 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout18,
+  entries: [{binding: 0, resource: {buffer: buffer51, offset: 2048, size: 1400}}],
+});
+let texture208 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView215 = texture124.createView({});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup128, new Uint32Array(719), 548, 0);
+} catch {}
+try {
+renderPassEncoder47.beginOcclusionQuery(332);
+} catch {}
+try {
+renderBundleEncoder33.drawIndexed(130, 18, 21, -87_740_252, 1_916_784_014);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture209 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 72},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle33 = renderBundleEncoder33.finish({});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(2, buffer51);
+} catch {}
+let commandEncoder196 = device0.createCommandEncoder({});
+let querySet31 = device0.createQuerySet({type: 'occlusion', count: 1223});
+let texture210 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder149 = commandEncoder196.beginComputePass({});
+try {
+computePassEncoder63.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+computePassEncoder148.setBindGroup(3, bindGroup13, new Uint32Array(1563), 197, 0);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup2, new Uint32Array(312), 150, 0);
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline11);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer96, 56, new Int16Array(8467), 1252, 492);
+} catch {}
+let imageData27 = new ImageData(32, 44);
+let shaderModule4 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+var<workgroup> vw8: VertexOutput3;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw3: array<atomic<u32>, 1>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct FragmentOutput4 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4f,
+}
+
+struct T3 {
+  @size(16) f0: array<f32>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw4: atomic<u32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw5: array<array<VertexOutput3, 1>, 1>;
+
+struct T0 {
+  @align(16) @size(16) f0: array<array<f32, 1>>,
+}
+
+struct T1 {
+  f0: T0,
+}
+
+var<workgroup> vw9: mat3x3h;
+
+var<workgroup> vw7: FragmentOutput4;
+
+var<private> vp6: array<array<vec4u, 1>, 13> = array(array<vec4u, 1>(), array<vec4u, 1>(vec4u(228, 88, 1, 202)), array(vec4u(101, 227, 72, 74)), array(vec4u(124, 77, 123, 77)), array<vec4u, 1>(), array(vec4u(151, 604, 39, 23)), array(vec4u(251, 34, 1000, 40)), array(vec4u(325, 209, 204, 308)), array(vec4u(386, 46, 21, 262)), array(vec4u(52, 172, 162, 132)), array<vec4u, 1>(vec4u(339, 238, 6, 170)), array<vec4u, 1>(), array(vec4u(520, 0, 86, 146)));
+
+alias vec3b = vec3<bool>;
+
+struct T2 {
+  @align(16) @size(16) f0: array<atomic<u32>>,
+}
+
+var<private> vp7 = array(array(modf(f16(5169.9))));
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw6: mat3x2f;
+
+struct VertexOutput3 {
+  @location(8) @interpolate(flat, sample) f10: vec2u,
+  @location(2) f11: vec2f,
+  @location(5) @interpolate(linear, sample) f12: vec4h,
+  @location(6) @interpolate(flat, sample) f13: vec2h,
+  @builtin(position) f14: vec4f,
+}
+
+fn fn0() -> mat2x2f {
+  var out: mat2x2f;
+  let ptr33 = &vp7[0];
+  out -= mat2x2f(bitcast<vec2f>(vp6[12][0].ww), vec2f(vp6[12][0].yz));
+  let ptr34: ptr<private, vec4u> = &vp6[u32(unconst_u32(13))][0];
+  discard;
+  let ptr35 = &vp7[0];
+  vp7[u32(unconst_u32(360))][u32(unconst_u32(53))] = modf((*ptr33)[u32(unconst_u32(152))].whole);
+  let ptr36: ptr<private, f16> = &(*ptr35)[0].fract;
+  let ptr37: ptr<private, f16> = &(*ptr35)[0].fract;
+  out = mat2x2f(f32(dot4I8Packed(u32(unconst_u32(169)), u32(unconst_u32(110)))), bitcast<f32>(dot4I8Packed(u32(unconst_u32(169)), u32(unconst_u32(110)))), bitcast<f32>(dot4I8Packed(u32(unconst_u32(169)), u32(unconst_u32(110)))), f32(dot4I8Packed(u32(unconst_u32(169)), u32(unconst_u32(110)))));
+  let ptr38 = &(*ptr35)[u32(unconst_u32(144))];
+  vp7[u32(unconst_u32(510))][u32(unconst_u32(131))].fract = vp7[0][0].fract;
+  let ptr39: ptr<private, vec4u> = &vp6[vp6[12][0][u32(unconst_u32(191))]][0];
+  let ptr40 = &vp7[0];
+  vp6[u32(unconst_u32(133))][u32(unconst_u32(247))] = vp6[u32(unconst_u32(194))][0];
+  let ptr41: ptr<private, f16> = &vp7[0][0].fract;
+  let vf67: vec2f = atanh(vec2f(unconst_f32(0.1796), unconst_f32(0.01959)));
+  let ptr42: ptr<private, f16> = &vp7[0][u32(unconst_u32(3))].fract;
+  return out;
+}
+
+@vertex
+fn vertex4(@location(3) @interpolate(flat, sample) a0: vec4i, @location(2) @interpolate(perspective) a1: vec4f, @location(5) a2: vec4u, @location(10) a3: f16, @location(7) a4: u32) -> VertexOutput3 {
+  var out: VertexOutput3;
+  out.f12 = vec4h(f16(countTrailingZeros(u32(unconst_u32(183)))));
+  let ptr43: ptr<private, vec4u> = &vp6[u32(unconst_u32(38))][0];
+  let ptr44 = &vp7;
+  let ptr45: ptr<private, f16> = &(*ptr44)[u32(unconst_u32(30))][0].fract;
+  out.f10 = vec2u(u32((*ptr44)[u32(unconst_u32(11))][0].whole));
+  vp7[vp6[u32(unconst_u32(40))][0][3]][u32(atanh(vec3f(unconst_f32(0.2899), unconst_f32(0.2375), unconst_f32(0.2364)))[1])] = (*ptr44)[0][0];
+  let ptr46: ptr<private, f16> = &(*ptr44)[0][0].whole;
+  out.f11 += a1.zw;
+  out.f10 += vp6[12][0].yx;
+  out.f14 = vec4f(a2);
+  return out;
+}
+
+@fragment
+fn fragment4() -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  let ptr47: ptr<private, vec4u> = &vp6[12][u32(unconst_u32(247))];
+  let ptr48 = &vp7[u32(unconst_u32(54))];
+  fn0();
+  var vf68 = fn0();
+  let vf69: u32 = vp6[12][0][u32(unconst_u32(42))];
+  vp7[u32(unconst_u32(274))][u32(unconst_u32(179))] = vp7[0][0];
+  let ptr49 = &(*ptr48)[u32(unconst_u32(82))];
+  vf68 = mat2x2f(f32((*ptr48)[0].fract), f32((*ptr48)[0].fract), f32((*ptr48)[0].fract), f32((*ptr48)[0].fract));
+  out.f0 *= u32(vp7[0][0].whole);
+  fn0();
+  fn0();
+  let ptr50: ptr<private, f16> = &vp7[0][u32(unconst_u32(398))].whole;
+  var vf70 = fn0();
+  vp6[u32(unconst_u32(35))][0] >>= (*ptr47);
+  let ptr51 = &vp7[0][u32(unconst_u32(23))];
+  var vf71: vec2h = acosh(vec2h(unconst_f16(9246.7), unconst_f16(8098.1)));
+  var vf72 = fn0();
+  var vf73 = fn0();
+  var vf74 = fn0();
+  out.f1 -= vf72[unconst_i32(1)].gggr;
+  fn0();
+  var vf75: vec2f = vf74[u32(unconst_u32(233))];
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 3)
+fn compute3() {
+  let ptr52: ptr<workgroup, vec4h> = &vw8.f12;
+  let ptr53: ptr<workgroup, vec4h> = &(*&vw5)[0][0].f12;
+  let vf76: f16 = vw5[u32(unconst_u32(99))][u32(unconst_u32(94))].f13[u32(unconst_u32(148))];
+  vw6 = mat3x2f(bitcast<f32>(atomicExchange(&vw3[u32(unconst_u32(8))], vw7.f0)), f32(atomicExchange(&vw3[u32(unconst_u32(8))], vw7.f0)), f32(atomicExchange(&vw3[u32(unconst_u32(8))], vw7.f0)), f32(atomicExchange(&vw3[u32(unconst_u32(8))], vw7.f0)), bitcast<f32>(atomicExchange(&vw3[u32(unconst_u32(8))], vw7.f0)), f32(atomicExchange(&vw3[u32(unconst_u32(8))], vw7.f0)));
+  vp6[12][u32(unconst_u32(60))] <<= unpack4xU8(bitcast<u32>((*&vw5)[0][u32(unconst_u32(178))].f11[u32(vp7[0][0].fract)]));
+  let ptr54: ptr<workgroup, vec2f> = &vw5[u32(unconst_u32(415))][u32(unconst_u32(167))].f11;
+  vw7 = FragmentOutput4(u32((*&vw5)[u32(unconst_u32(40))][0].f12[u32(unconst_u32(256))]), vec4f(f32((*&vw5)[u32(unconst_u32(40))][0].f12[u32(unconst_u32(256))])));
+  var vf77: vec4f = fma(vec4f(unconst_f32(0.3523), unconst_f32(0.4068), unconst_f32(0.1318), unconst_f32(0.05552)), vec4f(unconst_f32(0.04153), unconst_f32(0.1152), unconst_f32(0.5557), unconst_f32(0.3244)), vec4f(unconst_f32(0.09094), unconst_f32(0.09903), unconst_f32(0.07685), unconst_f32(0.2336)));
+  let ptr55: ptr<workgroup, vec4h> = &vw5[0][u32(unconst_u32(55))].f12;
+  let vf78: u32 = atomicExchange(&vw4, u32(unconst_u32(207)));
+  vp6[u32(unconst_u32(13))][u32(unconst_u32(36))] += unpack4xU8(vw5[u32(unconst_u32(61))][0].f10[u32(unconst_u32(64))]);
+  var vf79: u32 = atomicExchange(&vw3[u32(unconst_u32(39))], u32(unconst_u32(8)));
+  let ptr56: ptr<private, f16> = &vp7[0][u32(unconst_u32(12))].whole;
+  vp7[u32(unconst_u32(122))][u32(unconst_u32(242))].whole = (*&vw8).f12[u32(unconst_u32(220))];
+  let ptr57: ptr<private, array<vec4u, 1>> = &vp6[u32(unconst_u32(131))];
+}`,
+});
+let bindGroup134 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout7,
+  entries: [
+    {binding: 349, resource: {buffer: buffer115, offset: 4096, size: 2426}},
+    {binding: 58, resource: externalTexture6},
+    {binding: 12, resource: {buffer: buffer19, offset: 0}},
+    {binding: 88, resource: textureView76},
+    {binding: 49, resource: textureView78},
+    {binding: 72, resource: {buffer: buffer18, offset: 10240, size: 4560}},
+    {binding: 615, resource: textureView89},
+    {binding: 22, resource: textureView24},
+    {binding: 70, resource: textureView36},
+    {binding: 95, resource: textureView28},
+  ],
+});
+let buffer135 = device0.createBuffer({
+  size: 24487,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder197 = device0.createCommandEncoder({});
+let computePassEncoder150 = commandEncoder197.beginComputePass({});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup118);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup107);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(6, buffer130);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let imageBitmap4 = await createImageBitmap(img0);
+let texture211 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView216 = texture125.createView({});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup109, []);
+} catch {}
+try {
+computePassEncoder141.end();
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(2, bindGroup5, new Uint32Array(10), 8, 0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(6, buffer46, 2_648, 36);
+} catch {}
+try {
+commandEncoder183.copyBufferToBuffer(buffer58, 3384, buffer44, 292, 172);
+} catch {}
+try {
+commandEncoder183.copyBufferToTexture({
+  /* bytesInLastRow: 96 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 648 */
+  offset: 648,
+  bytesPerRow: 18176,
+  buffer: buffer101,
+}, {
+  texture: texture160,
+  mipLevel: 0,
+  origin: {x: 5, y: 8, z: 0},
+  aspect: 'all',
+}, {width: 12, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder183.resolveQuerySet(querySet12, 35, 32, buffer100, 256);
+} catch {}
+document.body.append(canvas0);
+let imageData28 = new ImageData(16, 40);
+let bindGroup135 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout28,
+  entries: [{binding: 0, resource: {buffer: buffer135, offset: 2048, size: 3807}}],
+});
+let commandEncoder198 = device0.createCommandEncoder({label: '\ubd6b\u{1f778}'});
+let commandBuffer3 = commandEncoder183.finish();
+let texture212 = device0.createTexture({
+  size: [195],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder151 = commandEncoder198.beginComputePass();
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle34 = renderBundleEncoder34.finish({});
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup114, []);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup52, new Uint32Array(1694), 201, 0);
+} catch {}
+document.body.prepend(img4);
+let shaderModule5 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+requires readonly_and_readwrite_storage_textures;
+
+var<workgroup> vw13: mat4x4h;
+
+struct T3 {
+  @size(224) f0: array<T1>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn1() -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  fn0();
+  fn0();
+  out = FragmentOutput5(pow(pow(vec2f(unconst_f32(0.1108), unconst_f32(0.2376)), vec2f(unconst_f32(0.2308), unconst_f32(-0.2108))), vec2f(unconst_f32(0.4689), unconst_f32(0.00987))).grrg);
+  var vf89: vec3h = floor(vec3h(unconst_f16(16221.3), unconst_f16(-8251.0), unconst_f16(4957.3)));
+  vp8 = modf(vec4h(f16(override7)));
+  var vf90 = fn0();
+  var vf91 = fn0();
+  fn0();
+  vf91[u32(unconst_u32(240))][u32(unconst_u32(54))] += mat2x2h(vf90[0][0][u32(unconst_u32(49))][u32(unconst_u32(216))], vf90[0][0][u32(unconst_u32(49))][u32(unconst_u32(216))], vf90[0][0][u32(unconst_u32(49))][u32(unconst_u32(216))], vf90[0][0][u32(unconst_u32(49))][u32(unconst_u32(216))]);
+  let vf92: f16 = vf91[0][u32(unconst_u32(404))][u32(unconst_u32(104))][u32(unconst_u32(191))];
+  out.f0 = vec4f(vp8.fract);
+  vp8 = modf(vf91[0][u32(unconst_u32(454))][unconst_i32(0)].rrgr);
+  return out;
+  _ = override6;
+  _ = override7;
+}
+
+fn fn0() -> array<array<mat2x2h, 1>, 1> {
+  var out: array<array<mat2x2h, 1>, 1>;
+  vp8 = modf(vec4h(f16(fma(f32(unconst_f32(0.03427)), f32(vp8.whole[0]), f32(unconst_f32(0.2132))))));
+  let vf80: f16 = sqrt(f16(unconst_f16(18980.1)));
+  var vf81: vec2h = ceil(vec2h(unconst_f16(23188.1), unconst_f16(399.0)));
+  vp8 = vp8;
+  let ptr58: ptr<private, vec4h> = &vp8.whole;
+  vp8 = modf(fma(vec2h(unconst_f16(9150.0), unconst_f16(7449.7)), vec2h(unconst_f16(17993.3), unconst_f16(1135.1)), vec2h(unconst_f16(-1976.7), unconst_f16(21915.8))).xxyy);
+  vf81 *= bitcast<vec2h>(clamp(f32(unconst_f32(0.01311)), f32(unconst_f32(0.02554)), f32(unconst_f32(0.2106))));
+  vf81 *= bitcast<vec2h>(insertBits(bitcast<u32>(ldexp(vec4f(unconst_f32(0.4341), unconst_f32(-0.2241), unconst_f32(0.1012), unconst_f32(0.2179)), vec4i(unconst_i32(55), unconst_i32(168), unconst_i32(53), unconst_i32(191)))[2]), u32(unconst_u32(127)), u32(unconst_u32(11)), u32(unconst_u32(203))));
+  out[u32(unconst_u32(221))][0] += mat2x2h(f16(insertBits(u32(unconst_u32(138)), u32(unconst_u32(1)), u32(unconst_u32(37)), u32(unconst_u32(66)))), f16(insertBits(u32(unconst_u32(138)), u32(unconst_u32(1)), u32(unconst_u32(37)), u32(unconst_u32(66)))), f16(insertBits(u32(unconst_u32(138)), u32(unconst_u32(1)), u32(unconst_u32(37)), u32(unconst_u32(66)))), f16(insertBits(u32(unconst_u32(138)), u32(unconst_u32(1)), u32(unconst_u32(37)), u32(unconst_u32(66)))));
+  vf81 = bitcast<vec2h>(pack4xU8Clamp(bitcast<vec4u>(sinh(vec3f(f32(vf81[u32(unconst_u32(24))]))).bgbr)));
+  out[u32(unconst_u32(78))][u32(unconst_u32(171))] = mat2x2h(step(vf81.ggrr, vec4h(override6)).yw, step(vf81.ggrr, vec4h(override6)).ww);
+  let vf82: f16 = (*ptr58)[u32(unconst_u32(231))];
+  var vf83: i32 = override7;
+  var vf84: vec2f = pow(vec2f(unconst_f32(-0.07053), unconst_f32(0.3356)), vec2f(unconst_f32(0.09758), unconst_f32(0.1047)));
+  var vf85: vec2f = pow(vec2f(unconst_f32(0.08039), unconst_f32(0.09046)), vec2f(unconst_f32(0.1548), unconst_f32(0.1720)));
+  vp8.fract *= vp8.whole;
+  var vf86: f16 = vf81[u32(unconst_u32(73))];
+  let vf87: f32 = sinh(f32(unconst_f32(0.3610)));
+  let vf88: u32 = insertBits(u32(unconst_u32(80)), u32(unconst_u32(235)), u32(unconst_u32(22)), u32(unconst_u32(120)));
+  return out;
+  _ = override6;
+  _ = override7;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw11: f16;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn fn2(a0: ptr<storage, array<T1>, read>) {
+  vp8.fract = (*a0)[arrayLength(&(*a0))].f0.yxxx;
+  fn0();
+  vp8 = modf(vec4h(select(vec3i(i32(ldexp(f16(unconst_f16(6597.1)), i32(unconst_i32(102))))), vec3i(unconst_i32(41), unconst_i32(82), unconst_i32(75)), bool(unconst_bool(false))).xyzy));
+  var vf93 = fn0();
+  vp8.whole = vf93[0][0][unconst_i32(1)].rrrg;
+  vp8.fract -= vf93[u32(unconst_u32(292))][bitcast<u32>(vf93[0][u32(unconst_u32(1))][unconst_i32(0)])][unconst_i32(1)].xxxy;
+  vf93[u32(unconst_u32(10))][u32(unconst_u32(33))] = mat2x2h(vec2h(exp(vec2f(unconst_f32(0.4277), unconst_f32(0.05108)))), vec2h(exp(vec2f(unconst_f32(0.4277), unconst_f32(0.05108)))));
+  vf93[u32(unconst_u32(38))][bitcast<u32>((*a0)[u32(unconst_u32(128))].f0)] = mat2x2h(vec2h(unpack4x8snorm(u32(unconst_u32(110))).yz), vec2h(unpack4x8snorm(u32(unconst_u32(110))).ww));
+  vf93[u32(unconst_u32(285))][u32(unconst_u32(242))] = mat2x2h(determinant(mat2x2h()), determinant(mat2x2h()), determinant(mat2x2h()), determinant(mat2x2h()));
+  vp8 = modf((*a0)[arrayLength(&(*a0))].f0.ggrr);
+  var vf94 = fn0();
+  vp8.fract += bitcast<vec4h>(smoothstep(vec2f(unconst_f32(0.2872), unconst_f32(0.2278)), vec2f(unconst_f32(0.04731), unconst_f32(0.1471)), vec2f(unconst_f32(0.2741), unconst_f32(0.1249))));
+  var vf95 = fn0();
+  var vf96 = fn0();
+  fn0();
+  var vf97 = fn0();
+  vf93[u32(unconst_u32(63))][u32(unconst_u32(97))] = mat2x2h(vf93[0][0][u32(unconst_u32(171))][u32(unconst_u32(88))], vf93[0][0][u32(unconst_u32(171))][u32(unconst_u32(88))], vf93[0][0][u32(unconst_u32(171))][u32(unconst_u32(88))], vf93[0][0][u32(unconst_u32(171))][u32(unconst_u32(88))]);
+  let ptr59: ptr<private, vec4h> = &vp8.whole;
+  _ = override7;
+  _ = override6;
+}
+
+var<workgroup> vw12: atomic<u32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+@id(11428) override override7: i32;
+
+struct T1 {
+  f0: vec2h,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw10: mat3x3f;
+
+struct T0 {
+  f0: array<vec2u>,
+}
+
+struct VertexOutput4 {
+  @builtin(position) f15: vec4f,
+}
+
+override override6: f16 = 18911.9;
+
+var<private> vp8 = modf(vec4h(-3544.8, 17987.7, 12660.3, 10857.9));
+
+struct T2 {
+  @size(8) f0: atomic<u32>,
+}
+
+struct FragmentOutput5 {
+  @location(0) @interpolate(flat) f0: vec4f,
+}
+
+@vertex
+fn vertex5(@location(14) @interpolate(flat) a0: vec4h) -> VertexOutput4 {
+  var out: VertexOutput4;
+  var vf98 = fn0();
+  var vf99 = fn0();
+  let ptr60: ptr<function, mat2x2h> = &vf99[0][0];
+  vf98[u32(unconst_u32(5))][u32(unconst_u32(122))] += mat2x2h(vp8.whole.gb, vp8.whole.ar);
+  let ptr61: ptr<function, mat2x2h> = &(*ptr60);
+  out.f15 = vec4f((*ptr60)[unconst_i32(0)].gggg);
+  out.f15 = vec4f(f32((*ptr61)[u32(unconst_u32(669))][bitcast<u32>(vf98[u32(override7)][u32(unconst_u32(65))][u32(unconst_u32(292))])]));
+  let vf100: u32 = dot4U8Packed(u32(unconst_u32(125)), u32(unconst_u32(138)));
+  fn0();
+  var vf101: f16 = vf98[u32(unconst_u32(324))][u32(unconst_u32(189))][u32(unconst_u32(112))][u32(unconst_u32(40))];
+  var vf102: u32 = vf100;
+  var vf103: u32 = pack4xU8Clamp(vec4u(unconst_u32(66), unconst_u32(60), unconst_u32(229), unconst_u32(96)));
+  let vf104: f16 = ldexp(f16(unconst_f16(39155.8)), i32(unconst_i32(31)));
+  vf101 -= vf98[u32(unconst_u32(748))][u32(unconst_u32(111))][u32(unconst_u32(20))][u32(unconst_u32(425))];
+  vf101 += vp8.fract[2];
+  let ptr62: ptr<function, f16> = &vf101;
+  let vf105: i32 = dot4I8Packed(u32(unconst_u32(369)), u32(unconst_u32(440)));
+  let ptr63: ptr<function, array<mat2x2h, 1>> = &vf98[u32(unconst_u32(289))];
+  var vf106 = fn0();
+  fn0();
+  vf101 = f16(normalize(vec2f(unconst_f32(0.5329), unconst_f32(0.2157))).g);
+  let ptr64: ptr<function, mat2x2h> = &vf99[0][0];
+  let ptr65: ptr<function, u32> = &vf103;
+  vf102 += u32(vf98[u32(unconst_u32(212))][0][u32(unconst_u32(324))][u32(unconst_u32(226))]);
+  return out;
+  _ = override6;
+  _ = override7;
+}
+
+@fragment
+fn fragment5() -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  var vf107 = fn1();
+  fn0();
+  let ptr66 = &vp8;
+  fn1();
+  let ptr67: ptr<private, vec4h> = &(*ptr66).whole;
+  vf107.f0 += vec4f(f32(override6));
+  var vf108 = fn1();
+  let vf109: f32 = floor(f32(unconst_f32(0.2669)));
+  fn1();
+  var vf110 = fn1();
+  out.f0 = vec4f(bitcast<f32>(override7));
+  let vf111: u32 = pack4xI8(vec4i(i32(log(f16(unconst_f16(1221.2))))));
+  vf108 = FragmentOutput5(vec4f(vp8.whole));
+  vf108.f0 -= vf110.f0;
+  fn1();
+  var vf112: vec2h = sin(vec2h(unconst_f16(14589.1), unconst_f16(108.1)));
+  let vf113: vec4h = fma(vec4h(unconst_f16(20817.9), unconst_f16(8576.3), unconst_f16(9574.4), unconst_f16(1227.2)), vec4h(unconst_f16(7079.5), unconst_f16(1170.1), unconst_f16(2841.2), unconst_f16(24328.2)), vec4h(f16(floor(f32(unconst_f32(0.2203))))));
+  fn1();
+  vf110 = FragmentOutput5(vec4f(vp8.whole));
+  let ptr68 = &vp8;
+  vf107 = FragmentOutput5(vec4f(vp8.fract));
+  out.f0 -= vec4f(abs(vec2h(unconst_f16(408.9), unconst_f16(3778.5))).gggg);
+  vf107 = FragmentOutput5(vec4f(bitcast<f32>(pack4xI8(vec4i(unconst_i32(553), unconst_i32(282), unconst_i32(241), unconst_i32(392))))));
+  return out;
+  _ = override7;
+  _ = override6;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute4(@builtin(global_invocation_id) a0: vec3u, @builtin(workgroup_id) a1: vec3u) {
+  var vf114: u32 = atomicExchange(&vw12, u32(unconst_u32(8)));
+}`,
+});
+let texture213 = device0.createTexture({
+  size: [480],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder145.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(0, bindGroup121, new Uint32Array(86), 2, 0);
+} catch {}
+try {
+computePassEncoder151.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup89, new Uint32Array(275), 106, 0);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle0, renderBundle22]);
+} catch {}
+let arrayBuffer25 = buffer5.getMappedRange(3320, 16);
+try {
+gpuCanvasContext4.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer31, 512, new BigUint64Array(604), 41);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 9},
+  aspect: 'all',
+}, new Uint8Array(22).fill(125), /* required buffer size: 22 */
+{offset: 22, bytesPerRow: 32}, {width: 4, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup136 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout46,
+  entries: [{binding: 0, resource: {buffer: buffer125, offset: 2816, size: 591}}],
+});
+let textureView217 = texture159.createView({label: '\ufbcc\u025a\u7741\uec4b', dimension: '2d-array', format: 'rgba16uint', mipLevelCount: 1});
+let sampler117 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat'});
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup44, new Uint32Array(1696), 320, 0);
+} catch {}
+try {
+renderPassEncoder40.setScissorRect(0, 18, 5, 10);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer17, 'uint16', 74, 41);
+} catch {}
+let veryExplicitBindGroupLayout37 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 19,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 24,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 134,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 184,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup137 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout11,
+  entries: [{binding: 0, resource: {buffer: buffer50, offset: 256, size: 261}}],
+});
+let texture214 = device0.createTexture({
+  size: [60],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder23.setIndexBuffer(buffer126, 'uint16', 6_530, 1_261);
+} catch {}
+await gc();
+let bindGroup138 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [{binding: 0, resource: {buffer: buffer40, offset: 1024, size: 488}}],
+});
+let textureView218 = texture130.createView({baseMipLevel: 0});
+try {
+computePassEncoder41.setBindGroup(2, bindGroup39);
+} catch {}
+try {
+computePassEncoder61.setBindGroup(3, bindGroup61, new Uint32Array(4691), 347, 0);
+} catch {}
+try {
+renderPassEncoder47.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline17);
+} catch {}
+document.body.prepend(canvas1);
+let buffer136 = device0.createBuffer({
+  size: 48144,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView219 = texture109.createView({arrayLayerCount: 1});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup20, new Uint32Array(2179), 283, 0);
+} catch {}
+try {
+computePassEncoder150.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(0, buffer39, 0, 3_948);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer51.unmap();
+} catch {}
+let pipeline22 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule1}});
+document.body.append(img2);
+try {
+renderPassEncoder44.setVertexBuffer(3, buffer61, 0, 324);
+} catch {}
+let veryExplicitBindGroupLayout38 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 39,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let texture215 = device0.createTexture({
+  size: [97, 60, 261],
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView220 = texture118.createView({aspect: 'depth-only', mipLevelCount: 1});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+computePassEncoder149.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup125);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(5, buffer16, 0, 1_731);
+} catch {}
+try {
+  await shaderModule1.getCompilationInfo();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture212,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(61).fill(231), /* required buffer size: 61 */
+{offset: 61}, {width: 41, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 23}
+*/
+{
+  source: videoFrame23,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline23 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout4,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment1',
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus',
+    depthWriteEnabled: false,
+    stencilReadMask: 73039152,
+    stencilWriteMask: 62873617,
+    depthBiasSlopeScale: 915.5828870616604,
+    depthBiasClamp: 791.4257753172849,
+  },
+  vertex: {
+    module: shaderModule5,
+    constants: {11_428: 0},
+    buffers: [{arrayStride: 1532, attributes: [{format: 'snorm16x2', offset: 12, shaderLocation: 14}]}],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front'},
+});
+let img7 = await imageWithData(20, 7, '#10101010', '#20202020');
+let autogeneratedBindGroupLayout66 = pipeline0.getBindGroupLayout(0);
+let buffer137 = device0.createBuffer({size: 44671, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let commandEncoder199 = device0.createCommandEncoder({});
+let textureView221 = texture207.createView({baseArrayLayer: 0});
+let computePassEncoder152 = commandEncoder199.beginComputePass({});
+try {
+computePassEncoder114.setBindGroup(3, bindGroup40);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline13);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let pipeline24 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {count: 4, mask: 0xffffffff, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment1',
+  targets: [{format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgba16sint', writeMask: 0}, {format: 'rg32uint', writeMask: GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth24plus',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {},
+    stencilReadMask: 1946097127,
+    stencilWriteMask: 65975671,
+    depthBiasClamp: 435.49826564918806,
+  },
+  vertex: {module: shaderModule3, constants: {27_508: 0}, buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+let autogeneratedBindGroupLayout67 = pipeline15.getBindGroupLayout(0);
+let commandEncoder200 = device0.createCommandEncoder();
+let texture216 = device0.createTexture({
+  size: [240, 1, 64],
+  mipLevelCount: 1,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder53 = commandEncoder200.beginRenderPass({
+  colorAttachments: [{
+  view: textureView11,
+  depthSlice: 15,
+  clearValue: { r: -507.7, g: 20.31, b: -73.10, a: -301.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder24.setIndexBuffer(buffer100, 'uint32', 1_540, 320);
+} catch {}
+try {
+computePassEncoder39.setBindGroup(1, bindGroup104);
+} catch {}
+try {
+computePassEncoder108.setBindGroup(0, bindGroup46, new Uint32Array(418), 112, 0);
+} catch {}
+try {
+computePassEncoder152.setPipeline(pipeline19);
+} catch {}
+let autogeneratedBindGroupLayout68 = pipeline2.getBindGroupLayout(0);
+let buffer138 = device0.createBuffer({size: 28653, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let commandEncoder201 = device0.createCommandEncoder({});
+let externalTexture24 = device0.importExternalTexture({source: videoFrame4});
+try {
+renderPassEncoder38.executeBundles([renderBundle5, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder46.setStencilReference(84);
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline17);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer50, 232, new Float32Array(18545), 832, 116);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 7}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 2, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline25 = await promise31;
+let veryExplicitBindGroupLayout39 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 137,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 151,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout69 = pipeline16.getBindGroupLayout(0);
+let textureView222 = texture126.createView({});
+try {
+renderPassEncoder13.setIndexBuffer(buffer124, 'uint16', 5_560, 4_448);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(6, buffer33, 12);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let pipeline26 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0}});
+let textureView223 = texture44.createView({label: '\u0771\u00df\ube89\ua3ba', baseMipLevel: 0});
+try {
+computePassEncoder110.setBindGroup(3, bindGroup50, new Uint32Array(654), 109, 0);
+} catch {}
+let promise32 = device0.createComputePipelineAsync({layout: pipelineLayout5, compute: {module: shaderModule1, constants: {}}});
+try {
+if (!arrayBuffer23.detached) { new Uint8Array(arrayBuffer23).fill(0x55); };
+} catch {}
+let buffer139 = device0.createBuffer({
+  size: 12362,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture217 = device0.createTexture({
+  size: {width: 195, height: 120, depthOrArrayLayers: 1},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder153 = commandEncoder201.beginComputePass({});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup42);
+} catch {}
+try {
+computePassEncoder153.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup114);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle4]);
+} catch {}
+let pipeline27 = await device0.createComputePipelineAsync({layout: pipelineLayout6, compute: {module: shaderModule5}});
+await gc();
+let imageData29 = new ImageData(16, 12);
+let texture218 = device0.createTexture({
+  size: [97, 60, 1],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView224 = texture4.createView({});
+try {
+computePassEncoder144.setBindGroup(2, bindGroup110, new Uint32Array(554), 25, 0);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup13, new Uint32Array(1625), 940, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame26,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 54, y: 78, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+videoFrame31 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'bt470bg', transfer: 'smpte170m'} });
+let bindGroup139 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout16,
+  entries: [
+    {binding: 82, resource: textureView33},
+    {binding: 95, resource: {buffer: buffer2, offset: 256, size: 848}},
+    {binding: 104, resource: textureView197},
+    {binding: 51, resource: textureView30},
+    {binding: 6, resource: {buffer: buffer138, offset: 4864, size: 7708}},
+    {binding: 203, resource: {buffer: buffer41, offset: 0, size: 2348}},
+    {binding: 13, resource: sampler48},
+    {binding: 183, resource: textureView23},
+    {binding: 153, resource: externalTexture20},
+    {binding: 93, resource: {buffer: buffer99, offset: 512, size: 344}},
+    {binding: 88, resource: sampler1},
+  ],
+});
+let commandEncoder202 = device0.createCommandEncoder({});
+let textureView225 = texture73.createView({dimension: '2d', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder154 = commandEncoder202.beginComputePass({});
+let sampler118 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat'});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+computePassEncoder148.setBindGroup(3, bindGroup73, new Uint32Array(693), 88, 0);
+} catch {}
+try {
+computePassEncoder154.setPipeline(pipeline15);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 240, height: 1, depthOrArrayLayers: 141}
+*/
+{
+  source: imageData1,
+  origin: { x: 3, y: 0 },
+  flipY: false,
+}, {
+  texture: texture166,
+  mipLevel: 1,
+  origin: {x: 43, y: 0, z: 62},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise33 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {module: shaderModule4, constants: {}, targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL}]},
+  vertex: {
+    module: shaderModule5,
+    constants: {11_428: 0, override6: 0},
+    buffers: [
+      {
+        arrayStride: 464,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x2', offset: 184, shaderLocation: 14}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'back'},
+});
+let buffer140 = device0.createBuffer({size: 7090, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let texture219 = device0.createTexture({
+  size: [60],
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture220 = gpuCanvasContext0.getCurrentTexture();
+let sampler119 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 72.29,
+});
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup1, new Uint32Array(601), 272, 0);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle33]);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer132, 'uint16', 306, 102);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline13);
+} catch {}
+let pipeline28 = device0.createRenderPipeline({
+  layout: pipelineLayout2,
+  multisample: {mask: 0x1693669c},
+  fragment: {
+  module: shaderModule4,
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  vertex: {module: shaderModule3, entryPoint: 'vertex3', constants: {27_508: 0}, buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'cw'},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55); };
+} catch {}
+await gc();
+let commandEncoder203 = device0.createCommandEncoder({});
+try {
+computePassEncoder114.setBindGroup(3, bindGroup75);
+} catch {}
+try {
+computePassEncoder99.setBindGroup(1, bindGroup25, new Uint32Array(1838), 687, 0);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup78, new Uint32Array(428), 7, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle3, renderBundle32, renderBundle1, renderBundle27]);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(0, buffer21, 44, 61);
+} catch {}
+try {
+  await buffer8.mapAsync(GPUMapMode.READ, 1712, 4276);
+} catch {}
+try {
+commandEncoder203.copyBufferToTexture({
+  /* bytesInLastRow: 152 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 744 */
+  offset: 744,
+  buffer: buffer58,
+}, {
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 0, y: 4, z: 1},
+  aspect: 'all',
+}, new Uint8Array(52).fill(27), /* required buffer size: 52 */
+{offset: 52, bytesPerRow: 83}, {width: 4, height: 2, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas2);
+try {
+globalThis.someLabel = bindGroup40.label;
+} catch {}
+let autogeneratedBindGroupLayout70 = pipeline8.getBindGroupLayout(0);
+let bindGroup140 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout61,
+  entries: [{binding: 0, resource: {buffer: buffer39, offset: 3584}}],
+});
+let buffer141 = device0.createBuffer({
+  size: 10296,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let computePassEncoder155 = commandEncoder203.beginComputePass();
+try {
+computePassEncoder155.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer115, 'uint32', 3_556, 3_709);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(7, buffer21);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 4332, new Int16Array(2626), 677, 148);
+} catch {}
+document.body.append(canvas1);
+let texture221 = device0.createTexture({
+  size: [780, 480, 3],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView226 = texture102.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 12});
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup53, new Uint32Array(3143), 326, 0);
+} catch {}
+try {
+renderPassEncoder51.setViewport(181.32733036280192, 226.63894747612255, 311.58403279222694, 247.66189830736099, 0.48735495310442334, 0.9588622173834753);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer76, 'uint32', 1_136, 3_014);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(7, buffer0, 0, 4_212);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 480, height: 1, depthOrArrayLayers: 141}
+*/
+{
+  source: videoFrame24,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture166,
+  mipLevel: 0,
+  origin: {x: 74, y: 0, z: 10},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup141 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout44,
+  entries: [{binding: 0, resource: {buffer: buffer133, offset: 0, size: 9992}}],
+});
+let textureView227 = texture69.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 5});
+let sampler120 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 87.38,
+  lodMaxClamp: 91.76,
+});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup124);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(2, bindGroup0, new Uint32Array(2123), 730, 0);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+externalTexture17.label = '\u0232\u{1fed8}\u960b\u0886\u534c';
+} catch {}
+let commandEncoder204 = device0.createCommandEncoder({});
+let computePassEncoder156 = commandEncoder204.beginComputePass();
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup80);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup19, new Uint32Array(273), 3, 0);
+} catch {}
+let pipeline29 = await promise32;
+let texture222 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 216},
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder156.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(7, buffer18);
+} catch {}
+try {
+globalThis.someLabel = externalTexture2.label;
+} catch {}
+let buffer142 = device0.createBuffer({
+  size: 2538,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup131, new Uint32Array(3174), 80, 0);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(1, bindGroup64);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup66, new Uint32Array(142), 11, 0);
+} catch {}
+try {
+renderPassEncoder48.setStencilReference(681);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer141, 'uint16', 6, 628);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(5, buffer118, 8, 86);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let arrayBuffer26 = buffer22.getMappedRange(128, 32);
+try {
+device0.queue.writeBuffer(buffer96, 812, new Int16Array(1318), 53, 8);
+} catch {}
+let bindGroup142 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout30,
+  entries: [{binding: 0, resource: {buffer: buffer17, offset: 0, size: 310}}],
+});
+let commandEncoder205 = device0.createCommandEncoder({});
+let texture223 = device0.createTexture({
+  size: {width: 195},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16sint'],
+});
+let sampler121 = device0.createSampler({addressModeW: 'mirror-repeat', minFilter: 'linear'});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup36);
+} catch {}
+try {
+computePassEncoder69.setBindGroup(0, bindGroup5, new Uint32Array(7030), 1_759, 0);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup97, new Uint32Array(914), 476, 0);
+} catch {}
+try {
+commandEncoder205.copyBufferToTexture({
+  /* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1904 */
+  offset: 1904,
+  bytesPerRow: 4096,
+  buffer: buffer28,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 194, y: 0, z: 3},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline13);
+} catch {}
+let arrayBuffer27 = buffer8.getMappedRange(1712, 1072);
+try {
+commandEncoder205.resolveQuerySet(querySet22, 345, 14, buffer81, 0);
+} catch {}
+try {
+renderPassEncoder45.insertDebugMarker('\u{1f691}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup143 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout9,
+  entries: [{binding: 0, resource: {buffer: buffer91, offset: 1024}}],
+});
+let commandEncoder206 = device0.createCommandEncoder({});
+let texture224 = device0.createTexture({
+  size: {width: 240},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture225 = device0.createTexture({
+  size: {width: 60, height: 1, depthOrArrayLayers: 74},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder54 = commandEncoder206.beginRenderPass({
+  colorAttachments: [{
+  view: textureView68,
+  clearValue: { r: -494.8, g: -776.0, b: -515.5, a: -699.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 155351498,
+});
+let sampler122 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.87,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder66.setBindGroup(0, bindGroup110);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer106, 'uint16', 6, 82);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(4, buffer10, 3_272);
+} catch {}
+try {
+commandEncoder205.copyBufferToBuffer(buffer56, 1200, buffer24, 1076, 8);
+} catch {}
+try {
+commandEncoder205.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 984 */
+  offset: 984,
+  bytesPerRow: 54528,
+  buffer: buffer113,
+}, {
+  texture: texture225,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 3},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+videoFrame32 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt470m', transfer: 'unspecified'} });
+try {
+externalTexture9.label = '\u5850\uecf3\u{1f7f8}\u0f92';
+} catch {}
+let autogeneratedBindGroupLayout71 = pipeline12.getBindGroupLayout(0);
+let computePassEncoder157 = commandEncoder205.beginComputePass({});
+let externalTexture25 = device0.importExternalTexture({source: videoFrame28, colorSpace: 'srgb'});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup126, new Uint32Array(594), 77, 0);
+} catch {}
+try {
+computePassEncoder157.setPipeline(pipeline29);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(285).fill(171), /* required buffer size: 285 */
+{offset: 285}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout14]});
+let commandEncoder207 = device0.createCommandEncoder();
+let computePassEncoder158 = commandEncoder207.beginComputePass({});
+try {
+renderPassEncoder15.setVertexBuffer(3, buffer21, 2_032);
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+let promise34 = device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule0}});
+let autogeneratedBindGroupLayout72 = pipeline6.getBindGroupLayout(0);
+let commandEncoder208 = device0.createCommandEncoder({});
+let texture226 = device0.createTexture({
+  size: {width: 480, height: 1, depthOrArrayLayers: 8},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView228 = texture5.createView({mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+computePassEncoder66.setBindGroup(1, bindGroup116, new Uint32Array(6109), 981, 0);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer39, 'uint32', 1_100, 1_292);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline11);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(img7);
+let buffer143 = device0.createBuffer({size: 8952, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder209 = device0.createCommandEncoder({});
+let texture227 = device0.createTexture({
+  size: [390, 240, 1],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder159 = commandEncoder208.beginComputePass({});
+let sampler123 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.36,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder159.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder209.clearBuffer(buffer70);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 13},
+  aspect: 'all',
+}, new Uint8Array(6_417).fill(230), /* required buffer size: 6_417 */
+{offset: 27, bytesPerRow: 127, rowsPerImage: 16}, {width: 5, height: 3, depthOrArrayLayers: 4});
+} catch {}
+let autogeneratedBindGroupLayout73 = pipeline1.getBindGroupLayout(0);
+let computePassEncoder160 = commandEncoder209.beginComputePass({});
+let sampler124 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 17.97,
+});
+try {
+computePassEncoder160.setPipeline(pipeline27);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let autogeneratedBindGroupLayout74 = pipeline25.getBindGroupLayout(0);
+let commandEncoder210 = device0.createCommandEncoder();
+let texture228 = device0.createTexture({
+  size: [16, 16, 569],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder114.setBindGroup(0, bindGroup112);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup107, []);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline16);
+} catch {}
+try {
+commandEncoder210.copyBufferToTexture({
+  /* bytesInLastRow: 48 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 152 */
+  offset: 152,
+  bytesPerRow: 8960,
+  buffer: buffer99,
+}, {
+  texture: texture116,
+  mipLevel: 0,
+  origin: {x: 14, y: 5, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 17, depthOrArrayLayers: 0});
+} catch {}
+let pipeline30 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule5,
+  constants: {11_428: 0},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule1,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 80,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 32, shaderLocation: 12}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'none'},
+});
+let recycledExplicitBindGroupLayout0 = pipeline28.getBindGroupLayout(0);
+let bindGroup144 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout22,
+  entries: [{binding: 0, resource: {buffer: buffer143, offset: 256}}],
+});
+let texture229 = device0.createTexture({size: [390, 240, 1], format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_DST});
+let textureView229 = texture29.createView({format: 'rgba32uint', baseMipLevel: 0, baseArrayLayer: 0});
+try {
+renderPassEncoder37.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer56, 'uint32', 112, 180);
+} catch {}
+let bindGroup145 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout27,
+  entries: [{binding: 0, resource: {buffer: buffer76, offset: 256, size: 1184}}],
+});
+let commandEncoder211 = device0.createCommandEncoder();
+try {
+renderPassEncoder0.setIndexBuffer(buffer124, 'uint32', 3_656, 1_355);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline21);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+document.body.prepend(canvas0);
+let bindGroup146 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout54,
+  entries: [
+    {binding: 19, resource: textureView86},
+    {binding: 184, resource: {buffer: buffer100, offset: 3328, size: 340}},
+    {binding: 134, resource: {buffer: buffer127, offset: 1536, size: 1134}},
+  ],
+});
+let commandEncoder212 = device0.createCommandEncoder();
+let querySet32 = device0.createQuerySet({type: 'occlusion', count: 293});
+let textureView230 = texture193.createView({aspect: 'depth-only', arrayLayerCount: 1});
+let renderPassEncoder55 = commandEncoder210.beginRenderPass({colorAttachments: [{view: textureView165, depthSlice: 6, loadOp: 'load', storeOp: 'discard'}]});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup80);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer61, 'uint16', 610, 469);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(4, buffer26, 3_544, 4_243);
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\u{1fead}');
+} catch {}
+let img8 = await imageWithData(26, 2, '#10101010', '#20202020');
+let commandEncoder213 = device0.createCommandEncoder({});
+let texture230 = device0.createTexture({size: [240, 1, 5], mipLevelCount: 2, format: 'rg8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let texture231 = gpuCanvasContext4.getCurrentTexture();
+let renderPassEncoder56 = commandEncoder212.beginRenderPass({
+  colorAttachments: [{
+  view: textureView79,
+  clearValue: { r: -31.07, g: -970.1, b: 839.6, a: -930.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet2,
+});
+try {
+computePassEncoder8.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(1, buffer10, 0, 2_804);
+} catch {}
+try {
+commandEncoder211.clearBuffer(buffer31);
+} catch {}
+let buffer144 = device0.createBuffer({size: 11527, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let textureView231 = texture219.createView({});
+let textureView232 = texture1.createView({mipLevelCount: 1});
+let computePassEncoder161 = commandEncoder211.beginComputePass({});
+let sampler125 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat'});
+let externalTexture26 = device0.importExternalTexture({source: videoFrame17});
+try {
+computePassEncoder59.setBindGroup(3, bindGroup145, new Uint32Array(146), 5, 0);
+} catch {}
+try {
+commandEncoder213.copyBufferToTexture({
+  /* bytesInLastRow: 1224 widthInBlocks: 153 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2312 */
+  offset: 2312,
+  bytesPerRow: 1792,
+  buffer: buffer23,
+}, {
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 627, y: 13, z: 11},
+  aspect: 'all',
+}, {width: 153, height: 151, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let recycledExplicitBindGroupLayout1 = pipeline19.getBindGroupLayout(0);
+let bindGroup147 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout12,
+  entries: [{binding: 0, resource: {buffer: buffer105, offset: 6400, size: 1272}}],
+});
+let textureView233 = texture104.createView({dimension: '2d-array', arrayLayerCount: 1});
+let computePassEncoder162 = commandEncoder213.beginComputePass({});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup146);
+} catch {}
+try {
+computePassEncoder149.setBindGroup(0, bindGroup109, new Uint32Array(1567), 83, 0);
+} catch {}
+try {
+computePassEncoder161.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle11, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer135, 'uint32', 4_120, 3_279);
+} catch {}
+let bindGroup148 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout72,
+  entries: [{binding: 0, resource: {buffer: buffer129, offset: 3072, size: 656}}],
+});
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: []});
+try {
+renderPassEncoder46.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(1, buffer112);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 780, height: 480, depthOrArrayLayers: 1}
+*/
+{
+  source: img8,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 226, y: 50, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u{1f6b0}\ue940';
+} catch {}
+let buffer145 = device0.createBuffer({
+  size: 15650,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture232 = device0.createTexture({
+  size: [16, 16, 22],
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder103.setBindGroup(0, bindGroup137);
+} catch {}
+try {
+computePassEncoder162.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer141, 'uint16', 494, 694);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder214 = device0.createCommandEncoder();
+let textureView234 = texture73.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder111.setBindGroup(1, bindGroup83, new Uint32Array(558), 79, 0);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(43);
+} catch {}
+try {
+renderPassEncoder29.insertDebugMarker('\u{1fb9c}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 448, new DataView(new ArrayBuffer(17096)), 10071, 152);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData18,
+  origin: { x: 1, y: 1 },
+  flipY: false,
+}, {
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture233 = device0.createTexture({size: [780], sampleCount: 1, dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder151.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder51.beginOcclusionQuery(38);
+} catch {}
+try {
+commandEncoder214.copyBufferToTexture({
+  /* bytesInLastRow: 18 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2034 */
+  offset: 2034,
+  buffer: buffer27,
+}, {
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 9, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let texture234 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder163 = commandEncoder214.beginComputePass({});
+let sampler126 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'repeat'});
+let pipeline31 = await promise34;
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+await gc();
+let bindGroup149 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout45,
+  entries: [{binding: 0, resource: {buffer: buffer28, offset: 0, size: 1912}}],
+});
+let buffer146 = device0.createBuffer({
+  size: 2387,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+try {
+computePassEncoder71.setBindGroup(3, bindGroup141, new Uint32Array(1353), 58, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup95);
+} catch {}
+try {
+renderPassEncoder51.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer108, 0, 2_387);
+} catch {}
+try {
+buffer52.unmap();
+} catch {}
+let commandEncoder215 = device0.createCommandEncoder({});
+let textureView235 = texture175.createView({});
+let computePassEncoder164 = commandEncoder215.beginComputePass({});
+let sampler127 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.73,
+});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup114);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(3, bindGroup131);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle0, renderBundle28, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer62, 'uint32', 176, 1_375);
+} catch {}
+try {
+computePassEncoder78.insertDebugMarker('\u{1f653}');
+} catch {}
+let commandEncoder216 = device0.createCommandEncoder({});
+let computePassEncoder165 = commandEncoder216.beginComputePass({});
+try {
+computePassEncoder129.setBindGroup(3, bindGroup65);
+} catch {}
+try {
+computePassEncoder158.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle11, renderBundle31, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline30);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData30 = new ImageData(152, 4);
+let veryExplicitBindGroupLayout40 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 167,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup150 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout29,
+  entries: [{binding: 191, resource: {buffer: buffer106, offset: 0, size: 772}}],
+});
+let texture235 = device0.createTexture({
+  size: [97],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder40.executeBundles([renderBundle22, renderBundle5, renderBundle32, renderBundle28, renderBundle28, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline21);
+} catch {}
+try {
+computePassEncoder49.pushDebugGroup('\u6dbe');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 1764, new BigUint64Array(1468));
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let imageData31 = new ImageData(40, 24);
+try {
+computePassEncoder164.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup114, new Uint32Array(2261), 542, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(0, 79, 8, 713_871_056, 597_559_116);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer113, 'uint16', 1_612, 1_088);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(1, buffer18);
+} catch {}
+let arrayBuffer28 = buffer90.getMappedRange(1760, 208);
+try {
+buffer37.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 12},
+  aspect: 'all',
+}, new Uint8Array(109_967).fill(148), /* required buffer size: 109_967 */
+{offset: 363, bytesPerRow: 120, rowsPerImage: 34}, {width: 22, height: 30, depthOrArrayLayers: 27});
+} catch {}
+let imageBitmap5 = await createImageBitmap(imageData9);
+let externalTexture27 = device0.importExternalTexture({source: videoFrame25, colorSpace: 'srgb'});
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer75, 552);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer124, 'uint32', 2_048, 1_599);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline30);
+} catch {}
+await gc();
+videoFrame33 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'bt709', transfer: 'linear'} });
+let sampler128 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 89.87});
+try {
+computePassEncoder163.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup52);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup118, new Uint32Array(1913), 576, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(64, 15, 63, 38_434_334, 233_059_285);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer60, 8);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline14);
+} catch {}
+let bindGroup151 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout32,
+  entries: [{binding: 0, resource: {buffer: buffer115, offset: 4608, size: 125}}],
+});
+let buffer147 = device0.createBuffer({
+  size: 9684,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder217 = device0.createCommandEncoder();
+let computePassEncoder166 = commandEncoder217.beginComputePass({});
+let sampler129 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMinClamp: 8.328, compare: 'never'});
+try {
+renderPassEncoder1.drawIndexed(65, 266, 19, 39_478_829, 690_138_915);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer121, 5_396);
+} catch {}
+try {
+globalThis.someLabel = texture202.label;
+} catch {}
+let bindGroup152 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout37,
+  entries: [{binding: 0, resource: {buffer: buffer127, offset: 1792, size: 761}}],
+});
+let commandEncoder218 = device0.createCommandEncoder({});
+let texture236 = device0.createTexture({
+  size: [60, 1, 78],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView236 = texture84.createView({});
+let computePassEncoder167 = commandEncoder218.beginComputePass({});
+try {
+computePassEncoder151.setBindGroup(3, bindGroup68, new Uint32Array(4643), 557, 0);
+} catch {}
+try {
+computePassEncoder165.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(1, bindGroup73);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(6, 100, 9, 15_792_461, 41_732_815);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer93, 328);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(5, buffer4, 676, 678);
+} catch {}
+let buffer148 = device0.createBuffer({size: 10715, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder167.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(10, 443, 168, 613_853_858, 2_241_972_317);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer133, 1_248);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer93, 3_548);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline13);
+} catch {}
+let pipeline32 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {mask: 0xffffffff},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment5',
+  constants: {11_428: 0},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 372,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 4, shaderLocation: 6}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', cullMode: 'back'},
+});
+let commandEncoder219 = device0.createCommandEncoder();
+let texture237 = device0.createTexture({
+  size: {width: 16},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView237 = texture153.createView({label: '\u0882\ub234\u0455\u002c\u24a5\u06fd\ua7b5\ub856\ue2ea\ubbaa', arrayLayerCount: 1});
+try {
+computePassEncoder53.setBindGroup(3, bindGroup152);
+} catch {}
+try {
+computePassEncoder23.setBindGroup(1, bindGroup135, new Uint32Array(2455), 601, 0);
+} catch {}
+try {
+computePassEncoder166.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer144, 556);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer144, 1_284);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer17, 'uint32', 24, 144);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline30);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(1, buffer98, 3_628, 97);
+} catch {}
+let promise35 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 23}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer17.detached) { new Uint8Array(arrayBuffer17).fill(0x55); };
+} catch {}
+let bindGroup153 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 21, resource: textureView13},
+    {binding: 400, resource: {buffer: buffer2, offset: 4096, size: 1456}},
+    {binding: 50, resource: sampler87},
+  ],
+});
+let commandEncoder220 = device0.createCommandEncoder({});
+let textureView238 = texture97.createView({dimension: '2d-array', aspect: 'all'});
+let computePassEncoder168 = commandEncoder220.beginComputePass({});
+let sampler130 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', mipmapFilter: 'linear'});
+let externalTexture28 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'display-p3'});
+try {
+computePassEncoder168.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup104, new Uint32Array(3602), 472, 0);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle32, renderBundle1, renderBundle6, renderBundle28, renderBundle33, renderBundle27]);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(71, 52, 9, 36_458_159, 1_076_627_012);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer127, 316);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer127, 'uint32', 2_236, 1_665);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline32);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+videoFrame34 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'smpte432', transfer: 'gamma22curve'} });
+let autogeneratedBindGroupLayout75 = pipeline10.getBindGroupLayout(0);
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout1]});
+let commandEncoder221 = device0.createCommandEncoder({});
+let texture238 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder169 = commandEncoder221.beginComputePass();
+try {
+computePassEncoder100.setBindGroup(1, bindGroup47, new Uint32Array(216), 70, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder1.draw(2, 74, 1, 176_909_792);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer34, 976);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline13);
+} catch {}
+try {
+buffer81.unmap();
+} catch {}
+try {
+  await promise35;
+} catch {}
+videoFrame35 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpte170m', transfer: 'logSqrt'} });
+let textureView239 = texture47.createView({dimension: '2d', baseArrayLayer: 2});
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer27, 7_640);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline21);
+} catch {}
+try {
+commandEncoder219.copyBufferToTexture({
+  /* bytesInLastRow: 324 widthInBlocks: 81 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 104 */
+  offset: 104,
+  buffer: buffer42,
+}, {
+  texture: texture206,
+  mipLevel: 0,
+  origin: {x: 59, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 81, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 195, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 8, y: 0 },
+  flipY: false,
+}, {
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 64, y: 13, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout42]});
+let textureView240 = texture114.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderPassEncoder57 = commandEncoder219.beginRenderPass({
+  colorAttachments: [{view: textureView79, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet9,
+});
+try {
+computePassEncoder100.setBindGroup(3, bindGroup87, new Uint32Array(827), 66, 0);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder9.drawIndexed(1_694, 75, 1_323, 129_030_694, 2_638_194_835);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer60, 'uint32', 396, 1_060);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(4, buffer26);
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+var<workgroup> vw14: T5;
+
+var<private> vp9: VertexOutput5 = VertexOutput5();
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T0 {
+  f0: f16,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T5 {
+  f0: f16,
+}
+
+struct FragmentOutput7 {
+  @location(2) @interpolate(flat, sample) f0: vec4u,
+  @location(0) @interpolate(flat) f1: vec4i,
+  @location(1) @interpolate(flat) f2: vec4u,
+  @location(7) @interpolate(flat, center) f3: i32,
+}
+
+fn fn0(a0: ptr<function, FragmentOutput6>) -> f32 {
+  var out: f32;
+  let ptr69: ptr<private, vec2f> = &vp9.f21;
+  out -= vp9.f18;
+  let vf115: vec3f = fma(vec3f(unconst_f32(0.04456), unconst_f32(0.1382), unconst_f32(0.09547)), vec3f(unconst_f32(0.1552), unconst_f32(0.01182), unconst_f32(0.08962)), vec3f(unconst_f32(0.1553), unconst_f32(0.06910), unconst_f32(0.1180)));
+  out += sqrt(vec4f(vp9.f16))[0];
+  (*a0) = FragmentOutput6(vec4u(fma(vec3f(unconst_f32(0.02515), unconst_f32(0.3110), unconst_f32(-0.2191)), vec3f(unconst_f32(0.2566), unconst_f32(0.01755), unconst_f32(0.1002)), vec3f(unconst_f32(0.1376), unconst_f32(0.2772), unconst_f32(0.5428))).xxyx), vec4u(fma(vec3f(unconst_f32(0.02515), unconst_f32(0.3110), unconst_f32(-0.2191)), vec3f(unconst_f32(0.2566), unconst_f32(0.01755), unconst_f32(0.1002)), vec3f(unconst_f32(0.1376), unconst_f32(0.2772), unconst_f32(0.5428))).zxxz), vec4i(fma(vec3f(unconst_f32(0.02515), unconst_f32(0.3110), unconst_f32(-0.2191)), vec3f(unconst_f32(0.2566), unconst_f32(0.01755), unconst_f32(0.1002)), vec3f(unconst_f32(0.1376), unconst_f32(0.2772), unconst_f32(0.5428))).yxxx), fma(vec3f(unconst_f32(0.02515), unconst_f32(0.3110), unconst_f32(-0.2191)), vec3f(unconst_f32(0.2566), unconst_f32(0.01755), unconst_f32(0.1002)), vec3f(unconst_f32(0.1376), unconst_f32(0.2772), unconst_f32(0.5428))).rbgb);
+  let vf116: i32 = vp9.f16[pack4x8unorm((*a0).f3)];
+  vp9 = VertexOutput5(vec4i(i32((*a0).f3[u32(unconst_u32(213))])), f16((*a0).f3[u32(unconst_u32(213))]), (*a0).f3[u32(unconst_u32(213))], vec2u(bitcast<u32>((*a0).f3[u32(unconst_u32(213))])), u32((*a0).f3[u32(unconst_u32(213))]), vec2f((*a0).f3[u32(unconst_u32(213))]), vec4u(bitcast<u32>((*a0).f3[u32(unconst_u32(213))])), vec4f((*a0).f3[u32(unconst_u32(213))]));
+  let vf117: f32 = vp9.f23[u32(unconst_u32(193))];
+  let ptr70: ptr<function, vec4i> = &(*a0).f2;
+  out = vf115[u32(unconst_u32(241))];
+  let ptr71: ptr<function, vec4u> = &(*a0).f0;
+  vp9.f21 += bitcast<vec2f>(textureDimensions(tex4, i32(unconst_i32(705))));
+  out += f32(vp9.f16[u32(unconst_u32(58))]);
+  let vf118: vec4f = textureLoad(et0, vec2u(unconst_u32(240), unconst_u32(6)));
+  let vf119: f32 = vf115[u32(unconst_u32(90))];
+  var vf120: i32 = (*ptr70)[u32(unconst_u32(217))];
+  (*a0) = FragmentOutput6(vec4u((*ptr69).rrgr), bitcast<vec4u>((*ptr69).xyyy), vec4i((*ptr69).gggr), (*ptr69).grrr);
+  return out;
+  _ = et0;
+  _ = tex4;
+}
+
+@group(0) @binding(51) var tex4: texture_depth_2d;
+
+@group(0) @binding(95) var<storage, read_write> buffer151: array<array<array<array<array<atomic<i32>, 1>, 1>, 3>, 1>>;
+
+struct T1 {
+  @size(12) f0: array<u32>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn fn1() -> array<T5, 1> {
+  var out: array<T5, 1>;
+  let ptr72: ptr<storage, atomic<i32>, read_write> = &buffer151[arrayLength(&buffer151)][u32(unconst_u32(34))][u32(unconst_u32(66))][u32(unconst_u32(555))][0];
+  textureStore(st0, vec3i(unconst_i32(180), unconst_i32(146), unconst_i32(303)), vec4f(vec4f(unconst_f32(0.03722), unconst_f32(0.06401), unconst_f32(0.07916), unconst_f32(0.1358))));
+  var vf121: i32 = atomicLoad(&(*ptr72));
+  let ptr73: ptr<storage, atomic<i32>, read_write> = &buffer151[u32(unconst_u32(63))][u32(unconst_u32(81))][u32(unconst_u32(798))][0][0];
+  let vf122: i32 = atomicLoad(&buffer151[arrayLength(&buffer151)][0][2][u32(unconst_u32(62))][0]);
+  var vf123: i32 = atomicExchange(&buffer151[u32(unconst_u32(39))][0][2][u32(unconst_u32(43))][u32(buffer152[575][1].f0)], atomicExchange(&buffer151[arrayLength(&buffer151)][0][u32(unconst_u32(288))][0][0], i32(unconst_i32(-39))));
+  let ptr74: ptr<storage, array<array<T5, 2>, 576>, read> = &buffer152;
+  let ptr75: ptr<storage, T5, read> = &(*ptr74)[u32(unconst_u32(204))][u32(unconst_u32(844))];
+  textureStore(st0, vec3i(unconst_i32(200), unconst_i32(250), unconst_i32(93)), vec4f(vec4f(unconst_f32(0.09051), unconst_f32(0.04480), unconst_f32(0.4048), unconst_f32(0.06394))));
+  textureStore(st0, vec3i(unconst_i32(30), unconst_i32(140), unconst_i32(160)), vec4f(vec4f(unconst_f32(0.1017), unconst_f32(0.03888), unconst_f32(0.04402), unconst_f32(0.05571))));
+  let vf124: i32 = atomicLoad(&(*&buffer151)[u32(unconst_u32(354))][u32(unconst_u32(3))][2][u32(unconst_u32(20))][u32(atomicExchange(&(*&buffer151)[arrayLength(&(*&buffer151))][0][2][0][0], i32(unconst_i32(69))))]);
+  let ptr76: ptr<storage, array<array<atomic<i32>, 1>, 1>, read_write> = &buffer151[arrayLength(&buffer151)][u32(unconst_u32(719))][u32(unconst_u32(209))];
+  vp9 = VertexOutput5();
+  return out;
+  _ = buffer151;
+  _ = st0;
+  _ = buffer152;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct VertexOutput5 {
+  @location(7) f16: vec4i,
+  @location(10) f17: f16,
+  @location(2) f18: f32,
+  @location(13) f19: vec2u,
+  @location(6) f20: u32,
+  @location(14) f21: vec2f,
+  @location(11) @interpolate(flat) f22: vec4u,
+  @invariant @builtin(position) f23: vec4f,
+}
+
+@group(0) @binding(6) var<storage, read> buffer149: array<array<u32, 17>>;
+
+@group(0) @binding(203) var<storage, read> buffer152: array<array<T5, 2>, 576>;
+
+@group(0) @binding(153) var et0: texture_external;
+
+@group(0) @binding(82) var st0: texture_storage_3d<r32float, read_write>;
+
+struct T2 {
+  @size(512) f0: array<atomic<u32>>,
+}
+
+@group(0) @binding(13) var sam2: sampler;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw15: VertexOutput5;
+
+struct T3 {
+  @align(128) @size(256) f0: atomic<i32>,
+  @align(64) @size(2048) f1: array<T0>,
+}
+
+struct T4 {
+  f0: array<f16>,
+}
+
+struct FragmentOutput6 {
+  @location(1) f0: vec4u,
+  @location(2) @interpolate(flat, centroid) f1: vec4u,
+  @location(0) @interpolate(flat) f2: vec4i,
+  @location(5) @interpolate(perspective) f3: vec4f,
+}
+
+@vertex
+fn vertex6(@builtin(vertex_index) a0: u32, @location(7) a1: vec4i) -> VertexOutput5 {
+  var out: VertexOutput5;
+  var vf125: vec4f = textureSampleBaseClampToEdge(et0, sam2, vec2f(unconst_f32(0.3101), unconst_f32(0.06478)));
+  out.f18 *= bitcast<f32>(unpack4xI8(u32(unconst_u32(81))).b);
+  let vf126: vec3h = ldexp(vec3h(unconst_f16(-588.2), unconst_f16(4799.9), unconst_f16(16291.7)), vec3i(textureLoad(et0, bitcast<vec2u>(vp9.f23.zz)).xyy));
+  vf125 -= vec4f(bitcast<f32>(vp9.f19[u32(unconst_u32(20))]));
+  out.f20 |= u32(firstTrailingBit(vec2i(unconst_i32(92), unconst_i32(169)))[1]);
+  out.f20 += vp9.f20;
+  return out;
+  _ = et0;
+  _ = sam2;
+}
+
+@fragment
+fn fragment6() -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  var vf127: i32 = atomicExchange(&(*&buffer151)[u32(unconst_u32(225))][0][2][0][0], i32(unconst_i32(464)));
+  let ptr77: ptr<storage, T5, read> = &(*&buffer152)[u32(unconst_u32(168))][1];
+  var vf128: i32 = atomicExchange(&buffer151[u32(unconst_u32(8))][u32(unconst_u32(213))][2][0][u32(unconst_u32(181))], i32(unconst_i32(264)));
+  let vf129: i32 = atomicExchange(&buffer151[u32(unconst_u32(167))][0][2][0][u32(unconst_u32(60))], atomicLoad(&(*&buffer151)[u32(unconst_u32(49))][u32(unconst_u32(261))][2][0][u32(unconst_u32(17))]));
+  let ptr78: ptr<storage, atomic<i32>, read_write> = &buffer151[u32(unconst_u32(9))][0][2][u32(unconst_u32(483))][0];
+  fn1();
+  fn1();
+  textureStore(st0, vec3i(unconst_i32(97), unconst_i32(67), unconst_i32(426)), vec4f(vec4f(unconst_f32(0.3081), unconst_f32(0.00847), unconst_f32(0.1222), unconst_f32(0.4401))));
+  textureStore(st0, vec3i(unconst_i32(308), unconst_i32(102), unconst_i32(227)), vec4f(vec4f(unconst_f32(0.3066), unconst_f32(0.3466), unconst_f32(0.06356), unconst_f32(0.06301))));
+  var vf130: i32 = atomicExchange(&(*&buffer151)[u32(unconst_u32(161))][0][u32(unconst_u32(89))][0][u32(unconst_u32(310))], i32(arrayLength(&(*&buffer151))));
+  let ptr79: ptr<storage, atomic<i32>, read_write> = &buffer151[u32(unconst_u32(40))][u32(unconst_u32(52))][2][0][u32(unconst_u32(66))];
+  return out;
+  _ = buffer152;
+  _ = st0;
+  _ = buffer151;
+}
+
+@fragment
+fn fragment7() -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  out.f0 = vec4u(u32(atomicExchange(&(*&buffer151)[u32(unconst_u32(175))][0][2][0][u32(unconst_u32(27))], i32(unconst_i32(79)))));
+  let vf131: i32 = atomicLoad(&(*&buffer151)[arrayLength(&(*&buffer151))][u32(unconst_u32(122))][u32(unconst_u32(63))][u32(unconst_u32(46))][0]);
+  var vf132 = fn1();
+  atomicMax(&buffer151[u32(unconst_u32(83))][vec2u(vp9.f21)[1]][u32(unconst_u32(82))][bitcast<u32>(atomicLoad(&(*&buffer151)[u32(unconst_u32(448))][0][u32(unconst_u32(3))][0][0]))][u32(unconst_u32(276))], i32(unconst_i32(332)));
+  return out;
+  _ = st0;
+  _ = buffer152;
+  _ = buffer151;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute5() {
+  let vf133: i32 = atomicExchange(&buffer151[u32(unconst_u32(581))][0][2][u32(unconst_u32(4))][u32(unconst_u32(17))], i32(unconst_i32(89)));
+  vw14.f0 = f16(arrayLength(&buffer151));
+  let ptr80: ptr<workgroup, vec2f> = &vw15.f21;
+  var vf134 = fn1();
+  fn1();
+  let ptr81: ptr<storage, array<array<u32, 17>>, read> = &(*&buffer149);
+  atomicStore(&buffer151[u32(unconst_u32(130))][u32(determinant(mat3x3h(vec3h(vp9.f22.aar), vec3h(vp9.f22.xww), vec3h(vp9.f22.bbg))))][u32(unconst_u32(25))][u32(unconst_u32(115))][u32(unconst_u32(88))], i32(unconst_i32(125)));
+  let ptr82: ptr<storage, u32, read> = &buffer149[u32(unconst_u32(251))][u32(unconst_u32(20))];
+  var vf135 = fn1();
+  let ptr83: ptr<storage, atomic<i32>, read_write> = &buffer151[u32(unconst_u32(529))][0][2][0][arrayLength(&buffer149)];
+  atomicOr(&buffer151[u32(unconst_u32(258))][u32(unconst_u32(13))][2][vp9.f19.g][u32(unconst_u32(36))], i32(unconst_i32(129)));
+  atomicAdd(&buffer151[u32(unconst_u32(20))][u32(unconst_u32(140))][u32(unconst_u32(286))][u32(unconst_u32(89))][bitcast<u32>(atomicExchange(&buffer151[arrayLength(&buffer151)][u32(unconst_u32(511))][u32(unconst_u32(13))][u32(unconst_u32(287))][0], i32(unconst_i32(70))))], i32(unconst_i32(15)));
+  atomicMax(&buffer151[u32(unconst_u32(156))][u32(unconst_u32(327))][u32(unconst_u32(39))][0][0], i32(unconst_i32(11)));
+  fn1();
+  let ptr84: ptr<storage, atomic<i32>, read_write> = &buffer151[arrayLength(&buffer151)][u32(unconst_u32(21))][u32(unconst_u32(23))][u32(unconst_u32(1))][0];
+  vw15.f18 = f32(atomicLoad(&buffer151[u32(unconst_u32(230))][u32(unconst_u32(44))][2][0][0]));
+  vw15 = VertexOutput5(vec4i(atomicLoad(&buffer151[u32(unconst_u32(109))][u32(unconst_u32(117))][u32(unconst_u32(389))][u32(unconst_u32(21))][0])), f16(atomicLoad(&buffer151[u32(unconst_u32(109))][u32(unconst_u32(117))][u32(unconst_u32(389))][u32(unconst_u32(21))][0])), bitcast<f32>(atomicLoad(&buffer151[u32(unconst_u32(109))][u32(unconst_u32(117))][u32(unconst_u32(389))][u32(unconst_u32(21))][0])), vec2u(u32(atomicLoad(&buffer151[u32(unconst_u32(109))][u32(unconst_u32(117))][u32(unconst_u32(389))][u32(unconst_u32(21))][0]))), bitcast<u32>(atomicLoad(&buffer151[u32(unconst_u32(109))][u32(unconst_u32(117))][u32(unconst_u32(389))][u32(unconst_u32(21))][0])), vec2f(bitcast<f32>(atomicLoad(&buffer151[u32(unconst_u32(109))][u32(unconst_u32(117))][u32(unconst_u32(389))][u32(unconst_u32(21))][0]))), vec4u(u32(atomicLoad(&buffer151[u32(unconst_u32(109))][u32(unconst_u32(117))][u32(unconst_u32(389))][u32(unconst_u32(21))][0]))), vec4f(f32(atomicLoad(&buffer151[u32(unconst_u32(109))][u32(unconst_u32(117))][u32(unconst_u32(389))][u32(unconst_u32(21))][0]))));
+  fn1();
+  vf135[u32(unconst_u32(41))].f0 *= f16(atomicExchange(&(*&buffer151)[arrayLength(&(*&buffer151))][u32(unconst_u32(43))][2][u32(unconst_u32(74))][u32(unconst_u32(380))], i32(unconst_i32(55))));
+  fn1();
+  _ = st0;
+  _ = buffer149;
+  _ = buffer151;
+  _ = buffer152;
+}`,
+});
+let commandEncoder222 = device0.createCommandEncoder();
+let texture239 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 22},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView241 = texture74.createView({dimension: 'cube-array', baseArrayLayer: 2, arrayLayerCount: 6});
+let sampler131 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 98.67});
+try {
+computePassEncoder51.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.draw(0, 10, 0, 2_026_794_739);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder11.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1012 */
+  offset: 1012,
+  bytesPerRow: 36352,
+  buffer: buffer41,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture72,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline33 = device0.createComputePipeline({layout: pipelineLayout9, compute: {module: shaderModule6, constants: {}}});
+let autogeneratedBindGroupLayout76 = pipeline2.getBindGroupLayout(0);
+let textureView242 = texture134.createView({dimension: 'cube', format: 'rg32sint', baseArrayLayer: 16});
+let computePassEncoder170 = commandEncoder11.beginComputePass({label: '\uc492\u6c99\udead\u{1f971}'});
+let renderPassEncoder58 = commandEncoder222.beginRenderPass({
+  colorAttachments: [{
+  view: textureView72,
+  clearValue: { r: 89.82, g: 692.2, b: 503.9, a: -938.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler132 = device0.createSampler({addressModeU: 'repeat', lodMaxClamp: 99.19});
+try {
+computePassEncoder131.setBindGroup(2, bindGroup52);
+} catch {}
+try {
+renderPassEncoder9.draw(0, 5, 0, 567_440_615);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer37, 1_416);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer19, 256);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+await gc();
+let autogeneratedBindGroupLayout77 = pipeline7.getBindGroupLayout(0);
+let commandEncoder223 = device0.createCommandEncoder({});
+let textureView243 = texture221.createView({
+  label: '\u{1fa95}\u3d66\u0c16\u86bf\u{1fbed}\u80f2\u735e\u059e',
+  aspect: 'all',
+  format: 'rg8unorm',
+  mipLevelCount: 1,
+});
+let sampler133 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 80.52});
+try {
+computePassEncoder88.setBindGroup(3, bindGroup14, new Uint32Array(693), 53, 0);
+} catch {}
+try {
+computePassEncoder130.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder18.setStencilReference(1999);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer51, 2_008);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer127, 84);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer32, 'uint32', 172, 92);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder223.copyBufferToBuffer(buffer23, 228, buffer37, 6588, 488);
+} catch {}
+try {
+computePassEncoder49.popDebugGroup();
+} catch {}
+document.body.prepend(canvas2);
+let veryExplicitBindGroupLayout41 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 357,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 378,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 382,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 395,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let bindGroup154 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout33,
+  entries: [{binding: 167, resource: {buffer: buffer106, offset: 0, size: 228}}],
+});
+let sampler134 = device0.createSampler({label: '\u{1fcb1}\u{1f671}\u6edf\ua813\u4866\u055b\u001b\u0de5\u60f6\u05b5', lodMaxClamp: 83.28});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup50, new Uint32Array(1741), 125, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(0, 209, 0, 1_993_968_952);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(11, 94, 40, 1_175_005_427, 1_265_153_669);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer139, 1_028);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer132, 'uint32', 64, 27);
+} catch {}
+try {
+renderPassEncoder55.setPipeline(pipeline30);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer111, 1640, new Int16Array(10454), 2275, 16);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let recycledExplicitBindGroupLayout2 = pipeline33.getBindGroupLayout(0);
+let texture240 = device0.createTexture({
+  size: [16],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder171 = commandEncoder223.beginComputePass({});
+let externalTexture29 = device0.importExternalTexture({source: videoFrame19, colorSpace: 'display-p3'});
+try {
+computePassEncoder171.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder19.setViewport(693.4064855520126, 215.9315106200564, 21.02302989070922, 56.97309354313336, 0.7696733197740863, 0.9465712622016973);
+} catch {}
+try {
+renderPassEncoder1.draw(2, 770, 1, 2_378_393_730);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer93, 464, 666);
+} catch {}
+try {
+gpuCanvasContext5.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST, alphaMode: 'opaque'});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer145, 4656, new BigUint64Array(3369), 1737, 660);
+} catch {}
+let img9 = await imageWithData(1, 15, '#10101010', '#20202020');
+let sampler135 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', minFilter: 'linear', mipmapFilter: 'nearest'});
+try {
+computePassEncoder170.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(15, 626, 56, 597_646_991, 1_103_755_089);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer137, 'uint16', 346, 1_830);
+} catch {}
+try {
+buffer141.unmap();
+} catch {}
+let textureView244 = texture209.createView({format: 'rgba8uint', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder117.setBindGroup(2, bindGroup102, new Uint32Array(119), 33, 0);
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(8, 298, 51, 566_335_712, 489_680_383);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer59, 616);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer19, 872);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder72.pushDebugGroup('\u0832');
+} catch {}
+let canvas3 = document.createElement('canvas');
+let bindGroup155 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout34,
+  entries: [{binding: 0, resource: {buffer: buffer23, offset: 0}}],
+});
+let commandEncoder224 = device0.createCommandEncoder({});
+try {
+renderPassEncoder52.setBindGroup(2, bindGroup121, new Uint32Array(1344), 122, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer122, 1_988);
+} catch {}
+try {
+commandEncoder224.copyBufferToBuffer(buffer27, 2580, buffer114, 312, 32);
+} catch {}
+try {
+commandEncoder224.copyTextureToTexture({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder225 = device0.createCommandEncoder();
+let texture241 = device0.createTexture({
+  size: [780, 480, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView245 = texture90.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 2});
+let computePassEncoder172 = commandEncoder224.beginComputePass();
+try {
+computePassEncoder30.setBindGroup(1, bindGroup149, new Uint32Array(73), 0, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder170); computePassEncoder170.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder172.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant({ r: 413.2, g: -338.3, b: -849.5, a: 633.3, });
+} catch {}
+try {
+renderPassEncoder8.setViewport(349.68031185533334, 406.69282874157767, 93.11635126522246, 52.080827042984474, 0.8761510583703056, 0.9779740824343629);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(21, 292, 269, 125_930_967, 161_243_689);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer118, 160);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer138, 400);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture206,
+  mipLevel: 0,
+  origin: {x: 93, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(206).fill(217), /* required buffer size: 206 */
+{offset: 206}, {width: 196, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder226 = device0.createCommandEncoder({});
+let commandBuffer4 = commandEncoder31.finish();
+let textureView246 = texture177.createView({aspect: 'all'});
+let computePassEncoder173 = commandEncoder226.beginComputePass({});
+try {
+computePassEncoder170.end();
+} catch {}
+try {
+computePassEncoder173.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer98, 1_320);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(6, buffer2, 0, 1_272);
+} catch {}
+let gpuCanvasContext6 = canvas3.getContext('webgpu');
+let pipelineLayout14 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout10]});
+let commandEncoder227 = device0.createCommandEncoder({});
+let texture242 = device0.createTexture({size: {width: 195}, dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder174 = commandEncoder227.beginComputePass();
+try {
+computePassEncoder25.setBindGroup(3, bindGroup86, new Uint32Array(248), 15, 0);
+} catch {}
+try {
+renderPassEncoder1.draw(1, 11, 0, 28_590_666);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer65, 'uint32', 40, 1_146);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline12);
+} catch {}
+try {
+adapter0.label = '\u04f7\u{1fb2a}\u{1fc53}';
+} catch {}
+let veryExplicitBindGroupLayout42 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 39,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let buffer153 = device0.createBuffer({
+  size: 3974,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView247 = texture45.createView({dimension: '1d'});
+try {
+computePassEncoder100.setBindGroup(1, bindGroup148);
+} catch {}
+try {
+computePassEncoder169.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup62, new Uint32Array(470), 35, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer34, 508);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(3, buffer53, 156, 165);
+} catch {}
+try {
+commandEncoder11.copyTextureToBuffer({
+  texture: texture221,
+  mipLevel: 1,
+  origin: {x: 142, y: 87, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 28 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 896 */
+  offset: 896,
+  bytesPerRow: 22528,
+  buffer: buffer28,
+}, {width: 14, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture158,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 9},
+  aspect: 'all',
+},
+{
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout43 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 140,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout78 = pipeline7.getBindGroupLayout(0);
+let buffer154 = device0.createBuffer({size: 3424, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder228 = device0.createCommandEncoder({label: '\u{1f96f}\u0d9d\u{1fb73}\u0194'});
+let commandBuffer5 = commandEncoder11.finish();
+let textureView248 = texture114.createView({format: 'rgb10a2uint', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup148);
+} catch {}
+try {
+computePassEncoder79.setBindGroup(0, bindGroup155, new Uint32Array(2800), 17, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup8, []);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer116, 3_904);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline17);
+} catch {}
+let arrayBuffer29 = buffer3.getMappedRange(296, 68);
+let texture243 = device0.createTexture({size: [390, 240, 1], mipLevelCount: 1, format: 'rgba16sint', usage: GPUTextureUsage.STORAGE_BINDING});
+let textureView249 = texture132.createView({aspect: 'all', baseMipLevel: 0});
+let sampler136 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 85.48,
+});
+try {
+renderPassEncoder1.draw(1, 177, 2, 24_901_238);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(123, 52, 21, -1_491_866_484, 1_235_916_153);
+} catch {}
+try {
+commandEncoder228.copyBufferToTexture({
+  /* bytesInLastRow: 112 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 304 */
+  offset: 304,
+  bytesPerRow: 54784,
+  buffer: buffer58,
+}, {
+  texture: texture183,
+  mipLevel: 0,
+  origin: {x: 37, y: 233, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 97, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(6) var<storage, read> buffer155: array<array<array<array<f16, 1>, 34>, 1>, 1>;
+
+@group(0) @binding(153) var et1: texture_external;
+
+@group(0) @binding(95) var<storage, read_write> buffer157: array<T1, 6>;
+
+struct T0 {
+  @size(12) f0: array<u32>,
+}
+
+struct T1 {
+  f0: array<f16, 1>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn fn2() -> T1 {
+  var out: T1;
+  out.f0[0] = step(vec3h(unconst_f16(17380.9), unconst_f16(24099.8), unconst_f16(46939.7)), vec3h(unconst_f16(14747.9), unconst_f16(2560.0), unconst_f16(15715.5))).y;
+  out = T1(array<f16, 1>(vec4h(unpack4xI8(u32(unconst_u32(380)))).a));
+  out = T1(array<f16, 1>(f16(determinant(mat2x2f()))));
+  let vf158: u32 = dot4U8Packed(u32(unconst_u32(52)), u32(unconst_u32(53)));
+  var vf159 = fn0();
+  fn0();
+  vf159 ^= vec2i(bitcast<i32>(distance(vec4f(unconst_f32(0.2402), unconst_f32(0.2433), unconst_f32(0.00944), unconst_f32(0.03846)), vec4f(unconst_f32(0.2627), unconst_f32(0.02798), unconst_f32(0.2299), unconst_f32(0.03112)))));
+  var vf160: f32 = distance(vec3f(unconst_f32(0.1146), unconst_f32(0.1397), unconst_f32(0.01386)), vec3f(unconst_f32(0.08395), unconst_f32(0.1203), unconst_f32(0.00263)));
+  vf159 *= vec2i(bitcast<i32>(determinant(mat2x2f(unconst_f32(0.2166), unconst_f32(0.1454), unconst_f32(0.00613), unconst_f32(0.09991)))));
+  out.f0[u32(unconst_u32(535))] = f16(dot4U8Packed(u32(unconst_u32(137)), u32(unconst_u32(129))));
+  var vf161: f32 = distance(vec4f(unconst_f32(0.05432), unconst_f32(0.07504), unconst_f32(0.00373), unconst_f32(0.3659)), vec4f(unconst_f32(0.6536), unconst_f32(0.7513), unconst_f32(0.4133), unconst_f32(0.04878)));
+  var vf162 = fn0();
+  return out;
+}
+
+@group(0) @binding(82) var st3: texture_storage_3d<r32float, read_write>;
+
+@group(0) @binding(203) var<storage, read> buffer158: array<array<array<array<vec2h, 3>, 6>, 32>>;
+
+fn fn1() -> f32 {
+  var out: f32;
+  fn0();
+  var vf152 = fn0();
+  vf152 += bitcast<vec2i>(log2(vec2f(unconst_f32(0.1034), unconst_f32(0.3847))));
+  let vf153: vec2u = textureDimensions(et1);
+  let vf154: vec4f = quantizeToF16(vec4f(unconst_f32(0.1038), unconst_f32(0.03431), unconst_f32(0.01309), unconst_f32(0.01675)));
+  var vf155 = fn0();
+  out *= f32(floor(f16(unconst_f16(2213.1))));
+  vf155 ^= vec2i(vf154.zx);
+  let vf156: vec4i = firstLeadingBit(vec4i(unconst_i32(263), unconst_i32(48), unconst_i32(168), unconst_i32(31)));
+  var vf157 = fn0();
+  return out;
+  _ = et1;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn fn0() -> vec2i {
+  var out: vec2i;
+  out += bitcast<vec2i>(unpack2x16unorm(vec2u(unpack2x16unorm(u32(unconst_u32(17)))).x));
+  let vf136: vec4f = unpack4x8unorm(u32(unconst_u32(217)));
+  out += bitcast<vec2i>(log2(vec4f(unconst_f32(0.00454), unconst_f32(0.1813), unconst_f32(0.05412), unconst_f32(0.1120))).xy);
+  var vf137: f16 = distance(vec3h(distance(vec3h(unconst_f16(8764.1), unconst_f16(10978.6), unconst_f16(19531.2)), vec3h(unconst_f16(25519.3), unconst_f16(22.22), unconst_f16(6989.3)))), vec3h(unconst_f16(285.5), unconst_f16(14123.9), unconst_f16(8806.6)));
+  let vf138: vec4f = log2(vec4f(unconst_f32(0.1088), unconst_f32(-0.3188), unconst_f32(0.2617), unconst_f32(0.00419)));
+  let vf139: vec4f = vf138;
+  let vf140: f16 = distance(vec3h(unconst_f16(3281.5), unconst_f16(2471.8), unconst_f16(2057.0)), vec3h(f16(vf138[u32(unconst_u32(36))])));
+  let vf141: vec4f = quantizeToF16(vec4f(f32(vf140)));
+  out &= vec2i(i32(pack4x8unorm(vec4f(unconst_f32(0.06381), unconst_f32(0.4359), unconst_f32(0.1315), unconst_f32(0.07842)))));
+  vf137 = vec4h(clamp(vec4f(unconst_f32(0.01292), unconst_f32(0.01307), unconst_f32(0.9506), unconst_f32(0.1433)), vec4f(unconst_f32(0.1056), unconst_f32(0.1572), unconst_f32(0.1006), unconst_f32(0.2024)), vec4f(unconst_f32(0.3341), unconst_f32(-0.04222), unconst_f32(0.1810), unconst_f32(0.1820))))[0];
+  let vf142: vec4h = mix(vec4h(unconst_f16(5380.3), unconst_f16(17630.5), unconst_f16(32402.7), unconst_f16(3570.1)), vec4h(unconst_f16(14317.6), unconst_f16(22027.3), unconst_f16(4677.1), unconst_f16(-3070.0)), vec4h(unconst_f16(11571.7), unconst_f16(15070.1), unconst_f16(2934.7), unconst_f16(15429.2)));
+  let vf143: f32 = vf141[u32(unconst_u32(32))];
+  let vf144: vec2f = unpack2x16unorm(u32(unconst_u32(52)));
+  vf137 += f16(vf139.b);
+  var vf145: vec4f = log2(vec4f(unconst_f32(0.2623), unconst_f32(0.1243), unconst_f32(0.1836), unconst_f32(0.2315)));
+  let vf146: vec3h = cosh(vec3h(unconst_f16(30196.5), unconst_f16(7061.2), unconst_f16(7501.6)));
+  let vf147: f32 = vf145[u32(unconst_u32(400))];
+  var vf148: f32 = vf138[u32(vf143)];
+  vf137 = f16(vf147);
+  var vf149: vec4f = vf138;
+  var vf150: vec4f = unpack4x8unorm(u32(unconst_u32(214)));
+  let vf151: f32 = vf150[u32(unconst_u32(211))];
+  let ptr85: ptr<function, vec4f> = &vf150;
+  return out;
+}
+
+struct FragmentOutput8 {
+  @location(2) @interpolate(flat, center) f0: vec4i,
+  @location(0) @interpolate(linear, centroid) f1: vec4f,
+  @location(1) @interpolate(flat) f2: vec4u,
+  @location(3) f3: vec2u,
+}
+
+@fragment
+fn fragment8() -> FragmentOutput8 {
+  var out: FragmentOutput8;
+  let ptr86: ptr<storage, vec2h, read> = &(*&buffer158)[u32(unconst_u32(228))][31][u32(unconst_u32(42))][2];
+  let ptr87: ptr<storage, vec2h, read> = &(*&buffer158)[arrayLength(&(*&buffer158))][31][5][2];
+  buffer157[u32(unconst_u32(72))].f0[u32(unconst_u32(91))] = (*&buffer158)[arrayLength(&(*&buffer158))][u32(unconst_u32(131))][u32(unconst_u32(76))][u32(unconst_u32(107))].g;
+  out.f2 ^= vec4u(buffer158[arrayLength(&buffer158)][31][5][2].yyxy);
+  fn1();
+  out.f2 = textureDimensions(st3).rrgb;
+  out.f3 = vec2u(buffer158[arrayLength(&buffer158)][u32(unconst_u32(43))][u32(unconst_u32(18))][u32(unconst_u32(544))]);
+  let ptr88: ptr<storage, vec2h, read> = &(*&buffer158)[u32(unconst_u32(17))][u32(unconst_u32(189))][5][bitcast<u32>(buffer158[u32(unconst_u32(28))][31][5][2])];
+  let ptr89: ptr<storage, array<vec2h, 3>, read> = &(*&buffer158)[u32(unconst_u32(7))][31][5];
+  let ptr90: ptr<storage, vec2h, read> = &(*&buffer158)[arrayLength(&(*&buffer158))][31][5][2];
+  return out;
+  _ = buffer157;
+  _ = st3;
+  _ = buffer158;
+  _ = et1;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute6(@builtin(workgroup_id) a0: vec3u, @builtin(local_invocation_index) a1: u32) {
+  fn0();
+  let ptr91: ptr<storage, array<vec2h, 3>, read> = &(*&buffer158)[u32(unconst_u32(235))][31][u32((*&buffer155)[u32(unconst_u32(728))][0][33][0])];
+  buffer157[u32(unconst_u32(86))] = (*&buffer157)[u32(unconst_u32(138))];
+  buffer157[u32(unconst_u32(216))].f0[u32(unconst_u32(165))] -= buffer155[0][u32(unconst_u32(740))][u32(unconst_u32(78))][0];
+  buffer157[u32(unconst_u32(146))] = T1(array<f16, 1>(buffer158[u32(unconst_u32(111))][u32(unconst_u32(341))][5][u32(unconst_u32(316))].x));
+  _ = buffer157;
+  _ = buffer158;
+  _ = buffer155;
+}`,
+});
+let veryExplicitBindGroupLayout44 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 143,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 451,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout79 = pipeline26.getBindGroupLayout(0);
+let texture244 = device0.createTexture({
+  size: [195, 120, 28],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture245 = device0.createTexture({
+  size: [240, 1, 104],
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView250 = texture10.createView({dimension: '2d-array'});
+let computePassEncoder175 = commandEncoder225.beginComputePass({});
+try {
+computePassEncoder161.setBindGroup(3, bindGroup97);
+} catch {}
+try {
+renderPassEncoder1.draw(4, 451, 0, 257_304_694);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(9, 230, 5, 810_666_740, 911_399_484);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer11, 5_256);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer126, 2_376);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer65, 0);
+} catch {}
+try {
+buffer113.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+let veryExplicitBindGroupLayout45 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 13,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 51,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 82,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+    {binding: 88, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 93,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 95,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 104,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d' },
+    },
+    {binding: 153, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 183,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 203,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder229 = device0.createCommandEncoder({});
+let texture246 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 102},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView251 = texture134.createView({dimension: '2d', baseArrayLayer: 1});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup44, new Uint32Array(1263), 638, 0);
+} catch {}
+try {
+computePassEncoder153.end();
+} catch {}
+try {
+computePassEncoder174.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder1.draw(0, 13, 0, 837_162_396);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer49, 1_836);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer42, 'uint32', 3_712, 455);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(7, buffer153, 0, 1_165);
+} catch {}
+try {
+commandEncoder228.clearBuffer(buffer76, 1512, 912);
+} catch {}
+try {
+computePassEncoder72.popDebugGroup();
+} catch {}
+let autogeneratedBindGroupLayout80 = pipeline3.getBindGroupLayout(0);
+let texture247 = device0.createTexture({
+  size: {width: 195, height: 120, depthOrArrayLayers: 388},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder173); computePassEncoder173.dispatchWorkgroups(2, 1); };
+} catch {}
+try {
+computePassEncoder175.setPipeline(pipeline33);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(137, 204, 2, 156_682_696, 92_601_523);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer107, 120);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer51, 2_312);
+} catch {}
+let arrayBuffer30 = buffer64.getMappedRange(208, 8);
+try {
+commandEncoder201.copyTextureToTexture({
+  texture: texture151,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 18, y: 9, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let commandEncoder230 = device0.createCommandEncoder({});
+let texture248 = device0.createTexture({
+  size: {width: 480, height: 1, depthOrArrayLayers: 254},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup150, new Uint32Array(354), 2, 0);
+} catch {}
+try {
+renderPassEncoder46.setStencilReference(385);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(5, 474, 202, 334_816_674, 799_652_472);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer65, 2_648);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(5, buffer42, 736, 952);
+} catch {}
+let textureView252 = texture159.createView({mipLevelCount: 1});
+let texture249 = device0.createTexture({
+  size: [480, 1, 1],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8unorm'],
+});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+computePassEncoder117.setBindGroup(3, bindGroup16, new Uint32Array(82), 8, 0);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(2, bindGroup146);
+} catch {}
+try {
+commandEncoder230.copyBufferToTexture({
+  /* bytesInLastRow: 508 widthInBlocks: 127 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2336 */
+  offset: 2336,
+  bytesPerRow: 3072,
+  buffer: buffer24,
+}, {
+  texture: texture174,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 127, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder201.clearBuffer(buffer124);
+} catch {}
+try {
+if (!arrayBuffer29.detached) { new Uint8Array(arrayBuffer29).fill(0x55); };
+} catch {}
+let bindGroup156 = device0.createBindGroup({layout: veryExplicitBindGroupLayout38, entries: [{binding: 39, resource: textureView27}]});
+let buffer159 = device0.createBuffer({
+  size: 25979,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView253 = texture190.createView({dimension: '2d-array', mipLevelCount: 1});
+let textureView254 = texture146.createView({mipLevelCount: 1});
+let renderBundle35 = renderBundleEncoder35.finish({});
+try {
+computePassEncoder102.setBindGroup(2, bindGroup97, new Uint32Array(215), 16, 0);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer137, 'uint16', 3_902, 15_357);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture177,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(347).fill(169), /* required buffer size: 347 */
+{offset: 347}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup157 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout39,
+  entries: [{binding: 151, resource: textureView112}, {binding: 137, resource: textureView189}],
+});
+let commandEncoder231 = device0.createCommandEncoder({});
+let textureView255 = texture248.createView({});
+let renderPassEncoder59 = commandEncoder230.beginRenderPass({colorAttachments: [{view: textureView71, loadOp: 'load', storeOp: 'store'}]});
+let sampler137 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat'});
+try {
+computePassEncoder155.setBindGroup(1, bindGroup11, new Uint32Array(6385), 1_048, 0);
+} catch {}
+try {
+computePassEncoder173.end();
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(54, 20, 33, 37_497_450, 1_016_136_002);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, undefined);
+} catch {}
+try {
+computePassEncoder108.insertDebugMarker('\u0888');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let imageData32 = new ImageData(12, 32);
+let bindGroup158 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout4,
+  entries: [{binding: 0, resource: {buffer: buffer42, offset: 0, size: 3457}}],
+});
+let commandEncoder232 = device0.createCommandEncoder({});
+let texture250 = device0.createTexture({
+  size: {width: 60, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup111);
+} catch {}
+try {
+computePassEncoder95.setBindGroup(0, bindGroup157, new Uint32Array(4857), 52, 0);
+} catch {}
+try {
+renderPassEncoder1.draw(0, 54, 4, 522_523_351);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(15, 87, 71, 326_695_703, 1_080_454_594);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer127, 4_120);
+} catch {}
+try {
+renderPassEncoder55.setIndexBuffer(buffer91, 'uint16', 80, 517);
+} catch {}
+try {
+commandEncoder229.copyBufferToTexture({
+  /* bytesInLastRow: 468 widthInBlocks: 117 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 280 */
+  offset: 280,
+  bytesPerRow: 10240,
+  buffer: buffer0,
+}, {
+  texture: texture227,
+  mipLevel: 0,
+  origin: {x: 31, y: 27, z: 0},
+  aspect: 'all',
+}, {width: 117, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer54, 5820, new BigUint64Array(8781), 30, 112);
+} catch {}
+let pipeline34 = device0.createRenderPipeline({
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment7',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex6',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 680,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint32x3', offset: 124, shaderLocation: 7}],
+      },
+    ],
+  },
+});
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+videoFrame36 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpte432', transfer: 'smpte240m'} });
+let buffer160 = device0.createBuffer({size: 19991, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder233 = device0.createCommandEncoder({});
+let commandBuffer6 = commandEncoder226.finish({});
+let texture251 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder176 = commandEncoder229.beginComputePass({});
+let sampler138 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', magFilter: 'nearest', lodMaxClamp: 87.99});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup80);
+} catch {}
+try {
+renderPassEncoder1.draw(0, 391, 1, 642_743_195);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer118, 0, 50);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer143, 2812, new Int16Array(9760), 6223, 256);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let imageData33 = new ImageData(48, 12);
+let autogeneratedBindGroupLayout81 = pipeline30.getBindGroupLayout(0);
+let buffer161 = device0.createBuffer({
+  size: 20733,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder234 = device0.createCommandEncoder({});
+let textureView256 = texture109.createView({});
+let computePassEncoder177 = commandEncoder232.beginComputePass({});
+let renderPassEncoder60 = commandEncoder228.beginRenderPass({
+  colorAttachments: [{
+  view: textureView112,
+  clearValue: { r: -820.4, g: 506.4, b: 213.8, a: 77.80, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 59939044,
+});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], stencilReadOnly: true});
+let sampler139 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMaxClamp: 96.49,
+});
+let externalTexture30 = device0.importExternalTexture({source: videoFrame20});
+try {
+computePassEncoder177.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup136);
+} catch {}
+try {
+renderPassEncoder7.setViewport(386.563895757722, 192.96210434213506, 2.5017257233390646, 37.94991606959953, 0.47561848836478493, 0.9338403432474534);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer153, 44);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer53, 448);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder4.insertDebugMarker('\u{1ff82}');
+} catch {}
+let imageData34 = new ImageData(44, 40);
+let autogeneratedBindGroupLayout82 = pipeline3.getBindGroupLayout(0);
+let bindGroup159 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout23,
+  entries: [{binding: 0, resource: {buffer: buffer136, offset: 8448}}],
+});
+let textureView257 = texture121.createView({arrayLayerCount: 1});
+let computePassEncoder178 = commandEncoder233.beginComputePass({label: '\u{1fd6f}\u505f\ue1e1\u{1f785}\ua559\u08b1\u7b0d\u{1f936}\u40c0'});
+let renderPassEncoder61 = commandEncoder201.beginRenderPass({
+  colorAttachments: [{view: textureView112, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 126349156,
+});
+try {
+computePassEncoder176.setPipeline(pipeline33);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup83);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup97, new Uint32Array(1294), 329, 0);
+} catch {}
+try {
+renderPassEncoder1.draw(1, 15, 0, 698_578_124);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer10, 'uint16', 666, 244);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline13);
+} catch {}
+try {
+computePassEncoder6.setBindGroup(0, bindGroup92, new Uint32Array(2106), 464, 0);
+} catch {}
+try {
+computePassEncoder178.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder55.setBindGroup(2, bindGroup94, new Uint32Array(1302), 381, 0);
+} catch {}
+try {
+renderPassEncoder24.drawIndirect(buffer127, 1_900);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(6, buffer25, 0, 706);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(1, buffer39);
+} catch {}
+try {
+gpuCanvasContext4.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'premultiplied'});
+} catch {}
+let bindGroup160 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [
+    {binding: 58, resource: externalTexture30},
+    {binding: 22, resource: textureView109},
+    {binding: 70, resource: textureView74},
+    {binding: 615, resource: textureView120},
+    {binding: 95, resource: textureView100},
+    {binding: 88, resource: textureView76},
+    {binding: 72, resource: {buffer: buffer114, offset: 0, size: 524}},
+    {binding: 349, resource: {buffer: buffer81, offset: 0, size: 684}},
+    {binding: 12, resource: {buffer: buffer159, offset: 1280, size: 2224}},
+    {binding: 49, resource: textureView239},
+  ],
+});
+let texture252 = device0.createTexture({
+  size: [390, 240, 282],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder179 = commandEncoder234.beginComputePass({});
+try {
+computePassEncoder168.setBindGroup(3, bindGroup126);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup73);
+} catch {}
+try {
+renderPassEncoder24.draw(0, 139, 0, 87_008_511);
+} catch {}
+try {
+renderPassEncoder24.drawIndexed(0, 104, 1, 74_427, 905_690_849);
+} catch {}
+try {
+renderPassEncoder24.drawIndexedIndirect(buffer56, 88);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(3, buffer108, 0, 1_110);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup39, new Uint32Array(1086), 106, 0);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline12);
+} catch {}
+let textureView258 = texture182.createView({aspect: 'depth-only', mipLevelCount: 1});
+let computePassEncoder180 = commandEncoder231.beginComputePass({});
+try {
+computePassEncoder180.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle0, renderBundle28, renderBundle4, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder24.draw(0, 313, 3, 449_586_790);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(24, 286, 46, -2_114_249_653, 129_864_684);
+} catch {}
+try {
+renderPassEncoder24.drawIndexedIndirect(buffer95, 456);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer94, 196);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer10, 'uint32', 3_876, 1);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer32, 'uint32', 108, 397);
+} catch {}
+try {
+renderBundleEncoder36.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(7, buffer74);
+} catch {}
+let pipelineLayout15 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout36]});
+let querySet33 = device0.createQuerySet({label: '\u040c\u{1fd59}', type: 'occlusion', count: 501});
+let sampler140 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.24,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup23, []);
+} catch {}
+try {
+computePassEncoder159.setBindGroup(2, bindGroup30, new Uint32Array(1562), 50, 0);
+} catch {}
+try {
+renderPassEncoder24.end();
+} catch {}
+try {
+renderPassEncoder1.draw(0, 30, 1, 1_298_912_957);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(21, 173, 34, 1_130_048_028, 619_692_492);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(2, bindGroup142);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer18, 'uint32', 13_092, 2_438);
+} catch {}
+try {
+gpuCanvasContext4.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+} catch {}
+let bindGroup161 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout38,
+  entries: [{binding: 0, resource: {buffer: buffer146, offset: 256, size: 53}}],
+});
+let commandEncoder235 = device0.createCommandEncoder({});
+let querySet34 = device0.createQuerySet({type: 'occlusion', count: 546});
+let texture253 = device0.createTexture({size: {width: 480}, dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.COPY_SRC});
+let textureView259 = texture61.createView({format: 'rg8unorm', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder181 = commandEncoder235.beginComputePass({});
+try {
+computePassEncoder133.setBindGroup(3, bindGroup115);
+} catch {}
+try {
+computePassEncoder181.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer161, 'uint16', 520, 1_539);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup160, new Uint32Array(274), 77, 0);
+} catch {}
+try {
+renderBundleEncoder36.setIndexBuffer(buffer33, 'uint32', 20, 7);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let autogeneratedBindGroupLayout83 = pipeline4.getBindGroupLayout(0);
+let texture254 = device0.createTexture({
+  label: '\u1656\uaddd',
+  size: {width: 60, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView260 = texture20.createView({dimension: '2d-array'});
+let computePassEncoder182 = commandEncoder62.beginComputePass({});
+let renderBundle36 = renderBundleEncoder36.finish({});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup4, new Uint32Array(826), 12, 0);
+} catch {}
+try {
+renderPassEncoder46.executeBundles([renderBundle36, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder6.copyBufferToBuffer(buffer52, 6936, buffer148, 2040, 1344);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let texture255 = device0.createTexture({size: [390, 240, 1], format: 'rgba16uint', usage: GPUTextureUsage.STORAGE_BINDING, viewFormats: []});
+let computePassEncoder183 = commandEncoder6.beginComputePass({});
+try {
+computePassEncoder38.setBindGroup(0, bindGroup66, new Uint32Array(974), 71, 0);
+} catch {}
+await gc();
+let offscreenCanvas4 = new OffscreenCanvas(43, 85);
+let commandEncoder236 = device0.createCommandEncoder({});
+let textureView261 = texture186.createView({aspect: 'all'});
+let texture256 = device0.createTexture({
+  size: [480, 1, 10],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder184 = commandEncoder236.beginComputePass({});
+let sampler141 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', magFilter: 'nearest', mipmapFilter: 'linear'});
+try {
+computePassEncoder179.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup46);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(162);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+buffer72.unmap();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let veryExplicitBindGroupLayout46 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout84 = pipeline4.getBindGroupLayout(0);
+let bindGroup162 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 70, resource: textureView36},
+    {binding: 12, resource: {buffer: buffer32, offset: 256, size: 372}},
+    {binding: 22, resource: textureView24},
+    {binding: 58, resource: externalTexture8},
+    {binding: 349, resource: {buffer: buffer40, offset: 1024, size: 765}},
+    {binding: 49, resource: textureView78},
+    {binding: 615, resource: textureView80},
+    {binding: 88, resource: textureView19},
+    {binding: 95, resource: textureView88},
+    {binding: 72, resource: {buffer: buffer38, offset: 4352, size: 1604}},
+  ],
+});
+let commandEncoder237 = device0.createCommandEncoder({});
+let textureView262 = texture240.createView({label: '\u0e19\u2911\u217e'});
+let computePassEncoder185 = commandEncoder237.beginComputePass({});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+computePassEncoder183.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(0, 11, 103, 34);
+} catch {}
+let commandEncoder238 = device0.createCommandEncoder({});
+let computePassEncoder186 = commandEncoder238.beginComputePass({});
+let sampler142 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.99,
+  compare: 'not-equal',
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder124.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+computePassEncoder169.setBindGroup(2, bindGroup30, new Uint32Array(20), 1, 0);
+} catch {}
+try {
+computePassEncoder182.setPipeline(pipeline29);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder58.setIndexBuffer(buffer32, 'uint16', 1_320, 40);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+let bindGroup163 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout45,
+  entries: [{binding: 0, resource: {buffer: buffer139, offset: 1280, size: 314}}],
+});
+try {
+computePassEncoder177.setBindGroup(3, bindGroup52);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(0, bindGroup15, new Uint32Array(424), 46, 0);
+} catch {}
+try {
+renderPassEncoder32.beginOcclusionQuery(175);
+} catch {}
+try {
+renderPassEncoder31.setViewport(239.7934367904157, 193.66577600606593, 89.24926653196535, 101.99867343548041, 0.4667232944615122, 0.7462282722967424);
+} catch {}
+try {
+renderPassEncoder56.setVertexBuffer(3, buffer31, 0, 2_851);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 195, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture55,
+  mipLevel: 2,
+  origin: {x: 9, y: 16, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder239 = device0.createCommandEncoder({});
+let textureView263 = texture235.createView({aspect: 'all', baseArrayLayer: 0});
+let computePassEncoder187 = commandEncoder239.beginComputePass({label: '\u0c71\u5e51\u08c7\ua491\u{1fc47}\uc8a7\u0eb4\u{1f951}\ua3d3\ub7db\u5bf1'});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({colorFormats: ['rg32sint', 'rgba16uint', 'rgba8uint'], stencilReadOnly: true});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup111, new Uint32Array(1191), 223, 0);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer71, 'uint32', 324, 20_614);
+} catch {}
+try {
+renderPassEncoder57.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(1, buffer161, 8_132);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(2, bindGroup118);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture233,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(548).fill(204), /* required buffer size: 548 */
+{offset: 548, bytesPerRow: 101, rowsPerImage: 11}, {width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout85 = pipeline16.getBindGroupLayout(0);
+let commandEncoder240 = device0.createCommandEncoder({});
+let computePassEncoder188 = commandEncoder240.beginComputePass({});
+try {
+computePassEncoder70.setBindGroup(0, bindGroup72);
+} catch {}
+try {
+computePassEncoder185.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder32.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline34);
+} catch {}
+let arrayBuffer31 = buffer5.getMappedRange(3200, 4);
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout85]});
+let buffer162 = device0.createBuffer({
+  size: 2072,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture257 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 18},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder88.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+computePassEncoder39.setBindGroup(3, bindGroup117, new Uint32Array(999), 164, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder185); computePassEncoder185.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder186.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder55.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(0, bindGroup153, new Uint32Array(339), 14, 0);
+} catch {}
+let textureView264 = texture81.createView({mipLevelCount: 1, baseArrayLayer: 5, arrayLayerCount: 2});
+let sampler143 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder184.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline32);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(1, bindGroup133);
+} catch {}
+let promise36 = device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule5,
+  constants: {11_428: 0},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}],
+},
+  vertex: {module: shaderModule3, constants: {27_508: 0}, buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back'},
+});
+try {
+globalThis.someLabel = textureView182.label;
+} catch {}
+let autogeneratedBindGroupLayout86 = pipeline0.getBindGroupLayout(0);
+let buffer163 = device0.createBuffer({
+  size: 1913,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let querySet35 = device0.createQuerySet({type: 'occlusion', count: 22});
+let textureView265 = texture130.createView({baseMipLevel: 0});
+try {
+computePassEncoder185.end();
+} catch {}
+try {
+computePassEncoder187.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(3, bindGroup130);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(3, bindGroup109, new Uint32Array(65), 4, 0);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer70, 'uint32', 4, 1_371);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+commandEncoder237.copyBufferToBuffer(buffer28, 1004, buffer111, 3868, 84);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder241 = device0.createCommandEncoder();
+let texture258 = device0.createTexture({
+  size: [390, 240, 1],
+  mipLevelCount: 1,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder189 = commandEncoder241.beginComputePass({});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup80, new Uint32Array(60), 7, 0);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer119, 'uint16', 128, 263);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(4, buffer18, 0, 1_285);
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+try {
+commandEncoder237.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6468 */
+  offset: 6468,
+  bytesPerRow: 5120,
+  buffer: buffer84,
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let autogeneratedBindGroupLayout87 = pipeline8.getBindGroupLayout(0);
+let commandEncoder242 = device0.createCommandEncoder({});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup60, new Uint32Array(1317), 34, 0);
+} catch {}
+try {
+renderPassEncoder21.draw(66, 175, 974_210_959, 70_505_808);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(11, 405, 72, -1_915_061_352, 474_703_978);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer46, 'uint16', 608, 3_978);
+} catch {}
+try {
+renderPassEncoder60.setPipeline(pipeline11);
+} catch {}
+document.body.prepend(canvas2);
+let canvas4 = document.createElement('canvas');
+let commandEncoder243 = device0.createCommandEncoder({});
+let textureView266 = texture186.createView({baseArrayLayer: 0});
+let computePassEncoder190 = commandEncoder243.beginComputePass();
+let renderPassEncoder62 = commandEncoder237.beginRenderPass({
+  colorAttachments: [{
+  view: textureView72,
+  clearValue: { r: -482.0, g: 572.8, b: 995.5, a: 385.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet6,
+});
+let renderBundle37 = renderBundleEncoder37.finish({});
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer159, 4_140);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(5, buffer4, 4_668, 94);
+} catch {}
+try {
+computePassEncoder12.insertDebugMarker('\u{1f7fd}');
+} catch {}
+let bindGroup164 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout20,
+  entries: [{binding: 0, resource: {buffer: buffer87, offset: 256, size: 1456}}],
+});
+let texture259 = device0.createTexture({
+  size: [390, 240, 1],
+  mipLevelCount: 5,
+  sampleCount: 1,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder191 = commandEncoder242.beginComputePass({});
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({colorFormats: ['rg32sint', 'rgba16uint', 'rgba8uint'], depthReadOnly: true});
+try {
+computePassEncoder190.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder21.draw(218, 448, 636_376_069, 122_262_191);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer38, 'uint32', 476, 3_007);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(5, undefined, 0, 1_864_981_026);
+} catch {}
+try {
+renderBundleEncoder38.setPipeline(pipeline34);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder244 = device0.createCommandEncoder();
+let texture260 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder63 = commandEncoder244.beginRenderPass({
+  colorAttachments: [{
+  view: textureView5,
+  depthSlice: 13,
+  clearValue: { r: -925.0, g: -338.5, b: 435.1, a: -978.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet25,
+});
+let sampler144 = device0.createSampler({minFilter: 'linear', lodMaxClamp: 92.99});
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer121, 740);
+} catch {}
+try {
+renderPassEncoder63.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(6, undefined, 602_436_667, 45_969_859);
+} catch {}
+try {
+renderBundleEncoder38.setPipeline(pipeline34);
+} catch {}
+await gc();
+let texture261 = device0.createTexture({size: {width: 480}, dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+});
+try {
+renderPassEncoder21.draw(205, 88, 807_152_515, 66_169_725);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer107, 992);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder39.setPipeline(pipeline24);
+} catch {}
+try {
+buffer58.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 50}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 93, y: 14, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture262 = device0.createTexture({
+  size: [240, 1, 100],
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler145 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 99.86,
+});
+try {
+renderPassEncoder21.draw(18, 23, 34_880_110, 334_356_045);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(109, 529, 39, 336_718_506, 105_286_837);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(3, bindGroup64);
+} catch {}
+try {
+renderBundleEncoder39.setIndexBuffer(buffer115, 'uint32', 5_672, 976);
+} catch {}
+try {
+renderBundleEncoder38.setPipeline(pipeline34);
+} catch {}
+let buffer164 = device0.createBuffer({size: 22630, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder245 = device0.createCommandEncoder({});
+let textureView267 = texture107.createView({dimension: '1d'});
+try {
+computePassEncoder188.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder61.executeBundles([renderBundle7, renderBundle36, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder4.setViewport(110.51043049400482, 182.1635616208158, 82.01762935939824, 0.9943461353783637, 0.798231340916473, 0.8915570635473362);
+} catch {}
+try {
+renderPassEncoder21.draw(127, 155, 831_315_233, 337_905_069);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder39.drawIndexed(0, 955, 29, 55_137_760, 159_520_186);
+} catch {}
+try {
+renderBundleEncoder38.setIndexBuffer(buffer115, 'uint16', 10_008, 298);
+} catch {}
+try {
+commandEncoder245.copyBufferToBuffer(buffer163, 564, buffer65, 1064, 356);
+} catch {}
+try {
+globalThis.someLabel = externalTexture15.label;
+} catch {}
+let bindGroup165 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout76,
+  entries: [{binding: 0, resource: {buffer: buffer40, offset: 1536}}],
+});
+let texture263 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder192 = commandEncoder245.beginComputePass({});
+try {
+renderPassEncoder53.setBindGroup(3, bindGroup130);
+} catch {}
+try {
+renderPassEncoder21.draw(182, 321, 2_987_722_115, 309_745_698);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(96, 33, 105, 17_054_152, 140_911_963);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer145, 1_048);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(3, bindGroup13, new Uint32Array(828), 153, 0);
+} catch {}
+try {
+renderBundleEncoder39.drawIndexed(17, 80, 17, 120_309_645, 524_517_740);
+} catch {}
+try {
+renderBundleEncoder39.drawIndexedIndirect(buffer141, 1_100);
+} catch {}
+try {
+renderBundleEncoder38.setPipeline(pipeline34);
+} catch {}
+let texture264 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 30},
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder21.draw(95, 154, 1_004_983_229, 56_232_306);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer162, 228);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(0, bindGroup81);
+} catch {}
+try {
+renderBundleEncoder39.drawIndexed(203, 171, 16, 48_429_148, 37_055_179);
+} catch {}
+try {
+renderBundleEncoder39.drawIndexedIndirect(buffer2, 224);
+} catch {}
+try {
+renderBundleEncoder39.drawIndirect(buffer116, 2_456);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let textureView268 = texture160.createView({});
+let renderBundle38 = renderBundleEncoder38.finish({});
+try {
+computePassEncoder52.setBindGroup(3, bindGroup21, new Uint32Array(1172), 70, 0);
+} catch {}
+try {
+computePassEncoder192.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(417);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.draw(47, 48, 552_268_985, 889_708_623);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(136, 60, 13, 168_672_663, 3_412_948_542);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer133, 8_156);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer10, 'uint16', 558, 399);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(1, bindGroup61);
+} catch {}
+try {
+renderBundleEncoder39.drawIndexed(122, 65, 23, 114_574_296, 651_750_545);
+} catch {}
+try {
+renderBundleEncoder39.drawIndexedIndirect(buffer89, 296);
+} catch {}
+try {
+renderBundleEncoder39.drawIndirect(buffer108, 904);
+} catch {}
+try {
+renderBundleEncoder39.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(0, buffer89);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 97, height: 60, depthOrArrayLayers: 43}
+*/
+{
+  source: img8,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 32, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+videoFrame37 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpte170m', transfer: 'log'} });
+let buffer165 = device0.createBuffer({size: 15569, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandEncoder246 = device0.createCommandEncoder({});
+let texture265 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder61.setBindGroup(1, bindGroup26, new Uint32Array(1675), 241, 0);
+} catch {}
+try {
+computePassEncoder119.setPipeline(pipeline5);
+} catch {}
+try {
+computePassEncoder189.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder21.draw(150, 383, 826_331_255, 29_353_215);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer99, 1_396);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(2, bindGroup148, new Uint32Array(103), 4, 0);
+} catch {}
+try {
+renderBundleEncoder39.setIndexBuffer(buffer62, 'uint32', 3_388, 3_316);
+} catch {}
+try {
+commandEncoder246.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 44 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 142 */
+  offset: 142,
+  bytesPerRow: 256,
+  buffer: buffer86,
+}, {
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 74, y: 34, z: 0},
+  aspect: 'all',
+}, {width: 44, height: 30, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+@group(0) @binding(203) var<storage, read> buffer169: array<array<i32, 576>>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn1() -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  let ptr93: ptr<storage, i32, read> = &(*&buffer169)[u32(unconst_u32(119))][575];
+  var vf171: vec3i = countLeadingZeros(vec3i(unconst_i32(255), unconst_i32(159), unconst_i32(10)));
+  let ptr94: ptr<storage, f16, read_write> = &buffer168[u32(unconst_u32(125))][u32(unconst_u32(16))][u32(buffer168[arrayLength(&buffer168)][1][2])];
+  out.f3 &= vec2u(vf171.yy);
+  buffer168[u32(unconst_u32(113))][1][u32(unconst_u32(126))] = (*&buffer168)[arrayLength(&(*&buffer168))][u32(unconst_u32(216))][2];
+  var vf172: f32 = textureSampleLevel(tex6, sam7, vec2f(unconst_f32(0.4681), unconst_f32(0.02779)), i32(unconst_i32(23)));
+  let ptr95: ptr<storage, f16, read_write> = &buffer168[arrayLength(&buffer168)][1][u32(unconst_u32(264))];
+  var vf173 = fn0();
+  out.f1 = unpack4xU8(u32((*&buffer169)[u32(unconst_u32(5))][575]));
+  let ptr96: ptr<storage, f16, read_write> = &(*&buffer168)[u32(tan(f16(unconst_f16(10629.4))))][u32(unconst_u32(46))][2];
+  out.f1 |= unpack4xU8(u32(buffer168[u32(unconst_u32(131))][1][2]));
+  return out;
+  _ = override8;
+  _ = buffer169;
+  _ = buffer168;
+  _ = tex6;
+  _ = sam7;
+}
+
+var<workgroup> vw20: atomic<i32>;
+
+fn fn0() -> mat3x4f {
+  var out: mat3x4f;
+  var vf163: vec2h = asinh(vec2h(unconst_f16(1765.1), unconst_f16(2422.4)));
+  var vf164: vec4h = step(vec4h(unconst_f16(1187.7), unconst_f16(1278.9), unconst_f16(-240.7), unconst_f16(13890.5)), vec4h(unconst_f16(2107.2), unconst_f16(14250.3), unconst_f16(45213.0), unconst_f16(29561.7)));
+  var vf165: f16 = atanh(vec3h(firstTrailingBit(vec3u(unconst_u32(55), unconst_u32(93), unconst_u32(942))))[2]);
+  let ptr92: ptr<function, vec2h> = &vf163;
+  var vf166: vec4f = unpack4x8snorm(u32(unconst_u32(39)));
+  vf165 *= sinh(vec3h(unconst_f16(3153.6), unconst_f16(27111.4), unconst_f16(35420.5)))[0];
+  var vf167: f32 = override8;
+  var vf168: u32 = countOneBits(u32(unconst_u32(96)));
+  let vf169: u32 = countOneBits(u32(unconst_u32(345)));
+  let vf170: vec3f = quantizeToF16(vec3f(unconst_f32(0.1120), unconst_f32(0.05174), unconst_f32(0.2068)));
+  return out;
+  _ = override8;
+}
+
+var<workgroup> vw24: atomic<i32>;
+
+@group(0) @binding(88) var sam7: sampler;
+
+var<workgroup> vw17: mat4x2h;
+
+@group(0) @binding(95) var<storage, read_write> buffer168: array<array<array<f16, 3>, 2>>;
+
+struct VertexOutput6 {
+  @location(3) @interpolate(flat, centroid) f24: i32,
+  @location(8) @interpolate(flat, centroid) f25: vec2u,
+  @location(5) @interpolate(linear, centroid) f26: f32,
+  @builtin(position) f27: vec4f,
+  @location(12) f28: f32,
+  @location(1) @interpolate(flat, sample) f29: vec4u,
+  @location(15) f30: vec2u,
+}
+
+var<workgroup> vw19: atomic<i32>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+override override8: f32;
+
+var<workgroup> vw23: atomic<u32>;
+
+var<workgroup> vw16: atomic<i32>;
+
+fn fn2(a0: VertexOutput6, a1: ptr<uniform, vec2h>) -> array<array<array<array<array<f32, 1>, 1>, 16>, 1>, 1> {
+  var out: array<array<array<array<array<f32, 1>, 1>, 16>, 1>, 1>;
+  textureStore(st6, vec3i(unconst_i32(16), unconst_i32(66), unconst_i32(-428)), vec4f(vec4f(f32((*&buffer168)[arrayLength(&(*&buffer168))][a0.f29.g][2]))));
+  buffer168[u32(unconst_u32(3))][u32(unconst_u32(515))][u32(unconst_u32(242))] = (*a1)[1];
+  out[u32(unconst_u32(116))][u32(unconst_u32(290))][u32(unconst_u32(27))][u32(unconst_u32(253))][0] *= bitcast<f32>(buffer169[arrayLength(&buffer169)][575]);
+  fn0();
+  let ptr97: ptr<storage, array<f16, 3>, read_write> = &buffer168[u32(unconst_u32(28))][u32(unconst_u32(159))];
+  buffer168[u32(unconst_u32(41))][u32(unconst_u32(13))][u32(unconst_u32(193))] += buffer168[arrayLength(&buffer168)][1][2];
+  let ptr98: ptr<storage, i32, read> = &buffer169[arrayLength(&buffer169)][575];
+  out[u32(unconst_u32(281))][u32(unconst_u32(150))][15][u32(unconst_u32(54))][u32(unconst_u32(12))] *= f32(buffer168[arrayLength(&buffer168)][1][2]);
+  fn0();
+  let ptr99: ptr<storage, f16, read_write> = &buffer168[u32(unconst_u32(9))][u32(unconst_u32(280))][2];
+  buffer168[u32(unconst_u32(162))][u32(unconst_u32(555))][u32(unconst_u32(33))] = f16((*&buffer169)[i32(unconst_i32(399))][575]);
+  let ptr100: ptr<storage, i32, read> = &(*&buffer169)[u32(unconst_u32(27))][u32(unconst_u32(38))];
+  let vf174: vec2i = countTrailingZeros(vec2i(unconst_i32(44), unconst_i32(150)));
+  return out;
+  _ = override8;
+  _ = buffer168;
+  _ = st6;
+  _ = buffer169;
+}
+
+@group(0) @binding(93) var<storage, read> buffer167: array<array<array<f16, 1>, 1>, 1>;
+
+struct T1 {
+  @size(16) f0: array<vec2f>,
+}
+
+var<workgroup> vw21: VertexOutput6;
+
+alias vec3b = vec3<bool>;
+
+@group(0) @binding(82) var st6: texture_storage_3d<r32float, read_write>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(51) var tex6: texture_depth_2d;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw18: FragmentOutput9;
+
+var<workgroup> vw22: VertexOutput6;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @size(16) f0: array<vec2u, 1>,
+}
+
+struct FragmentOutput9 {
+  @location(0) @interpolate(perspective, centroid) f0: vec4f,
+  @location(1) @interpolate(flat) f1: vec4u,
+  @location(2) f2: vec4i,
+  @location(3) f3: vec2u,
+}
+
+@vertex
+fn vertex7(@location(11) a0: vec2h, @location(6) a1: u32) -> VertexOutput6 {
+  var out: VertexOutput6;
+  let ptr101: ptr<storage, f16, read> = &buffer167[u32(unconst_u32(70))][u32(unconst_u32(580))][u32(unconst_u32(191))];
+  let ptr102: ptr<storage, f16, read> = &(*&buffer167)[u32(unconst_u32(124))][0][u32(unconst_u32(354))];
+  out.f30 += vec2u(u32(buffer167[0][0][0]));
+  var vf175 = fn0();
+  out.f25 *= vec2u(u32(buffer167[u32(unconst_u32(144))][0][0]));
+  fn0();
+  out.f30 ^= vec2u(u32(buffer167[0][0][0]));
+  var vf176 = fn0();
+  out.f30 *= vec2u(u32((*&buffer167)[0][0][0]));
+  return out;
+  _ = override8;
+  _ = buffer167;
+}
+
+@fragment
+fn fragment9() -> FragmentOutput9 {
+  var out: FragmentOutput9;
+  var vf177 = fn1();
+  var vf178 = fn1();
+  vf178 = FragmentOutput9(vec4f(f32((*&buffer168)[arrayLength(&(*&buffer168))][1][2])), unpack4xU8(u32((*&buffer168)[arrayLength(&(*&buffer168))][1][2])), vec4i(i32((*&buffer168)[arrayLength(&(*&buffer168))][1][2])), vec2u(u32((*&buffer168)[arrayLength(&(*&buffer168))][1][2])));
+  vf177 = FragmentOutput9(vec4f(textureSample(tex6, sam7, vec2f(unconst_f32(0.2787), unconst_f32(0.1238)), clamp(vec2i(226, 275), vec2i(-8), vec2i(7)))), unpack4xU8(bitcast<u32>(textureSample(tex6, sam7, vec2f(unconst_f32(0.2787), unconst_f32(0.1238)), clamp(vec2i(226, 275), vec2i(-8), vec2i(7))))), vec4i(bitcast<i32>(textureSample(tex6, sam7, vec2f(unconst_f32(0.2787), unconst_f32(0.1238)), clamp(vec2i(226, 275), vec2i(-8), vec2i(7))))), vec2u(u32(textureSample(tex6, sam7, vec2f(unconst_f32(0.2787), unconst_f32(0.1238)), clamp(vec2i(226, 275), vec2i(-8), vec2i(7))))));
+  let ptr103: ptr<function, vec4f> = &vf177.f0;
+  let ptr104: ptr<storage, i32, read> = &buffer169[u32(unconst_u32(16))][575];
+  vf178.f2 = unpack4xI8(textureNumLevels(tex6));
+  vf177 = FragmentOutput9(vec4f(bitcast<f32>((*&buffer169)[arrayLength(&(*&buffer169))][575])), vec4u(u32((*&buffer169)[arrayLength(&(*&buffer169))][575])), vec4i((*&buffer169)[arrayLength(&(*&buffer169))][575]), vec2u(bitcast<u32>((*&buffer169)[arrayLength(&(*&buffer169))][575])));
+  let ptr105: ptr<storage, array<array<f16, 3>, 2>, read_write> = &buffer168[u32(unconst_u32(89))];
+  let ptr106: ptr<storage, f16, read_write> = &(*&buffer168)[arrayLength(&(*&buffer168))][bitcast<u32>(normalize(vec2h(unconst_f16(12613.3), unconst_f16(9460.6))))][2];
+  vf177 = FragmentOutput9(vf177.f0, vec4u(vf177.f0), vec4i(vf177.f0), vec2u(vf177.f0.xx));
+  textureStore(st6, vec3i((*ptr103).gga), vec4f(vec4f(unconst_f32(0.3951), unconst_f32(0.05755), unconst_f32(0.9521), unconst_f32(0.03965))));
+  var vf179: u32 = vf177.f1[u32(unconst_u32(145))];
+  fn0();
+  vf178 = FragmentOutput9(vec4f(f32((*ptr105)[1][2])), vec4u(u32((*ptr105)[1][2])), vec4i(i32((*ptr105)[1][2])), vec2u(u32((*ptr105)[1][2])));
+  let ptr107: ptr<function, vec4f> = &vf177.f0;
+  let ptr108: ptr<storage, f16, read_write> = &buffer168[u32(unconst_u32(16))][1][u32(unconst_u32(63))];
+  let ptr109: ptr<function, u32> = &vf179;
+  out.f2 = vf178.f2;
+  fn1();
+  let ptr110: ptr<storage, i32, read> = &buffer169[u32(unconst_u32(257))][575];
+  fn1();
+  buffer168[u32(unconst_u32(6))][u32(unconst_u32(161))][u32(unconst_u32(39))] += (*&buffer168)[arrayLength(&(*&buffer168))][1][2];
+  return out;
+  _ = override8;
+  _ = st6;
+  _ = sam7;
+  _ = tex6;
+  _ = buffer169;
+  _ = buffer168;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute7() {
+  fn0();
+  vw22.f28 *= f32((*&buffer168)[u32(buffer168[u32(unconst_u32(104))][u32(unconst_u32(41))][u32(unconst_u32(406))])][u32(unconst_u32(287))][u32(unconst_u32(152))]);
+  let vf180: i32 = atomicExchange(&(*&vw16), i32(unconst_i32(10)));
+  buffer168[u32(unconst_u32(7))][1][u32(unconst_u32(204))] += f16((*&vw22).f25[u32(unconst_u32(106))]);
+  let ptr111: ptr<workgroup, i32> = &(*&vw21).f24;
+  textureStore(st6, vec3i(unconst_i32(6), unconst_i32(111), unconst_i32(59)), vec4f(vec4f(unconst_f32(0.1588), unconst_f32(0.1608), unconst_f32(0.6006), unconst_f32(0.3292))));
+  vw18 = FragmentOutput9(vec4f(f32((*&buffer168)[u32(unconst_u32(62))][u32(unconst_u32(55))][u32(unconst_u32(1))])), vec4u(u32((*&buffer168)[u32(unconst_u32(62))][u32(unconst_u32(55))][u32(unconst_u32(1))])), vec4i(i32((*&buffer168)[u32(unconst_u32(62))][u32(unconst_u32(55))][u32(unconst_u32(1))])), vec2u(u32((*&buffer168)[u32(unconst_u32(62))][u32(unconst_u32(55))][u32(unconst_u32(1))])));
+  var vf181 = fn0();
+  _ = override8;
+  _ = st6;
+  _ = buffer168;
+}`,
+});
+let commandEncoder247 = device0.createCommandEncoder({});
+let texture266 = device0.createTexture({
+  size: {width: 480, height: 1, depthOrArrayLayers: 27},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder64 = commandEncoder247.beginRenderPass({
+  colorAttachments: [{
+  view: textureView234,
+  clearValue: { r: 196.8, g: 367.5, b: 592.7, a: -731.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder191.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder21.draw(112, 31, 1_811_600_154, 1_500_825_633);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer9, 1_600);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(3, buffer127);
+} catch {}
+try {
+commandEncoder246.resolveQuerySet(querySet31, 71, 14, buffer142, 0);
+} catch {}
+let imageData35 = new ImageData(108, 92);
+try {
+globalThis.someLabel = externalTexture23.label;
+} catch {}
+let veryExplicitBindGroupLayout47 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 17,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 23, hasDynamicOffset: false },
+    },
+    {
+      binding: 56,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup166 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout56,
+  entries: [{binding: 0, resource: {buffer: buffer56, offset: 0}}],
+});
+let buffer170 = device0.createBuffer({
+  size: 3455,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet36 = device0.createQuerySet({type: 'occlusion', count: 1112});
+let texture267 = device0.createTexture({size: {width: 390}, dimension: '1d', format: 'rg32sint', usage: GPUTextureUsage.STORAGE_BINDING});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup138);
+} catch {}
+try {
+renderPassEncoder64.executeBundles([renderBundle31]);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(396, 136, 85, 109_984_110, 406_594_165);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer45, 2_140);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(2, buffer80, 128, 6);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(1, bindGroup100, new Uint32Array(1720), 86, 0);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(3, buffer87);
+} catch {}
+let texture268 = device0.createTexture({size: [480, 1, 29], mipLevelCount: 4, format: 'rg32uint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder193 = commandEncoder246.beginComputePass();
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+let sampler146 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', minFilter: 'nearest'});
+try {
+renderPassEncoder52.executeBundles([renderBundle8, renderBundle2, renderBundle32]);
+} catch {}
+try {
+renderPassEncoder43.setBlendConstant({ r: 887.0, g: -748.9, b: -547.2, a: -373.6, });
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer65, 244);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(5, buffer98, 760);
+} catch {}
+try {
+  await buffer58.mapAsync(GPUMapMode.WRITE, 1008);
+} catch {}
+let veryExplicitBindGroupLayout48 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 113,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 206,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout88 = pipeline16.getBindGroupLayout(0);
+let buffer171 = device0.createBuffer({size: 2746, usage: GPUBufferUsage.COPY_SRC});
+let commandEncoder248 = device0.createCommandEncoder({});
+let renderPassEncoder65 = commandEncoder248.beginRenderPass({
+  colorAttachments: [{
+  view: textureView79,
+  clearValue: { r: -372.0, g: -454.2, b: -942.0, a: 32.57, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let externalTexture31 = device0.importExternalTexture({source: videoFrame18});
+try {
+renderPassEncoder63.beginOcclusionQuery(14);
+} catch {}
+try {
+renderPassEncoder63.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder65.executeBundles([renderBundle31, renderBundle3, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder21.draw(17, 245, 1_003_993_472, 198_642_463);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(2, bindGroup137);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(0, bindGroup110, new Uint32Array(5960), 1_546, 0);
+} catch {}
+try {
+renderBundleEncoder39.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(7, buffer108);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+  await shaderModule7.getCompilationInfo();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let promise37 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(canvas2);
+let autogeneratedBindGroupLayout89 = pipeline13.getBindGroupLayout(0);
+try {
+computePassEncoder193.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer118, 156);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(1, bindGroup2, new Uint32Array(473), 1, 0);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer100, 'uint32', 1_040, 665);
+} catch {}
+try {
+renderBundleEncoder39.setPipeline(pipeline24);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let querySet37 = device0.createQuerySet({type: 'occlusion', count: 1018});
+let textureView269 = texture33.createView({baseMipLevel: 0, mipLevelCount: 1});
+let sampler147 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', compare: 'always'});
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer75, 40);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(3, bindGroup48, new Uint32Array(373), 9, 0);
+} catch {}
+try {
+renderBundleEncoder39.drawIndexedIndirect(buffer76, 1_180);
+} catch {}
+let arrayBuffer32 = buffer57.getMappedRange(0, 40);
+try {
+device0.queue.writeBuffer(buffer60, 808, new Int16Array(8800), 1330, 284);
+} catch {}
+try {
+globalThis.someLabel = textureView83.label;
+} catch {}
+let autogeneratedBindGroupLayout90 = pipeline16.getBindGroupLayout(0);
+let renderBundle39 = renderBundleEncoder39.finish({});
+try {
+renderPassEncoder40.setBindGroup(0, bindGroup106, new Uint32Array(2191), 343, 0);
+} catch {}
+try {
+renderPassEncoder21.draw(221, 19, 252_684_329, 570_598_646);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(107, 873, 26, 315_643_445, 2_628_158_274);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer95, 1_756);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(3, bindGroup116);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer132, 'uint16', 234, 0);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(4, buffer0);
+} catch {}
+try {
+buffer111.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer143, 1652, new Float32Array(13939), 423, 76);
+} catch {}
+let gpuCanvasContext7 = canvas4.getContext('webgpu');
+let bindGroup167 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout72,
+  entries: [{binding: 0, resource: {buffer: buffer139, offset: 768, size: 1070}}],
+});
+let buffer172 = device0.createBuffer({
+  size: 285,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder249 = device0.createCommandEncoder({});
+let texture269 = device0.createTexture({
+  size: {width: 120, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder194 = commandEncoder249.beginComputePass({});
+let sampler148 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 66.10,
+});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+computePassEncoder137.setBindGroup(1, bindGroup68, new Uint32Array(1890), 197, 0);
+} catch {}
+try {
+computePassEncoder194.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle11, renderBundle33]);
+} catch {}
+try {
+renderPassEncoder21.draw(119, 143, 73_917_381, 144_640_597);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(454, 8, 130, 435_681_166, 1_367_515_916);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer11, 1_224);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer56, 'uint16', 190, 1_308);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(7, buffer145);
+} catch {}
+let bindGroup168 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout14,
+  entries: [{binding: 0, resource: {buffer: buffer23, offset: 0}}],
+});
+let buffer173 = device0.createBuffer({
+  size: 2092,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let sampler149 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'greater',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder23.setViewport(60.551380364428105, 55.12814225833637, 19.663610921813433, 4.545327509991927, 0.2595623019937717, 0.6079802935984413);
+} catch {}
+try {
+renderPassEncoder21.draw(395, 10, 482_821_359, 1_419_587_175);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer9, 1_448);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer138, 5_196);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(1, buffer96, 3_004, 61);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline12);
+} catch {}
+try {
+  await promise37;
+} catch {}
+let bindGroup169 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout67,
+  entries: [{binding: 0, resource: {buffer: buffer147, offset: 0}}],
+});
+let textureView270 = texture136.createView({dimension: '2d-array'});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(167, 272, 64, 463_619_162, 66_900_051);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(3, bindGroup169, new Uint32Array(2325), 82, 0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+buffer106.unmap();
+} catch {}
+let sampler150 = device0.createSampler({magFilter: 'nearest', minFilter: 'linear'});
+try {
+renderPassEncoder47.setBindGroup(2, bindGroup124, new Uint32Array(3408), 783, 0);
+} catch {}
+try {
+renderPassEncoder21.drawIndexed(9, 111, 186, 95_926_073, 850_928_180);
+} catch {}
+try {
+renderPassEncoder21.drawIndexedIndirect(buffer46, 2_408);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer23, 200);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(2, bindGroup40);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer170, 'uint32', 4, 68);
+} catch {}
+let buffer174 = device0.createBuffer({size: 7905, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let textureView271 = texture256.createView({aspect: 'all', baseMipLevel: 0});
+try {
+computePassEncoder174.setBindGroup(3, bindGroup154, new Uint32Array(417), 35, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder21.drawIndirect(buffer27, 808);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(1, bindGroup77);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer56, 'uint16', 906, 723);
+} catch {}
+try {
+renderPassEncoder48.executeBundles([renderBundle3, renderBundle36, renderBundle2, renderBundle4, renderBundle33]);
+} catch {}
+try {
+renderPassEncoder21.draw(209, 24, 304_436_396, 70_584_187);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(3, bindGroup29, []);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(0, buffer65, 8, 423);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture120,
+  mipLevel: 2,
+  origin: {x: 6, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(141).fill(126), /* required buffer size: 141 */
+{offset: 141, bytesPerRow: 34, rowsPerImage: 154}, {width: 0, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup170 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout29,
+  entries: [{binding: 0, resource: {buffer: buffer53, offset: 0, size: 391}}],
+});
+let textureView272 = texture240.createView({});
+let sampler151 = device0.createSampler({addressModeV: 'repeat', mipmapFilter: 'linear', lodMaxClamp: 58.03});
+try {
+renderPassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer127, 'uint16', 1_598, 15);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(0, buffer129);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer36, 'uint16', 878, 10);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline30);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+videoFrame38 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'smpteRp431', transfer: 'logSqrt'} });
+let buffer175 = device0.createBuffer({
+  size: 6162,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder250 = device0.createCommandEncoder({});
+let texture270 = device0.createTexture({
+  size: [390, 240, 1],
+  mipLevelCount: 2,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView273 = texture123.createView({});
+let computePassEncoder195 = commandEncoder58.beginComputePass({});
+try {
+computePassEncoder117.setBindGroup(0, bindGroup66);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup153, new Uint32Array(1556), 17, 0);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(0, buffer159);
+} catch {}
+let arrayBuffer33 = buffer3.getMappedRange(376, 20);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 97, height: 60, depthOrArrayLayers: 43}
+*/
+{
+  source: img9,
+  origin: { x: 0, y: 3 },
+  flipY: true,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 26, y: 8, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext8 = offscreenCanvas4.getContext('webgpu');
+let autogeneratedBindGroupLayout91 = pipeline6.getBindGroupLayout(0);
+let buffer176 = device0.createBuffer({size: 5702, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder251 = device0.createCommandEncoder({});
+let textureView274 = texture136.createView({});
+let computePassEncoder196 = commandEncoder250.beginComputePass({});
+let sampler152 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder100.setBindGroup(3, bindGroup76);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(4, buffer161, 288, 1_442);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline30);
+} catch {}
+try {
+commandEncoder251.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 5784 */
+  offset: 5784,
+  bytesPerRow: 22528,
+  rowsPerImage: 0,
+  buffer: buffer115,
+}, {
+  texture: texture167,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 8},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 9});
+} catch {}
+try {
+commandEncoder251.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1784 widthInBlocks: 446 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6440 */
+  offset: 6440,
+  bytesPerRow: 21760,
+  buffer: buffer10,
+}, {width: 446, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout92 = pipeline0.getBindGroupLayout(0);
+let bindGroup171 = device0.createBindGroup({layout: veryExplicitBindGroupLayout30, entries: [{binding: 140, resource: textureView182}]});
+let buffer177 = device0.createBuffer({size: 4810, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder252 = device0.createCommandEncoder({});
+let sampler153 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 81.79});
+try {
+computePassEncoder61.setBindGroup(1, bindGroup20, new Uint32Array(2218), 55, 0);
+} catch {}
+try {
+computePassEncoder92.end();
+} catch {}
+try {
+computePassEncoder178.setPipeline(pipeline10);
+} catch {}
+try {
+computePassEncoder195.setPipeline(pipeline33);
+} catch {}
+try {
+renderPassEncoder63.setBlendConstant({ r: -339.6, g: 939.4, b: 716.3, a: -876.8, });
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(0, bindGroup77);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(1, bindGroup75, new Uint32Array(1332), 112, 0);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer71, 'uint16', 1_892, 15_171);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(0, buffer61);
+} catch {}
+try {
+commandEncoder252.copyBufferToBuffer(buffer62, 12468, buffer173, 900, 732);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame33,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 69, y: 28, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder253 = device0.createCommandEncoder({});
+let texture271 = device0.createTexture({
+  size: {width: 60, height: 1, depthOrArrayLayers: 39},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView275 = texture128.createView({baseMipLevel: 0, baseArrayLayer: 0});
+let sampler154 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.93,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder196.setPipeline(pipeline33);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(0, bindGroup142);
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer33, 'uint16', 4, 18);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer130, 'uint32', 16, 233);
+} catch {}
+let arrayBuffer34 = buffer64.getMappedRange(256, 0);
+document.body.prepend(canvas3);
+let autogeneratedBindGroupLayout93 = pipeline26.getBindGroupLayout(0);
+let buffer178 = device0.createBuffer({
+  label: '\u0881\u0a2a\u0c4c\uac77\uec28\u{1fbe2}\u{1f7e3}\u5c58\u03cd\ub2ae',
+  size: 15946,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX,
+});
+let texture272 = device0.createTexture({
+  size: [195, 120, 1],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder197 = commandEncoder252.beginComputePass({});
+try {
+renderPassEncoder54.setPipeline(pipeline30);
+} catch {}
+try {
+computePassEncoder63.insertDebugMarker('\u{1fef3}');
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+let textureView276 = texture233.createView({});
+let computePassEncoder198 = commandEncoder125.beginComputePass();
+try {
+computePassEncoder28.setBindGroup(2, bindGroup73, new Uint32Array(2418), 577, 0);
+} catch {}
+try {
+computePassEncoder198.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline13);
+} catch {}
+try {
+commandEncoder253.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 70, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7828 */
+  offset: 7828,
+  buffer: buffer31,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+videoFrame39 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'smpte432', transfer: 'bt2020_10bit'} });
+let buffer179 = device0.createBuffer({
+  size: 1272,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder254 = device0.createCommandEncoder({});
+let renderBundle40 = renderBundleEncoder40.finish({});
+try {
+computePassEncoder72.setBindGroup(0, bindGroup124);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle31]);
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer71, 'uint16', 13_090, 5_711);
+} catch {}
+try {
+renderPassEncoder57.setPipeline(pipeline32);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder254.resolveQuerySet(querySet1, 73, 52, buffer113, 2560);
+} catch {}
+let pipeline35 = await promise36;
+let veryExplicitBindGroupLayout49 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 16,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 464,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+  ],
+});
+let texture273 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder16.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(7, buffer145, 1_756, 841);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData19,
+  origin: { x: 6, y: 1 },
+  flipY: true,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 10, y: 7, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let commandEncoder255 = device0.createCommandEncoder();
+let computePassEncoder199 = commandEncoder253.beginComputePass({});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+computePassEncoder197.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(3, bindGroup40, new Uint32Array(696), 61, 0);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(259, 7, 172, 63_452_569, 289_890_617);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer83, 328);
+} catch {}
+let arrayBuffer35 = buffer90.getMappedRange(1968, 324);
+let autogeneratedBindGroupLayout94 = pipeline4.getBindGroupLayout(0);
+let bindGroup172 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout4,
+  entries: [{binding: 0, resource: {buffer: buffer162, offset: 0}}],
+});
+let buffer180 = device0.createBuffer({
+  size: 17984,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder256 = device0.createCommandEncoder({});
+try {
+computePassEncoder116.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+computePassEncoder199.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup147, new Uint32Array(6039), 272, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder16.draw(152, 141, 1_543_450_650, 180_097_253);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(35, 505, 81, 73_301_205, 793_477_554);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer59, 616);
+} catch {}
+try {
+renderPassEncoder56.setIndexBuffer(buffer102, 'uint32', 752, 169);
+} catch {}
+try {
+renderPassEncoder58.setVertexBuffer(1, buffer74);
+} catch {}
+try {
+buffer136.unmap();
+} catch {}
+let bindGroup173 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout35,
+  entries: [
+    {binding: 382, resource: textureView30},
+    {binding: 378, resource: {buffer: buffer94, offset: 1024, size: 1003}},
+    {binding: 395, resource: externalTexture16},
+    {binding: 357, resource: sampler89},
+  ],
+});
+let commandEncoder257 = device0.createCommandEncoder({});
+let computePassEncoder200 = commandEncoder254.beginComputePass({});
+try {
+computePassEncoder200.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder16.drawIndexedIndirect(buffer87, 756);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer87, 428);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(5, buffer4, 168, 1_330);
+} catch {}
+try {
+computePassEncoder136.pushDebugGroup('\u{1fade}');
+} catch {}
+let commandEncoder258 = device0.createCommandEncoder({});
+let texture274 = device0.createTexture({
+  size: {width: 480, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder66 = commandEncoder251.beginRenderPass({
+  colorAttachments: [{view: textureView208, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet23,
+  maxDrawCount: 34148943,
+});
+let sampler155 = device0.createSampler({
+  label: '\u67d7\u8844\u033d\u044e\uafc8\u0b28\ube26\u096c\u{1ff30}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'less',
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup136, new Uint32Array(444), 4, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup36, new Uint32Array(843), 18, 0);
+} catch {}
+try {
+renderPassEncoder16.draw(162, 77, 1_805_623_481, 477_163_260);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(166, 59, 197, 413_957_607, 449_149_047);
+} catch {}
+try {
+renderPassEncoder16.drawIndexedIndirect(buffer132, 328);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer176, 1_876);
+} catch {}
+try {
+renderPassEncoder59.setIndexBuffer(buffer76, 'uint32', 1_932, 228);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(0, buffer145);
+} catch {}
+let arrayBuffer36 = buffer57.getMappedRange(48, 28);
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+let autogeneratedBindGroupLayout95 = pipeline16.getBindGroupLayout(0);
+let bindGroup174 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout47,
+  entries: [
+    {binding: 17, resource: {buffer: buffer159, offset: 7168, size: 3020}},
+    {binding: 56, resource: {buffer: buffer125, offset: 768, size: 5088}},
+  ],
+});
+let buffer181 = device0.createBuffer({
+  size: 2574,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let texture275 = device0.createTexture({
+  size: [480, 1, 2],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder67 = commandEncoder256.beginRenderPass({
+  colorAttachments: [{
+  view: textureView211,
+  clearValue: { r: -914.1, g: -904.0, b: 195.3, a: -52.67, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 41547065,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder197); computePassEncoder197.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(2, bindGroup47, new Uint32Array(786), 33, 0);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle4, renderBundle7, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder16.draw(8, 158, 1_430_134_069, 8_196_263);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(109, 258, 14, -1_684_443_809, 55_021_551);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer130, 236);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer173, 'uint32', 872, 547);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline32);
+} catch {}
+try {
+buffer128.unmap();
+} catch {}
+try {
+commandEncoder255.resolveQuerySet(querySet12, 16, 51, buffer9, 1024);
+} catch {}
+let img10 = await imageWithData(17, 86, '#10101010', '#20202020');
+let texture276 = device0.createTexture({
+  size: {width: 240},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder201 = commandEncoder257.beginComputePass({});
+let renderPassEncoder68 = commandEncoder258.beginRenderPass({
+  colorAttachments: [{view: textureView41, depthSlice: 28, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet5,
+});
+let sampler156 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 96.12, maxAnisotropy: 1});
+try {
+computePassEncoder201.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(2, bindGroup15, []);
+} catch {}
+try {
+renderPassEncoder16.draw(99, 268, 502_234_401, 115_082_368);
+} catch {}
+try {
+renderPassEncoder16.drawIndexedIndirect(buffer159, 4_920);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline30);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let pipeline36 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule3,
+  constants: {override1: 0, override3: 0, override2: 0, 27_508: 0},
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule2,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 324, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+let commandEncoder259 = device0.createCommandEncoder({});
+let computePassEncoder202 = commandEncoder255.beginComputePass({});
+let renderPassEncoder69 = commandEncoder259.beginRenderPass({
+  colorAttachments: [{
+  view: textureView136,
+  depthSlice: 4,
+  clearValue: { r: 676.8, g: 108.4, b: -182.3, a: 106.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder197); computePassEncoder197.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder197); computePassEncoder197.dispatchWorkgroupsIndirect(buffer161, 8_640); };
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup152);
+} catch {}
+try {
+renderPassEncoder16.draw(113, 319, 180_799_003, 280_617_424);
+} catch {}
+try {
+renderPassEncoder16.drawIndexedIndirect(buffer175, 1_076);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline30);
+} catch {}
+let arrayBuffer37 = buffer79.getMappedRange(0, 28);
+try {
+device0.queue.writeTexture({
+  texture: texture264,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(45_474).fill(47), /* required buffer size: 45_474 */
+{offset: 114, bytesPerRow: 40, rowsPerImage: 126}, {width: 9, height: 0, depthOrArrayLayers: 10});
+} catch {}
+try {
+computePassEncoder72.setBindGroup(3, bindGroup160);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(1, bindGroup7, new Uint32Array(647), 124, 0);
+} catch {}
+try {
+renderPassEncoder16.draw(171, 431, 282_630_150, 651_593_186);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(137, 60, 102, 88_984_749, 334_138_463);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer11, 4_840);
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(4, buffer106, 52);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let autogeneratedBindGroupLayout96 = pipeline7.getBindGroupLayout(0);
+try {
+computePassEncoder10.setBindGroup(0, bindGroup124, new Uint32Array(501), 1, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder197); computePassEncoder197.dispatchWorkgroupsIndirect(buffer181, 576); };
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderPassEncoder16.draw(31, 91, 571_402_628, 975_621_891);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(104, 93, 306, 45_485_037, 624_779_428);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer98, 1_744);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3, buffer161, 3_384, 1_165);
+} catch {}
+videoFrame40 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'film', transfer: 'bt1361ExtendedColourGamut'} });
+let commandEncoder260 = device0.createCommandEncoder({});
+let texture277 = device0.createTexture({
+  size: [480, 1, 35],
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView277 = texture214.createView({});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup117);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder197); computePassEncoder197.dispatchWorkgroupsIndirect(buffer99, 864); };
+} catch {}
+try {
+renderPassEncoder16.draw(82, 9, 634_802_769, 126_021_837);
+} catch {}
+try {
+renderPassEncoder16.drawIndexedIndirect(buffer51, 1_380);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer41, 468);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer71, 'uint16', 1_328, 27_514);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(3, undefined, 193_154_012, 115_613_407);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let arrayBuffer38 = buffer3.getMappedRange(368, 0);
+try {
+commandEncoder260.copyBufferToBuffer(buffer122, 40, buffer50, 24, 468);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer163, 4, new Float32Array(3039), 470, 12);
+} catch {}
+document.body.prepend(img8);
+videoFrame41 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'unspecified', transfer: 'hlg'} });
+let autogeneratedBindGroupLayout97 = pipeline4.getBindGroupLayout(0);
+let buffer182 = device0.createBuffer({
+  size: 1332,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandEncoder261 = device0.createCommandEncoder();
+let computePassEncoder203 = commandEncoder260.beginComputePass({});
+let sampler157 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', minFilter: 'nearest', lodMaxClamp: 96.41});
+try {
+{ clearResourceUsages(device0, computePassEncoder197); computePassEncoder197.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder203.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder16.draw(165, 166, 369_106_414, 757_177_077);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(378, 34, 73, 167_371_834, 739_911_957);
+} catch {}
+try {
+renderPassEncoder16.drawIndexedIndirect(buffer136, 8_440);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer138, 15_124);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(1, buffer173);
+} catch {}
+try {
+commandEncoder261.copyBufferToTexture({
+  /* bytesInLastRow: 232 widthInBlocks: 58 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5232 */
+  offset: 5232,
+  bytesPerRow: 8704,
+  rowsPerImage: 1102,
+  buffer: buffer97,
+}, {
+  texture: texture178,
+  mipLevel: 0,
+  origin: {x: 8, y: 61, z: 0},
+  aspect: 'all',
+}, {width: 58, height: 229, depthOrArrayLayers: 0});
+} catch {}
+let promise38 = device0.queue.onSubmittedWorkDone();
+let texture278 = device0.createTexture({
+  size: [780],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView278 = texture18.createView({});
+try {
+computePassEncoder110.setBindGroup(3, bindGroup110, new Uint32Array(589), 12, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder197); computePassEncoder197.dispatchWorkgroupsIndirect(buffer34, 80); };
+} catch {}
+try {
+computePassEncoder202.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder69.setBindGroup(2, bindGroup98, new Uint32Array(2699), 239, 0);
+} catch {}
+try {
+renderPassEncoder16.draw(272, 388, 1_097_673_976, 138_409_468);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(274, 110, 1, 75_484_729, 287_503_135);
+} catch {}
+try {
+renderPassEncoder16.drawIndexedIndirect(buffer139, 2_020);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture221,
+  mipLevel: 1,
+  origin: {x: 40, y: 78, z: 0},
+  aspect: 'all',
+}, new Uint8Array(28).fill(28), /* required buffer size: 28 */
+{offset: 28}, {width: 13, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 240, height: 1, depthOrArrayLayers: 35}
+*/
+{
+  source: videoFrame32,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture277,
+  mipLevel: 1,
+  origin: {x: 129, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup175 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout48,
+  entries: [
+    {binding: 206, resource: {buffer: buffer161, offset: 2816, size: 9848}},
+    {binding: 113, resource: sampler82},
+  ],
+});
+let buffer183 = device0.createBuffer({
+  size: 16699,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let sampler158 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.67,
+});
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let veryExplicitBindGroupLayout50 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 50, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 400,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout98 = pipeline3.getBindGroupLayout(0);
+try {
+computePassEncoder152.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(0, bindGroup67);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(23, 683, 124, 895_342_859, 3_176_342_802);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer127, 2_292);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer39, 'uint16', 3_716, 549);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(3, buffer26, 420, 2_870);
+} catch {}
+let arrayBuffer39 = buffer90.getMappedRange(1544, 0);
+try {
+commandEncoder261.copyTextureToBuffer({
+  texture: texture234,
+  mipLevel: 0,
+  origin: {x: 71, y: 10, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 544 widthInBlocks: 68 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 4136 */
+  offset: 4136,
+  bytesPerRow: 8192,
+  buffer: buffer62,
+}, {width: 68, height: 27, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 173, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(31).fill(143), /* required buffer size: 31 */
+{offset: 31, bytesPerRow: 235}, {width: 26, height: 73, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder262 = device0.createCommandEncoder({});
+let computePassEncoder204 = commandEncoder262.beginComputePass({});
+let sampler159 = device0.createSampler({addressModeW: 'clamp-to-edge', magFilter: 'nearest', lodMaxClamp: 96.98});
+try {
+computePassEncoder139.setBindGroup(0, bindGroup62, new Uint32Array(229), 47, 0);
+} catch {}
+try {
+renderPassEncoder16.draw(361, 197, 380_284_701, 1_796_243_485);
+} catch {}
+document.body.append(canvas0);
+let computePassEncoder205 = commandEncoder261.beginComputePass({label: '\u2850\u009c\u0a99\u7da4\ua02a'});
+try {
+computePassEncoder204.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 93, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline37 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule6, constants: {}}});
+try {
+bindGroup26.label = '\u3d59\uc1f1\u77ad\u0762\u726c\u578a\u0d88\u3915\u0fd3';
+} catch {}
+let buffer184 = device0.createBuffer({
+  size: 5676,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture279 = device0.createTexture({
+  size: {width: 120, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let sampler160 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder205.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup163);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(270);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder46.copyBufferToTexture({
+  /* bytesInLastRow: 364 widthInBlocks: 91 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1076 */
+  offset: 1076,
+  bytesPerRow: 28672,
+  buffer: buffer26,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 197, y: 22, z: 0},
+  aspect: 'all',
+}, {width: 91, height: 33, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandBuffer7 = commandEncoder46.finish();
+let texture280 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder37.executeBundles([renderBundle27]);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas3,
+  origin: { x: 56, y: 0 },
+  flipY: true,
+}, {
+  texture: texture55,
+  mipLevel: 1,
+  origin: {x: 121, y: 26, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 18, height: 29, depthOrArrayLayers: 0});
+} catch {}
+let buffer185 = device0.createBuffer({size: 142, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture281 = device0.createTexture({
+  size: {width: 480},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler161 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 63.45, maxAnisotropy: 1});
+try {
+renderPassEncoder65.setBindGroup(2, bindGroup97);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandEncoder263 = device0.createCommandEncoder();
+let textureView279 = texture203.createView({aspect: 'depth-only', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder206 = commandEncoder263.beginComputePass();
+try {
+computePassEncoder197.end();
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(3, buffer10, 1_524);
+} catch {}
+document.body.append(img9);
+let bindGroup176 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout59,
+  entries: [{binding: 0, resource: {buffer: buffer70, offset: 0, size: 224}}],
+});
+let texture282 = device0.createTexture({
+  size: {width: 60, height: 1, depthOrArrayLayers: 54},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder70 = commandEncoder252.beginRenderPass({
+  colorAttachments: [{
+  view: textureView143,
+  clearValue: { r: -445.6, g: 930.6, b: -211.8, a: -197.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler162 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat'});
+try {
+computePassEncoder206.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline35);
+} catch {}
+try {
+  await promise38;
+} catch {}
+videoFrame42 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'smpte170m', transfer: 'gamma28curve'} });
+let textureView280 = texture106.createView({dimension: '2d-array', format: 'depth24plus', mipLevelCount: 1});
+try {
+renderPassEncoder37.draw(70, 418, 490_937_605, 1_055_693_656);
+} catch {}
+try {
+renderPassEncoder37.drawIndirect(buffer87, 1_148);
+} catch {}
+document.body.prepend(canvas3);
+await gc();
+let autogeneratedBindGroupLayout99 = pipeline8.getBindGroupLayout(0);
+let bindGroup177 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout45,
+  entries: [{binding: 0, resource: {buffer: buffer42, offset: 1280, size: 2402}}],
+});
+let texture283 = device0.createTexture({
+  size: [120, 1, 1],
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler163 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+});
+try {
+renderPassEncoder37.draw(271, 200, 475_605_612, 1_258_868_188);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+externalTexture19.label = '\u{1fa54}\u8905\u9feb\udee8\u9e31';
+} catch {}
+let sampler164 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup49);
+} catch {}
+try {
+renderPassEncoder37.draw(73, 91, 1_234_501_561, 1_279_236_967);
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(3, buffer17, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 15, y: 50, z: 0},
+  aspect: 'all',
+}, new Uint8Array(124).fill(188), /* required buffer size: 124 */
+{offset: 124, bytesPerRow: 18}, {width: 0, height: 40, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder37.drawIndirect(buffer140, 1_160);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer170);
+} catch {}
+let textureView281 = texture217.createView({dimension: '2d'});
+let sampler165 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 58.60,
+});
+let externalTexture32 = device0.importExternalTexture({source: videoFrame19});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup76);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(1, bindGroup23, []);
+} catch {}
+try {
+renderPassEncoder37.end();
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer61, 'uint16', 86, 648);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(2, buffer178, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let bindGroup178 = device0.createBindGroup({
+  label: '\u9ea7\uf398\u03ef\ud9c4\u302d\u49b8\u{1fd3c}\ucf77\u5cf9\uce49',
+  layout: autogeneratedBindGroupLayout40,
+  entries: [{binding: 0, resource: {buffer: buffer160, offset: 256, size: 225}}],
+});
+let pipelineLayout17 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout96]});
+let texture284 = device0.createTexture({
+  size: {width: 195, height: 120, depthOrArrayLayers: 1},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView282 = texture83.createView({});
+let sampler166 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMaxClamp: 67.57});
+try {
+computePassEncoder130.setBindGroup(0, bindGroup114, []);
+} catch {}
+try {
+computePassEncoder30.setBindGroup(0, bindGroup10, new Uint32Array(147), 3, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup73);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(1, bindGroup61, new Uint32Array(1463), 264, 0);
+} catch {}
+try {
+renderPassEncoder54.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer19, 'uint32', 788, 302);
+} catch {}
+let arrayBuffer40 = buffer58.getMappedRange(1008, 180);
+try {
+device0.queue.writeBuffer(buffer55, 2388, new Int16Array(4346), 418, 20);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer186 = device0.createBuffer({
+  size: 10906,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView283 = texture246.createView({arrayLayerCount: 1});
+try {
+computePassEncoder136.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture199,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(29).fill(141), /* required buffer size: 29 */
+{offset: 29}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: img4,
+  origin: { x: 10, y: 25 },
+  flipY: false,
+}, {
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture285 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 22},
+  dimension: '3d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView284 = texture104.createView({arrayLayerCount: 1});
+let sampler167 = device0.createSampler({minFilter: 'linear', mipmapFilter: 'linear'});
+try {
+computePassEncoder186.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(0, bindGroup125, new Uint32Array(25), 1, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder139); computePassEncoder139.dispatchWorkgroupsIndirect(buffer66, 7_320); };
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup169);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup91, new Uint32Array(693), 12, 0);
+} catch {}
+try {
+renderPassEncoder45.setViewport(157.04384769492802, 7.200116493152384, 10.54586295255189, 208.90020644986498, 0.567950780639229, 0.9979812307165062);
+} catch {}
+try {
+commandEncoder137.clearBuffer(buffer122, 3512, 1576);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(33).fill(120), /* required buffer size: 33 */
+{offset: 33}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledAutogeneratedBindGroupLayout0 = pipeline29.getBindGroupLayout(0);
+let bindGroup179 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout84,
+  entries: [{binding: 0, resource: {buffer: buffer143, offset: 1280}}],
+});
+let texture286 = device0.createTexture({
+  size: {width: 60, height: 1, depthOrArrayLayers: 3},
+  dimension: '3d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder71 = commandEncoder137.beginRenderPass({
+  colorAttachments: [{
+  view: textureView130,
+  depthSlice: 19,
+  clearValue: { r: 520.5, g: 558.7, b: -519.0, a: 579.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet25,
+});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup175, new Uint32Array(519), 305, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer102, 'uint16', 644, 307);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer112, 4_644, 226);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture121,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 12},
+  aspect: 'all',
+}, new Uint8Array(9_742).fill(229), /* required buffer size: 9_742 */
+{offset: 122, bytesPerRow: 481, rowsPerImage: 5}, {width: 51, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let textureView285 = texture272.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+renderPassEncoder30.executeBundles([renderBundle32, renderBundle0, renderBundle4]);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData30,
+  origin: { x: 7, y: 0 },
+  flipY: false,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = externalTexture10.label;
+} catch {}
+let shaderModule9 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+diagnostic(info, xyz);
+
+fn fn1() -> f16 {
+  var out: f16;
+  fn0();
+  out = f16(vp10.fract);
+  discard;
+  fn0();
+  vp10 = modf(vp10.fract);
+  let vf190: vec3h = sinh(vec3h(unconst_f16(-27963.7), unconst_f16(5555.0), unconst_f16(5597.0)));
+  fn0();
+  var vf191: vec3f = max(vec3f(unconst_f32(0.4731), unconst_f32(0.02515), unconst_f32(0.1878)), vec3f(unconst_f32(0.2779), unconst_f32(0.1100), unconst_f32(0.05540)));
+  var vf192: f32 = vf191[u32(unconst_u32(61))];
+  vp10 = modf(f32(vf190[u32(unconst_u32(108))]));
+  fn0();
+  vp10.whole += mix(pow(vec3f(f32(vf190[u32(unconst_u32(8))])), vec3f(unconst_f32(0.03302), unconst_f32(0.2968), unconst_f32(0.05725))).yy, vec2f(unconst_f32(0.1988), unconst_f32(0.04563)), vec2f(unconst_f32(0.5296), unconst_f32(0.01055))).r;
+  vp10.whole = fract(vec4f(unconst_f32(0.4845), unconst_f32(0.01762), unconst_f32(0.2169), unconst_f32(0.2682))).a;
+  vp11.fract *= bitcast<f32>(extractBits(vec3u(unconst_u32(210), unconst_u32(165), unconst_u32(87)), u32(unconst_u32(70)), u32(unconst_u32(608))).x);
+  vf192 += vp10.whole;
+  vf192 = mix(vec2f(unconst_f32(0.3072), unconst_f32(0.07204)), vec2f(unconst_f32(-0.2673), unconst_f32(0.1090)), vec2f(unconst_f32(0.02285), unconst_f32(0.3309))).x;
+  var vf193: vec3u = extractBits(vec3u(unconst_u32(68), unconst_u32(89), unconst_u32(67)), u32(unconst_u32(92)), u32(unconst_u32(352)));
+  vf192 = f32(countLeadingZeros(vec3u(unconst_u32(52), unconst_u32(3), unconst_u32(123))).b);
+  vf191 = vec3f(countLeadingZeros(vec3u(unconst_u32(207), unconst_u32(152), unconst_u32(61))));
+  let vf194: vec4u = max(vec4u(unconst_u32(584), unconst_u32(35), unconst_u32(23), unconst_u32(56)), vec4u(unconst_u32(94), unconst_u32(123), unconst_u32(0), unconst_u32(47)));
+  return out;
+}
+
+fn fn0() {
+  let ptr112 = &vp10;
+  var vf182: u32 = pack4xI8Clamp(vec4i(unconst_i32(104), unconst_i32(-492), unconst_i32(21), unconst_i32(65)));
+  vp10.fract -= f32(asinh(f16(unconst_f16(1119.9))));
+  var vf183: bool = all(bool(unconst_bool(true)));
+  var vf184: i32 = dot4I8Packed(u32(unconst_u32(46)), u32(unconst_u32(433)));
+  vf183 = bool((*ptr112).fract);
+  vp11.whole *= bitcast<f32>(pack4xI8Clamp(vec4i(unconst_i32(56), unconst_i32(11), unconst_i32(142), unconst_i32(96))));
+  vf183 = bool(dot4I8Packed(u32(unconst_u32(45)), u32(unconst_u32(262))));
+  vf182 = pack4xI8Clamp(vec4i(unconst_i32(41), unconst_i32(86), unconst_i32(89), unconst_i32(594)));
+  let vf185: f16 = atan(f16(unconst_f16(4414.2)));
+  let ptr113: ptr<function, u32> = &vf182;
+  var vf186: f32 = quantizeToF16(f32(unconst_f32(0.1350)));
+  vp11.fract = (*ptr112).whole;
+  var vf187: vec3h = cross(vec3h(unconst_f16(16149.9), unconst_f16(6939.2), unconst_f16(22568.6)), vec3h(unconst_f16(2998.1), unconst_f16(2796.4), unconst_f16(17168.0)));
+  vp10 = modf(unpack2x16float(pack4x8unorm(min(vec4f(unconst_f32(0.02796), unconst_f32(0.1169), unconst_f32(0.02145), unconst_f32(-0.1308)), vec4f(unconst_f32(0.05961), unconst_f32(0.4398), unconst_f32(0.00599), unconst_f32(-0.05945)))))[0]);
+  let ptr114 = &vp11;
+  let ptr115: ptr<function, vec3h> = &vf187;
+  vf182 ^= vf182;
+  let vf188: u32 = pack4xU8Clamp(vec4u(cross(vec3h(unconst_f16(489.5), unconst_f16(29327.4), unconst_f16(-15939.4)), vec3h(unconst_f16(21530.0), unconst_f16(906.7), unconst_f16(-14340.0))).brrg));
+  vf184 |= i32((*ptr113));
+  var vf189: vec3f = log(vec3f(unconst_f32(0.1625), unconst_f32(0.07228), unconst_f32(0.01602)));
+  vp10.fract = (*ptr114).fract;
+  let ptr116 = &vp11;
+  let ptr117: ptr<private, f32> = &vp10.fract;
+}
+
+@group(0) @binding(0) var<uniform> buffer187: mat4x3f;
+
+struct VertexOutput7 {
+  @location(2) @interpolate(flat, sample) f31: f16,
+  @invariant @builtin(position) f32: vec4f,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw26: atomic<u32>;
+
+var<workgroup> vw25: array<VertexOutput7, 1>;
+
+struct T0 {
+  @align(8) @size(8) f0: i32,
+  @align(8) @size(24) f1: array<mat4x2h, 1>,
+  @size(48) f2: array<array<array<array<mat2x2f, 1>, 1>, 2>, 1>,
+  @align(4) @size(8) f3: f16,
+}
+
+var<private> vp11 = modf(f32(-0.04519));
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<private> vp10 = modf(f32(0.2083));
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn fn2() -> VertexOutput7 {
+  var out: VertexOutput7;
+  let ptr118: ptr<private, f32> = &vp10.fract;
+  out.f31 = f16(vp10.fract);
+  out.f32 *= vec4f(vp10.whole);
+  out.f32 = vec4f(vp11.whole);
+  vp10 = vp11;
+  var vf195: vec4f = asinh(vec4f(unconst_f32(0.7156), unconst_f32(0.1242), unconst_f32(0.1558), unconst_f32(0.4761)));
+  let ptr119 = &vp10;
+  let ptr120 = &vp10;
+  var vf196: vec2h = refract(vec2h(unconst_f16(4814.5), unconst_f16(-41322.2)), vec2h(unconst_f16(38996.0), unconst_f16(14369.7)), f16(unconst_f16(5584.0)));
+  let ptr121 = &(*ptr119);
+  let vf197: f16 = vf196[u32(unconst_u32(249))];
+  let ptr122 = &(*ptr120);
+  vf196 = tan(vec4h(unconst_f16(-3448.2), unconst_f16(5066.9), unconst_f16(17450.0), unconst_f16(6865.8))).yy;
+  let ptr123: ptr<private, f32> = &(*ptr120).whole;
+  let ptr124: ptr<private, f32> = &vp11.fract;
+  let ptr125: ptr<private, f32> = &(*ptr121).whole;
+  return out;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@vertex
+fn vertex8() -> VertexOutput7 {
+  var out: VertexOutput7;
+  let vf198: vec2f = saturate(vec2f(unconst_f32(0.03220), unconst_f32(0.03306)));
+  var vf199 = fn2();
+  fn2();
+  let vf200: vec4i = firstLeadingBit(vec4i(unconst_i32(96), unconst_i32(2), unconst_i32(6), unconst_i32(-29)));
+  var vf201: vec3h = inverseSqrt(vec3h(unconst_f16(41788.6), unconst_f16(12924.7), unconst_f16(2714.8)));
+  vp10 = vp11;
+  let ptr126 = &vp11;
+  fn2();
+  let vf202: vec2i = firstTrailingBit(vec2i(unconst_i32(12), unconst_i32(-99)));
+  vf201 = vec3h(vf199.f31);
+  let vf203: vec3h = inverseSqrt(vec3h(unconst_f16(3225.9), unconst_f16(5672.6), unconst_f16(13411.3)));
+  vf201 = vec3h(f16(vp11.fract));
+  vp11.whole = vf199.f32[u32(unconst_u32(43))];
+  vp10.whole = vp10.whole;
+  var vf204: f32 = buffer187[u32(unconst_u32(90))][u32(unconst_u32(440))];
+  var vf205 = fn2();
+  fn2();
+  let vf206: f32 = vf205.f32[u32(unconst_u32(325))];
+  var vf207: f16 = vf203[u32(unconst_u32(138))];
+  var vf208 = fn2();
+  vf207 *= vf199.f31;
+  return out;
+  _ = buffer187;
+}
+
+@fragment
+fn fragment10() -> @location(200) @interpolate(linear) vec4f {
+  var out: vec4f;
+  var vf209: u32 = pack2x16snorm(vec2f(unconst_f32(0.06625), unconst_f32(-0.1060)));
+  let vf210: vec4h = atan2(vec4h(unconst_f16(-5824.2), unconst_f16(10124.7), unconst_f16(493.5), unconst_f16(8857.5)), vec4h(unconst_f16(546.7), unconst_f16(4091.7), unconst_f16(-8916.7), unconst_f16(25015.3)));
+  out = vec4f(f32(sign(i32(unconst_i32(175)))));
+  fn0();
+  fn1();
+  let ptr127 = &vp10;
+  vp11.fract = f32(saturate(f16(unconst_f16(4156.3))));
+  vp10 = modf(vp10.fract);
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute8(@builtin(local_invocation_index) a0: u32, @builtin(local_invocation_id) a1: vec3u) {
+  fn2();
+  vp10 = modf(f32(a1[2]));
+  vp11 = modf((*&vw25)[u32(unconst_u32(238))].f32.b);
+  vp11 = modf(log(f32(unconst_f32(0.08842))));
+  vp11 = modf(vw25[0].f32.g);
+  atomicAnd(&vw26, u32(unconst_u32(183)));
+  vp10 = modf(bitcast<f32>(atomicExchange(&(*&vw26), u32(unconst_u32(279)))));
+  fn2();
+  var vf211 = fn2();
+  fn2();
+  let ptr128: ptr<function, vec4f> = &vf211.f32;
+  var vf212: u32 = atomicLoad(&(*&vw26));
+  let ptr129: ptr<workgroup, f16> = &(*&vw25)[0].f31;
+  vw25[u32(unconst_u32(221))].f31 = (*&vw25)[0].f31;
+}
+
+@compute @workgroup_size(1, 1, 2)
+fn compute9() {
+  var vf213 = fn2();
+}`,
+});
+let pipelineLayout18 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout2]});
+let buffer188 = device0.createBuffer({
+  size: 16271,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView286 = texture285.createView({});
+try {
+renderPassEncoder51.setBlendConstant({ r: -37.94, g: 388.3, b: 372.4, a: -723.7, });
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(2, buffer16);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture186,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(271).fill(77), /* required buffer size: 271 */
+{offset: 271}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture287 = device0.createTexture({
+  size: {width: 390},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+computePassEncoder205.setBindGroup(0, bindGroup119);
+} catch {}
+document.body.append(img7);
+let imageData36 = new ImageData(56, 100);
+let texture288 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 2},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler168 = device0.createSampler({addressModeU: 'repeat', lodMaxClamp: 96.96});
+try {
+computePassEncoder135.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder139); computePassEncoder139.dispatchWorkgroupsIndirect(buffer99, 452); };
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup71);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer183, 'uint16', 7_288, 9);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 195, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame41,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 9, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+videoFrame43 = new VideoFrame(img10, {timestamp: 0});
+let buffer189 = device0.createBuffer({size: 16056, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let querySet38 = device0.createQuerySet({type: 'occlusion', count: 913});
+let texture289 = device0.createTexture({
+  size: {width: 97},
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView287 = texture47.createView({dimension: '2d', baseArrayLayer: 125, arrayLayerCount: 1});
+try {
+computePassEncoder100.setBindGroup(3, bindGroup131);
+} catch {}
+try {
+renderPassEncoder50.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(3, buffer32, 0);
+} catch {}
+let bindGroup180 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout67,
+  entries: [{binding: 0, resource: {buffer: buffer179, offset: 0}}],
+});
+let buffer190 = device0.createBuffer({
+  size: 6506,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView288 = texture17.createView({format: 'rgba8unorm-srgb', baseArrayLayer: 1, arrayLayerCount: 2});
+try {
+renderPassEncoder63.setBindGroup(2, bindGroup109);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer110, 'uint16', 146, 1_346);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 22}
+*/
+{
+  source: imageData15,
+  origin: { x: 5, y: 12 },
+  flipY: true,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 11, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup181 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout56,
+  entries: [{binding: 0, resource: {buffer: buffer23, offset: 256, size: 539}}],
+});
+let texture290 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 36},
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture291 = gpuCanvasContext6.getCurrentTexture();
+let sampler169 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', minFilter: 'linear', lodMaxClamp: 79.86});
+try {
+computePassEncoder172.setBindGroup(1, bindGroup134);
+} catch {}
+try {
+computePassEncoder133.setBindGroup(3, bindGroup134, new Uint32Array(913), 126, 0);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(2, buffer161, 4_020, 7_231);
+} catch {}
+document.body.prepend(img8);
+try {
+computePassEncoder0.label = '\u{1fc89}\ud01c\u6ff2\u075b\u7eeb\u3dfe\u86f6';
+} catch {}
+let textureView289 = texture232.createView({dimension: 'cube', aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 6});
+try {
+computePassEncoder78.setBindGroup(3, bindGroup85);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup66, new Uint32Array(515), 21, 0);
+} catch {}
+try {
+renderPassEncoder66.setPipeline(pipeline21);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 60, y: 7 },
+  flipY: true,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 34, y: 58, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 11, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup182 = device0.createBindGroup({layout: veryExplicitBindGroupLayout21, entries: [{binding: 140, resource: textureView66}]});
+let buffer191 = device0.createBuffer({size: 2177, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder202.setBindGroup(0, bindGroup72, new Uint32Array(152), 12, 0);
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup122, [1536]);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup134, new Uint32Array(2397), 365, 0);
+} catch {}
+try {
+renderPassEncoder58.setScissorRect(2, 16, 8, 6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 50}
+*/
+{
+  source: videoFrame21,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 164, y: 40, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u{1f98a}\u0377\u8ebc\u5b4b\u0771\u9dfa\u0c2e\u1290\u0d44';
+} catch {}
+let querySet39 = device0.createQuerySet({type: 'occlusion', count: 79});
+let textureView290 = texture244.createView({baseMipLevel: 0, arrayLayerCount: 1});
+try {
+computePassEncoder80.setBindGroup(1, bindGroup156, new Uint32Array(3740), 479, 0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup135, new Uint32Array(1962), 437, 0);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer38, 'uint32', 4_400, 235);
+} catch {}
+try {
+buffer59.unmap();
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer99, 'uint16', 244, 885);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline14);
+} catch {}
+let bindGroup183 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout47,
+  entries: [
+    {binding: 17, resource: {buffer: buffer111, offset: 256, size: 5092}},
+    {binding: 56, resource: {buffer: buffer112, offset: 768}},
+  ],
+});
+let texture292 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 22},
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler170 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.83,
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder62.setBindGroup(3, bindGroup92);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline14);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline30);
+} catch {}
+document.body.prepend(canvas3);
+let imageData37 = new ImageData(12, 8);
+let buffer192 = device0.createBuffer({size: 11587, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView291 = texture144.createView({dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 1});
+let sampler171 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', minFilter: 'nearest', lodMaxClamp: 89.94});
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup148);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer95, 'uint32', 188, 837);
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline28);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer95, 'uint32', 928, 572);
+} catch {}
+let pipeline38 = device0.createRenderPipeline({
+  layout: pipelineLayout14,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment2',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'add', srcFactor: 'src', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {module: shaderModule3, constants: {27_508: 0}, buffers: []},
+});
+let bindGroup184 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout36,
+  entries: [
+    {binding: 19, resource: textureView186},
+    {binding: 134, resource: {buffer: buffer110, offset: 1280, size: 176}},
+    {binding: 184, resource: {buffer: buffer190, offset: 2304, size: 352}},
+  ],
+});
+let textureView292 = texture283.createView({dimension: '2d', mipLevelCount: 1});
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup131);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(1, buffer25, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer128, 984, new DataView(new ArrayBuffer(10137)), 9156, 20);
+} catch {}
+let buffer193 = device0.createBuffer({
+  size: 291,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView293 = texture240.createView({});
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup182);
+} catch {}
+let pipeline39 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {module: shaderModule9, targets: [{format: 'rg8unorm'}]},
+  vertex: {
+    module: shaderModule0,
+    constants: {},
+    buffers: [
+      {arrayStride: 20, stepMode: 'instance', attributes: [{format: 'uint32', offset: 0, shaderLocation: 6}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32'},
+});
+let bindGroup185 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout30,
+  entries: [{binding: 0, resource: {buffer: buffer154, offset: 256, size: 192}}],
+});
+let textureView294 = texture71.createView({});
+try {
+computePassEncoder201.setBindGroup(3, bindGroup149);
+} catch {}
+try {
+computePassEncoder64.setBindGroup(3, bindGroup152, new Uint32Array(5235), 270, 0);
+} catch {}
+try {
+renderPassEncoder41.setViewport(389.92196572525, 90.36067875665647, 0.012924432447324967, 127.13585983461269, 0.2829993981831258, 0.5460680470398316);
+} catch {}
+let arrayBuffer41 = buffer8.getMappedRange(4352, 60);
+let promise39 = device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule9, entryPoint: 'compute9'}});
+let buffer194 = device0.createBuffer({size: 24924, usage: GPUBufferUsage.INDEX});
+try {
+renderPassEncoder4.setIndexBuffer(buffer194, 'uint16', 1_686, 2_294);
+} catch {}
+try {
+buffer126.destroy();
+} catch {}
+let autogeneratedBindGroupLayout100 = pipeline13.getBindGroupLayout(0);
+let textureView295 = texture279.createView({dimension: '2d-array', aspect: 'depth-only', baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup154);
+} catch {}
+try {
+computePassEncoder114.setBindGroup(0, bindGroup162, new Uint32Array(853), 196, 0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline32);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(5, buffer26, 0, 4_246);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 82}
+*/
+{
+  source: videoFrame20,
+  origin: { x: 5, y: 107 },
+  flipY: true,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline40 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule3, constants: {override3: 0}}});
+let buffer195 = device0.createBuffer({size: 25190, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let sampler172 = device0.createSampler({addressModeW: 'repeat'});
+try {
+computePassEncoder139.end();
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline28);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let autogeneratedBindGroupLayout101 = pipeline40.getBindGroupLayout(1);
+let bindGroup186 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 50, resource: sampler31},
+    {binding: 21, resource: textureView274},
+    {binding: 400, resource: {buffer: buffer26, offset: 6400}},
+  ],
+});
+let texture293 = device0.createTexture({
+  size: [240, 1, 82],
+  sampleCount: 1,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder122.setBindGroup(2, bindGroup94, new Uint32Array(5546), 1_187, 0);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer106, 'uint32', 12, 24);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(6, buffer25, 2_232);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+document.body.append(canvas0);
+let shaderModule10 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+requires pointer_composite_access;
+
+fn fn1() -> array<array<vec2u, 1>, 1> {
+  var out: array<array<vec2u, 1>, 1>;
+  discard;
+  vp12[bitcast<u32>(vp12[13].whole)].whole = vec2h(clamp(vec3f(unconst_f32(0.5170), unconst_f32(0.06458), unconst_f32(0.5653)), vec3f(unconst_f32(0.1098), unconst_f32(0.1306), unconst_f32(0.00943)), vec3f(clamp(vec2h(unconst_f16(2763.5), unconst_f16(35823.8)), vec2h(unconst_f16(6203.7), unconst_f16(2103.2)), vec2h(unconst_f16(20764.9), unconst_f16(2025.4))).xyx)).bb);
+  out[u32(unconst_u32(63))][0] += vec2u(pack4xU8(vec4u(u32(saturate(f16(unconst_f16(3869.8)))))));
+  out[u32(unconst_u32(245))][u32(unconst_u32(97))] <<= vec2u(vp12[13].fract);
+  out[u32(unconst_u32(0))][u32(unconst_u32(36))] *= vec2u(vp12[u32(unconst_u32(494))].fract);
+  return out;
+}
+
+struct VertexOutput8 {
+  @invariant @builtin(position) f33: vec4f,
+}
+
+struct T0 {
+  @align(8) @size(8) f0: f32,
+  @size(64) f1: vec4u,
+  @size(16) f2: vec2u,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw27: array<VertexOutput8, 1>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw28: atomic<u32>;
+
+struct FragmentOutput10 {
+  @location(2) f0: vec4u,
+  @location(0) f1: vec2i,
+  @location(1) f2: vec4u,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T1 {
+  @align(8) @size(88) f0: array<u32>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(0) var<uniform> buffer196: mat4x3h;
+
+var<workgroup> vw29: VertexOutput8;
+
+fn fn0(a0: ptr<function, vec4<bool>>) -> FragmentOutput10 {
+  var out: FragmentOutput10;
+  let vf214: vec3f = cross(vec3f(unconst_f32(0.05468), unconst_f32(0.2544), unconst_f32(0.2187)), vec3f(unconst_f32(0.1703), unconst_f32(0.1191), unconst_f32(0.1520)));
+  let ptr130: ptr<private, vec2h> = &vp12[13].whole;
+  let ptr131 = &vp12[13];
+  out.f2 = unpack4xU8(u32((*a0)[u32(unconst_u32(393))]));
+  return out;
+}
+
+var<private> vp12 = array(modf(vec2h(10574.5, 14722.1)), modf(vec2h(10242.7, 25631.3)), modf(vec2h(8034.8, -27208.2)), modf(vec2h(-1906.9, 21389.8)), modf(vec2h(362.8, 1273.0)), modf(vec2h(6056.3, 16033.9)), modf(vec2h(3138.2, 2784.8)), modf(vec2h(16259.9, 2151.1)), modf(vec2h(2037.3, 1532.3)), modf(vec2h(5032.1, -31612.4)), modf(vec2h(39484.1, 12961.3)), modf(vec2h(11151.4, -39330.3)), modf(vec2h(16151.7, 10944.2)), modf(vec2h(45222.1, 5527.4)));
+
+@vertex
+fn vertex9(@location(12) a0: vec4h) -> VertexOutput8 {
+  var out: VertexOutput8;
+  var vf215: vec3h = buffer196[u32(unconst_u32(56))];
+  out.f33 -= vec4f(vp12[u32(unconst_u32(338))].whole.yyyy);
+  out = VertexOutput8(vec4f(vp12[u32(unconst_u32(81))].whole.gggr));
+  vp12[u32(unconst_u32(187))].whole += vec2h(faceForward(vec3f(unconst_f32(0.04121), unconst_f32(0.04939), unconst_f32(0.2781)), vec3f(unconst_f32(0.05700), unconst_f32(0.02641), unconst_f32(-0.2968)), vec3f(unconst_f32(0.02991), unconst_f32(0.1013), unconst_f32(0.4009))).xx);
+  vf215 = a0.yyx;
+  let ptr132: ptr<private, vec2h> = &vp12[13].whole;
+  let ptr133 = &vp12[13];
+  let vf216: vec4f = log(vec4f(unconst_f32(0.1230), unconst_f32(0.04268), unconst_f32(0.1602), unconst_f32(0.3326)));
+  let ptr134: ptr<uniform, mat4x3h> = &(*&buffer196);
+  out.f33 *= vec4f(vp12[13].whole.grgg);
+  return out;
+  _ = buffer196;
+}
+
+@fragment
+fn fragment11(@location(3) a0: vec4u, @location(14) @interpolate(flat, sample) a1: vec2i, @builtin(position) a2: vec4f, @location(15) a3: vec2f) -> FragmentOutput10 {
+  var out: FragmentOutput10;
+  fn1();
+  out.f0 = unpack4xU8(a0[u32(unconst_u32(63))]);
+  out = FragmentOutput10(vec4u(reflect(vec2h(unconst_f16(15200.3), unconst_f16(17755.7)), vec2h(unconst_f16(8049.3), unconst_f16(4854.6))).yyyx), vec2i(reflect(vec2h(unconst_f16(15200.3), unconst_f16(17755.7)), vec2h(unconst_f16(8049.3), unconst_f16(4854.6)))), vec4u(reflect(vec2h(unconst_f16(15200.3), unconst_f16(17755.7)), vec2h(unconst_f16(8049.3), unconst_f16(4854.6))).xyyx));
+  out.f1 |= extractBits(vec4i(unconst_i32(-155), unconst_i32(25), unconst_i32(6), unconst_i32(29)), bitcast<u32>(vp12[13].whole), u32(unconst_u32(199))).rb;
+  var vf217 = fn1();
+  vp12[u32(unconst_u32(137))].fract = vec2h(vf217[0][0]);
+  fn1();
+  out.f0 *= vec4u(cos(fma(vec2h(unconst_f16(1514.8), unconst_f16(14207.3)), vec2h(unconst_f16(9851.7), unconst_f16(21332.5)), vec2h(unconst_f16(3261.6), unconst_f16(14554.0))).rgr).zyxy);
+  out.f2 = vf217[0][0].rrrr;
+  vp12[13].whole -= vp12[u32(unconst_u32(181))].whole;
+  vf217[u32(unconst_u32(81))][u32(unconst_u32(207))] <<= bitcast<vec2u>(a3);
+  return out;
+}
+
+@compute @workgroup_size(1, 3, 4)
+fn compute10() {
+  let vf218: vec3h = inverseSqrt(vec3h(unconst_f16(16288.9), unconst_f16(-21363.9), unconst_f16(33177.6)));
+  let ptr135: ptr<workgroup, VertexOutput8> = &vw27[0];
+  let ptr136: ptr<workgroup, vec4f> = &(*&vw27)[0].f33;
+  atomicMax(&vw28, u32(unconst_u32(300)));
+  vp12[u32(unconst_u32(65))].fract = vec2h((*&vw27)[u32(unconst_u32(133))].f33.bb);
+  let ptr137: ptr<workgroup, atomic<u32>> = &(*&vw28);
+  vp12[u32(unconst_u32(91))] = modf(vec2h((*ptr135).f33.yw));
+}`,
+});
+let texture294 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 4},
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder207 = commandEncoder184.beginComputePass({});
+try {
+computePassEncoder207.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder35.executeBundles([renderBundle10, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer139, 'uint16', 3_552, 44);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer197 = device0.createBuffer({size: 4914, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let textureView296 = texture210.createView({});
+try {
+computePassEncoder167.setBindGroup(1, bindGroup41);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(2, bindGroup34, new Uint32Array(610), 85, 0);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline30);
+} catch {}
+try {
+if (!arrayBuffer23.detached) { new Uint8Array(arrayBuffer23).fill(0x55); };
+} catch {}
+videoFrame44 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'film', transfer: 'unspecified'} });
+let bindGroup187 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout84,
+  entries: [{binding: 0, resource: {buffer: buffer136, offset: 5632}}],
+});
+let textureView297 = texture234.createView({baseMipLevel: 0, mipLevelCount: 1});
+let texture295 = gpuCanvasContext1.getCurrentTexture();
+let textureView298 = texture284.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler173 = device0.createSampler({lodMinClamp: 13.34, compare: 'greater-equal'});
+try {
+computePassEncoder38.setBindGroup(2, bindGroup72);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(3, bindGroup11, new Uint32Array(3877), 454, 0);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(4, buffer49, 0, 2_670);
+} catch {}
+try {
+if (!arrayBuffer40.detached) { new Uint8Array(arrayBuffer40).fill(0x55); };
+} catch {}
+let autogeneratedBindGroupLayout102 = pipeline30.getBindGroupLayout(0);
+let querySet40 = device0.createQuerySet({type: 'occlusion', count: 2148});
+let sampler174 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.12,
+});
+try {
+computePassEncoder87.end();
+} catch {}
+try {
+renderPassEncoder68.executeBundles([renderBundle6, renderBundle11, renderBundle27]);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(5, buffer2);
+} catch {}
+let recycledExplicitBindGroupLayout3 = pipeline19.getBindGroupLayout(0);
+let computePassEncoder208 = commandEncoder119.beginComputePass({});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup136, new Uint32Array(901), 80, 0);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -427.1, g: -428.9, b: -812.5, a: 396.8, });
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer186, 'uint16', 1_762, 2_068);
+} catch {}
+let autogeneratedBindGroupLayout103 = pipeline10.getBindGroupLayout(0);
+let bindGroup188 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout72,
+  entries: [{binding: 0, resource: {buffer: buffer21, offset: 256}}],
+});
+try {
+computePassEncoder179.end();
+} catch {}
+try {
+computePassEncoder208.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer99, 'uint32', 2_388, 1_668);
+} catch {}
+let autogeneratedBindGroupLayout104 = pipeline25.getBindGroupLayout(0);
+let computePassEncoder209 = commandEncoder234.beginComputePass({});
+let externalTexture33 = device0.importExternalTexture({source: videoFrame7});
+try {
+computePassEncoder126.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder208); computePassEncoder208.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder209.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer194, 'uint16', 578, 142);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline14);
+} catch {}
+let arrayBuffer42 = buffer8.getMappedRange(4432, 300);
+try {
+adapter0.label = '\u632d\u{1f68a}\uf8b1';
+} catch {}
+try {
+globalThis.someLabel = textureView111.label;
+} catch {}
+let texture296 = device0.createTexture({
+  size: {width: 195, height: 120, depthOrArrayLayers: 151},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture297 = gpuCanvasContext2.getCurrentTexture();
+try {
+renderPassEncoder57.setBindGroup(3, bindGroup122, new Uint32Array(1219), 103, 1);
+} catch {}
+try {
+renderPassEncoder59.executeBundles([renderBundle10, renderBundle6, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder68.setPipeline(pipeline16);
+} catch {}
+try {
+gpuCanvasContext3.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_DST});
+} catch {}
+let texture298 = device0.createTexture({
+  size: {width: 60, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView299 = texture217.createView({dimension: '2d-array', aspect: 'all', baseArrayLayer: 0});
+try {
+computePassEncoder55.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer102, 'uint32', 1_192, 963);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(5, buffer2);
+} catch {}
+let autogeneratedBindGroupLayout105 = pipeline15.getBindGroupLayout(0);
+let pipelineLayout19 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout36]});
+let texture299 = device0.createTexture({
+  size: [780, 480, 1],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder38.setBindGroup(0, bindGroup88);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(3, bindGroup170, new Uint32Array(2211), 395, 0);
+} catch {}
+let buffer198 = device0.createBuffer({size: 6265, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup147, new Uint32Array(86), 35, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup100, new Uint32Array(4320), 88, 0);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline38);
+} catch {}
+let promise40 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(canvas0);
+let texture300 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 22},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder200.setBindGroup(0, bindGroup21, []);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup152);
+} catch {}
+try {
+renderPassEncoder66.setPipeline(pipeline13);
+} catch {}
+let texture301 = device0.createTexture({
+  size: [480, 1, 134],
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler175 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat', mipmapFilter: 'nearest'});
+try {
+computePassEncoder150.setBindGroup(0, bindGroup47);
+} catch {}
+try {
+computePassEncoder128.setBindGroup(0, bindGroup92, new Uint32Array(5787), 1_127, 0);
+} catch {}
+try {
+computePassEncoder49.end();
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+gpuCanvasContext5.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING, viewFormats: []});
+} catch {}
+let textureView300 = texture127.createView({aspect: 'depth-only', arrayLayerCount: 1});
+let computePassEncoder210 = commandEncoder75.beginComputePass({});
+try {
+computePassEncoder210.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder157.setBindGroup(2, bindGroup172);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(4, buffer170, 0, 1_443);
+} catch {}
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle41 = renderBundleEncoder41.finish({});
+let sampler176 = device0.createSampler({});
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup107, []);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer11, 'uint32', 56, 136);
+} catch {}
+try {
+buffer62.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 187, y: 51, z: 0},
+  aspect: 'all',
+}, new Uint8Array(32).fill(24), /* required buffer size: 32 */
+{offset: 32, bytesPerRow: 438, rowsPerImage: 162}, {width: 107, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let imageData38 = new ImageData(12, 44);
+let texture302 = device0.createTexture({
+  size: [16, 16, 22],
+  mipLevelCount: 1,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder204.setBindGroup(0, bindGroup146);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup142, []);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer4, 'uint16', 952, 1_766);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline17);
+} catch {}
+try {
+buffer175.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture128,
+  mipLevel: 0,
+  origin: {x: 135, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(63).fill(142), /* required buffer size: 63 */
+{offset: 63}, {width: 96, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup57, new Uint32Array(7849), 2_521, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle28]);
+} catch {}
+let texture303 = device0.createTexture({
+  size: [16, 16, 22],
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder208); computePassEncoder208.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+renderPassEncoder29.beginOcclusionQuery(4);
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder64.executeBundles([renderBundle31]);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer102, 'uint16', 1_344, 138);
+} catch {}
+let bindGroup189 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout11,
+  entries: [{binding: 0, resource: {buffer: buffer66, offset: 768, size: 366}}],
+});
+let buffer199 = device0.createBuffer({size: 9045, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder194.setBindGroup(0, bindGroup43, new Uint32Array(228), 59, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder208); computePassEncoder208.dispatchWorkgroupsIndirect(buffer95, 64); };
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(3, bindGroup104, new Uint32Array(290), 20, 0);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(6, buffer23);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await promise40;
+} catch {}
+let autogeneratedBindGroupLayout106 = pipeline6.getBindGroupLayout(0);
+let bindGroup190 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout75,
+  entries: [{binding: 0, resource: {buffer: buffer39, offset: 2048}}],
+});
+let buffer200 = device0.createBuffer({
+  size: 9172,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture304 = device0.createTexture({size: [195, 120, 1], format: 'rgb10a2uint', usage: GPUTextureUsage.RENDER_ATTACHMENT, viewFormats: []});
+let textureView301 = texture81.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 1});
+try {
+computePassEncoder39.setBindGroup(1, bindGroup34);
+} catch {}
+try {
+renderPassEncoder64.executeBundles([renderBundle32, renderBundle31, renderBundle7, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline32);
+} catch {}
+try {
+renderPassEncoder66.setVertexBuffer(4, buffer93);
+} catch {}
+let img11 = await imageWithData(7, 15, '#10101010', '#20202020');
+let imageData39 = new ImageData(140, 92);
+try {
+globalThis.someLabel = commandEncoder60.label;
+} catch {}
+let textureView302 = texture41.createView({mipLevelCount: 1});
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55); };
+} catch {}
+let veryExplicitBindGroupLayout51 = device0.createBindGroupLayout({entries: [{binding: 96, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }}]});
+let bindGroup191 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout38,
+  entries: [{binding: 0, resource: {buffer: buffer39, offset: 512}}],
+});
+let textureView303 = texture14.createView({});
+let sampler177 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.74,
+  maxAnisotropy: 8,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder208); computePassEncoder208.dispatchWorkgroupsIndirect(buffer139, 2_352); };
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(0, bindGroup154);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup80, new Uint32Array(498), 253, 0);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle32]);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline13);
+} catch {}
+let pipeline41 = await promise33;
+let texture305 = device0.createTexture({
+  size: [16, 16, 22],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 82}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup192 = device0.createBindGroup({layout: veryExplicitBindGroupLayout13, entries: [{binding: 140, resource: textureView23}]});
+let renderBundleEncoder42 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], stencilReadOnly: true});
+let renderBundle42 = renderBundleEncoder42.finish({});
+let sampler178 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', lodMinClamp: 73.10, lodMaxClamp: 87.33});
+try {
+computePassEncoder150.setBindGroup(3, bindGroup156);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer34, 'uint32', 412, 19);
+} catch {}
+let recycledExplicitBindGroupLayout4 = pipeline34.getBindGroupLayout(0);
+let texture306 = device0.createTexture({
+  size: {width: 195, height: 120, depthOrArrayLayers: 146},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup61);
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer163, 'uint16', 76, 107);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline32);
+} catch {}
+offscreenCanvas4.width = 707;
+let bindGroup193 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout11,
+  entries: [
+    {binding: 21, resource: textureView56},
+    {binding: 50, resource: sampler161},
+    {binding: 400, resource: {buffer: buffer188, offset: 3072, size: 1168}},
+  ],
+});
+let buffer201 = device0.createBuffer({
+  size: 24899,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let querySet41 = device0.createQuerySet({type: 'occlusion', count: 303});
+let textureView304 = texture285.createView({mipLevelCount: 1});
+let sampler179 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.17,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder146.setBindGroup(0, bindGroup94);
+} catch {}
+let autogeneratedBindGroupLayout107 = pipeline18.getBindGroupLayout(0);
+let buffer202 = device0.createBuffer({size: 17283, usage: GPUBufferUsage.UNIFORM});
+let texture307 = device0.createTexture({
+  size: [120, 1, 8],
+  mipLevelCount: 6,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView305 = texture194.createView({mipLevelCount: 1});
+try {
+computePassEncoder100.setBindGroup(3, bindGroup173, new Uint32Array(2421), 200, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup137);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer1, 'uint32', 308, 12);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline35);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(img8);
+let shaderModule11 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires packed_4x8_integer_dot_product;
+
+@group(0) @binding(13) var sam8: sampler;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw31: atomic<i32>;
+
+struct VertexOutput9 {
+  @builtin(position) f34: vec4f,
+}
+
+fn fn0(a0: ptr<storage, array<u32>, read_write>) -> mat4x3h {
+  var out: mat4x3h;
+  out += mat4x3h(f16((*a0)[arrayLength(&(*a0))]), f16((*a0)[arrayLength(&(*a0))]), f16((*a0)[arrayLength(&(*a0))]), f16((*a0)[arrayLength(&(*a0))]), f16((*a0)[arrayLength(&(*a0))]), f16((*a0)[arrayLength(&(*a0))]), f16((*a0)[arrayLength(&(*a0))]), f16((*a0)[arrayLength(&(*a0))]), f16((*a0)[arrayLength(&(*a0))]), f16((*a0)[arrayLength(&(*a0))]), f16((*a0)[arrayLength(&(*a0))]), f16((*a0)[arrayLength(&(*a0))]));
+  let ptr138: ptr<storage, u32, read_write> = &(*a0)[i32(unconst_i32(220))];
+  var vf219: vec2u = textureDimensions(st9);
+  out = mat4x3h(vec3h(textureDimensions(tex7).xxy), vec3h(textureDimensions(tex7).yxy), vec3h(textureDimensions(tex7).yxx), vec3h(textureDimensions(tex7).yyx));
+  vf219 = vec2u(textureLoad(et3, vec2u(unconst_u32(89), unconst_u32(45))).rg);
+  let ptr139: ptr<storage, array<u32>, read_write> = &(*a0);
+  let vf220: u32 = pack4xU8(vec4u(unconst_u32(26), unconst_u32(9), unconst_u32(138), unconst_u32(286)));
+  return out;
+  _ = tex7;
+  _ = et3;
+  _ = st9;
+}
+
+fn fn1() -> array<VertexOutput9, 2> {
+  var out: array<VertexOutput9, 2>;
+  out[u32(unconst_u32(284))] = VertexOutput9(vec4f(log2(vec2h(insertBits(vec4u(unconst_u32(34), unconst_u32(116), unconst_u32(249), unconst_u32(107)), vec4u(unconst_u32(61), unconst_u32(101), unconst_u32(116), unconst_u32(45)), u32(unconst_u32(116)), u32(unconst_u32(268))).wy)).xxyy));
+  let vf221: vec4u = insertBits(unpack4xU8(u32(all(vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(true), unconst_bool(false))))), vec4u(unconst_u32(206), unconst_u32(290), unconst_u32(426), unconst_u32(211)), u32(unconst_u32(12)), u32(unconst_u32(32)));
+  return out;
+}
+
+fn fn2() -> VertexOutput9 {
+  var out: VertexOutput9;
+  var vf222 = fn1();
+  let ptr140: ptr<function, vec4f> = &vf222[1].f34;
+  var vf223 = fn1();
+  fn1();
+  out.f34 *= vf222[1].f34;
+  var vf224 = fn1();
+  var vf225 = fn1();
+  out.f34 += vf223[u32(unconst_u32(97))].f34;
+  out.f34 -= vf223[1].f34;
+  vf225[u32(unconst_u32(228))] = VertexOutput9(vec4f(acos(vec2h(unconst_f16(403.9), unconst_f16(16584.2))).yyxx));
+  vf225[u32(unconst_u32(23))] = VertexOutput9(vec4f(vf225[u32(unconst_u32(192))].f34[u32(unconst_u32(248))]));
+  vf222[u32(unconst_u32(45))].f34 -= unpack4x8unorm(pack4xU8Clamp(vec4u(unconst_u32(261), unconst_u32(66), unconst_u32(216), unconst_u32(106))));
+  let ptr141: ptr<function, VertexOutput9> = &vf224[1];
+  let ptr142: ptr<function, vec4f> = &vf225[u32(unconst_u32(117))].f34;
+  let ptr143: ptr<function, vec4f> = &vf225[u32(vf225[1].f34[2])].f34;
+  return out;
+}
+
+@group(0) @binding(153) var et3: texture_external;
+
+@group(0) @binding(104) var st9: texture_storage_2d<rgba16sint, read>;
+
+@group(0) @binding(51) var tex7: texture_depth_2d;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T0 {
+  @align(4) @size(12) f0: array<f16>,
+}
+
+var<workgroup> vw30: VertexOutput9;
+
+@vertex
+fn vertex10(@location(3) a0: u32, @location(8) a1: vec4i, @location(9) a2: vec2h, @location(6) a3: vec4h) -> VertexOutput9 {
+  var out: VertexOutput9;
+  out.f34 += vec4f(textureDimensions(st9).rrgr);
+  var vf226: f16 = a2[u32(unconst_u32(13))];
+  let vf227: u32 = textureNumLevels(tex7);
+  var vf228 = fn1();
+  vf226 = vec4h(degrees(vec4f(unconst_f32(0.1508), unconst_f32(0.2570), unconst_f32(0.1472), unconst_f32(0.1137))))[2];
+  var vf229 = fn1();
+  vf229[u32(unconst_u32(230))].f34 = vec4f(min(vec2h(unconst_f16(3930.8), unconst_f16(8048.4)), vec2h(vf228[1].f34.ga)).yxxx);
+  out = VertexOutput9(vf229[1].f34);
+  let ptr144: ptr<function, vec4f> = &vf228[u32(unconst_u32(378))].f34;
+  vf226 -= vec4h(vf229[1].f34)[2];
+  let vf230: vec2u = textureDimensions(tex7, i32(unconst_i32(36)));
+  var vf231: f32 = vf229[u32(unconst_u32(22))].f34[u32(unconst_u32(120))];
+  let vf232: vec2u = textureDimensions(tex7);
+  fn1();
+  let ptr145: ptr<function, vec4f> = &vf228[1].f34;
+  vf226 += vec4h(vf228[u32(unconst_u32(33))].f34).x;
+  out.f34 -= vec4f(f32(a0));
+  let vf233: vec4f = degrees(vec4f(unconst_f32(0.3721), unconst_f32(0.00417), unconst_f32(0.1287), unconst_f32(0.5778)));
+  let vf234: vec2h = min(vec2h(textureGather(tex7, sam8, vec2f(unconst_f32(0.2425), unconst_f32(0.09877))).rr), vec2h(vf228[1].f34.ba));
+  return out;
+  _ = st9;
+  _ = sam8;
+  _ = tex7;
+}
+
+@compute @workgroup_size(1, 1, 2)
+fn compute11(@builtin(local_invocation_id) a0: vec3u) {
+  var vf235 = fn1();
+}`,
+});
+let sampler180 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 78.16});
+try {
+{ clearResourceUsages(device0, computePassEncoder208); computePassEncoder208.dispatchWorkgroupsIndirect(buffer37, 6_568); };
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(159).fill(253), /* required buffer size: 159 */
+{offset: 159}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup194 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 88, resource: textureView289},
+    {binding: 49, resource: textureView126},
+    {binding: 95, resource: textureView129},
+    {binding: 72, resource: {buffer: buffer19, offset: 0}},
+    {binding: 615, resource: textureView80},
+    {binding: 22, resource: textureView24},
+    {binding: 12, resource: {buffer: buffer10, offset: 1280}},
+    {binding: 58, resource: externalTexture0},
+    {binding: 70, resource: textureView74},
+    {binding: 349, resource: {buffer: buffer132, offset: 0, size: 640}},
+  ],
+});
+let querySet42 = device0.createQuerySet({type: 'occlusion', count: 496});
+try {
+computePassEncoder41.setBindGroup(1, bindGroup157);
+} catch {}
+try {
+computePassEncoder205.setBindGroup(3, bindGroup152, new Uint32Array(649), 25, 0);
+} catch {}
+try {
+renderPassEncoder52.draw(51, 327, 561_274_522, 1_709_685_418);
+} catch {}
+try {
+renderPassEncoder60.setVertexBuffer(3, buffer170, 1_732, 133);
+} catch {}
+let autogeneratedBindGroupLayout108 = pipeline1.getBindGroupLayout(0);
+let textureView306 = texture232.createView({dimension: 'cube', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 4});
+let texture308 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView307 = texture139.createView({baseMipLevel: 0, mipLevelCount: 1});
+let sampler181 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.99,
+  lodMaxClamp: 93.06,
+});
+try {
+computePassEncoder208.end();
+} catch {}
+try {
+renderPassEncoder62.setBindGroup(0, bindGroup4, new Uint32Array(324), 136, 0);
+} catch {}
+try {
+renderPassEncoder52.draw(170, 62, 234_219_503, 1_707_276_441);
+} catch {}
+try {
+renderPassEncoder52.drawIndirect(buffer18, 3_488);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST, alphaMode: 'premultiplied'});
+} catch {}
+let computePassEncoder211 = commandEncoder119.beginComputePass();
+try {
+renderPassEncoder71.setBindGroup(2, bindGroup82);
+} catch {}
+try {
+renderPassEncoder62.draw(48, 138, 1_391_554_644, 153_346_451);
+} catch {}
+try {
+renderPassEncoder62.setIndexBuffer(buffer182, 'uint32', 588, 73);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline14);
+} catch {}
+try {
+buffer198.unmap();
+} catch {}
+await gc();
+let textureView308 = texture195.createView({arrayLayerCount: 1});
+try {
+computePassEncoder131.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+computePassEncoder134.setBindGroup(2, bindGroup124, new Uint32Array(343), 90, 0);
+} catch {}
+try {
+computePassEncoder211.setPipeline(pipeline29);
+} catch {}
+videoFrame45 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'unspecified', transfer: 'bt2020_12bit'} });
+let texture309 = gpuCanvasContext2.getCurrentTexture();
+let textureView309 = texture72.createView({mipLevelCount: 1});
+try {
+computePassEncoder50.setBindGroup(1, bindGroup100, new Uint32Array(54), 7, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer106, 0, 144);
+} catch {}
+let arrayBuffer43 = buffer5.getMappedRange(856, 8);
+let recycledAutogeneratedBindGroupLayout1 = pipeline29.getBindGroupLayout(0);
+try {
+computePassEncoder58.setBindGroup(1, bindGroup168, new Uint32Array(1260), 30, 0);
+} catch {}
+try {
+renderPassEncoder62.drawIndexed(2, 98, 0, 467_372_205, 590_425_412);
+} catch {}
+try {
+renderPassEncoder52.drawIndirect(buffer154, 1_520);
+} catch {}
+try {
+renderPassEncoder62.setVertexBuffer(2, buffer153, 0, 391);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 3544, new Int16Array(6324), 1365, 892);
+} catch {}
+let imageBitmap6 = await createImageBitmap(videoFrame26);
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup166, new Uint32Array(1786), 652, 0);
+} catch {}
+try {
+renderPassEncoder22.beginOcclusionQuery(70);
+} catch {}
+try {
+renderPassEncoder62.drawIndexedIndirect(buffer56, 852);
+} catch {}
+try {
+renderPassEncoder62.drawIndirect(buffer138, 368);
+} catch {}
+let arrayBuffer44 = buffer90.getMappedRange(2456, 352);
+try {
+device0.queue.writeTexture({
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(87).fill(25), /* required buffer size: 87 */
+{offset: 87}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler182 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.98,
+});
+try {
+computePassEncoder183.setBindGroup(2, bindGroup73);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup151, new Uint32Array(6106), 2_233, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer91);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer76, 816, new BigUint64Array(13068), 101, 112);
+} catch {}
+let canvas5 = document.createElement('canvas');
+let autogeneratedBindGroupLayout109 = pipeline0.getBindGroupLayout(0);
+let bindGroup195 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout29,
+  entries: [{binding: 0, resource: {buffer: buffer21, offset: 2048, size: 3940}}],
+});
+let texture310 = device0.createTexture({
+  size: [240, 1, 825],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView310 = texture49.createView({aspect: 'all', format: 'rg8unorm', baseArrayLayer: 0});
+let sampler183 = device0.createSampler({
+  label: '\u6a94\u0258\ued7b\u{1f71d}\u{1f71c}\u0d22\u{1f99d}\u0ea5\u00fc',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 64.28,
+});
+try {
+renderPassEncoder22.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder57.executeBundles([renderBundle31, renderBundle28]);
+} catch {}
+try {
+renderPassEncoder62.drawIndexed(2, 8, 3, 804_280_691, 379_308_031);
+} catch {}
+try {
+buffer55.unmap();
+} catch {}
+let img12 = await imageWithData(15, 120, '#10101010', '#20202020');
+let veryExplicitBindGroupLayout52 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 357,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 378,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 382,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 395,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let sampler184 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 99.52,
+});
+try {
+computePassEncoder63.setBindGroup(1, bindGroup169, new Uint32Array(269), 8, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup152, new Uint32Array(253), 67, 0);
+} catch {}
+try {
+renderPassEncoder55.setIndexBuffer(buffer42, 'uint16', 484, 1_537);
+} catch {}
+try {
+renderPassEncoder63.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(0, buffer65, 1_840, 7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer114, 96, new BigUint64Array(12500), 1127, 12);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let sampler185 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', mipmapFilter: 'linear', lodMaxClamp: 87.44});
+try {
+computePassEncoder100.setBindGroup(3, bindGroup2, new Uint32Array(1659), 320, 0);
+} catch {}
+try {
+renderPassEncoder64.executeBundles([renderBundle22]);
+} catch {}
+try {
+renderPassEncoder62.drawIndexedIndirect(buffer130, 368);
+} catch {}
+let pipeline42 = device0.createRenderPipeline({
+  layout: pipelineLayout9,
+  multisample: {count: 4, mask: 0x12c6657},
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment8',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'zero'},
+  },
+  writeMask: 0,
+}, {format: 'rgb10a2uint'}, {format: 'rgba16sint', writeMask: 0}, {format: 'rg32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilWriteMask: 1428628974,
+    depthBiasSlopeScale: 41.12005994167342,
+    depthBiasClamp: 32.58421786637285,
+  },
+  vertex: {module: shaderModule3, entryPoint: 'vertex3', constants: {27_508: 0}, buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'back'},
+});
+let textureView311 = texture26.createView({});
+let sampler186 = device0.createSampler({addressModeW: 'mirror-repeat', lodMaxClamp: 84.78});
+try {
+renderPassEncoder62.drawIndexed(3, 54, 1, 197_443_052, 292_287_807);
+} catch {}
+let texture311 = device0.createTexture({size: [120], dimension: '1d', format: 'rgba16sint', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder209.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup147, new Uint32Array(1137), 129, 0);
+} catch {}
+try {
+renderPassEncoder52.draw(992, 758, 583_906_860, 233_273_981);
+} catch {}
+try {
+renderPassEncoder62.drawIndexedIndirect(buffer76, 296);
+} catch {}
+try {
+renderPassEncoder62.drawIndirect(buffer56, 312);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer201, 'uint16', 850, 3_224);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(8_677).fill(241), /* required buffer size: 8_677 */
+{offset: 468, bytesPerRow: 37, rowsPerImage: 55}, {width: 4, height: 2, depthOrArrayLayers: 5});
+} catch {}
+let bindGroup196 = device0.createBindGroup({
+  label: '\u039f\u6200\u0e68\u9475\ub22c\u35be\u0569\u0ddf\u1fcd',
+  layout: autogeneratedBindGroupLayout68,
+  entries: [{binding: 0, resource: {buffer: buffer91, offset: 1280, size: 1781}}],
+});
+try {
+computePassEncoder138.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+computePassEncoder206.setBindGroup(3, bindGroup118, new Uint32Array(4578), 1_104, 0);
+} catch {}
+try {
+renderPassEncoder47.setScissorRect(91, 108, 38, 42);
+} catch {}
+try {
+renderPassEncoder52.draw(142, 210, 372_704_666, 69_072_662);
+} catch {}
+try {
+renderPassEncoder62.drawIndexed(8, 91, 4, 567_687_033, 39_791_538);
+} catch {}
+try {
+renderPassEncoder62.drawIndirect(buffer50, 292);
+} catch {}
+try {
+renderPassEncoder61.setVertexBuffer(2, buffer120, 0);
+} catch {}
+let arrayBuffer45 = buffer8.getMappedRange(4416, 4);
+try {
+computePassEncoder165.setBindGroup(2, bindGroup162, new Uint32Array(1047), 97, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder62.draw(230, 80, 689_487_490, 1_156_046_814);
+} catch {}
+let buffer207 = device0.createBuffer({size: 32481, usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let texture312 = device0.createTexture({
+  size: [480, 1, 1],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup66, new Uint32Array(1135), 98, 0);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle33]);
+} catch {}
+try {
+renderPassEncoder62.drawIndexed(0, 154, 1, 42_683_802, 1_719_952_639);
+} catch {}
+try {
+renderPassEncoder62.drawIndexedIndirect(buffer121, 1_740);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline17);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer141, 1004, new Float32Array(6620), 102, 228);
+} catch {}
+let gpuCanvasContext9 = canvas5.getContext('webgpu');
+try {
+globalThis.someLabel = buffer184.label;
+} catch {}
+let bindGroup197 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout34,
+  entries: [{binding: 17, resource: {buffer: buffer41, offset: 256, size: 365}}],
+});
+let textureView312 = texture277.createView({dimension: '2d', mipLevelCount: 1});
+try {
+renderPassEncoder52.draw(506, 196, 1_469_889_545, 123_253_814);
+} catch {}
+try {
+renderPassEncoder62.drawIndexed(6, 72, 3, 87_261_026, 254_126_806);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer173, 'uint32', 628, 762);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture213,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(34).fill(117), /* required buffer size: 34 */
+{offset: 34, rowsPerImage: 13}, {width: 81, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas1);
+let buffer208 = device0.createBuffer({size: 4162, usage: GPUBufferUsage.COPY_SRC});
+let texture313 = device0.createTexture({
+  size: [240, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder62.drawIndexed(0, 307, 1, 32_566_231, 337_728_814);
+} catch {}
+let bindGroup198 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout23,
+  entries: [
+    {binding: 93, resource: {buffer: buffer29, offset: 2304, size: 452}},
+    {binding: 95, resource: {buffer: buffer127, offset: 0, size: 2784}},
+    {binding: 82, resource: textureView33},
+    {binding: 88, resource: sampler178},
+    {binding: 6, resource: {buffer: buffer17, offset: 0, size: 252}},
+    {binding: 51, resource: textureView30},
+    {binding: 203, resource: {buffer: buffer139, offset: 1024, size: 2860}},
+    {binding: 104, resource: textureView37},
+    {binding: 183, resource: textureView182},
+    {binding: 13, resource: sampler99},
+    {binding: 153, resource: externalTexture7},
+  ],
+});
+let buffer209 = device0.createBuffer({size: 3724, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let texture314 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 22},
+  mipLevelCount: 2,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder35.setStencilReference(442);
+} catch {}
+try {
+renderPassEncoder62.drawIndexed(2, 408, 1, -2_070_694_074, 3_801_098);
+} catch {}
+let pipeline43 = device0.createComputePipeline({layout: pipelineLayout6, compute: {module: shaderModule10, entryPoint: 'compute10'}});
+let textureView313 = texture237.createView({dimension: '1d', aspect: 'all', format: 'rgba8unorm', arrayLayerCount: 1});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderPassEncoder48.beginOcclusionQuery(48);
+} catch {}
+try {
+renderPassEncoder62.draw(8, 51, 66_169_965, 377_831_541);
+} catch {}
+try {
+renderPassEncoder62.drawIndexedIndirect(buffer59, 1_396);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline35);
+} catch {}
+let imageData40 = new ImageData(4, 16);
+try {
+renderPassEncoder48.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle33]);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(2_738, 199, 442, 108_608_969, 569_451_211);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline21);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer129, 524, new BigUint64Array(11619), 2017, 92);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 240, height: 1, depthOrArrayLayers: 35}
+*/
+{
+  source: imageData27,
+  origin: { x: 0, y: 28 },
+  flipY: false,
+}, {
+  texture: texture277,
+  mipLevel: 1,
+  origin: {x: 23, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout20 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout83, autogeneratedBindGroupLayout105]});
+let buffer210 = device0.createBuffer({size: 20260, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+try {
+renderPassEncoder52.draw(380, 126, 994_655_339, 360_727_329);
+} catch {}
+try {
+renderPassEncoder62.drawIndirect(buffer141, 884);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer96, 'uint32', 752, 3_168);
+} catch {}
+await gc();
+let shaderModule12 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+@id(16582) override override12: i32 = 49;
+
+var<private> vp16 = array(modf(vec4h(792.8, 26917.5, 486.3, 236.0)), modf(vec4h(29765.3, 5009.1, 7421.1, 20555.3)), modf(vec4h(16187.4, 13790.5, 3527.6, 438.8)), modf(vec4h(-2960.6, 6208.6, 12676.6, 4872.3)));
+
+struct T0 {
+  @align(16) @size(16) f0: atomic<u32>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<private> vp17: mat3x4f = mat3x4f();
+
+var<workgroup> vw32: T0;
+
+@id(53284) override override11: i32 = 14;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@id(21772) override override9: bool;
+
+@id(24387) override override13: f16;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw33: mat2x2h;
+
+var<private> vp13 = modf(vec2f(0.03655, 0.07090));
+
+var<private> vp15: f32 = f32(0.5416);
+
+var<private> vp14 = array(array(modf(f32(0.00530))), array(modf(f32(0.03514))), array(modf(f32(0.3252))), array(modf(f32(0.02825))), array(modf(f32(0.6321))), array(modf(f32(0.1493))), array(modf(f32(0.05166))));
+
+override override10: f16;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@compute @workgroup_size(1, 1, 2)
+fn compute12() {
+  var vf236: vec4f = vp17[u32(unconst_u32(177))];
+  var vf237: vec2h = degrees(vec2h(unconst_f16(2891.4), unconst_f16(823.0)));
+}`,
+});
+try {
+computePassEncoder194.setBindGroup(3, bindGroup131);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup169, []);
+} catch {}
+try {
+renderPassEncoder45.setBindGroup(3, bindGroup5, new Uint32Array(858), 45, 0);
+} catch {}
+try {
+renderPassEncoder62.draw(326, 111, 453_191_327, 335_467_251);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(735, 70, 248, 465_406_706, 658_938_846);
+} catch {}
+try {
+renderPassEncoder62.drawIndexedIndirect(buffer34, 16);
+} catch {}
+try {
+renderPassEncoder62.drawIndirect(buffer70, 376);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline17);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 97, height: 60, depthOrArrayLayers: 43}
+*/
+{
+  source: img2,
+  origin: { x: 0, y: 17 },
+  flipY: false,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 2, y: 6, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 27, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup199 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout16,
+  entries: [{binding: 0, resource: {buffer: buffer170, offset: 256, size: 186}}],
+});
+let buffer212 = device0.createBuffer({size: 8251, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture315 = device0.createTexture({
+  size: {width: 480, height: 1, depthOrArrayLayers: 1},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView314 = texture65.createView({});
+try {
+computePassEncoder210.setBindGroup(1, bindGroup115, new Uint32Array(1566), 146, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup7, new Uint32Array(640), 440, 0);
+} catch {}
+try {
+renderPassEncoder52.draw(380, 5, 673_741_997, 547_010_544);
+} catch {}
+try {
+  await shaderModule10.getCompilationInfo();
+} catch {}
+try {
+globalThis.someLabel = externalTexture21.label;
+} catch {}
+let autogeneratedBindGroupLayout110 = pipeline0.getBindGroupLayout(0);
+try {
+computePassEncoder65.setBindGroup(3, bindGroup138, new Uint32Array(3186), 10, 0);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(3, bindGroup158, new Uint32Array(2407), 423, 0);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(795, 14, 2_730, 38_425_017, 463_492_042);
+} catch {}
+document.body.append(img12);
+await gc();
+let imageData41 = new ImageData(8, 16);
+let buffer213 = device0.createBuffer({
+  size: 1214,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView315 = texture45.createView({});
+try {
+computePassEncoder167.setBindGroup(1, bindGroup32, new Uint32Array(535), 63, 0);
+} catch {}
+try {
+renderPassEncoder56.setBindGroup(0, bindGroup126);
+} catch {}
+try {
+renderPassEncoder32.drawIndexedIndirect(buffer161, 2_144);
+} catch {}
+try {
+renderPassEncoder52.drawIndirect(buffer116, 2_712);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+globalThis.someLabel = externalTexture19.label;
+} catch {}
+let autogeneratedBindGroupLayout111 = pipeline13.getBindGroupLayout(0);
+let buffer214 = device0.createBuffer({
+  size: 9453,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup166, new Uint32Array(1805), 78, 0);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(4_146, 181, 1_397, -2_047_780_042, 175_680_470);
+} catch {}
+try {
+renderPassEncoder64.setPipeline(pipeline41);
+} catch {}
+let texture316 = device0.createTexture({
+  size: [97, 60, 1],
+  sampleCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder43 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint'], depthReadOnly: false, stencilReadOnly: true});
+let renderBundle43 = renderBundleEncoder43.finish({});
+let externalTexture34 = device0.importExternalTexture({source: videoFrame31});
+try {
+computePassEncoder76.setBindGroup(0, bindGroup42);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(0, bindGroup83);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(1, bindGroup100, new Uint32Array(3359), 165, 0);
+} catch {}
+try {
+renderPassEncoder32.drawIndirect(buffer60, 708);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let promise41 = device0.queue.onSubmittedWorkDone();
+let buffer215 = device0.createBuffer({size: 5480, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let renderBundleEncoder44 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup3, []);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(3, bindGroup199);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline32);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let texture317 = device0.createTexture({
+  size: {width: 97},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder148.setBindGroup(0, bindGroup71);
+} catch {}
+try {
+computePassEncoder23.setBindGroup(2, bindGroup101, new Uint32Array(828), 157, 0);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(1_621, 48, 63, 72_618_593, 2_111_529_966);
+} catch {}
+try {
+renderBundleEncoder44.setIndexBuffer(buffer113, 'uint32', 1_212, 1_872);
+} catch {}
+try {
+computePassEncoder65.insertDebugMarker('\u{1f854}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 82}
+*/
+{
+  source: videoFrame23,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 49},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup200 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout71,
+  entries: [
+    {binding: 184, resource: {buffer: buffer145, offset: 0, size: 3968}},
+    {binding: 134, resource: {buffer: buffer31, offset: 0, size: 3040}},
+    {binding: 19, resource: textureView279},
+  ],
+});
+let buffer216 = device0.createBuffer({
+  size: 32919,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture318 = device0.createTexture({
+  size: {width: 240},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler187 = device0.createSampler({addressModeV: 'repeat', minFilter: 'linear', lodMaxClamp: 82.59});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+computePassEncoder80.setBindGroup(0, bindGroup118, new Uint32Array(6967), 358, 0);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(1, bindGroup79);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(3, bindGroup149, new Uint32Array(357), 37, 0);
+} catch {}
+try {
+renderPassEncoder32.draw(35, 5, 1_844_472_763, 57_786_682);
+} catch {}
+try {
+renderPassEncoder32.drawIndexedIndirect(buffer154, 1_280);
+} catch {}
+try {
+renderPassEncoder52.drawIndirect(buffer108, 2_840);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer165, 'uint16', 1_160, 809);
+} catch {}
+try {
+renderBundleEncoder44.setIndexBuffer(buffer4, 'uint16', 2_840, 2_440);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline35);
+} catch {}
+try {
+computePassEncoder47.setBindGroup(0, bindGroup198, new Uint32Array(360), 25, 0);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(3, bindGroup106, new Uint32Array(972), 92, 0);
+} catch {}
+try {
+renderPassEncoder71.setIndexBuffer(buffer68, 'uint16', 1_314, 1_395);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(4, buffer153, 1_540, 1_293);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(0, buffer32);
+} catch {}
+videoFrame46 = new VideoFrame(img1, {timestamp: 0});
+let buffer217 = device0.createBuffer({size: 10565, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let texture319 = device0.createTexture({
+  size: {width: 195},
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder66.setBindGroup(1, bindGroup50);
+} catch {}
+try {
+renderPassEncoder52.draw(156, 39, 85_664_835, 86_738_085);
+} catch {}
+try {
+renderBundleEncoder44.setPipeline(pipeline30);
+} catch {}
+let arrayBuffer46 = buffer64.getMappedRange(264, 0);
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let bindGroup201 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout18,
+  entries: [{binding: 0, resource: {buffer: buffer114, offset: 768, size: 433}}],
+});
+let texture320 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 111},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let sampler188 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 54.45});
+try {
+computePassEncoder93.setBindGroup(0, bindGroup197, new Uint32Array(3146), 170, 0);
+} catch {}
+try {
+renderPassEncoder36.setStencilReference(577);
+} catch {}
+try {
+renderPassEncoder32.drawIndexedIndirect(buffer83, 204);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(1, bindGroup106, new Uint32Array(726), 21, 0);
+} catch {}
+try {
+renderBundleEncoder44.setIndexBuffer(buffer61, 'uint32', 848, 89);
+} catch {}
+try {
+  await promise41;
+} catch {}
+let texture321 = device0.createTexture({
+  size: {width: 60},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle44 = renderBundleEncoder44.finish({});
+try {
+computePassEncoder102.setBindGroup(2, bindGroup48, new Uint32Array(5), 1, 0);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle6, renderBundle11, renderBundle33, renderBundle28]);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(1_880, 335, 1_913, -1_550_583_332, 588_277_878);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline17);
+} catch {}
+let recycledAutogeneratedBindGroupLayout2 = pipeline29.getBindGroupLayout(0);
+let buffer218 = device0.createBuffer({size: 12160, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView316 = texture100.createView({mipLevelCount: 1});
+let sampler189 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 93.61,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder52.draw(107, 232, 291_478_701, 702_980_048);
+} catch {}
+try {
+renderPassEncoder32.drawIndexedIndirect(buffer45, 5_704);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+buffer83.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 0,
+  origin: {x: 23, y: 24, z: 0},
+  aspect: 'all',
+}, new Uint8Array(243).fill(174), /* required buffer size: 243 */
+{offset: 243, bytesPerRow: 545}, {width: 67, height: 62, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas4);
+await gc();
+let texture322 = device0.createTexture({
+  size: {width: 120},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView317 = texture227.createView({dimension: '2d-array'});
+try {
+computePassEncoder95.setBindGroup(2, bindGroup48, new Uint32Array(5063), 2_384, 0);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+renderPassEncoder32.drawIndirect(buffer2, 356);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer179, 0, 175);
+} catch {}
+let recycledExplicitBindGroupLayout5 = pipeline19.getBindGroupLayout(0);
+let texture323 = device0.createTexture({
+  size: [195, 120, 85],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler190 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 98.37,
+});
+try {
+renderPassEncoder52.draw(164, 60, 140_255_362, 3_426_360_300);
+} catch {}
+try {
+renderPassEncoder52.drawIndirect(buffer65, 252);
+} catch {}
+try {
+renderPassEncoder57.setIndexBuffer(buffer95, 'uint32', 248, 258);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer178, 0, 2_255);
+} catch {}
+try {
+computePassEncoder52.insertDebugMarker('\u0e6b');
+} catch {}
+let recycledAutogeneratedBindGroupLayout3 = pipeline43.getBindGroupLayout(0);
+let textureView318 = texture265.createView({aspect: 'depth-only', mipLevelCount: 1});
+try {
+computePassEncoder105.setBindGroup(2, bindGroup30, []);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(531, 51, 53, 175_967_935, 554_622_447);
+} catch {}
+try {
+renderPassEncoder52.drawIndirect(buffer107, 792);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(1, buffer173, 0);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let img13 = await imageWithData(18, 10, '#10101010', '#20202020');
+let textureView319 = texture294.createView({baseArrayLayer: 1, arrayLayerCount: 1});
+let sampler191 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 97.76,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder31.setViewport(357.6009005722747, 343.9457981467696, 220.21301901935306, 132.08554306887382, 0.7057391122528028, 0.7455692129976452);
+} catch {}
+try {
+renderPassEncoder32.draw(186, 23, 24_846_668, 1_016_931_080);
+} catch {}
+try {
+renderPassEncoder32.drawIndexedIndirect(buffer87, 888);
+} catch {}
+let arrayBuffer47 = buffer90.getMappedRange(2312, 8);
+let pipeline44 = await device0.createComputePipelineAsync({layout: pipelineLayout7, compute: {module: shaderModule4, constants: {}}});
+let bindGroup202 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout30,
+  entries: [{binding: 0, resource: {buffer: buffer94, offset: 256, size: 31}}],
+});
+let texture324 = device0.createTexture({
+  size: {width: 16},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup68, new Uint32Array(2496), 75, 0);
+} catch {}
+try {
+renderPassEncoder62.end();
+} catch {}
+try {
+renderPassEncoder32.draw(223, 24, 282_550_081, 436_063_631);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(805, 34, 967, 38_028_434, 577_255_512);
+} catch {}
+try {
+renderPassEncoder32.drawIndirect(buffer83, 132);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer100, 'uint16', 3_350, 23);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture223,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(21).fill(77), /* required buffer size: 21 */
+{offset: 21}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture325 = device0.createTexture({
+  size: [60, 1, 1],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder212 = commandEncoder237.beginComputePass({});
+try {
+renderPassEncoder32.draw(175, 40, 193_258_933, 1_295_281_338);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(864, 356, 2_436, 681_401_206, 1_045_251_994);
+} catch {}
+try {
+renderPassEncoder32.drawIndexedIndirect(buffer118, 364);
+} catch {}
+try {
+renderPassEncoder50.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(5, buffer66, 1_756, 3_936);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer181, 600, new DataView(new ArrayBuffer(5361)), 51, 32);
+} catch {}
+let texture326 = device0.createTexture({
+  size: [60, 1, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder102.setBindGroup(2, bindGroup121);
+} catch {}
+try {
+renderPassEncoder52.end();
+} catch {}
+try {
+renderPassEncoder50.drawIndexed(1, 323, 1, 2_038_906_884, 249_946_100);
+} catch {}
+try {
+renderPassEncoder50.drawIndexedIndirect(buffer53, 456);
+} catch {}
+try {
+renderPassEncoder50.drawIndirect(buffer50, 112);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline45 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment7',
+  constants: {},
+  targets: [{format: 'rg32sint', writeMask: 0}, {format: 'rgba16uint'}, {format: 'rgba8uint'}],
+},
+  vertex: {
+    module: shaderModule8,
+    constants: {override8: 0},
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float32x3', offset: 320, shaderLocation: 11},
+          {format: 'uint8x2', offset: 46, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+});
+let buffer219 = device0.createBuffer({
+  size: 5667,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandBuffer8 = commandEncoder194.finish({});
+try {
+renderPassEncoder32.draw(187, 161, 1_497_823_512, 1_647_802_923);
+} catch {}
+try {
+renderPassEncoder50.drawIndexedIndirect(buffer27, 484);
+} catch {}
+try {
+renderPassEncoder32.drawIndirect(buffer135, 11_260);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline13);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture221,
+  mipLevel: 2,
+  origin: {x: 20, y: 64, z: 0},
+  aspect: 'all',
+}, new Uint8Array(376).fill(111), /* required buffer size: 376 */
+{offset: 376}, {width: 22, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageData42 = new ImageData(4, 20);
+let bindGroup203 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout34,
+  entries: [{binding: 17, resource: {buffer: buffer145, offset: 2560, size: 4238}}],
+});
+let textureView320 = texture244.createView({});
+try {
+computePassEncoder108.setBindGroup(2, bindGroup76);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(1_831, 168, 1_080, 353_565_564, 458_355_458);
+} catch {}
+try {
+renderPassEncoder32.drawIndexedIndirect(buffer60, 1_312);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline30);
+} catch {}
+try {
+  await buffer52.mapAsync(GPUMapMode.WRITE, 1048, 5652);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let autogeneratedBindGroupLayout112 = pipeline25.getBindGroupLayout(0);
+let bindGroup204 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout14,
+  entries: [{binding: 0, resource: {buffer: buffer188, offset: 6400, size: 1709}}],
+});
+let texture327 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 545},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler192 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 78.70,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder212.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup169, new Uint32Array(1829), 2, 0);
+} catch {}
+try {
+renderPassEncoder50.end();
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer46, 'uint32', 4_316, 1_158);
+} catch {}
+let buffer220 = device0.createBuffer({
+  size: 4270,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let renderPassEncoder72 = commandEncoder187.beginRenderPass({
+  colorAttachments: [{
+  view: textureView153,
+  depthSlice: 15,
+  clearValue: { r: 182.5, g: -116.9, b: 221.3, a: 27.52, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder55.setBindGroup(2, bindGroup63, new Uint32Array(258), 5, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture270,
+  mipLevel: 1,
+  origin: {x: 22, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(166).fill(93), /* required buffer size: 166 */
+{offset: 166, bytesPerRow: 130, rowsPerImage: 75}, {width: 10, height: 28, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img7);
+let recycledAutogeneratedBindGroupLayout4 = pipeline29.getBindGroupLayout(0);
+let texture328 = gpuCanvasContext8.getCurrentTexture();
+try {
+computePassEncoder151.setBindGroup(1, bindGroup41);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+document.body.append(canvas2);
+try {
+renderPassEncoder31.setPipeline(pipeline12);
+} catch {}
+let promise42 = device0.queue.onSubmittedWorkDone();
+let commandEncoder264 = device0.createCommandEncoder({});
+let texture329 = device0.createTexture({
+  size: {width: 120, height: 1, depthOrArrayLayers: 197},
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder213 = commandEncoder264.beginComputePass();
+let sampler193 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 50.82,
+  maxAnisotropy: 1,
+});
+let externalTexture35 = device0.importExternalTexture({source: videoFrame37});
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup86);
+} catch {}
+let img14 = await imageWithData(20, 5, '#10101010', '#20202020');
+let autogeneratedBindGroupLayout113 = pipeline37.getBindGroupLayout(0);
+let texture330 = device0.createTexture({
+  label: '\u{1fc37}\u3a0a\ueea2',
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView321 = texture320.createView({mipLevelCount: 1});
+try {
+computePassEncoder57.setBindGroup(2, bindGroup161);
+} catch {}
+try {
+computePassEncoder184.setBindGroup(0, bindGroup147, new Uint32Array(1371), 702, 0);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(0, bindGroup164);
+} catch {}
+try {
+renderPassEncoder56.setPipeline(pipeline41);
+} catch {}
+try {
+globalThis.someLabel = externalTexture33.label;
+} catch {}
+let veryExplicitBindGroupLayout53 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 33, visibility: 0, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 247,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 627, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let textureView322 = texture207.createView({dimension: '2d-array', aspect: 'all'});
+try {
+renderPassEncoder4.setViewport(161.21035918496403, 17.958597547424667, 213.88335335756048, 153.66863390762003, 0.1674242269918863, 0.41072038230115115);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer99, 'uint16', 262, 374);
+} catch {}
+try {
+renderPassEncoder58.setPipeline(pipeline39);
+} catch {}
+let promise43 = device0.queue.onSubmittedWorkDone();
+try {
+sampler135.label = '\u235d\u{1fc32}\u8604\u1168\u468a';
+} catch {}
+let sampler194 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', minFilter: 'linear', lodMaxClamp: 94.74});
+try {
+computePassEncoder213.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup164, new Uint32Array(1587), 128, 0);
+} catch {}
+try {
+renderPassEncoder71.beginOcclusionQuery(1);
+} catch {}
+try {
+renderPassEncoder71.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder70.setVertexBuffer(4, buffer179, 0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+computePassEncoder202.pushDebugGroup('\u0d27');
+} catch {}
+try {
+computePassEncoder108.insertDebugMarker('\u0a21');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let promise44 = device0.queue.onSubmittedWorkDone();
+videoFrame47 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'bt470m', transfer: 'gamma22curve'} });
+let bindGroup205 = device0.createBindGroup({
+  layout: recycledAutogeneratedBindGroupLayout4,
+  entries: [{binding: 0, resource: {buffer: buffer17, offset: 0, size: 84}}],
+});
+let buffer221 = device0.createBuffer({
+  size: 3693,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+try {
+computePassEncoder123.setBindGroup(0, bindGroup89, new Uint32Array(585), 198, 0);
+} catch {}
+try {
+renderPassEncoder64.beginOcclusionQuery(31);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer145, 8_596);
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer61, 0, 1_471);
+} catch {}
+let veryExplicitBindGroupLayout54 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 38,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let textureView323 = texture272.createView({baseMipLevel: 0});
+let texture331 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 269},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup100);
+} catch {}
+try {
+renderPassEncoder8.draw(588, 65, 303_125_430, 2_548_322_993);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer159, 2_012);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(2, buffer51);
+} catch {}
+try {
+computePassEncoder202.popDebugGroup();
+} catch {}
+try {
+renderPassEncoder64.setIndexBuffer(buffer214, 'uint32', 120, 1_686);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let veryExplicitBindGroupLayout55 = device0.createBindGroupLayout({
+  entries: [{binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: true }}],
+});
+let bindGroup206 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 85, resource: {buffer: buffer161, offset: 1280, size: 2608}}],
+});
+let externalTexture36 = device0.importExternalTexture({source: videoFrame34, colorSpace: 'display-p3'});
+try {
+renderPassEncoder51.setBindGroup(1, bindGroup8, new Uint32Array(1369), 135, 0);
+} catch {}
+try {
+renderPassEncoder32.end();
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(111, 124, 102, 517_983_986, 832_626_886);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer76, 6_068);
+} catch {}
+try {
+renderPassEncoder58.setPipeline(pipeline41);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture213,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(33).fill(251), /* required buffer size: 33 */
+{offset: 33}, {width: 82, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer222 = device0.createBuffer({
+  size: 1389,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let querySet43 = device0.createQuerySet({type: 'occlusion', count: 2429});
+try {
+renderPassEncoder45.setBindGroup(0, bindGroup135, new Uint32Array(1336), 381, 0);
+} catch {}
+try {
+renderPassEncoder46.setViewport(49.838539494310986, 27.783348522790998, 242.7475381967977, 298.36810670837536, 0.8798106288996608, 0.9984253971557258);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline28);
+} catch {}
+try {
+commandEncoder109.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2676 */
+  offset: 2676,
+  buffer: buffer183,
+}, {
+  texture: texture307,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder109.copyTextureToTexture({
+  texture: texture305,
+  mipLevel: 0,
+  origin: {x: 0, y: 7, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture167,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder214 = commandEncoder109.beginComputePass({});
+let sampler195 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 97.02,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder64.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.draw(90, 252, 495_838_947, 373_377_802);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+videoFrame48 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'smpteSt4281', transfer: 'smpte240m'} });
+try {
+adapter0.label = '\u{1f68b}\u0beb';
+} catch {}
+let bindGroup207 = device0.createBindGroup({layout: veryExplicitBindGroupLayout51, entries: [{binding: 96, resource: sampler68}]});
+let buffer223 = device0.createBuffer({
+  size: 13062,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture332 = device0.createTexture({
+  size: {width: 120, height: 1, depthOrArrayLayers: 157},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder214.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(3, bindGroup124);
+} catch {}
+try {
+renderPassEncoder66.executeBundles([renderBundle10, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder8.draw(380, 152, 144_523_806, 490_649_971);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer45, 248);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer74, 'uint16', 6, 20);
+} catch {}
+try {
+renderPassEncoder71.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder69.executeBundles([renderBundle43, renderBundle43, renderBundle43, renderBundle43]);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer153, 'uint32', 524, 384);
+} catch {}
+try {
+  await promise42;
+} catch {}
+document.body.prepend(img5);
+let bindGroup208 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout73,
+  entries: [{binding: 0, resource: {buffer: buffer117, offset: 0, size: 350}}],
+});
+let buffer224 = device0.createBuffer({
+  size: 283,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView324 = texture318.createView({dimension: '1d', baseArrayLayer: 0});
+let sampler196 = device0.createSampler({addressModeU: 'repeat', minFilter: 'linear'});
+let externalTexture37 = device0.importExternalTexture({label: '\u0787\u1e39\uc972\u88ac\ue25a', source: videoFrame6, colorSpace: 'srgb'});
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer184, 1_292);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer93, 752);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture272,
+  mipLevel: 0,
+  origin: {x: 4, y: 8, z: 0},
+  aspect: 'all',
+}, new Uint8Array(387).fill(16), /* required buffer size: 387 */
+{offset: 387, bytesPerRow: 138}, {width: 12, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let sampler197 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup185);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup157);
+} catch {}
+try {
+renderPassEncoder42.executeBundles([renderBundle22, renderBundle4, renderBundle3, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder8.draw(174, 4, 66_338_894, 1_270_028_060);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(36, 301, 215, 263_251_091, 680_299_372);
+} catch {}
+try {
+renderPassEncoder61.setBindGroup(0, bindGroup173, new Uint32Array(972), 27, 0);
+} catch {}
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder58.setIndexBuffer(buffer170, 'uint32', 1_564, 240);
+} catch {}
+try {
+renderPassEncoder72.setVertexBuffer(3, buffer130, 56, 202);
+} catch {}
+videoFrame49 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt470bg', transfer: 'linear'} });
+let bindGroup209 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout30,
+  entries: [{binding: 0, resource: {buffer: buffer160, offset: 256, size: 1281}}],
+});
+let buffer225 = device0.createBuffer({
+  size: 24489,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture333 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  dimension: '2d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup66, new Uint32Array(5772), 1_314, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer212, 312, new BigUint64Array(20857), 3487, 176);
+} catch {}
+let promise45 = device0.queue.onSubmittedWorkDone();
+let veryExplicitBindGroupLayout56 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 199,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup210 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout13,
+  entries: [{binding: 0, resource: {buffer: buffer209, offset: 1536}}],
+});
+let computePassEncoder215 = commandEncoder25.beginComputePass({});
+try {
+computePassEncoder215.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer16, 'uint16', 498, 587);
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+struct T2 {
+  @size(8) f0: atomic<u32>,
+  @align(8) @size(80) f1: array<vec2h>,
+}
+
+@group(0) @binding(0) var<uniform> buffer226: array<VertexOutput10, 1>;
+
+override override15: f32;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T1 {
+  @size(96) f0: array<array<array<vec4f, 1>, 1>, 5>,
+}
+
+struct FragmentOutput11 {
+  @location(2) f0: vec4u,
+  @location(1) @interpolate(flat) f1: vec4u,
+  @builtin(sample_mask) f2: u32,
+  @location(0) f3: vec2i,
+}
+
+struct T0 {
+  @align(32) @size(544) f0: array<vec2i>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn fn0() -> T1 {
+  var out: T1;
+  let ptr146: ptr<private, f32> = &vp18.whole;
+  var vf238: f32 = vp23[u32(unconst_u32(7))].f35[u32(unconst_u32(143))];
+  out = T1(array<array<array<vec4f, 1>, 1>, 5>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(vec4f(f32(vp20.f0[u32(unconst_u32(282))])))), array<array<vec4f, 1>, 1>(array<vec4f, 1>(unpack4x8unorm(vp20.f0[u32(unconst_u32(282))]))), array<array<vec4f, 1>, 1>(array<vec4f, 1>(unpack4x8unorm(vp20.f0[u32(unconst_u32(282))]))), array<array<vec4f, 1>, 1>(array<vec4f, 1>(unpack4x8snorm(vp20.f0[u32(unconst_u32(282))]))), array<array<vec4f, 1>, 1>(array<vec4f, 1>(vec4f(bitcast<f32>(vp20.f0[u32(unconst_u32(282))]))))));
+  vf238 = bitcast<f32>(vp20.f2);
+  let ptr147: ptr<private, f16> = &vp19.fract;
+  var vf239: u32 = pack4x8unorm(vec4f(unconst_f32(-0.01510), unconst_f32(0.02862), unconst_f32(0.1206), unconst_f32(0.1984)));
+  vp18.whole = f32(vp21[u32(unconst_u32(133))]);
+  let vf240: vec3h = sqrt(vec3h(unconst_f16(10524.4), unconst_f16(2510.4), unconst_f16(2728.9)));
+  let ptr148: ptr<private, VertexOutput10> = &vp23[7];
+  let ptr149: ptr<private, vec2i> = &vp20.f3;
+  return out;
+}
+
+var<private> vp23: array<VertexOutput10, 8> = array(VertexOutput10(vec4f(0.1129, 0.3374, 0.1260, 0.03963)), VertexOutput10(), VertexOutput10(), VertexOutput10(), VertexOutput10(vec4f(0.07089, 0.2008, 0.1306, -0.1480)), VertexOutput10(), VertexOutput10(), VertexOutput10());
+
+var<private> vp19 = modf(f16(20488.3));
+
+var<private> vp20: FragmentOutput11 = FragmentOutput11(vec4u(133, 71, 15, 3), vec4u(136, 2, 116, 77), u32(79), vec2i(34, -84));
+
+var<private> vp22: mat3x2h = mat3x2h(33509.9, 18437.6, 698.8, 21940.0, 8026.8, 4065.5);
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<private> vp21: array<u32, 1> = array<u32, 1>();
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct VertexOutput10 {
+  @builtin(position) f35: vec4f,
+}
+
+override override14: f16 = 1095.1;
+
+var<private> vp18 = modf(f32(0.1251));
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@vertex
+fn vertex11(@location(0) @interpolate(flat, centroid) a0: vec2i) -> VertexOutput10 {
+  var out: VertexOutput10;
+  vp22 = mat3x2h(vec2h(buffer226[u32(unconst_u32(121))].f35.yz), vec2h(buffer226[u32(unconst_u32(121))].f35.ga), vec2h(buffer226[u32(unconst_u32(121))].f35.ra));
+  vp19.whole *= vp22[u32(unconst_u32(57))][u32(unconst_u32(67))];
+  out = buffer226[0];
+  vp20 = FragmentOutput11(vec4u(vp22[unconst_i32(0)].grgr), vec4u(vp22[unconst_i32(2)].rrrr), bitcast<u32>(vp22[unconst_i32(0)]), vec2i(vp22[unconst_i32(2)]));
+  let ptr150: ptr<uniform, array<VertexOutput10, 1>> = &buffer226;
+  vp18 = modf(vp23[7].f35[1]);
+  out.f35 = buffer226[0].f35;
+  var vf241: u32 = dot4U8Packed(u32(unconst_u32(285)), u32(vp18.fract));
+  let vf242: f32 = (*ptr150)[u32(unconst_u32(698))].f35[u32(unconst_u32(322))];
+  let ptr151: ptr<private, vec4f> = &vp23[u32(unconst_u32(13))].f35;
+  fn0();
+  fn0();
+  let ptr152 = &vp18;
+  return out;
+  _ = buffer226;
+}
+
+@fragment
+fn fragment12() -> FragmentOutput11 {
+  var out: FragmentOutput11;
+  out.f3 = vec2i(bitcast<i32>(vp21[0]));
+  let ptr153: ptr<private, u32> = &vp21[u32(unconst_u32(8))];
+  out.f2 <<= u32(vp23[7].f35[0]);
+  let ptr154: ptr<private, u32> = &vp21[0];
+  vp22 -= mat3x2h(f16(vp20.f1[u32(unconst_u32(122))]), f16(vp20.f1[u32(unconst_u32(122))]), f16(vp20.f1[u32(unconst_u32(122))]), f16(vp20.f1[u32(unconst_u32(122))]), f16(vp20.f1[u32(unconst_u32(122))]), f16(vp20.f1[u32(unconst_u32(122))]));
+  let vf243: vec4h = reflect(vec4h(unconst_f16(3607.1), unconst_f16(11707.3), unconst_f16(13417.8), unconst_f16(-18235.7)), vec4h(vp23[u32(unconst_u32(240))].f35));
+  vp21[u32(unconst_u32(276))] &= vp21[0];
+  let ptr155: ptr<private, vec4f> = &vp23[7].f35;
+  out.f3 = bitcast<vec2i>(reflect(vec4h(unconst_f16(43927.4), unconst_f16(6756.6), unconst_f16(2735.6), unconst_f16(6361.9)), vec4h(unconst_f16(7395.5), unconst_f16(7312.9), unconst_f16(4421.3), unconst_f16(7733.5))));
+  vp22 = mat3x2h(vec2h(vp23[u32(vp19.whole)].f35.rr), vec2h(vp23[u32(vp19.whole)].f35.xw), vec2h(vp23[u32(vp19.whole)].f35.xw));
+  let vf244: vec4h = vf243;
+  vp23[7] = VertexOutput10(vec4f(bitcast<f32>(vp20.f3[u32(unconst_u32(446))])));
+  let ptr156: ptr<private, FragmentOutput11> = &vp20;
+  vp19.fract = f16(vp20.f0[u32(unconst_u32(166))]);
+  vp22 = mat3x2h(vec2h(firstLeadingBit(vec2i(unconst_i32(27), unconst_i32(359)))), vec2h(firstLeadingBit(vec2i(unconst_i32(27), unconst_i32(359)))), vec2h(firstLeadingBit(vec2i(unconst_i32(27), unconst_i32(359)))));
+  let vf245: vec4u = firstTrailingBit(vec4u(unconst_u32(49), unconst_u32(35), unconst_u32(7), unconst_u32(181)));
+  vp19 = modf(vf243[u32(unconst_u32(211))]);
+  let ptr157: ptr<private, vec4u> = &vp20.f1;
+  out.f2 <<= (*ptr156).f2;
+  out.f3 = vec2i(bitcast<i32>(vp21[0]));
+  let ptr158: ptr<private, vec4f> = &vp23[vec2u(vp20.f3).y].f35;
+  let ptr159: ptr<private, vec4u> = &vp20.f1;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute13() {
+  var vf246 = fn0();
+  vp23[u32(unconst_u32(285))].f35 = vf246.f0[u32(unconst_u32(6))][u32(unconst_u32(412))][0];
+  vp20 = FragmentOutput11(bitcast<vec4u>(vf246.f0[4][0][u32(unconst_u32(177))]), bitcast<vec4u>(vf246.f0[4][0][u32(unconst_u32(177))]), pack4x8unorm(vf246.f0[4][0][u32(unconst_u32(177))]), bitcast<vec2i>(vf246.f0[4][0][u32(unconst_u32(177))].yz));
+  vp20 = FragmentOutput11(vp20.f0, vp20.f0, pack4xU8Clamp(vp20.f0), bitcast<vec2i>(vp20.f0.xw));
+  vp18 = modf(vf246.f0[4][u32(unconst_u32(15))][0].w);
+  fn0();
+  var vf247 = fn0();
+  vp19.fract += f16(atan(f32(unconst_f32(0.02274))));
+  vp22 = mat3x2h(f16(pack4xU8(vec4u(u32(vp19.whole)))), f16(pack4xU8(vec4u(u32(vp19.whole)))), f16(pack4xU8(vec4u(u32(vp19.whole)))), f16(pack4xU8(vec4u(u32(vp19.whole)))), f16(pack4xU8(vec4u(u32(vp19.whole)))), f16(pack4xU8(vec4u(u32(vp19.whole)))));
+  let ptr160: ptr<function, array<array<array<vec4f, 1>, 1>, 5>> = &vf247.f0;
+  var vf248: u32 = vp20.f1[u32(unconst_u32(413))];
+  fn0();
+  var vf249 = fn0();
+  fn0();
+  vp23[vec4u((*ptr160)[4][u32(unconst_u32(187))][0])[0]].f35 -= vec4f(vf247.f0[u32(unconst_u32(18))][0][0][u32(unconst_u32(362))]);
+  var vf250 = fn0();
+  var vf251 = fn0();
+  vp22 = mat3x2h(vec2h((*ptr160)[4][0][0].wy), vec2h((*ptr160)[4][0][0].zy), vec2h((*ptr160)[4][0][0].wy));
+  var vf252 = fn0();
+  vf246 = T1(array<array<array<vec4f, 1>, 1>, 5>(array<array<vec4f, 1>, 1>(array<vec4f, 1>(vf251.f0[4][u32(unconst_u32(179))][u32(unconst_u32(25))])), array<array<vec4f, 1>, 1>(array<vec4f, 1>(vf251.f0[4][u32(unconst_u32(179))][u32(unconst_u32(25))])), array<array<vec4f, 1>, 1>(array<vec4f, 1>(vf251.f0[4][u32(unconst_u32(179))][u32(unconst_u32(25))])), array<array<vec4f, 1>, 1>(array<vec4f, 1>(vf251.f0[4][u32(unconst_u32(179))][u32(unconst_u32(25))])), array<array<vec4f, 1>, 1>(array<vec4f, 1>(vf251.f0[4][u32(unconst_u32(179))][u32(unconst_u32(25))]))));
+}`,
+});
+try {
+renderPassEncoder28.setBindGroup(2, bindGroup136);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup53, new Uint32Array(6744), 87, 0);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(4, buffer198, 2_476, 804);
+} catch {}
+let arrayBuffer48 = buffer90.getMappedRange(2808, 12);
+try {
+device0.queue.writeBuffer(buffer189, 6776, new BigUint64Array(3730), 587, 564);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup211 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout56,
+  entries: [{binding: 0, resource: {buffer: buffer215, offset: 256}}],
+});
+let texture334 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 1},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler198 = device0.createSampler({
+  label: '\u022c\u007a\ued41\ud425\u{1f99e}',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup181, new Uint32Array(222), 32, 0);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(3, bindGroup174, new Uint32Array(1012), 260, 0);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline12);
+} catch {}
+try {
+  await buffer72.mapAsync(GPUMapMode.WRITE, 0, 132);
+} catch {}
+let texture335 = gpuCanvasContext2.getCurrentTexture();
+let textureView325 = texture11.createView({dimension: '2d-array', aspect: 'all', format: 'rg8unorm', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder62.setBindGroup(0, bindGroup65, new Uint32Array(181), 3, 0);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup128, new Uint32Array(3354), 846, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 23}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 13 },
+  flipY: false,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder58.setBindGroup(1, bindGroup137);
+} catch {}
+try {
+computePassEncoder190.setBindGroup(1, bindGroup207, new Uint32Array(224), 15, 0);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline11);
+} catch {}
+let arrayBuffer49 = buffer52.getMappedRange(1720, 2420);
+let pipeline46 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule10, constants: {}}});
+let pipeline47 = device0.createRenderPipeline({
+  layout: pipelineLayout9,
+  multisample: {mask: 0x4e3671a},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment6',
+  targets: [{format: 'rg32sint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba16uint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule3, constants: {27_508: 0}, buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw'},
+});
+let autogeneratedBindGroupLayout114 = pipeline12.getBindGroupLayout(0);
+let bindGroup212 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout4,
+  entries: [
+    {binding: 51, resource: textureView90},
+    {binding: 6, resource: {buffer: buffer145, offset: 2304, size: 828}},
+    {binding: 82, resource: textureView60},
+    {binding: 153, resource: externalTexture33},
+    {binding: 13, resource: sampler138},
+    {binding: 183, resource: textureView135},
+    {binding: 93, resource: {buffer: buffer200, offset: 256}},
+    {binding: 95, resource: {buffer: buffer67, offset: 512, size: 112}},
+    {binding: 203, resource: {buffer: buffer99, offset: 2048, size: 2712}},
+    {binding: 104, resource: textureView65},
+    {binding: 88, resource: sampler134},
+  ],
+});
+let textureView326 = texture286.createView({});
+let renderBundleEncoder45 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true});
+let renderBundle45 = renderBundleEncoder45.finish();
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup208);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+  await buffer14.mapAsync(GPUMapMode.WRITE, 0, 812);
+} catch {}
+let veryExplicitBindGroupLayout57 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 50, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 400,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup205);
+} catch {}
+try {
+renderPassEncoder28.setPipeline(pipeline30);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(55).fill(119), /* required buffer size: 55 */
+{offset: 55}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder47.setBindGroup(0, bindGroup92);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup82, new Uint32Array(189), 21, 0);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer139, 'uint32', 920, 116);
+} catch {}
+try {
+buffer71.unmap();
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let pipeline48 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule7,
+  targets: [{format: 'rgba8unorm-srgb'}, {format: 'rgb10a2uint'}, {format: 'rgba16sint'}, {format: 'rg32uint'}],
+},
+  depthStencil: {
+    format: 'depth24plus',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {depthFailOp: 'keep'},
+    stencilReadMask: 999638003,
+    depthBias: 0,
+    depthBiasClamp: 231.85591244303544,
+  },
+  vertex: {
+    module: shaderModule13,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 456,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 4, shaderLocation: 0}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+let veryExplicitBindGroupLayout58 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 33, visibility: 0, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 247,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 627, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: false }},
+  ],
+});
+let buffer227 = device0.createBuffer({size: 13390, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let sampler199 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder82.setBindGroup(2, bindGroup38, new Uint32Array(179), 4, 0);
+} catch {}
+try {
+renderPassEncoder56.beginOcclusionQuery(269);
+} catch {}
+try {
+renderPassEncoder56.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder72.setIndexBuffer(buffer11, 'uint32', 668, 2_918);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer89, 0);
+} catch {}
+try {
+computePassEncoder78.pushDebugGroup('\ue748');
+} catch {}
+let bindGroup213 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout19,
+  entries: [
+    {binding: 22, resource: textureView24},
+    {binding: 72, resource: {buffer: buffer138, offset: 256, size: 712}},
+    {binding: 95, resource: textureView88},
+    {binding: 349, resource: {buffer: buffer215, offset: 768}},
+    {binding: 615, resource: textureView229},
+    {binding: 88, resource: textureView289},
+    {binding: 12, resource: {buffer: buffer172, offset: 0, size: 268}},
+    {binding: 70, resource: textureView260},
+    {binding: 49, resource: textureView78},
+    {binding: 58, resource: externalTexture7},
+  ],
+});
+try {
+renderPassEncoder66.setIndexBuffer(buffer17, 'uint16', 54, 434);
+} catch {}
+let bindGroup214 = device0.createBindGroup({layout: veryExplicitBindGroupLayout22, entries: [{binding: 140, resource: textureView135}]});
+let querySet44 = device0.createQuerySet({type: 'occlusion', count: 68});
+let texture336 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 1},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture337 = gpuCanvasContext3.getCurrentTexture();
+let sampler200 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  compare: 'not-equal',
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup93);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(3, bindGroup78, new Uint32Array(470), 24, 0);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(1, bindGroup150, new Uint32Array(2804), 55, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer182, 'uint16', 302, 139);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+await gc();
+let buffer228 = device0.createBuffer({
+  size: 18306,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView327 = texture6.createView({label: '\u{1fc6a}\u6ec9\udfb1\u{1ffaf}\udeea\u285f\u{1fe17}\u{1fa66}', baseArrayLayer: 0});
+let sampler201 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'repeat'});
+try {
+renderPassEncoder27.setIndexBuffer(buffer207, 'uint16', 9_374, 19_648);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 195, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 46, y: 40, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas5);
+let renderBundleEncoder46 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+let sampler202 = device0.createSampler({addressModeV: 'clamp-to-edge', addressModeW: 'repeat', lodMaxClamp: 98.48});
+try {
+computePassEncoder200.setBindGroup(1, bindGroup118, new Uint32Array(2366), 798, 0);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(1, bindGroup61);
+} catch {}
+try {
+renderPassEncoder63.setBlendConstant({ r: 751.1, g: -625.6, b: 694.9, a: -540.6, });
+} catch {}
+try {
+renderPassEncoder70.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(0, buffer224, 152);
+} catch {}
+try {
+renderBundleEncoder46.setPipeline(pipeline30);
+} catch {}
+let textureView328 = texture201.createView({mipLevelCount: 1});
+let sampler203 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 36.24,
+  lodMaxClamp: 78.40,
+});
+try {
+renderPassEncoder43.setIndexBuffer(buffer172, 'uint32', 0, 95);
+} catch {}
+try {
+renderBundleEncoder46.setPipeline(pipeline35);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(4, buffer10, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 36, y: 19 },
+  flipY: true,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 75, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 77, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle46 = renderBundleEncoder46.finish({});
+try {
+computePassEncoder151.setBindGroup(0, bindGroup136, new Uint32Array(862), 77, 0);
+} catch {}
+try {
+renderPassEncoder65.setBindGroup(2, bindGroup34);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup164, new Uint32Array(1250), 538, 0);
+} catch {}
+try {
+renderPassEncoder69.setIndexBuffer(buffer54, 'uint32', 1_656, 870);
+} catch {}
+try {
+renderPassEncoder71.setVertexBuffer(6, buffer25);
+} catch {}
+let pipeline49 = device0.createRenderPipeline({
+  layout: 'auto',
+  multisample: {mask: 0x5640d94e},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment2',
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {
+        arrayStride: 224,
+        stepMode: 'vertex',
+        attributes: [{format: 'float32', offset: 32, shaderLocation: 12}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+let autogeneratedBindGroupLayout115 = pipeline5.getBindGroupLayout(0);
+let bindGroup215 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout21,
+  entries: [{binding: 0, resource: {buffer: buffer36, offset: 0, size: 32}}],
+});
+let texture338 = gpuCanvasContext3.getCurrentTexture();
+try {
+computePassEncoder59.setBindGroup(0, bindGroup8, new Uint32Array(1633), 18, 0);
+} catch {}
+try {
+renderPassEncoder69.setBindGroup(1, bindGroup208, []);
+} catch {}
+try {
+computePassEncoder78.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let autogeneratedBindGroupLayout116 = pipeline4.getBindGroupLayout(0);
+let texture339 = device0.createTexture({
+  size: [240, 1, 1],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler204 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.14,
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder56.setBindGroup(2, bindGroup101);
+} catch {}
+document.body.append(img3);
+let bindGroup216 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout74,
+  entries: [{binding: 0, resource: {buffer: buffer86, offset: 3072, size: 38}}],
+});
+let textureView329 = texture147.createView({dimension: '1d'});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup91, new Uint32Array(6338), 1_181, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder59); computePassEncoder59.dispatchWorkgroupsIndirect(buffer162, 80); };
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup201, []);
+} catch {}
+let texture340 = device0.createTexture({
+  size: [195, 120, 9],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler205 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup208, new Uint32Array(4187), 763, 0);
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(2, bindGroup208);
+} catch {}
+try {
+renderPassEncoder71.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder64.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(2, buffer46, 2_592, 512);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup217 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout97,
+  entries: [{binding: 0, resource: {buffer: buffer186, offset: 3328, size: 1350}}],
+});
+let textureView330 = texture152.createView({dimension: '2d-array'});
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup204, new Uint32Array(826), 87, 0);
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+let sampler206 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'repeat', minFilter: 'linear'});
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup155);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(5, buffer16);
+} catch {}
+let textureView331 = texture54.createView({dimension: '2d-array', format: 'rgba8uint', baseMipLevel: 0, mipLevelCount: 1});
+try {
+renderPassEncoder45.setBindGroup(2, bindGroup1, new Uint32Array(709), 102, 0);
+} catch {}
+try {
+renderPassEncoder65.setVertexBuffer(3, buffer108);
+} catch {}
+try {
+computePassEncoder200.insertDebugMarker('\uf477');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 30, y: 16, z: 0},
+  aspect: 'all',
+}, new Uint8Array(8).fill(210), /* required buffer size: 8 */
+{offset: 8, bytesPerRow: 125}, {width: 16, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let autogeneratedBindGroupLayout117 = pipeline13.getBindGroupLayout(0);
+try {
+computePassEncoder189.setBindGroup(2, bindGroup133);
+} catch {}
+try {
+computePassEncoder59.end();
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline28);
+} catch {}
+try {
+commandEncoder87.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1408 */
+  offset: 1408,
+  buffer: buffer60,
+}, {
+  texture: texture128,
+  mipLevel: 0,
+  origin: {x: 140, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder61.insertDebugMarker('\u0b0d');
+} catch {}
+try {
+if (!arrayBuffer19.detached) { new Uint8Array(arrayBuffer19).fill(0x55); };
+} catch {}
+let veryExplicitBindGroupLayout59 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 156,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let buffer229 = device0.createBuffer({size: 3844, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+renderPassEncoder45.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(7, buffer39, 4_804, 407);
+} catch {}
+try {
+commandEncoder87.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 336 */
+  offset: 336,
+  buffer: buffer229,
+}, {
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 86, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture287,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 32, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(209).fill(117), /* required buffer size: 209 */
+{offset: 209, bytesPerRow: 11}, {width: 1, height: 26, depthOrArrayLayers: 0});
+} catch {}
+let promise46 = device0.createComputePipelineAsync({layout: pipelineLayout10, compute: {module: shaderModule13, constants: {}}});
+let autogeneratedBindGroupLayout118 = pipeline3.getBindGroupLayout(0);
+let texture341 = device0.createTexture({size: {width: 97}, dimension: '1d', format: 'rgba16uint', usage: GPUTextureUsage.COPY_SRC});
+let textureView332 = texture119.createView({label: '\u3fac\u3851\u0a98\u2bd1\uf8ae\u94cb', arrayLayerCount: 1});
+let renderPassEncoder73 = commandEncoder87.beginRenderPass({
+  colorAttachments: [{
+  view: textureView254,
+  clearValue: { r: 577.0, g: -385.6, b: -854.7, a: -714.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder55.setBindGroup(1, bindGroup81, new Uint32Array(1978), 309, 0);
+} catch {}
+try {
+renderPassEncoder64.setPipeline(pipeline17);
+} catch {}
+let texture342 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 33},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup151);
+} catch {}
+try {
+renderPassEncoder56.beginOcclusionQuery(429);
+} catch {}
+try {
+renderPassEncoder56.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder61.draw(122, 282, 380_582_228, 356_349_219);
+} catch {}
+try {
+renderPassEncoder61.drawIndirect(buffer162, 792);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let textureView333 = texture169.createView({dimension: '2d-array'});
+let sampler207 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.92,
+});
+try {
+renderPassEncoder73.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder61.drawIndirect(buffer176, 300);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline41);
+} catch {}
+let shaderModule14 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+@group(0) @binding(19) var tex8: texture_depth_2d;
+
+var<private> vp26: VertexOutput11 = VertexOutput11(vec2u(89, 91), u32(28), vec4f(0.1181, 0.1810, 0.7490, 0.06477), vec4i(312, 122, 57, 19), f16(3825.0));
+
+fn fn0() -> array<S0, 2> {
+  var out: array<S0, 2>;
+  var vf253: f32 = length(f32(unconst_f32(0.01236)));
+  vf253 -= f32(vp25.fract[1]);
+  out[u32(unconst_u32(57))] = S0(bitcast<vec4f>(vp26.f39).w, f16(vp26.f39[2]), f16(vp26.f39[1]));
+  vp26.f38 += unpack4x8unorm(dot(vec3u(unconst_u32(173), unconst_u32(409), unconst_u32(121)), vec3u(unconst_u32(63), unconst_u32(9), unconst_u32(167))));
+  vf253 = f32(any(vec4<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(true), unconst_bool(true))));
+  let ptr161: ptr<private, VertexOutput11> = &vp26;
+  vp26 = VertexOutput11(bitcast<vec2u>(degrees(vec4f(unconst_f32(0.7400), unconst_f32(0.4907), unconst_f32(0.07567), unconst_f32(0.04109))).ba), bitcast<u32>(degrees(vec4f(unconst_f32(0.7400), unconst_f32(0.4907), unconst_f32(0.07567), unconst_f32(0.04109))).z), degrees(vec4f(unconst_f32(0.7400), unconst_f32(0.4907), unconst_f32(0.07567), unconst_f32(0.04109))), bitcast<vec4i>(degrees(vec4f(unconst_f32(0.7400), unconst_f32(0.4907), unconst_f32(0.07567), unconst_f32(0.04109)))), f16(degrees(vec4f(unconst_f32(0.7400), unconst_f32(0.4907), unconst_f32(0.07567), unconst_f32(0.04109))).w));
+  vp26 = VertexOutput11(vec2u(u32(vw34[u32(unconst_u32(58))])), u32(vw34[u32(unconst_u32(58))]), vec4f(f32(vw34[u32(unconst_u32(58))])), vec4i(i32(vw34[u32(unconst_u32(58))])), vw34[u32(unconst_u32(58))]);
+  vp25 = modf(vec4h(vw34[0]));
+  let ptr162: ptr<workgroup, f16> = &vw34[u32(unconst_u32(84))];
+  var vf254: vec3h = normalize(vec3h(unconst_f16(8329.7), unconst_f16(-22228.0), unconst_f16(10340.8)));
+  vf254 = vec3h((*ptr161).f40);
+  var vf255: f32 = length(f32(unconst_f32(0.04414)));
+  vp26 = VertexOutput11(vec2u(u32((*&vw34)[0])), u32((*&vw34)[0]), vec4f(f32((*&vw34)[0])), vec4i(i32((*&vw34)[0])), (*&vw34)[0]);
+  vf254 += vec3h((*&vw34)[u32(unconst_u32(3))]);
+  vf255 = f32((*&vw34)[u32(unconst_u32(68))]);
+  let vf256: u32 = pack4xU8(vec4u(unconst_u32(135), unconst_u32(102), unconst_u32(334), unconst_u32(106)));
+  let vf257: vec3h = atan2(vec3h(unconst_f16(559.7), unconst_f16(4744.1), unconst_f16(9886.0)), vec3h(unconst_f16(3000.3), unconst_f16(10278.1), unconst_f16(9853.5)));
+  vf255 = vec3f(vf257).g;
+  return out;
+}
+
+@group(0) @binding(24) var tex9: texture_cube_array<u32>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(134) var<uniform> buffer230: array<mat2x3h, 10>;
+
+struct T0 {
+  @align(32) @size(224) f0: mat2x4h,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct VertexOutput11 {
+  @location(14) @interpolate(flat, sample) f36: vec2u,
+  @location(12) @interpolate(flat) f37: u32,
+  @builtin(position) f38: vec4f,
+  @location(5) f39: vec4i,
+  @location(7) @interpolate(linear, sample) f40: f16,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn fn1(a0: VertexOutput11) {
+  var vf258: vec4f = a0.f38;
+  vp25 = modf(pow(vec4h(unconst_f16(6865.9), unconst_f16(6733.4), unconst_f16(-30587.2), unconst_f16(12746.5)), vec4h(unconst_f16(6394.3), unconst_f16(-5849.8), unconst_f16(686.0), unconst_f16(1092.4))));
+  let vf259: i32 = vp26.f39[u32(unconst_u32(13))];
+  vp24 &= a0.f39;
+  vp24 |= bitcast<vec4i>(vp26.f36.xyxx);
+  var vf260: vec2u = a0.f36;
+  var vf261: vec2i = abs(vec2i(unconst_i32(377), unconst_i32(75)));
+  let vf262: vec4h = pow(vec4h(unconst_f16(3127.1), unconst_f16(4638.8), unconst_f16(1599.0), unconst_f16(10728.7)), vec4h(unconst_f16(5367.7), unconst_f16(10736.1), unconst_f16(24469.3), unconst_f16(13868.3)));
+  let vf263: u32 = a0.f36[u32(unconst_u32(19))];
+  var vf264: vec2u = a0.f36;
+  let ptr163: ptr<private, u32> = &vp26.f37;
+  let ptr164 = &vp25;
+  var vf265: vec3h = floor(vec3h(unconst_f16(5050.7), unconst_f16(257.4), unconst_f16(616.0)));
+  var vf266: vec2u = a0.f36;
+  let ptr165: ptr<private, u32> = &vp26.f37;
+  let vf267: vec4f = atan2(vec4f(unconst_f32(0.05924), unconst_f32(0.04785), unconst_f32(0.2363), unconst_f32(0.06111)), vec4f(unconst_f32(0.1158), unconst_f32(0.4545), unconst_f32(0.2162), unconst_f32(0.1807)));
+  vf260 = vec2u(a0.f39.xy);
+  var vf268: u32 = vf266[u32(unconst_u32(167))];
+  var vf269: i32 = vf261[u32(unconst_u32(9))];
+  var vf270: u32 = vf263;
+  let ptr166: ptr<function, vec3h> = &vf265;
+  var vf271: f32 = a0.f38[u32(unconst_u32(128))];
+  vf260 = vec2u(u32(vp26.f38[u32(unconst_u32(493))]));
+  let ptr167: ptr<function, vec2u> = &vf266;
+  let ptr168: ptr<function, f32> = &vf271;
+}
+
+struct FragmentOutput12 {
+  @location(3) @interpolate(flat) f0: vec4u,
+  @location(1) @interpolate(flat, centroid) f1: vec4u,
+  @location(0) @interpolate(perspective) f2: vec4f,
+  @location(2) @interpolate(flat) f3: vec4i,
+  @location(6) @interpolate(flat, centroid) f4: u32,
+  @builtin(sample_mask) f5: u32,
+}
+
+var<workgroup> vw34: array<f16, 1>;
+
+struct S0 {
+  @location(4) @interpolate(flat) f0: f32,
+  @location(8) @interpolate(flat) f1: f16,
+  @location(7) @interpolate(linear) f2: f16,
+}
+
+var<private> vp25 = modf(vec4h(6829.7, 11048.8, 23385.6, 3079.1));
+
+var<private> vp24: vec4i = vec4i(21, 98, 278, 277);
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(184) var<storage, read_write> buffer231: array<f16, 152>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@vertex @must_use
+fn vertex12(@location(0) @interpolate(flat) a0: i32, @location(2) @interpolate(flat) a1: vec4i, a2: S0, @location(15) @interpolate(flat) a3: vec4h, @location(12) a4: vec2u, @location(10) @interpolate(flat) a5: vec4i, @location(11) @interpolate(flat, centroid) a6: vec4i, @location(3) @interpolate(flat, center) a7: vec4h, @location(5) a8: f32) -> VertexOutput11 {
+  var out: VertexOutput11;
+  out.f39 -= vec4i(vp26.f39[u32(unconst_u32(414))]);
+  out = VertexOutput11(vec2u(u32(a3[u32(unconst_u32(67))])), u32(a3[u32(unconst_u32(67))]), vec4f(f32(a3[u32(unconst_u32(67))])), vec4i(i32(a3[u32(unconst_u32(67))])), a3[u32(unconst_u32(67))]);
+  let vf272: i32 = vp24[u32(unconst_u32(70))];
+  vp25 = modf(vec4h(vp26.f39));
+  out = VertexOutput11(vec2u((*&buffer230)[u32(unconst_u32(270))][unconst_i32(0)].xz), vec3u((*&buffer230)[u32(unconst_u32(270))][unconst_i32(1)])[2], vec4f((*&buffer230)[u32(unconst_u32(270))][unconst_i32(0)].zxzz), vec4i((*&buffer230)[u32(unconst_u32(270))][unconst_i32(0)].yyxx), (*&buffer230)[u32(unconst_u32(270))][unconst_i32(0)].y);
+  vp25.whole = vec4h(f16(vp26.f39[u32(unconst_u32(74))]));
+  fn1(VertexOutput11(vec2u(unconst_u32(354), unconst_u32(362)), u32(unconst_u32(74)), vec4f(unconst_f32(0.1590), unconst_f32(-0.1927), unconst_f32(0.1539), unconst_f32(0.02422)), vec4i(unconst_i32(-47), unconst_i32(51), unconst_i32(229), unconst_i32(-336)), f16(unconst_f16(2565.0))));
+  out.f40 = f16(textureLoad(tex8, vec2i(unconst_i32(35), unconst_i32(456)), i32(a2.f1)));
+  let vf273: f32 = a2.f0;
+  fn1(VertexOutput11(vec2u((*&buffer230)[u32(unconst_u32(133))][unconst_i32(0)].zx), vec3u((*&buffer230)[u32(unconst_u32(133))][unconst_i32(1)])[0], vec4f((*&buffer230)[u32(unconst_u32(133))][unconst_i32(1)].yxyy), vec4i((*&buffer230)[u32(unconst_u32(133))][unconst_i32(0)].rbrg), (*&buffer230)[u32(unconst_u32(133))][unconst_i32(1)][2]));
+  fn1(VertexOutput11(bitcast<vec2u>(vp25.whole), pack4xU8(vec4u(vp25.whole)), vec4f(vp25.whole), vec4i(vp25.whole), vp25.whole.z));
+  out.f36 >>= vec2u(vp26.f36[u32(unconst_u32(37))]);
+  let vf274: vec3f = asin(vec3f(unconst_f32(0.3496), unconst_f32(0.2562), unconst_f32(-0.1397)));
+  out.f40 -= atan(vec4h(unconst_f16(-1279.6), unconst_f16(7193.8), unconst_f16(374.3), unconst_f16(-9955.0)))[3];
+  let vf275: f32 = distance(f32(unconst_f32(0.2260)), f32(unconst_f32(0.1405)));
+  var vf276: f16 = smoothstep(f16(unconst_f16(20665.0)), f16(unconst_f16(46612.0)), f16(unconst_f16(3673.5)));
+  vp24 |= vec4i(asin(vec3f(unconst_f32(0.1479), unconst_f32(0.00543), unconst_f32(0.07170))).rgbg);
+  fn1(VertexOutput11(vec2u(bitcast<u32>(vp26.f39[u32(unconst_u32(58))])), u32(vp26.f39[u32(unconst_u32(58))]), vec4f(f32(vp26.f39[u32(unconst_u32(58))])), vec4i(vp26.f39[u32(unconst_u32(58))]), f16(vp26.f39[u32(unconst_u32(58))])));
+  vp24 ^= unpack4xI8(countOneBits(u32(unconst_u32(74))));
+  let vf277: f16 = a2.f1;
+  var vf278: f16 = a2.f2;
+  fn1(VertexOutput11());
+  fn1(VertexOutput11(vec2u(bitcast<u32>(a2.f0)), u32(a2.f0), vec4f(a2.f0), vec4i(i32(a2.f0)), f16(a2.f0)));
+  return out;
+  _ = tex8;
+  _ = buffer230;
+}
+
+@fragment
+fn fragment13(@location(12) a0: f32) -> FragmentOutput12 {
+  var out: FragmentOutput12;
+  out.f4 = u32(buffer230[u32(unconst_u32(54))][unconst_i32(0)].x);
+  discard;
+  let ptr169: ptr<uniform, array<mat2x3h, 10>> = &buffer230;
+  out.f4 &= u32((*&buffer231)[151]);
+  buffer231[u32(unconst_u32(51))] += buffer230[u32(unconst_u32(126))][unconst_i32(0)].b;
+  vp26.f36 = textureDimensions(tex9, i32(unconst_i32(140)));
+  out.f5 = u32((*ptr169)[u32(unconst_u32(62))][unconst_i32(1)][1]);
+  return out;
+  _ = tex9;
+  _ = buffer230;
+  _ = buffer231;
+}
+
+@compute @workgroup_size(1, 2, 1)
+fn compute14(@builtin(local_invocation_id) a0: vec3u, @builtin(workgroup_id) a1: vec3u) {
+  let vf279: vec4u = firstLeadingBit(vec4u(unconst_u32(25), unconst_u32(235), unconst_u32(135), unconst_u32(78)));
+  var vf280: i32 = vp24[u32(unconst_u32(148))];
+  vp25 = modf(vec4h(f16(vf280)));
+  vf280 += bitcast<vec4i>(vp26.f38).g;
+  fn0();
+  var vf281 = fn0();
+  fn1(VertexOutput11(vec2u(firstTrailingBit(u32(unconst_u32(579)))), firstTrailingBit(u32(unconst_u32(579))), unpack4x8unorm(firstTrailingBit(u32(unconst_u32(579)))), vec4i(bitcast<i32>(firstTrailingBit(u32(unconst_u32(579))))), f16(firstTrailingBit(u32(unconst_u32(579))))));
+  fn1(VertexOutput11(vec2u(vp26.f37), vp26.f37, unpack4x8snorm(vp26.f37), vec4i(bitcast<i32>(vp26.f37)), f16(vp26.f37)));
+  let ptr170: ptr<workgroup, f16> = &(*&vw34)[u32(unconst_u32(51))];
+  let vf282: u32 = a1[u32(unconst_u32(523))];
+  var vf283 = fn0();
+  var vf284 = fn0();
+  let ptr171: ptr<function, S0> = &vf283[u32(unconst_u32(87))];
+  vf281[1].f1 *= vec3h(a1)[1];
+  fn1(VertexOutput11());
+  fn0();
+  vf280 = i32(vf284[bitcast<u32>(vf283[1].f0)].f1);
+  fn1(VertexOutput11(vec2u(u32(vf281[u32(unconst_u32(98))].f2)), u32(vf281[u32(unconst_u32(98))].f2), vec4f(f32(vf281[u32(unconst_u32(98))].f2)), vec4i(i32(vf281[u32(unconst_u32(98))].f2)), vf281[u32(unconst_u32(98))].f2));
+  vw34[u32(unconst_u32(74))] = f16(min(vec3u(bitcast<u32>((*ptr171).f0)), vec3u(unconst_u32(28), unconst_u32(40), unconst_u32(176)))[2]);
+  let ptr172: ptr<private, VertexOutput11> = &vp26;
+  let ptr173: ptr<workgroup, f16> = &(*&vw34)[u32(unconst_u32(561))];
+  vw34[u32(unconst_u32(141))] = f16(vf283[1].f0);
+  vp25.whole *= vec4h((*&vw34)[0]);
+  vp26.f36 <<= vec2u(vf279[u32(unconst_u32(130))]);
+}`,
+});
+let sampler208 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', mipmapFilter: 'nearest'});
+try {
+computePassEncoder53.setBindGroup(2, bindGroup217, []);
+} catch {}
+try {
+renderPassEncoder61.end();
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer95, 'uint16', 1_206, 765);
+} catch {}
+try {
+renderPassEncoder55.setPipeline(pipeline38);
+} catch {}
+let promise47 = shaderModule8.getCompilationInfo();
+try {
+renderPassEncoder10.insertDebugMarker('\u061d');
+} catch {}
+let pipeline50 = await device0.createComputePipelineAsync({layout: pipelineLayout14, compute: {module: shaderModule1, constants: {}}});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer232 = device0.createBuffer({
+  size: 18861,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+try {
+renderPassEncoder30.setBindGroup(3, bindGroup124);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(5, buffer31, 124);
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let imageData43 = new ImageData(36, 108);
+let querySet45 = device0.createQuerySet({type: 'occlusion', count: 435});
+let sampler209 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 96.96});
+try {
+computePassEncoder47.setBindGroup(2, bindGroup101);
+} catch {}
+try {
+commandEncoder201.copyBufferToTexture({
+  /* bytesInLastRow: 1120 widthInBlocks: 140 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3448 */
+  offset: 3448,
+  bytesPerRow: 10752,
+  buffer: buffer65,
+}, {
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 7, y: 107, z: 0},
+  aspect: 'all',
+}, {width: 140, height: 30, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 1, depthOrArrayLayers: 39}
+*/
+{
+  source: imageData4,
+  origin: { x: 29, y: 1 },
+  flipY: true,
+}, {
+  texture: texture271,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise44;
+} catch {}
+let bindGroup218 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout88,
+  entries: [
+    {binding: 184, resource: {buffer: buffer200, offset: 512}},
+    {binding: 19, resource: textureView30},
+    {binding: 134, resource: {buffer: buffer41, offset: 0, size: 419}},
+  ],
+});
+let commandBuffer9 = commandEncoder201.finish();
+let texture343 = device0.createTexture({
+  size: [390, 240, 1],
+  mipLevelCount: 2,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView334 = texture3.createView({});
+try {
+renderPassEncoder64.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer145, 'uint32', 168, 9_291);
+} catch {}
+try {
+  await promise45;
+} catch {}
+let img15 = await imageWithData(168, 65, '#10101010', '#20202020');
+let commandEncoder265 = device0.createCommandEncoder({});
+let texture344 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 1},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder216 = commandEncoder265.beginComputePass();
+let sampler210 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 99.60});
+try {
+computePassEncoder19.setBindGroup(0, bindGroup203, new Uint32Array(3998), 148, 0);
+} catch {}
+try {
+computePassEncoder216.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder73.setBindGroup(2, bindGroup216);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture120,
+  mipLevel: 2,
+  origin: {x: 37, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(208).fill(87), /* required buffer size: 208 */
+{offset: 208, bytesPerRow: 279}, {width: 31, height: 32, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise43;
+} catch {}
+document.body.append(img11);
+let textureView335 = texture172.createView({});
+let sampler211 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 55.58,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder47.setBindGroup(3, bindGroup13, new Uint32Array(335), 30, 0);
+} catch {}
+try {
+renderPassEncoder55.setPipeline(pipeline38);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer114, 112, new Float32Array(25173), 3831, 520);
+} catch {}
+let pipeline51 = device0.createComputePipeline({layout: pipelineLayout13, compute: {module: shaderModule1, constants: {}}});
+let imageData44 = new ImageData(8, 36);
+videoFrame50 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'film', transfer: 'bt709'} });
+let texture345 = device0.createTexture({size: [97, 60, 1], format: 'rgb10a2uint', usage: GPUTextureUsage.COPY_DST});
+let externalTexture38 = device0.importExternalTexture({source: videoFrame13});
+try {
+computePassEncoder207.setBindGroup(1, bindGroup41);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline49);
+} catch {}
+try {
+buffer229.unmap();
+} catch {}
+let imageBitmap7 = await createImageBitmap(imageData7);
+let bindGroup219 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout32,
+  entries: [{binding: 85, resource: {buffer: buffer24, offset: 0, size: 2168}}],
+});
+let pipelineLayout21 = device0.createPipelineLayout({
+  bindGroupLayouts: [autogeneratedBindGroupLayout87, recycledAutogeneratedBindGroupLayout2, autogeneratedBindGroupLayout90],
+});
+let texture346 = device0.createTexture({
+  size: [780, 480, 1],
+  mipLevelCount: 3,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler212 = device0.createSampler({magFilter: 'linear', minFilter: 'linear', mipmapFilter: 'linear', lodMaxClamp: 73.49, maxAnisotropy: 5});
+try {
+renderPassEncoder42.setPipeline(pipeline39);
+} catch {}
+let imageBitmap8 = await createImageBitmap(videoFrame36);
+let recycledExplicitBindGroupLayout6 = pipeline41.getBindGroupLayout(0);
+let buffer233 = device0.createBuffer({
+  size: 3671,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture347 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView336 = texture27.createView({mipLevelCount: 1, baseArrayLayer: 8, arrayLayerCount: 67});
+let sampler213 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat'});
+try {
+renderPassEncoder46.executeBundles([renderBundle27, renderBundle11, renderBundle42]);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+buffer193.unmap();
+} catch {}
+let recycledExplicitBindGroupLayout7 = pipeline45.getBindGroupLayout(0);
+let texture348 = device0.createTexture({
+  size: [195, 120, 1],
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder45.setBindGroup(3, bindGroup132);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline28);
+} catch {}
+try {
+renderPassEncoder49.insertDebugMarker('\u4cfb');
+} catch {}
+try {
+  await promise47;
+} catch {}
+document.body.prepend(canvas2);
+let buffer234 = device0.createBuffer({size: 15026, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let textureView337 = texture308.createView({dimension: '2d-array'});
+try {
+computePassEncoder199.setBindGroup(3, bindGroup150, new Uint32Array(194), 14, 0);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(1, buffer225, 0, 1_532);
+} catch {}
+try {
+renderPassEncoder71.setPipeline(pipeline39);
+} catch {}
+let arrayBuffer50 = buffer52.getMappedRange(1208, 4);
+try {
+computePassEncoder116.insertDebugMarker('\u0137');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let texture349 = gpuCanvasContext2.getCurrentTexture();
+try {
+computePassEncoder88.setBindGroup(2, bindGroup107);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(6, undefined, 0);
+} catch {}
+try {
+gpuCanvasContext5.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+let veryExplicitBindGroupLayout60 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout119 = pipeline16.getBindGroupLayout(0);
+let textureView338 = texture327.createView({format: 'rg8unorm', mipLevelCount: 1});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup47);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(6, undefined, 192_893_176);
+} catch {}
+try {
+computePassEncoder77.pushDebugGroup('\u0a3d');
+} catch {}
+videoFrame51 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'smpte432', transfer: 'logSqrt'} });
+let bindGroup220 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout77,
+  entries: [{binding: 0, resource: {buffer: buffer117, offset: 0, size: 738}}],
+});
+let textureView339 = texture209.createView({aspect: 'all', baseMipLevel: 0, mipLevelCount: 1});
+try {
+renderPassEncoder63.beginOcclusionQuery(9);
+} catch {}
+try {
+renderPassEncoder28.setVertexBuffer(5, buffer209, 1_080);
+} catch {}
+let buffer235 = device0.createBuffer({
+  size: 3009,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder104.setBindGroup(2, bindGroup1, new Uint32Array(1413), 123, 0);
+} catch {}
+try {
+renderPassEncoder63.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle32]);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline11);
+} catch {}
+try {
+computePassEncoder124.pushDebugGroup('\u5cf5');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer220, 916, new DataView(new ArrayBuffer(4253)), 1321, 720);
+} catch {}
+let textureView340 = texture69.createView({format: 'rg8unorm', mipLevelCount: 1, baseArrayLayer: 6, arrayLayerCount: 13});
+try {
+renderPassEncoder69.setBindGroup(1, bindGroup49, new Uint32Array(2730), 176, 0);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer190, 'uint32', 1_460, 516);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 1, depthOrArrayLayers: 39}
+*/
+{
+  source: imageData24,
+  origin: { x: 0, y: 27 },
+  flipY: false,
+}, {
+  texture: texture271,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture350 = device0.createTexture({size: [240, 1, 1], mipLevelCount: 2, format: 'rg8unorm', usage: GPUTextureUsage.COPY_SRC});
+try {
+buffer225.unmap();
+} catch {}
+document.body.append(img0);
+let img16 = await imageWithData(134, 24, '#10101010', '#20202020');
+let autogeneratedBindGroupLayout120 = pipeline3.getBindGroupLayout(0);
+let texture351 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 31},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView341 = texture219.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder17.setPipeline(pipeline13);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 195, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData22,
+  origin: { x: 3, y: 1 },
+  flipY: true,
+}, {
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 6, y: 14, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55); };
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(340, 69);
+let buffer236 = device0.createBuffer({size: 1747, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+try {
+computePassEncoder135.setBindGroup(3, bindGroup98, new Uint32Array(1212), 405, 0);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline21);
+} catch {}
+let arrayBuffer51 = buffer5.getMappedRange(3344, 0);
+try {
+computePassEncoder77.popDebugGroup();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(img7);
+let textureView342 = texture113.createView({});
+try {
+renderPassEncoder38.executeBundles([renderBundle32]);
+} catch {}
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+let renderBundleEncoder47 = device0.createRenderBundleEncoder({colorFormats: ['rg32sint', 'rgba16uint', 'rgba8uint'], stencilReadOnly: true});
+try {
+computePassEncoder160.setBindGroup(1, bindGroup3, new Uint32Array(3911), 33, 0);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(3, bindGroup101, new Uint32Array(104), 2, 0);
+} catch {}
+try {
+renderPassEncoder39.setViewport(616.9513472150713, 261.69934786200173, 93.83261498909215, 70.63331620463822, 0.3003756225423382, 0.5919145319442258);
+} catch {}
+try {
+renderBundleEncoder47.setBindGroup(1, bindGroup175, new Uint32Array(115), 1, 0);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(4, buffer51, 1_200, 145);
+} catch {}
+let buffer237 = device0.createBuffer({size: 584, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView343 = texture104.createView({});
+let renderBundle47 = renderBundleEncoder47.finish({});
+let sampler214 = device0.createSampler({addressModeV: 'mirror-repeat', minFilter: 'nearest', lodMaxClamp: 80.90, compare: 'not-equal'});
+try {
+renderPassEncoder43.setBindGroup(3, bindGroup171, []);
+} catch {}
+try {
+renderPassEncoder64.setPipeline(pipeline28);
+} catch {}
+try {
+buffer220.unmap();
+} catch {}
+try {
+computePassEncoder124.popDebugGroup();
+} catch {}
+let texture352 = device0.createTexture({
+  size: [195, 120, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView344 = texture123.createView({});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder7.draw(123, 239, 55_188_206, 39_278_140);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer50, 280);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture351,
+  mipLevel: 2,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(91).fill(59), /* required buffer size: 91 */
+{offset: 91}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder11.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderPassEncoder59.setBlendConstant({ r: 18.68, g: 167.7, b: 452.1, a: -884.0, });
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer114, 568);
+} catch {}
+try {
+renderPassEncoder60.setIndexBuffer(buffer170, 'uint16', 1_142, 147);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(2, buffer118, 60, 79);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'all',
+}, new Uint8Array(844).fill(246), /* required buffer size: 844 */
+{offset: 844}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup221 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout68,
+  entries: [{binding: 0, resource: {buffer: buffer17, offset: 256, size: 148}}],
+});
+let textureView345 = texture91.createView({});
+let sampler215 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat'});
+try {
+computePassEncoder174.setBindGroup(3, bindGroup47);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(1, bindGroup14, new Uint32Array(681), 16, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup208, new Uint32Array(1573), 953, 0);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer99, 1_620);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline28);
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas5.getContext('webgpu');
+try {
+computePassEncoder141.label = '\u090d\u{1ff8e}\u01ac\u{1fb77}\u{1fdbe}\u{1fef4}\u090c\u0318\ue1c4\uac43\uf5db';
+} catch {}
+let recycledExplicitBindGroupLayout8 = pipeline45.getBindGroupLayout(0);
+let sampler216 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 98.04,
+  compare: 'never',
+});
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup104);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup173, new Uint32Array(1601), 206, 0);
+} catch {}
+try {
+renderPassEncoder51.executeBundles([renderBundle22, renderBundle22]);
+} catch {}
+try {
+renderPassEncoder26.setViewport(45.15810433656629, 57.69128234122894, 44.14783381899961, 1.8615012911369735, 0.6961374224615406, 0.8126770176028422);
+} catch {}
+try {
+renderPassEncoder7.draw(37, 182, 172_888_791, 813_950_273);
+} catch {}
+try {
+renderPassEncoder7.drawIndexed(0, 214, 97, 96_432_678, 59_428_206);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer94, 272);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+videoFrame52 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'smpteRp431', transfer: 'gamma28curve'} });
+let veryExplicitBindGroupLayout61 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 50, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+    {
+      binding: 400,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer238 = device0.createBuffer({
+  size: 16872,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView346 = texture6.createView({});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup115);
+} catch {}
+try {
+renderPassEncoder7.draw(115, 342, 565_970_675, 665_347_774);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer133, 2_868);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture246,
+  mipLevel: 0,
+  origin: {x: 21, y: 21, z: 38},
+  aspect: 'all',
+}, new Uint8Array(297).fill(41), /* required buffer size: 297 */
+{offset: 297, bytesPerRow: 149, rowsPerImage: 62}, {width: 14, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder163.setBindGroup(3, bindGroup122, [2560]);
+} catch {}
+try {
+computePassEncoder116.setBindGroup(0, bindGroup115, new Uint32Array(1924), 77, 0);
+} catch {}
+try {
+renderPassEncoder72.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle45, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer69, 1_572);
+} catch {}
+let texture353 = device0.createTexture({
+  size: [60, 1, 9],
+  sampleCount: 1,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler217 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 88.97,
+  lodMaxClamp: 96.00,
+  compare: 'always',
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer124, 'uint32', 1_120, 269);
+} catch {}
+try {
+  await shaderModule3.getCompilationInfo();
+} catch {}
+let recycledExplicitBindGroupLayout9 = pipeline46.getBindGroupLayout(0);
+let buffer239 = device0.createBuffer({
+  size: 772,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView347 = texture24.createView({dimension: '2d', aspect: 'all', format: 'r32float'});
+try {
+computePassEncoder176.setBindGroup(3, bindGroup47);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(0, bindGroup107);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup53, new Uint32Array(595), 164, 0);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(5, buffer183, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(212).fill(52), /* required buffer size: 212 */
+{offset: 212, rowsPerImage: 19}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame29,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 98, y: 19, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData45 = new ImageData(140, 52);
+try {
+externalTexture24.label = '\u09b7\u3ae3\u904a\u193c\ub639';
+} catch {}
+let texture354 = device0.createTexture({
+  size: {width: 195, height: 120, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder217 = commandEncoder24.beginComputePass({});
+try {
+computePassEncoder217.setPipeline(pipeline6);
+} catch {}
+let pipeline52 = await promise46;
+let texture355 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 1},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup53);
+} catch {}
+let pipeline53 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule7}});
+let renderBundleEncoder48 = device0.createRenderBundleEncoder({colorFormats: ['rg32sint', 'rgba16uint', 'rgba8uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder98.setBindGroup(0, bindGroup197, new Uint32Array(1230), 183, 0);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(4, buffer112, 472, 660);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(0, bindGroup105, new Uint32Array(1646), 90, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img10);
+let buffer240 = device0.createBuffer({
+  size: 9853,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView348 = texture162.createView({});
+try {
+renderPassEncoder48.setBindGroup(3, bindGroup216, new Uint32Array(5033), 272, 0);
+} catch {}
+try {
+renderPassEncoder57.setPipeline(pipeline38);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(0, bindGroup176, new Uint32Array(1327), 252, 0);
+} catch {}
+try {
+renderBundleEncoder48.setIndexBuffer(buffer213, 'uint16', 328, 203);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(0, buffer170, 332, 183);
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(245, 130);
+let bindGroup222 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout96,
+  entries: [{binding: 0, resource: {buffer: buffer113, offset: 256, size: 1913}}],
+});
+let buffer241 = device0.createBuffer({
+  size: 39336,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder53.setVertexBuffer(0, buffer51, 0, 666);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(1, bindGroup28);
+} catch {}
+try {
+computePassEncoder19.setBindGroup(3, bindGroup81);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline41);
+} catch {}
+try {
+renderBundleEncoder48.setPipeline(pipeline36);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(3, undefined, 0, 149_416_152);
+} catch {}
+let recycledExplicitBindGroupLayout10 = pipeline45.getBindGroupLayout(0);
+let texture356 = device0.createTexture({
+  size: {width: 390, height: 240, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder4.draw(24, 0, 1_154_248_299);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer219, 'uint16', 1_012, 27);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline39);
+} catch {}
+try {
+renderPassEncoder54.setVertexBuffer(7, undefined, 649_774_197, 670_788_928);
+} catch {}
+try {
+renderBundleEncoder48.setIndexBuffer(buffer17, 'uint32', 252, 5);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 97, height: 60, depthOrArrayLayers: 43}
+*/
+{
+  source: imageData24,
+  origin: { x: 7, y: 12 },
+  flipY: false,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 68, y: 0, z: 13},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let imageData46 = new ImageData(100, 16);
+let autogeneratedBindGroupLayout121 = pipeline53.getBindGroupLayout(0);
+let bindGroup223 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 85, resource: {buffer: buffer70, offset: 0, size: 1384}}],
+});
+let renderBundle48 = renderBundleEncoder48.finish({});
+try {
+renderPassEncoder35.beginOcclusionQuery(46);
+} catch {}
+try {
+renderPassEncoder4.draw(51, 0, 1_366_122_623);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer180, 5_024);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(3, buffer51, 0, 1_378);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup224 = device0.createBindGroup({layout: veryExplicitBindGroupLayout46, entries: [{binding: 0, resource: textureView30}]});
+let texture357 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 522},
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder4.draw(685, 0, 122_000_359);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer240, 328);
+} catch {}
+try {
+computePassEncoder20.pushDebugGroup('\ud359');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 1, y: 26, z: 0},
+  aspect: 'all',
+}, new Uint8Array(171).fill(46), /* required buffer size: 171 */
+{offset: 171, bytesPerRow: 112}, {width: 23, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas6.getContext('webgl2');
+} catch {}
+let texture358 = device0.createTexture({
+  size: [120, 1, 12],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView349 = texture300.createView({dimension: 'cube-array', baseArrayLayer: 6, arrayLayerCount: 6});
+let sampler218 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.21,
+});
+try {
+computePassEncoder215.setBindGroup(1, bindGroup161);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer127, 368);
+} catch {}
+try {
+renderPassEncoder49.setPipeline(pipeline17);
+} catch {}
+let promise48 = device0.queue.onSubmittedWorkDone();
+let bindGroup225 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout15,
+  entries: [{binding: 0, resource: {buffer: buffer147, offset: 512}}],
+});
+let buffer242 = device0.createBuffer({
+  size: 9901,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let renderBundleEncoder49 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm']});
+let renderBundle49 = renderBundleEncoder49.finish({label: '\u2ef0\u{1f645}\u{1f6da}\u57e5\u061f\uf648\u{1f697}\u029f\u0796'});
+try {
+renderPassEncoder64.executeBundles([renderBundle36]);
+} catch {}
+try {
+renderPassEncoder4.draw(160, 0, 414_600_740);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture311,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(96).fill(180), /* required buffer size: 96 */
+{offset: 96}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder50 = device0.createRenderBundleEncoder({colorFormats: ['rg32sint', 'rgba16uint', 'rgba8uint']});
+try {
+computePassEncoder31.setBindGroup(1, bindGroup196, []);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer144, 7_120);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline49);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer67, 0);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(0, buffer241, 652);
+} catch {}
+try {
+buffer171.unmap();
+} catch {}
+let promise49 = device0.queue.onSubmittedWorkDone();
+let imageData47 = new ImageData(28, 148);
+let texture359 = device0.createTexture({
+  size: [390, 240, 12],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder193.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+computePassEncoder77.setBindGroup(0, bindGroup110, new Uint32Array(360), 13, 0);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(0, bindGroup101);
+} catch {}
+try {
+renderPassEncoder4.draw(42, 0, 977_142_764);
+} catch {}
+try {
+renderBundleEncoder50.setPipeline(pipeline36);
+} catch {}
+let arrayBuffer52 = buffer64.getMappedRange(272, 0);
+try {
+renderBundleEncoder50.insertDebugMarker('\ud73d');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer111, 1400, new Float32Array(27196), 2178, 616);
+} catch {}
+let buffer243 = device0.createBuffer({
+  size: 11463,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder152.setBindGroup(3, bindGroup38);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(3, bindGroup77);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer161, 4_400);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer201, 'uint32', 1_284, 3_360);
+} catch {}
+try {
+renderBundleEncoder50.setPipeline(pipeline45);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+externalTexture7.label = '\u42c6\u0b23\ubd33\u8ec7\ubc48\u09bc';
+} catch {}
+let bindGroup226 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout105,
+  entries: [{binding: 0, resource: {buffer: buffer114, offset: 256, size: 802}}],
+});
+let textureView350 = texture352.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup3, new Uint32Array(1125), 138, 0);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(1, bindGroup42, new Uint32Array(479), 68, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(201, 1, 921_519_306);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer107, 188);
+} catch {}
+try {
+renderBundleEncoder50.setIndexBuffer(buffer118, 'uint32', 24, 526);
+} catch {}
+let textureView351 = texture219.createView({arrayLayerCount: 1});
+try {
+computePassEncoder215.setBindGroup(0, bindGroup41);
+} catch {}
+try {
+renderPassEncoder35.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer159, 392);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer184, 712);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(1, bindGroup161, new Uint32Array(2208), 603, 0);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let imageData48 = new ImageData(20, 52);
+let sampler219 = device0.createSampler({addressModeV: 'clamp-to-edge', addressModeW: 'mirror-repeat', mipmapFilter: 'nearest'});
+try {
+renderPassEncoder4.draw(35, 0, 222_847_803);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer122, 'uint32', 760, 1_079);
+} catch {}
+try {
+renderBundleEncoder50.setIndexBuffer(buffer76, 'uint16', 706, 2_774);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer240, 636);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer130, 112);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer130, 'uint16', 264, 175);
+} catch {}
+try {
+renderPassEncoder71.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(2, bindGroup192, new Uint32Array(7486), 526, 0);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(6, buffer65);
+} catch {}
+try {
+buffer96.unmap();
+} catch {}
+try {
+if (!arrayBuffer49.detached) { new Uint8Array(arrayBuffer49).fill(0x55); };
+} catch {}
+await gc();
+let autogeneratedBindGroupLayout122 = pipeline0.getBindGroupLayout(0);
+let renderBundle50 = renderBundleEncoder50.finish({});
+try {
+computePassEncoder129.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.draw(13, 0, 2_503_835_045);
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(1, buffer145, 0, 1_050);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_SRC});
+} catch {}
+try {
+renderPassEncoder55.end();
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer105, 7_344);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder210.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 360 */
+  offset: 360,
+  buffer: buffer69,
+}, {
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 1},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let autogeneratedBindGroupLayout123 = pipeline4.getBindGroupLayout(0);
+let textureView352 = texture54.createView({dimension: '2d-array', aspect: 'all', baseArrayLayer: 0});
+let computePassEncoder218 = commandEncoder210.beginComputePass({});
+try {
+renderPassEncoder63.setBindGroup(0, bindGroup200);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup182, new Uint32Array(2712), 551, 0);
+} catch {}
+try {
+renderPassEncoder4.draw(458, 1, 458_496_006);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer60, 380);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(1, buffer0, 0);
+} catch {}
+let textureView353 = texture233.createView({});
+let sampler220 = device0.createSampler({addressModeU: 'repeat', lodMaxClamp: 99.95});
+try {
+computePassEncoder218.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder67.executeBundles([renderBundle44]);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer11, 1_568);
+} catch {}
+let texture360 = device0.createTexture({
+  size: [390, 240, 1],
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler221 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 73.29,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder127.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+computePassEncoder65.setBindGroup(3, bindGroup68, new Uint32Array(739), 94, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer50, 148);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer93, 684);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer186, 'uint16', 1_620, 213);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 39}
+*/
+{
+  source: videoFrame32,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture271,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup227 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout65,
+  entries: [
+    {binding: 19, resource: textureView279},
+    {binding: 184, resource: {buffer: buffer10, offset: 1024}},
+    {binding: 134, resource: {buffer: buffer176, offset: 512, size: 345}},
+  ],
+});
+let buffer244 = device0.createBuffer({
+  label: '\ub4bd\u587e\u07e7\u{1f68c}\u2337\u7b6a',
+  size: 34774,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let sampler222 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 61.17,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder97.setBindGroup(2, bindGroup66);
+} catch {}
+try {
+renderPassEncoder23.end();
+} catch {}
+try {
+renderPassEncoder4.draw(125, 0, 456_171_539);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer59, 1_068);
+} catch {}
+try {
+renderPassEncoder58.setPipeline(pipeline32);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(6, buffer10, 12);
+} catch {}
+let veryExplicitBindGroupLayout62 = device0.createBindGroupLayout({entries: []});
+let recycledExplicitBindGroupLayout11 = pipeline19.getBindGroupLayout(0);
+let texture361 = device0.createTexture({size: [97], dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let renderPassEncoder74 = commandEncoder60.beginRenderPass({
+  label: '\u0e8b\ud821\u5022',
+  colorAttachments: [{
+  view: textureView222,
+  clearValue: { r: 41.02, g: -394.3, b: 235.3, a: -651.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet9,
+});
+let externalTexture39 = device0.importExternalTexture({source: videoFrame41});
+try {
+computePassEncoder147.setBindGroup(3, bindGroup47);
+} catch {}
+try {
+renderPassEncoder63.setBindGroup(0, bindGroup135, new Uint32Array(44), 8, 0);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer239, 12);
+} catch {}
+try {
+renderPassEncoder51.setPipeline(pipeline14);
+} catch {}
+try {
+  await promise48;
+} catch {}
+let autogeneratedBindGroupLayout124 = pipeline17.getBindGroupLayout(0);
+let buffer245 = device0.createBuffer({size: 6396, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT});
+let texture362 = device0.createTexture({
+  size: {width: 780},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+renderPassEncoder4.draw(17, 0, 1_866_648_446);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer239, 60);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+videoFrame53 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'bt709', transfer: 'smpteSt4281'} });
+let shaderModule15 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+@group(1) @binding(140) var st11: texture_storage_1d<r32float, read_write>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw37: atomic<i32>;
+
+var<workgroup> vw36: array<mat2x4f, 1>;
+
+var<workgroup> vw35: array<mat2x3f, 1>;
+
+struct T0 {
+  @align(8) @size(7488) f0: array<u32>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(476) var<uniform> buffer246: array<array<vec4f, 5>, 18>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(3) @binding(464) var tex10: texture_multisampled_2d<u32>;
+
+var<workgroup> vw38: atomic<i32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(2) @binding(476) var<uniform> buffer247: array<array<array<array<mat2x3h, 1>, 2>, 3>, 15>;
+
+@vertex
+fn vertex13(@builtin(instance_index) a0: u32, @location(4) a1: vec2i, @location(11) @interpolate(flat, center) a2: vec2i) -> @builtin(position) vec4f {
+  var out: vec4f;
+  out = vec4f(reverseBits(vec4u(unconst_u32(512), unconst_u32(96), unconst_u32(12), unconst_u32(412))));
+  let vf285: vec4f = quantizeToF16(vec4f(f32(floor(f16(unconst_f16(156.9))))));
+  var vf286: vec2f = unpack2x16unorm(u32(unconst_u32(87)));
+  vf286 += bitcast<vec2f>(radians(vec4h(unconst_f16(3900.0), unconst_f16(9216.1), unconst_f16(3080.1), unconst_f16(23639.2))));
+  let vf287: u32 = textureNumSamples(tex10);
+  out = vec4f(vf285[u32(unconst_u32(222))]);
+  let vf288: vec3f = cross(vec3f(unconst_f32(0.08158), unconst_f32(0.1240), unconst_f32(0.1740)), vec3f(unconst_f32(0.2918), unconst_f32(0.1792), unconst_f32(0.1620)));
+  out = vec4f(vf285[u32(unconst_u32(103))]);
+  vf286 = bitcast<vec2f>(textureLoad(tex10, vec2i(unconst_i32(-101), unconst_i32(86)), i32(unconst_i32(-17))).zx);
+  let vf289: f32 = vf285[u32(unconst_u32(260))];
+  let vf290: vec2f = unpack2x16unorm(u32(unconst_u32(62)));
+  out = vec4f(bitcast<f32>(a2[u32(unconst_u32(135))]));
+  var vf291: vec3f = cross(vec3f(unconst_f32(0.2530), unconst_f32(0.1400), unconst_f32(0.04407)), vec3f(unconst_f32(0.4070), unconst_f32(0.1125), unconst_f32(0.1840)));
+  var vf292: vec2i = a1;
+  let vf293: f32 = vf288[u32(unconst_u32(93))];
+  var vf294: vec4h = ceil(vec4h(unconst_f16(11325.9), unconst_f16(11808.3), unconst_f16(3883.0), unconst_f16(2428.6)));
+  var vf295: u32 = textureNumSamples(tex10);
+  return out;
+  _ = tex10;
+}
+
+@compute @workgroup_size(2, 1, 1)
+fn compute15(@builtin(workgroup_id) a0: vec3u) {
+  let ptr174: ptr<uniform, array<mat2x3h, 1>> = &(*&buffer247)[14][2][u32(unconst_u32(301))];
+  vw35[u32(unconst_u32(64))] = mat2x3f(vec3f(buffer247[u32(unconst_u32(67))][2][1][0][unconst_i32(0)]), vec3f(buffer247[u32(unconst_u32(67))][2][1][0][unconst_i32(0)]));
+  let vf296: i32 = atomicExchange(&(*&vw37), i32(unconst_i32(12)));
+  let ptr175: ptr<uniform, array<array<mat2x3h, 1>, 2>> = &buffer247[14][2];
+  let vf297: vec3h = (*&buffer247)[u32(unconst_u32(33))][2][1][0][u32(unconst_u32(342))];
+  let ptr176: ptr<workgroup, array<mat2x3f, 1>> = &(*&vw35);
+  vw35[u32(unconst_u32(509))] = mat2x3f(bitcast<f32>(pack4x8unorm(vec4f(unconst_f32(0.1255), unconst_f32(-0.02442), unconst_f32(0.01802), unconst_f32(0.4725)))), f32(pack4x8unorm(vec4f(unconst_f32(0.1255), unconst_f32(-0.02442), unconst_f32(0.01802), unconst_f32(0.4725)))), f32(pack4x8unorm(vec4f(unconst_f32(0.1255), unconst_f32(-0.02442), unconst_f32(0.01802), unconst_f32(0.4725)))), bitcast<f32>(pack4x8unorm(vec4f(unconst_f32(0.1255), unconst_f32(-0.02442), unconst_f32(0.01802), unconst_f32(0.4725)))), bitcast<f32>(pack4x8unorm(vec4f(unconst_f32(0.1255), unconst_f32(-0.02442), unconst_f32(0.01802), unconst_f32(0.4725)))), bitcast<f32>(pack4x8unorm(vec4f(unconst_f32(0.1255), unconst_f32(-0.02442), unconst_f32(0.01802), unconst_f32(0.4725)))));
+  let vf298: f32 = (*&buffer246)[vec3u(buffer247[14][u32(unconst_u32(103))][1][u32(unconst_u32(282))][unconst_i32(1)])[0]][u32(unconst_u32(110))][u32(unconst_u32(181))];
+  let ptr177: ptr<uniform, array<array<mat2x3h, 1>, 2>> = &(*&buffer247)[14][2];
+  let ptr178: ptr<uniform, array<mat2x3h, 1>> = &(*&buffer247)[u32(unconst_u32(117))][u32(unconst_u32(102))][u32(unconst_u32(8))];
+  vw35[0] = mat2x3f(f32(clamp(i32(unconst_i32(3)), i32(unconst_i32(12)), i32(unconst_i32(121)))), bitcast<f32>(clamp(i32(unconst_i32(3)), i32(unconst_i32(12)), i32(unconst_i32(121)))), bitcast<f32>(clamp(i32(unconst_i32(3)), i32(unconst_i32(12)), i32(unconst_i32(121)))), f32(clamp(i32(unconst_i32(3)), i32(unconst_i32(12)), i32(unconst_i32(121)))), f32(clamp(i32(unconst_i32(3)), i32(unconst_i32(12)), i32(unconst_i32(121)))), f32(clamp(i32(unconst_i32(3)), i32(unconst_i32(12)), i32(unconst_i32(121)))));
+  var vf299: vec3h = (*&buffer247)[u32(unconst_u32(104))][u32(unconst_u32(5))][u32(unconst_u32(64))][u32(unconst_u32(8))][u32(unconst_u32(96))];
+  atomicOr(&vw37, i32(buffer247[u32(unconst_u32(150))][2][u32(unconst_u32(30))][0][unconst_i32(0)][2]));
+  vw35[u32(unconst_u32(112))] = mat2x3f(bitcast<f32>(atomicExchange(&vw38, i32(unconst_i32(16)))), f32(atomicExchange(&vw38, i32(unconst_i32(16)))), f32(atomicExchange(&vw38, i32(unconst_i32(16)))), f32(atomicExchange(&vw38, i32(unconst_i32(16)))), f32(atomicExchange(&vw38, i32(unconst_i32(16)))), bitcast<f32>(atomicExchange(&vw38, i32(unconst_i32(16)))));
+  atomicStore(&vw37, i32(unconst_i32(206)));
+  let vf300: i32 = atomicExchange(&(*&vw38), i32(unconst_i32(51)));
+  atomicXor(&vw38, i32(unconst_i32(3)));
+  let vf301: f16 = (*ptr178)[0][u32(unconst_u32(274))][bitcast<u32>((*ptr176)[u32(unconst_u32(30))][u32(unconst_u32(28))][0])];
+  atomicOr(&vw38, i32(unconst_i32(58)));
+  var vf302: u32 = textureDimensions(st11);
+  let ptr179: ptr<uniform, mat2x3h> = &(*ptr177)[1][u32(unconst_u32(3))];
+  textureStore(st11, i32(unconst_i32(63)), vec4f(vec4f((*&buffer247)[14][u32(unconst_u32(34))][vec3u((*&buffer247)[14][u32(unconst_u32(72))][1][u32(unconst_u32(688))][unconst_i32(0)]).g][u32(unconst_u32(201))][unconst_i32(1)].yyxy)));
+  vw36[u32(unconst_u32(195))] = mat2x4f(atanh(vec4f(unconst_f32(0.1153), unconst_f32(0.02993), unconst_f32(0.2292), unconst_f32(0.04423))), atanh(vec4f(unconst_f32(0.1153), unconst_f32(0.02993), unconst_f32(0.2292), unconst_f32(0.04423))));
+  var vf303: f16 = (*&buffer247)[14][2][1][0][u32(unconst_u32(73))][u32(unconst_u32(149))];
+  _ = st11;
+  _ = buffer246;
+  _ = buffer247;
+}`,
+});
+let veryExplicitBindGroupLayout63 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 16,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 464,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout125 = pipeline40.getBindGroupLayout(0);
+let texture363 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16sint'],
+});
+try {
+renderPassEncoder4.drawIndexedIndirect(buffer225, 3_052);
+} catch {}
+try {
+renderPassEncoder4.drawIndirect(buffer11, 4_636);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer16, 'uint16', 820, 157);
+} catch {}
+await gc();
+let texture364 = device0.createTexture({
+  size: [480, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder163.setBindGroup(1, bindGroup124, new Uint32Array(800), 55, 0);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(3, bindGroup161, []);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer68, 1088, new DataView(new ArrayBuffer(5690)), 585, 796);
+} catch {}
+try {
+if (!arrayBuffer45.detached) { new Uint8Array(arrayBuffer45).fill(0x55); };
+} catch {}
+let buffer248 = device0.createBuffer({
+  size: 11657,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandBuffer10 = commandEncoder5.finish();
+try {
+buffer120.unmap();
+} catch {}
+try {
+computePassEncoder20.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 15}
+*/
+{
+  source: videoFrame41,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture351,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup228 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout40,
+  entries: [{binding: 167, resource: {buffer: buffer160, offset: 1280, size: 4416}}],
+});
+let buffer249 = device0.createBuffer({size: 2097, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder266 = device0.createCommandEncoder({});
+let textureView354 = texture290.createView({});
+let computePassEncoder219 = commandEncoder266.beginComputePass({});
+try {
+computePassEncoder28.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+computePassEncoder41.setBindGroup(1, bindGroup128, new Uint32Array(144), 47, 0);
+} catch {}
+try {
+computePassEncoder190.setPipeline(pipeline27);
+} catch {}
+try {
+computePassEncoder219.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder72.executeBundles([renderBundle43, renderBundle43]);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(33, 0, 48, 0);
+} catch {}
+try {
+renderPassEncoder74.setIndexBuffer(buffer38, 'uint16', 1_820, 5_645);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline13);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer55, 3260, new Int16Array(853), 478, 28);
+} catch {}
+let buffer250 = device0.createBuffer({
+  size: 3440,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture365 = device0.createTexture({
+  size: [780, 480, 155],
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture40 = device0.importExternalTexture({label: '\u0013\u5b8d\u{1f6fb}\u9470\u0e31\u4383', source: videoFrame10, colorSpace: 'display-p3'});
+try {
+renderPassEncoder60.setBindGroup(0, bindGroup215);
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(3, bindGroup75, new Uint32Array(324), 54, 0);
+} catch {}
+try {
+renderPassEncoder63.executeBundles([renderBundle46]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer216, 'uint16', 12_734, 491);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline54 = await promise39;
+try {
+  await promise49;
+} catch {}
+try {
+adapter0.label = '\u6fc6\u4543\u4844\u7018\u8feb\u{1fd58}\uc104\u0c5a\u9023';
+} catch {}
+let bindGroup229 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 85, resource: {buffer: buffer125, offset: 256, size: 2892}}],
+});
+let buffer251 = device0.createBuffer({size: 17212, usage: GPUBufferUsage.UNIFORM});
+try {
+renderPassEncoder0.setScissorRect(108, 240, 16, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer10]);
+} catch {}
+let sampler223 = device0.createSampler({addressModeU: 'repeat', minFilter: 'nearest', lodMaxClamp: 34.37});
+try {
+renderPassEncoder44.end();
+} catch {}
+try {
+renderPassEncoder35.setBlendConstant({ r: 346.3, g: 386.8, b: 824.0, a: 454.4, });
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame30,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture55,
+  mipLevel: 1,
+  origin: {x: 8, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup230 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout63,
+  entries: [{binding: 0, resource: {buffer: buffer235, offset: 256, size: 92}}],
+});
+let buffer252 = device0.createBuffer({
+  label: '\u06ed\u{1feb0}\u{1fccb}\u07c7',
+  size: 15302,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let computePassEncoder220 = commandEncoder167.beginComputePass({});
+try {
+computePassEncoder88.setBindGroup(1, bindGroup98);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline32);
+} catch {}
+try {
+buffer104.unmap();
+} catch {}
+let bindGroup231 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout37,
+  entries: [
+    {binding: 184, resource: {buffer: buffer67, offset: 0, size: 320}},
+    {binding: 134, resource: {buffer: buffer25, offset: 1792, size: 7429}},
+    {binding: 24, resource: textureView132},
+    {binding: 19, resource: textureView269},
+  ],
+});
+let texture366 = device0.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth24plus'],
+});
+let sampler224 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+renderPassEncoder53.setScissorRect(5, 28, 78, 28);
+} catch {}
+try {
+renderPassEncoder48.drawIndirect(buffer239, 32);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer32, 844, new Float32Array(14562), 1154, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(2, bindGroup109);
+} catch {}
+try {
+renderPassEncoder48.draw(172, 13, 1_416_127_720, 3);
+} catch {}
+try {
+renderPassEncoder48.drawIndirect(buffer60, 168);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 23}
+*/
+{
+  source: imageData34,
+  origin: { x: 1, y: 1 },
+  flipY: false,
+}, {
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup232 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout55,
+  entries: [{binding: 0, resource: {buffer: buffer216, offset: 256, size: 540}}],
+});
+let renderBundleEncoder51 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], sampleCount: 1, stencilReadOnly: false});
+let sampler225 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 60.42,
+});
+try {
+renderPassEncoder48.draw(228, 6, 65_578_626, 2);
+} catch {}
+try {
+renderPassEncoder48.drawIndexedIndirect(buffer245, 1_036);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer118, 'uint16', 10, 59);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(4, buffer93);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 7}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 2, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55); };
+} catch {}
+document.body.prepend(img13);
+videoFrame54 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'unspecified', transfer: 'bt709'} });
+let autogeneratedBindGroupLayout126 = pipeline53.getBindGroupLayout(0);
+let texture367 = device0.createTexture({
+  size: {width: 16, height: 16, depthOrArrayLayers: 83},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView355 = texture363.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder175.setBindGroup(3, bindGroup224);
+} catch {}
+try {
+computePassEncoder202.setBindGroup(3, bindGroup94, new Uint32Array(191), 23, 0);
+} catch {}
+try {
+renderPassEncoder22.beginOcclusionQuery(136);
+} catch {}
+try {
+renderPassEncoder22.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder48.draw(27, 1, 53_286_668, 3);
+} catch {}
+try {
+renderPassEncoder48.drawIndexedIndirect(buffer95, 44);
+} catch {}
+try {
+renderPassEncoder48.drawIndirect(buffer59, 1_496);
+} catch {}
+try {
+renderBundleEncoder51.setIndexBuffer(buffer36, 'uint32', 108, 108);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(3, buffer18, 1_616, 4_859);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 2676, new Int16Array(4972), 1881, 164);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture132,
+  mipLevel: 0,
+  origin: {x: 52, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(60).fill(56), /* required buffer size: 60 */
+{offset: 60}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(3, bindGroup60, new Uint32Array(5146), 94, 0);
+} catch {}
+try {
+renderPassEncoder48.end();
+} catch {}
+try {
+renderPassEncoder73.setVertexBuffer(1, buffer207, 0, 94);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(1, bindGroup172);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder181.copyBufferToBuffer(buffer47, 360, buffer113, 160, 20);
+} catch {}
+let buffer253 = device0.createBuffer({
+  size: 4134,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let renderPassEncoder75 = commandEncoder181.beginRenderPass({
+  colorAttachments: [{
+  view: textureView222,
+  clearValue: { r: 954.3, g: 711.3, b: -65.44, a: -867.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet4,
+});
+try {
+computePassEncoder161.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+computePassEncoder220.setPipeline(pipeline37);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup201);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup76, new Uint32Array(583), 7, 0);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer130, 'uint32', 140, 11);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(1, bindGroup192, new Uint32Array(765), 23, 0);
+} catch {}
+try {
+renderBundleEncoder51.setIndexBuffer(buffer183, 'uint16', 3_732, 2_036);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(1, buffer17);
+} catch {}
+let imageData49 = new ImageData(124, 256);
+try {
+computePassEncoder85.setBindGroup(3, bindGroup150);
+} catch {}
+try {
+computePassEncoder198.setBindGroup(3, bindGroup111, new Uint32Array(3875), 897, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer221, 'uint32', 832, 374);
+} catch {}
+try {
+renderBundleEncoder51.setIndexBuffer(buffer32, 'uint16', 178, 561);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline39);
+} catch {}
+let pipeline55 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout9,
+  fragment: {module: shaderModule9, constants: {}, targets: [{format: 'rg8unorm'}]},
+  vertex: {
+    module: shaderModule6,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 964,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 248, shaderLocation: 7}],
+      },
+    ],
+  },
+});
+let buffer254 = device0.createBuffer({
+  size: 2514,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture368 = device0.createTexture({
+  size: {width: 97},
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let externalTexture41 = device0.importExternalTexture({source: videoFrame9});
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup89);
+} catch {}
+try {
+renderPassEncoder67.setBindGroup(3, bindGroup215, new Uint32Array(254), 129, 0);
+} catch {}
+try {
+renderPassEncoder66.executeBundles([renderBundle49, renderBundle36]);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline49);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(2, buffer137, 0, 4_720);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(4, buffer189, 4_916, 1_018);
+} catch {}
+let autogeneratedBindGroupLayout127 = pipeline31.getBindGroupLayout(0);
+let bindGroup233 = device0.createBindGroup({layout: veryExplicitBindGroupLayout62, entries: []});
+let buffer255 = device0.createBuffer({
+  size: 6402,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView356 = texture226.createView({mipLevelCount: 1});
+try {
+computePassEncoder143.setBindGroup(1, bindGroup5, new Uint32Array(326), 29, 0);
+} catch {}
+try {
+renderPassEncoder34.setViewport(430.6857690766253, 392.87922178760823, 215.39830682532485, 27.865511774307418, 0.593643446988387, 0.9617326671868344);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(0, bindGroup62);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(0, bindGroup220, new Uint32Array(64), 21, 0);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline39);
+} catch {}
+let recycledExplicitBindGroupLayout12 = pipeline42.getBindGroupLayout(0);
+let renderBundle51 = renderBundleEncoder51.finish({});
+try {
+renderPassEncoder20.setPipeline(pipeline39);
+} catch {}
+try {
+renderPassEncoder73.setVertexBuffer(4, buffer153, 404, 1_819);
+} catch {}
+videoFrame55 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt470bg', transfer: 'log'} });
+let renderBundleEncoder52 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let sampler226 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.20,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder211.setBindGroup(1, bindGroup195, new Uint32Array(1024), 185, 0);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer135, 'uint16', 3_888, 1_267);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(0, bindGroup71);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(2, bindGroup43, new Uint32Array(2058), 147, 0);
+} catch {}
+try {
+renderBundleEncoder52.setIndexBuffer(buffer221, 'uint32', 112, 667);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer32, 32, new BigUint64Array(5345), 51, 0);
+} catch {}
+try {
+adapter0.label = '\u05e8\u03b4\u0428\ub5ee\u92a2\u00c3\uc0a7\u9590\u{1f72f}\u0332';
+} catch {}
+let bindGroup234 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout10,
+  entries: [
+    {binding: 51, resource: textureView86},
+    {binding: 203, resource: {buffer: buffer175, offset: 512, size: 2828}},
+    {binding: 6, resource: {buffer: buffer74, offset: 0, size: 68}},
+    {binding: 153, resource: externalTexture35},
+    {binding: 88, resource: sampler48},
+    {binding: 82, resource: textureView60},
+    {binding: 95, resource: {buffer: buffer99, offset: 256, size: 40}},
+    {binding: 13, resource: sampler134},
+    {binding: 183, resource: textureView66},
+    {binding: 93, resource: {buffer: buffer222, offset: 0, size: 104}},
+    {binding: 104, resource: textureView37},
+  ],
+});
+let buffer256 = device0.createBuffer({
+  size: 15241,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture369 = device0.createTexture({
+  size: [97],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler227 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 78.01,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder57.setBindGroup(1, bindGroup224);
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(36, 10, 232, 18);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer102, 'uint16', 14, 76);
+} catch {}
+try {
+renderBundleEncoder52.setPipeline(pipeline39);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer73, 32, new Int16Array(12190), 2705, 0);
+} catch {}
+let veryExplicitBindGroupLayout64 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 17,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer257 = device0.createBuffer({
+  size: 9733,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture370 = device0.createTexture({
+  size: [390, 240, 1],
+  format: 'r32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture371 = device0.createTexture({
+  size: [480, 1, 1],
+  mipLevelCount: 3,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder67.setBindGroup(0, bindGroup177);
+} catch {}
+try {
+renderPassEncoder74.setBindGroup(1, bindGroup107);
+} catch {}
+try {
+renderPassEncoder68.beginOcclusionQuery(51);
+} catch {}
+try {
+renderPassEncoder20.draw(136, 0, 162_438_267);
+} catch {}
+try {
+renderPassEncoder65.setIndexBuffer(buffer48, 'uint16', 508, 320);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(3, bindGroup14, new Uint32Array(5570), 1_176, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 55, y: 10, z: 0},
+  aspect: 'all',
+}, new Uint8Array(116).fill(248), /* required buffer size: 116 */
+{offset: 116, bytesPerRow: 451}, {width: 222, height: 107, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 7}
+*/
+{
+  source: videoFrame35,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture372 = device0.createTexture({
+  size: [60],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderBundle52 = renderBundleEncoder52.finish({});
+let sampler228 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 40.27,
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup173, new Uint32Array(3263), 1_400, 0);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(1, buffer93, 0, 269);
+} catch {}
+let textureView357 = texture372.createView({aspect: 'all'});
+try {
+renderPassEncoder20.drawIndirect(buffer65, 388);
+} catch {}
+try {
+renderPassEncoder59.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder17.insertDebugMarker('\ubff4');
+} catch {}
+try {
+if (!arrayBuffer29.detached) { new Uint8Array(arrayBuffer29).fill(0x55); };
+} catch {}
+await gc();
+let imageData50 = new ImageData(160, 8);
+try {
+globalThis.someLabel = externalTexture24.label;
+} catch {}
+let buffer258 = device0.createBuffer({size: 30432, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+renderPassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder51.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer19, 'uint16', 136, 169);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 97, height: 60, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame43,
+  origin: { x: 0, y: 10 },
+  flipY: true,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 9, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img3);
+let buffer259 = device0.createBuffer({size: 9955, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let computePassEncoder221 = commandEncoder57.beginComputePass({});
+try {
+computePassEncoder165.setPipeline(pipeline50);
+} catch {}
+try {
+computePassEncoder221.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup160, new Uint32Array(3654), 3_025, 0);
+} catch {}
+try {
+renderPassEncoder68.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder71.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder68.setVertexBuffer(0, buffer21, 2_756, 845);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 390, height: 240, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData15,
+  origin: { x: 1, y: 3 },
+  flipY: true,
+}, {
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 13, y: 7, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 15, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let pipeline56 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment5',
+  constants: {11_428: 0},
+  targets: [{
+  format: 'rg8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule10,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 160,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 36, shaderLocation: 12}],
+      },
+    ],
+  },
+});
+let texture373 = device0.createTexture({
+  size: {width: 60, height: 1, depthOrArrayLayers: 1},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView358 = texture52.createView({baseArrayLayer: 2, arrayLayerCount: 2});
+try {
+computePassEncoder216.setBindGroup(2, bindGroup134);
+} catch {}
+try {
+computePassEncoder118.setBindGroup(3, bindGroup167, new Uint32Array(332), 17, 0);
+} catch {}
+try {
+renderPassEncoder68.setBindGroup(2, bindGroup30, new Uint32Array(7118), 356, 0);
+} catch {}
+try {
+renderPassEncoder66.beginOcclusionQuery(147);
+} catch {}
+document.body.prepend(img4);
+let veryExplicitBindGroupLayout65 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 167,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup235 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [{binding: 0, resource: {buffer: buffer110, offset: 256, size: 512}}],
+});
+let texture374 = device0.createTexture({
+  size: [195],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView359 = texture95.createView({aspect: 'all'});
+try {
+renderPassEncoder13.executeBundles([renderBundle42, renderBundle32]);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline41);
+} catch {}
+document.body.append(img11);
+let bindGroup236 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout2,
+  entries: [{binding: 0, resource: {buffer: buffer86, offset: 0, size: 554}}],
+});
+let texture375 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 1},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView360 = texture215.createView({dimension: '3d'});
+let sampler229 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 83.90,
+  compare: 'greater',
+  maxAnisotropy: 16,
+});
+let externalTexture42 = device0.importExternalTexture({source: videoFrame6});
+try {
+renderPassEncoder72.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder66.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder68.setScissorRect(60, 0, 8, 42);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer127, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture376 = gpuCanvasContext3.getCurrentTexture();
+try {
+renderPassEncoder68.setIndexBuffer(buffer18, 'uint16', 1_666, 14_391);
+} catch {}
+try {
+buffer84.unmap();
+} catch {}
+let bindGroup237 = device0.createBindGroup({
+  label: '\u{1f942}\ued60\u74e1\u9912\u52e3',
+  layout: veryExplicitBindGroupLayout21,
+  entries: [{binding: 140, resource: textureView66}],
+});
+let pipelineLayout22 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout6]});
+try {
+renderPassEncoder30.setBindGroup(3, bindGroup50, new Uint32Array(497), 0, 0);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer243, 'uint32', 256, 6_092);
+} catch {}
+try {
+computePassEncoder146.insertDebugMarker('\u{1f8b1}');
+} catch {}
+try {
+computePassEncoder20.setBindGroup(0, bindGroup47);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup237, new Uint32Array(3818), 158, 0);
+} catch {}
+let texture377 = device0.createTexture({
+  size: [195, 120, 1],
+  mipLevelCount: 6,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler230 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat'});
+try {
+computePassEncoder91.setBindGroup(3, bindGroup150, new Uint32Array(3533), 1_191, 0);
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle3, renderBundle33, renderBundle28, renderBundle42, renderBundle45, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(4, buffer233);
+} catch {}
+let buffer260 = device0.createBuffer({
+  size: 22801,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup97);
+} catch {}
+try {
+computePassEncoder55.setBindGroup(2, bindGroup149, new Uint32Array(6991), 456, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup156, new Uint32Array(2399), 469, 0);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle40, renderBundle6, renderBundle32]);
+} catch {}
+let veryExplicitBindGroupLayout66 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 76,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView361 = texture273.createView({dimension: '2d-array'});
+let renderBundleEncoder53 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+let renderBundle53 = renderBundleEncoder53.finish({});
+try {
+renderPassEncoder45.setBindGroup(3, bindGroup44);
+} catch {}
+try {
+computePassEncoder177.pushDebugGroup('\u07c4');
+} catch {}
+try {
+renderPassEncoder68.insertDebugMarker('\u89b1');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 195, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas4,
+  origin: { x: 25, y: 2 },
+  flipY: false,
+}, {
+  texture: texture73,
+  mipLevel: 1,
+  origin: {x: 59, y: 22, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 20, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = texture283.label;
+} catch {}
+let buffer261 = device0.createBuffer({
+  size: 5031,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let sampler231 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 72.92,
+});
+try {
+renderPassEncoder38.setIndexBuffer(buffer95, 'uint32', 720, 305);
+} catch {}
+let buffer262 = device0.createBuffer({
+  size: 8885,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder135.setBindGroup(0, bindGroup116, new Uint32Array(740), 121, 0);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: 345.8, g: -191.4, b: -831.9, a: -983.0, });
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture378 = device0.createTexture({
+  size: {width: 480, height: 1, depthOrArrayLayers: 12},
+  mipLevelCount: 2,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView362 = texture230.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+try {
+computePassEncoder178.setBindGroup(1, bindGroup92);
+} catch {}
+try {
+renderPassEncoder65.setPipeline(pipeline32);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 0, y: 139, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(155).fill(24), /* required buffer size: 155 */
+{offset: 155}, {width: 780, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas2);
+let texture379 = device0.createTexture({
+  size: [195, 120, 1],
+  mipLevelCount: 2,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder54 = device0.createRenderBundleEncoder({label: '\u7bfa\u{1fbdc}', colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle54 = renderBundleEncoder54.finish({});
+try {
+renderPassEncoder11.setIndexBuffer(buffer254, 'uint16', 920, 489);
+} catch {}
+try {
+renderPassEncoder75.setVertexBuffer(6, buffer207, 948, 3_099);
+} catch {}
+let arrayBuffer53 = buffer64.getMappedRange(280, 0);
+try {
+buffer222.unmap();
+} catch {}
+try {
+computePassEncoder177.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer170, 952, new Int16Array(2052), 425, 112);
+} catch {}
+let pipelineLayout23 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout113]});
+let textureView363 = texture210.createView({dimension: '2d-array', aspect: 'all'});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 240, height: 1, depthOrArrayLayers: 34}
+*/
+{
+  source: img12,
+  origin: { x: 2, y: 120 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 58, y: 0, z: 9},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder53.executeBundles([renderBundle33, renderBundle27, renderBundle8, renderBundle53]);
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer181, 192, new DataView(new ArrayBuffer(4454)), 1088, 2052);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 16, height: 16, depthOrArrayLayers: 83}
+*/
+{
+  source: img8,
+  origin: { x: 6, y: 0 },
+  flipY: true,
+}, {
+  texture: texture367,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 10},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture380 = device0.createTexture({
+  label: '\u3b6d\u{1f91c}\u024b\u351c\u41dd',
+  size: [480, 1, 1],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView364 = texture178.createView({dimension: '2d-array'});
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup109);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer61, 'uint32', 1_324, 1_387);
+} catch {}
+try {
+renderPassEncoder63.setPipeline(pipeline49);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let pipelineLayout24 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout83]});
+let texture381 = device0.createTexture({
+  size: [780, 480, 13],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder55 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'rgb10a2uint', 'rgba16sint', 'rg32uint'],
+  depthStencilFormat: 'depth24plus',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder51.setBindGroup(0, bindGroup201, new Uint32Array(210), 16, 0);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(3, bindGroup46, new Uint32Array(577), 51, 0);
+} catch {}
+let autogeneratedBindGroupLayout128 = pipeline14.getBindGroupLayout(0);
+try {
+computePassEncoder67.setBindGroup(1, bindGroup178);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(1, bindGroup155, new Uint32Array(3972), 911, 0);
+} catch {}
+try {
+renderBundleEncoder55.setVertexBuffer(5, undefined, 172_947_045, 793_417_269);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+document.body.append(img7);
+try {
+renderPassEncoder6.setVertexBuffer(1, undefined, 4_472_745);
+} catch {}
+try {
+computePassEncoder133.pushDebugGroup('\u5e4e');
+} catch {}
+try {
+if (!arrayBuffer34.detached) { new Uint8Array(arrayBuffer34).fill(0x55); };
+} catch {}
+let imageData51 = new ImageData(4, 16);
+try {
+adapter0.label = '\u0929\uee6b\u0a8e\u{1fd64}\u{1f922}\u{1f761}\u{1fdc2}';
+} catch {}
+let shaderModule16 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+@group(0) @binding(6) var<storage, read> buffer263: array<array<array<f16, 1>, 1>, 34>;
+
+@group(0) @binding(95) var<storage, read_write> buffer265: array<array<array<f16, 1>, 6>, 1>;
+
+@group(0) @binding(203) var<storage, read> buffer266: array<array<vec2i, 288>>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct VertexOutput13 {
+  @location(13) f49: vec4u,
+  @location(10) f50: vec2u,
+  @location(5) @interpolate(flat, centroid) f51: f32,
+  @location(12) @interpolate(flat, center) f52: vec4u,
+  @location(0) f53: f16,
+  @builtin(position) f54: vec4f,
+  @location(11) @interpolate(flat, centroid) f55: u32,
+  @location(7) @interpolate(flat, centroid) f56: vec4h,
+  @location(14) @interpolate(perspective, centroid) f57: vec4h,
+  @location(1) f58: vec4f,
+  @location(9) @interpolate(linear, centroid) f59: vec2f,
+  @location(3) f60: vec4u,
+  @location(4) @interpolate(flat, sample) f61: vec4f,
+  @location(15) @interpolate(flat, sample) f62: vec4u,
+  @location(2) f63: f32,
+  @location(6) f64: u32,
+  @location(8) @interpolate(linear, sample) f65: vec4f,
+}
+
+var<private> vp29: array<VertexOutput12, 1> = array<VertexOutput12, 1>(VertexOutput12(vec2h(12476.8, 18052.6), vec4f(0.02817, 0.4229, 0.01939, 0.1360), vec4u(34, 94, 961, 33), vec4i(87, 125, 35, 102), vec2i(84, 13), i32(44), f32(0.2327), vec4f(0.05164, 0.03103, 0.2058, 0.4219)));
+
+var<workgroup> vw39: atomic<u32>;
+
+struct VertexOutput12 {
+  @location(12) @interpolate(perspective, centroid) f41: vec2h,
+  @location(7) @interpolate(perspective, sample) f42: vec4f,
+  @location(0) f43: vec4u,
+  @location(4) f44: vec4i,
+  @location(3) @interpolate(flat, centroid) f45: vec2i,
+  @location(9) @interpolate(flat) f46: i32,
+  @location(8) @interpolate(flat) f47: f32,
+  @builtin(position) f48: vec4f,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<private> vp27 = array(modf(vec4f(0.1299, 0.2755, 0.08583, -0.5549)));
+
+@group(0) @binding(93) var<storage, read> buffer264: f16;
+
+@group(0) @binding(51) var tex11: texture_depth_2d;
+
+var<workgroup> vw40: VertexOutput12;
+
+var<private> vp28: array<VertexOutput12, 1> = array(VertexOutput12());
+
+fn fn0(a0: ptr<uniform, array<array<vec4f, 1>, 1>>) -> VertexOutput12 {
+  var out: VertexOutput12;
+  out.f44 = vec4i(vp27[0].whole);
+  out.f42 = vec4f(f32(vp29[u32(unconst_u32(168))].f41[u32(unconst_u32(25))]));
+  var vf304: f32 = exp2(f32(unconst_f32(0.5119)));
+  out.f48 = vec4f(vp28[u32(unconst_u32(100))].f47);
+  let ptr180: ptr<private, vec4u> = &vp28[0].f43;
+  out.f44 = vec4i(vp29[0].f45[u32(unconst_u32(41))]);
+  var vf305: f32 = vp29[u32(unconst_u32(164))].f48[u32(unconst_u32(119))];
+  let ptr181: ptr<private, vec2h> = &vp28[u32(unconst_u32(174))].f41;
+  vp28[0] = VertexOutput12(vec2h(vp29[0].f48.zw), vp29[0].f48, bitcast<vec4u>(vp29[0].f48), vec4i(vp29[0].f48), bitcast<vec2i>(vp29[0].f48.bg), bitcast<i32>(vp29[0].f48.w), vp29[0].f48.w, vp29[0].f48);
+  let ptr182: ptr<uniform, array<vec4f, 1>> = &(*a0)[0];
+  let ptr183: ptr<private, vec4f> = &vp29[u32(unconst_u32(63))].f48;
+  var vf306: u32 = vp28[u32(unconst_u32(6))].f43[u32(unconst_u32(213))];
+  let ptr184: ptr<private, vec4f> = &vp28[pack4xI8Clamp(vp29[0].f44)].f48;
+  return out;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(82) var st12: texture_storage_3d<r32float, read_write>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T0 {
+  @align(64) @size(1536) f0: array<array<mat4x2f, 2>, 4>,
+}
+
+@vertex
+fn vertex14() -> VertexOutput12 {
+  var out: VertexOutput12;
+  out.f41 += bitcast<vec2h>(vp29[0].f46);
+  out.f45 ^= vec2i(bitcast<i32>(vp29[0].f47));
+  let ptr185: ptr<private, vec2i> = &vp29[u32(unconst_u32(265))].f45;
+  vp27[u32(unconst_u32(136))].whole = vp27[0].whole;
+  vp27[u32(unconst_u32(71))] = modf(vec4f(vp28[u32(unconst_u32(76))].f47));
+  let ptr186: ptr<storage, f16, read> = &buffer264;
+  out.f44 = vec4i(bitcast<i32>(vp29[u32(unconst_u32(11))].f48[u32(unconst_u32(102))]));
+  out.f46 += bitcast<i32>(textureDimensions(tex11)[0]);
+  vp28[u32(unconst_u32(26))].f41 *= vp28[0].f41;
+  let ptr187: ptr<private, vec4f> = &vp27[0].whole;
+  let ptr188: ptr<private, VertexOutput12> = &vp29[0];
+  return out;
+  _ = buffer264;
+  _ = tex11;
+}
+
+@vertex
+fn vertex15(@location(6) a0: vec2u, @location(15) @interpolate(flat) a1: vec4i, @location(9) a2: vec4f) -> VertexOutput13 {
+  var out: VertexOutput13;
+  var vf307: u32 = vp28[0].f43[u32(unconst_u32(77))];
+  out.f64 -= pack4xU8(vec4u(vp28[0].f48));
+  vf307 |= u32(vp28[u32(unconst_u32(256))].f46);
+  out.f54 += unpack4x8snorm(dot4U8Packed(u32(unconst_u32(97)), u32(unconst_u32(100))));
+  let vf308: f32 = vp29[0].f42[u32(unconst_u32(173))];
+  out.f51 = vp28[u32(unconst_u32(347))].f42[pack4xU8Clamp(vec4u(vp28[0].f48))];
+  let ptr189: ptr<private, vec4f> = &vp29[0].f42;
+  return out;
+}
+
+@compute @workgroup_size(3, 1, 1)
+fn compute16() {
+  let ptr190: ptr<storage, array<f16, 1>, read_write> = &(*&buffer265)[0][5];
+  vw40 = VertexOutput12(vec2h((*&buffer266)[arrayLength(&(*&buffer266)) - 1][287]), vec4f((*&buffer266)[arrayLength(&(*&buffer266)) - 1][287].yxxy), bitcast<vec4u>((*&buffer266)[arrayLength(&(*&buffer266)) - 1][287].yxxy), (*&buffer266)[arrayLength(&(*&buffer266)) - 1][287].gggg, (*&buffer266)[arrayLength(&(*&buffer266)) - 1][287], (*&buffer266)[arrayLength(&(*&buffer266)) - 1][287].g, vec2f((*&buffer266)[arrayLength(&(*&buffer266)) - 1][287])[0], vec4f((*&buffer266)[arrayLength(&(*&buffer266)) - 1][287].xxyx));
+  vp28[u32(unconst_u32(93))] = VertexOutput12(vec2h(vp28[0].f45), vec4f(vp28[0].f45.ggrr), bitcast<vec4u>(vp28[0].f45.ggrg), vp28[0].f45.yxxy, vp28[0].f45, vp28[0].f45[0], bitcast<f32>(vp28[0].f45.g), bitcast<vec4f>(vp28[0].f45.rrgg));
+  let ptr191: ptr<storage, f16, read_write> = &(*ptr190)[bitcast<u32>(vp28[u32(unconst_u32(227))].f45[u32(unconst_u32(3))])];
+  vp29[u32(vp29[u32(unconst_u32(34))].f44[u32(unconst_u32(166))])] = VertexOutput12(vec2h((*&buffer263)[33][0][0]), vec4f(f32((*&buffer263)[33][0][0])), vec4u(u32((*&buffer263)[33][0][0])), vec4i(i32((*&buffer263)[33][0][0])), vec2i(i32((*&buffer263)[33][0][0])), i32((*&buffer263)[33][0][0]), f32((*&buffer263)[33][0][0]), vec4f(f32((*&buffer263)[33][0][0])));
+  vw40 = VertexOutput12(vec2h(buffer265[0][5][u32(unconst_u32(86))]), vec4f(f32(buffer265[0][5][u32(unconst_u32(86))])), vec4u(u32(buffer265[0][5][u32(unconst_u32(86))])), vec4i(i32(buffer265[0][5][u32(unconst_u32(86))])), vec2i(i32(buffer265[0][5][u32(unconst_u32(86))])), i32(buffer265[0][5][u32(unconst_u32(86))]), f32(buffer265[0][5][u32(unconst_u32(86))]), vec4f(f32(buffer265[0][5][u32(unconst_u32(86))])));
+  textureStore(st12, vec3i(unconst_i32(-34), unconst_i32(114), unconst_i32(154)), vec4f(vec4f(unconst_f32(0.1173), unconst_f32(0.2750), unconst_f32(-0.04965), unconst_f32(0.3679))));
+  let ptr192: ptr<storage, f16, read_write> = &(*&buffer265)[0][5][u32(unconst_u32(342))];
+  _ = buffer266;
+  _ = st12;
+  _ = buffer263;
+  _ = buffer265;
+}`,
+});
+let veryExplicitBindGroupLayout67 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 93,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 102,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 103,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let pipelineLayout25 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout23, veryExplicitBindGroupLayout65]});
+let texture382 = device0.createTexture({
+  size: {width: 120, height: 1, depthOrArrayLayers: 18},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle55 = renderBundleEncoder55.finish({});
+try {
+computePassEncoder154.setBindGroup(1, bindGroup162, new Uint32Array(609), 62, 0);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup208, new Uint32Array(908), 265, 0);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline32);
+} catch {}
+try {
+computePassEncoder133.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+await gc();
+try {
+renderPassEncoder59.setBindGroup(2, bindGroup34, new Uint32Array(1505), 110, 0);
+} catch {}
+try {
+renderPassEncoder57.executeBundles([renderBundle32, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer233, 124);
+} catch {}
+try {
+computePassEncoder210.insertDebugMarker('\u7b67');
+} catch {}
+await gc();
+videoFrame56 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpteRp431', transfer: 'bt2020_10bit'} });
+let buffer267 = device0.createBuffer({
+  size: 1090,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView365 = texture215.createView({baseMipLevel: 0});
+try {
+computePassEncoder202.setBindGroup(0, bindGroup132);
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline38);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55); };
+} catch {}
+let textureView366 = texture266.createView({arrayLayerCount: 1});
+let sampler232 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.36,
+  compare: 'greater-equal',
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder193.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(4, buffer42, 864, 1_667);
+} catch {}
+document.body.append(canvas3);
+let img17 = await imageWithData(6, 58, '#10101010', '#20202020');
+let imageData52 = new ImageData(96, 80);
+let querySet46 = device0.createQuerySet({type: 'occlusion', count: 288});
+let texture383 = device0.createTexture({
+  size: [120, 1, 1],
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView367 = texture248.createView({});
+try {
+computePassEncoder190.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup207, new Uint32Array(432), 217, 0);
+} catch {}
+try {
+buffer68.unmap();
+} catch {}
+let recycledAutogeneratedBindGroupLayout5 = pipeline51.getBindGroupLayout(0);
+let buffer268 = device0.createBuffer({size: 13936, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView368 = texture383.createView({dimension: '2d-array'});
+let sampler233 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 81.73,
+  lodMaxClamp: 83.91,
+});
+try {
+computePassEncoder211.setBindGroup(0, bindGroup147, new Uint32Array(3137), 1_382, 0);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(1, bindGroup205, new Uint32Array(1151), 142, 0);
+} catch {}
+try {
+renderPassEncoder56.setScissorRect(127, 20, 24, 140);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer137, 'uint32', 12_468, 224);
+} catch {}
+let texture384 = device0.createTexture({
+  size: [120, 1, 1],
+  sampleCount: 4,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler234 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+let externalTexture43 = device0.importExternalTexture({source: videoFrame24, colorSpace: 'srgb'});
+try {
+computePassEncoder163.setBindGroup(1, bindGroup201, new Uint32Array(2025), 691, 0);
+} catch {}
+try {
+renderPassEncoder71.setBindGroup(1, bindGroup49);
+} catch {}
+try {
+renderPassEncoder75.setIndexBuffer(buffer100, 'uint32', 820, 225);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(3, buffer98);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+document.body.prepend(canvas4);
+try {
+externalTexture19.label = '\ud9ce\u5a86\u0580\u061b\u09d9\u0685\u8cc5\u2cae\u5cd3\ua87f';
+} catch {}
+let pipelineLayout26 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout0]});
+let buffer269 = device0.createBuffer({size: 9823, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture385 = device0.createTexture({
+  size: {width: 97, height: 60, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView369 = texture95.createView({aspect: 'depth-only'});
+try {
+computePassEncoder162.setBindGroup(2, bindGroup185, new Uint32Array(3960), 1_001, 0);
+} catch {}
+try {
+renderPassEncoder69.setBindGroup(1, bindGroup222);
+} catch {}
+try {
+renderPassEncoder66.setBindGroup(1, bindGroup40, new Uint32Array(2383), 98, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+await gc();
+let textureView370 = texture384.createView({});
+let texture386 = device0.createTexture({
+  label: '\u{1fa59}\ubf3d\u4e3e\u0b1b\ub299',
+  size: {width: 480, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16uint'],
+});
+let sampler235 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 59.37,
+});
+let externalTexture44 = device0.importExternalTexture({source: videoFrame23});
+try {
+computePassEncoder151.setBindGroup(3, bindGroup154, new Uint32Array(6538), 436, 0);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer170, 'uint16', 1_572, 42);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer48, 0, 1_137);
+} catch {}
+await gc();
+let recycledExplicitBindGroupLayout13 = pipeline28.getBindGroupLayout(0);
+let bindGroup238 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout29,
+  entries: [{binding: 191, resource: {buffer: buffer139, offset: 1280, size: 2576}}],
+});
+let texture387 = device0.createTexture({
+  size: [780, 480, 1],
+  mipLevelCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture388 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler236 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 72.20,
+  maxAnisotropy: 17,
+});
+try {
+renderPassEncoder29.setPipeline(pipeline32);
+} catch {}
+try {
+renderPassEncoder70.setVertexBuffer(4, buffer161);
+} catch {}
+let arrayBuffer54 = buffer64.getMappedRange(216, 0);
+try {
+buffer147.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 42, y: 9, z: 0},
+  aspect: 'all',
+}, new Uint8Array(162).fill(211), /* required buffer size: 162 */
+{offset: 162, bytesPerRow: 51}, {width: 8, height: 18, depthOrArrayLayers: 0});
+} catch {}
+let promise50 = device0.queue.onSubmittedWorkDone();
+let veryExplicitBindGroupLayout68 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 106,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 195,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16sint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let autogeneratedBindGroupLayout129 = pipeline10.getBindGroupLayout(0);
+let textureView371 = texture387.createView({aspect: 'all', baseMipLevel: 0});
+let textureView372 = texture154.createView({dimension: '2d', aspect: 'stencil-only', baseMipLevel: 0, arrayLayerCount: 1});
+try {
+renderPassEncoder19.executeBundles([renderBundle6, renderBundle33]);
+} catch {}
+try {
+renderPassEncoder15.setViewport(13.852426886713534, 177.43799061035452, 5.343705658409611, 52.70798425234207, 0.9078543732434851, 0.912351817519246);
+} catch {}
+try {
+renderPassEncoder45.setIndexBuffer(buffer183, 'uint16', 12_012, 453);
+} catch {}
+try {
+renderPassEncoder56.setPipeline(pipeline12);
+} catch {}
+let textureView373 = texture132.createView({dimension: '2d', format: 'rgba8unorm-srgb'});
+let sampler237 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+renderPassEncoder58.setIndexBuffer(buffer223, 'uint16', 3_894, 94);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture129,
+  mipLevel: 0,
+  origin: {x: 2, y: 3, z: 2},
+  aspect: 'all',
+}, new Uint8Array(8).fill(240), /* required buffer size: 8 */
+{offset: 8}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 97, height: 60, depthOrArrayLayers: 43}
+*/
+{
+  source: videoFrame17,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 19, y: 5, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder70.setBindGroup(0, bindGroup21, new Uint32Array(4108), 813, 0);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(2, bindGroup137, new Uint32Array(5601), 276, 0);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline13);
+} catch {}
+videoFrame57 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'bt470bg', transfer: 'gamma22curve'} });
+try {
+texture148.label = '\u1320\uc6cd\u76f5';
+} catch {}
+let veryExplicitBindGroupLayout69 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 93,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 102,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 103,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let bindGroup239 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout9,
+  entries: [{binding: 0, resource: {buffer: buffer222, offset: 0, size: 316}}],
+});
+try {
+computePassEncoder157.setBindGroup(3, bindGroup228);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(1, bindGroup180);
+} catch {}
+try {
+renderPassEncoder68.setIndexBuffer(buffer135, 'uint16', 914, 3_845);
+} catch {}
+try {
+renderPassEncoder30.setPipeline(pipeline38);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(3, buffer159);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer189, 1840, new Int16Array(22777), 1780, 676);
+} catch {}
+let textureView374 = texture115.createView({dimension: '2d-array'});
+let sampler238 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 61.13,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup168, new Uint32Array(1229), 138, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup40, new Uint32Array(975), 137, 0);
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle10, renderBundle6, renderBundle8]);
+} catch {}
+try {
+  await shaderModule5.getCompilationInfo();
+} catch {}
+let buffer270 = device0.createBuffer({
+  size: 3413,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture389 = device0.createTexture({
+  label: '\u3274\ufdfb\u{1fe75}\u1eb0',
+  size: [16, 16, 22],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let externalTexture45 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup33, new Uint32Array(457), 190, 0);
+} catch {}
+try {
+renderPassEncoder72.setBindGroup(3, bindGroup124);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([renderBundle28, renderBundle42]);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(5, undefined, 0, 232_079_280);
+} catch {}
+let promise51 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise51;
+} catch {}
+try {
+globalThis.someLabel = autogeneratedBindGroupLayout73.label;
+} catch {}
+let buffer271 = device0.createBuffer({
+  label: '\uab4a\u{1fa46}\u5c5b\u0510\u094c\u03ad\u0912\u{1f7d6}\u9685',
+  size: 5781,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup168, new Uint32Array(2117), 1_539, 0);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer213, 'uint32', 252, 75);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline28);
+} catch {}
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55); };
+} catch {}
+let buffer272 = device0.createBuffer({
+  size: 26048,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView375 = texture29.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder73.setBindGroup(1, bindGroup201);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture62,
+  mipLevel: 0,
+  origin: {x: 29, y: 9, z: 5},
+  aspect: 'all',
+}, new Uint8Array(29_578).fill(145), /* required buffer size: 29_578 */
+{offset: 60, bytesPerRow: 88, rowsPerImage: 46}, {width: 19, height: 14, depthOrArrayLayers: 8});
+} catch {}
+let recycledExplicitBindGroupLayout14 = pipeline33.getBindGroupLayout(0);
+let textureView376 = texture109.createView({mipLevelCount: 1});
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup89);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer172, 'uint16', 26, 1);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(1, buffer106);
+} catch {}
+let promise52 = device0.queue.onSubmittedWorkDone();
+let shaderModule17 = device0.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn fn0(a0: array<array<mat2x2f, 1>, 3>) -> array<array<array<array<VertexOutput14, 1>, 1>, 1>, 1> {
+  var out: array<array<array<array<VertexOutput14, 1>, 1>, 1>, 1>;
+  var vf309: vec3u = insertBits(vec3u(sin(vec4h(unconst_f16(3804.1), unconst_f16(24913.8), unconst_f16(12145.7), unconst_f16(-1392.0))).aar), vec3u(bitcast<u32>(a0[u32(unconst_u32(148))][0][u32(unconst_u32(160))][u32(unconst_u32(382))])), u32(unconst_u32(43)), u32(unconst_u32(216)));
+  out[u32(unconst_u32(50))][u32(unconst_u32(306))][u32(unconst_u32(14))][u32(unconst_u32(244))].f66 = asinh(vec2f(unconst_f32(0.05046), unconst_f32(0.1316))).grrr;
+  return out;
+}
+
+struct T4 {
+  f0: array<T2, 1>,
+}
+
+@group(0) @binding(0) var<uniform> buffer273: vec2f;
+
+var<workgroup> vw42: mat2x2f;
+
+var<workgroup> vw41: T0;
+
+@id(30455) override override17: f16 = -1076.4;
+
+struct FragmentOutput13 {
+  @location(1) @interpolate(flat) f0: vec4u,
+  @location(2) @interpolate(flat) f1: vec4u,
+  @location(0) @interpolate(flat, center) f2: vec4i,
+}
+
+struct VertexOutput14 {
+  @builtin(position) f66: vec4f,
+}
+
+struct T1 {
+  @size(88) f0: array<atomic<u32>>,
+}
+
+var<workgroup> vw43: atomic<i32>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T0 {
+  @size(96) f0: array<array<vec4i, 1>, 5>,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp30: VertexOutput14 = VertexOutput14(vec4f(0.08585, 0.3711, 0.00023, 0.06241));
+
+struct T2 {
+  @align(8) @size(88) f0: atomic<u32>,
+}
+
+@id(47811) override override16: u32;
+
+var<workgroup> vw44: atomic<i32>;
+
+struct T3 {
+  f0: array<T2>,
+}
+
+@vertex
+fn vertex16() -> VertexOutput14 {
+  var out: VertexOutput14;
+  var vf310: f32 = (*&buffer273)[u32(unconst_u32(60))];
+  fn0(array<array<mat2x2f, 1>, 3>(array<mat2x2f, 1>(mat2x2f(acos(vec2f(unconst_f32(0.08683), unconst_f32(0.1100))), acos(vec2f(unconst_f32(0.08683), unconst_f32(0.1100))))), array<mat2x2f, 1>(mat2x2f(acos(vec2f(unconst_f32(0.08683), unconst_f32(0.1100))), acos(vec2f(unconst_f32(0.08683), unconst_f32(0.1100))))), array<mat2x2f, 1>(mat2x2f(acos(vec2f(unconst_f32(0.08683), unconst_f32(0.1100))), acos(vec2f(unconst_f32(0.08683), unconst_f32(0.1100)))))));
+  let vf311: vec3f = sign(vec3f(unconst_f32(0.02530), unconst_f32(0.4027), unconst_f32(0.2287)));
+  fn0(array<array<mat2x2f, 1>, 3>(array<mat2x2f, 1>(mat2x2f(round(vec4f(unconst_f32(-0.3001), unconst_f32(0.01072), unconst_f32(0.02735), unconst_f32(0.00385))).zw, round(vec4f(unconst_f32(-0.3001), unconst_f32(0.01072), unconst_f32(0.02735), unconst_f32(0.00385))).aa)), array<mat2x2f, 1>(mat2x2f(round(vec4f(unconst_f32(-0.3001), unconst_f32(0.01072), unconst_f32(0.02735), unconst_f32(0.00385))).ag, round(vec4f(unconst_f32(-0.3001), unconst_f32(0.01072), unconst_f32(0.02735), unconst_f32(0.00385))).xw)), array<mat2x2f, 1>(mat2x2f(round(vec4f(unconst_f32(-0.3001), unconst_f32(0.01072), unconst_f32(0.02735), unconst_f32(0.00385))).rb, round(vec4f(unconst_f32(-0.3001), unconst_f32(0.01072), unconst_f32(0.02735), unconst_f32(0.00385))).yz))));
+  fn0(array<array<mat2x2f, 1>, 3>(array<mat2x2f, 1>(mat2x2f(buffer273, buffer273)), array<mat2x2f, 1>(mat2x2f(buffer273, buffer273)), array<mat2x2f, 1>(mat2x2f(buffer273, buffer273))));
+  fn0(array<array<mat2x2f, 1>, 3>(array<mat2x2f, 1>(mat2x2f(acos(vec2f(unconst_f32(0.01045), unconst_f32(0.02752))), acos(vec2f(unconst_f32(0.01045), unconst_f32(0.02752))))), array<mat2x2f, 1>(mat2x2f(acos(vec2f(unconst_f32(0.01045), unconst_f32(0.02752))), acos(vec2f(unconst_f32(0.01045), unconst_f32(0.02752))))), array<mat2x2f, 1>(mat2x2f(acos(vec2f(unconst_f32(0.01045), unconst_f32(0.02752))), acos(vec2f(unconst_f32(0.01045), unconst_f32(0.02752)))))));
+  let ptr193: ptr<uniform, vec2f> = &(*&buffer273);
+  let vf312: vec4i = countOneBits(vec4i(unconst_i32(42), unconst_i32(21), unconst_i32(30), unconst_i32(23)));
+  fn0(array<array<mat2x2f, 1>, 3>(array<mat2x2f, 1>(mat2x2f(atan(vec4f(unconst_f32(0.02368), unconst_f32(0.1075), unconst_f32(0.1292), unconst_f32(0.09657))).aa, atan(vec4f(unconst_f32(0.02368), unconst_f32(0.1075), unconst_f32(0.1292), unconst_f32(0.09657))).wx)), array<mat2x2f, 1>(mat2x2f(atan(vec4f(unconst_f32(0.02368), unconst_f32(0.1075), unconst_f32(0.1292), unconst_f32(0.09657))).bb, atan(vec4f(unconst_f32(0.02368), unconst_f32(0.1075), unconst_f32(0.1292), unconst_f32(0.09657))).ga)), array<mat2x2f, 1>(mat2x2f(atan(vec4f(unconst_f32(0.02368), unconst_f32(0.1075), unconst_f32(0.1292), unconst_f32(0.09657))).aa, atan(vec4f(unconst_f32(0.02368), unconst_f32(0.1075), unconst_f32(0.1292), unconst_f32(0.09657))).ag))));
+  vp30 = VertexOutput14(vec4f(tanh(f32(unconst_f32(0.03679)))));
+  var vf313: vec2u = reverseBits(vec2u(unconst_u32(39), unconst_u32(70)));
+  let vf314: vec4f = floor(vec4f(unconst_f32(-0.01139), unconst_f32(0.07658), unconst_f32(0.1118), unconst_f32(0.1161)));
+  var vf315: vec2h = log2(vec2h(unconst_f16(9047.5), unconst_f16(13079.5)));
+  out.f66 += vec4f(vp30.f66[u32(unconst_u32(466))]);
+  vf315 *= bitcast<vec2h>(vf312[u32(unconst_u32(391))]);
+  let vf316: vec4u = countTrailingZeros(vec4u(unconst_u32(20), unconst_u32(412), unconst_u32(129), unconst_u32(61)));
+  return out;
+  _ = buffer273;
+}
+
+@fragment
+fn fragment14(@builtin(sample_index) a0: u32) -> FragmentOutput13 {
+  var out: FragmentOutput13;
+  out.f1 >>= vec4u(transpose(mat4x4h())[unconst_i32(3)]);
+  let ptr194: ptr<private, vec4f> = &vp30.f66;
+  let ptr195: ptr<private, vec4f> = &vp30.f66;
+  let vf317: vec4f = sign(vec4f(unconst_f32(0.3708), unconst_f32(0.1215), unconst_f32(0.2890), unconst_f32(0.09600)));
+  out.f2 &= abs(vec2i(vp30.f66.xx)).rrgg;
+  let ptr196: ptr<private, vec4f> = &vp30.f66;
+  out.f1 = vec4u(a0);
+  var vf318: vec2f = mix(vec2f(unconst_f32(0.06837), unconst_f32(0.2268)), vec2f(unconst_f32(0.2132), unconst_f32(0.08814)), f32(unconst_f32(0.05529)));
+  var vf319: mat2x2f = transpose(mat2x2f());
+  let ptr197: ptr<function, mat2x2f> = &vf319;
+  var vf320: vec4f = sign(vec4f(unconst_f32(0.00123), unconst_f32(0.01226), unconst_f32(0.03249), unconst_f32(0.3691)));
+  out.f2 = vec4i(abs(vec2f(unconst_f32(0.00419), unconst_f32(0.08232))).xxyy);
+  let ptr198: ptr<private, vec4f> = &(*ptr195);
+  vf319 = mat2x2f(select(vec3f(unconst_f32(0.8620), unconst_f32(0.06765), unconst_f32(0.1282)), vec3f(unconst_f32(0.1561), unconst_f32(0.5001), unconst_f32(0.00541)), vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(true))).yx, select(vec3f(unconst_f32(0.8620), unconst_f32(0.06765), unconst_f32(0.1282)), vec3f(unconst_f32(0.1561), unconst_f32(0.5001), unconst_f32(0.00541)), vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(true))).bb);
+  var vf321: u32 = firstLeadingBit(u32(unconst_u32(299)));
+  var vf322: vec3f = radians(vec3f(bitcast<f32>(vf321)));
+  vf322 = vec3f(insertBits(vec2u(unconst_u32(230), unconst_u32(118)), vec2u(unconst_u32(159), unconst_u32(201)), u32(unconst_u32(19)), u32(unconst_u32(161))).ggg);
+  let vf323: vec3f = sinh(vec3f(unconst_f32(0.07080), unconst_f32(0.1504), unconst_f32(0.07856)));
+  vf320 = vf318.xyxx;
+  return out;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn compute17() {
+  atomicSub(&vw43, i32(unconst_i32(197)));
+  let ptr199: ptr<workgroup, mat2x2f> = &(*&vw42);
+  let ptr200: ptr<workgroup, array<array<vec4i, 1>, 5>> = &vw41.f0;
+  vw41 = T0(array<array<vec4i, 1>, 5>(array<vec4i, 1>(vec4i(bitcast<i32>(pack4xI8Clamp(vec4i(unconst_i32(243), unconst_i32(81), unconst_i32(113), unconst_i32(41)))))), array<vec4i, 1>(vec4i(bitcast<i32>(pack4xI8Clamp(vec4i(unconst_i32(243), unconst_i32(81), unconst_i32(113), unconst_i32(41)))))), array<vec4i, 1>(vec4i(bitcast<i32>(pack4xI8Clamp(vec4i(unconst_i32(243), unconst_i32(81), unconst_i32(113), unconst_i32(41)))))), array<vec4i, 1>(unpack4xI8(pack4xI8Clamp(vec4i(unconst_i32(243), unconst_i32(81), unconst_i32(113), unconst_i32(41))))), array<vec4i, 1>(vec4i(bitcast<i32>(pack4xI8Clamp(vec4i(unconst_i32(243), unconst_i32(81), unconst_i32(113), unconst_i32(41))))))));
+  var vf324: vec3h = cross(vec3h(unconst_f16(5677.9), unconst_f16(584.2), unconst_f16(13436.2)), vec3h(unconst_f16(2440.6), unconst_f16(1713.9), unconst_f16(9084.1)));
+  let vf325: vec3f = round(vec3f(unconst_f32(0.09236), unconst_f32(-0.5492), unconst_f32(0.2328)));
+  let ptr201: ptr<workgroup, array<array<vec4i, 1>, 5>> = &(*&vw41).f0;
+  vw41 = T0(array<array<vec4i, 1>, 5>(array<vec4i, 1>((*ptr200)[pack4xI8Clamp(vec4i(unconst_i32(26), unconst_i32(4), unconst_i32(130), unconst_i32(137)))][pack4xI8((*ptr201)[4][0])]), array<vec4i, 1>((*ptr200)[pack4xI8Clamp(vec4i(unconst_i32(26), unconst_i32(4), unconst_i32(130), unconst_i32(137)))][pack4xI8((*ptr201)[4][0])]), array<vec4i, 1>((*ptr200)[pack4xI8Clamp(vec4i(unconst_i32(26), unconst_i32(4), unconst_i32(130), unconst_i32(137)))][pack4xI8((*ptr201)[4][0])]), array<vec4i, 1>((*ptr200)[pack4xI8Clamp(vec4i(unconst_i32(26), unconst_i32(4), unconst_i32(130), unconst_i32(137)))][pack4xI8((*ptr201)[4][0])]), array<vec4i, 1>((*ptr200)[pack4xI8Clamp(vec4i(unconst_i32(26), unconst_i32(4), unconst_i32(130), unconst_i32(137)))][pack4xI8((*ptr201)[4][0])])));
+  let ptr202: ptr<workgroup, vec4i> = &(*ptr200)[4][0];
+  let vf326: i32 = (*&vw41).f0[u32(unconst_u32(17))][u32(unconst_u32(208))][u32(unconst_u32(10))];
+  vf324 += vec3h(vw41.f0[u32(unconst_u32(529))][0].rgg);
+  vw41 = T0(array<array<vec4i, 1>, 5>(array<vec4i, 1>(vec4i(atomicLoad(&(*&vw44)))), array<vec4i, 1>(vec4i(atomicLoad(&(*&vw44)))), array<vec4i, 1>(vec4i(atomicLoad(&(*&vw44)))), array<vec4i, 1>(vec4i(atomicLoad(&(*&vw44)))), array<vec4i, 1>(vec4i(atomicLoad(&(*&vw44))))));
+  vf324 = vec3h((*ptr201)[u32(unconst_u32(135))][0].xwx);
+  let ptr203: ptr<workgroup, vec4i> = &(*ptr202);
+  let ptr204: ptr<workgroup, vec4i> = &(*ptr201)[u32(unconst_u32(132))][u32(unconst_u32(29))];
+  var vf327: bool = all(bool(unconst_bool(false)));
+  vf324 -= vec3h(f16(pack4xI8Clamp(vec4i(i32(vf325[u32(unconst_u32(268))])))));
+  vf324 = vec3h(f16(pack4xI8(vec4i(unconst_i32(59), unconst_i32(140), unconst_i32(91), unconst_i32(36)))));
+  let ptr205: ptr<workgroup, vec4i> = &(*ptr201)[pack4xI8(vw41.f0[u32(unconst_u32(163))][0])][0];
+  let ptr206: ptr<workgroup, array<vec4i, 1>> = &(*ptr200)[u32(unconst_u32(355))];
+}`,
+});
+let recycledAutogeneratedBindGroupLayout6 = pipeline43.getBindGroupLayout(0);
+let bindGroup240 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout13,
+  entries: [{binding: 85, resource: {buffer: buffer65, offset: 1536, size: 1272}}],
+});
+let texture390 = device0.createTexture({
+  size: {width: 60, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler239 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', minFilter: 'linear', lodMaxClamp: 91.40});
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup78, new Uint32Array(10000), 3_202, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture317,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(60).fill(125), /* required buffer size: 60 */
+{offset: 60}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline57 = device0.createRenderPipeline({
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule8,
+  constants: {override8: 0},
+  targets: [{format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.BLUE}, {format: 'rgb10a2uint', writeMask: 0}, {format: 'rgba16sint', writeMask: GPUColorWrite.RED}, {format: 'rg32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus',
+    depthWriteEnabled: false,
+    stencilReadMask: 624611374,
+    stencilWriteMask: 25428569,
+    depthBiasSlopeScale: 439.2763811001081,
+    depthBiasClamp: 576.2379003752396,
+  },
+  vertex: {module: shaderModule17, entryPoint: 'vertex16', buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw'},
+});
+let recycledExplicitBindGroupLayout15 = pipeline41.getBindGroupLayout(0);
+let buffer274 = device0.createBuffer({size: 7729, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder130.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder63.setPipeline(pipeline49);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let autogeneratedBindGroupLayout130 = pipeline17.getBindGroupLayout(0);
+let bindGroup241 = device0.createBindGroup({layout: veryExplicitBindGroupLayout30, entries: [{binding: 140, resource: textureView182}]});
+let renderBundleEncoder56 = device0.createRenderBundleEncoder({colorFormats: ['rgba16sint'], depthReadOnly: true});
+try {
+renderPassEncoder13.setBlendConstant({ r: 837.8, g: -123.9, b: -979.5, a: -429.0, });
+} catch {}
+try {
+renderPassEncoder17.drawIndexed(128, 246, 0, 221_450_506, 1_693_376_069);
+} catch {}
+try {
+renderPassEncoder17.drawIndirect(buffer56, 644);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer135, 'uint32', 13_680, 843);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(7, buffer51, 1_136, 241);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(0, buffer178, 0);
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let img18 = await imageWithData(81, 37, '#10101010', '#20202020');
+videoFrame58 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'smpte432', transfer: 'iec6196624'} });
+let autogeneratedBindGroupLayout131 = pipeline18.getBindGroupLayout(0);
+let texture391 = device0.createTexture({
+  size: {width: 480},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder207.setBindGroup(1, bindGroup75);
+} catch {}
+try {
+computePassEncoder135.setBindGroup(0, bindGroup82, new Uint32Array(135), 70, 0);
+} catch {}
+try {
+renderPassEncoder17.draw(220, 434, 1_467_420_321, 756_296_842);
+} catch {}
+let pipeline58 = await device0.createComputePipelineAsync({layout: pipelineLayout22, compute: {module: shaderModule4, entryPoint: 'compute3', constants: {}}});
+try {
+if (!arrayBuffer32.detached) { new Uint8Array(arrayBuffer32).fill(0x55); };
+} catch {}
+let texture392 = device0.createTexture({
+  size: [780, 480, 1],
+  mipLevelCount: 2,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+computePassEncoder207.setPipeline(pipeline33);
+} catch {}
+try {
+renderPassEncoder17.drawIndexed(1, 201, 18, 672_470_128, 702_263_000);
+} catch {}
+try {
+renderPassEncoder17.drawIndirect(buffer233, 132);
+} catch {}
+try {
+renderBundleEncoder56.setIndexBuffer(buffer179, 'uint32', 156, 350);
+} catch {}
+try {
+  await buffer103.mapAsync(GPUMapMode.WRITE, 112, 28);
+} catch {}
+let promise53 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: canvas1,
+  origin: { x: 35, y: 12 },
+  flipY: true,
+}, {
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 40, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise53;
+} catch {}
+let textureView377 = texture2.createView({baseArrayLayer: 0});
+try {
+renderPassEncoder45.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+renderPassEncoder69.executeBundles([renderBundle43]);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(7, buffer51, 664, 580);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(5, buffer100, 0, 1_809);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let promise54 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 195, height: 120, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap2,
+  origin: { x: 34, y: 980 },
+  flipY: false,
+}, {
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 29, y: 25, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 29, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise52;
+} catch {}
+document.body.append(canvas3);
+let renderBundle56 = renderBundleEncoder56.finish({});
+let sampler240 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 83.41});
+try {
+computePassEncoder143.setBindGroup(2, bindGroup150, new Uint32Array(4128), 656, 0);
+} catch {}
+try {
+renderPassEncoder72.setBindGroup(0, bindGroup198);
+} catch {}
+try {
+renderPassEncoder17.drawIndexed(2, 49, 10, 701_038_448, 1_412_190_901);
+} catch {}
+try {
+renderPassEncoder17.drawIndexedIndirect(buffer132, 304);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer219, 'uint32', 224, 760);
+} catch {}
+try {
+renderPassEncoder70.setPipeline(pipeline12);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let veryExplicitBindGroupLayout70 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 120,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 38, hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView378 = texture52.createView({baseArrayLayer: 6, arrayLayerCount: 2});
+try {
+renderPassEncoder45.setBindGroup(1, bindGroup189, new Uint32Array(993), 324, 0);
+} catch {}
+try {
+renderPassEncoder17.drawIndexed(20, 179, 15, 121_582_358, 981_347_070);
+} catch {}
+try {
+renderPassEncoder17.drawIndexedIndirect(buffer145, 32);
+} catch {}
+try {
+renderPassEncoder17.drawIndirect(buffer242, 168);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline21);
+} catch {}
+try {
+buffer60.unmap();
+} catch {}
+try {
+  await promise50;
+} catch {}
+let bindGroup242 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout70,
+  entries: [{binding: 0, resource: {buffer: buffer235, offset: 0, size: 311}}],
+});
+let buffer275 = device0.createBuffer({
+  label: '\u86ae\u0721',
+  size: 3312,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup220, new Uint32Array(1860), 29, 0);
+} catch {}
+try {
+renderPassEncoder17.drawIndexed(13, 195, 19, 26_485_202, 308_227_768);
+} catch {}
+try {
+renderPassEncoder17.drawIndirect(buffer126, 324);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer172, 'uint32', 40, 161);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroup243 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout72,
+  entries: [{binding: 0, resource: {buffer: buffer38, offset: 1792, size: 822}}],
+});
+let externalTexture46 = device0.importExternalTexture({source: videoFrame56});
+try {
+computePassEncoder105.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder215.setBindGroup(0, bindGroup124, new Uint32Array(30), 1, 0);
+} catch {}
+try {
+renderPassEncoder17.draw(317, 9, 592_098_596, 810_856_667);
+} catch {}
+try {
+renderPassEncoder17.drawIndexed(19, 23, 2, 1_064_153_631, 364_899_566);
+} catch {}
+let promise55 = device0.queue.onSubmittedWorkDone();
+let bindGroup244 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout129,
+  entries: [{binding: 0, resource: {buffer: buffer172, offset: 0, size: 51}}],
+});
+let querySet47 = device0.createQuerySet({type: 'occlusion', count: 1077});
+let sampler241 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 84.59, compare: 'greater-equal'});
+try {
+computePassEncoder28.setBindGroup(2, bindGroup53);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(2, bindGroup217, new Uint32Array(848), 309, 0);
+} catch {}
+try {
+renderPassEncoder17.drawIndexed(1, 8, 30, 292_448_964, 246_121_704);
+} catch {}
+try {
+renderPassEncoder17.drawIndexedIndirect(buffer163, 1_384);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer180, 'uint32', 9_280, 4_701);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(37).fill(112), /* required buffer size: 37 */
+{offset: 37, rowsPerImage: 144}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer36.detached) { new Uint8Array(arrayBuffer36).fill(0x55); };
+} catch {}
+let sampler242 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMaxClamp: 85.83, compare: 'not-equal'});
+let externalTexture47 = device0.importExternalTexture({source: videoFrame54});
+try {
+computePassEncoder83.setBindGroup(0, bindGroup131, new Uint32Array(574), 194, 0);
+} catch {}
+try {
+renderPassEncoder54.setBindGroup(0, bindGroup100, new Uint32Array(3287), 192, 0);
+} catch {}
+try {
+renderPassEncoder17.draw(21, 18, 821_307_822, 307_501_549);
+} catch {}
+try {
+renderPassEncoder17.drawIndexed(47, 13, 4, 443_492_216, 171_746_863);
+} catch {}
+try {
+renderPassEncoder17.drawIndirect(buffer46, 412);
+} catch {}
+try {
+renderPassEncoder67.setIndexBuffer(buffer250, 'uint16', 220, 95);
+} catch {}
+let pipeline59 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule6}});
+let recycledAutogeneratedBindGroupLayout7 = pipeline43.getBindGroupLayout(0);
+let texture393 = device0.createTexture({
+  size: [60, 1, 2],
+  mipLevelCount: 1,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView379 = texture240.createView({});
+try {
+computePassEncoder149.setBindGroup(3, bindGroup52);
+} catch {}
+try {
+computePassEncoder164.setBindGroup(3, bindGroup189, new Uint32Array(218), 31, 0);
+} catch {}
+try {
+renderPassEncoder17.end();
+} catch {}
+let veryExplicitBindGroupLayout71 = device0.createBindGroupLayout({
+  entries: [{binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform', hasDynamicOffset: true }}],
+});
+let texture394 = device0.createTexture({
+  size: {width: 195, height: 120, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder222 = commandEncoder49.beginComputePass({});
+try {
+computePassEncoder211.setBindGroup(1, bindGroup239);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline38);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer262, 0, 2_808);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture271,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(1_064).fill(56), /* required buffer size: 1_064 */
+{offset: 264, bytesPerRow: 40, rowsPerImage: 5}, {width: 2, height: 0, depthOrArrayLayers: 5});
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let sampler243 = device0.createSampler({addressModeW: 'mirror-repeat', lodMaxClamp: 54.81, compare: 'equal'});
+try {
+computePassEncoder222.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder64.setBindGroup(2, bindGroup72, new Uint32Array(419), 68, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer172, 'uint16', 4, 0);
+} catch {}
+let img19 = await imageWithData(28, 40, '#10101010', '#20202020');
+let texture395 = device0.createTexture({
+  size: [16, 16, 22],
+  sampleCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView380 = texture35.createView({baseArrayLayer: 0});
+try {
+computePassEncoder94.setBindGroup(3, bindGroup124, []);
+} catch {}
+try {
+renderPassEncoder49.setBindGroup(0, bindGroup13, new Uint32Array(2444), 645, 0);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer118, 'uint16', 236, 47);
+} catch {}
+let pipeline60 = await device0.createComputePipelineAsync({layout: pipelineLayout22, compute: {module: shaderModule17}});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+videoFrame59 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'smpte432', transfer: 'log'} });
+let buffer276 = device0.createBuffer({size: 8687, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let sampler244 = device0.createSampler({label: '\u08c3\u02b2\u{1f69c}\udf2b', addressModeU: 'mirror-repeat', maxAnisotropy: 1});
+try {
+computePassEncoder216.setBindGroup(0, bindGroup28, new Uint32Array(1765), 365, 0);
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder63.setIndexBuffer(buffer42, 'uint16', 954, 267);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer270, 228, new Float32Array(55606), 12732, 96);
+} catch {}
+let promise56 = device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule5,
+  constants: {11_428: 0},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule13,
+    buffers: [
+      {
+        arrayStride: 132,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint32x2', offset: 52, shaderLocation: 0}],
+      },
+    ],
+  },
+  primitive: {},
+});
+await gc();
+let bindGroup245 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout67,
+  entries: [{binding: 0, resource: {buffer: buffer37, offset: 2304, size: 5917}}],
+});
+let buffer277 = device0.createBuffer({
+  size: 90,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let texture396 = device0.createTexture({
+  size: {width: 780, height: 480, depthOrArrayLayers: 1},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView381 = texture284.createView({arrayLayerCount: 1});
+try {
+computePassEncoder194.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder30.executeBundles([renderBundle22, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline28);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 8, depthOrArrayLayers: 15}
+*/
+{
+  source: videoFrame35,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture351,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup246 = device0.createBindGroup({layout: veryExplicitBindGroupLayout27, entries: [{binding: 140, resource: textureView23}]});
+let buffer278 = device0.createBuffer({size: 24529, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView382 = texture235.createView({dimension: '1d', arrayLayerCount: 1});
+try {
+computePassEncoder41.setBindGroup(3, bindGroup219);
+} catch {}
+let sampler245 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMaxClamp: 41.81});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup180, new Uint32Array(2671), 503, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer101, 'uint32', 96, 10_704);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(1, undefined, 72_902_496);
+} catch {}
+try {
+buffer239.unmap();
+} catch {}
+try {
+computePassEncoder149.setBindGroup(0, bindGroup67);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup220, new Uint32Array(172), 8, 0);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer201, 'uint16', 1_932, 234);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline55);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(6, buffer173);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+});
+} catch {}
+let querySet48 = device0.createQuerySet({type: 'occlusion', count: 129});
+let externalTexture48 = device0.importExternalTexture({source: videoFrame49, colorSpace: 'srgb'});
+try {
+computePassEncoder134.setBindGroup(2, bindGroup52);
+} catch {}
+try {
+computePassEncoder189.setBindGroup(1, bindGroup214, new Uint32Array(382), 30, 0);
+} catch {}
+try {
+renderPassEncoder75.setPipeline(pipeline32);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(7, buffer132, 536);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer73, 12, new Int16Array(3113), 268, 88);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 1, depthOrArrayLayers: 22}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 53, y: 19 },
+  flipY: false,
+}, {
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 47, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer279 = device0.createBuffer({
+  size: 114,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView383 = texture383.createView({dimension: '2d-array', arrayLayerCount: 1});
+try {
+computePassEncoder95.setBindGroup(2, bindGroup135);
+} catch {}
+try {
+renderPassEncoder58.setBindGroup(3, bindGroup67);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle27, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder75.setViewport(129.54398260473099, 37.146730608332476, 25.09367922838481, 81.3155753223034, 0.9944735420440319, 0.9973436262763825);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer180, 'uint32', 700, 5_507);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer31, 8, new Int16Array(4210));
+} catch {}
+
+await device0.queue.onSubmittedWorkDone();
+} catch {}
+videoFrame0?.close();
+videoFrame1?.close();
+videoFrame3?.close();
+videoFrame4?.close();
+videoFrame6?.close();
+videoFrame7?.close();
+videoFrame8?.close();
+videoFrame9?.close();
+videoFrame11?.close();
+videoFrame13?.close();
+videoFrame14?.close();
+videoFrame15?.close();
+videoFrame17?.close();
+videoFrame18?.close();
+videoFrame19?.close();
+videoFrame20?.close();
+videoFrame22?.close();
+videoFrame24?.close();
+videoFrame26?.close();
+videoFrame29?.close();
+videoFrame30?.close();
+videoFrame32?.close();
+videoFrame33?.close();
+videoFrame34?.close();
+videoFrame37?.close();
+videoFrame38?.close();
+videoFrame40?.close();
+videoFrame41?.close();
+videoFrame42?.close();
+videoFrame44?.close();
+videoFrame45?.close();
+videoFrame48?.close();
+videoFrame49?.close();
+videoFrame50?.close();
+videoFrame51?.close();
+videoFrame52?.close();
+videoFrame53?.close();
+videoFrame54?.close();
+videoFrame55?.close();
+videoFrame56?.close();
+videoFrame57?.close();
+videoFrame58?.close();
+videoFrame59?.close();
+// END
+log('the end')
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  log('notify done')
+
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -439,6 +439,7 @@ Device::ExternalTextureData Device::createExternalTextureFromPixelBuffer(CVPixel
         return [texture newTextureViewWithPixelFormat:texture.pixelFormat textureType:texture.textureType levels:NSMakeRange(0, texture.mipmapLevelCount) slices:NSMakeRange(0, texture.arrayLength) swizzle:alphaFirst ? MTLTextureSwizzleChannelsMake(MTLTextureSwizzleBlue, MTLTextureSwizzleAlpha, MTLTextureSwizzleZero, MTLTextureSwizzleZero) : MTLTextureSwizzleChannelsMake(MTLTextureSwizzleGreen, MTLTextureSwizzleBlue, MTLTextureSwizzleZero, MTLTextureSwizzleZero)];
     };
 
+    CVMetalTextureCacheFlush(m_coreVideoTextureCache.get(), 0);
     const bool supportsExtendedFormats = [m_device supportsFamily:MTLGPUFamilyApple4];
     IOSurfaceRef ioSurface = CVPixelBufferGetIOSurface(pixelBuffer);
     if (!ioSurface || isIntel()) {

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -169,7 +169,7 @@ Buffer::Buffer(id<MTLBuffer> buffer, uint64_t initialSize, WGPUBufferUsageFlags 
 #endif
 {
     if (m_usage & WGPUBufferUsage_Indirect)
-        m_indirectBuffer = device.safeCreateBuffer(sizeof(MTLDrawPrimitivesIndirectArguments), MTLStorageModePrivate);
+        m_indirectBuffer = device.safeCreateBuffer(sizeof(MTLDrawPrimitivesIndirectArguments) + sizeof(uint32_t), MTLStorageModeShared);
     if (m_usage & (WGPUBufferUsage_Indirect | WGPUBufferUsage_Index))
         m_indirectIndexedBuffer = device.safeCreateBuffer(sizeof(MTLDrawIndexedPrimitivesIndirectArguments) + sizeof(uint32_t), MTLStorageModeShared);
 }

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -205,6 +205,7 @@ public:
     id<MTLCounterSampleBuffer> timestampsBuffer(id<MTLCommandBuffer>, size_t);
     void resolveTimestampsForBuffer(id<MTLCommandBuffer>);
     id<MTLSharedEvent> resolveTimestampsSharedEvent();
+    uint32_t maxVerticesPerDrawCall() const { return m_maxVerticesPerDrawCall; }
 
 private:
     Device(id<MTLDevice>, id<MTLCommandQueue> defaultQueue, HardwareCapabilities&&, Adapter&);
@@ -281,6 +282,7 @@ private:
     NSMapTable<id<MTLCommandBuffer>, NSMutableArray<id<MTLBuffer>>*>* m_resolvedSampleCounterBuffers;
     id<MTLSharedEvent> m_resolveTimestampsSharedEvent { nil };
     bool m_supressAllErrors { false };
+    const uint32_t m_maxVerticesPerDrawCall { 0 };
 } SWIFT_SHARED_REFERENCE(refDevice, derefDevice);
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -105,8 +105,8 @@ public:
     static double quantizedDepthValue(double, WGPUTextureFormat);
     NSString* errorValidatingPipeline(const RenderPipeline&) const;
 
-    static std::pair<id<MTLBuffer>, uint64_t> clampIndirectIndexBufferToValidValues(Buffer*, Buffer&, MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, MTLPrimitiveType, Device&, uint32_t rasterSampleCount, id<MTLRenderCommandEncoder>, bool& splitEncoder);
-    static id<MTLBuffer> clampIndirectBufferToValidValues(Buffer&, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, Device&, uint32_t rasterSampleCount, id<MTLRenderCommandEncoder>, bool& splitEncoder);
+    static std::pair<id<MTLBuffer>, uint64_t> clampIndirectIndexBufferToValidValues(Buffer*, Buffer&, MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, MTLPrimitiveType, Device&, uint32_t rasterSampleCount, RenderPassEncoder&, bool& splitEncoder);
+    static std::pair<id<MTLBuffer>, uint64_t> clampIndirectBufferToValidValues(Buffer&, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, Device&, uint32_t rasterSampleCount, RenderPassEncoder&, bool& splitEncoder);
     enum class IndexCall { Draw, IndirectDraw, Skip, CachedIndirectDraw };
     static IndexCall clampIndexBufferToValidValues(uint32_t indexCount, uint32_t instanceCount, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes, Buffer*, uint32_t minVertexCount, uint32_t minInstanceCount, RenderPassEncoder&, Device&, uint32_t rasterSampleCount, MTLPrimitiveType);
     void splitRenderPass();
@@ -136,7 +136,7 @@ private:
     IndexCall clampIndexBufferToValidValues(uint32_t indexCount, uint32_t instanceCount, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes);
     std::pair<uint32_t, uint32_t> computeMininumVertexInstanceCount() const;
     std::pair<id<MTLBuffer>, uint64_t> clampIndirectIndexBufferToValidValues(Buffer&, MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, bool& splitEncoder);
-    id<MTLBuffer> clampIndirectBufferToValidValues(Buffer&, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, bool& splitEncoder);
+    std::pair<id<MTLBuffer>, uint64_t> clampIndirectBufferToValidValues(Buffer&, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, bool& splitEncoder);
     void setCachedRenderPassState(id<MTLRenderCommandEncoder>);
 
     id<MTLRenderCommandEncoder> m_renderCommandEncoder { nil };

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -798,8 +798,13 @@ void ShaderModule::getCompilationInfo(CompletionHandler<void(WGPUCompilationInfo
             compilationMessageData.compilationMessages.data(),
         };
         callback(WGPUCompilationInfoRequestStatus_Error, compilationInfo);
-    }, [](std::monostate) {
-        ASSERT_NOT_REACHED();
+    }, [&](std::monostate) {
+        WGPUCompilationInfo compilationInfo {
+            nullptr,
+            0u,
+            nullptr,
+        };
+        callback(WGPUCompilationInfoRequestStatus_Error, compilationInfo);
     });
 }
 


### PR DESCRIPTION
#### 49f0ede27a9accfa0761059074ff63d17a0cefba
<pre>
[WebGPU] Large indirect draw calls should trigger device lost
<a href="https://bugs.webkit.org/show_bug.cgi?id=284937">https://bugs.webkit.org/show_bug.cgi?id=284937</a>
<a href="https://rdar.apple.com/141433630">rdar://141433630</a>

Reviewed by Dan Glastonbury.

Sending very large (vertex or index) * instance counts to drawIndirect
or drawIndexedIndirect would lead to an unresponsive device, command
buffer errors, or other unfortunate perceived device behavior.

Limit draw calls to reasonable numbers, trigger device lost when
too complex.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createExternalTextureFromPixelBuffer const):
* Source/WebGPU/WebGPU/Device.h:
(WebGPU::Device::maxVerticesPerDrawCall const):
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::computeMaxCountForDevice):
Use reasonable limits based on GPU family.

(WebGPU::Device::Device):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::drawIndirect):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::draw):
(WebGPU::RenderPassEncoder::clampIndirectBufferToValidValues):
(WebGPU::RenderPassEncoder::drawIndexed):
(WebGPU::RenderPassEncoder::drawIndirect):

* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::ShaderModule::getCompilationInfo):
Assertion noticed in debug running test. It should not be an
assertion since calling getCompilationInfo() on an invalid
GPUShaderModule would trigger this, rather we should report
an empty message.

Canonical link: <a href="https://commits.webkit.org/288256@main">https://commits.webkit.org/288256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9e49263af2bdcd7d324332ec43b7c75ab446ee1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33315 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9800 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64107 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21855 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1384 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74846 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44385 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29027 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32356 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88742 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72499 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9786 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71717 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17883 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15853 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14870 "9 flakes 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/914 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9513 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15033 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9387 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12853 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->