### PR TITLE
Ensure visually contiguous boundaries when extending selection using Shift+Arrow keys

### DIFF
--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-extending-expected.txt
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-extending-expected.txt
@@ -1,0 +1,15 @@
+This text — مثل هذا النص — is right to left
+
+
+أرسل بريدًا إلكترونيًا إلى foo@example.com وانتظر الرد
+
+This test verifies that the text selection remains visually contiguous when extending the selection across bidi text.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS Selected all text in LTR paragraph
+PASS Selected all text in RTL paragraph
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-extending.html
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-extending.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true VisuallyContiguousBidiTextSelectionEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 16px;
+    font-family: system-ui;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+async function extendSelectionByWordInEditableContainer(container) {
+    await UIHelper.activateElementAndWaitForInputSession(container);
+    getSelection().setPosition(container.childNodes[0], 0);
+    do {
+        await UIHelper.callFunctionAndWaitForEvent(async () => {
+            await UIHelper.keyDown("rightArrow", ["shiftKey", "altKey"]);
+        }, document, "selectionchange");
+        await UIHelper.ensurePresentationUpdate();
+        if (!(await UIHelper.isSelectionVisuallyContiguous()))
+            testFailed(`Found visually discontiguous selection '${getSelection().toString()}'`);
+    } while (getSelection().toString() != container.textContent);
+
+    container.blur();
+    await UIHelper.waitForKeyboardToHide();
+}
+
+addEventListener("load", async () => {
+    description("This test verifies that the text selection remains visually contiguous when extending the selection across bidi text.");
+
+    await extendSelectionByWordInEditableContainer(document.getElementById("ltr"));
+    testPassed("Selected all text in LTR paragraph");
+
+    await extendSelectionByWordInEditableContainer(document.getElementById("rtl"));
+    testPassed("Selected all text in RTL paragraph");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <p id="ltr" contenteditable>This text — مثل هذا النص — is right to left</p>
+    <div><br></div>
+    <p id="rtl" contenteditable dir="rtl">أرسل بريدًا إلكترونيًا إلى foo@example.com وانتظر الرد</p>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -161,6 +161,13 @@ VisiblePosition visiblePositionForIndexUsingCharacterIterator(Node&, int index);
 
 WEBCORE_EXPORT VisiblePosition closestEditablePositionInElementForAbsolutePoint(const Element&, const IntPoint&);
 
+enum class SelectionExtentMovement : uint8_t {
+    Closest,
+    Left,
+    Right,
+};
+void adjustVisibleExtentPreservingVisualContiguity(const VisiblePosition& base, VisiblePosition& extent, SelectionExtentMovement);
+
 // -------------------------------------------------------------------------
 // HTMLElement
 // -------------------------------------------------------------------------

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -310,14 +310,16 @@ private:
     VisiblePosition endForPlatform() const;
     VisiblePosition nextWordPositionForPlatform(const VisiblePosition&);
 
-    VisiblePosition modifyExtendingRight(TextGranularity);
-    VisiblePosition modifyExtendingForward(TextGranularity);
+    VisiblePosition modifyExtendingRight(TextGranularity, UserTriggered);
+    VisiblePosition modifyExtendingForward(TextGranularity, UserTriggered);
     VisiblePosition modifyMovingRight(TextGranularity, bool* reachedBoundary = nullptr);
     VisiblePosition modifyMovingForward(TextGranularity, bool* reachedBoundary = nullptr);
-    VisiblePosition modifyExtendingLeft(TextGranularity);
-    VisiblePosition modifyExtendingBackward(TextGranularity);
+    VisiblePosition modifyExtendingLeft(TextGranularity, UserTriggered);
+    VisiblePosition modifyExtendingBackward(TextGranularity, UserTriggered);
     VisiblePosition modifyMovingLeft(TextGranularity, bool* reachedBoundary = nullptr);
     VisiblePosition modifyMovingBackward(TextGranularity, bool* reachedBoundary = nullptr);
+
+    void adjustSelectionExtentIfNeeded(VisiblePosition& extent, bool isForward, UserTriggered);
 
     enum class PositionType : uint8_t { Start, End, Extent };
     LayoutUnit lineDirectionPointForBlockDirectionNavigation(PositionType);

--- a/Source/WebCore/editing/RenderedPosition.cpp
+++ b/Source/WebCore/editing/RenderedPosition.cpp
@@ -230,6 +230,18 @@ IntRect RenderedPosition::absoluteRect(CaretRectMode caretRectMode) const
     return localRect == IntRect() ? IntRect() : m_renderer->localToAbsoluteQuad(FloatRect(localRect)).enclosingBoundingBox();
 }
 
+std::optional<BoundaryPoint> RenderedPosition::boundaryPoint() const
+{
+    if (!m_box)
+        return std::nullopt;
+
+    RefPtr node = m_box->renderer().node();
+    if (!node)
+        return std::nullopt;
+
+    return BoundaryPoint { *node, offset() };
+}
+
 bool renderObjectContainsPosition(const RenderObject* target, const Position& position)
 {
     for (auto* renderer = rendererFromPosition(position); renderer && renderer->node(); renderer = renderer->parent()) {

--- a/Source/WebCore/editing/RenderedPosition.h
+++ b/Source/WebCore/editing/RenderedPosition.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "BoundaryPoint.h"
 #include "CaretRectComputation.h"
 #include "InlineIteratorBox.h"
 #include "InlineIteratorLineBox.h"
@@ -72,6 +73,8 @@ public:
     Position positionAtRightBoundaryOfBiDiRun() const;
 
     IntRect absoluteRect(CaretRectMode = CaretRectMode::Normal) const;
+
+    std::optional<BoundaryPoint> boundaryPoint() const;
 
 private:
     bool operator==(const RenderedPosition&) const { return false; }


### PR DESCRIPTION
#### 965f70e7b6c9145e2f9977f3087f42f7aa09a1ae
<pre>
Ensure visually contiguous boundaries when extending selection using Shift+Arrow keys
<a href="https://bugs.webkit.org/show_bug.cgi?id=284981">https://bugs.webkit.org/show_bug.cgi?id=284981</a>
<a href="https://rdar.apple.com/141786406">rdar://141786406</a>

Reviewed by Aditya Keerthi and Ryosuke Niwa.

Add support for snapping to the nearest bidi text boundary that results in a visually contiguous
selection on iOS, in the case where `VisuallyContiguousBidiTextSelectionEnabled` is turned on. To
achieve this, we refactor the existing utilities in `Editing.cpp` that are currently used to adjust
a selection to nearest visually-contiguous bidi text boundaries, and expose a new helper function
that&apos;s used in `FrameSelection` when performing user-triggered selection extension.

See below for more details.

* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-extending-expected.txt: Added.
* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-extending.html: Added.

Add a layout test to exercise this change by extending the selection by word granularity, through
LTR and RTL paragraphs containing bidi text.

* Source/WebCore/editing/Editing.cpp:
(WebCore::findBidiBoundary):

Add a `SelectionExtentMovement` enum argument to control whether we should pick the left or right
bidi boundary when determining the adjusted boundary point that maintains visual contiguity.

(WebCore::boxWithMinimumBidiLevelBetween):

Add a helper method to find the inline box with the minimum bidi level between two
`RenderedPosition`s, and use it in a couple places below.

(WebCore::primaryDirectionForSingleLineRange):
(WebCore::makeVisuallyContiguousIfNeeded):

Pull the existing logic in `adjustToVisuallyContiguousRange` into a static helper, that returns
a visually contiguous range for the given range (or `nullopt` if there&apos;s no adjustment needed).

(WebCore::adjustToVisuallyContiguousRange):

Reimplement this in terms of `makeVisuallyContiguousIfNeeded`.

(WebCore::adjustVisibleExtentPreservingVisualContiguity):

Expose a new helper function that takes a base and (mutable) extent, and adjusts the extent in order
to produce a visually contiguous selection across bidi text.

(WebCore::visuallyClosestBidiBoundary): Deleted.
* Source/WebCore/editing/Editing.h:
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::adjustSelectionExtentIfNeeded):

In addition to adjusting the position for `user-select: all;`, we now also ensure that the new
selection extent will result in a visually contiguous selection using the above helper.

(WebCore::FrameSelection::modifyExtendingRight):
(WebCore::FrameSelection::modifyExtendingForward):
(WebCore::FrameSelection::modifyExtendingLeft):
(WebCore::FrameSelection::modifyExtendingBackward):
(WebCore::FrameSelection::modify):

Plumb the `UserTriggered` flag into `modifyExtending*`.

(WebCore::FrameSelection::updateAppearance):
(WebCore::adjustPositionForUserSelectAll): Deleted.

Rename this to `adjustSelectionExtentIfNeeded`, and make it a private method on `FrameSelection`.

* Source/WebCore/editing/FrameSelection.h:
(WebCore::RenderedPosition::boundaryPoint const):
* Source/WebCore/editing/RenderedPosition.h:

Add a helper to make a `BoundaryPoint` from the `RenderedPosition`.

Canonical link: <a href="https://commits.webkit.org/288183@main">https://commits.webkit.org/288183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b845d29591bc94e667d6974615e12b7ab2f74496

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86614 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33089 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63966 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21688 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44250 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28836 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31509 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88047 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6631 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72336 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9484 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71558 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17849 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15683 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14594 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9250 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14792 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9090 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12616 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10898 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->