### PR TITLE
Further reduce the use of memcpy() in audio code

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
@@ -80,12 +80,12 @@ static JSObject* toJSObject(JSValueInWrappedObject& wrapper)
     return wrapper ? jsDynamicCast<JSObject*>(wrapper.getValue()) : nullptr;
 }
 
-static JSFloat32Array* constructJSFloat32Array(JSGlobalObject& globalObject, unsigned length, const float* data = nullptr)
+static JSFloat32Array* constructJSFloat32Array(JSGlobalObject& globalObject, unsigned length, std::span<const float> data = { })
 {
     constexpr bool isResizableOrGrowableShared = false;
     auto* jsArray = JSFloat32Array::create(&globalObject, globalObject.typedArrayStructure(TypeFloat32, isResizableOrGrowableShared), length);
-    if (data)
-        memcpy(jsArray->typedVector(), data, sizeof(float) * length);
+    if (!data.empty())
+        memcpySpan(jsArray->typedSpan(), data.first(length));
     return jsArray;
 }
 
@@ -98,7 +98,7 @@ static JSObject* constructFrozenKeyValueObject(VM& vm, JSGlobalObject& globalObj
         PutPropertySlot slot(object, false, PutPropertySlot::PutById);
         // Per the specification, if the value is constant, we pass the JS an array with length 1, with the array item being the constant.
         unsigned jsArraySize = pair.value->containsConstantValue() ? 1 : pair.value->size();
-        object->putInline(&globalObject, Identifier::fromString(vm, pair.key), constructJSFloat32Array(globalObject, jsArraySize, pair.value->data()), slot);
+        object->putInline(&globalObject, Identifier::fromString(vm, pair.key), constructJSFloat32Array(globalObject, jsArraySize, pair.value->span()), slot);
     }
     JSC::objectConstructorFreeze(&globalObject, object);
     EXCEPTION_ASSERT_UNUSED(scope, !scope.exception());
@@ -114,7 +114,7 @@ static JSArray* constructFrozenJSArray(VM& vm, JSGlobalObject& globalObject, JSC
     auto* channelsData = JSArray::create(vm, globalObject.originalArrayStructureForIndexingType(ArrayWithContiguous), numberOfChannels);
     for (unsigned j = 0; j < numberOfChannels; ++j) {
         auto* channel = bus->channel(j);
-        channelsData->setIndexQuickly(vm, j, constructJSFloat32Array(globalObject, channel->length(), shouldPopulateWithBusData == ShouldPopulateWithBusData::Yes ? channel->data() : nullptr));
+        channelsData->setIndexQuickly(vm, j, constructJSFloat32Array(globalObject, channel->length(), shouldPopulateWithBusData == ShouldPopulateWithBusData::Yes ? channel->span() : std::span<const float> { }));
     }
     JSC::objectConstructorFreeze(&globalObject, channelsData);
     EXCEPTION_ASSERT_UNUSED(scope, !scope.exception());
@@ -147,7 +147,7 @@ static void copyDataFromJSArrayToBuses(JSGlobalObject& globalObject, JSArray& js
             auto* channel = bus->channel(j);
             auto* jsChannelData = getArrayAtIndex<JSFloat32Array>(*channelsArray, globalObject, j);
             if (LIKELY(jsChannelData && !jsChannelData->isShared() && jsChannelData->length() == channel->length()))
-                memcpy(channel->mutableData(), jsChannelData->typedVector(), sizeof(float) * channel->length());
+                memcpySpan(channel->mutableSpan(), jsChannelData->typedSpan().first(channel->length()));
             else
                 channel->zero();
         }
@@ -170,7 +170,7 @@ static bool copyDataFromBusesToJSArray(JSGlobalObject& globalObject, const Vecto
             auto* jsChannelArray = getArrayAtIndex<JSFloat32Array>(*jsChannelsArray, globalObject, channelIndex);
             if (!jsChannelArray || jsChannelArray->isShared() || jsChannelArray->length() != channel->length())
                 return false;
-            memcpy(jsChannelArray->typedVector(), channel->mutableData(), sizeof(float) * jsChannelArray->length());
+            memcpySpan(jsChannelArray->typedSpan(), channel->mutableSpan().first(jsChannelArray->length()));
         }
     }
     return true;
@@ -188,7 +188,7 @@ static bool copyDataFromParameterMapToJSObject(VM& vm, JSGlobalObject& globalObj
         unsigned expectedLength = pair.value->containsConstantValue() ? 1 : pair.value->size();
         if (jsTypedArray->length() != expectedLength)
             return false;
-        memcpy(jsTypedArray->typedVector(), pair.value->data(), sizeof(float) * jsTypedArray->length());
+        memcpySpan(jsTypedArray->typedSpan(), pair.value->span().first(jsTypedArray->length()));
     }
     return true;
 }

--- a/Source/WebCore/Modules/webaudio/ConvolverNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ConvolverNode.cpp
@@ -131,7 +131,7 @@ ExceptionOr<void> ConvolverNode::setBufferForBindings(RefPtr<AudioBuffer>&& buff
     if (!isChannelCountGood)
         return Exception { ExceptionCode::NotSupportedError, "Buffer should have 1, 2 or 4 channels"_s };
 
-    // Wrap the AudioBuffer by an AudioBus. It's an efficient pointer set and not a memcpy().
+    // Wrap the AudioBuffer by an AudioBus. It's an efficient pointer set and not a memcpySpan().
     // This memory is simply used in the Reverb constructor and no reference to it is kept for later use in that class.
     auto bufferBus = AudioBus::create(numberOfChannels, bufferLength, false);
     for (unsigned i = 0; i < numberOfChannels; ++i)

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
@@ -35,6 +35,8 @@
 #include "WebAudioBufferList.h"
 #include <CoreAudio/CoreAudioTypes.h>
 #include <pal/avfoundation/MediaTimeAVFoundation.h>
+#include <wtf/StdLibExtras.h>
+
 #include <pal/cf/CoreMediaSoftLink.h>
 #include "CoreVideoSoftLink.h"
 
@@ -60,7 +62,7 @@ static inline void copyChannelData(AudioChannel& channel, AudioBuffer& buffer, s
         zeroSpan(dataMutableByteSpan(buffer));
         return;
     }
-    memcpy(buffer.mData, channel.data(), buffer.mDataByteSize);
+    memcpySpan(dataMutableByteSpan(buffer), asByteSpan(channel.span()).first(buffer.mDataByteSize));
 }
 
 void MediaStreamAudioSource::consumeAudio(AudioBus& bus, size_t numberOfFrames)

--- a/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp
@@ -42,6 +42,7 @@
 #include <JavaScriptCore/JSGenericTypedArrayViewInlines.h>
 #include <algorithm>
 #include <wtf/MainThread.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/threads/BinarySemaphore.h>
 
@@ -187,9 +188,9 @@ auto OfflineAudioDestinationNode::renderOnAudioThread() -> RenderResult
         size_t framesAvailableToCopy = std::min(m_framesToProcess, AudioUtilities::renderQuantumSize);
         
         for (unsigned channelIndex = 0; channelIndex < numberOfChannels; ++channelIndex) {
-            const float* source = m_renderBus->channel(channelIndex)->data();
-            float* destination = m_renderTarget->channelData(channelIndex)->data();
-            memcpy(destination + m_destinationOffset, source, sizeof(float) * framesAvailableToCopy);
+            auto source = m_renderBus->channel(channelIndex)->span().first(framesAvailableToCopy);
+            auto destination = m_renderTarget->channelData(channelIndex)->typedMutableSpan();
+            memcpySpan(destination.subspan(m_destinationOffset), source);
         }
         
         m_destinationOffset += framesAvailableToCopy;

--- a/Source/WebCore/Modules/webaudio/PeriodicWave.cpp
+++ b/Source/WebCore/Modules/webaudio/PeriodicWave.cpp
@@ -233,13 +233,13 @@ void PeriodicWave::createBandLimitedTables(const float* realData, const float* i
         m_bandLimitedTables.append(makeUnique<AudioFloatArray>(waveSize));
 
         // Apply an inverse FFT to generate the time-domain table data.
-        float* data = m_bandLimitedTables[rangeIndex]->data();
+        auto data = m_bandLimitedTables[rangeIndex]->span();
         frame.doInverseFFT(data);
 
         // For the first range (which has the highest power), calculate its peak value then compute normalization scale.
         if (disableNormalization == ShouldDisableNormalization::No) {
             if (!rangeIndex) {
-                float maxValue = VectorMath::maximumMagnitude(data, fftSize);
+                float maxValue = VectorMath::maximumMagnitude(data.data(), fftSize);
 
                 if (maxValue)
                     normalizationScale = 1.0f / maxValue;
@@ -247,7 +247,7 @@ void PeriodicWave::createBandLimitedTables(const float* realData, const float* i
         }
 
         // Apply normalization scale.
-        VectorMath::multiplyByScalar(data, normalizationScale, data, fftSize);
+        VectorMath::multiplyByScalar(data.data(), normalizationScale, data.data(), fftSize);
     }
 }
 

--- a/Source/WebCore/platform/audio/AudioArray.h
+++ b/Source/WebCore/platform/audio/AudioArray.h
@@ -116,7 +116,7 @@ public:
         zeroSpan(span().subspan(start, end - start));
     }
 
-    void copyToRange(const T* sourceData, unsigned start, unsigned end)
+    void copyToRange(std::span<const T> sourceData, unsigned start, unsigned end)
     {
         bool isSafe = (start <= end) && (end <= size());
         ASSERT(isSafe);
@@ -125,7 +125,7 @@ public:
 
         // This expression cannot overflow because end - start cannot be
         // greater than m_size, which is safe due to the check in resize().
-        memcpy(this->data() + start, sourceData, sizeof(T) * (end - start));
+        memcpySpan(this->span().subspan(start), sourceData.first(end - start));
     }
 
     bool containsConstantValue() const

--- a/Source/WebCore/platform/audio/AudioChannel.h
+++ b/Source/WebCore/platform/audio/AudioChannel.h
@@ -120,7 +120,7 @@ public:
     // Scales all samples by the same amount.
     void scale(float scale);
 
-    // A simple memcpy() from the source channel
+    // A simple memcpySpan() from the source channel
     void copyFrom(const AudioChannel* sourceChannel);
 
     // Copies the given range from the source channel.

--- a/Source/WebCore/platform/audio/FFTConvolver.cpp
+++ b/Source/WebCore/platform/audio/FFTConvolver.cpp
@@ -93,9 +93,9 @@ void FFTConvolver::process(FFTFrame* fftKernel, std::span<const float> source, s
         // Check if it's time to perform the next FFT
         if (m_readWriteIndex == halfSize) {
             // The input buffer is now filled (get frequency-domain version)
-            m_frame.doFFT(m_inputBuffer.data());
+            m_frame.doFFT(m_inputBuffer.span());
             m_frame.multiply(*fftKernel);
-            m_frame.doInverseFFT(m_outputBuffer.data());
+            m_frame.doInverseFFT(m_outputBuffer.span());
 
             // Overlap-add 1st half from previous time
             VectorMath::add(m_outputBuffer.data(), m_lastOverlapBuffer.data(), m_outputBuffer.data(), halfSize);

--- a/Source/WebCore/platform/audio/FFTFrame.cpp
+++ b/Source/WebCore/platform/audio/FFTFrame.cpp
@@ -46,14 +46,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FFTFrame);
 
-void FFTFrame::doPaddedFFT(const float* data, size_t dataSize)
+void FFTFrame::doPaddedFFT(std::span<const float> data)
 {
     // Zero-pad the impulse response
     AudioFloatArray paddedResponse(fftSize()); // zero-initialized
-    paddedResponse.copyToRange(data, 0, dataSize);
+    paddedResponse.copyToRange(data, 0, data.size());
 
     // Get the frequency-domain version of padded response
-    doFFT(paddedResponse.data());
+    doFFT(paddedResponse.span());
 }
 
 std::unique_ptr<FFTFrame> FFTFrame::createInterpolatedFrame(const FFTFrame& frame1, const FFTFrame& frame2, double x)
@@ -65,11 +65,11 @@ std::unique_ptr<FFTFrame> FFTFrame::createInterpolatedFrame(const FFTFrame& fram
     // In the time-domain, the 2nd half of the response must be zero, to avoid circular convolution aliasing...
     int fftSize = newFrame->fftSize();
     AudioFloatArray buffer(fftSize);
-    newFrame->doInverseFFT(buffer.data());
+    newFrame->doInverseFFT(buffer.span());
     buffer.zeroRange(fftSize / 2, fftSize);
 
     // Put back into frequency domain.
-    newFrame->doFFT(buffer.data());
+    newFrame->doFFT(buffer.span());
 
     return newFrame;
 }

--- a/Source/WebCore/platform/audio/FFTFrame.h
+++ b/Source/WebCore/platform/audio/FFTFrame.h
@@ -60,8 +60,8 @@ public:
     ~FFTFrame();
 
     static void initialize();
-    void doFFT(const float* data);
-    void doInverseFFT(float* data);
+    void doFFT(std::span<const float> data);
+    void doInverseFFT(std::span<float> data);
     void multiply(const FFTFrame& frame); // multiplies ourself with frame : effectively operator*=()
     void scaleFFT(float factor);
 
@@ -81,7 +81,7 @@ public:
     // Interpolates from frame1 -> frame2 as x goes from 0.0 -> 1.0
     static std::unique_ptr<FFTFrame> createInterpolatedFrame(const FFTFrame& frame1, const FFTFrame& frame2, double x);
 
-    void doPaddedFFT(const float* data, size_t dataSize); // zero-padding with dataSize <= fftSize
+    void doPaddedFFT(std::span<const float> data); // zero-padding with data.size() <= fftSize
     double extractAverageGroupDelay();
     void addConstantGroupDelay(double sampleFrameDelay);
 

--- a/Source/WebCore/platform/audio/FFTFrameStub.cpp
+++ b/Source/WebCore/platform/audio/FFTFrameStub.cpp
@@ -64,12 +64,12 @@ FFTFrame::~FFTFrame()
     ASSERT_NOT_REACHED();
 }
 
-void FFTFrame::doFFT(const float* data)
+void FFTFrame::doFFT(std::span<const float> data)
 {
     ASSERT_NOT_REACHED();
 }
 
-void FFTFrame::doInverseFFT(float* data)
+void FFTFrame::doInverseFFT(std::span<float> data)
 {
     ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/platform/audio/HRTFKernel.cpp
+++ b/Source/WebCore/platform/audio/HRTFKernel.cpp
@@ -50,7 +50,7 @@ static float extractAverageGroupDelay(AudioChannel* channel, size_t analysisFFTS
 {
     ASSERT(channel);
         
-    float* impulseP = channel->mutableData();
+    auto impulseP = channel->mutableSpan();
     
     bool isSizeGood = channel->length() >= analysisFFTSize;
     ASSERT(isSizeGood);
@@ -77,7 +77,7 @@ HRTFKernel::HRTFKernel(AudioChannel* channel, size_t fftSize, float sampleRate)
     // Determine the leading delay (average group delay) for the response.
     m_frameDelay = extractAverageGroupDelay(channel, fftSize / 2);
 
-    float* impulseResponse = channel->mutableData();
+    auto impulseResponse = channel->mutableSpan();
     size_t responseLength = channel->length();
 
     // We need to truncate to fit into 1/2 the FFT size (with zero padding) in order to do proper convolution.
@@ -94,7 +94,7 @@ HRTFKernel::HRTFKernel(AudioChannel* channel, size_t fftSize, float sampleRate)
     }
 
     m_fftFrame = makeUnique<FFTFrame>(fftSize);
-    m_fftFrame->doPaddedFFT(impulseResponse, truncatedResponseLength);
+    m_fftFrame->doPaddedFFT(impulseResponse.first(truncatedResponseLength));
 }
 
 size_t HRTFKernel::fftSize() const
@@ -109,7 +109,7 @@ std::unique_ptr<AudioChannel> HRTFKernel::createImpulseResponse()
 
     // Add leading delay back in.
     fftFrame.addConstantGroupDelay(m_frameDelay);
-    fftFrame.doInverseFFT(channel->mutableData());
+    fftFrame.doInverseFFT(channel->mutableSpan());
 
     return channel;
 }

--- a/Source/WebCore/platform/audio/ReverbConvolver.cpp
+++ b/Source/WebCore/platform/audio/ReverbConvolver.cpp
@@ -73,7 +73,7 @@ ReverbConvolver::ReverbConvolver(AudioChannel* impulseResponse, size_t renderSli
     // Otherwise, assume we're being run from a command-line tool.
     bool hasRealtimeConstraint = useBackgroundThreads;
 
-    const float* response = impulseResponse->data();
+    auto response = impulseResponse->span();
     size_t totalResponseLength = impulseResponse->length();
 
     // The total latency is zero because the direct-convolution is used in the leading portion.
@@ -95,7 +95,7 @@ ReverbConvolver::ReverbConvolver(AudioChannel* impulseResponse, size_t renderSli
 
         bool useDirectConvolver = !stageOffset;
 
-        auto stage = makeUnique<ReverbConvolverStage>(response, totalResponseLength, reverbTotalLatency, stageOffset, stageSize, fftSize, renderPhase, renderSliceSize, &m_accumulationBuffer, scale, useDirectConvolver);
+        auto stage = makeUnique<ReverbConvolverStage>(response, reverbTotalLatency, stageOffset, stageSize, fftSize, renderPhase, renderSliceSize, &m_accumulationBuffer, scale, useDirectConvolver);
 
         bool isBackgroundStage = false;
 

--- a/Source/WebCore/platform/audio/ReverbConvolverStage.h
+++ b/Source/WebCore/platform/audio/ReverbConvolverStage.h
@@ -48,7 +48,7 @@ class ReverbConvolverStage final {
 public:
     // renderPhase is useful to know so that we can manipulate the pre versus post delay so that stages will perform
     // their heavy work (FFT processing) on different slices to balance the load in a real-time thread.
-    ReverbConvolverStage(const float* impulseResponse, size_t responseLength, size_t reverbTotalLatency, size_t stageOffset, size_t stageLength, size_t fftSize, size_t renderPhase, size_t renderSliceSize, ReverbAccumulationBuffer*, float scale, bool directMode = false);
+    ReverbConvolverStage(std::span<const float> impulseResponse, size_t reverbTotalLatency, size_t stageOffset, size_t stageLength, size_t fftSize, size_t renderPhase, size_t renderSliceSize, ReverbAccumulationBuffer*, float scale, bool directMode = false);
     ~ReverbConvolverStage();
 
     // WARNING: source.size() must be such that it evenly divides the delay buffer size (stage_offset).

--- a/Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp
@@ -87,9 +87,9 @@ void FFTFrame::initialize()
 
 FFTFrame::~FFTFrame() = default;
 
-void FFTFrame::doFFT(const float* data)
+void FFTFrame::doFFT(std::span<const float> data)
 {
-    gst_fft_f32_fft(m_fft.get(), data, m_complexData.get());
+    gst_fft_f32_fft(m_fft.get(), data.data(), m_complexData.get());
 
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
     float* imagData = m_imagData.data();
@@ -101,7 +101,7 @@ void FFTFrame::doFFT(const float* data)
     }
 }
 
-void FFTFrame::doInverseFFT(float* data)
+void FFTFrame::doInverseFFT(std::span<float> data)
 {
     //  Merge the real and imaginary vectors to complex vector.
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
@@ -114,10 +114,10 @@ void FFTFrame::doInverseFFT(float* data)
         m_complexData[i].r = realData[i];
     }
 
-    gst_fft_f32_inverse_fft(m_inverseFft.get(), m_complexData.get(), data);
+    gst_fft_f32_inverse_fft(m_inverseFft.get(), m_complexData.get(), data.data());
 
     // Scale so that a forward then inverse FFT yields exactly the original data.
-    VectorMath::multiplyByScalar(data, 1.0 / m_FFTSize, data, m_FFTSize);
+    VectorMath::multiplyByScalar(data.data(), 1.0 / m_FFTSize, data.data(), m_FFTSize);
 }
 
 int FFTFrame::minFFTSize()

--- a/Source/WebCore/platform/audio/mac/FFTFrameMac.cpp
+++ b/Source/WebCore/platform/audio/mac/FFTFrameMac.cpp
@@ -104,10 +104,12 @@ FFTFrame::FFTFrame(const FFTFrame& frame)
 
 FFTFrame::~FFTFrame() = default;
 
-void FFTFrame::doFFT(const float* data)
+void FFTFrame::doFFT(std::span<const float> data)
 {
     unsigned halfSize = m_FFTSize / 2;
-    vDSP_ctoz(reinterpret_cast<const DSPComplex*>(data), 2, &m_frame, 1, halfSize);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    vDSP_ctoz(reinterpret_cast<const DSPComplex*>(data.data()), 2, &m_frame, 1, halfSize);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     vDSP_fft_zrip(m_FFTSetup, &m_frame, 1, m_log2FFTSize, FFT_FORWARD);
 
     RELEASE_ASSERT(realData().size() >= halfSize);
@@ -122,13 +124,15 @@ void FFTFrame::doFFT(const float* data)
     VectorMath::multiplyByScalar(imagData().data(), 0.5, imagData().data(), halfSize);
 }
 
-void FFTFrame::doInverseFFT(float* data)
+void FFTFrame::doInverseFFT(std::span<float> data)
 {
     vDSP_fft_zrip(m_FFTSetup, &m_frame, 1, m_log2FFTSize, FFT_INVERSE);
-    vDSP_ztoc(&m_frame, 1, (DSPComplex*)data, 2, m_FFTSize / 2);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    vDSP_ztoc(&m_frame, 1, reinterpret_cast<DSPComplex*>(data.data()), 2, m_FFTSize / 2);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     // Do final scaling so that x == IFFT(FFT(x))
-    VectorMath::multiplyByScalar(data, 1.0f / m_FFTSize, data, m_FFTSize);
+    VectorMath::multiplyByScalar(data.data(), 1.0f / m_FFTSize, data.data(), m_FFTSize);
 }
 
 FFTSetup FFTFrame::fftSetupForSize(unsigned fftSize)


### PR DESCRIPTION
#### dae2160187aadc9a565f5193647a40c8ecb33936
<pre>
Further reduce the use of memcpy() in audio code
<a href="https://bugs.webkit.org/show_bug.cgi?id=284982">https://bugs.webkit.org/show_bug.cgi?id=284982</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp:
(WebCore::constructJSFloat32Array):
(WebCore::constructFrozenKeyValueObject):
(WebCore::constructFrozenJSArray):
(WebCore::copyDataFromJSArrayToBuses):
(WebCore::copyDataFromBusesToJSArray):
(WebCore::copyDataFromParameterMapToJSObject):
* Source/WebCore/Modules/webaudio/ConvolverNode.cpp:
(WebCore::ConvolverNode::setBufferForBindings):
* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp:
(WebCore::copyChannelData):
* Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp:
(WebCore::OfflineAudioDestinationNode::renderOnAudioThread):
* Source/WebCore/Modules/webaudio/PeriodicWave.cpp:
(WebCore::PeriodicWave::createBandLimitedTables):
* Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp:
(WebCore::RealtimeAnalyser::writeInput):
(WebCore::RealtimeAnalyser::doFFTAnalysisIfNecessary):
* Source/WebCore/platform/audio/AudioArray.h:
(WebCore::AudioArray::copyToRange):
* Source/WebCore/platform/audio/AudioChannel.h:
* Source/WebCore/platform/audio/FFTConvolver.cpp:
(WebCore::FFTConvolver::process):
* Source/WebCore/platform/audio/FFTFrame.cpp:
(WebCore::FFTFrame::doPaddedFFT):
(WebCore::FFTFrame::createInterpolatedFrame):
* Source/WebCore/platform/audio/FFTFrame.h:
* Source/WebCore/platform/audio/FFTFrameStub.cpp:
(WebCore::FFTFrame::doFFT):
(WebCore::FFTFrame::doInverseFFT):
* Source/WebCore/platform/audio/HRTFKernel.cpp:
(WebCore::extractAverageGroupDelay):
(WebCore::HRTFKernel::HRTFKernel):
(WebCore::HRTFKernel::createImpulseResponse):
* Source/WebCore/platform/audio/ReverbConvolver.cpp:
(WebCore::ReverbConvolver::ReverbConvolver):
* Source/WebCore/platform/audio/ReverbConvolverStage.cpp:
(WebCore::ReverbConvolverStage::ReverbConvolverStage):
(WebCore::ReverbConvolverStage::process):
* Source/WebCore/platform/audio/ReverbConvolverStage.h:
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::AudioFileReader::readProc):
* Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp:
(WebCore::FFTFrame::doFFT):
(WebCore::FFTFrame::doInverseFFT):
* Source/WebCore/platform/audio/mac/FFTFrameMac.cpp:
(WebCore::FFTFrame::doFFT):
(WebCore::FFTFrame::doInverseFFT):

Canonical link: <a href="https://commits.webkit.org/288172@main">https://commits.webkit.org/288172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/566294d50644b38cfcbc7206dd84cd86805cc3d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86618 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33093 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9415 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63969 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/21695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85131 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/1208 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44253 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/1112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28840 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31513 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29451 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/88059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9303 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/88059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9488 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70481 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/88059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17843 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15686 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9254 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9094 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12620 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->