### PR TITLE
Populate Quirks state in the UIProcess and message to the Web Content process

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2011 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -85,6 +85,7 @@
 #include "PolicyChecker.h"
 #include "ProgressTracker.h"
 #include "Quirks.h"
+#include "QuirksData.h"
 #include "ResourceLoadObserver.h"
 #include "ResourceMonitor.h"
 #include "SWClientConnection.h"
@@ -1910,6 +1911,11 @@ void DocumentLoader::stopRecordingResponses()
 void DocumentLoader::setCustomHeaderFields(Vector<CustomHeaderFields>&& fields)
 {
     m_customHeaderFields = WTFMove(fields);
+}
+
+void DocumentLoader::setQuirksData(std::optional<QuirksData>&& quirksData)
+{
+    m_maybeQuirksData = WTFMove(quirksData);
 }
 
 void DocumentLoader::setTitle(const StringWithDirection& title)

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2011 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,6 +45,7 @@
 #include "LinkIcon.h"
 #include "NavigationAction.h"
 #include "NavigationIdentifier.h"
+#include "QuirksData.h"
 #include "ResourceError.h"
 #include "ResourceLoaderIdentifier.h"
 #include "ResourceLoaderOptions.h"
@@ -106,6 +107,7 @@ class SharedBuffer;
 class SubresourceLoader;
 class SubstituteResource;
 class UserContentURLPattern;
+struct WebsiteQuirks;
 
 enum class ClearSiteDataValue : uint8_t;
 enum class LoadWillContinueInAnotherProcess : bool;
@@ -382,6 +384,9 @@ public:
 
     OptionSet<AutoplayQuirk> allowedAutoplayQuirks() const { return m_allowedAutoplayQuirks; }
     void setAllowedAutoplayQuirks(OptionSet<AutoplayQuirk> allowedQuirks) { m_allowedAutoplayQuirks = allowedQuirks; }
+
+    std::optional<QuirksData> maybeQuirksData() const { return m_maybeQuirksData; }
+    WEBCORE_EXPORT void setQuirksData(std::optional<QuirksData>&&);
 
     PopUpPolicy popUpPolicy() const { return m_popUpPolicy; }
     void setPopUpPolicy(PopUpPolicy popUpPolicy) { m_popUpPolicy = popUpPolicy; }
@@ -750,6 +755,7 @@ private:
     HTTPSByDefaultMode m_httpsByDefaultMode { HTTPSByDefaultMode::Disabled };
     ShouldOpenExternalURLsPolicy m_shouldOpenExternalURLsPolicy { ShouldOpenExternalURLsPolicy::ShouldNotAllow };
     PushAndNotificationsEnabledPolicy m_pushAndNotificationsEnabledPolicy { PushAndNotificationsEnabledPolicy::UseGlobalPolicy };
+    std::optional<QuirksData> m_maybeQuirksData;
 
     bool m_idempotentModeAutosizingOnlyHonorsPercentages { false };
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -121,6 +121,7 @@ static inline bool shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeIn
 
 Quirks::Quirks(Document& document)
     : m_document(document)
+    , m_maybeQuirksData(document.loader() ? document.loader()->maybeQuirksData() : std::nullopt)
 {
     determineRelevantQuirks();
 }
@@ -164,7 +165,7 @@ bool Quirks::isEmbedDomain(const String& domainString) const
 bool Quirks::needsFormControlToBeMouseFocusable() const
 {
 #if PLATFORM(MAC)
-    return needsQuirks() && m_quirksData.needsFormControlToBeMouseFocusableQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsFormControlToBeMouseFocusableQuirk;
 #else
     return false;
 #endif // PLATFORM(MAC)
@@ -189,7 +190,7 @@ bool Quirks::needsAutoplayPlayPauseEvents() const
 // - iOS PiP
 bool Quirks::needsSeekingSupportDisabled() const
 {
-    return needsQuirks() && m_quirksData.needsSeekingSupportDisabledQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsSeekingSupportDisabledQuirk;
 }
 
 // netflix.com https://bugs.webkit.org/show_bug.cgi?id=193301
@@ -200,14 +201,14 @@ bool Quirks::needsPerDocumentAutoplayBehavior() const
     ASSERT(document.ptr() == &document->topDocument());
     return needsQuirks() && allowedAutoplayQuirks(document).contains(AutoplayQuirk::PerDocumentAutoplayBehavior);
 #else
-    return needsQuirks() && m_quirksData.isNetflix;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->isNetflix;
 #endif
 }
 
 // zoom.com https://bugs.webkit.org/show_bug.cgi?id=223180
 bool Quirks::shouldAutoplayWebAudioForArbitraryUserGesture() const
 {
-    return needsQuirks() && m_quirksData.shouldAutoplayWebAudioForArbitraryUserGestureQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldAutoplayWebAudioForArbitraryUserGestureQuirk;
 }
 
 // youtube.com https://bugs.webkit.org/show_bug.cgi?id=195598
@@ -216,7 +217,7 @@ bool Quirks::hasBrokenEncryptedMediaAPISupportQuirk() const
 #if ENABLE(THUNDER)
     return false;
 #else
-    return needsQuirks() && m_quirksData.hasBrokenEncryptedMediaAPISupportQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->hasBrokenEncryptedMediaAPISupportQuirk;
 #endif
 }
 
@@ -224,7 +225,7 @@ bool Quirks::hasBrokenEncryptedMediaAPISupportQuirk() const
 bool Quirks::isTouchBarUpdateSuppressedForHiddenContentEditable() const
 {
 #if PLATFORM(MAC)
-    return needsQuirks() && m_quirksData.isTouchBarUpdateSuppressedForHiddenContentEditableQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->isTouchBarUpdateSuppressedForHiddenContentEditableQuirk;
 #else
     return false;
 #endif
@@ -237,7 +238,7 @@ bool Quirks::isTouchBarUpdateSuppressedForHiddenContentEditable() const
 bool Quirks::isNeverRichlyEditableForTouchBar() const
 {
 #if PLATFORM(MAC)
-    return needsQuirks() && m_quirksData.isNeverRichlyEditableForTouchBarQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->isNeverRichlyEditableForTouchBarQuirk;
 #else
     return false;
 #endif
@@ -248,7 +249,7 @@ bool Quirks::isNeverRichlyEditableForTouchBar() const
 bool Quirks::shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && m_quirksData.shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk;
 #else
     return false;
 #endif
@@ -261,7 +262,7 @@ bool Quirks::shouldDispatchSyntheticMouseEventsWhenModifyingSelection() const
     if (m_document->settings().shouldDispatchSyntheticMouseEventsWhenModifyingSelection())
         return true;
 
-    return needsQuirks() && m_quirksData.shouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk;
 }
 
 // www.youtube.com rdar://52361019
@@ -271,7 +272,7 @@ bool Quirks::needsYouTubeMouseOutQuirk() const
     if (m_document->settings().shouldDispatchSyntheticMouseOutAfterSyntheticClick())
         return true;
 
-    return needsQuirks() && m_quirksData.needsYouTubeMouseOutQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsYouTubeMouseOutQuirk;
 #else
     return false;
 #endif
@@ -281,7 +282,7 @@ bool Quirks::needsYouTubeMouseOutQuirk() const
 // FIXME (rdar://138585709): Remove this quirk for safe.menlosecurity.com once investigation into text corruption on the site is completed and the issue is resolved.
 bool Quirks::shouldDisableWritingSuggestionsByDefault() const
 {
-    return needsQuirks() && m_quirksData.shouldDisableWritingSuggestionsByDefaultQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldDisableWritingSuggestionsByDefaultQuirk;
 }
 
 void Quirks::updateStorageAccessUserAgentStringQuirks(HashMap<RegistrableDomain, String>&& userAgentStringQuirks)
@@ -318,22 +319,32 @@ bool Quirks::shouldDisableElementFullscreenQuirk() const
     if (!needsQuirks())
         return false;
 
-    // Vimeo.com has incorrect layout on iOS on certain videos with wider
-    // aspect ratios than the device's screen in landscape mode.
-    // (Ref: rdar://116531089)
-    // Instagram.com stories flow under the notch and status bar
-    // (Ref: rdar://121014613)
-    // x.com (Twitter) video embeds have controls that are too tiny and
-    // show page behind fullscreen.
-    // (Ref: rdar://121473410)
-    // YouTube.com does not provide AirPlay controls in fullscreen
-    // (Ref: rdar://121471373)
-    if (!m_quirksData.shouldDisableElementFullscreen && !m_document->isTopDocument()) {
-        m_quirksData.shouldDisableElementFullscreen = isEmbedDomain("x.com"_s)
-            || (PAL::currentUserInterfaceIdiomIsSmallScreen() && isYoutubeEmbedDomain());
+    if (m_document->isTopDocument()) {
+        // Vimeo.com has incorrect layout on iOS on certain videos with wider
+        // aspect ratios than the device's screen in landscape mode.
+        // (Ref: rdar://116531089)
+        // Instagram.com stories flow under the notch and status bar
+        // (Ref: rdar://121014613)
+        // YouTube.com does not provide AirPlay controls in fullscreen
+        // (Ref: rdar://121471373)
+        return m_maybeQuirksData && m_maybeQuirksData->shouldDisableElementFullscreenQuirk;
     }
 
-    return m_quirksData.shouldDisableElementFullscreen;
+    if (!m_didAssessEmbeddedFullscreenQuirk) {
+        // x.com (Twitter) video embeds have controls that are too tiny and
+        // show page behind fullscreen.
+        // (Ref: rdar://121473410)
+        // YouTube.com does not provide AirPlay controls in fullscreen
+        // (Ref: rdar://121471373)
+        if (isEmbedDomain("x.com"_s) || (PAL::currentUserInterfaceIdiomIsSmallScreen() && isYoutubeEmbedDomain())) {
+            if (!m_maybeQuirksData)
+                m_maybeQuirksData = QuirksData();
+            m_maybeQuirksData->shouldDisableElementFullscreenQuirk = true;
+        }
+        m_didAssessEmbeddedFullscreenQuirk = true;
+    }
+
+    return m_maybeQuirksData && m_maybeQuirksData->shouldDisableElementFullscreenQuirk;
 #else
     return false;
 #endif
@@ -351,6 +362,9 @@ bool Quirks::shouldDispatchSimulatedMouseEvents(const EventTarget* target) const
     if (m_document->settings().mouseEventsSimulationEnabled())
         return true;
 
+    if (!m_maybeQuirksData)
+        return false;
+
     if (!needsQuirks())
         return false;
 
@@ -359,11 +373,11 @@ bool Quirks::shouldDispatchSimulatedMouseEvents(const EventTarget* target) const
         if (!loader || loader->simulatedMouseEventsDispatchPolicy() != SimulatedMouseEventsDispatchPolicy::Allow)
             return QuirksData::ShouldDispatchSimulatedMouseEvents::No;
 
-        if (m_quirksData.isAmazon)
+        if (m_maybeQuirksData->isAmazon)
             return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
-        if (m_quirksData.isGoogleMaps)
+        if (m_maybeQuirksData->isGoogleMaps)
             return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
-        if (m_quirksData.isSoundCloud)
+        if (m_maybeQuirksData->isSoundCloud)
             return QuirksData::ShouldDispatchSimulatedMouseEvents::Yes;
 
         const URL& topDocumentURL = this->topDocumentURL();
@@ -401,10 +415,10 @@ bool Quirks::shouldDispatchSimulatedMouseEvents(const EventTarget* target) const
         return QuirksData::ShouldDispatchSimulatedMouseEvents::No;
     };
 
-    if (m_quirksData.shouldDispatchSimulatedMouseEventsQuirk == QuirksData::ShouldDispatchSimulatedMouseEvents::Unknown)
-        m_quirksData.shouldDispatchSimulatedMouseEventsQuirk = doShouldDispatchChecks();
+    if (m_maybeQuirksData->shouldDispatchSimulatedMouseEventsQuirk == QuirksData::ShouldDispatchSimulatedMouseEvents::Unknown)
+        m_maybeQuirksData->shouldDispatchSimulatedMouseEventsQuirk = doShouldDispatchChecks();
 
-    switch (m_quirksData.shouldDispatchSimulatedMouseEventsQuirk) {
+    switch (m_maybeQuirksData->shouldDispatchSimulatedMouseEventsQuirk) {
     case QuirksData::ShouldDispatchSimulatedMouseEvents::Unknown:
         ASSERT_NOT_REACHED();
         return false;
@@ -435,14 +449,17 @@ bool Quirks::shouldDispatchedSimulatedMouseEventsAssumeDefaultPrevented(EventTar
     if (!needsQuirks() || !shouldDispatchSimulatedMouseEvents(target))
         return false;
 
-    if (!m_quirksData.shouldDispatchedSimulatedMouseEventsAssumeDefaultPreventedQuirk)
+    if (!m_maybeQuirksData)
+        return false;
+
+    if (!m_maybeQuirksData->shouldDispatchedSimulatedMouseEventsAssumeDefaultPreventedQuirk)
         return false;
 
     RefPtr element = dynamicDowncast<Element>(target);
     if (!element)
         return false;
 
-    if (m_quirksData.isAmazon) {
+    if (m_maybeQuirksData->isAmazon) {
         // When panning on an Amazon product image, we're either touching on the #magnifierLens element
         // or its previous sibling.
         if (element->getIdAttribute() == "magnifierLens"_s)
@@ -451,7 +468,7 @@ bool Quirks::shouldDispatchedSimulatedMouseEventsAssumeDefaultPrevented(EventTar
             return sibling->getIdAttribute() == "magnifierLens"_s;
     }
 
-    if (m_quirksData.isSoundCloud)
+    if (m_maybeQuirksData->isSoundCloud)
         return element->hasClassName("sceneLayer"_s);
 
     return false;
@@ -463,7 +480,10 @@ bool Quirks::shouldPreventDispatchOfTouchEvent(const AtomString& touchEventType,
     if (!needsQuirks())
         return false;
 
-    if (!m_quirksData.shouldPreventDispatchOfTouchEventQuirk)
+    if (!m_maybeQuirksData)
+        return false;
+
+    if (!m_maybeQuirksData->shouldPreventDispatchOfTouchEventQuirk)
         return false;
 
     if (RefPtr element = dynamicDowncast<Element>(target); element && touchEventType == eventNames().touchendEvent)
@@ -479,14 +499,14 @@ bool Quirks::shouldPreventDispatchOfTouchEvent(const AtomString& touchEventType,
 // maps.google.com https://bugs.webkit.org/show_bug.cgi?id=214945
 bool Quirks::shouldAvoidResizingWhenInputViewBoundsChange() const
 {
-    return needsQuirks() && m_quirksData.shouldAvoidResizingWhenInputViewBoundsChangeQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldAvoidResizingWhenInputViewBoundsChangeQuirk;
 }
 
 // mailchimp.com rdar://47868965
 bool Quirks::shouldDisablePointerEventsQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && m_quirksData.shouldDisablePointerEventsQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldDisablePointerEventsQuirk;
 #else
     return false;
 #endif
@@ -499,7 +519,7 @@ bool Quirks::needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommand() const
     if (m_document->settings().needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk())
         return true;
 
-    return needsQuirks() && m_quirksData.isGoogleDocs;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->isGoogleDocs;
 #else
     return false;
 #endif
@@ -510,7 +530,7 @@ bool Quirks::needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommand() const
 bool Quirks::needsGMailOverflowScrollQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && m_quirksData.needsGMailOverflowScrollQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsGMailOverflowScrollQuirk;
 #else
     return false;
 #endif
@@ -520,7 +540,7 @@ bool Quirks::needsGMailOverflowScrollQuirk() const
 bool Quirks::needsIPadSkypeOverflowScrollQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && m_quirksData.needsIPadSkypeOverflowScrollQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsIPadSkypeOverflowScrollQuirk;
 #else
     return false;
 #endif
@@ -531,7 +551,7 @@ bool Quirks::needsIPadSkypeOverflowScrollQuirk() const
 bool Quirks::needsYouTubeOverflowScrollQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && m_quirksData.needsYouTubeOverflowScrollQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsYouTubeOverflowScrollQuirk;
 #else
     return false;
 #endif
@@ -541,7 +561,7 @@ bool Quirks::needsYouTubeOverflowScrollQuirk() const
 bool Quirks::needsPrimeVideoUserSelectNoneQuirk() const
 {
 #if PLATFORM(MAC)
-    return needsQuirks() && m_quirksData.needsPrimeVideoUserSelectNoneQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsPrimeVideoUserSelectNoneQuirk;
 #else
     return false;
 #endif
@@ -551,20 +571,20 @@ bool Quirks::needsPrimeVideoUserSelectNoneQuirk() const
 // NOTE: Also remove `BuilderConverter::convertScrollbarWidth` and related code when removing this quirk.
 bool Quirks::needsScrollbarWidthThinDisabledQuirk() const
 {
-    return needsQuirks() && m_quirksData.needsScrollbarWidthThinDisabledQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsScrollbarWidthThinDisabledQuirk;
 }
 
 // spotify.com rdar://138918575
 bool Quirks::needsBodyScrollbarWidthNoneDisabledQuirk() const
 {
-    return needsQuirks() && m_quirksData.needsBodyScrollbarWidthNoneDisabledQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsBodyScrollbarWidthNoneDisabledQuirk;
 }
 
 // gizmodo.com rdar://102227302
 bool Quirks::needsFullscreenDisplayNoneQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && m_quirksData.needsFullscreenDisplayNoneQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsFullscreenDisplayNoneQuirk;
 #else
     return false;
 #endif
@@ -574,7 +594,7 @@ bool Quirks::needsFullscreenDisplayNoneQuirk() const
 bool Quirks::needsFullscreenObjectFitQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && m_quirksData.needsFullscreenObjectFitQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsFullscreenObjectFitQuirk;
 #else
     return false;
 #endif
@@ -595,7 +615,7 @@ bool Quirks::needsWeChatScrollingQuirk() const
 bool Quirks::needsGoogleMapsScrollingQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && m_quirksData.needsGoogleMapsScrollingQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsGoogleMapsScrollingQuirk;
 #else
     return false;
 #endif
@@ -619,6 +639,9 @@ bool Quirks::shouldSilenceResizeObservers() const
     if (!needsQuirks())
         return false;
 
+    if (!m_maybeQuirksData)
+        return false;
+
     // ResizeObservers are silenced on YouTube during the 'homing out' snapshout sequence to
     // resolve rdar://109837319. This is due to a bug on the site that is causing unexpected
     // content layout and can be removed when it is addressed.
@@ -626,7 +649,7 @@ bool Quirks::shouldSilenceResizeObservers() const
     if (!page || !page->isTakingSnapshotsForApplicationSuspension())
         return false;
 
-    return m_quirksData.shouldSilenceResizeObservers;
+    return m_maybeQuirksData->shouldSilenceResizeObservers;
 #else
     return false;
 #endif
@@ -638,7 +661,10 @@ bool Quirks::shouldSilenceWindowResizeEvents() const
     if (!needsQuirks())
         return false;
 
-    if (!m_quirksData.shouldSilenceWindowResizeEvents)
+    if (!m_maybeQuirksData)
+        return false;
+
+    if (!m_maybeQuirksData->shouldSilenceWindowResizeEvents)
         return false;
 
     // We silence window resize events during the 'homing out' snapshot sequence when on nytimes.com
@@ -660,7 +686,10 @@ bool Quirks::shouldSilenceMediaQueryListChangeEvents() const
     if (!needsQuirks())
         return false;
 
-    if (!m_quirksData.shouldSilenceMediaQueryListChangeEvents)
+    if (!m_maybeQuirksData)
+        return false;
+
+    if (!m_maybeQuirksData->shouldSilenceMediaQueryListChangeEvents)
         return false;
 
     // We silence MediaQueryList's change events during the 'homing out' snapshot sequence when on x.com (twitter)
@@ -678,20 +707,20 @@ bool Quirks::shouldSilenceMediaQueryListChangeEvents() const
 // zillow.com rdar://53103732
 bool Quirks::shouldAvoidScrollingWhenFocusedContentIsVisible() const
 {
-    return needsQuirks() && m_quirksData.shouldAvoidScrollingWhenFocusedContentIsVisibleQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldAvoidScrollingWhenFocusedContentIsVisibleQuirk;
 }
 
 // att.com rdar://55185021
 bool Quirks::shouldUseLegacySelectPopoverDismissalBehaviorInDataActivation() const
 {
-    return needsQuirks() && m_quirksData.shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk;
 }
 
 // ralphlauren.com rdar://55629493
 bool Quirks::shouldIgnoreAriaForFastPathContentObservationCheck() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && m_quirksData.shouldIgnoreAriaForFastPathContentObservationCheckQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldIgnoreAriaForFastPathContentObservationCheckQuirk;
 #else
     return false;
 #endif
@@ -701,7 +730,7 @@ bool Quirks::shouldIgnoreAriaForFastPathContentObservationCheck() const
 bool Quirks::shouldIgnoreViewportArgumentsToAvoidExcessiveZoom() const
 {
 #if ENABLE(META_VIEWPORT)
-    return needsQuirks() && m_quirksData.shouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk;
 #endif
     return false;
 }
@@ -735,7 +764,7 @@ bool Quirks::shouldOpenAsAboutBlank(const String& stringToOpen) const
 bool Quirks::needsPreloadAutoQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && m_quirksData.needsPreloadAutoQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsPreloadAutoQuirk;
 #else
     return false;
 #endif
@@ -749,7 +778,10 @@ bool Quirks::shouldBypassBackForwardCache() const
     if (!needsQuirks())
         return false;
 
-    if (!m_quirksData.maybeBypassBackForwardCache)
+    if (!m_maybeQuirksData)
+        return false;
+
+    if (!m_maybeQuirksData->maybeBypassBackForwardCache)
         return false;
 
     RefPtr document = m_document.get();
@@ -758,20 +790,20 @@ bool Quirks::shouldBypassBackForwardCache() const
     // We started caching such content in r250437 but the vimeo.com content unfortunately is not currently compatible
     // because it changes the opacity of its body to 0 when navigating away and fails to restore the original opacity
     // when coming back from the back/forward cache (e.g. in 'pageshow' event handler). See <rdar://problem/56996057>.
-    if (m_quirksData.isVimeo && topDocumentURL().protocolIs("https"_s)) {
+    if (m_maybeQuirksData->isVimeo && topDocumentURL().protocolIs("https"_s)) {
         if (auto* documentLoader = document->frame() ? document->frame()->loader().documentLoader() : nullptr)
             return documentLoader->response().cacheControlContainsNoStore();
     }
 
     // Spinner issue from image search for bing.com.
-    if (m_quirksData.isBing) {
+    if (m_maybeQuirksData->isBing) {
         static MainThreadNeverDestroyed<const AtomString> imageSearchDialogID("sb_sbidialog"_s);
         if (RefPtr element = document->getElementById(imageSearchDialogID.get()))
             return element->renderer();
     }
 
     // Login issue on bankofamerica.com (rdar://104938789).
-    if (m_quirksData.isBankOfAmerica) {
+    if (m_maybeQuirksData->isBankOfAmerica) {
         if (RefPtr window = document->domWindow()) {
             if (window->hasEventListeners(eventNames().unloadEvent)) {
                 static MainThreadNeverDestroyed<const AtomString> signInId("signIn"_s);
@@ -782,7 +814,7 @@ bool Quirks::shouldBypassBackForwardCache() const
         }
     }
 
-    if (m_quirksData.isGoogleProperty) {
+    if (m_maybeQuirksData->isGoogleProperty) {
         // Google Docs used to bypass the back/forward cache by serving "Cache-Control: no-store" over HTTPS.
         // We started caching such content in r250437 but the Google Docs index page unfortunately is not currently compatible
         // because it puts an overlay (with class "docs-homescreen-freeze-el-full") over the page when navigating away and fails
@@ -805,7 +837,7 @@ bool Quirks::shouldBypassAsyncScriptDeferring() const
 {
     // Deferring 'mapbox-gl.js' script on bungalow.com causes the script to get in a bad state (rdar://problem/61658940).
     // Deferring the google maps script on sfusd.edu may get the page in a bad state (rdar://116292738).
-    return needsQuirks() && m_quirksData.shouldBypassAsyncScriptDeferring;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldBypassAsyncScriptDeferring;
 }
 
 // smoothscroll JS library rdar://52712513
@@ -849,20 +881,20 @@ bool Quirks::shouldMakeEventListenerPassive(const EventTarget& eventTarget, cons
 // baidu.com rdar://56421276
 bool Quirks::shouldEnableLegacyGetUserMediaQuirk() const
 {
-    return needsQuirks() && m_quirksData.shouldEnableLegacyGetUserMediaQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldEnableLegacyGetUserMediaQuirk;
 }
 
 // zoom.us rdar://118185086
 bool Quirks::shouldDisableImageCaptureQuirk() const
 {
-    return needsQuirks() && m_quirksData.shouldDisableImageCaptureQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldDisableImageCaptureQuirk;
 }
 #endif
 
 // hulu.com rdar://55041979
 bool Quirks::needsCanPlayAfterSeekedQuirk() const
 {
-    return needsQuirks() && m_quirksData.needsCanPlayAfterSeekedQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsCanPlayAfterSeekedQuirk;
 }
 
 // wikipedia.org rdar://54856323
@@ -870,14 +902,14 @@ bool Quirks::shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraints() co
 {
     // FIXME: We should consider replacing this with a heuristic to determine whether
     // or not the edges of the page mostly lack content after shrinking to fit.
-    return needsQuirks() && m_quirksData.shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk;
 }
 
 // mail.yahoo.com rdar://63511613
 bool Quirks::shouldAvoidPastingImagesAsWebContent() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && m_quirksData.shouldAvoidPastingImagesAsWebContent;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldAvoidPastingImagesAsWebContent;
 #else
     return false;
 #endif
@@ -1097,7 +1129,7 @@ Quirks::StorageAccessResult Quirks::triggerOptionalStorageAccessQuirk(Element& e
 // youtube.com rdar://66242343
 bool Quirks::needsVP9FullRangeFlagQuirk() const
 {
-    return needsQuirks() && m_quirksData.needsVP9FullRangeFlagQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsVP9FullRangeFlagQuirk;
 }
 
 // facebook.com: rdar://67273166
@@ -1110,7 +1142,7 @@ bool Quirks::requiresUserGestureToPauseInPictureInPicture() const
     // Facebook, X (twitter), and Reddit will naively pause a <video> element that has scrolled out of the viewport,
     // regardless of whether that element is currently in PiP mode.
     // We should remove the quirk once <rdar://problem/67273166>, <rdar://problem/73369869>, and <rdar://problem/80645747> have been fixed.
-    return needsQuirks() && m_quirksData.requiresUserGestureToPauseInPictureInPictureQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->requiresUserGestureToPauseInPictureInPictureQuirk;
 #else
     return false;
 #endif
@@ -1119,7 +1151,7 @@ bool Quirks::requiresUserGestureToPauseInPictureInPicture() const
 // bbc.co.uk: rdar://126494734
 bool Quirks::returnNullPictureInPictureElementDuringFullscreenChange() const
 {
-    return needsQuirks() && m_quirksData.returnNullPictureInPictureElementDuringFullscreenChangeQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->returnNullPictureInPictureElementDuringFullscreenChangeQuirk;
 }
 
 // twitter.com: rdar://73369869
@@ -1129,7 +1161,7 @@ bool Quirks::requiresUserGestureToLoadInPictureInPicture() const
     // X (Twitter) will remove the "src" attribute of a <video> element that has scrolled out of the viewport and
     // load the <video> element with an empty "src" regardless of whether that element is currently in PiP mode.
     // We should remove the quirk once <rdar://problem/73369869> has been fixed.
-    return needsQuirks() && m_quirksData.requiresUserGestureToLoadInPictureInPictureQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->requiresUserGestureToLoadInPictureInPictureQuirk;
 #else
     return false;
 #endif
@@ -1143,7 +1175,7 @@ bool Quirks::blocksReturnToFullscreenFromPictureInPictureQuirk() const
     // returns to fullscreen from picture-in-picture. This quirk disables the "return to fullscreen
     // from picture-in-picture" feature for those sites. We should remove the quirk once
     // rdar://problem/73167931 has been fixed.
-    return needsQuirks() && m_quirksData.blocksReturnToFullscreenFromPictureInPictureQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->blocksReturnToFullscreenFromPictureInPictureQuirk;
 #else
     return false;
 #endif
@@ -1155,7 +1187,7 @@ bool Quirks::blocksEnteringStandardFullscreenFromPictureInPictureQuirk() const
 #if ENABLE(FULLSCREEN_API) && ENABLE(VIDEO_PRESENTATION_MODE)
     // Vimeo enters fullscreen when starting playback from the inline play button while already in PIP.
     // This behavior is revealing a bug in the fullscreen handling. See rdar://107592139.
-    return needsQuirks() && m_quirksData.blocksEnteringStandardFullscreenFromPictureInPictureQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->blocksEnteringStandardFullscreenFromPictureInPictureQuirk;
 #else
     return false;
 #endif
@@ -1170,7 +1202,7 @@ bool Quirks::shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFull
     // from fullscreen for the sites which cannot handle the event properly in that case.
     // We should remove once the quirks have been fixed.
     // <rdar://90393832> vimeo.com
-    return needsQuirks() && m_quirksData.shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk;
 #else
     return false;
 #endif
@@ -1182,7 +1214,7 @@ bool Quirks::shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk() const
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     // This quirk delay the "webkitstartfullscreen" and "fullscreenchange" event when a video exits picture-in-picture
     // to fullscreen.
-    return needsQuirks() && m_quirksData.shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk;
 #else
     return false;
 #endif
@@ -1199,7 +1231,7 @@ bool Quirks::shouldAllowNavigationToCustomProtocolWithoutUserGesture(StringView 
 // espn.com: rdar://problem/95651814
 bool Quirks::allowLayeredFullscreenVideos() const
 {
-    return needsQuirks() && m_quirksData.allowLayeredFullscreenVideos;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->allowLayeredFullscreenVideos;
 }
 #endif
 
@@ -1208,7 +1240,7 @@ bool Quirks::allowLayeredFullscreenVideos() const
 // FIXME (rdar://124579556): Remove once 'x.com' adjusts video handling for visionOS.
 bool Quirks::shouldDisableFullscreenVideoAspectRatioAdaptiveSizing() const
 {
-    return needsQuirks() && m_quirksData.shouldDisableFullscreenVideoAspectRatioAdaptiveSizingQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldDisableFullscreenVideoAspectRatioAdaptiveSizingQuirk;
 }
 #endif
 
@@ -1221,16 +1253,16 @@ bool Quirks::shouldEnableApplicationCacheQuirk() const
 // play.hbomax.com https://bugs.webkit.org/show_bug.cgi?id=244737
 bool Quirks::shouldEnableFontLoadingAPIQuirk() const
 {
-    if (!needsQuirks() || m_document->settings().downloadableBinaryFontTrustedTypes() == DownloadableBinaryFontTrustedTypes::Any)
+    if (!needsQuirks() || !m_maybeQuirksData || m_document->settings().downloadableBinaryFontTrustedTypes() == DownloadableBinaryFontTrustedTypes::Any)
         return false;
 
-    return m_quirksData.shouldEnableFontLoadingAPIQuirk;
+    return m_maybeQuirksData->shouldEnableFontLoadingAPIQuirk;
 }
 
 // hulu.com rdar://100199996
 bool Quirks::needsVideoShouldMaintainAspectRatioQuirk() const
 {
-    return needsQuirks() && m_quirksData.needsVideoShouldMaintainAspectRatioQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsVideoShouldMaintainAspectRatioQuirk;
 }
 
 // Marcus: <rdar://101086391>.
@@ -1238,14 +1270,14 @@ bool Quirks::needsVideoShouldMaintainAspectRatioQuirk() const
 // Soundcloud: <rdar://102913500>.
 bool Quirks::shouldExposeShowModalDialog() const
 {
-    return needsQuirks() && m_quirksData.shouldExposeShowModalDialog;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldExposeShowModalDialog;
 }
 
 // marcus.com rdar://102959860
 bool Quirks::shouldNavigatorPluginsBeEmpty() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && m_quirksData.shouldNavigatorPluginsBeEmpty;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldNavigatorPluginsBeEmpty;
 #else
     return false;
 #endif
@@ -1254,19 +1286,19 @@ bool Quirks::shouldNavigatorPluginsBeEmpty() const
 // Fix for the UNIQLO app (rdar://104519846).
 bool Quirks::shouldDisableLazyIframeLoadingQuirk() const
 {
-    return needsQuirks() && m_quirksData.shouldDisableLazyIframeLoadingQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldDisableLazyIframeLoadingQuirk;
 }
 
 // Breaks express checkout on victoriassecret.com (rdar://104818312).
 bool Quirks::shouldDisableFetchMetadata() const
 {
-    return needsQuirks() && m_quirksData.shouldDisableFetchMetadata;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldDisableFetchMetadata;
 }
 
 // Push state file path restrictions break Mimeo Photo Plugin (rdar://112445672).
 bool Quirks::shouldDisablePushStateFilePathRestrictions() const
 {
-    return needsQuirks() && m_quirksData.shouldDisablePushStateFilePathRestrictions;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldDisablePushStateFilePathRestrictions;
 }
 
 // ungap/@custom-elements polyfill (rdar://problem/111008826).
@@ -1324,7 +1356,7 @@ String Quirks::advancedPrivacyProtectionSubstituteDataURLForScriptWithFeatures(c
 bool Quirks::needsResettingTransitionCancelsRunningTransitionQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && m_quirksData.needsResettingTransitionCancelsRunningTransitionQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsResettingTransitionCancelsRunningTransitionQuirk;
 #else
     return false;
 #endif
@@ -1333,7 +1365,7 @@ bool Quirks::needsResettingTransitionCancelsRunningTransitionQuirk() const
 // Microsoft office online generates data URLs with incorrect padding on Safari only (rdar://114573089).
 bool Quirks::shouldDisableDataURLPaddingValidation() const
 {
-    return needsQuirks() && m_quirksData.shouldDisableDataURLPaddingValidation;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldDisableDataURLPaddingValidation;
 }
 
 bool Quirks::needsDisableDOMPasteAccessQuirk() const
@@ -1341,36 +1373,43 @@ bool Quirks::needsDisableDOMPasteAccessQuirk() const
     if (!needsQuirks())
         return false;
 
-    if (m_quirksData.needsDisableDOMPasteAccessQuirk)
-        return *m_quirksData.needsDisableDOMPasteAccessQuirk;
+    if (!m_didAssessDisableDOMPasteAccessQuirk) {
+        auto needsDisableDOMPasteAccessQuirk = [&] {
+            if (!m_document)
+                return false;
+            auto* globalObject = m_document->globalObject();
+            if (!globalObject)
+                return false;
 
-    m_quirksData.needsDisableDOMPasteAccessQuirk = [&] {
-        if (!m_document)
-            return false;
-        auto* globalObject = m_document->globalObject();
-        if (!globalObject)
-            return false;
+            Ref vm = globalObject->vm();
+            JSC::JSLockHolder lock(vm);
+            auto tableauPrepProperty = JSC::Identifier::fromString(vm, "tableauPrep"_s);
+            return globalObject->hasProperty(globalObject, tableauPrepProperty);
+        }();
 
-        Ref vm = globalObject->vm();
-        JSC::JSLockHolder lock(vm);
-        auto tableauPrepProperty = JSC::Identifier::fromString(vm, "tableauPrep"_s);
-        return globalObject->hasProperty(globalObject, tableauPrepProperty);
-    }();
+        if (needsDisableDOMPasteAccessQuirk) {
+            if (!m_maybeQuirksData)
+                m_maybeQuirksData = QuirksData();
+            m_maybeQuirksData->needsDisableDOMPasteAccessQuirk = true;
+        }
 
-    return *m_quirksData.needsDisableDOMPasteAccessQuirk;
+        m_didAssessDisableDOMPasteAccessQuirk = true;
+    }
+
+    return m_maybeQuirksData && m_maybeQuirksData->needsDisableDOMPasteAccessQuirk;
 }
 
 // rdar://133423460
 bool Quirks::shouldPreventOrientationMediaQueryFromEvaluatingToLandscape() const
 {
-    return needsQuirks() && m_quirksData.shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk;
 }
 
 // rdar://133423460
 bool Quirks::shouldFlipScreenDimensions() const
 {
 #if ENABLE(FLIP_SCREEN_DIMENSIONS_QUIRKS)
-    return needsQuirks() && m_quirksData.shouldFlipScreenDimensionsQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldFlipScreenDimensionsQuirk;
 #else
     return false;
 #endif
@@ -1379,7 +1418,7 @@ bool Quirks::shouldFlipScreenDimensions() const
 // FIXME: Remove this when rdar://137625935 is resolved.
 bool Quirks::shouldAllowDownloadsInSpiteOfCSP() const
 {
-    return needsQuirks() && m_quirksData.shouldAllowDownloadsInSpiteOfCSPQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldAllowDownloadsInSpiteOfCSPQuirk;
 }
 
 // This section is dedicated to UA override for iPad. iPads (but iPad Mini) are sending a desktop user agent
@@ -1467,7 +1506,7 @@ bool Quirks::needsPartitionedCookies(const ResourceRequest& request)
 bool Quirks::shouldIgnorePlaysInlineRequirementQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
-    return needsQuirks() && m_quirksData.shouldIgnorePlaysInlineRequirementQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldIgnorePlaysInlineRequirementQuirk;
 #else
     return false;
 #endif
@@ -1493,7 +1532,7 @@ bool Quirks::shouldUseEphemeralPartitionedStorageForDOMCookies(const URL& url) c
 bool Quirks::needsGetElementsByNameQuirk() const
 {
 #if PLATFORM(IOS)
-    return needsQuirks() && m_quirksData.needsGetElementsByNameQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsGetElementsByNameQuirk;
 #else
     return false;
 #endif
@@ -1503,7 +1542,7 @@ bool Quirks::needsGetElementsByNameQuirk() const
 // FIXME: Remove this quirk when <rdar://127247321> is complete
 bool Quirks::needsRelaxedCorsMixedContentCheckQuirk() const
 {
-    return needsQuirks() && m_quirksData.needsRelaxedCorsMixedContentCheckQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsRelaxedCorsMixedContentCheckQuirk;
 }
 
 // rdar://127398734
@@ -1519,7 +1558,7 @@ bool Quirks::needsLaxSameSiteCookieQuirk(const URL& requestURL) const
 // news.ycombinator.com: rdar://127246368
 bool Quirks::shouldIgnoreTextAutoSizing() const
 {
-    return needsQuirks() && m_quirksData.shouldIgnoreTextAutoSizingQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldIgnoreTextAutoSizingQuirk;
 }
 #endif
 
@@ -1539,15 +1578,18 @@ String Quirks::scriptToEvaluateBeforeRunningScriptFromURL(const URL& scriptURL)
     if (!needsQuirks())
         return { };
 
-    if (!m_quirksData.needsScriptToEvaluateBeforeRunningScriptFromURLQuirk)
+    if (!m_maybeQuirksData)
+        return { };
+
+    if (!m_maybeQuirksData->needsScriptToEvaluateBeforeRunningScriptFromURLQuirk)
         return { };
 
     // player.anyclip.com rdar://138789765
-    if (UNLIKELY(m_quirksData.isThesaurus && scriptURL.lastPathComponent().endsWith("lre.js"_s)) && scriptURL.host() == "player.anyclip.com"_s)
+    if (UNLIKELY(m_maybeQuirksData->isThesaurus && scriptURL.lastPathComponent().endsWith("lre.js"_s)) && scriptURL.host() == "player.anyclip.com"_s)
         return "(function() { let userAgent = navigator.userAgent; Object.defineProperty(navigator, 'userAgent', { get: () => { return userAgent + ' Chrome/130.0.0.0 Android/15.0'; }, configurable: true }); })();"_s;
 
 #if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
-    if (UNLIKELY(m_quirksData.isWebEx && scriptURL.lastPathComponent().startsWith("pushdownload."_s)))
+    if (UNLIKELY(m_maybeQuirksData->isWebEx && scriptURL.lastPathComponent().startsWith("pushdownload."_s)))
         return "Object.defineProperty(window, 'Touch', { get: () => undefined });"_s;
 #endif
 #else
@@ -1561,7 +1603,7 @@ String Quirks::scriptToEvaluateBeforeRunningScriptFromURL(const URL& scriptURL)
 bool Quirks::shouldHideCoarsePointerCharacteristics() const
 {
 #if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
-    return needsQuirks() && m_quirksData.shouldHideCoarsePointerCharacteristicsQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldHideCoarsePointerCharacteristicsQuirk;
 #else
     return false;
 #endif
@@ -1571,7 +1613,7 @@ bool Quirks::shouldHideCoarsePointerCharacteristics() const
 bool Quirks::implicitMuteWhenVolumeSetToZero() const
 {
 #if HAVE(MEDIA_VOLUME_PER_ELEMENT)
-    return needsQuirks() && m_quirksData.implicitMuteWhenVolumeSetToZero;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->implicitMuteWhenVolumeSetToZero;
 #else
     return false;
 #endif
@@ -1587,7 +1629,7 @@ bool Quirks::shouldOmitTouchEventDOMAttributesForDesktopWebsite(const URL& reque
 // soylent.*; rdar://113314067
 bool Quirks::shouldDispatchPointerOutAfterHandlingSyntheticClick() const
 {
-    return needsQuirks() && m_quirksData.shouldDispatchPointerOutAfterHandlingSyntheticClick;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldDispatchPointerOutAfterHandlingSyntheticClick;
 }
 
 #endif // ENABLE(TOUCH_EVENTS)
@@ -1596,7 +1638,7 @@ bool Quirks::shouldDispatchPointerOutAfterHandlingSyntheticClick() const
 bool Quirks::needsZeroMaxTouchPointsQuirk() const
 {
 #if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
-    return needsQuirks() && m_quirksData.needsZeroMaxTouchPointsQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsZeroMaxTouchPointsQuirk;
 #else
     return false;
 #endif
@@ -1605,7 +1647,7 @@ bool Quirks::needsZeroMaxTouchPointsQuirk() const
 // imdb.com: rdar://137991466
 bool Quirks::needsChromeMediaControlsPseudoElement() const
 {
-    return needsQuirks() && m_quirksData.needsChromeMediaControlsPseudoElementQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsChromeMediaControlsPseudoElementQuirk;
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -1613,7 +1655,7 @@ bool Quirks::needsChromeMediaControlsPseudoElement() const
 // store.steampowered.com: rdar://142573562
 bool Quirks::shouldTreatAddingMouseOutEventListenerAsContentChange() const
 {
-    return needsQuirks() && m_quirksData.shouldTreatAddingMouseOutEventListenerAsContentChange;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->shouldTreatAddingMouseOutEventListenerAsContentChange;
 }
 
 // cbssports.com <rdar://139478801>.
@@ -1623,13 +1665,16 @@ bool Quirks::shouldSynthesizeTouchEventsAfterNonSyntheticClick(const Element& ta
     if (!needsQuirks())
         return false;
 
-    if (!m_quirksData.shouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk)
+    if (!m_maybeQuirksData)
         return false;
 
-    if (m_quirksData.isCBSSports)
+    if (!m_maybeQuirksData->shouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk)
+        return false;
+
+    if (m_maybeQuirksData->isCBSSports)
         return target.nodeName() == "AVIA-BUTTON"_s;
 
-    if (m_quirksData.isGoogleDocs) {
+    if (m_maybeQuirksData->isGoogleDocs) {
         unsigned numberOfAncestorsToCheck = 3;
         for (Ref ancestor : lineageOfType<HTMLElement>(target)) {
             if (ancestor->hasClassName("docs-ml-promotion-action-container"_s))
@@ -1654,7 +1699,10 @@ bool Quirks::shouldIgnoreContentObservationForClick(const Node& targetNode) cons
     if (!needsQuirks())
         return false;
 
-    if (!m_quirksData.mayNeedToIgnoreContentObservation)
+    if (!m_maybeQuirksData)
+        return false;
+
+    if (!m_maybeQuirksData->mayNeedToIgnoreContentObservation)
         return false;
 
     RefPtr target = dynamicDowncast<Element>(targetNode);
@@ -1673,7 +1721,7 @@ bool Quirks::shouldIgnoreContentObservationForClick(const Node& targetNode) cons
 // outlook.live.com: rdar://136624720
 bool Quirks::needsMozillaFileTypeForDataTransfer() const
 {
-    return needsQuirks() && m_quirksData.needsMozillaFileTypeForDataTransferQuirk;
+    return m_maybeQuirksData && needsQuirks() && m_maybeQuirksData->needsMozillaFileTypeForDataTransferQuirk;
 }
 
 // bing.com rdar://126573838
@@ -1682,7 +1730,10 @@ bool Quirks::needsBingGestureEventQuirk(EventTarget* target) const
     if (!needsQuirks())
         return false;
 
-    if (!m_quirksData.needsBingGestureEventQuirk)
+    if (!m_maybeQuirksData)
+        return false;
+
+    if (!m_maybeQuirksData->needsBingGestureEventQuirk)
         return false;
 
     if (RefPtr element = dynamicDowncast<Element>(target)) {
@@ -1700,7 +1751,10 @@ bool Quirks::shouldAvoidStartingSelectionOnMouseDown(const Node& target) const
     if (!needsQuirks())
         return false;
 
-    if (!m_quirksData.shouldAvoidStartingSelectionOnMouseDown)
+    if (!m_maybeQuirksData)
+        return false;
+
+    if (!m_maybeQuirksData->shouldAvoidStartingSelectionOnMouseDown)
         return false;
 
     if (CheckedPtr style = target.renderStyle()) {
@@ -1751,7 +1805,10 @@ bool Quirks::needsFacebookStoriesCreationFormQuirk(const Element& element, const
     if (!needsQuirks())
         return false;
 
-    if (!m_quirksData.isFacebook)
+    if (!m_maybeQuirksData)
+        return false;
+
+    if (!m_maybeQuirksData->isFacebook)
         return false;
 
     if (!topDocumentURL().path().startsWith("/stories/create"_s)) {
@@ -2643,35 +2700,49 @@ static void handleZoomQuirks(QuirksData& quirksData, const URL& quirksURL, const
 #endif
 }
 
-void Quirks::determineRelevantQuirks()
+std::optional<QuirksData> Quirks::identifyQuirksForURL(const URL& quirksURL)
 {
-    RELEASE_ASSERT(m_document);
-    m_quirksData = { };
+    std::optional<QuirksData> quirksData;
 
 #if PLATFORM(IOS_FAMILY)
     static const bool shouldDisableLazyIframeLoadingQuirk = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoUNIQLOLazyIframeLoadingQuirk) && WTF::IOSApplication::isUNIQLOApp();
     static const bool needsResettingTransitionCancelsRunningTransitionQuirk = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ResettingTransitionCancelsRunningTransitionQuirk) && WTF::IOSApplication::isDOFUSTouch();
 
-    m_quirksData.shouldDisableLazyIframeLoadingQuirk = shouldDisableLazyIframeLoadingQuirk;
-    // DOFUS Touch app (rdar://112679186)
-    m_quirksData.needsResettingTransitionCancelsRunningTransitionQuirk = needsResettingTransitionCancelsRunningTransitionQuirk;
+    if (shouldDisableLazyIframeLoadingQuirk || needsResettingTransitionCancelsRunningTransitionQuirk) {
+        if (!quirksData)
+            quirksData = QuirksData();
+
+        quirksData->shouldDisableLazyIframeLoadingQuirk = shouldDisableLazyIframeLoadingQuirk;
+        // DOFUS Touch app (rdar://112679186)
+        quirksData->needsResettingTransitionCancelsRunningTransitionQuirk = needsResettingTransitionCancelsRunningTransitionQuirk;
+    }
 #endif
 
 #if PLATFORM(IOS)
     // This quirk has intentionally limited exposure to increase the odds of being able to remove it
     // again within a reasonable timeframe as the impacted apps are being updated. <rdar://122548304>
     static const bool needsGetElementsByNameQuirk = !PAL::currentUserInterfaceIdiomIsSmallScreen() && !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoGetElementsByNameQuirk);
-    m_quirksData.needsGetElementsByNameQuirk = needsGetElementsByNameQuirk;
+    if (needsGetElementsByNameQuirk) {
+        if (!quirksData)
+            quirksData = QuirksData();
+
+        quirksData->needsGetElementsByNameQuirk = needsGetElementsByNameQuirk;
+    }
 #endif
 
 #if PLATFORM(MAC)
-    // Push state file path restrictions break Mimeo Photo Plugin (rdar://112445672).
-    m_quirksData.shouldDisablePushStateFilePathRestrictions = WTF::MacApplication::isMimeoPhotoProject();
+    static const bool isMimeoPhotoProject = WTF::MacApplication::isMimeoPhotoProject();
+    if (isMimeoPhotoProject) {
+        if (!quirksData)
+            quirksData = QuirksData();
+
+        // Push state file path restrictions break Mimeo Photo Plugin (rdar://112445672).
+        quirksData->shouldDisablePushStateFilePathRestrictions = isMimeoPhotoProject;
+    }
 #endif
 
-    auto quirksURL = topDocumentURL();
     if (quirksURL.isEmpty())
-        return;
+        return quirksData;
 
     auto quirksDomainString = RegistrableDomain(quirksURL).string();
     auto quirkDomainWithoutPSL = PublicSuffixStore::singleton().domainWithoutPublicSuffix(quirksDomainString);
@@ -2793,8 +2864,12 @@ void Quirks::determineRelevantQuirks()
     });
 
     auto findResult = dispatchMap->find(quirkDomainWithoutPSL);
-    if (findResult != dispatchMap->end())
-        (findResult->value)(m_quirksData, quirksURL, quirksDomainString, m_document->url());
+    if (findResult != dispatchMap->end()) {
+        if (!quirksData)
+            quirksData = QuirksData();
+
+        (findResult->value)(*quirksData, quirksURL, quirksDomainString, URL());
+    }
 
     // Note: `needsDisableDOMPasteAccessQuirk` needs a live document to assess
     // Note: `shouldDisableElementFullscreen` needs a live document for embedded sites
@@ -2802,11 +2877,30 @@ void Quirks::determineRelevantQuirks()
     // FIXME: The below quirks should be handled more efficiently in a
 #if ENABLE(FLIP_SCREEN_DIMENSIONS_QUIRKS)
     // rdar://133423460
-    m_quirksData.shouldFlipScreenDimensionsQuirk = shouldFlipScreenDimensionsInternal(quirksURL);
+    if (shouldFlipScreenDimensionsInternal(quirksURL)) {
+        if (!quirksData)
+            quirksData = QuirksData();
+
+        quirksData->shouldFlipScreenDimensionsQuirk = true;
+    }
 #endif
 
     // rdar://133423460
-    m_quirksData.shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk = shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeInternal(quirksURL);
+    if (shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeInternal(quirksURL)) {
+        if (!quirksData)
+            quirksData = QuirksData();
+
+        quirksData->shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk = true;
+    }
+
+    return quirksData;
+}
+
+void Quirks::determineRelevantQuirks()
+{
+    RELEASE_ASSERT(m_document);
+
+    m_maybeQuirksData = identifyQuirksForURL(topDocumentURL());
 }
 
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -241,6 +241,8 @@ public:
 
     bool needsFacebookStoriesCreationFormQuirk(const Element&, const RenderStyle&) const;
 
+    WEBCORE_EXPORT static std::optional<QuirksData> identifyQuirksForURL(const URL&);
+
 private:
     bool needsQuirks() const;
     bool isDomain(const String&) const;
@@ -263,10 +265,12 @@ private:
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     mutable WeakPtr<const Element, WeakPtrImplWithEventTargetData> m_facebookStoriesCreationFormContainer;
 
-    mutable QuirksData m_quirksData;
+    mutable std::optional<QuirksData> m_maybeQuirksData;
 
     bool m_needsConfigurableIndexedPropertiesQuirk { false };
     bool m_needsToCopyUserSelectNoneQuirk { false };
+    mutable bool m_didAssessEmbeddedFullscreenQuirk { false };
+    mutable bool m_didAssessDisableDOMPasteAccessQuirk { false };
 
     Vector<RegistrableDomain> m_subFrameDomainsForStorageAccessQuirk;
     URL m_topDocumentURLForTesting;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -52,6 +52,7 @@ struct WEBCORE_EXPORT QuirksData {
     bool needsBodyScrollbarWidthNoneDisabledQuirk { false };
     bool needsCanPlayAfterSeekedQuirk { false };
     bool needsChromeMediaControlsPseudoElementQuirk { false };
+    bool needsDisableDOMPasteAccessQuirk { false };
     bool needsMozillaFileTypeForDataTransferQuirk { false };
     bool needsRelaxedCorsMixedContentCheckQuirk { false };
     bool needsResettingTransitionCancelsRunningTransitionQuirk { false };
@@ -79,9 +80,6 @@ struct WEBCORE_EXPORT QuirksData {
     bool shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk { false };
     bool shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk { false };
     bool shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk { false };
-
-    // Requires check at moment of use
-    std::optional<bool> needsDisableDOMPasteAccessQuirk;
 
 #if PLATFORM(IOS_FAMILY)
     bool mayNeedToIgnoreContentObservation { false };

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -542,6 +542,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/WebsitePoliciesData.serialization.in
     Shared/WebsitePopUpPolicy.serialization.in
     Shared/WebsitePushAndNotificationsEnabledPolicy.serialization.in
+    Shared/WebsiteQuirks.serialization.in
 
     Shared/API/APIArray.serialization.in
     Shared/API/APIData.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -476,6 +476,7 @@ $(PROJECT_DIR)/Shared/WebsiteDataStoreParameters.serialization.in
 $(PROJECT_DIR)/Shared/WebsitePoliciesData.serialization.in
 $(PROJECT_DIR)/Shared/WebsitePopUpPolicy.serialization.in
 $(PROJECT_DIR)/Shared/WebsitePushAndNotificationsEnabledPolicy.serialization.in
+$(PROJECT_DIR)/Shared/WebsiteQuirks.serialization.in
 $(PROJECT_DIR)/Shared/XR/PlatformXR.serialization.in
 $(PROJECT_DIR)/Shared/XR/XRSystem.serialization.in
 $(PROJECT_DIR)/Shared/cf/CFTypes.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -750,6 +750,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/WebsitePoliciesData.serialization.in \
 	Shared/WebsitePopUpPolicy.serialization.in \
 	Shared/WebsitePushAndNotificationsEnabledPolicy.serialization.in \
+    Shared/WebsiteQuirks.serialization.in \
 	Shared/ApplePay/ApplePayPaymentSetupFeatures.serialization.in \
 	Shared/ApplePay/PaymentSetupConfiguration.serialization.in \
 	Shared/Databases/IndexedDB/WebIDBResult.serialization.in \

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8903,3 +8903,153 @@ header: <WebCore/DocumentClasses.h>
 #endif
     PDF
 };
+
+#if ENABLE(TOUCH_EVENTS)
+[Nested] enum class WebCore::QuirksData::ShouldDispatchSimulatedMouseEvents : uint8_t {
+    Unknown,
+    No,
+    DependingOnTargetFor_mybinder_org,
+    Yes,
+};
+#endif
+
+header: <WebCore/QuirksData.h>
+struct WebCore::QuirksData {
+    bool isAmazon;
+    bool isBankOfAmerica;
+    bool isBing;
+    bool isCBSSports;
+    bool isESPN;
+    bool isFacebook;
+    bool isGoogleDocs;
+    bool isGoogleProperty;
+    bool isGoogleMaps;
+    bool isNetflix;
+    bool isSoundCloud;
+    bool isSpotify;
+    bool isThesaurus;
+    bool isVimeo;
+    bool isWebEx;
+    bool isYouTube;
+    bool isZoom;
+
+    bool hasBrokenEncryptedMediaAPISupportQuirk;
+    bool implicitMuteWhenVolumeSetToZero;
+    bool maybeBypassBackForwardCache;
+    bool needsBingGestureEventQuirk;
+    bool needsBodyScrollbarWidthNoneDisabledQuirk;
+    bool needsCanPlayAfterSeekedQuirk;
+    bool needsChromeMediaControlsPseudoElementQuirk;
+    bool needsDisableDOMPasteAccessQuirk;
+    bool needsMozillaFileTypeForDataTransferQuirk;
+    bool needsRelaxedCorsMixedContentCheckQuirk;
+    bool needsResettingTransitionCancelsRunningTransitionQuirk;
+    bool needsScrollbarWidthThinDisabledQuirk;
+    bool needsSeekingSupportDisabledQuirk;
+    bool needsVP9FullRangeFlagQuirk;
+    bool needsVideoShouldMaintainAspectRatioQuirk;
+    bool returnNullPictureInPictureElementDuringFullscreenChangeQuirk;
+    bool shouldAllowDownloadsInSpiteOfCSPQuirk;
+    bool shouldAutoplayWebAudioForArbitraryUserGestureQuirk;
+    bool shouldAvoidResizingWhenInputViewBoundsChangeQuirk;
+    bool shouldAvoidScrollingWhenFocusedContentIsVisibleQuirk;
+    bool shouldBypassAsyncScriptDeferring;
+    bool shouldDisableDataURLPaddingValidation;
+    bool shouldDisableElementFullscreen;
+    bool shouldDisableFetchMetadata;
+    bool shouldDisableLazyIframeLoadingQuirk;
+    bool shouldDisablePushStateFilePathRestrictions;
+    bool shouldDisableWritingSuggestionsByDefaultQuirk;
+    bool shouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk;
+    bool shouldDispatchedSimulatedMouseEventsAssumeDefaultPreventedQuirk;
+    bool shouldEnableFontLoadingAPIQuirk;
+    bool shouldExposeShowModalDialog;
+    bool shouldIgnorePlaysInlineRequirementQuirk;
+    bool shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraintsQuirk;
+    bool shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeQuirk;
+    bool shouldUseLegacySelectPopoverDismissalBehaviorInDataActivationQuirk;
+
+#if PLATFORM(IOS_FAMILY)
+    bool mayNeedToIgnoreContentObservation;
+    bool needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk;
+    bool needsFullscreenDisplayNoneQuirk;
+    bool needsFullscreenObjectFitQuirk;
+    bool needsGMailOverflowScrollQuirk;
+    bool needsGoogleMapsScrollingQuirk;
+    bool needsIPadSkypeOverflowScrollQuirk;
+    bool needsPreloadAutoQuirk;
+    bool needsScriptToEvaluateBeforeRunningScriptFromURLQuirk;
+    bool needsYouTubeMouseOutQuirk;
+    bool needsYouTubeOverflowScrollQuirk;
+    bool shouldAvoidPastingImagesAsWebContent;
+    bool shouldDisablePointerEventsQuirk;
+    bool shouldEnableApplicationCacheQuirk;
+    bool shouldIgnoreAriaForFastPathContentObservationCheckQuirk;
+    bool shouldNavigatorPluginsBeEmpty;
+    bool shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreasQuirk;
+    bool shouldSynthesizeTouchEventsAfterNonSyntheticClickQuirk;
+#endif
+
+#if PLATFORM(IOS)
+    bool needsGetElementsByNameQuirk;
+#endif
+
+#if PLATFORM(IOS) || PLATFORM(VISION)
+    bool allowLayeredFullscreenVideos;
+    bool shouldSilenceMediaQueryListChangeEvents;
+    bool shouldSilenceResizeObservers;
+    bool shouldSilenceWindowResizeEvents;
+#endif
+
+#if PLATFORM(VISION)
+    bool shouldDisableFullscreenVideoAspectRatioAdaptiveSizingQuirk;
+#endif
+
+#if PLATFORM(MAC)
+    bool isNeverRichlyEditableForTouchBarQuirk;
+    bool isTouchBarUpdateSuppressedForHiddenContentEditableQuirk;
+    bool needsFormControlToBeMouseFocusableQuirk;
+    bool needsPrimeVideoUserSelectNoneQuirk;
+    bool shouldAvoidStartingSelectionOnMouseDown;
+#endif
+
+#if ENABLE(DESKTOP_CONTENT_MODE_QUIRKS)
+    bool needsZeroMaxTouchPointsQuirk;
+    bool shouldHideCoarsePointerCharacteristicsQuirk;
+#endif
+
+#if ENABLE(FLIP_SCREEN_DIMENSIONS_QUIRKS)
+    bool shouldFlipScreenDimensionsQuirk;
+#endif
+
+#if ENABLE(MEDIA_STREAM)
+    bool shouldDisableImageCaptureQuirk;
+    bool shouldEnableLegacyGetUserMediaQuirk;
+#endif
+
+#if ENABLE(META_VIEWPORT)
+    bool shouldIgnoreViewportArgumentsToAvoidExcessiveZoomQuirk;
+#endif
+
+#if ENABLE(TEXT_AUTOSIZING)
+    bool shouldIgnoreTextAutoSizingQuirk;
+#endif
+
+#if ENABLE(TOUCH_EVENTS)
+    QuirksData::ShouldDispatchSimulatedMouseEvents shouldDispatchSimulatedMouseEventsQuirk { WebCore::QuirksData::ShouldDispatchSimulatedMouseEvents::Unknown };
+    bool shouldDispatchPointerOutAfterHandlingSyntheticClick;
+    bool shouldPreventDispatchOfTouchEventQuirk;
+#endif
+
+#if ENABLE(FULLSCREEN_API) && ENABLE(VIDEO_PRESENTATION_MODE)
+    bool blocksEnteringStandardFullscreenFromPictureInPictureQuirk;
+    bool blocksReturnToFullscreenFromPictureInPictureQuirk;
+#endif
+
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    bool requiresUserGestureToLoadInPictureInPictureQuirk;
+    bool requiresUserGestureToPauseInPictureInPictureQuirk;
+    bool shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk;
+    bool shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk;
+#endif
+};

--- a/Source/WebKit/Shared/WebsitePoliciesData.cpp
+++ b/Source/WebKit/Shared/WebsitePoliciesData.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/Page.h>
+#include <WebCore/QuirksData.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
@@ -179,6 +180,8 @@ void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePol
         documentLoader.setPushAndNotificationsEnabledPolicy(WebCore::PushAndNotificationsEnabledPolicy::Yes);
         break;
     }
+
+    documentLoader.setQuirksData(WTFMove(websitePolicies.maybeSiteQuirks));
 
     RefPtr frame = documentLoader.frame();
     if (!frame)

--- a/Source/WebKit/Shared/WebsitePoliciesData.h
+++ b/Source/WebKit/Shared/WebsitePoliciesData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,6 +39,7 @@
 #include <WebCore/DeviceOrientationOrMotionPermissionState.h>
 #include <WebCore/DocumentLoader.h>
 #include <WebCore/FrameLoaderTypes.h>
+#include <WebCore/QuirksData.h>
 #include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
 #include <wtf/TZoneMalloc.h>
@@ -86,6 +87,7 @@ public:
     bool allowPrivacyProxy { true };
     bool allowSiteSpecificQuirksToOverrideContentMode { false };
     WebsitePushAndNotificationsEnabledPolicy pushAndNotificationsEnabledPolicy { WebsitePushAndNotificationsEnabledPolicy::UseGlobalPolicy };
+    std::optional<WebCore::QuirksData> maybeSiteQuirks;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
+++ b/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
@@ -83,4 +83,5 @@ struct WebKit::WebsitePoliciesData {
     bool allowPrivacyProxy;
     bool allowSiteSpecificQuirksToOverrideContentMode;
     WebKit::WebsitePushAndNotificationsEnabledPolicy pushAndNotificationsEnabledPolicy;
+    std::optional<WebCore::QuirksData> maybeSiteQuirks;
 };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -233,6 +233,7 @@
 #include <WebCore/PlatformEvent.h>
 #include <WebCore/PublicSuffixStore.h>
 #include <WebCore/Quirks.h>
+#include <WebCore/QuirksData.h>
 #include <WebCore/RealtimeMediaSourceCenter.h>
 #include <WebCore/RemoteUserInputEventData.h>
 #include <WebCore/RenderEmbeddedObject.h>
@@ -4821,7 +4822,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
             auto isPerformingHTTPFallback = navigationAction->data().isPerformingHTTPFallback ? IsPerformingHTTPFallback::Yes : IsPerformingHTTPFallback::No;
             continueNavigationInNewProcess(navigation, frame.get(), WTFMove(suspendedPage), WTFMove(processNavigatingTo), processSwapRequestedByClient, ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision, std::nullopt, loadedWebArchive, isPerformingHTTPFallback, replacedDataStoreForWebArchiveLoad.get());
 
-            receivedPolicyDecision(policyAction, navigation.ptr(), nullptr, WTFMove(navigationAction), WillContinueLoadInNewProcess::Yes, std::nullopt, WTFMove(message), WTFMove(completionHandler));
+            receivedPolicyDecision(policyAction, navigation.ptr(), navigation->protectedWebsitePolicies().get(), WTFMove(navigationAction), WillContinueLoadInNewProcess::Yes, std::nullopt, WTFMove(message), WTFMove(completionHandler));
             return;
         }
 
@@ -4847,13 +4848,13 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
                 maybeInitializeSandboxExtensionHandle(processNavigatingTo.get(), fullURL, item->resourceDirectoryURL(), true, [weakThis = WeakPtr { *this }, navigation = WTFMove(navigation), navigationAction = WTFMove(navigationAction), message = WTFMove(message), completionHandler = WTFMove(completionHandler), policyAction] (std::optional<SandboxExtension::Handle>&& sandboxExtension) mutable {
                     if (!weakThis)
                         return;
-                    weakThis->receivedPolicyDecision(policyAction, navigation.ptr(), navigation->websitePolicies(), WTFMove(navigationAction), WillContinueLoadInNewProcess::No, WTFMove(sandboxExtension), WTFMove(message), WTFMove(completionHandler));
+                    weakThis->receivedPolicyDecision(policyAction, navigation.ptr(), navigation->protectedWebsitePolicies().get(), WTFMove(navigationAction), WillContinueLoadInNewProcess::No, WTFMove(sandboxExtension), WTFMove(message), WTFMove(completionHandler));
                 });
                 return;
             }
         }
 
-        receivedPolicyDecision(policyAction, navigation.ptr(), navigation->websitePolicies(), WTFMove(navigationAction), WillContinueLoadInNewProcess::No, WTFMove(optionalHandle), WTFMove(message), WTFMove(completionHandler));
+        receivedPolicyDecision(policyAction, navigation.ptr(), navigation->protectedWebsitePolicies().get(), WTFMove(navigationAction), WillContinueLoadInNewProcess::No, WTFMove(optionalHandle), WTFMove(message), WTFMove(completionHandler));
     };
 
     protectedConfiguration()->protectedProcessPool()->processForNavigation(*this, frame, *navigation, sourceURL, processSwapRequestedByClient, lockdownMode, frameInfo, WTFMove(websiteDataStore), WTFMove(continueWithProcessForNavigation));
@@ -4891,6 +4892,9 @@ void WebPageProxy::receivedPolicyDecision(PolicyAction action, API::Navigation* 
     std::optional<WebsitePoliciesData> websitePoliciesData;
     if (websitePolicies)
         websitePoliciesData = websitePolicies->data();
+
+    if (navigation && websitePoliciesData)
+        websitePoliciesData->maybeSiteQuirks = Quirks::identifyQuirksForURL(navigation->currentRequest().url());
 
     completionHandler(PolicyDecision { isNavigatingToAppBoundDomain(), action, navigation ? std::optional { navigation->navigationID() } : std::nullopt, downloadID, WTFMove(websitePoliciesData), WTFMove(sandboxExtensionHandle), WTFMove(consoleMessage) });
 }


### PR DESCRIPTION
#### 48b7eedc2a578c0b4f279a55bc8690d51e9ffb76
<pre>
Populate Quirks state in the UIProcess and message to the Web Content process
<a href="https://bugs.webkit.org/show_bug.cgi?id=284960">https://bugs.webkit.org/show_bug.cgi?id=284960</a>
<a href="https://rdar.apple.com/141768271">rdar://141768271</a>

Reviewed by NOBODY (OOPS!).

This change computes the Quirks state at object creation in the UIProcess, and
includes this state in the state used to initialize the WebContent process. This
avoids evaluating this state in the WebContent process, and should allow us to
(eventually) bypass Quirks checks entirely for domains that are deemed to not need
any quirks at all.

A follow-up patch will remove the m_quirksData member from the Quirks object (in favor
of the optional m_maybeQuirksData member)

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::setQuirksData): Added.
* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::maybeQuirksData const): Added.
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::Quirks): Populate quirks object at construction.
(WebCore::Quirks::identifyQuirksForURL): Added.
(WebCore::Quirks::determineRelevantQuirks): Call new helper function.
* Source/WebCore/page/Quirks.h:
* Source/WebKit/CMakeLists.txt: Add new WebsiteQuirks serializer.
* Source/WebKit/DerivedSources-input.xcfilelist: Ditto.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in: Add serialization
instructions for QuirksData.
* Source/WebKit/Shared/WebsitePoliciesData.cpp:
(WebKit::WebsitePoliciesData::applyToDocumentLoader): Set computed QuirksData
sent from UIProcess.
* Source/WebKit/Shared/WebsitePoliciesData.h: Add QuirksData to set of policies
serialized to WebProcess.
* Source/WebKit/Shared/WebsitePoliciesData.serialization.in: Ditto.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision): Pass precomputed
quirks data to navigation.
(WebKit::WebPageProxy::receivedPolicyDecision): Compute quirks for load
request now that load has been approved.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48b7eedc2a578c0b4f279a55bc8690d51e9ffb76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84532 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4157 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38837 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89614 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35543 "Hash 48b7eedc for PR 38211 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86617 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4242 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12143 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/89614 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/35543 "Hash 48b7eedc for PR 38211 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87578 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/4242 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/38837 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/89614 "Hash 48b7eedc for PR 38211 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/4242 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/38837 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34591 "Hash 48b7eedc for PR 38211 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/4242 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/38837 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90995 "Hash 48b7eedc for PR 38211 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11799 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/12143 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/90995 "Hash 48b7eedc for PR 38211 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12027 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/38837 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/90995 "Hash 48b7eedc for PR 38211 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/38837 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3237 "Hash 48b7eedc for PR 38211 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11751 "Hash 48b7eedc for PR 38211 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17264 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11600 "Hash 48b7eedc for PR 38211 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15076 "Hash 48b7eedc for PR 38211 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13373 "Hash 48b7eedc for PR 38211 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->