### PR TITLE
iOS 18.2 - WebRTC audio input device issues

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -435,6 +435,9 @@ webkit.org/b/266465 imported/w3c/web-platform-tests/editing/run/delete.html?6001
 # This test's output is not stable from run to run.
 imported/w3c/web-platform-tests/editing/run/undo-redo.html [ Skip ]
 
+# Failing as we disable setting kAUVoiceIOProperty_MuteOutput
+http/wpt/mediasession/voiceActivityDetection.html [ Failure ]
+
 http/wpt/selection-live-range/collapse-00.html [ Slow ]
 http/wpt/selection-live-range/collapse-15.html [ Slow ]
 http/wpt/selection-live-range/collapse-30.html [ Slow ]


### PR DESCRIPTION
#### 4003251a646cb7fb1fdbd2a601bb913b1ef9ddb9
<pre>
iOS 18.2 - WebRTC audio input device issues
<a href="https://rdar.apple.com/139797608">rdar://139797608</a>

Reviewed by Jean-Yves Avenard.

When stopping capture, if audio rendering is ongoing with VPIO, we were setting kAUVoiceIOProperty_MuteOutput to 1.
This is new in 18.2 code base and is in preparation of supporting voice activity detection.

We were correctly setting kAUVoiceIOProperty_MuteOutput back to 0 if we were keeping the same VPIO unit when restarting.
It appears kAUVoiceIOProperty_MuteOutput is sticky so we would need to set kAUVoiceIOProperty_MuteOutput back to 0 on the new unit.

Instead, we are removing the setting of kAUVoiceIOProperty_MuteOutput.
Setting kAUVoiceIOProperty_MuteOutput is useful to enable muted talker detection, which is a future feature, not available in this branch.

There is no such issue in WebKit trunk since, after the fork to this branch, we added explicit mute setting via [AVAudioApplication setInputMuted:error:].

Marking http/wpt/mediasession/voiceActivityDetection.html as failing since we no longer instruct the mock audio unit that the output is muted.

Manually tested on iOS.

* LayoutTests/TestExpectations:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::isProducingMicrophoneSamplesChanged):

Originally-landed-as: 2d1b510c05b1. <a href="https://rdar.apple.com/141317272">rdar://141317272</a>
Canonical link: <a href="https://commits.webkit.org/288179@main">https://commits.webkit.org/288179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8867c6045b2babf5606914fd6ee70a90da8d54b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33011 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63912 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21637 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44195 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1039 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28767 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31430 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72363 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29387 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87967 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6567 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72278 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71500 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15615 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14533 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/607 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12729 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9172 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9012 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12537 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10820 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->