### PR TITLE
[css-masonry] Update masonry-parsing test to remove masonry-auto-flow checks

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/parsing/masonry-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/parsing/masonry-parsing-expected.txt
@@ -56,14 +56,4 @@ PASS e.style['grid'] = "10px / masonry" should set grid-template-areas
 PASS e.style['grid'] = "10px / masonry" should set grid-template-columns
 PASS e.style['grid'] = "10px / masonry" should set grid-template-rows
 PASS e.style['grid'] = "10px / masonry" should not set unrelated longhands
-PASS e.style['masonry-auto-flow'] = "pack" should set the property value
-PASS e.style['masonry-auto-flow'] = "pack ordered" should set the property value
-PASS e.style['masonry-auto-flow'] = "ordered next" should set the property value
-PASS e.style['masonry-auto-flow'] = "next definite-first" should set the property value
-PASS e.style['masonry-auto-flow'] = "definite-first pack" should set the property value
-PASS e.style['masonry-auto-flow'] = "auto" should not set the property value
-PASS e.style['masonry-auto-flow'] = "none" should not set the property value
-PASS e.style['masonry-auto-flow'] = "10px" should not set the property value
-PASS e.style['masonry-auto-flow'] = "row" should not set the property value
-PASS e.style['masonry-auto-flow'] = "dense" should not set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/parsing/masonry-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/parsing/masonry-parsing.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>CSS Masonry Test: parsing properties and shortands</title>
 <link rel="help" href="https://drafts.csswg.org/css-grid-3/#grid-template-masonry">
-<link rel="help" href="https://drafts.csswg.org/css-grid-3/#masonry-auto-flow">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
@@ -73,17 +72,6 @@ test_shorthand_value("grid", '10px / masonry', {
   'grid-auto-columns': 'auto',
   'grid-auto-flow': 'row'
 });
-
-test_valid_value("masonry-auto-flow", 'pack');
-test_valid_value("masonry-auto-flow", 'pack ordered', 'ordered');
-test_valid_value("masonry-auto-flow", 'ordered next', 'next ordered');
-test_valid_value("masonry-auto-flow", 'next definite-first', 'next');
-test_valid_value("masonry-auto-flow", 'definite-first pack', 'pack');
-test_invalid_value("masonry-auto-flow", 'auto');
-test_invalid_value("masonry-auto-flow", 'none');
-test_invalid_value("masonry-auto-flow", '10px');
-test_invalid_value("masonry-auto-flow", 'row');
-test_invalid_value("masonry-auto-flow", 'dense');
 
 </script>
 </body>


### PR DESCRIPTION
#### 6f45cc75a424e18c0ceff62e7164168fe911d1d0
<pre>
[css-masonry] Update masonry-parsing test to remove masonry-auto-flow checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=284953">https://bugs.webkit.org/show_bug.cgi?id=284953</a>
<a href="https://rdar.apple.com/problem/141755610">rdar://problem/141755610</a>

Reviewed by Sammy Gill.

masonry-auto-flow is no longer in the css-grid-3 spec. Removing from tests.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/parsing/masonry-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/parsing/masonry-parsing.html:

Canonical link: <a href="https://commits.webkit.org/288105@main">https://commits.webkit.org/288105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1869eb8b2ec6bafeb4aa7368d76fbe67afe40b26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86422 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32864 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63853 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21581 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74502 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44139 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/951 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28678 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31317 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87852 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72218 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71440 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17803 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15530 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14450 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9059 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8900 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12423 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->