### PR TITLE
Add PAS_PROFILE macros for deallocation

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
@@ -549,6 +549,7 @@ static PAS_ALWAYS_INLINE uintptr_t pas_bitfit_page_deallocate_with_page_impl(
     uintptr_t word_index;
     uintptr_t bit_index_in_word;
     uintptr_t other_word_index;
+    uintptr_t original_object_size;
     uint64_t* free_words;
     uint64_t* object_end_words;
     uint64_t object_end_word;
@@ -642,6 +643,8 @@ static PAS_ALWAYS_INLINE uintptr_t pas_bitfit_page_deallocate_with_page_impl(
 
     object_end_word = object_end_words[word_index];
     shifted_object_end_word = object_end_word >> bit_index_in_word;
+    original_object_size = 1 << ((uint64_t)(__builtin_ctzll(shifted_object_end_word)) + 1);
+
     if (shifted_object_end_word) {
         uint64_t object_end_bit_index;
 
@@ -895,6 +898,8 @@ static PAS_ALWAYS_INLINE uintptr_t pas_bitfit_page_deallocate_with_page_impl(
         pas_lock_unlock(&owner->ownership_lock);
         break;
     } }
+
+    PAS_PROFILE(BITFIT_PAGE_DEALLOCATION, page_config, begin, original_object_size);
 
     return num_bits;
 }


### PR DESCRIPTION
#### ffc44fab0968a5c043ca14fd6a18a71f9074618d
<pre>
Add PAS_PROFILE macros for deallocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=284896">https://bugs.webkit.org/show_bug.cgi?id=284896</a>
<a href="https://rdar.apple.com/141700911">rdar://141700911</a>

Reviewed by David Degazio.

This allows us to make measurements about deallocations happening within
libpas, whereas previously we could only look at initial and subsequent
allocations (or page-level decommits, which are less common).

* Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h:
(pas_bitfit_page_deallocate_with_page_impl):
* Source/bmalloc/libpas/src/libpas/pas_segregated_page_inlines.h:
(pas_segregated_page_deallocate_with_page):

Canonical link: <a href="https://commits.webkit.org/289079@main">https://commits.webkit.org/289079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41a448b83da2a31b195609fe033e2adbaa41cd42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85072 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90218 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36126 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66187 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24010 "Found 60 new test failures: animations/3d/animate-to-transform-perpective-to-none.html animations/3d/change-transform-in-end-event.html animations/3d/full-rotation-animation.html animations/3d/replace-filling-transform.html animations/3d/state-at-end-event-transform.html animations/3d/transform-origin-vs-functions.html animations/3d/transform-perspective.html animations/CSSKeyframesRule-name-null.html animations/CSSKeyframesRule-parameters.html animations/added-while-suspended.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46455 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3607 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31536 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35199 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/78043 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74409 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91607 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84121 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74694 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12643 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73817 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18204 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16647 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4428 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13291 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12362 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106513 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12198 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25695 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15693 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->