### PR TITLE
Reduce use of memcpy() / memset() in WTF/

### DIFF
--- a/Source/WTF/wtf/BitVector.cpp
+++ b/Source/WTF/wtf/BitVector.cpp
@@ -47,7 +47,7 @@ void BitVector::setSlow(const BitVector& other)
         newBitsOrPointer = other.m_bitsOrPointer;
     else {
         OutOfLineBits* newOutOfLineBits = OutOfLineBits::create(other.size());
-        memcpy(newOutOfLineBits->bits(), other.bits(), byteCount(other.size()));
+        memcpySpan(newOutOfLineBits->byteSpan(), other.byteSpan());
         newBitsOrPointer = std::bit_cast<uintptr_t>(newOutOfLineBits) >> 1;
     }
     if (!isInline() && !isEmptyOrDeletedValue())
@@ -62,7 +62,7 @@ void BitVector::resize(size_t numBits)
             return;
     
         OutOfLineBits* myOutOfLineBits = outOfLineBits();
-        m_bitsOrPointer = makeInlineBits(*myOutOfLineBits->bits());
+        m_bitsOrPointer = makeInlineBits(myOutOfLineBits->wordsSpan().front());
         OutOfLineBits::destroy(myOutOfLineBits);
         return;
     }
@@ -75,15 +75,14 @@ void BitVector::clearAll()
     if (isInline())
         m_bitsOrPointer = makeInlineBits(0);
     else
-        memset(outOfLineBits()->bits(), 0, byteCount(size()));
+        zeroSpan(outOfLineBits()->byteSpan());
 }
 
-BitVector::OutOfLineBits* BitVector::OutOfLineBits::create(size_t numBits)
+auto BitVector::OutOfLineBits::create(size_t numBits) -> OutOfLineBits*
 {
     numBits = (numBits + bitsInPointer() - 1) & ~(static_cast<size_t>(bitsInPointer()) - 1);
     size_t size = sizeof(OutOfLineBits) + sizeof(uintptr_t) * (numBits / bitsInPointer());
-    OutOfLineBits* result = new (NotNull, BitVectorMalloc::malloc(size)) OutOfLineBits(numBits);
-    return result;
+    return new (NotNull, BitVectorMalloc::malloc(size)) OutOfLineBits(numBits);
 }
 
 void BitVector::OutOfLineBits::destroy(OutOfLineBits* outOfLineBits)
@@ -104,22 +103,20 @@ void BitVector::resizeOutOfLine(size_t numBits, size_t shiftInWords)
 {
     ASSERT(numBits > maxInlineBits());
     OutOfLineBits* newOutOfLineBits = OutOfLineBits::create(numBits);
-    size_t newNumWords = newOutOfLineBits->numWords();
+    auto newWords = newOutOfLineBits->wordsSpan();
     if (isInline()) {
-        memset(newOutOfLineBits->bits(), 0, shiftInWords * sizeof(void*));
+        zeroSpan(newWords.first(shiftInWords));
         // Make sure that all of the bits are zero in case we do a no-op resize.
-        *(newOutOfLineBits->bits() + shiftInWords) = m_bitsOrPointer & ~(static_cast<uintptr_t>(1) << maxInlineBits());
-        RELEASE_ASSERT(shiftInWords + 1 <= newNumWords);
-        memset(newOutOfLineBits->bits() + shiftInWords + 1, 0, (newNumWords - 1 - shiftInWords) * sizeof(void*));
+        newWords[shiftInWords] = m_bitsOrPointer & ~(static_cast<uintptr_t>(1) << maxInlineBits());
+        zeroSpan(newWords.subspan(shiftInWords + 1));
     } else {
+        auto oldWords = outOfLineBits()->wordsSpan();
         if (numBits > size()) {
-            size_t oldNumWords = outOfLineBits()->numWords();
-            memset(newOutOfLineBits->bits(), 0, shiftInWords * sizeof(void*));
-            memcpy(newOutOfLineBits->bits() + shiftInWords, outOfLineBits()->bits(), oldNumWords * sizeof(void*));
-            RELEASE_ASSERT(shiftInWords + oldNumWords <= newNumWords);
-            memset(newOutOfLineBits->bits() + shiftInWords + oldNumWords, 0, (newNumWords - oldNumWords - shiftInWords) * sizeof(void*));
+            zeroSpan(newWords.first(shiftInWords));
+            memcpySpan(newWords.subspan(shiftInWords), oldWords);
+            zeroSpan(newWords.subspan(shiftInWords + oldWords.size()));
         } else
-            memcpy(newOutOfLineBits->bits(), outOfLineBits()->bits(), newOutOfLineBits->numWords() * sizeof(void*));
+            memcpySpan(newWords, oldWords.first(newOutOfLineBits->numWords()));
         OutOfLineBits::destroy(outOfLineBits());
     }
     m_bitsOrPointer = std::bit_cast<uintptr_t>(newOutOfLineBits) >> 1;
@@ -129,7 +126,7 @@ void BitVector::mergeSlow(const BitVector& other)
 {
     if (other.isInline()) {
         ASSERT(!isInline());
-        *bits() |= cleanseInlineBits(other.m_bitsOrPointer);
+        outOfLineBits()->wordsSpan().front() |= cleanseInlineBits(other.m_bitsOrPointer);
         return;
     }
     
@@ -137,57 +134,59 @@ void BitVector::mergeSlow(const BitVector& other)
     ASSERT(!isInline());
     ASSERT(!other.isInline());
     
-    OutOfLineBits* a = outOfLineBits();
-    const OutOfLineBits* b = other.outOfLineBits();
-    for (unsigned i = a->numWords(); i--;)
-        a->bits()[i] |= b->bits()[i];
+    auto a = outOfLineBits()->wordsSpan();
+    auto b = other.outOfLineBits()->wordsSpan();
+    for (size_t i = 0; i < a.size(); ++i)
+        a[i] |= b[i];
 }
 
 void BitVector::filterSlow(const BitVector& other)
 {
     if (other.isInline()) {
         ASSERT(!isInline());
-        *bits() &= cleanseInlineBits(other.m_bitsOrPointer);
+        outOfLineBits()->wordsSpan().front() &= cleanseInlineBits(other.m_bitsOrPointer);
         return;
     }
     
     if (isInline()) {
         ASSERT(!other.isInline());
-        m_bitsOrPointer &= *other.outOfLineBits()->bits();
+        m_bitsOrPointer &= other.outOfLineBits()->wordsSpan().front();
         m_bitsOrPointer |= (static_cast<uintptr_t>(1) << maxInlineBits());
         ASSERT(isInline());
         return;
     }
     
-    OutOfLineBits* a = outOfLineBits();
-    const OutOfLineBits* b = other.outOfLineBits();
-    for (unsigned i = std::min(a->numWords(), b->numWords()); i--;)
-        a->bits()[i] &= b->bits()[i];
+    auto a = outOfLineBits()->wordsSpan();
+    auto b = other.outOfLineBits()->wordsSpan();
+    auto commonSize = std::min(a.size(), b.size());
+    for (size_t i = 0; i < commonSize; ++i)
+        a[i] &= b[i];
     
-    for (unsigned i = b->numWords(); i < a->numWords(); ++i)
-        a->bits()[i] = 0;
+    if (a.size() > b.size())
+        zeroSpan(a.subspan(b.size()));
 }
 
 void BitVector::excludeSlow(const BitVector& other)
 {
     if (other.isInline()) {
         ASSERT(!isInline());
-        *bits() &= ~cleanseInlineBits(other.m_bitsOrPointer);
+        outOfLineBits()->wordsSpan().front() &= ~cleanseInlineBits(other.m_bitsOrPointer);
         return;
     }
     
     if (isInline()) {
         ASSERT(!other.isInline());
-        m_bitsOrPointer &= ~*other.outOfLineBits()->bits();
+        m_bitsOrPointer &= ~other.outOfLineBits()->wordsSpan().front();
         m_bitsOrPointer |= (static_cast<uintptr_t>(1) << maxInlineBits());
         ASSERT(isInline());
         return;
     }
     
-    OutOfLineBits* a = outOfLineBits();
-    const OutOfLineBits* b = other.outOfLineBits();
-    for (unsigned i = std::min(a->numWords(), b->numWords()); i--;)
-        a->bits()[i] &= ~b->bits()[i];
+    auto a = outOfLineBits()->wordsSpan();
+    auto b = other.outOfLineBits()->wordsSpan();
+    auto commonSize = std::min(a.size(), b.size());
+    for (size_t i = 0; i < commonSize; ++i)
+        a[i] &= ~b[i];
 }
 
 size_t BitVector::bitCountSlow() const
@@ -195,8 +194,8 @@ size_t BitVector::bitCountSlow() const
     ASSERT(!isInline());
     const OutOfLineBits* bits = outOfLineBits();
     size_t result = 0;
-    for (unsigned i = bits->numWords(); i--;)
-        result += bitCount(bits->bits()[i]);
+    for (auto word : bits->wordsSpan())
+        result += bitCount(word);
     return result;
 }
 
@@ -214,10 +213,8 @@ bool BitVector::isEmptySlow() const
     };
 
     using UnitType = std::conditional_t<sizeof(uintptr_t) == sizeof(uint32_t), uint32_t, uint64_t>;
-    const auto* bits = outOfLineBits();
-    const auto* begin = std::bit_cast<const UnitType*>(bits->bits());
-    const auto* end = begin + bits->numWords();
-    return SIMD::find(std::span { begin, end }, vectorMatch, scalarMatch) == end;
+    auto span = spanReinterpretCast<const UnitType>(outOfLineBits()->wordsSpan());
+    return SIMD::find(span, vectorMatch, scalarMatch) == std::to_address(span.end());
 }
 
 bool BitVector::equalsSlowCase(const BitVector& other) const
@@ -232,36 +229,25 @@ bool BitVector::equalsSlowCaseFast(const BitVector& other) const
     if (isInline() != other.isInline())
         return equalsSlowCaseSimple(other);
     
-    const OutOfLineBits* myBits = outOfLineBits();
-    const OutOfLineBits* otherBits = other.outOfLineBits();
+    auto myWords = outOfLineBits()->wordsSpan();
+    auto otherWords = other.outOfLineBits()->wordsSpan();
     
-    size_t myNumWords = myBits->numWords();
-    size_t otherNumWords = otherBits->numWords();
-    size_t minNumWords;
-    size_t maxNumWords;
+    size_t myNumWords = myWords.size();
+    size_t otherNumWords = otherWords.size();
     
-    const OutOfLineBits* longerBits;
+    std::span<const uintptr_t> extraBits;
     if (myNumWords < otherNumWords) {
-        minNumWords = myNumWords;
-        maxNumWords = otherNumWords;
-        longerBits = otherBits;
+        extraBits = otherWords.subspan(myNumWords);
+        otherWords = otherWords.first(myNumWords);
     } else {
-        minNumWords = otherNumWords;
-        maxNumWords = myNumWords;
-        longerBits = myBits;
+        extraBits = myWords.subspan(otherNumWords);
+        myWords = myWords.first(otherNumWords);
     }
     
-    for (size_t i = minNumWords; i < maxNumWords; ++i) {
-        if (longerBits->bits()[i])
-            return false;
-    }
+    if (std::ranges::find_if(extraBits, [](auto word) { return !!word; }) != extraBits.end())
+        return false;
     
-    for (size_t i = minNumWords; i--;) {
-        if (myBits->bits()[i] != otherBits->bits()[i])
-            return false;
-    }
-
-    return true;
+    return equalSpans(myWords, otherWords);
 }
 
 bool BitVector::equalsSlowCaseSimple(const BitVector& other) const
@@ -277,10 +263,9 @@ bool BitVector::equalsSlowCaseSimple(const BitVector& other) const
 uintptr_t BitVector::hashSlowCase() const
 {
     ASSERT(!isInline());
-    const OutOfLineBits* bits = outOfLineBits();
     uintptr_t result = 0;
-    for (unsigned i = bits->numWords(); i--;)
-        result ^= bits->bits()[i];
+    for (auto word : outOfLineBits()->wordsSpan())
+        result ^= word;
     return result;
 }
 

--- a/Source/WTF/wtf/Brigand.h
+++ b/Source/WTF/wtf/Brigand.h
@@ -55,6 +55,7 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <wtf/StdLibExtras.h>
 
 #if !defined(BRIGAND_NO_BOOST_SUPPORT)
 #include <boost/fusion/container/vector/vector_fwd.hpp>
@@ -2480,7 +2481,8 @@ namespace brigand
     inline operator value_type() const
     {
       value_type that;
-      std::memcpy(&that, &parent::value, sizeof(value_type));
+      static_assert(sizeof(that) == sizeof(parent::value));
+      memcpySpan(asMutableByteSpan(that), asByteSpan(parent::value));
       return that;
     }
   };

--- a/Source/WTF/wtf/CurrentTime.cpp
+++ b/Source/WTF/wtf/CurrentTime.cpp
@@ -34,7 +34,7 @@
 #include "config.h"
 #include <wtf/ApproximateTime.h>
 #include <wtf/MonotonicTime.h>
-
+#include <wtf/StdLibExtras.h>
 #include <wtf/WallTime.h>
 
 #if OS(DARWIN)
@@ -83,7 +83,8 @@ static double lowResUTCTime()
     // prevent alignment faults on 64-bit Windows).
 
     ULARGE_INTEGER dateTime;
-    memcpy(&dateTime, &fileTime, sizeof(dateTime));
+    static_assert(sizeof(dateTime) == sizeof(fileTime));
+    memcpySpan(asMutableByteSpan(dateTime), asByteSpan(fileTime));
 
     // Windows file times are in 100s of nanoseconds.
     return (dateTime.QuadPart - epochBias) / hundredsOfNanosecondsPerMillisecond;

--- a/Source/WTF/wtf/FastBitVector.cpp
+++ b/Source/WTF/wtf/FastBitVector.cpp
@@ -36,12 +36,11 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(FastBitVector);
 
 void FastBitVectorWordOwner::setEqualsSlow(const FastBitVectorWordOwner& other)
 {
-    uint32_t* newArray = static_cast<uint32_t*>(FastBitVectorMalloc::malloc(other.arrayLength() * sizeof(uint32_t)));
-    memcpy(newArray, other.m_words, other.arrayLength() * sizeof(uint32_t));
     if (m_words)
         FastBitVectorMalloc::free(m_words);
-    m_words = newArray;
+    m_words = static_cast<uint32_t*>(FastBitVectorMalloc::malloc(other.arrayLength() * sizeof(uint32_t)));
     m_numBits = other.m_numBits;
+    memcpySpan(wordsSpan(), other.wordsSpan());
 }
 
 void FastBitVectorWordOwner::resizeSlow(size_t numBits)
@@ -53,12 +52,12 @@ void FastBitVectorWordOwner::resizeSlow(size_t numBits)
     // Use fastMalloc instead of fastRealloc because we expect the common
     // use case for this method to be initializing the size of the bitvector.
     
-    uint32_t* newArray = static_cast<uint32_t*>(FastBitVectorMalloc::malloc(newLength * sizeof(uint32_t)));
-    memcpy(newArray, m_words, oldLength * sizeof(uint32_t));
-    memset(newArray + oldLength, 0, (newLength - oldLength) * sizeof(uint32_t));
+    auto newArray = unsafeMakeSpan(static_cast<uint32_t*>(FastBitVectorMalloc::malloc(newLength * sizeof(uint32_t))), newLength);
+    memcpySpan(newArray, wordsSpan());
+    zeroSpan(newArray.subspan(oldLength));
     if (m_words)
         FastBitVectorMalloc::free(m_words);
-    m_words = newArray;
+    m_words = newArray.data();
 }
 
 void FastBitVector::clearRange(size_t begin, size_t end)

--- a/Source/WTF/wtf/FastBitVector.h
+++ b/Source/WTF/wtf/FastBitVector.h
@@ -101,7 +101,7 @@ public:
         if (arrayLength() != other.arrayLength())
             setEqualsSlow(other);
         else {
-            memcpy(m_words, other.m_words, arrayLength() * sizeof(uint32_t));
+            memcpySpan(wordsSpan(), other.wordsSpan());
             m_numBits = other.m_numBits;
         }
         return *this;
@@ -116,18 +116,18 @@ public:
     
     void setAll()
     {
-        memset(m_words, 255, arrayLength() * sizeof(uint32_t));
+        memsetSpan(wordsSpan(), 255);
     }
     
     void clearAll()
     {
-        memset(m_words, 0, arrayLength() * sizeof(uint32_t));
+        zeroSpan(wordsSpan());
     }
     
     void set(const FastBitVectorWordOwner& other)
     {
         ASSERT_WITH_SECURITY_IMPLICATION(m_numBits == other.m_numBits);
-        memcpy(m_words, other.m_words, arrayLength() * sizeof(uint32_t));
+        memcpySpan(wordsSpan(), other.wordsSpan());
     }
     
     size_t numBits() const
@@ -161,6 +161,9 @@ public:
     
     const uint32_t* words() const { return m_words; }
     uint32_t* words() { return m_words; }
+
+    std::span<uint32_t> wordsSpan() { return unsafeMakeSpan(m_words, arrayLength()); }
+    std::span<const uint32_t> wordsSpan() const { return unsafeMakeSpan(m_words, arrayLength()); }
 
 private:
     WTF_EXPORT_PRIVATE void setEqualsSlow(const FastBitVectorWordOwner& other);

--- a/Source/WTF/wtf/Packed.h
+++ b/Source/WTF/wtf/Packed.h
@@ -144,9 +144,9 @@ public:
         uintptr_t value = 0;
 
 #if CPU(LITTLE_ENDIAN)
-        memcpy(&value, m_storage.data(), storageSize);
+        memcpySpan(asMutableByteSpan(value), std::span { m_storage });
 #else
-        memcpy(std::bit_cast<uint8_t*>(&value) + (sizeof(void*) - storageSize), m_storage.data(), storageSize);
+        memcpySpan(asMutableByteSpan(value).last(storageSize), std::span { m_storage });
 #endif
 
         if (isAlignmentShiftProfitable)
@@ -174,9 +174,9 @@ public:
         if (isAlignmentShiftProfitable)
             value >>= alignmentShiftSize;
 #if CPU(LITTLE_ENDIAN)
-        memcpy(m_storage.data(), &value, storageSize);
+        memcpySpan(std::span { m_storage }, asByteSpan(value).first(storageSize));
 #else
-        memcpy(m_storage.data(), std::bit_cast<uint8_t*>(&value) + (sizeof(void*) - storageSize), storageSize);
+        memcpySpan(std::span { m_storage }, asByteSpan(value).last(storageSize));
 #endif
         ASSERT(std::bit_cast<uintptr_t>(get()) == value);
     }

--- a/Source/WTF/wtf/SHA1.cpp
+++ b/Source/WTF/wtf/SHA1.cpp
@@ -38,6 +38,10 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 
+#if USE(CF)
+#include <wtf/cf/VectorCF.h>
+#endif
+
 namespace WTF {
 
 #if PLATFORM(COCOA)
@@ -219,8 +223,8 @@ void SHA1::addUTF8Bytes(StringView string)
 #if USE(CF)
 void SHA1::addUTF8Bytes(CFStringRef string)
 {
-    if (auto* characters = CFStringGetCStringPtr(string, kCFStringEncodingASCII)) {
-        addBytes(unsafeMakeSpan(byteCast<uint8_t>(characters), CFStringGetLength(string)));
+    if (auto characters = CFStringGetASCIICStringSpan(string); characters.data()) {
+        addBytes(byteCast<uint8_t>(characters));
         return;
     }
 

--- a/Source/WTF/wtf/SmallSet.h
+++ b/Source/WTF/wtf/SmallSet.h
@@ -29,6 +29,7 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/HashFunctions.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/StdLibExtras.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -69,7 +70,7 @@ public:
 
     SmallSet(SmallSet&& other)
     {
-        memcpy(static_cast<void*>(this), static_cast<void*>(&other), sizeof(SmallSet));
+        memcpySpan(asMutableByteSpan(*this), asByteSpan(other));
         other.initialize();
     }
 

--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -75,13 +75,13 @@ public:
 
     explicit UUID(std::span<const uint8_t, 16> span)
     {
-        memcpy(&m_data, span.data(), 16);
+        memcpySpan(asMutableByteSpan(m_data), span);
     }
 
     explicit UUID(std::span<const uint8_t> span)
     {
         RELEASE_ASSERT(span.size() == 16);
-        memcpy(&m_data, span.data(), 16);
+        memcpySpan(asMutableByteSpan(m_data), span);
     }
 
     explicit constexpr UUID(UInt128 data)

--- a/Source/WTF/wtf/UnalignedAccess.h
+++ b/Source/WTF/wtf/UnalignedAccess.h
@@ -36,7 +36,7 @@ inline Type unalignedLoad(const void* pointer)
 {
     static_assert(std::is_trivially_copyable<Type>::value);
     Type result { };
-    memcpy(&result, pointer, sizeof(Type));
+    memcpySpan(asMutableByteSpan(result), unsafeMakeSpan(static_cast<const uint8_t*>(pointer), sizeof(Type)));
     return result;
 }
 
@@ -44,7 +44,7 @@ template<typename Type>
 inline void unalignedStore(void* pointer, Type value)
 {
     static_assert(std::is_trivially_copyable<Type>::value);
-    memcpy(pointer, &value, sizeof(Type));
+    memcpySpan(unsafeMakeSpan(static_cast<uint8_t*>(pointer), sizeof(Type)), asByteSpan(value));
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/cf/VectorCF.h
+++ b/Source/WTF/wtf/cf/VectorCF.h
@@ -160,6 +160,22 @@ template<typename MapLambdaType> Vector<typename LambdaTypeTraits<MapLambdaType>
     return vector;
 }
 
+inline std::span<const char> CFStringGetASCIICStringSpan(CFStringRef string)
+{
+    auto* characters = CFStringGetCStringPtr(string, kCFStringEncodingASCII);
+    if (!characters)
+        return { };
+    return unsafeMakeSpan(characters, CFStringGetLength(string));
+}
+
+inline std::span<const char> CFStringGetLatin1CStringSpan(CFStringRef string)
+{
+    auto* characters = CFStringGetCStringPtr(string, kCFStringEncodingISOLatin1);
+    if (!characters)
+        return { };
+    return unsafeMakeSpan(characters, CFStringGetLength(string));
+}
+
 inline std::span<const uint8_t> span(CFDataRef data)
 {
     return unsafeMakeSpan(static_cast<const uint8_t*>(CFDataGetBytePtr(data)), Checked<size_t>(CFDataGetLength(data)));
@@ -196,6 +212,8 @@ inline std::optional<float> makeVectorElement(const float*, CFNumberRef cfNumber
 
 } // namespace WTF
 
+using WTF::CFStringGetASCIICStringSpan;
+using WTF::CFStringGetLatin1CStringSpan;
 using WTF::createCFArray;
 using WTF::makeVector;
 using WTF::mutableSpan;

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -1411,7 +1411,7 @@ inline Expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8Conver
         size_t prefixLength = firstNonASCII - characters.data();
         size_t remainingLength = characters.size() - prefixLength;
         Vector<char8_t, 1024> buffer(prefixLength + remainingLength * 2);
-        memcpy(buffer.data(), characters.data(), prefixLength);
+        memcpySpan(buffer.mutableSpan(), characters.first(prefixLength));
         auto result = Unicode::convert(characters.subspan(prefixLength), buffer.mutableSpan().subspan(prefixLength));
         ASSERT(result.code == Unicode::ConversionResultCode::Success); // 2x is sufficient for any conversion from Latin1
         return function(buffer.span().first(prefixLength + result.buffer.size()));

--- a/Source/WTF/wtf/text/cf/AtomStringImplCF.cpp
+++ b/Source/WTF/wtf/text/cf/AtomStringImplCF.cpp
@@ -29,6 +29,7 @@
 #if USE(CF)
 
 #include <CoreFoundation/CoreFoundation.h>
+#include <wtf/cf/VectorCF.h>
 #include <wtf/text/CString.h>
 
 namespace WTF {
@@ -38,11 +39,10 @@ RefPtr<AtomStringImpl> AtomStringImpl::add(CFStringRef string)
     if (!string)
         return nullptr;
 
+    if (auto span = byteCast<LChar>(CFStringGetLatin1CStringSpan(string)); span.data())
+        return add(span);
+
     size_t length = CFStringGetLength(string);
-
-    if (const LChar* ptr = byteCast<LChar>(CFStringGetCStringPtr(string, kCFStringEncodingISOLatin1)))
-        return add(unsafeMakeSpan(ptr, length));
-
     if (const UniChar* ptr = CFStringGetCharactersPtr(string))
         return add(unsafeMakeSpan(reinterpret_cast<const UChar*>(ptr), length));
 

--- a/Source/WTF/wtf/text/cf/StringConcatenateCF.h
+++ b/Source/WTF/wtf/text/cf/StringConcatenateCF.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/StdLibExtras.h>
+#include <wtf/cf/VectorCF.h>
 #include <wtf/text/StringConcatenate.h>
 
 #if USE(CF)
@@ -50,7 +52,7 @@ inline StringTypeAdapter<CFStringRef>::StringTypeAdapter(CFStringRef string)
 template<> inline void StringTypeAdapter<CFStringRef>::writeTo<LChar>(std::span<LChar> destination) const
 {
     if (m_string)
-        std::memcpy(destination.data(), CFStringGetCStringPtr(m_string, kCFStringEncodingISOLatin1), CFStringGetLength(m_string));
+        memcpySpan(destination, CFStringGetLatin1CStringSpan(m_string));
 }
 
 template<> inline void StringTypeAdapter<CFStringRef>::writeTo<UChar>(std::span<UChar> destination) const

--- a/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
+++ b/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
@@ -157,7 +157,7 @@ private:
         if (!utf8Locale.length())
             return locale;
         Vector<char> scratchBuffer(utf8Locale.length() + 11, 0);
-        memcpy(scratchBuffer.data(), utf8Locale.data(), utf8Locale.length());
+        memcpySpan(scratchBuffer.mutableSpan(), utf8Locale.span());
 
         const char* keywordValue = nullptr;
         switch (behavior) {

--- a/Source/WebCore/platform/network/HTTPHeaderMap.cpp
+++ b/Source/WebCore/platform/network/HTTPHeaderMap.cpp
@@ -37,6 +37,10 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringView.h>
 
+#if USE(CF)
+#include <wtf/cf/VectorCF.h>
+#endif
+
 namespace WebCore {
 
 HTTPHeaderMap::HTTPHeaderMap() = default;
@@ -85,8 +89,7 @@ String HTTPHeaderMap::getUncommonHeader(StringView name) const
 void HTTPHeaderMap::set(CFStringRef name, const String& value)
 {
     // Fast path: avoid constructing a temporary String in the common header case.
-    if (auto* nameCharacters = CFStringGetCStringPtr(name, kCFStringEncodingASCII)) {
-        auto asciiCharacters = unsafeMakeSpan(nameCharacters, CFStringGetLength(name));
+    if (auto asciiCharacters = CFStringGetASCIICStringSpan(name); asciiCharacters.data()) {
         HTTPHeaderName headerName;
         if (findHTTPHeaderName(StringView(asciiCharacters), headerName))
             set(headerName, value);


### PR DESCRIPTION
#### fecc646ca0f6dc15715760d970795164f6af9106
<pre>
Reduce use of memcpy() / memset() in WTF/
<a href="https://bugs.webkit.org/show_bug.cgi?id=285004">https://bugs.webkit.org/show_bug.cgi?id=285004</a>

Reviewed by Geoffrey Garen and Darin Adler.

* Source/WTF/wtf/Assertions.cpp:
* Source/WTF/wtf/BitVector.cpp:
(WTF::BitVector::setSlow):
(WTF::BitVector::clearAll):
(WTF::BitVector::resizeOutOfLine):
* Source/WTF/wtf/BitVector.h:
* Source/WTF/wtf/Brigand.h:
(brigand::real_::operator value_type const):
* Source/WTF/wtf/ConcurrentBuffer.h:
* Source/WTF/wtf/CurrentTime.cpp:
(WTF::lowResUTCTime):
* Source/WTF/wtf/FastBitVector.cpp:
(WTF::FastBitVectorWordOwner::setEqualsSlow):
(WTF::FastBitVectorWordOwner::resizeSlow):
* Source/WTF/wtf/FastBitVector.h:
(WTF::FastBitVectorWordOwner::operator=):
(WTF::FastBitVectorWordOwner::setAll):
(WTF::FastBitVectorWordOwner::clearAll):
(WTF::FastBitVectorWordOwner::set):
(WTF::FastBitVectorWordOwner::wordsSpan):
(WTF::FastBitVectorWordOwner::wordsSpan const):
* Source/WTF/wtf/Packed.h:
(WTF::PackedAlignedPtr::get const):
(WTF::PackedAlignedPtr::set):
* Source/WTF/wtf/SmallSet.h:
* Source/WTF/wtf/StdLibExtras.h:
(WTF::memcpySpan):
* Source/WTF/wtf/UUID.h:
(WTF::UUID::UUID):
* Source/WTF/wtf/UnalignedAccess.h:
(WTF::unalignedLoad):
(WTF::unalignedStore):
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::createTemporaryDirectory):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::tryGetUTF8ForCharacters):
* Source/WTF/wtf/text/cf/StringConcatenateCF.h:
(WTF::StringTypeAdapter&lt;CFStringRef&gt;::writeTo&lt;LChar&gt; const):
* Source/WTF/wtf/text/icu/TextBreakIteratorICU.h:
(WTF::TextBreakIteratorICU::makeLocaleWithBreakKeyword):

Canonical link: <a href="https://commits.webkit.org/288265@main">https://commits.webkit.org/288265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1eebbd94115751e0090424509a0c1ed246052441

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82286 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87418 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33347 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84391 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64130 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21881 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44408 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29054 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32388 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75272 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88774 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81340 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9592 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6850 "Found 3 new test failures: http/tests/download/anchor-download-redirect-cross-origin-top-level.html http/tests/webgpu/webgpu/api/validation/queue/destroyed/query_set.html media/video-replaces-poster.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72528 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/81923 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9818 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71746 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15878 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14885 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/947 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12774 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9545 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15066 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103753 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9419 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25170 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12885 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->