### PR TITLE
Declarative Web Push: Move the window context PushManager from Navigator to DOMWindow

### DIFF
--- a/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
@@ -29,7 +29,6 @@ navigator.platform is OK
 navigator.plugins is OK
 navigator.product is OK
 navigator.productSub is OK
-navigator.pushManager is OK
 navigator.requestMediaKeySystemAccess() is OK
 navigator.sendBeacon() threw err TypeError: Not enough arguments
 navigator.serviceWorker is OK
@@ -73,7 +72,6 @@ navigator.platform is OK
 navigator.plugins is OK
 navigator.product is OK
 navigator.productSub is OK
-navigator.pushManager is OK
 navigator.requestMediaKeySystemAccess() is OK
 navigator.sendBeacon() threw err TypeError: Not enough arguments
 navigator.serviceWorker is OK

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -614,7 +614,6 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/pictureinpicture/PictureInPictureEvent.idl
     Modules/pictureinpicture/PictureInPictureWindow.idl
 
-    Modules/push-api/NavigatorPush.idl
     Modules/push-api/PushEncryptionKeyName.idl
     Modules/push-api/PushEvent.idl
     Modules/push-api/PushEventInit.idl
@@ -629,6 +628,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/push-api/PushSubscriptionOptionsInit.idl
     Modules/push-api/ServiceWorkerGlobalScope+PushAPI.idl
     Modules/push-api/ServiceWorkerRegistration+PushAPI.idl
+    Modules/push-api/WindowPush.idl
 
     Modules/remoteplayback/RemotePlayback.idl
     Modules/remoteplayback/RemotePlaybackAvailabilityCallback.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -822,7 +822,6 @@ $(PROJECT_DIR)/Modules/pictureinpicture/DocumentOrShadowRoot+PictureInPicture.id
 $(PROJECT_DIR)/Modules/pictureinpicture/HTMLVideoElement+PictureInPicture.idl
 $(PROJECT_DIR)/Modules/pictureinpicture/PictureInPictureEvent.idl
 $(PROJECT_DIR)/Modules/pictureinpicture/PictureInPictureWindow.idl
-$(PROJECT_DIR)/Modules/push-api/NavigatorPush.idl
 $(PROJECT_DIR)/Modules/push-api/PushEncryptionKeyName.idl
 $(PROJECT_DIR)/Modules/push-api/PushEvent.idl
 $(PROJECT_DIR)/Modules/push-api/PushEventInit.idl
@@ -837,6 +836,7 @@ $(PROJECT_DIR)/Modules/push-api/PushSubscriptionOptions.idl
 $(PROJECT_DIR)/Modules/push-api/PushSubscriptionOptionsInit.idl
 $(PROJECT_DIR)/Modules/push-api/ServiceWorkerGlobalScope+PushAPI.idl
 $(PROJECT_DIR)/Modules/push-api/ServiceWorkerRegistration+PushAPI.idl
+$(PROJECT_DIR)/Modules/push-api/WindowPush.idl
 $(PROJECT_DIR)/Modules/remoteplayback/HTMLMediaElement+RemotePlayback.idl
 $(PROJECT_DIR)/Modules/remoteplayback/RemotePlayback.idl
 $(PROJECT_DIR)/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -3431,6 +3431,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWindowOrWorkerGlobalScope.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWindowOrWorkerGlobalScope.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWindowPostMessageOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWindowPostMessageOptions.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWindowPush.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWindowPush.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWindowSessionStorage.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWindowSessionStorage.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWorker.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -585,7 +585,6 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/pictureinpicture/HTMLVideoElement+PictureInPicture.idl \
     $(WebCore)/Modules/pictureinpicture/PictureInPictureEvent.idl \
     $(WebCore)/Modules/pictureinpicture/PictureInPictureWindow.idl \
-    $(WebCore)/Modules/push-api/NavigatorPush.idl \
     $(WebCore)/Modules/push-api/PushEncryptionKeyName.idl \
     $(WebCore)/Modules/push-api/PushEvent.idl \
     $(WebCore)/Modules/push-api/PushEventInit.idl \
@@ -600,6 +599,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/push-api/PushSubscriptionOptionsInit.idl \
     $(WebCore)/Modules/push-api/ServiceWorkerGlobalScope+PushAPI.idl \
     $(WebCore)/Modules/push-api/ServiceWorkerRegistration+PushAPI.idl \
+    $(WebCore)/Modules/push-api/WindowPush.idl \
     $(WebCore)/Modules/remoteplayback/HTMLMediaElement+RemotePlayback.idl \
     $(WebCore)/Modules/remoteplayback/RemotePlayback.idl \
     $(WebCore)/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -557,11 +557,17 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Modules/push-api/PushCrypto.h
     Modules/push-api/PushDatabase.h
+    Modules/push-api/PushEncryptionKeyName.h
+    Modules/push-api/PushManager.h
     Modules/push-api/PushMessageCrypto.h
     Modules/push-api/PushPermissionState.h
     Modules/push-api/PushStrategy.h
+    Modules/push-api/PushSubscription.h
     Modules/push-api/PushSubscriptionData.h
     Modules/push-api/PushSubscriptionIdentifier.h
+    Modules/push-api/PushSubscriptionJSON.h
+    Modules/push-api/PushSubscriptionOptionsInit.h
+    Modules/push-api/PushSubscriptionOwner.h
 
     Modules/reporting/DeprecationReportBody.h
     Modules/reporting/Report.h

--- a/Source/WebCore/Modules/push-api/PushStrategy.h
+++ b/Source/WebCore/Modules/push-api/PushStrategy.h
@@ -38,16 +38,16 @@ public:
     virtual ~PushStrategy() = default;
 
     using SubscribeToPushServiceCallback = CompletionHandler<void(ExceptionOr<PushSubscriptionData>&&)>;
-    virtual void navigatorSubscribeToPushService(const URL& scope, const Vector<uint8_t>& applicationServerKey, SubscribeToPushServiceCallback&&) = 0;
+    virtual void windowSubscribeToPushService(const URL& scope, const Vector<uint8_t>& applicationServerKey, SubscribeToPushServiceCallback&&) = 0;
 
     using UnsubscribeFromPushServiceCallback = CompletionHandler<void(ExceptionOr<bool>&&)>;
-    virtual void navigatorUnsubscribeFromPushService(const URL& scope, std::optional<PushSubscriptionIdentifier>, UnsubscribeFromPushServiceCallback&&) = 0;
+    virtual void windowUnsubscribeFromPushService(const URL& scope, std::optional<PushSubscriptionIdentifier>, UnsubscribeFromPushServiceCallback&&) = 0;
 
     using GetPushSubscriptionCallback = CompletionHandler<void(ExceptionOr<std::optional<PushSubscriptionData>>&&)>;
-    virtual void navigatorGetPushSubscription(const URL& scope, GetPushSubscriptionCallback&&) = 0;
+    virtual void windowGetPushSubscription(const URL& scope, GetPushSubscriptionCallback&&) = 0;
 
     using GetPushPermissionStateCallback = CompletionHandler<void(ExceptionOr<PushPermissionState>&&)>;
-    virtual void navigatorGetPushPermissionState(const URL& scope, GetPushPermissionStateCallback&&) = 0;
+    virtual void windowGetPushPermissionState(const URL& scope, GetPushPermissionStateCallback&&) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/push-api/WindowPush.idl
+++ b/Source/WebCore/Modules/push-api/WindowPush.idl
@@ -27,6 +27,6 @@
 [
     Conditional=DECLARATIVE_WEB_PUSH,
     EnabledBySetting=DeclarativeWebPush,
-] interface mixin NavigatorPush {
-    readonly attribute PushManager pushManager;
+] interface mixin WindowPush {
+    [SameObject] readonly attribute PushManager pushManager;
 };

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -675,6 +675,7 @@ namespace WebCore {
     macro(pullAgain) \
     macro(pullAlgorithm) \
     macro(pulling) \
+    macro(pushManager) \
     macro(queue) \
     macro(queuedAddIceCandidate) \
     macro(queuedCreateAnswer) \

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -39,6 +39,7 @@
 #include "NodeList.h"
 #include "Page.h"
 #include "PageConsoleClient.h"
+#include "PlatformStrategies.h"
 #include "RemoteDOMWindow.h"
 #include "ResourceLoadObserver.h"
 #include "ScheduledAction.h"
@@ -906,5 +907,15 @@ ExceptionOr<String> DOMWindow::atob(const String& stringToEncode)
         return Exception { ExceptionCode::SecurityError };
     return Base64Utilities::atob(stringToEncode);
 }
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+ExceptionOr<PushManager&> DOMWindow::pushManager()
+{
+    auto* localThis = dynamicDowncast<LocalDOMWindow>(*this);
+    if (!localThis)
+        return Exception { ExceptionCode::SecurityError };
+    return localThis->pushManager();
+}
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -63,6 +63,7 @@ class NodeList;
 class Page;
 class PageConsoleClient;
 class Performance;
+class PushManager;
 class RequestAnimationFrameCallback;
 class RequestIdleCallback;
 class ScheduledAction;
@@ -215,6 +216,10 @@ public:
     ExceptionOr<JSC::JSValue> structuredClone(JSDOMGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& relevantGlobalObject, JSC::JSValue, StructuredSerializeOptions&&);
     ExceptionOr<String> btoa(const String&);
     ExceptionOr<String> atob(const String&);
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    ExceptionOr<PushManager&> pushManager();
+#endif
 
 protected:
     explicit DOMWindow(GlobalWindowIdentifier&&, DOMWindowType);

--- a/Source/WebCore/page/DOMWindow.idl
+++ b/Source/WebCore/page/DOMWindow.idl
@@ -127,4 +127,5 @@ DOMWindow includes GlobalEventHandlers;
 DOMWindow includes WindowEventHandlers;
 DOMWindow includes WindowOrWorkerGlobalScope;
 DOMWindow includes WindowLocalStorage;
+DOMWindow includes WindowPush;
 DOMWindow includes WindowSessionStorage;

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -31,6 +31,8 @@
 #include "DOMWindow.h"
 #include "ExceptionOr.h"
 #include "LocalFrame.h"
+#include "PushManager.h"
+#include "PushSubscriptionOwner.h"
 #include "ReducedResolutionSeconds.h"
 #include "ScrollToOptions.h"
 #include "Supplementable.h"
@@ -79,7 +81,11 @@ class LocalDOMWindow final
     , public ContextDestructionObserver
     , public Base64Utilities
     , public WindowOrWorkerGlobalScope
-    , public Supplementable<LocalDOMWindow> {
+    , public Supplementable<LocalDOMWindow>
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    , public PushSubscriptionOwner
+#endif
+    {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(LocalDOMWindow);
 public:
 
@@ -363,6 +369,13 @@ public:
 
     CookieStore& cookieStore();
 
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    PushManager& pushManager();
+
+    void ref() const final { DOMWindow::ref(); }
+    void deref() const final { DOMWindow::deref(); }
+#endif
+
 private:
     explicit LocalDOMWindow(Document&);
 
@@ -391,6 +404,16 @@ private:
 #endif
 
     void processPostMessage(JSC::JSGlobalObject&, const String& origin, const MessageWithMessagePorts&, RefPtr<WindowProxy>&&, RefPtr<SecurityOrigin>&&);
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    bool isActive() const final { return true; }
+
+    void subscribeToPushService(const Vector<uint8_t>& applicationServerKey, DOMPromiseDeferred<IDLInterface<PushSubscription>>&&) final;
+    void unsubscribeFromPushService(std::optional<PushSubscriptionIdentifier>, DOMPromiseDeferred<IDLBoolean>&&) final;
+    void getPushSubscription(DOMPromiseDeferred<IDLNullable<IDLInterface<PushSubscription>>>&&) final;
+    void getPushPermissionState(DOMPromiseDeferred<IDLEnumeration<PushPermissionState>>&&) final;
+#endif // ENABLE(DECLARATIVE_WEB_PUSH)
+
     bool m_shouldPrintWhenFinishedLoading { false };
     bool m_suspendedForDocumentSuspension { false };
     bool m_isSuspendingObservers { false };
@@ -451,6 +474,10 @@ private:
 #endif
 
     RefPtr<CookieStore> m_cookieStore;
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    PushManager m_pushManager;
+#endif
 };
 
 inline String LocalDOMWindow::status() const

--- a/Source/WebCore/page/Navigator.h
+++ b/Source/WebCore/page/Navigator.h
@@ -21,8 +21,6 @@
 
 #include "LocalDOMWindowProperty.h"
 #include "NavigatorBase.h"
-#include "PushManager.h"
-#include "PushSubscriptionOwner.h"
 #include "ScriptWrappable.h"
 #include "ShareData.h"
 #include "Supplementable.h"
@@ -43,18 +41,10 @@ class Navigator final
     , public ScriptWrappable
     , public LocalDOMWindowProperty
     , public Supplementable<Navigator>
-#if ENABLE(DECLARATIVE_WEB_PUSH)
-    , public PushSubscriptionOwner
-#endif
 {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(Navigator);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Navigator);
 public:
-#if ENABLE(DECLARATIVE_WEB_PUSH)
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
-#endif
-
     static Ref<Navigator> create(ScriptExecutionContext* context, LocalDOMWindow& window) { return adoptRef(*new Navigator(context, window)); }
     virtual ~Navigator();
 
@@ -92,10 +82,6 @@ public:
     void setClientBadge(std::optional<unsigned long long>, Ref<DeferredPromise>&&);
     void clearClientBadge(Ref<DeferredPromise>&&);
 
-#if ENABLE(DECLARATIVE_WEB_PUSH)
-    PushManager& pushManager();
-#endif
-
 private:
     void showShareData(ExceptionOr<ShareDataWithParsedURL&>, Ref<DeferredPromise>&&);
     explicit Navigator(ScriptExecutionContext*, LocalDOMWindow&);
@@ -110,16 +96,5 @@ private:
     mutable String m_userAgent;
     mutable String m_platform;
     RefPtr<GPU> m_gpuForWebGPU;
-
-#if ENABLE(DECLARATIVE_WEB_PUSH)
-    bool isActive() const final { return true; }
-
-    void subscribeToPushService(const Vector<uint8_t>& applicationServerKey, DOMPromiseDeferred<IDLInterface<PushSubscription>>&&) final;
-    void unsubscribeFromPushService(std::optional<PushSubscriptionIdentifier>, DOMPromiseDeferred<IDLBoolean>&&) final;
-    void getPushSubscription(DOMPromiseDeferred<IDLNullable<IDLInterface<PushSubscription>>>&&) final;
-    void getPushPermissionState(DOMPromiseDeferred<IDLEnumeration<PushPermissionState>>&&) final;
-
-    PushManager m_pushManager;
-#endif
 };
 }

--- a/Source/WebCore/page/Navigator.idl
+++ b/Source/WebCore/page/Navigator.idl
@@ -36,7 +36,6 @@ Navigator includes NavigatorMaxTouchPoints;
 Navigator includes NavigatorOnLine;
 Navigator includes NavigatorCookies;
 Navigator includes NavigatorPlugins;
-Navigator includes NavigatorPush;
 Navigator includes NavigatorServiceWorker;
 Navigator includes NavigatorShare;
 Navigator includes NavigatorStorage;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -450,7 +450,7 @@ String WebPlatformStrategies::readStringFromPasteboard(size_t index, const Strin
 
 #if ENABLE(DECLARATIVE_WEB_PUSH)
 
-void WebPlatformStrategies::navigatorSubscribeToPushService(const URL& scope, const Vector<uint8_t>& applicationServerKey, SubscribeToPushServiceCallback&& callback)
+void WebPlatformStrategies::windowSubscribeToPushService(const URL& scope, const Vector<uint8_t>& applicationServerKey, SubscribeToPushServiceCallback&& callback)
 {
     auto completionHandler = [callback = WTFMove(callback)](auto&& valueOrException) mutable {
         if (!valueOrException.has_value()) {
@@ -463,7 +463,7 @@ void WebPlatformStrategies::navigatorSubscribeToPushService(const URL& scope, co
     WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::NavigatorSubscribeToPushService(scope, applicationServerKey), WTFMove(completionHandler));
 }
 
-void WebPlatformStrategies::navigatorUnsubscribeFromPushService(const URL& scope, std::optional<PushSubscriptionIdentifier> subscriptionIdentifier, UnsubscribeFromPushServiceCallback&& callback)
+void WebPlatformStrategies::windowUnsubscribeFromPushService(const URL& scope, std::optional<PushSubscriptionIdentifier> subscriptionIdentifier, UnsubscribeFromPushServiceCallback&& callback)
 {
     auto completionHandler = [callback = WTFMove(callback)](auto&& valueOrException) mutable {
         if (!valueOrException.has_value()) {
@@ -476,7 +476,7 @@ void WebPlatformStrategies::navigatorUnsubscribeFromPushService(const URL& scope
     WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::NavigatorUnsubscribeFromPushService(scope, *subscriptionIdentifier), WTFMove(completionHandler));
 }
 
-void WebPlatformStrategies::navigatorGetPushSubscription(const URL& scope, GetPushSubscriptionCallback&& callback)
+void WebPlatformStrategies::windowGetPushSubscription(const URL& scope, GetPushSubscriptionCallback&& callback)
 {
     auto completionHandler = [callback = WTFMove(callback)](auto&& valueOrException) mutable {
         if (!valueOrException.has_value()) {
@@ -489,7 +489,7 @@ void WebPlatformStrategies::navigatorGetPushSubscription(const URL& scope, GetPu
     WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::NavigatorGetPushSubscription(scope), WTFMove(completionHandler));
 }
 
-void WebPlatformStrategies::navigatorGetPushPermissionState(const URL& scope, GetPushPermissionStateCallback&& callback)
+void WebPlatformStrategies::windowGetPushPermissionState(const URL& scope, GetPushPermissionStateCallback&& callback)
 {
     auto completionHandler = [callback = WTFMove(callback)](auto&& valueOrException) mutable {
         if (!valueOrException.has_value())

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h
@@ -111,10 +111,10 @@ private:
 
     // WebCore::PushStrategy
 #if ENABLE(DECLARATIVE_WEB_PUSH)
-    void navigatorSubscribeToPushService(const URL& scope, const Vector<uint8_t>& applicationServerKey, SubscribeToPushServiceCallback&&) override;
-    void navigatorUnsubscribeFromPushService(const URL& scope, std::optional<WebCore::PushSubscriptionIdentifier>, UnsubscribeFromPushServiceCallback&&) override;
-    void navigatorGetPushSubscription(const URL& scope, GetPushSubscriptionCallback&&) override;
-    void navigatorGetPushPermissionState(const URL& scope, GetPushPermissionStateCallback&&) override;
+    void windowSubscribeToPushService(const URL& scope, const Vector<uint8_t>& applicationServerKey, SubscribeToPushServiceCallback&&) override;
+    void windowUnsubscribeFromPushService(const URL& scope, std::optional<WebCore::PushSubscriptionIdentifier>, UnsubscribeFromPushServiceCallback&&) override;
+    void windowGetPushSubscription(const URL& scope, GetPushSubscriptionCallback&&) override;
+    void windowGetPushPermissionState(const URL& scope, GetPushPermissionStateCallback&&) override;
 #endif
 };
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -402,7 +402,7 @@ window.onload = function()
 async function subscribe(key)
 {
     try {
-        globalSubscription = await navigator.pushManager.subscribe({
+        globalSubscription = await window.pushManager.subscribe({
             userVisibleOnly: true,
             applicationServerKey: key
         });
@@ -425,7 +425,7 @@ async function unsubscribe()
 async function getPushSubscription()
 {
     try {
-        let subscription = await navigator.pushManager.getSubscription();
+        let subscription = await window.pushManager.getSubscription();
         return subscription ? subscription.toJSON() : null;
     } catch (error) {
         return "Error: " + error;


### PR DESCRIPTION
#### b96ecd4d82e2ac0f15580a7a1ea7e54b653d3867
<pre>
Declarative Web Push: Move the window context PushManager from Navigator to DOMWindow
<a href="https://rdar.apple.com/141786288">rdar://141786288</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284980">https://bugs.webkit.org/show_bug.cgi?id=284980</a>

Reviewed by Chris Dumez.

Since our initial implementation, standards work has moved this from window.navigator directly onto window.

* LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/push-api/PushStrategy.h:
* Source/WebCore/Modules/push-api/WindowPush.idl: Renamed from Source/WebCore/Modules/push-api/NavigatorPush.idl.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/page/DOMWindow.cpp:
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/DOMWindow.idl:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::m_pushManager):
(WebCore::LocalDOMWindow::pushManager):
(WebCore::toScope):
(WebCore::LocalDOMWindow::subscribeToPushService):
(WebCore::LocalDOMWindow::unsubscribeFromPushService):
(WebCore::LocalDOMWindow::getPushSubscription):
(WebCore::LocalDOMWindow::getPushPermissionState):
(WebCore::ContextDestructionObserver): Deleted.
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::Navigator):
(WebCore::Navigator::pushManager): Deleted.
(WebCore::toScope): Deleted.
(WebCore::Navigator::subscribeToPushService): Deleted.
(WebCore::Navigator::unsubscribeFromPushService): Deleted.
(WebCore::Navigator::getPushSubscription): Deleted.
(WebCore::Navigator::getPushPermissionState): Deleted.
* Source/WebCore/page/Navigator.h:
* Source/WebCore/page/Navigator.idl:
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
(WebKit::WebPlatformStrategies::windowSubscribeToPushService):
(WebKit::WebPlatformStrategies::windowUnsubscribeFromPushService):
(WebKit::WebPlatformStrategies::windowGetPushSubscription):
(WebKit::WebPlatformStrategies::windowGetPushPermissionState):
(WebKit::WebPlatformStrategies::navigatorSubscribeToPushService): Deleted.
(WebKit::WebPlatformStrategies::navigatorUnsubscribeFromPushService): Deleted.
(WebKit::WebPlatformStrategies::navigatorGetPushSubscription): Deleted.
(WebKit::WebPlatformStrategies::navigatorGetPushPermissionState): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::subscribe):
(TestWebKitAPI::getPushSubscription):

Canonical link: <a href="https://commits.webkit.org/288144@main">https://commits.webkit.org/288144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aff5c25ec3471ded41624155d0dbd2e27477d7b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86559 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/33034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9353 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/33034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74613 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/44210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28790 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31454 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87992 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9244 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/72294 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71516 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17827 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15635 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9195 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9035 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12560 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10843 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->