### PR TITLE
getDisplayMedia video track should have non persistent deviceIds

### DIFF
--- a/LayoutTests/fast/mediastream/get-display-media-settings.html
+++ b/LayoutTests/fast/mediastream/get-display-media-settings.html
@@ -8,19 +8,19 @@
         <script src="resources/getDisplayMedia-utils.js"></script>
     </head>
     <body>
-
         <script>
             promise_test(async () => {
                 stream = await callGetDisplayMedia({ video: true });
                 const settings = stream.getVideoTracks()[0].getSettings();
+                const capabilities = stream.getVideoTracks()[0].getCapabilities();
 
                 assert_equals(settings.height, 1080);
                 assert_equals(settings.width, 1920);
                 assert_equals(settings.frameRate, 30);
                 assert_true(typeof settings.deviceId === 'string', true);
-
+                assert_true(typeof capabilities.deviceId === 'string', true);
+                assert_equals(capabilities.deviceId, settings.deviceId);
             }, "check settings");
-
         </script>
     </body>
 </html>

--- a/LayoutTests/http/wpt/mediastream/getDisplayMedia-deviceid-persistency-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/getDisplayMedia-deviceid-persistency-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS check deviceId persistency
+

--- a/LayoutTests/http/wpt/mediastream/getDisplayMedia-deviceid-persistency.html
+++ b/LayoutTests/http/wpt/mediastream/getDisplayMedia-deviceid-persistency.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script>
+           function with_iframe(url) {
+               return new Promise(function(resolve) {
+                   var frame = document.createElement('iframe');
+                   frame.className = 'test-iframe';
+                   frame.src = url;
+                   frame.onload = function() { resolve(frame); };
+                   document.body.appendChild(frame);
+               });
+           }
+
+            let firstDeviceId;
+            promise_test(async () => {
+                const iframe1 = await with_iframe("/");
+                const iframe2 = await with_iframe("/");
+
+                let stream1, stream2, stream3;
+                let promise1, promise2, promise3;
+                internals.withUserGesture(() => {
+                    promise1 = iframe1.contentWindow.navigator.mediaDevices.getDisplayMedia({ video: true}).then(s => stream1 = s);
+                });
+                internals.withUserGesture(() => {
+                    promise2 = iframe2.contentWindow.navigator.mediaDevices.getDisplayMedia({ video: true}).then(s => stream2 = s);
+                });
+                internals.withUserGesture(() => {
+                    promise3 = iframe1.contentWindow.navigator.mediaDevices.getDisplayMedia({ video: true}).then(s => stream3 = s);
+                });
+
+                await promise1;
+                await promise2;
+                await promise3;
+
+                assert_not_equals(stream1.getVideoTracks()[0].getSettings().deviceId, stream2.getVideoTracks()[0].getSettings().deviceId);
+                assert_equals(stream1.getVideoTracks()[0].getSettings().deviceId, stream3.getVideoTracks()[0].getSettings().deviceId);
+            }, "check deviceId persistency");
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/platform/mediastream/CaptureDevice.h
+++ b/Source/WebCore/platform/mediastream/CaptureDevice.h
@@ -33,6 +33,7 @@ namespace WebCore {
 class CaptureDevice {
 public:
     enum class DeviceType : uint8_t { Unknown, Microphone, Speaker, Camera, Screen, Window, SystemAudio };
+    static bool isScreenShareType(DeviceType type) { return type == DeviceType::Screen || type == DeviceType::Window || type == DeviceType::SystemAudio; }
 
     CaptureDevice(const String& persistentId, DeviceType type, const String& label, const String& groupId = emptyString(), bool isEnabled = false, bool isDefault = false, bool isMock = false, bool isEphemeral = false)
         : m_persistentId(persistentId)
@@ -42,7 +43,7 @@ public:
         , m_enabled(isEnabled)
         , m_default(isDefault)
         , m_isMockDevice(isMock)
-        , m_isEphemeral(isEphemeral)
+        , m_isEphemeral(isEphemeral || isScreenShareType(m_type))
     {
     }
 

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -139,6 +139,7 @@ const RealtimeMediaSourceCapabilities& DisplayCaptureSourceCocoa::capabilities()
         capabilities.setWidth({ 1, intrinsicSize.width() });
         capabilities.setHeight({ 1, intrinsicSize.height() });
         capabilities.setFrameRate({ .01, 30.0 });
+        capabilities.setDeviceId(hashedId());
 
         m_capabilities = WTFMove(capabilities);
     }

--- a/Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.cpp
@@ -89,6 +89,8 @@ const RealtimeMediaSourceCapabilities& MockDisplayCaptureSourceGStreamer::capabi
         capabilities.setHeight({ 1, 1080 });
         capabilities.setFrameRate({ .01, 30.0 });
 
+        capabilities.setDeviceId(hashedId());
+
         m_capabilities = WTFMove(capabilities);
     }
     return m_capabilities.value();

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -203,6 +203,9 @@ const RealtimeMediaSourceCapabilities& MockRealtimeVideoSource::capabilities()
 
     auto supportedConstraints = settings().supportedConstraints();
     RealtimeMediaSourceCapabilities capabilities(supportedConstraints);
+
+    capabilities.setDeviceId(hashedId());
+
     if (mockCamera()) {
         auto facingMode = std::get<MockCameraProperties>(m_device.properties).facingMode;
         if (facingMode != VideoFacingMode::Unknown)


### PR DESCRIPTION
#### 0bd8e819d75a53ce1d362399efd853856fb4270a
<pre>
getDisplayMedia video track should have non persistent deviceIds
<a href="https://bugs.webkit.org/show_bug.cgi?id=284952">https://bugs.webkit.org/show_bug.cgi?id=284952</a>
<a href="https://rdar.apple.com/141754036">rdar://141754036</a>

Reviewed by Eric Carlson.

As per latest meeting and spec change, deviceId persistency should be per document, and not per origin.
Marking screen share capture device as ephemeral to do so.
Also make sure to have capabilities filled properly for deviceId.

* LayoutTests/fast/mediastream/get-display-media-settings.html:
* LayoutTests/http/wpt/mediastream/getDisplayMedia-deviceid-persistency-expected.txt: Added.
* LayoutTests/http/wpt/mediastream/getDisplayMedia-deviceid-persistency.html: Added.
* Source/WebCore/platform/mediastream/CaptureDevice.h:
(WebCore::CaptureDevice::isScreenShareType):
(WebCore::CaptureDevice::CaptureDevice):
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::capabilities):
* Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.cpp:
(WebCore::MockDisplayCaptureSourceGStreamer::capabilities):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::capabilities):

Canonical link: <a href="https://commits.webkit.org/288112@main">https://commits.webkit.org/288112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7c7bdb5cda8e592d82026d4f705d9869c73d072

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1414 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32889 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9237 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63871 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21596 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74522 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44155 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/969 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/28699 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31338 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87875 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9129 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6507 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/72236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71458 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17808 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15547 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14471 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9080 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14616 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8920 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12445 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->