### PR TITLE
[margin-trim][Invalidation] Block box descendants need invalidation when block container margin-trim is changed.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/invalidation/block-container-block-start-child-with-border-no-trim-to-block-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/invalidation/block-container-block-start-child-with-border-no-trim-to-block-expected.txt
@@ -1,0 +1,6 @@
+
+PASS item 1
+PASS item 2
+PASS item 3
+PASS item 4
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/invalidation/block-container-block-start-child-with-border-no-trim-to-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/invalidation/block-container-block-start-child-with-border-no-trim-to-block.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Block start margin trimming is performed when property margin-trim goes from none to block">
+<style>
+container {
+    display: block;
+    border: 1px solid black;
+    margin-block-start: 10px;
+}
+item {
+    display: block;
+    inline-size: 50px;
+    block-size: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block: 50px;
+    block-size: 0px
+}
+.with-border-and-margin {
+    border: 1px solid black;
+    margin-block-start: 30px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('item')">
+    <container>
+        <item data-expected-margin-top="0" class="collapsed">
+            <item data-expected-margin-top="0" class="collapsed"></item>
+        </item>
+        <item class="with-border-and-margin" data-expected-margin-top="0">
+            <item class="with-border-and-margin" data-expected-margin-top="30"></item>
+        </item>
+    </container>
+</body>
+<script>
+document.body.offsetHeight;
+document.querySelector("container").style["margin-trim"] = "block";
+document.body.offsetHeight;
+</script>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/invalidation/block-container-block-start-self-collapsing-nested-no-trim-to-block-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/invalidation/block-container-block-start-self-collapsing-nested-no-trim-to-block-expected.txt
@@ -1,0 +1,9 @@
+
+PASS container, item 1
+PASS container, item 2
+PASS container, item 3
+PASS container, item 4
+PASS container, item 5
+PASS container, item 6
+PASS container, item 7
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/invalidation/block-container-block-start-self-collapsing-nested-no-trim-to-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/invalidation/block-container-block-start-self-collapsing-nested-no-trim-to-block.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-block">
+<meta name="assert" content="Block start margin trimming is performed when property margin-trim goes from none to block">
+<style>
+container {
+    display: block;
+    border: 1px solid black;
+    margin-block-start: 10px;
+}
+item {
+    display: block;
+    inline-size: 50px;
+    background-color: green;
+}
+.collapsed {
+    margin-block-start: 50px;
+    block-size: 0px
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload=" checkLayout('container, item');">
+    <container data-expected-margin-top="10">
+        <item data-expected-margin-top="0" class="collapsed">
+            <item data-expected-margin-top="0" class="collapsed"></item>
+        </item>
+        <item data-expected-margin-top="0" style="margin-block: 40px">
+            <item data-expected-margin-top="0" data-expected-margin-bottom="0" class="collapsed"></item>
+            <item data-expected-margin-top="0" style="margin-top: 30px;">
+                <item data-expected-margin-top="0" style="margin-block-start: 100px; height: 50px;"></item>
+            </item>
+        </item>
+    </container>
+</body>
+<script>
+document.body.offsetHeight;
+document.querySelector("container").style["margin-trim"] = "block";
+document.body.offsetHeight;
+</script>
+</html>
+

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -708,7 +708,8 @@ bool LocalFrameViewLayoutContext::pushLayoutState(RenderBox& renderer, const Lay
             , pageHeightChanged
             , layoutState ? layoutState->lineClamp() : std::nullopt
             , layoutState ? layoutState->legacyLineClamp() : std::nullopt
-            , layoutState ? layoutState->textBoxTrim() : RenderLayoutState::TextBoxTrim()));
+            , layoutState ? layoutState->textBoxTrim() : RenderLayoutState::TextBoxTrim()
+            , layoutState ? layoutState->blockStartTrimming() : false));
         return true;
     }
     return false;

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -2297,6 +2297,12 @@ void RenderBlockFlow::styleDidChange(StyleDifference diff, const RenderStyle* ol
 
     if (multiColumnFlow())
         updateStylesForColumnChildren(oldStyle);
+
+    if (oldStyle && style().marginTrim() != oldStyle->marginTrim() && !childrenInline()) {
+        auto descendants = descendantsOfType<RenderBox>(*this);
+        for (auto descendantItr = descendants.begin(); descendantItr; descendantItr->isBlockBox() ? ++descendantItr : descendantItr.traverseNextSkippingChildren())
+            descendantItr->setNeedsLayout();
+    }
 }
 
 void RenderBlockFlow::updateStylesForColumnChildren(const RenderStyle* oldStyle)

--- a/Source/WebCore/rendering/RenderIterator.h
+++ b/Source/WebCore/rendering/RenderIterator.h
@@ -267,6 +267,19 @@ inline T* next(U& current, const RenderObject* stayWithin)
     return static_cast<T*>(descendant);
 }
 
+template <typename T, typename U>
+inline T* nextSkippingChildren(U& current, const RenderObject* stayWithin)
+{
+    if (&current == stayWithin)
+        return nullptr;
+
+    auto* next = RenderObjectTraversal::nextSkippingChildren(current, stayWithin);
+    while (next && !isRendererOfType<T>(*next))
+        next = RenderObjectTraversal::nextSkippingChildren(current, stayWithin);
+
+    return static_cast<T*>(next);
+}
+
 } // namespace WebCore::RenderTraversal
 
 namespace RenderPostOrderTraversal {
@@ -327,7 +340,7 @@ template <typename T>
 inline RenderIterator<T>& RenderIterator<T>::traverseNextSkippingChildren()
 {
     ASSERT(m_current);
-    m_current = RenderObjectTraversal::nextSkippingChildren(*m_current, m_root);
+    m_current = RenderTraversal::nextSkippingChildren<T>(*m_current, m_root);
     return *this;
 }
 

--- a/Source/WebCore/rendering/RenderLayoutState.cpp
+++ b/Source/WebCore/rendering/RenderLayoutState.cpp
@@ -69,7 +69,7 @@ RenderLayoutState::RenderLayoutState(RenderElement& renderer)
     }
 }
 
-RenderLayoutState::RenderLayoutState(const LocalFrameViewLayoutContext::LayoutStateStack& layoutStateStack, RenderBox& renderer, const LayoutSize& offset, LayoutUnit pageLogicalHeight, bool pageLogicalHeightChanged, std::optional<LineClamp> lineClamp, std::optional<LegacyLineClamp> legacyLineClamp, std::optional<TextBoxTrim> textBoxTrim)
+RenderLayoutState::RenderLayoutState(const LocalFrameViewLayoutContext::LayoutStateStack& layoutStateStack, RenderBox& renderer, const LayoutSize& offset, LayoutUnit pageLogicalHeight, bool pageLogicalHeightChanged, std::optional<LineClamp> lineClamp, std::optional<LegacyLineClamp> legacyLineClamp, std::optional<TextBoxTrim> textBoxTrim, bool blockStartTrimming)
     : m_clipped(false)
     , m_isPaginated(false)
     , m_pageLogicalHeightChanged(false)
@@ -77,7 +77,7 @@ RenderLayoutState::RenderLayoutState(const LocalFrameViewLayoutContext::LayoutSt
     , m_layoutDeltaXSaturated(false)
     , m_layoutDeltaYSaturated(false)
 #endif
-    , m_blockStartTrimming(false)
+    , m_blockStartTrimming(blockStartTrimming)
     , m_lineClamp(lineClamp)
     , m_legacyLineClamp(legacyLineClamp)
     , m_textBoxTrim(textBoxTrim)

--- a/Source/WebCore/rendering/RenderLayoutState.h
+++ b/Source/WebCore/rendering/RenderLayoutState.h
@@ -74,7 +74,7 @@ public:
         , m_blockStartTrimming(false)
     {
     }
-    RenderLayoutState(const LocalFrameViewLayoutContext::LayoutStateStack&, RenderBox&, const LayoutSize& offset, LayoutUnit pageHeight, bool pageHeightChanged, std::optional<LineClamp>, std::optional<LegacyLineClamp>, std::optional<TextBoxTrim>);
+    RenderLayoutState(const LocalFrameViewLayoutContext::LayoutStateStack&, RenderBox&, const LayoutSize& offset, LayoutUnit pageHeight, bool pageHeightChanged, std::optional<LineClamp>, std::optional<LegacyLineClamp>, std::optional<TextBoxTrim>, bool blockStartTrimming);
     explicit RenderLayoutState(RenderElement&);
 
     bool isPaginated() const { return m_isPaginated; }


### PR DESCRIPTION
#### 0867022a3013d3bdfb5612b1601de1a3519c8784
<pre>
[margin-trim][Invalidation] Block box descendants need invalidation when block container margin-trim is changed.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284954">https://bugs.webkit.org/show_bug.cgi?id=284954</a>
<a href="https://rdar.apple.com/124971386">rdar://124971386</a>

Reviewed by NOBODY (OOPS!).

When margin-trim changes on a block container, this can have an impact on
block-level descendants since the effects of the property can propagate
to them. Currently, a margin-trim change requires layout on the block
container, but it does nothing to its descendants. This may mean we may
perform layout properly after this mutation occurs. Instead, we should
also propagate the damage to the subtree in the following ways:

1.) In LocalFrameViewLayoutContext::pushLayoutState, if we end up
pushing a new RenderLayoutState onto the stack, we should propagate the
potentially already existing margin trimming state. This requires
changing the constructor for RenderLayoutState to take in a bool for the
margin trimming state instead of just unconditionally initializing it to
false.

2.) In RenderBlockFlow::styleDidChange, traverse through the subtree and
setNeedsLayout on the descendants. If a descendant is a block box, then
continue to traverse through since it&apos;s possible that it and its
children, which are block-level boxes, are affected by the margin-trim
change from the block container. If it is not, then we should skip its
children.

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/invalidation/block-container-block-start-child-with-border-no-trim-to-block-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/invalidation/block-container-block-start-child-with-border-no-trim-to-block.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/invalidation/block-container-block-start-self-collapsing-nested-no-trim-to-block-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/invalidation/block-container-block-start-self-collapsing-nested-no-trim-to-block.html: Added.
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::pushLayoutState):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::styleDidChange):
* Source/WebCore/rendering/RenderIterator.h:
(WebCore::RenderTraversal::nextSkippingChildren):
(WebCore::RenderIterator&lt;T&gt;::traverseNextSkippingChildren):
* Source/WebCore/rendering/RenderLayoutState.cpp:
(WebCore::RenderLayoutState::RenderLayoutState):
* Source/WebCore/rendering/RenderLayoutState.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0867022a3013d3bdfb5612b1601de1a3519c8784

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86499 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32974 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63900 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21621 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1114 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74567 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44183 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28744 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31393 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72345 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29355 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87930 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9184 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6547 "Found 1 new test failure: http/wpt/mediarecorder/pause-recording-timeSlice.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72266 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71488 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15590 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14513 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/570 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9135 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14671 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103408 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8975 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/103408 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12500 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10783 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->