### PR TITLE
.measureText() returns TextMetrics object with rounded values for bounding box

### DIFF
--- a/LayoutTests/fast/canvas/canvas-measureText-2-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-measureText-2-expected.txt
@@ -6,7 +6,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightAscent) is 0
+PASS Math.abs(metrics.emHeightAscent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -16,7 +16,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightAscent) is 0
+PASS Math.abs(metrics.emHeightAscent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -26,7 +26,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightAscent) is 0
+PASS Math.abs(metrics.emHeightAscent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -36,7 +36,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightAscent) is 0
+PASS Math.abs(metrics.emHeightAscent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -46,7 +46,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightAscent) is 0
+PASS Math.abs(metrics.emHeightAscent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -56,7 +56,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.hangingBaseline) is 0
+PASS Math.abs(metrics.hangingBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -66,7 +66,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.hangingBaseline) is 0
+PASS Math.abs(metrics.hangingBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -76,7 +76,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.hangingBaseline) is 0
+PASS Math.abs(metrics.hangingBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -86,7 +86,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.hangingBaseline) is 0
+PASS Math.abs(metrics.hangingBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -96,7 +96,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.hangingBaseline) is 0
+PASS Math.abs(metrics.hangingBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -151,7 +151,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.alphabeticBaseline) is 0
+PASS Math.abs(metrics.alphabeticBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -161,7 +161,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.alphabeticBaseline) is 0
+PASS Math.abs(metrics.alphabeticBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -171,7 +171,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.alphabeticBaseline) is 0
+PASS Math.abs(metrics.alphabeticBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -181,7 +181,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.alphabeticBaseline) is 0
+PASS Math.abs(metrics.alphabeticBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -191,7 +191,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.alphabeticBaseline) is 0
+PASS Math.abs(metrics.alphabeticBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -201,7 +201,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.ideographicBaseline) is 0
+PASS Math.abs(metrics.ideographicBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -211,7 +211,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.ideographicBaseline) is 0
+PASS Math.abs(metrics.ideographicBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -221,7 +221,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.ideographicBaseline) is 0
+PASS Math.abs(metrics.ideographicBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -231,7 +231,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.ideographicBaseline) is 0
+PASS Math.abs(metrics.ideographicBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -241,7 +241,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.ideographicBaseline) is 0
+PASS Math.abs(metrics.ideographicBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -251,7 +251,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightDescent) is 0
+PASS Math.abs(metrics.emHeightDescent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -261,7 +261,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightDescent) is 0
+PASS Math.abs(metrics.emHeightDescent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -271,7 +271,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightDescent) is 0
+PASS Math.abs(metrics.emHeightDescent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -281,7 +281,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightDescent) is 0
+PASS Math.abs(metrics.emHeightDescent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -291,7 +291,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightDescent) is 0
+PASS Math.abs(metrics.emHeightDescent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -301,7 +301,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightAscent) is 0
+PASS Math.abs(metrics.emHeightAscent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -311,7 +311,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightAscent) is 0
+PASS Math.abs(metrics.emHeightAscent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -321,7 +321,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightAscent) is 0
+PASS Math.abs(metrics.emHeightAscent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -331,7 +331,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightAscent) is 0
+PASS Math.abs(metrics.emHeightAscent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -341,7 +341,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightAscent) is 0
+PASS Math.abs(metrics.emHeightAscent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -351,7 +351,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.hangingBaseline) is 0
+PASS Math.abs(metrics.hangingBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -361,7 +361,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.hangingBaseline) is 0
+PASS Math.abs(metrics.hangingBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -371,7 +371,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.hangingBaseline) is 0
+PASS Math.abs(metrics.hangingBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -381,7 +381,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.hangingBaseline) is 0
+PASS Math.abs(metrics.hangingBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -391,7 +391,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.hangingBaseline) is 0
+PASS Math.abs(metrics.hangingBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -446,7 +446,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.alphabeticBaseline) is 0
+PASS Math.abs(metrics.alphabeticBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -456,7 +456,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.alphabeticBaseline) is 0
+PASS Math.abs(metrics.alphabeticBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -466,7 +466,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.alphabeticBaseline) is 0
+PASS Math.abs(metrics.alphabeticBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -476,7 +476,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.alphabeticBaseline) is 0
+PASS Math.abs(metrics.alphabeticBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -486,7 +486,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.alphabeticBaseline) is 0
+PASS Math.abs(metrics.alphabeticBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -496,7 +496,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.ideographicBaseline) is 0
+PASS Math.abs(metrics.ideographicBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -506,7 +506,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.ideographicBaseline) is 0
+PASS Math.abs(metrics.ideographicBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -516,7 +516,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.ideographicBaseline) is 0
+PASS Math.abs(metrics.ideographicBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -526,7 +526,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.ideographicBaseline) is 0
+PASS Math.abs(metrics.ideographicBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -536,7 +536,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.ideographicBaseline) is 0
+PASS Math.abs(metrics.ideographicBaseline) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -546,7 +546,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightDescent) is 0
+PASS Math.abs(metrics.emHeightDescent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -556,7 +556,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightDescent) is 0
+PASS Math.abs(metrics.emHeightDescent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -566,7 +566,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightDescent) is 0
+PASS Math.abs(metrics.emHeightDescent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -576,7 +576,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightDescent) is 0
+PASS Math.abs(metrics.emHeightDescent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline
@@ -586,7 +586,7 @@ PASS metrics.actualBoundingBoxLeft + metrics.actualBoundingBoxRight - metrics.wi
 PASS metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent is >= 0
 PASS metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent is >= 0
 PASS metrics.emHeightAscent + metrics.emHeightDescent is >= 0
-PASS Math.abs(metrics.emHeightDescent) is 0
+PASS Math.abs(metrics.emHeightDescent) is within 0.25 of 0
 PASS metrics.emHeightAscent is >= metrics.hangingBaseline
 PASS metrics.hangingBaseline is >= metrics.alphabeticBaseline
 PASS metrics.alphabeticBaseline is >= metrics.ideographicBaseline

--- a/LayoutTests/fast/canvas/canvas-measureText-2.html
+++ b/LayoutTests/fast/canvas/canvas-measureText-2.html
@@ -33,15 +33,15 @@
                             shouldBeGreaterThanOrEqual("metrics.emHeightAscent + metrics.emHeightDescent", "0");
 
                             if (baseline === 'top')
-                                shouldBeZero("Math.abs(metrics.emHeightAscent)");
+                                shouldBeCloseTo("Math.abs(metrics.emHeightAscent)", 0, 0.25);
                             if (baseline === 'bottom')
-                                shouldBeZero("Math.abs(metrics.emHeightDescent)");
+                                shouldBeCloseTo("Math.abs(metrics.emHeightDescent)", 0, 0.25);
                             if (baseline === 'hanging')
-                                shouldBeZero("Math.abs(metrics.hangingBaseline)");
+                                shouldBeCloseTo("Math.abs(metrics.hangingBaseline)", 0, 0.25);
                             if (baseline === 'alphabetic')
-                                shouldBeZero("Math.abs(metrics.alphabeticBaseline)");
+                                shouldBeCloseTo("Math.abs(metrics.alphabeticBaseline)", 0, 0.25);
                             if (baseline === 'ideographic')
-                                shouldBeZero("Math.abs(metrics.ideographicBaseline)");
+                                shouldBeCloseTo("Math.abs(metrics.ideographicBaseline)", 0, 0.25);
 
                             shouldBeGreaterThanOrEqual("metrics.emHeightAscent", "metrics.hangingBaseline");
                             shouldBeGreaterThanOrEqual("metrics.hangingBaseline", "metrics.alphabeticBaseline");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.baselines-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.baselines-expected.txt
@@ -2,5 +2,5 @@
 Testing baselines
 Actual output:
 
-FAIL Testing baselines assert_equals: ctx.measureText('A').ideographicBaseline === 6.25 (got -13[number], expected 6.25[number]) expected 6.25 but got -13
+FAIL Testing baselines assert_equals: ctx.measureText('A').ideographicBaseline === 6.25 (got -12.5[number], expected 6.25[number]) expected 6.25 but got -12.5
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines-expected.txt
@@ -3,5 +3,5 @@
 Testing baselines
 
 
-FAIL Testing baselines assert_equals: ctx.measureText('A').ideographicBaseline === 6.25 (got -13[number], expected 6.25[number]) expected 6.25 but got -13
+FAIL Testing baselines assert_equals: ctx.measureText('A').ideographicBaseline === 6.25 (got -12.5[number], expected 6.25[number]) expected 6.25 but got -12.5
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Testing baselines assert_equals: ctx.measureText('A').ideographicBaseline === 6.25 (got -13[number], expected 6.25[number]) expected 6.25 but got -13
+FAIL Testing baselines assert_equals: ctx.measureText('A').ideographicBaseline === 6.25 (got -12.5[number], expected 6.25[number]) expected 6.25 but got -12.5
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.baselines-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.baselines-expected.txt
@@ -1,0 +1,6 @@
+2d.text.measure.baselines
+Testing baselines
+Actual output:
+
+FAIL Testing baselines assert_equals: ctx.measureText('A').ideographicBaseline === 6.25 (got -13[number], expected 6.25[number]) expected 6.25 but got -13
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines-expected.txt
@@ -1,0 +1,7 @@
+2d.text.measure.baselines
+
+Testing baselines
+
+
+FAIL Testing baselines assert_equals: ctx.measureText('A').ideographicBaseline === 6.25 (got -13[number], expected 6.25[number]) expected 6.25 but got -13
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines.worker-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Testing baselines assert_equals: ctx.measureText('A').ideographicBaseline === 6.25 (got -13[number], expected 6.25[number]) expected 6.25 but got -13
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.baselines-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.baselines-expected.txt
@@ -1,0 +1,6 @@
+2d.text.measure.baselines
+Testing baselines
+Actual output:
+
+FAIL Testing baselines assert_equals: ctx.measureText('A').ideographicBaseline === 6.25 (got -13[number], expected 6.25[number]) expected 6.25 but got -13
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines-expected.txt
@@ -1,0 +1,7 @@
+2d.text.measure.baselines
+
+Testing baselines
+
+
+FAIL Testing baselines assert_equals: ctx.measureText('A').ideographicBaseline === 6.25 (got -13[number], expected 6.25[number]) expected 6.25 but got -13
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines.worker-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines.worker-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Testing baselines assert_equals: ctx.measureText('A').ideographicBaseline === 6.25 (got -13[number], expected 6.25[number]) expected 6.25 but got -13
+

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2948,13 +2948,13 @@ Ref<TextMetrics> CanvasRenderingContext2DBase::measureTextInternal(const TextRun
     metrics->setWidth(fontWidth);
 
     FloatPoint offset = textOffset(fontWidth, textRun.direction());
-    int ascent = fontMetrics.intAscent();
-    int descent = fontMetrics.intDescent();
+    auto ascent = fontMetrics.ascent();
+    auto descent = fontMetrics.descent();
 
     metrics->setActualBoundingBoxAscent(glyphOverflow.top - offset.y());
     metrics->setActualBoundingBoxDescent(glyphOverflow.bottom + offset.y());
-    metrics->setFontBoundingBoxAscent(ascent - offset.y());
-    metrics->setFontBoundingBoxDescent(descent + offset.y());
+    metrics->setFontBoundingBoxAscent(fontMetrics.intAscent() - offset.y());
+    metrics->setFontBoundingBoxDescent(fontMetrics.intDescent() + offset.y());
     metrics->setEmHeightAscent(ascent - offset.y());
     metrics->setEmHeightDescent(descent + offset.y());
     metrics->setHangingBaseline(ascent - offset.y());

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1570,10 +1570,10 @@ float FontCascade::widthForSimpleText(const TextRun& run, SingleThreadWeakHashSe
     it.finalize(glyphBuffer);
 
     if (glyphOverflow) {
-        glyphOverflow->top = std::max<int>(glyphOverflow->top, ceilf(-it.minGlyphBoundingBoxY()) - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().intAscent()));
-        glyphOverflow->bottom = std::max<int>(glyphOverflow->bottom, ceilf(it.maxGlyphBoundingBoxY()) - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().intDescent()));
-        glyphOverflow->left = ceilf(it.firstGlyphOverflow());
-        glyphOverflow->right = ceilf(it.lastGlyphOverflow());
+        glyphOverflow->top = std::max<double>(glyphOverflow->top, -it.minGlyphBoundingBoxY() - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().ascent()));
+        glyphOverflow->bottom = std::max<double>(glyphOverflow->bottom, it.maxGlyphBoundingBoxY() - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().descent()));
+        glyphOverflow->left = it.firstGlyphOverflow();
+        glyphOverflow->right = it.lastGlyphOverflow();
     }
 
     return it.runWidthSoFar();
@@ -1583,10 +1583,10 @@ float FontCascade::widthForComplexText(const TextRun& run, SingleThreadWeakHashS
 {
     ComplexTextController controller(*this, run, true, fallbackFonts);
     if (glyphOverflow) {
-        glyphOverflow->top = std::max<int>(glyphOverflow->top, ceilf(-controller.minGlyphBoundingBoxY()) - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().intAscent()));
-        glyphOverflow->bottom = std::max<int>(glyphOverflow->bottom, ceilf(controller.maxGlyphBoundingBoxY()) - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().intDescent()));
-        glyphOverflow->left = std::max<int>(0, ceilf(-controller.minGlyphBoundingBoxX()));
-        glyphOverflow->right = std::max<int>(0, ceilf(controller.maxGlyphBoundingBoxX() - controller.totalAdvance().width()));
+        glyphOverflow->top = std::max<double>(glyphOverflow->top, -controller.minGlyphBoundingBoxY() - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().ascent()));
+        glyphOverflow->bottom = std::max<double>(glyphOverflow->bottom, controller.maxGlyphBoundingBoxY() - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().descent()));
+        glyphOverflow->left = std::max<double>(0, -controller.minGlyphBoundingBoxX());
+        glyphOverflow->right = std::max<double>(0, controller.maxGlyphBoundingBoxX() - controller.totalAdvance().width());
     }
     return controller.totalAdvance().width();
 }


### PR DESCRIPTION
#### b3809e07dc65e5678706c3ee334ca12930ebf129
<pre>
.measureText() returns TextMetrics object with rounded values for bounding box
<a href="https://bugs.webkit.org/show_bug.cgi?id=240213">https://bugs.webkit.org/show_bug.cgi?id=240213</a>

Reviewed by Said Abou-Hallawa.

Stop rounding intermediate calculations to integer values, potentially ending up with float values for TextMetrics bounding box.

Note that iOS/glib platforms seem to always round ascent/descent to integer values so have some different test results. Stopping the rounding
there would lead to a big amount of needed rebaselines, so it is left out of this PR.

* LayoutTests/fast/canvas/canvas-measureText-2-expected.txt:
* LayoutTests/fast/canvas/canvas-measureText-2.html:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.baselines-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines.worker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.baselines-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.baselines-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines.worker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines.worker-expected.txt.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.baselines-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.measure.baselines-expected.txt.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines-expected.txt.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines.worker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/text/2d.text.measure.baselines.worker-expected.txt.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::measureTextInternal):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::widthForSimpleText const):
(WebCore::FontCascade::widthForComplexText const):

Canonical link: <a href="https://commits.webkit.org/288439@main">https://commits.webkit.org/288439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/782226a810ab418575d70edf47f34165624d3d45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34303 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64799 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22544 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45083 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2085 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29902 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33352 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89743 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73232 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72462 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17952 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16671 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15407 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10513 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15988 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10365 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12136 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->