### PR TITLE
AX: Add support for handling AXFontColorChangeSearchKey and AXStyleChangeSearchKey off the main-thread

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/non-collapsed-selection-insertion-point-line-number.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/non-collapsed-selection-insertion-point-line-number.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
-<!-- Copy of existing test. Remove after accessibilityThreadTextApisEnabled is enabled by default. -->
+<!-- New test added as part of the AccessibilityThreadTextApisEnabled effort. Move to LayoutTests/accessibility/mac after the feature is enabled by default. -->
 <html>
 <head>
 <script src="../../resources/accessibility-helper.js"></script>

--- a/LayoutTests/accessibility/ax-thread-text-apis/search-predicate-style-change-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/search-predicate-style-change-expected.txt
@@ -1,0 +1,17 @@
+This test ensures that our handling of the AXStyleChangeSearchKey behaves correctly.
+
+PASS: startText.stringValue === 'AXValue: One'
+PASS: resultText.stringValue === 'AXValue: Two'
+PASS: resultText.stringValue === 'AXValue: Three'
+PASS: resultText.stringValue === 'AXValue: Four'
+PASS: resultText.stringValue === 'AXValue: Five'
+PASS: resultText.stringValue === 'AXValue: Six'
+PASS: resultText.stringValue === 'AXValue: Seven'
+PASS: resultText.stringValue === 'AXValue: Eight'
+PASS: resultText.stringValue === 'AXValue: Last text'
+PASS: Returned the right element after a dynamic page change.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+OneEight Skip Two Skip Three Skip Four Skip Five Skip Six Skip Seven Skip SkipLast text

--- a/LayoutTests/accessibility/ax-thread-text-apis/search-predicate-style-change.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/search-predicate-style-change.html
@@ -1,0 +1,94 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- New test added as part of the AccessibilityThreadTextApisEnabled effort. Move to LayoutTests/accessibility/mac after the feature is enabled by default. -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+.font { font: sans-serif; }
+.text-color { color: orange; }
+.background-color: { background-color: red; }
+.subscript { vertical-align: sub; }
+.superscript { vertical-align: super; }
+.text-shadow { text-shadow: 1px 1px 2px pink; }
+.underline { text-decoration: underline; }
+.linethrough { text-decoration: line-through; }
+</style>
+</head>
+<body>
+
+<span id="span-1" class="font">One</span>
+<span class="font">Skip</span>
+
+<span class="text-color">Two</span>
+<span class="text-color">Skip</span>
+
+<span class="background-color">Three</span>
+<span class="background-color">Skip</span>
+
+<span class="subscript">Four</span>
+<span class="subscript">Skip</span>
+
+<span class="superscript">Five</span>
+<span class="superscript">Skip</span>
+
+<span class="text-shadow">Six</span>
+<span class="text-shadow">Skip</span>
+
+<span class="underline">Seven</span>
+<span class="underline">Skip</span>
+
+<span id="span-8" class="linethrough">Eight</span>
+<span class="linethrough">Skip</span>Last text
+    
+<script>
+var output = "This test ensures that our handling of the AXStyleChangeSearchKey behaves correctly.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    var startText = webArea.childAtIndex(0);
+    output += expect("startText.stringValue", "'AXValue: One'");
+
+    var resultText = webArea.uiElementForSearchPredicate(startText, true, "AXStyleChangeSearchKey", "", false);
+    output += expect("resultText.stringValue", "'AXValue: Two'");
+
+    resultText = webArea.uiElementForSearchPredicate(resultText, true, "AXStyleChangeSearchKey", "", false);
+    output += expect("resultText.stringValue", "'AXValue: Three'");
+
+    resultText = webArea.uiElementForSearchPredicate(resultText, true, "AXStyleChangeSearchKey", "", false);
+    output += expect("resultText.stringValue", "'AXValue: Four'");
+
+    resultText = webArea.uiElementForSearchPredicate(resultText, true, "AXStyleChangeSearchKey", "", false);
+    output += expect("resultText.stringValue", "'AXValue: Five'");
+
+    resultText = webArea.uiElementForSearchPredicate(resultText, true, "AXStyleChangeSearchKey", "", false);
+    output += expect("resultText.stringValue", "'AXValue: Six'");
+
+    resultText = webArea.uiElementForSearchPredicate(resultText, true, "AXStyleChangeSearchKey", "", false);
+    output += expect("resultText.stringValue", "'AXValue: Seven'");
+
+    resultText = webArea.uiElementForSearchPredicate(resultText, true, "AXStyleChangeSearchKey", "", false);
+    output += expect("resultText.stringValue", "'AXValue: Eight'");
+
+    resultText = webArea.uiElementForSearchPredicate(resultText, true, "AXStyleChangeSearchKey", "", false);
+    output += expect("resultText.stringValue", "'AXValue: Last text'");
+
+    // Ensure we behave correctly after a dynamic change.
+    document.getElementById("span-1").after(document.getElementById("span-8"));
+    setTimeout(async function() {
+        await waitFor(() => {
+            var resultText = webArea.uiElementForSearchPredicate(startText, true, "AXStyleChangeSearchKey", "", false);
+            return resultText && resultText.stringValue === "AXValue: Eight";
+        });
+        output += "PASS: Returned the right element after a dynamic page change.\n";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -976,8 +976,8 @@ public:
     virtual std::optional<SimpleRange> visibleCharacterRange() const = 0;
     virtual bool hasPlainText() const = 0;
     virtual bool hasSameFont(AXCoreObject&) = 0;
-    virtual bool hasSameFontColor(const AXCoreObject&) const = 0;
-    virtual bool hasSameStyle(const AXCoreObject&) const = 0;
+    virtual bool hasSameFontColor(AXCoreObject&) = 0;
+    virtual bool hasSameStyle(AXCoreObject&) = 0;
     bool isStaticText() const { return roleValue() == AccessibilityRole::StaticText; }
     virtual bool hasUnderline() const = 0;
     virtual bool hasHighlighting() const = 0;

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -227,8 +227,8 @@ public:
     std::optional<SimpleRange> misspellingRange(const SimpleRange& start, AccessibilitySearchDirection) const final;
     bool hasPlainText() const override { return false; }
     bool hasSameFont(AXCoreObject&) override { return false; }
-    bool hasSameFontColor(const AXCoreObject&) const override { return false; }
-    bool hasSameStyle(const AXCoreObject&) const override { return false; }
+    bool hasSameFontColor(AXCoreObject&) override { return false; }
+    bool hasSameStyle(AXCoreObject&) override { return false; }
     bool hasUnderline() const override { return false; }
     bool hasHighlighting() const final;
     AXTextMarkerRange textInputMarkedTextMarkerRange() const final;

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2694,7 +2694,7 @@ ApplePayButtonType AccessibilityRenderObject::applePayButtonType() const
 }
 #endif
 
-bool AccessibilityRenderObject::hasSameFontColor(const AXCoreObject& object) const
+bool AccessibilityRenderObject::hasSameFontColor(AXCoreObject& object)
 {
     auto* renderer = object.renderer();
     if (!m_renderer || !renderer)
@@ -2703,7 +2703,7 @@ bool AccessibilityRenderObject::hasSameFontColor(const AXCoreObject& object) con
     return m_renderer->style().visitedDependentColor(CSSPropertyColor) == renderer->style().visitedDependentColor(CSSPropertyColor);
 }
 
-bool AccessibilityRenderObject::hasSameStyle(const AXCoreObject& object) const
+bool AccessibilityRenderObject::hasSameStyle(AXCoreObject& object)
 {
     auto* renderer = object.renderer();
     if (!m_renderer || !renderer)

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -67,8 +67,8 @@ public:
     bool hasItalicFont() const final;
     bool hasPlainText() const final;
     bool hasSameFont(AXCoreObject&) final;
-    bool hasSameFontColor(const AXCoreObject&) const final;
-    bool hasSameStyle(const AXCoreObject&) const final;
+    bool hasSameFontColor(AXCoreObject&) final;
+    bool hasSameStyle(AXCoreObject&) final;
     bool hasUnderline() const final;
 
     void setAccessibleName(const AtomString&) final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -1853,8 +1853,19 @@ bool AXIsolatedObject::hasSameFont(AXCoreObject& otherObject)
     });
 }
 
-bool AXIsolatedObject::hasSameFontColor(const AXCoreObject& otherObject) const
+bool AXIsolatedObject::hasSameFontColor(AXCoreObject& otherObject)
 {
+#if ENABLE(AX_THREAD_TEXT_APIS)
+    if (AXObjectCache::useAXThreadTextApis()) {
+        RefPtr thisText = downcast<AXIsolatedObject>(selfOrFirstTextDescendant());
+        RefPtr otherText = downcast<AXIsolatedObject>(otherObject.selfOrFirstTextDescendant());
+
+        if (!thisText || !otherText)
+            return false;
+        return thisText->colorAttributeValue(AXPropertyName::TextColor) == otherText->colorAttributeValue(AXPropertyName::TextColor);
+    }
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
+
     if (!is<AXIsolatedObject>(otherObject))
         return false;
 
@@ -1867,8 +1878,19 @@ bool AXIsolatedObject::hasSameFontColor(const AXCoreObject& otherObject) const
     });
 }
 
-bool AXIsolatedObject::hasSameStyle(const AXCoreObject& otherObject) const
+bool AXIsolatedObject::hasSameStyle(AXCoreObject& otherObject)
 {
+#if ENABLE(AX_THREAD_TEXT_APIS)
+    if (AXObjectCache::useAXThreadTextApis()) {
+        RefPtr thisText = selfOrFirstTextDescendant();
+        RefPtr otherText = otherObject.selfOrFirstTextDescendant();
+
+        if (!thisText || !otherText)
+            return false;
+        return thisText->stylesForAttributedString() == otherText->stylesForAttributedString();
+    }
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
+
     if (!is<AXIsolatedObject>(otherObject))
         return false;
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -477,8 +477,8 @@ private:
     Vector<AXTextMarkerRange> misspellingRanges() const final;
     bool hasPlainText() const final { return boolAttributeValue(AXPropertyName::HasPlainText); }
     bool hasSameFont(AXCoreObject&) final;
-    bool hasSameFontColor(const AXCoreObject&) const final;
-    bool hasSameStyle(const AXCoreObject&) const final;
+    bool hasSameFontColor(AXCoreObject&) final;
+    bool hasSameStyle(AXCoreObject&) final;
     bool hasUnderline() const final { return boolAttributeValue(AXPropertyName::HasUnderline); }
     bool hasHighlighting() const final { return boolAttributeValue(AXPropertyName::HasHighlighting); }
     AXTextMarkerRange textInputMarkedTextMarkerRange() const final;


### PR DESCRIPTION
#### a957f500fc729c49e0419ca90debd686790728cb
<pre>
AX: Add support for handling AXFontColorChangeSearchKey and AXStyleChangeSearchKey off the main-thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=284970">https://bugs.webkit.org/show_bug.cgi?id=284970</a>
<a href="https://rdar.apple.com/141774908">rdar://141774908</a>

Reviewed by Chris Fleizach.

We can compute AXFontColorChangeSearchKey and AXStyleChangeSearchKey using the information we added to serve attributed
strings off the main-thread, so this commit does so, and adds a new test proving we behave correctly.

* LayoutTests/accessibility/ax-thread-text-apis/non-collapsed-selection-insertion-point-line-number.html:
Fix incorrect comment saying this test was a copy of an existing one.
* LayoutTests/accessibility/ax-thread-text-apis/search-predicate-style-change-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/search-predicate-style-change.html: Added.
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::hasSameFontColor):
(WebCore::AccessibilityRenderObject::hasSameStyle):
(WebCore::AccessibilityRenderObject::hasSameFontColor const): Deleted.
(WebCore::AccessibilityRenderObject::hasSameStyle const): Deleted.
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::hasSameFontColor):
(WebCore::AXIsolatedObject::hasSameStyle):
(WebCore::AXIsolatedObject::hasSameFontColor const): Deleted.
(WebCore::AXIsolatedObject::hasSameStyle const): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:

Canonical link: <a href="https://commits.webkit.org/288129@main">https://commits.webkit.org/288129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7503b7e8dd7bb865de4f2ff1e636d41dd39de2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32916 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63883 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21607 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84981 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44167 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/989 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28717 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31362 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29326 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87899 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9153 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72246 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71468 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17818 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15570 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14487 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/538 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9104 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14640 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8944 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12469 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10752 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->