### PR TITLE
Assert when layout in subgrid is updated as per added test case

### DIFF
--- a/LayoutTests/fast/css-grid-layout/layout-update-assert-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/layout-update-assert-expected.txt
@@ -1,0 +1,1 @@
+PASSES if no crash

--- a/LayoutTests/fast/css-grid-layout/layout-update-assert.html
+++ b/LayoutTests/fast/css-grid-layout/layout-update-assert.html
@@ -1,0 +1,29 @@
+<html>
+<head>
+<style>
+.grid {
+  display: grid;
+}
+.subgrid-rows {
+  grid-template-rows: subgrid [b] [a] [c];
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div id="outer-subgrid" class="grid subgrid-rows">
+    <div></div>
+    <div id="inner-subgrid" class="grid subgrid-rows">PASSES if no crash</div>
+  </div>
+</div>
+</body>
+
+<script>
+  if (testRunner)
+     testRunner.dumpAsText();
+
+  document.body.offsetHeight;
+  document.getElementById("outer-subgrid").style.contain = "layout";
+  document.getElementById("inner-subgrid").style.border = "1px solid black";
+  document.body.offsetHeight;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-layout-dynamic-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-layout-dynamic-001-expected.txt
@@ -1,8 +1,8 @@
 
 PASS contain: none
 PASS contain: layout
-FAIL switching contain from none to layout assert_equals: vertical baseline suppressed expected true but got false
-FAIL switching contain from layout to none assert_equals: vertical baseline suppressed expected false but got true
+PASS switching contain from none to layout
+PASS switching contain from layout to none
 X
 X
 X

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -127,7 +127,8 @@ void RenderGrid::styleDidChange(StyleDifference diff, const RenderStyle* oldStyl
 bool RenderGrid::subgridDidChange(const RenderStyle& oldStyle) const
 {
     return oldStyle.gridSubgridRows() != style().gridSubgridRows()
-        || oldStyle.gridSubgridColumns() != style().gridSubgridColumns();
+        || oldStyle.gridSubgridColumns() != style().gridSubgridColumns()
+        || oldStyle.usedContain().contains(Containment::Layout) !=style().usedContain().contains(Containment::Layout);
 }
 
 bool RenderGrid::explicitGridDidResize(const RenderStyle& oldStyle) const

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -847,7 +847,8 @@ static bool rareDataChangeRequiresLayout(const StyleRareNonInheritedData& first,
         return true;
 
     if (first.usedContain().contains(Containment::Size) != second.usedContain().contains(Containment::Size)
-        || first.usedContain().contains(Containment::InlineSize) != second.usedContain().contains(Containment::InlineSize))
+        || first.usedContain().contains(Containment::InlineSize) != second.usedContain().contains(Containment::InlineSize)
+        || first.usedContain().contains(Containment::Layout) != second.usedContain().contains(Containment::Layout))
         return true;
 
     // content-visibiliy:hidden turns on contain:size which requires relayout.


### PR DESCRIPTION
#### 64a8b3437e7cee3196ddc9271e849aa13336379b
<pre>
Assert when layout in subgrid is updated as per added test case
<a href="https://bugs.webkit.org/show_bug.cgi?id=284862">https://bugs.webkit.org/show_bug.cgi?id=284862</a>

<a href="https://rdar.apple.com/137177436">rdar://137177436</a>

Reviewed by NOBODY (OOPS!).

The cause of the issue and the fix:
In some cases, when the difference between the old and the new value is layout change, the diff was flagged as zero, causing the subgridDidChange not to flag a change required condition. The issue was fixed by checking for layout update between the old and new styles and marking it as a valid difference.

* LayoutTests/fast/css-grid-layout/layout-update-assert-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/layout-update-assert.html: Added.
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::subgridDidChange const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::rareDataChangeRequiresLayout):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64a8b3437e7cee3196ddc9271e849aa13336379b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86646 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33124 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9443 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63992 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21716 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74688 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44273 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1142 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28867 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31543 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72442 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29479 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88082 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9330 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6667 "Found 1 new test failure: imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-mimetype.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72365 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9515 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71584 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15712 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14625 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/743 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9283 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14821 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9121 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12650 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10929 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->