### PR TITLE
Remove AVAssetWriter requiresInProcessOperation usage

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AVAssetWriterSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVAssetWriterSPI.h
@@ -48,7 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
 #if !HAVE(AVASSETWRITERDELEGATE_API)
 @property (weak, nullable) id <AVAssetWriterDelegate> delegate SPI_AVAILABLE(macos(10.15), ios(13.0), tvos(13.0), watchos(6.0));
 #endif
-@property (nonatomic) BOOL requiresInProcessOperation SPI_AVAILABLE(ios(16.4), tvos(16.4), watchos(9.4), visionos(1.0)) API_UNAVAILABLE(macos, macCatalyst);
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm
@@ -143,9 +143,6 @@ bool MediaRecorderPrivateWriterAVFObjC::allTracksAdded()
     // AVFileTypeProfileMPEG4AppleHLS allows muxed audio and video inputs
     // AVFileTypeProfileMPEG4CMAFCompliant allows only a single audio or video input
     [m_writer setOutputFileTypeProfile:m_currentTrackIndex > 1 ? AVFileTypeProfileMPEG4AppleHLS : AVFileTypeProfileMPEG4CMAFCompliant];
-#if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
-    [m_writer setRequiresInProcessOperation:YES];
-#endif
 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     if (![m_writer startWriting]) {


### PR DESCRIPTION
#### c59d753513ab3dfea8cf7d4f2a36fb113326e8aa
<pre>
Remove AVAssetWriter requiresInProcessOperation usage
<a href="https://rdar.apple.com/141747327">rdar://141747327</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284947">https://bugs.webkit.org/show_bug.cgi?id=284947</a>

Reviewed by Eric Carlson.

Moving to GPUProcess removes the need for using this AVAssetWriter option.

* Source/WebCore/PAL/pal/spi/cocoa/AVAssetWriterSPI.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm:
(WebCore::MediaRecorderPrivateWriterAVFObjC::allTracksAdded):

Canonical link: <a href="https://commits.webkit.org/288095@main">https://commits.webkit.org/288095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/654783af0aa2581393f8e62c768c32bfb429e6ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32850 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83960 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63840 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21567 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1038 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74486 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44126 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/937 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28661 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/idbobjectstore_keyPath.any.worker.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31303 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87838 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72191 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71421 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17799 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15513 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14434 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9045 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14577 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8886 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12409 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10694 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->