### PR TITLE
Move HistoryController to FrameLoader

### DIFF
--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -899,8 +899,8 @@ void ScriptController::executeJavaScriptURL(const URL& url, const NavigationActi
 
         // If there is no current history item, create one since we're about to commit a document
         // from the JS URL.
-        if (!m_frame.history().currentItem())
-            m_frame.checkedHistory()->updateForRedirectWithLockedBackForwardList();
+        if (!m_frame.loader().history().currentItem())
+            m_frame.loader().checkedHistory()->updateForRedirectWithLockedBackForwardList();
 
         // Since we're replacing the document, this JavaScript URL load acts as a "Replace" navigation.
         // Make sure the triggering action get set on the DocumentLoader since some logic in

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -149,7 +149,7 @@ static bool canCacheFrame(LocalFrame& frame, DiagnosticLoggingClient& diagnostic
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::httpsNoStoreKey());
         isCacheable = false;
     }
-    if (frame.isMainFrame() && !frame.history().currentItem()) {
+    if (frame.isMainFrame() && !frame.loader().history().currentItem()) {
         PCLOG("   -Main frame has no current history item"_s);
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::noCurrentHistoryItemKey());
         isCacheable = false;

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -786,7 +786,7 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
 
     // FIXME: Add a load type check.
     auto& policyChecker = frameLoader()->policyChecker();
-    RELEASE_ASSERT(!isBackForwardLoadType(policyChecker.loadType()) || m_frame->history().provisionalItem());
+    RELEASE_ASSERT(!isBackForwardLoadType(policyChecker.loadType()) || m_frame->loader().history().provisionalItem());
     policyChecker.checkNavigationPolicy(WTFMove(newRequest), redirectResponse, WTFMove(navigationPolicyCompletionHandler));
 }
 

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -220,7 +220,7 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
         contentSecurityPolicy->setInsecureNavigationRequestsToUpgrade(ownerContentSecurityPolicy->takeNavigationRequestsToUpgrade());
     } else if (url.protocolIsAbout() || url.protocolIsData()) {
         // https://html.spec.whatwg.org/multipage/origin.html#determining-navigation-params-policy-container
-        RefPtr currentHistoryItem = frame->history().currentItem();
+        RefPtr currentHistoryItem = frame->loader().history().currentItem();
 
         auto isLoadingBrowserControlledHTML = [document] {
             return document->loader() && document->loader()->substituteData().isValid();

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -72,6 +72,7 @@ class FormState;
 class FormSubmission;
 class FrameLoadRequest;
 class FrameNetworkingContext;
+class HistoryController;
 class HistoryItem;
 class LocalDOMWindow;
 class LocalFrameLoaderClient;
@@ -120,6 +121,9 @@ public:
     WEBCORE_EXPORT Ref<LocalFrame> protectedFrame() const;
 
     PolicyChecker& policyChecker() const { return *m_policyChecker; }
+
+    HistoryController& history() const { return m_history; }
+    WEBCORE_EXPORT CheckedRef<HistoryController> checkedHistory() const;
 
     ResourceLoadNotifier& notifier() const { return m_notifier; }
 
@@ -464,6 +468,7 @@ private:
     UniqueRef<LocalFrameLoaderClient> m_client;
 
     const std::unique_ptr<PolicyChecker> m_policyChecker;
+    const UniqueRef<HistoryController> m_history;
     mutable ResourceLoadNotifier m_notifier;
     const std::unique_ptr<SubframeLoader> m_subframeLoader;
     mutable FrameLoaderStateMachine m_stateMachine;

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -61,7 +61,7 @@ static inline void addVisitedLink(Page& page, const URL& url)
     page.visitedLinkStore().addVisitedLink(page, computeSharedStringHash(url.string()));
 }
 
-HistoryController::HistoryController(Frame& frame)
+HistoryController::HistoryController(LocalFrame& frame)
     : m_frame(frame)
     , m_frameLoadComplete(true)
     , m_defersLoading(false)
@@ -72,14 +72,11 @@ HistoryController::~HistoryController() = default;
 
 void HistoryController::saveScrollPositionAndViewStateToItem(HistoryItem* item)
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
-    RefPtr frameView = frame->view();
+    RefPtr frameView = m_frame->view();
     if (!item || !frameView)
         return;
 
-    if (frame->document()->backForwardCacheState() != Document::NotInBackForwardCache) {
+    if (m_frame->document()->backForwardCacheState() != Document::NotInBackForwardCache) {
         item->setScrollPosition(frameView->cachedScrollPosition());
 #if PLATFORM(IOS_FAMILY)
         item->setUnobscuredContentRect(frameView->cachedUnobscuredContentRect());
@@ -102,13 +99,13 @@ void HistoryController::saveScrollPositionAndViewStateToItem(HistoryItem* item)
     }
 
     // FIXME: It would be great to work out a way to put this code in WebCore instead of calling through to the client.
-    frame->protectedLoader()->client().saveViewStateToItem(*item);
+    m_frame->loader().client().saveViewStateToItem(*item);
 
     // Notify clients that the HistoryItem has changed.
     item->notifyChanged();
 }
 
-Ref<Frame> HistoryController::protectedFrame() const
+Ref<LocalFrame> HistoryController::protectedFrame() const
 {
     return m_frame.get();
 }
@@ -126,14 +123,11 @@ Ref<Frame> HistoryController::protectedFrame() const
 */
 void HistoryController::restoreScrollPositionAndViewState()
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
     RefPtr currentItem = m_currentItem;
-    if (!currentItem || !frame->loader().stateMachine().committedFirstRealDocumentLoad())
+    if (!currentItem || !m_frame->loader().stateMachine().committedFirstRealDocumentLoad())
         return;
 
-    RefPtr view = frame->view();
+    RefPtr view = m_frame->view();
 
     // FIXME: There is some scrolling related work that needs to happen whenever a page goes into the
     // back/forward cache and similar work that needs to occur when it comes out. This is where we do the work
@@ -141,8 +135,8 @@ void HistoryController::restoreScrollPositionAndViewState()
     // Document::setIsInBackForwardCache(bool). It would be nice if there was more symmetry in these spots.
     // https://bugs.webkit.org/show_bug.cgi?id=98698
     if (view) {
-        RefPtr page = frame->page();
-        if (page && frame->isMainFrame()) {
+        RefPtr page = m_frame->page();
+        if (page && m_frame->isMainFrame()) {
             if (RefPtr scrollingCoordinator = page->scrollingCoordinator())
                 scrollingCoordinator->frameViewRootLayerDidChange(*view);
         }
@@ -150,27 +144,27 @@ void HistoryController::restoreScrollPositionAndViewState()
 
     // FIXME: It would be great to work out a way to put this code in WebCore instead of calling
     // through to the client.
-    frame->protectedLoader()->client().restoreViewState();
+    m_frame->loader().client().restoreViewState();
 
 #if !PLATFORM(IOS_FAMILY)
     // Don't restore scroll point on iOS as LocalFrameLoaderClient::restoreViewState() does that.
     if (view && !view->wasScrolledByUser()) {
         view->scrollToFocusedElementImmediatelyIfNeeded();
 
-        RefPtr page = frame->page();
+        RefPtr page = m_frame->page();
         auto desiredScrollPosition = currentItem->shouldRestoreScrollPosition() ? currentItem->scrollPosition() : view->scrollPosition();
         LOG(Scrolling, "HistoryController::restoreScrollPositionAndViewState scrolling to %d,%d", desiredScrollPosition.x(), desiredScrollPosition.y());
         // FIXME: Page scale should be set in the UI process using WebPageProxy.
-        if (page && frame->isMainFrame() && currentItem->pageScaleFactor())
+        if (page && m_frame->isMainFrame() && currentItem->pageScaleFactor())
             page->setPageScaleFactor(currentItem->pageScaleFactor() * page->viewScaleFactor(), desiredScrollPosition);
         else
             view->setScrollPosition(desiredScrollPosition);
 
         // If the scroll position doesn't have to be clamped, consider it successfully restored.
-        if (frame->isMainFrame()) {
+        if (m_frame->isMainFrame()) {
             auto adjustedDesiredScrollPosition = view->adjustScrollPositionWithinRange(desiredScrollPosition);
             if (desiredScrollPosition == adjustedDesiredScrollPosition)
-                frame->protectedLoader()->client().didRestoreScrollPosition();
+                m_frame->loader().client().didRestoreScrollPosition();
         }
 
     }
@@ -184,12 +178,9 @@ void HistoryController::updateBackForwardListForFragmentScroll()
 
 void HistoryController::saveDocumentState()
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
     // FIXME: Reading this bit of FrameLoader state here is unfortunate.  I need to study
     // this more to see if we can remove this dependency.
-    if (frame->protectedLoader()->stateMachine().creatingInitialEmptyDocument())
+    if (m_frame->loader().stateMachine().creatingInitialEmptyDocument())
         return;
 
     // For a standard page load, we will have a previous item set, which will be used to
@@ -207,13 +198,13 @@ void HistoryController::saveDocumentState()
     if (!item)
         return;
 
-    ASSERT(frame->document());
-    Ref document = *frame->document();
+    ASSERT(m_frame->document());
+    Ref document = *m_frame->document();
     if (item->isCurrentDocument(document) && document->hasLivingRenderTree()) {
         if (RefPtr documentLoader = document->loader())
             item->setShouldOpenExternalURLsPolicy(documentLoader->shouldOpenExternalURLsPolicyToPropagate());
 
-        LOG(Loading, "WebCoreLoading frame %" PRIu64 ": saving form state to %p", frame->frameID().object().toUInt64(), item.get());
+        LOG(Loading, "WebCoreLoading frame %" PRIu64 ": saving form state to %p", m_frame->frameID().object().toUInt64(), item.get());
         item->setDocumentState(document->formElementsState());
     }
 }
@@ -226,7 +217,7 @@ void HistoryController::saveDocumentAndScrollState()
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
-        CheckedRef history = localFrame->history();
+        CheckedRef history = localFrame->loader().history();
         history->saveDocumentState();
         history->saveScrollPositionAndViewStateToItem(history->protectedCurrentItem().get());
     }
@@ -234,10 +225,7 @@ void HistoryController::saveDocumentAndScrollState()
 
 void HistoryController::restoreDocumentState()
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
-    switch (frame->loader().loadType()) {
+    switch (m_frame->loader().loadType()) {
     case FrameLoadType::Reload:
     case FrameLoadType::ReloadFromOrigin:
     case FrameLoadType::ReloadExpiredOnly:
@@ -256,16 +244,16 @@ void HistoryController::restoreDocumentState()
     RefPtr currentItem = m_currentItem;
     if (!currentItem)
         return;
-    if (!frame->loader().requestedHistoryItem() || (frame->loader().requestedHistoryItem()->identifier() != currentItem->identifier()))
+    if (!m_frame->loader().requestedHistoryItem() || (m_frame->loader().requestedHistoryItem()->identifier() != currentItem->identifier()))
         return;
-    RefPtr documentLoader = frame->loader().documentLoader();
+    RefPtr documentLoader = m_frame->loader().documentLoader();
     if (documentLoader->isClientRedirect())
         return;
 
     documentLoader->setShouldOpenExternalURLsPolicy(currentItem->shouldOpenExternalURLsPolicy());
 
-    LOG(Loading, "WebCoreLoading frame %" PRIu64 ": restoring form state from %p", frame->frameID().object().toUInt64(), currentItem.get());
-    frame->protectedDocument()->setStateForNewFormElements(currentItem->documentState());
+    LOG(Loading, "WebCoreLoading frame %" PRIu64 ": restoring form state from %p", m_frame->frameID().object().toUInt64(), currentItem.get());
+    m_frame->protectedDocument()->setStateForNewFormElements(currentItem->documentState());
 }
 
 void HistoryController::invalidateCurrentItemCachedPage()
@@ -283,13 +271,9 @@ void HistoryController::invalidateCurrentItemCachedPage()
     // Somehow the PageState object is not properly updated, and is holding onto a stale document.
     // Both Xcode and FileMaker see this crash, Safari does not.
 
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
-
     RefPtr cachedPageDocument = cachedPage->document();
-    ASSERT(cachedPageDocument == frame->document());
-    if (cachedPageDocument == frame->document()) {
+    ASSERT(cachedPageDocument == m_frame->document());
+    if (cachedPageDocument == m_frame->document()) {
         cachedPageDocument->setBackForwardCacheState(Document::NotInBackForwardCache);
         cachedPage->clear();
     }
@@ -323,10 +307,8 @@ void HistoryController::goToItem(HistoryItem& targetItem, FrameLoadType type, Sh
     RefPtr page = m_frame->page();
     if (!page)
         return;
-    if (RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr())) {
-        if (!frame->protectedLoader()->client().shouldGoToHistoryItem(targetItem))
-            return;
-    }
+    if (!m_frame->loader().client().shouldGoToHistoryItem(targetItem))
+        return;
     if (m_defersLoading) {
         m_deferredItem = &targetItem;
         m_deferredFrameLoadType = type;
@@ -361,7 +343,6 @@ void HistoryController::goToItemForNavigationAPI(HistoryItem& targetItem, FrameL
     LOG(History, "HistoryController %p goToItemForNavigationAPI %p type=%d", this, &targetItem, static_cast<int>(type));
 
     ASSERT(m_frame->isRootFrame());
-    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_frame.get());
 
     // shouldGoToHistoryItem is a private delegate method. This is needed to fix:
     // <rdar://problem/3951283> can view pages from the back/forward cache that should be disallowed by Parental Controls
@@ -370,7 +351,7 @@ void HistoryController::goToItemForNavigationAPI(HistoryItem& targetItem, FrameL
     RefPtr page = m_frame->page();
     if (!page)
         return;
-    if (localFrame && !localFrame->protectedLoader()->client().shouldGoToHistoryItem(targetItem))
+    if (!m_frame->protectedLoader()->client().shouldGoToHistoryItem(targetItem))
         return;
 
     Vector<FrameToNavigate> framesToNavigate;
@@ -392,7 +373,7 @@ void HistoryController::goToItemForNavigationAPI(HistoryItem& targetItem, FrameL
     // all frames have provisional items set before the commit.
     recursiveSetProvisionalItem(targetItem, currentItem.get(), ForNavigationAPI::Yes);
 
-    RefPtr upcomingTraverseMethodTracker = localFrame ? localFrame->window()->navigation().upcomingTraverseMethodTracker(targetNavigationEntryKey) : nullptr;
+    RefPtr upcomingTraverseMethodTracker = m_frame->window()->navigation().upcomingTraverseMethodTracker(targetNavigationEntryKey);
     for (auto& frameToNavigate : framesToNavigate) {
         frameToNavigate.frame->protectedLoader()->loadItem(frameToNavigate.toItem, frameToNavigate.fromItem.get(), type, ShouldTreatAsContinuingLoad::No);
         // If the navigation was aborted (by the JS called preventDefault() on the navigate event), then
@@ -444,10 +425,7 @@ void HistoryController::setDefersLoading(bool defer)
 
 void HistoryController::updateForBackForwardNavigation()
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
-    LOG(History, "HistoryController %p updateForBackForwardNavigation: Updating History for back/forward navigation in frame %p (main frame %d) %s", this, frame.get(), frame->isMainFrame(), frame->loader().documentLoader() ? frame->loader().documentLoader()->url().string().utf8().data() : "");
+    LOG(History, "HistoryController %p updateForBackForwardNavigation: Updating History for back/forward navigation in frame %p (main frame %d) %s", this, m_frame.ptr(), m_frame->isMainFrame(), m_frame->loader().documentLoader() ? m_frame->loader().documentLoader()->url().string().utf8().data() : "");
 
     // Must grab the current scroll position before disturbing it
     if (!m_frameLoadComplete)
@@ -460,15 +438,12 @@ void HistoryController::updateForBackForwardNavigation()
 
 void HistoryController::updateForReload()
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
-    LOG(History, "HistoryController %p updateForReload: Updating History for reload in frame %p (main frame %d) %s", this, frame.get(), frame->isMainFrame(), frame->loader().documentLoader() ? frame->loader().documentLoader()->url().string().utf8().data() : "");
+    LOG(History, "HistoryController %p updateForReload: Updating History for reload in frame %p (main frame %d) %s", this, m_frame.ptr(), m_frame->isMainFrame(), m_frame->loader().documentLoader() ? m_frame->loader().documentLoader()->url().string().utf8().data() : "");
 
     if (RefPtr currentItem = m_currentItem) {
         BackForwardCache::singleton().remove(*currentItem);
 
-        if (frame->loader().loadType() == FrameLoadType::Reload || frame->loader().loadType() == FrameLoadType::ReloadFromOrigin)
+        if (m_frame->loader().loadType() == FrameLoadType::Reload || m_frame->loader().loadType() == FrameLoadType::ReloadFromOrigin)
             saveScrollPositionAndViewStateToItem(currentItem.get());
 
         // Rebuild the history item tree when reloading as trying to re-associate everything is too error-prone.
@@ -488,12 +463,9 @@ void HistoryController::updateForReload()
 
 void HistoryController::updateForStandardLoad(HistoryUpdateType updateType)
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
-    LOG(History, "HistoryController %p updateForStandardLoad: Updating History for standard load in frame %p (main frame %d) %s", this, frame.get(), frame->isMainFrame(), frame->loader().documentLoader()->url().string().ascii().data());
+    LOG(History, "HistoryController %p updateForStandardLoad: Updating History for standard load in frame %p (main frame %d) %s", this, m_frame.ptr(), m_frame->isMainFrame(), m_frame->loader().documentLoader()->url().string().ascii().data());
 
-    Ref frameLoader = frame->loader();
+    Ref frameLoader = m_frame->loader();
 
     bool usesEphemeralSession = m_frame->page() ? m_frame->page()->usesEphemeralSession() : true;
     const URL& historyURL = frameLoader->protectedDocumentLoader()->urlForHistory();
@@ -519,28 +491,25 @@ void HistoryController::updateForStandardLoad(HistoryUpdateType updateType)
         if (RefPtr page = m_frame->page())
             addVisitedLink(*page, historyURL);
 
-        if (!documentLoader->didCreateGlobalHistoryEntry() && documentLoader->unreachableURL().isEmpty() && !frame->document()->url().isEmpty())
+        if (!documentLoader->didCreateGlobalHistoryEntry() && documentLoader->unreachableURL().isEmpty() && !m_frame->document()->url().isEmpty())
             frameLoader->client().updateGlobalHistoryRedirectLinks();
     }
 }
 
 void HistoryController::updateForRedirectWithLockedBackForwardList()
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
-    LOG(History, "HistoryController %p updateForRedirectWithLockedBackForwardList: Updating History for redirect load in frame %p (main frame %d) %s", this, frame.get(), frame->isMainFrame(), frame->loader().documentLoader() ? frame->loader().documentLoader()->url().string().utf8().data() : "");
+    LOG(History, "HistoryController %p updateForRedirectWithLockedBackForwardList: Updating History for redirect load in frame %p (main frame %d) %s", this, m_frame.ptr(), m_frame->isMainFrame(), m_frame->loader().documentLoader() ? m_frame->loader().documentLoader()->url().string().utf8().data() : "");
 
-    RefPtr documentLoader = frame->loader().documentLoader();
-    bool usesEphemeralSession = frame->page() ? frame->page()->usesEphemeralSession() : true;
+    RefPtr documentLoader = m_frame->loader().documentLoader();
+    bool usesEphemeralSession = m_frame->page() ? m_frame->page()->usesEphemeralSession() : true;
     auto historyURL = documentLoader ? documentLoader->urlForHistory() : URL { };
 
     if (documentLoader && documentLoader->isClientRedirect()) {
-        if (!m_currentItem && !frame->tree().parent()) {
+        if (!m_currentItem && !m_frame->tree().parent()) {
             if (!historyURL.isEmpty()) {
                 updateBackForwardListClippedAtTarget(true);
                 if (!usesEphemeralSession) {
-                    Ref frameLoader = frame->loader();
+                    Ref frameLoader = m_frame->loader();
                     frameLoader->client().updateGlobalHistory();
                     documentLoader->setDidCreateGlobalHistoryEntry(true);
                     if (documentLoader->unreachableURL().isEmpty())
@@ -554,7 +523,7 @@ void HistoryController::updateForRedirectWithLockedBackForwardList()
         RefPtr page = m_frame->page();
         RefPtr parentFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent());
         if (page && parentFrame) {
-            if (RefPtr parentCurrentItem = parentFrame->history().currentItem()) {
+            if (RefPtr parentCurrentItem = parentFrame->loader().history().currentItem()) {
                 Ref item = createItem(page->historyItemClient());
                 parentCurrentItem->setChildItem(item.copyRef());
                 page->checkedBackForward()->setChildItem(parentCurrentItem->identifier(), WTFMove(item));
@@ -567,16 +536,13 @@ void HistoryController::updateForRedirectWithLockedBackForwardList()
             addVisitedLink(*page, historyURL);
 
         if (!documentLoader->didCreateGlobalHistoryEntry() && documentLoader->unreachableURL().isEmpty())
-            frame->protectedLoader()->client().updateGlobalHistoryRedirectLinks();
+            m_frame->loader().client().updateGlobalHistoryRedirectLinks();
     }
 }
 
 void HistoryController::updateForClientRedirect()
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
-    LOG(History, "HistoryController %p updateForClientRedirect: Updating History for client redirect in frame %p (main frame %d) %s", this, frame.get(), frame->isMainFrame(), frame->loader().documentLoader() ? frame->loader().documentLoader()->url().string().utf8().data() : "");
+    LOG(History, "HistoryController %p updateForClientRedirect: Updating History for client redirect in frame %p (main frame %d) %s", this, m_frame.ptr(), m_frame->isMainFrame(), m_frame->loader().documentLoader() ? m_frame->loader().documentLoader()->url().string().utf8().data() : "");
 
     // Clear out form data so we don't try to restore it into the incoming page.  Must happen after
     // webcore has closed the URL and saved away the form state.
@@ -585,22 +551,19 @@ void HistoryController::updateForClientRedirect()
         currentItem->clearScrollPosition();
     }
 
-    bool usesEphemeralSession = frame->page() ? frame->page()->usesEphemeralSession() : true;
-    const URL& historyURL = frame->loader().protectedDocumentLoader()->urlForHistory();
+    bool usesEphemeralSession = m_frame->page() ? m_frame->page()->usesEphemeralSession() : true;
+    const URL& historyURL = m_frame->loader().protectedDocumentLoader()->urlForHistory();
 
     if (!historyURL.isEmpty() && !usesEphemeralSession) {
-        if (RefPtr page = frame->page())
+        if (RefPtr page = m_frame->page())
             addVisitedLink(*page, historyURL);
     }
 }
 
 void HistoryController::updateForCommit()
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
-    Ref frameLoader = frame->loader();
-    LOG(History, "HistoryController %p updateForCommit: Updating History for commit in frame %p (main frame %d) %s", this, frame.get(), frame->isMainFrame(), frame->loader().documentLoader() ? frame->loader().documentLoader()->url().string().utf8().data() : "");
+    Ref frameLoader = m_frame->loader();
+    LOG(History, "HistoryController %p updateForCommit: Updating History for commit in frame %p (main frame %d) %s", this, m_frame.ptr(), m_frame->isMainFrame(), m_frame->loader().documentLoader() ? m_frame->loader().documentLoader()->url().string().utf8().data() : "");
 
     FrameLoadType type = frameLoader->loadType();
     if (isBackForwardLoadType(type)
@@ -624,9 +587,9 @@ void HistoryController::updateForCommit()
         // Tell all other frames in the tree to commit their provisional items and
         // restore their scroll position.  We'll avoid this frame (which has already
         // committed) and its children (which will be replaced).
-        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame())) {
-            if (localFrame->checkedHistory()->isFrameLoadComplete())
-                localFrame->checkedHistory()->recursiveUpdateForCommit();
+        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(m_frame->mainFrame())) {
+            if (localFrame->loader().checkedHistory()->isFrameLoadComplete())
+                localFrame->loader().checkedHistory()->recursiveUpdateForCommit();
         }
     }
 }
@@ -658,7 +621,7 @@ void HistoryController::recursiveUpdateForCommit()
         saveDocumentState();
         saveScrollPositionAndViewStateToItem(protectedCurrentItem().get());
 
-        if (RefPtr view = dynamicDowncast<LocalFrameView>(m_frame->virtualView()))
+        if (RefPtr view = m_frame->view())
             view->setWasScrolledByUser(false);
 
         // Now commit the provisional item
@@ -677,33 +640,30 @@ void HistoryController::recursiveUpdateForCommit()
     // Iterate over the rest of the tree
     for (RefPtr child = m_frame->tree().firstChild(); child; child = child->tree().nextSibling()) {
         if (auto* localChild = dynamicDowncast<LocalFrame>(child.get()))
-            localChild->checkedHistory()->recursiveUpdateForCommit();
+            localChild->loader().checkedHistory()->recursiveUpdateForCommit();
     }
 }
 
 void HistoryController::updateForSameDocumentNavigation()
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
-    if (frame->document()->url().isEmpty())
+    if (m_frame->document()->url().isEmpty())
         return;
 
-    RefPtr page = frame->page();
+    RefPtr page = m_frame->page();
     if (!page)
         return;
 
     bool usesEphemeralSession = page->usesEphemeralSession();
     if (!usesEphemeralSession)
-        addVisitedLink(*page, frame->document()->url());
+        addVisitedLink(*page, m_frame->document()->url());
 
-    if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame()))
-        localFrame->checkedHistory()->recursiveUpdateForSameDocumentNavigation();
+    if (RefPtr localFrame = dynamicDowncast<LocalFrame>(m_frame->mainFrame()))
+        localFrame->loader().checkedHistory()->recursiveUpdateForSameDocumentNavigation();
 
     if (RefPtr currentItem = m_currentItem) {
-        currentItem->setURL(frame->document()->url());
+        currentItem->setURL(m_frame->document()->url());
         if (!usesEphemeralSession)
-            frame->protectedLoader()->client().updateGlobalHistory();
+            m_frame->loader().client().updateGlobalHistory();
     }
 }
 
@@ -728,7 +688,7 @@ void HistoryController::recursiveUpdateForSameDocumentNavigation()
     // Iterate over the rest of the tree.
     for (RefPtr child = m_frame->tree().firstChild(); child; child = child->tree().nextSibling()) {
         if (auto* localChild = dynamicDowncast<LocalFrame>(child.get()))
-            localChild->checkedHistory()->recursiveUpdateForSameDocumentNavigation();
+            localChild->loader().checkedHistory()->recursiveUpdateForSameDocumentNavigation();
     }
 }
 
@@ -767,7 +727,7 @@ void HistoryController::clearPreviousItem()
     m_previousItem = nullptr;
     for (RefPtr child = m_frame->tree().firstChild(); child; child = child->tree().nextSibling()) {
         if (auto* localChild = dynamicDowncast<LocalFrame>(child.get()))
-            localChild->checkedHistory()->clearPreviousItem();
+            localChild->loader().checkedHistory()->clearPreviousItem();
     }
 }
 
@@ -778,9 +738,6 @@ void HistoryController::setProvisionalItem(RefPtr<HistoryItem>&& item)
 
 void HistoryController::initializeItem(HistoryItem& item, RefPtr<DocumentLoader> documentLoader)
 {
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
     ASSERT(documentLoader);
 
     URL unreachableURL = documentLoader->unreachableURL();
@@ -809,8 +766,8 @@ void HistoryController::initializeItem(HistoryItem& item, RefPtr<DocumentLoader>
     StringWithDirection title = documentLoader->title();
 
     item.setURL(url);
-    item.setTarget(frame->tree().uniqueName());
-    item.setFrameID(frame->frameID());
+    item.setTarget(m_frame->tree().uniqueName());
+    item.setFrameID(m_frame->frameID());
     // FIXME: Should store the title direction as well.
     item.setTitle(title.string);
     item.setOriginalURLString(originalURL.string());
@@ -827,11 +784,7 @@ void HistoryController::initializeItem(HistoryItem& item, RefPtr<DocumentLoader>
 Ref<HistoryItem> HistoryController::createItem(HistoryItemClient& client)
 {
     Ref item = HistoryItem::create(client);
-
-    if (RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr())) {
-        RefPtr documentLoader = frame->loader().documentLoader();
-        initializeItem(item, documentLoader);
-    }
+    initializeItem(item, m_frame->loader().protectedDocumentLoader());
 
     // Set the item for which we will save document state
     setCurrentItem(item.copyRef());
@@ -868,7 +821,7 @@ Ref<HistoryItem> HistoryController::createItemTree(HistoryItemClient& client, Lo
         }
 
         for (RefPtr child = m_frame->tree().firstLocalDescendant(); child; child = child->tree().nextLocalSibling())
-            item->addChildItem(child->checkedHistory()->createItemTree(client, targetFrame, clipAtTarget));
+            item->addChildItem(child->loader().checkedHistory()->createItemTree(client, targetFrame, clipAtTarget));
     }
     return item;
 }
@@ -896,8 +849,8 @@ void HistoryController::recursiveSetProvisionalItem(HistoryItem& item, HistoryIt
         if (!fromChildItem)
             continue;
 
-        if (RefPtr childFrame = m_frame->tree().descendantByFrameID(*frameID))
-            childFrame->checkedHistory()->recursiveSetProvisionalItem(childItem, fromChildItem.get());
+        if (RefPtr childFrame = dynamicDowncast<LocalFrame>(m_frame->tree().descendantByFrameID(*frameID)))
+            childFrame->loader().checkedHistory()->recursiveSetProvisionalItem(childItem, fromChildItem.get());
     }
 }
 
@@ -905,11 +858,8 @@ void HistoryController::recursiveSetProvisionalItem(HistoryItem& item, HistoryIt
 // do have the content the item requests.
 void HistoryController::recursiveGoToItem(HistoryItem& item, HistoryItem* fromItem, FrameLoadType type, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad)
 {
-    if (!itemsAreClones(item, fromItem)) {
-        if (RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr()))
-            frame->protectedLoader()->loadItem(item, fromItem, type, shouldTreatAsContinuingLoad);
-        return;
-    }
+    if (!itemsAreClones(item, fromItem))
+        return m_frame->loader().loadItem(item, fromItem, type, shouldTreatAsContinuingLoad);
 
     // Just iterate over the rest, looking for frames to navigate.
     for (Ref childItem : item.children()) {
@@ -921,8 +871,8 @@ void HistoryController::recursiveGoToItem(HistoryItem& item, HistoryItem* fromIt
         if (!fromChildItem)
             continue;
 
-        if (RefPtr childFrame = m_frame->tree().descendantByFrameID(*frameID))
-            childFrame->checkedHistory()->recursiveGoToItem(childItem, fromChildItem.get(), type, shouldTreatAsContinuingLoad);
+        if (RefPtr childFrame = dynamicDowncast<LocalFrame>(m_frame->tree().descendantByFrameID(*frameID)))
+            childFrame->loader().checkedHistory()->recursiveGoToItem(childItem, fromChildItem.get(), type, shouldTreatAsContinuingLoad);
     }
 }
 
@@ -947,23 +897,18 @@ void HistoryController::updateBackForwardListClippedAtTarget(bool doClip)
     // The item that was the target of the user's navigation is designated as the "targetItem".  
     // When this function is called with doClip=true we're able to create the whole tree except for the target's children, 
     // which will be loaded in the future. That part of the tree will be filled out as the child loads are committed.
-
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
-
-    RefPtr page = frame->page();
+    RefPtr page = m_frame->page();
     if (!page)
         return;
 
-    if (frame->loader().protectedDocumentLoader()->urlForHistory().isEmpty())
+    if (m_frame->loader().protectedDocumentLoader()->urlForHistory().isEmpty())
         return;
 
-    Ref rootFrame = frame->rootFrame();
-    Ref topItem = rootFrame->checkedHistory()->createItemTree(page->historyItemClient(), *frame, doClip);
-    LOG(History, "HistoryController %p updateBackForwardListClippedAtTarget: Adding backforward item %p in frame %p (main frame %d) %s", this, topItem.ptr(), frame.get(), frame->isMainFrame(), frame->loader().documentLoader()->url().string().utf8().data());
+    Ref rootFrame = m_frame->rootFrame();
+    Ref topItem = rootFrame->loader().checkedHistory()->createItemTree(page->historyItemClient(), m_frame, doClip);
+    LOG(History, "HistoryController %p updateBackForwardListClippedAtTarget: Adding backforward item %p in frame %p (main frame %d) %s", this, topItem.ptr(), m_frame.ptr(), m_frame->isMainFrame(), m_frame->loader().documentLoader()->url().string().utf8().data());
 
-    page->checkedBackForward()->addItem(frame->frameID(), WTFMove(topItem));
+    page->checkedBackForward()->addItem(m_frame->frameID(), WTFMove(topItem));
 }
 
 void HistoryController::updateCurrentItem()
@@ -972,10 +917,7 @@ void HistoryController::updateCurrentItem()
     if (!currentItem)
         return;
 
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
-    RefPtr documentLoader = frame->loader().documentLoader();
+    RefPtr documentLoader = m_frame->loader().documentLoader();
     if (!documentLoader || !documentLoader->unreachableURL().isEmpty())
         return;
 
@@ -997,10 +939,7 @@ void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, c
     if (!m_currentItem)
         return;
 
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
-    RefPtr page = frame->page();
+    RefPtr page = m_frame->page();
     if (!page) {
         ASSERT_NOT_REACHED();
         return;
@@ -1009,10 +948,9 @@ void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, c
     bool shouldRestoreScrollPosition = m_currentItem->shouldRestoreScrollPosition();
 
     // Get a HistoryItem tree for the current frame tree.
-    Ref mainFrame = frame->mainFrame();
-    Ref topItem = mainFrame->checkedHistory()->createItemTree(page->historyItemClient(), *frame, false);
+    Ref topItem = m_frame->rootFrame().loader().checkedHistory()->createItemTree(page->historyItemClient(), m_frame, false);
 
-    RefPtr document = frame->document();
+    RefPtr document = m_frame->document();
     if (document && !document->hasRecentUserInteractionForNavigationFromJS())
         topItem->setWasCreatedByJSWithoutUserInteraction(true);
 
@@ -1025,13 +963,13 @@ void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, c
 
     LOG(History, "HistoryController %p pushState: Adding top item %p, setting url of current item %p to %s, scrollRestoration is %s", this, topItem.ptr(), m_currentItem.get(), urlString.ascii().data(), topItem->shouldRestoreScrollPosition() ? "auto" : "manual");
 
-    page->checkedBackForward()->addItem(frame->frameID(), WTFMove(topItem));
+    page->checkedBackForward()->addItem(m_frame->frameID(), WTFMove(topItem));
 
     if (page->usesEphemeralSession())
         return;
 
     addVisitedLink(*page, URL({ }, urlString));
-    frame->protectedLoader()->client().updateGlobalHistory();
+    m_frame->loader().client().updateGlobalHistory();
 
     if (document && document->settings().navigationAPIEnabled())
         document->protectedWindow()->protectedNavigation()->updateForNavigation(*currentItem, NavigationNavigationType::Push);
@@ -1052,19 +990,15 @@ void HistoryController::replaceState(RefPtr<SerializedScriptValue>&& stateObject
     currentItem->setFormContentType(String());
     currentItem->notifyChanged();
 
-    RefPtr frame = dynamicDowncast<LocalFrame>(m_frame.ptr());
-    if (!frame)
-        return;
-
-    RefPtr page = frame->page();
+    RefPtr page = m_frame->page();
     ASSERT(page);
     if (page->usesEphemeralSession())
         return;
 
     addVisitedLink(*page, URL({ }, urlString));
-    frame->protectedLoader()->client().updateGlobalHistory();
+    m_frame->loader().client().updateGlobalHistory();
 
-    if (RefPtr document = frame->document(); document && document->settings().navigationAPIEnabled()) {
+    if (RefPtr document = m_frame->document(); document && document->settings().navigationAPIEnabled()) {
         currentItem->setNavigationAPIStateObject(nullptr);
         document->protectedWindow()->protectedNavigation()->updateForNavigation(*currentItem, NavigationNavigationType::Replace);
     }

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -34,7 +34,6 @@
 
 namespace WebCore {
 
-class Frame;
 class HistoryItem;
 class HistoryItemClient;
 class LocalFrame;
@@ -51,7 +50,7 @@ class HistoryController final : public CanMakeCheckedPtr<HistoryController> {
 public:
     enum HistoryUpdateType { UpdateAll, UpdateAllExceptBackForwardList };
 
-    explicit HistoryController(Frame&);
+    explicit HistoryController(LocalFrame&);
     ~HistoryController();
 
     WEBCORE_EXPORT void saveScrollPositionAndViewStateToItem(HistoryItem*);
@@ -120,10 +119,9 @@ private:
 
     struct FrameToNavigate;
     static void recursiveGatherFramesToNavigate(LocalFrame&, Vector<FrameToNavigate>&, HistoryItem& targetItem, HistoryItem* fromItem);
+    Ref<LocalFrame> protectedFrame() const;
 
-    Ref<Frame> protectedFrame() const;
-
-    WeakRef<Frame> m_frame;
+    const WeakRef<LocalFrame> m_frame;
 
     RefPtr<HistoryItem> m_currentItem;
     RefPtr<HistoryItem> m_previousItem;

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -29,7 +29,6 @@
 #include "FrameLoaderClient.h"
 #include "HTMLFrameOwnerElement.h"
 #include "HTMLIFrameElement.h"
-#include "HistoryController.h"
 #include "LocalDOMWindow.h"
 #include "NavigationScheduler.h"
 #include "Page.h"
@@ -114,7 +113,6 @@ Frame::Frame(Page& page, FrameIdentifier frameID, FrameType frameType, HTMLFrame
     , m_frameType(frameType)
     , m_navigationScheduler(makeUniqueRefWithoutRefCountedCheck<NavigationScheduler>(*this))
     , m_opener(opener)
-    , m_history(makeUniqueRef<HistoryController>(*this))
 {
     if (parent)
         parent->tree().appendChild(*this);
@@ -266,11 +264,6 @@ void Frame::detachFromAllOpenedFrames()
 bool Frame::hasOpenedFrames() const
 {
     return !m_openedFrames.isEmptyIgnoringNullReferences();
-}
-
-CheckedRef<HistoryController> Frame::checkedHistory() const
-{
-    return m_history.get();
 }
 
 void Frame::setOwnerElement(HTMLFrameOwnerElement* element)

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -43,7 +43,6 @@ class FrameView;
 class FrameLoaderClient;
 class FrameLoadRequest;
 class HTMLFrameOwnerElement;
-class HistoryController;
 class NavigationScheduler;
 class Page;
 class RenderWidget;
@@ -101,9 +100,6 @@ public:
     Ref<NavigationScheduler> protectedNavigationScheduler() const;
     WEBCORE_EXPORT void takeWindowProxyAndOpenerFrom(Frame&);
 
-    HistoryController& history() const { return m_history.get(); }
-    WEBCORE_EXPORT CheckedRef<HistoryController> checkedHistory() const;
-
     virtual void frameDetached() = 0;
     virtual bool preventsParentFromBeingComplete() const = 0;
     virtual void changeLocation(FrameLoadRequest&&) = 0;
@@ -150,7 +146,6 @@ private:
     mutable UniqueRef<NavigationScheduler> m_navigationScheduler;
     WeakPtr<Frame> m_opener;
     WeakHashSet<Frame> m_openedFrames;
-    mutable UniqueRef<HistoryController> m_history;
     std::optional<OwnerPermissionsPolicyData> m_ownerPermisssionsPolicyOverride;
 };
 

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -88,7 +88,7 @@ ExceptionOr<History::ScrollRestoration> History::scrollRestoration() const
     if (!isDocumentFullyActive(frame.get()))
         return documentNotFullyActive();
 
-    auto* historyItem = frame->history().currentItem();
+    auto* historyItem = frame->loader().history().currentItem();
     if (!historyItem)
         return ScrollRestoration::Auto;
     
@@ -101,7 +101,7 @@ ExceptionOr<void> History::setScrollRestoration(ScrollRestoration scrollRestorat
     if (!isDocumentFullyActive(frame.get()))
         return documentNotFullyActive();
 
-    if (RefPtr historyItem = frame->history().currentItem())
+    if (RefPtr historyItem = frame->loader().history().currentItem())
         historyItem->setShouldRestoreScrollPosition(scrollRestoration == ScrollRestoration::Auto);
 
     return { };
@@ -121,7 +121,7 @@ SerializedScriptValue* History::stateInternal() const
     auto* frame = this->frame();
     if (!frame)
         return nullptr;
-    auto* historyItem = frame->history().currentItem();
+    auto* historyItem = frame->loader().history().currentItem();
     if (!historyItem)
         return nullptr;
     return historyItem->stateObject();

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -364,7 +364,7 @@ private:
 
     Vector<std::pair<Ref<DOMWrapperWorld>, UniqueRef<UserScript>>> m_userScriptsAwaitingNotification;
 
-    UniqueRef<FrameLoader> m_loader;
+    const UniqueRef<FrameLoader> m_loader;
 
     RefPtr<LocalFrameView> m_view;
     RefPtr<Document> m_doc;

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -123,7 +123,7 @@ void NavigateEvent::processScrollBehavior(Document& document)
     m_interceptionState = InterceptionState::Scrolled;
 
     if (m_navigationType == NavigationNavigationType::Traverse || m_navigationType == NavigationNavigationType::Reload)
-        document.frame()->checkedHistory()->restoreScrollPositionAndViewState();
+        document.frame()->loader().checkedHistory()->restoreScrollPositionAndViewState();
     else if (!document.frame()->view()->scrollToFragment(document.url())) {
         if (!document.url().hasFragmentIdentifier())
             document.frame()->view()->scrollTo({ 0, 0 });

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -117,7 +117,7 @@ void Navigation::initializeForNewWindow(std::optional<NavigationNavigationType> 
     if (!page)
         return;
 
-    RefPtr currentItem = frame()->history().currentItem();
+    RefPtr currentItem = frame()->loader().history().currentItem();
     if (!currentItem)
         return;
     // For main frames we can still rely on the page b/f list. However for subframes we need below logic to not lose the bookkeeping done in the previous window.
@@ -139,7 +139,7 @@ void Navigation::initializeForNewWindow(std::optional<NavigationNavigationType> 
             if (navigationType == NavigationNavigationType::Traverse) {
                 m_currentEntryIndex = getEntryIndexOfHistoryItem(m_entries, *currentItem);
                 if (m_currentEntryIndex) {
-                    updateForActivation(frame()->history().previousItem(), navigationType);
+                    updateForActivation(frame()->loader().history().previousItem(), navigationType);
                     return;
                 }
                 // We are doing a cross document subframe traversal, we can't rely on previous window, so clear
@@ -195,7 +195,7 @@ void Navigation::initializeForNewWindow(std::optional<NavigationNavigationType> 
         m_entries.append(NavigationHistoryEntry::create(*this, WTFMove(item)));
 
     m_currentEntryIndex = getEntryIndexOfHistoryItem(m_entries, *currentItem, start);
-    updateForActivation(frame()->history().previousItem(), navigationType);
+    updateForActivation(frame()->loader().history().previousItem(), navigationType);
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-activation
@@ -242,7 +242,7 @@ RefPtr<NavigationActivation> Navigation::createForPageswapEvent(HistoryItem* new
     RefPtr<NavigationHistoryEntry> oldEntry;
     if (frame()->document() && frame()->document()->settings().navigationAPIEnabled())
         oldEntry = currentEntry();
-    else if (RefPtr currentItem = frame()->checkedHistory()->currentItem())
+    else if (RefPtr currentItem = frame()->loader().checkedHistory()->currentItem())
         oldEntry = NavigationHistoryEntry::create(*this, *currentItem);
 
     RefPtr<NavigationHistoryEntry> newEntry;
@@ -1030,7 +1030,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-traverse-navigate-event
 Navigation::DispatchResult Navigation::dispatchTraversalNavigateEvent(HistoryItem& historyItem)
 {
-    auto* currentItem = frame() ? frame()->history().currentItem() : nullptr;
+    auto* currentItem = frame() ? frame()->loader().history().currentItem() : nullptr;
     bool isSameDocument = currentItem && currentItem->documentSequenceNumber() == historyItem.documentSequenceNumber();
 
     RefPtr<NavigationHistoryEntry> destinationEntry;

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -129,7 +129,7 @@ bool NavigationHistoryEntry::sameDocument() const
     RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     if (!document || !document->isFullyActive())
         return false;
-    RefPtr currentItem = document->frame()->checkedHistory()->currentItem();
+    RefPtr currentItem = document->frame() ? document->frame()->loader().history().currentItem() : nullptr;
     if (!currentItem)
         return false;
     return currentItem->documentSequenceNumber() == m_associatedHistoryItem->documentSequenceNumber();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -558,7 +558,7 @@ void Page::clearPreviousItemFromAllPages(BackForwardItemIdentifier itemID)
         if (!localMainFrame)
             return;
 
-        CheckedRef controller = localMainFrame->history();
+        CheckedRef controller = localMainFrame->loader().history();
         if (controller->previousItem() && controller->previousItem()->identifier() == itemID) {
             controller->clearPreviousItem();
             return;
@@ -939,17 +939,17 @@ void Page::goToItem(LocalFrame& frame, HistoryItem& item, FrameLoadType type, Sh
     Ref protectedItem { item };
 
     ASSERT(frame.isRootFrame());
-    if (frame.checkedHistory()->shouldStopLoadingForHistoryItem(item))
+    if (frame.loader().checkedHistory()->shouldStopLoadingForHistoryItem(item))
         frame.protectedLoader()->stopAllLoadersAndCheckCompleteness();
-    frame.checkedHistory()->goToItem(item, type, shouldTreatAsContinuingLoad);
+    frame.loader().checkedHistory()->goToItem(item, type, shouldTreatAsContinuingLoad);
 }
 
 void Page::goToItemForNavigationAPI(LocalFrame& frame, HistoryItem& item, FrameLoadType type, const String& targetNavigationEntryKey)
 {
     ASSERT(frame.isRootFrame());
-    if (frame.checkedHistory()->shouldStopLoadingForHistoryItem(item))
+    if (frame.loader().checkedHistory()->shouldStopLoadingForHistoryItem(item))
         frame.protectedLoader()->stopAllLoadersAndCheckCompleteness();
-    frame.checkedHistory()->goToItemForNavigationAPI(item, type, targetNavigationEntryKey);
+    frame.loader().checkedHistory()->goToItemForNavigationAPI(item, type, targetNavigationEntryKey);
 }
 
 void Page::setGroupName(const String& name)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1657,7 +1657,7 @@ void Internals::selectColorInColorChooser(HTMLInputElement& element, const Strin
 
 ExceptionOr<Vector<AtomString>> Internals::formControlStateOfPreviousHistoryItem()
 {
-    HistoryItem* mainItem = frame()->history().previousItem();
+    HistoryItem* mainItem = frame()->loader().history().previousItem();
     if (!mainItem)
         return Exception { ExceptionCode::InvalidAccessError };
     auto frameID = frame()->frameID();
@@ -1668,7 +1668,7 @@ ExceptionOr<Vector<AtomString>> Internals::formControlStateOfPreviousHistoryItem
 
 ExceptionOr<void> Internals::setFormControlStateOfPreviousHistoryItem(const Vector<AtomString>& state)
 {
-    HistoryItem* mainItem = frame()->history().previousItem();
+    HistoryItem* mainItem = frame()->loader().history().previousItem();
     if (!mainItem)
         return Exception { ExceptionCode::InvalidAccessError };
     auto frameID = frame()->frameID();
@@ -4022,8 +4022,8 @@ Ref<MemoryInfo> Internals::memoryInfo() const
 
 Vector<String> Internals::getReferencedFilePaths() const
 {
-    frame()->history().saveDocumentAndScrollState();
-    return FormController::referencedFilePaths(frame()->history().currentItem()->documentState());
+    frame()->loader().history().saveDocumentAndScrollState();
+    return FormController::referencedFilePaths(frame()->loader().history().currentItem()->documentState());
 }
 
 ExceptionOr<void> Internals::startTrackingRepaints()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1407,7 +1407,7 @@ void WebLocalFrameLoaderClient::saveViewStateToItem(HistoryItem& historyItem)
 void WebLocalFrameLoaderClient::restoreViewState()
 {
 #if PLATFORM(IOS_FAMILY)
-    auto* currentItem = m_localFrame->history().currentItem();
+    auto* currentItem = m_localFrame->loader().history().currentItem();
     if (auto* view =  m_localFrame->view()) {
         if (m_frame->isMainFrame())
             m_frame->page()->restorePageState(*currentItem);
@@ -1416,7 +1416,7 @@ void WebLocalFrameLoaderClient::restoreViewState()
     }
 #else
     // Inform the UI process of the scale factor.
-    double scaleFactor = m_localFrame->history().currentItem()->pageScaleFactor();
+    double scaleFactor = m_localFrame->loader().history().currentItem()->pageScaleFactor();
 
     // A scale factor of 0 means the history item has the default scale factor, thus we do not need to update it.
     if (scaleFactor)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2024,7 +2024,7 @@ void WebPage::suspendForProcessSwap()
     };
 
     // FIXME: Make this work if the main frame is not a LocalFrame.
-    RefPtr currentHistoryItem = m_mainFrame->coreLocalFrame()->history().currentItem();
+    RefPtr currentHistoryItem = m_mainFrame->coreLocalFrame()->loader().history().currentItem();
     if (!currentHistoryItem) {
         failedToSuspend();
         return;
@@ -2382,7 +2382,7 @@ void WebPage::goToBackForwardItemWaitingForProcessLaunch(GoToBackForwardItemPara
 void WebPage::tryRestoreScrollPosition()
 {
     if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
-        localMainFrame->checkedHistory()->restoreScrollPositionAndViewState();
+        localMainFrame->loader().checkedHistory()->restoreScrollPositionAndViewState();
 }
 
 WebPage* WebPage::fromCorePage(Page& page)
@@ -3270,7 +3270,7 @@ void WebPage::pageStoppedScrolling()
 {
     // Maintain the current history item's scroll position up-to-date.
     if (RefPtr frame = m_mainFrame->coreLocalFrame())
-        frame->checkedHistory()->saveScrollPositionAndViewStateToItem(frame->history().currentItem());
+        frame->loader().checkedHistory()->saveScrollPositionAndViewStateToItem(frame->loader().history().currentItem());
 }
 
 void WebPage::setHasActiveAnimatedScrolls(bool hasActiveAnimatedScrolls)
@@ -3822,7 +3822,7 @@ void WebPage::setNeedsFontAttributes(bool needsFontAttributes)
 void WebPage::setCurrentHistoryItemForReattach(Ref<FrameState>&& mainFrameState)
 {
     if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(corePage()->mainFrame()))
-        localMainFrame->checkedHistory()->setCurrentItem(toHistoryItem(m_historyItemClient, mainFrameState));
+        localMainFrame->loader().checkedHistory()->setCurrentItem(toHistoryItem(m_historyItemClient, mainFrameState));
 }
 
 void WebPage::requestFontAttributesAtSelectionStart(CompletionHandler<void(const WebCore::FontAttributes&)>&& completionHandler)
@@ -4161,7 +4161,7 @@ void WebPage::visibilityDidChange()
         // We save the document / scroll state when backgrounding a tab so that we are able to restore it
         // if it gets terminated while in the background.
         if (RefPtr frame = m_mainFrame->coreLocalFrame())
-            frame->checkedHistory()->saveDocumentAndScrollState();
+            frame->loader().checkedHistory()->saveDocumentAndScrollState();
     }
 }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1241,7 +1241,7 @@ void WebFrameLoaderClient::saveViewStateToItem(WebCore::HistoryItem& item)
 
 void WebFrameLoaderClient::restoreViewState()
 {
-    WebCore::HistoryItem* currentItem = core(m_webFrame.get())->history().currentItem();
+    WebCore::HistoryItem* currentItem = core(m_webFrame.get())->loader().history().currentItem();
     ASSERT(currentItem);
 
     // FIXME: As the ASSERT attests, it seems we should always have a currentItem here.

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1239,7 +1239,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
 {
     ASSERT(!WebThreadIsEnabled() || WebThreadIsLocked());
     auto& frameLoader = _private->coreFrame->loader();
-    auto* item = _private->coreFrame->history().currentItem();
+    auto* item = frameLoader.history().currentItem();
     if (item)
         frameLoader.client().saveViewStateToItem(*item);
 }

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1876,7 +1876,7 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
 {
     auto* frame = [self _mainCoreFrame];
     if (frame)
-        frame->history().replaceCurrentItem(core(item));
+        frame->loader().history().replaceCurrentItem(core(item));
 }
 
 + (void)willEnterBackgroundWithCompletionHandler:(void(^)(void))handler
@@ -2785,7 +2785,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             // since that might have changed since loading and it is normally not saved
             // until we leave that page.
             if (auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(otherView->_private->page->mainFrame()))
-                localMainFrame->history().saveDocumentAndScrollState();
+                localMainFrame->loader().history().saveDocumentAndScrollState();
         }
         Ref newItem = otherBackForward->itemAtIndex(i)->copy();
         if (i == 0)


### PR DESCRIPTION
#### 44dc8ee6457affcb37576547684db11c148acdc0
<pre>
Move HistoryController to FrameLoader
<a href="https://bugs.webkit.org/show_bug.cgi?id=284987">https://bugs.webkit.org/show_bug.cgi?id=284987</a>
<a href="https://rdar.apple.com/141788191">rdar://141788191</a>

Reviewed by Alex Christensen.

Earlier in site isolation development HistoryController was moved to Frame, but things have changed such
that HistoryController should only be responsible for loading and committing history state to the UI
process for local frames.

* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::executeJavaScriptURL):
* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::canCacheFrame):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::willSendRequest):
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::begin):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::FrameLoader):
(WebCore::FrameLoader::setDefersLoading):
(WebCore::FrameLoader::closeURL):
(WebCore::FrameLoader::didBeginDocument):
(WebCore::FrameLoader::loadURLIntoChildFrame):
(WebCore::FrameLoader::updateURLAndHistory):
(WebCore::FrameLoader::loadInSameDocument):
(WebCore::FrameLoader::loadFrameRequest):
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::stopAllLoaders):
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::transitionToCommitted):
(WebCore::FrameLoader::clientRedirected):
(WebCore::FrameLoader::dispatchDidFailProvisionalLoad):
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
(WebCore::FrameLoader::restoreScrollPositionAndViewStateNowIfNeeded):
(WebCore::FrameLoader::frameLoadCompleted):
(WebCore::FrameLoader::detachFromParent):
(WebCore::FrameLoader::receivedMainResourceError):
(WebCore::FrameLoader::scrollToFragmentWithParentBoundary):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
(WebCore::FrameLoader::shouldTreatURLAsSameAsCurrent const):
(WebCore::FrameLoader::loadSameDocumentItem):
(WebCore::FrameLoader::checkedHistory const):
(WebCore::FrameLoader::loadDifferentDocumentItem):
(WebCore::FrameLoader::loadItem):
(WebCore::FrameLoader::retryAfterFailedCacheOnlyMainResourceLoad):
(WebCore::FrameLoader::didChangeTitle):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::HistoryController):
(WebCore::HistoryController::saveScrollPositionAndViewStateToItem):
(WebCore::HistoryController::protectedFrame const):
(WebCore::HistoryController::restoreScrollPositionAndViewState):
(WebCore::HistoryController::saveDocumentState):
(WebCore::HistoryController::saveDocumentAndScrollState):
(WebCore::HistoryController::restoreDocumentState):
(WebCore::HistoryController::invalidateCurrentItemCachedPage):
(WebCore::HistoryController::goToItem):
(WebCore::HistoryController::updateForBackForwardNavigation):
(WebCore::HistoryController::updateForReload):
(WebCore::HistoryController::updateForStandardLoad):
(WebCore::HistoryController::updateForRedirectWithLockedBackForwardList):
(WebCore::HistoryController::updateForClientRedirect):
(WebCore::HistoryController::updateForCommit):
(WebCore::HistoryController::recursiveUpdateForCommit):
(WebCore::HistoryController::updateForSameDocumentNavigation):
(WebCore::HistoryController::recursiveUpdateForSameDocumentNavigation):
(WebCore::HistoryController::clearPreviousItem):
(WebCore::HistoryController::initializeItem):
(WebCore::HistoryController::createItem):
(WebCore::HistoryController::createItemTree):
(WebCore::HistoryController::recursiveSetProvisionalItem):
(WebCore::HistoryController::recursiveGoToItem):
(WebCore::HistoryController::updateBackForwardListClippedAtTarget):
(WebCore::HistoryController::updateCurrentItem):
(WebCore::HistoryController::pushState):
(WebCore::HistoryController::replaceState):
* Source/WebCore/loader/HistoryController.h:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::Frame):
(WebCore::Frame::checkedHistory const): Deleted.
* Source/WebCore/page/Frame.h:
(WebCore::Frame::history const): Deleted.
* Source/WebCore/page/History.cpp:
(WebCore::History::scrollRestoration const):
(WebCore::History::setScrollRestoration):
(WebCore::History::stateInternal const):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::processScrollBehavior):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::initializeForNewWindow):
(WebCore::Navigation::createForPageswapEvent):
(WebCore::Navigation::dispatchTraversalNavigateEvent):
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::sameDocument const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::clearPreviousItemFromAllPages):
(WebCore::Page::goToItem):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::formControlStateOfPreviousHistoryItem):
(WebCore::Internals::setFormControlStateOfPreviousHistoryItem):
(WebCore::Internals::getReferencedFilePaths const):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::restoreViewState):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::suspendForProcessSwap):
(WebKit::WebPage::tryRestoreScrollPosition):
(WebKit::WebPage::pageStoppedScrolling):
(WebKit::WebPage::setCurrentHistoryItemForReattach):
(WebKit::WebPage::visibilityDidChange):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::restoreViewState):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _saveViewState]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _replaceCurrentHistoryItem:]):
(-[WebView _loadBackForwardListFromOtherView:]):

Canonical link: <a href="https://commits.webkit.org/288146@main">https://commits.webkit.org/288146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33dd9ea9954a181e1e22c4531e0911219c548c23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86540 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33015 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63918 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21638 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44201 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28775 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31434 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87971 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9225 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72283 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71505 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15622 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14538 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12706 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9176 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14712 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9016 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12541 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10824 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->