### PR TITLE
text-spacing: text-autospace: handle combining marks

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-combining-marks-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-combining-marks-expected.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-autospace-property">
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<style>
+.test {
+  font-size: 40px;
+  border: solid 3px salmon;
+  width: fit-content;
+  margin-bottom: 2px;
+  text-autospace: no-autospace;
+}
+.manual-spacing {
+  margin-right: 0.125em;
+}
+</style>
+<div class="test"><span class="manual-spacing">国&#x301;</span>X</div>
+<div class="test"><span>国&#x301;</span>国</div>
+<div class="test"><span class="manual-spacing">国&#x301;</span>X&#x301;</div>
+<div class="test"><span>国&#x301;</span>国&#x301;</div>
+<br>
+<div class="test"><span>X&#x301;</span>X</div>
+<div class="test"><span class="manual-spacing">X&#x301;</span>国</div>
+<div class="test"><span>X&#x301;</span>X&#x301;</div>
+<div class="test"><span class="manual-spacing">X&#x301;</span>国&#x301;</div>
+<br>
+<div class="test"><span>X</span>X</div>
+<div class="test"><span class="manual-spacing">X</span>国</div>
+<div class="test"><span>X</span>X&#x301;</div>
+<div class="test"><span class="manual-spacing">X</span>国&#x301;</div>
+<br>
+<div class="test"><span class="manual-spacing">国</span>X</div>
+<div class="test"><span>国</span>国</div>
+<div class="test"><span class="manual-spacing">国</span>X&#x301;</div>
+<div class="test"><span>国</span>国&#x301;</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-combining-marks-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-combining-marks-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-autospace-property">
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<style>
+.test {
+  font-size: 40px;
+  border: solid 3px salmon;
+  width: fit-content;
+  margin-bottom: 2px;
+  text-autospace: no-autospace;
+}
+.manual-spacing {
+  margin-right: 0.125em;
+}
+</style>
+<div class="test"><span class="manual-spacing">国&#x301;</span>X</div>
+<div class="test"><span>国&#x301;</span>国</div>
+<div class="test"><span class="manual-spacing">国&#x301;</span>X&#x301;</div>
+<div class="test"><span>国&#x301;</span>国&#x301;</div>
+<br>
+<div class="test"><span>X&#x301;</span>X</div>
+<div class="test"><span class="manual-spacing">X&#x301;</span>国</div>
+<div class="test"><span>X&#x301;</span>X&#x301;</div>
+<div class="test"><span class="manual-spacing">X&#x301;</span>国&#x301;</div>
+<br>
+<div class="test"><span>X</span>X</div>
+<div class="test"><span class="manual-spacing">X</span>国</div>
+<div class="test"><span>X</span>X&#x301;</div>
+<div class="test"><span class="manual-spacing">X</span>国&#x301;</div>
+<br>
+<div class="test"><span class="manual-spacing">国</span>X</div>
+<div class="test"><span>国</span>国</div>
+<div class="test"><span class="manual-spacing">国</span>X&#x301;</div>
+<div class="test"><span>国</span>国&#x301;</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-combining-marks.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-combining-marks.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#text-autospace-property">
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="match" href="text-autospace-combining-marks-ref.html">
+<style>
+.test {
+  font-size: 40px;
+  border: solid 3px salmon;
+  width: fit-content;
+  margin-bottom: 2px;
+}
+.normal {
+  text-autospace: normal;
+}
+</style>
+<div class="test normal">国&#x301;X</div>
+<div class="test normal">国&#x301;国</div>
+<div class="test normal">国&#x301;X&#x301;</div>
+<div class="test normal">国&#x301;国&#x301;</div>
+<br>
+<div class="test normal">X&#x301;X</div>
+<div class="test normal">X&#x301;国</div>
+<div class="test normal">X&#x301;X&#x301;</div>
+<div class="test normal">X&#x301;国&#x301;</div>
+<br>
+<div class="test normal">XX</div>
+<div class="test normal">X国</div>
+<div class="test normal">XX&#x301;</div>
+<div class="test normal">X国&#x301;</div>
+<br>
+<div class="test normal">国X</div>
+<div class="test normal">国国</div>
+<div class="test normal">国X&#x301;</div>
+<div class="test normal">国国&#x301;</div>

--- a/Source/WTF/wtf/text/CharacterProperties.h
+++ b/Source/WTF/wtf/text/CharacterProperties.h
@@ -164,6 +164,11 @@ inline bool isFullwidthMiddleDotPunctuation(char32_t character)
     return character == 0x00B7 || character == 0x2027 || character == 0x30FB;
 }
 
+inline bool isCombiningMark(char32_t character)
+{
+    return 0x0300 <= character && character <= 0x036F;
+}
+
 } // namespace WTF
 
 using WTF::isEmojiGroupCandidate;
@@ -183,3 +188,4 @@ using WTF::isOfScriptType;
 using WTF::isEastAsianFullWidth;
 using WTF::isCJKSymbolOrPunctuation;
 using WTF::isFullwidthMiddleDotPunctuation;
+using WTF::isCombiningMark;

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -40,6 +40,7 @@
 #include "TextSpacing.h"
 #include "WidthIterator.h"
 #include <unicode/ubidi.h>
+#include <wtf/text/CharacterProperties.h>
 #include <wtf/text/TextBreakIterator.h>
 
 namespace WebCore {
@@ -690,6 +691,19 @@ bool TextUtil::hasPositionDependentContentWidth(StringView textContent)
     if (textContent.is8Bit())
         return charactersContain<LChar, tabCharacter>(textContent.span8());
     return charactersContain<UChar, tabCharacter>(textContent.span16());
+}
+
+char32_t TextUtil::lastBaseCharacterFromText(StringView string)
+{
+    if (!string.length())
+        return 0;
+
+    for (size_t characterIndex = string.length() - 1; characterIndex >= 0; --characterIndex) {
+        auto character = string.characterAt(characterIndex);
+        if (!isCombiningMark(character))
+            return character;
+    }
+    return 0;
 }
 
 }

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
@@ -108,6 +108,10 @@ public:
 
     static bool canUseSimplifiedTextMeasuring(StringView, const FontCascade&, bool whitespaceIsCollapsed, const RenderStyle* firstLineStyle);
     static bool hasPositionDependentContentWidth(StringView);
+
+
+    static char32_t baseCharacterFromGraphemeCluster(StringView graphemeCluster);
+    static char32_t lastBaseCharacterFromText(StringView);
 };
 
 } // namespace Layout

--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -776,12 +776,17 @@ void ComplexTextController::adjustGlyphsAndAdvances()
             const auto& textAutoSpace =  m_font.textAutospace();
             float textAutoSpaceSpacing = 0;
             auto characterClass = TextSpacing::CharacterClass::Undefined;
-            if (!textAutoSpace.isNoAutospace())
+            // Since we are iterating through glyphs here we skip combining marks, since we just care about the grapheme cluster base for text-autospace.
+            if (!textAutoSpace.isNoAutospace() && !isCombiningMark(character)) {
                 characterClass = TextSpacing::characterClass(character);
-            if (textAutoSpace.shouldApplySpacing(previousCharacterClass, characterClass)) {
-                textAutoSpaceSpacing = complexTextRun.textAutospaceSize();
-                advance.expand(textAutoSpaceSpacing, 0);
+                if (textAutoSpace.shouldApplySpacing(previousCharacterClass, characterClass)) {
+                    textAutoSpaceSpacing = complexTextRun.textAutospaceSize();
+                    advance.expand(textAutoSpaceSpacing, 0);
+                }
+
+                previousCharacterClass = characterClass;
             }
+
             if (!textAutoSpace.isNoAutospace())
                 m_textAutoSpaceSpacings.append(textAutoSpaceSpacing);
 
@@ -814,7 +819,6 @@ void ComplexTextController::adjustGlyphsAndAdvances()
             glyphOrigin.move(advance);
 
             previousCharacterIndex = characterIndex;
-            previousCharacterClass = characterClass;
         }
         if (!isMonotonic)
             complexTextRun.setIsNonMonotonic();


### PR DESCRIPTION
#### 41ea61ca1ed39dbad7dd08a24d86d8158a6dabed
<pre>
text-spacing: text-autospace: handle combining marks
<a href="https://bugs.webkit.org/show_bug.cgi?id=284979">https://bugs.webkit.org/show_bug.cgi?id=284979</a>
<a href="https://rdar.apple.com/133797833">rdar://133797833</a>

Reviewed by Ryan Reno.

When a combining mark is present, we should consider its base character
for analyzing the character class for text-autospace.

* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-combining-marks-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-combining-marks.html: Added.
* Source/WTF/wtf/text/CharacterProperties.h:
(WTF::isCombiningMark):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::computeInlineBoxBoundaryTextSpacingsIfNeeded):
(WebCore::Layout::handleTextSpacing):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::baseCharacterFromGraphemeCluster):
(WebCore::Layout::TextUtil::lastBaseCharacterFromText):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h:
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::adjustGlyphsAndAdvances):

Canonical link: <a href="https://commits.webkit.org/288202@main">https://commits.webkit.org/288202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/754580e859f2bc85d012cc8362a2fca320c33f9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36091 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/86702 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33162 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84230 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/1705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9487 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/86702 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/21741 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85194 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/1705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74721 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/86702 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/1705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28900 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/31617 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75107 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/1705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29515 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/88150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81179 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9374 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/88150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9562 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70538 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/88150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17860 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15738 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9329 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103591 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/9176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25136 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/12694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10976 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->