### PR TITLE
ASAN_TRAP in WebCore::WorkletGlobalScope::WorkletGlobalScope

### DIFF
--- a/LayoutTests/fast/worklets/worklet-global-scope-constructor-expected.txt
+++ b/LayoutTests/fast/worklets/worklet-global-scope-constructor-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/fast/worklets/worklet-global-scope-constructor.html
+++ b/LayoutTests/fast/worklets/worklet-global-scope-constructor.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<p>This test passes if WebKit does not crash.</p>
+<body>
+<script>
+globalThis.testRunner?.dumpAsText();
+
+const iframe = document.createElement('iframe');
+document.body.appendChild(iframe);
+const contentCSS = iframe.contentWindow.CSS;
+iframe.remove();
+const moduleURL = {};
+const options = {};
+contentCSS.paintWorklet.addModule(moduleURL, options);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -245,7 +245,6 @@ css/CSSValueList.h
 css/CSSVariableReferenceValue.cpp
 css/CSSViewTransitionRule.cpp
 css/ComputedStyleExtractor.cpp
-css/DOMCSSPaintWorklet.cpp
 css/DeprecatedCSSOMPrimitiveValue.cpp
 css/FontFaceSet.cpp
 css/FontVariantBuilder.cpp

--- a/Source/WebCore/css/DOMCSSPaintWorklet.cpp
+++ b/Source/WebCore/css/DOMCSSPaintWorklet.cpp
@@ -60,9 +60,14 @@ ASCIILiteral DOMCSSPaintWorklet::supplementName()
 // FIXME: Get rid of this override and rely on the standard-compliant Worklet::addModule() instead.
 void PaintWorklet::addModule(const String& moduleURL, WorkletOptions&&, DOMPromiseDeferred<void>&& promise)
 {
-    auto* document = this->document();
+    RefPtr document = this->document();
     if (!document) {
         promise.reject(Exception { ExceptionCode::InvalidStateError, "This frame is detached"_s });
+        return;
+    }
+
+    if (!document->hasBrowsingContext()) {
+        promise.reject(Exception { ExceptionCode::InvalidStateError, "This document does not have a browsing context"_s });
         return;
     }
 


### PR DESCRIPTION
#### f834e56e78df4c0a34dd1e210203aaafc4746b4c
<pre>
ASAN_TRAP in WebCore::WorkletGlobalScope::WorkletGlobalScope
<a href="https://bugs.webkit.org/show_bug.cgi?id=284969">https://bugs.webkit.org/show_bug.cgi?id=284969</a>
<a href="https://rdar.apple.com/141683469">rdar://141683469</a>

Reviewed by Chris Dumez and Ryosuke Niwa.

Added a check for document having browsing context.

* LayoutTests/fast/worklets/worklet-global-scope-constructor-expected.txt: Added.
* LayoutTests/fast/worklets/worklet-global-scope-constructor.html: Added.
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/css/DOMCSSPaintWorklet.cpp:
(WebCore::PaintWorklet::addModule):

Canonical link: <a href="https://commits.webkit.org/288257@main">https://commits.webkit.org/288257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf72028816fda2ae2fd1e565b5b5f0cc2aa87d06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87393 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33322 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64113 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21863 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44391 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1293 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29033 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32363 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72592 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88749 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9567 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6830 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-changetype.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72504 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71722 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15860 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14874 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/922 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12768 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9520 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15041 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9394 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12860 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->