### PR TITLE
Build PlayStation with Skia and GPU Process

### DIFF
--- a/Source/WebKit/GPUProcess/playstation/GPUProcessMainPlayStation.cpp
+++ b/Source/WebKit/GPUProcess/playstation/GPUProcessMainPlayStation.cpp
@@ -31,9 +31,21 @@
 #include "AuxiliaryProcessMain.h"
 #include "GPUProcess.h"
 
+#if USE(SKIA)
+#include <skia/core/SkGraphics.h>
+#endif
+
 namespace WebKit {
 
 class GPUProcessMainPlayStation final: public AuxiliaryProcessMainBase<GPUProcess> {
+public:
+    bool platformInitialize() override
+    {
+#if USE(SKIA)
+        SkGraphics::Init();
+#endif
+        return true;
+    }
 };
 
 int GPUProcessMain(int argc, char** argv)

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
@@ -53,7 +53,7 @@ PageClientImpl::PageClientImpl(PlayStationWebView& view)
 #if USE(GRAPHICS_LAYER_WC) && USE(WPE_RENDERER)
 uint64_t PageClientImpl::viewWidget()
 {
-    return 0;
+    return 1;
 }
 #endif
 
@@ -193,7 +193,7 @@ WebCore::IntPoint PageClientImpl::accessibilityScreenToRootView(const WebCore::I
 
 WebCore::IntRect PageClientImpl::rootViewToAccessibilityScreen(const WebCore::IntRect& rect)
 {
-    return rootViewToScreen(rect);    
+    return rootViewToScreen(rect);
 }
 
 void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent& event, bool wasEventHandled)

--- a/Source/WebKit/UIProcess/playstation/WebPageProxyPlayStation.cpp
+++ b/Source/WebKit/UIProcess/playstation/WebPageProxyPlayStation.cpp
@@ -76,7 +76,7 @@ void WebPageProxy::didUpdateEditorState(const EditorState&, const EditorState&)
 #if USE(GRAPHICS_LAYER_WC)
 uint64_t WebPageProxy::viewWidget()
 {
-    return static_cast<PageClientImpl&>(pageClient()).viewWidget();
+    return static_cast<PageClientImpl&>(*pageClient()).viewWidget();
 }
 #endif
 


### PR DESCRIPTION
#### bce0ceea036ca13a4d131b5b553c1a6f7a2aa169
<pre>
Build PlayStation with Skia and GPU Process
<a href="https://bugs.webkit.org/show_bug.cgi?id=285002">https://bugs.webkit.org/show_bug.cgi?id=285002</a>

Reviewed by NOBODY (OOPS!).

Support the PlayStation build with `ENABLE(GPU_PROCESS)` and `USE(SKIA)`.

* Source/WebKit/GPUProcess/playstation/GPUProcessMainPlayStation.cpp:
* Source/WebKit/UIProcess/playstation/PageClientImpl.cpp:
(WebKit::PageClientImpl::viewWidget):
(WebKit::PageClientImpl::rootViewToAccessibilityScreen):
* Source/WebKit/UIProcess/playstation/WebPageProxyPlayStation.cpp:
(WebKit::WebPageProxy::viewWidget):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bce0ceea036ca13a4d131b5b553c1a6f7a2aa169

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86561 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33036 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1566 "Hash bce0ceea for PR 38251 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63926 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21646 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85074 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/1566 "Hash bce0ceea for PR 38251 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74612 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44209 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/1566 "Hash bce0ceea for PR 38251 does not build (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31456 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/1566 "Hash bce0ceea for PR 38251 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87994 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6584 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72296 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71518 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15636 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14550 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/632 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9197 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14733 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9037 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12562 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->