### PR TITLE
AX: AXPropertyName::CanSetSelectedAttribute is not updated when element enabled state changes

### DIFF
--- a/LayoutTests/accessibility/mac/dynamic-aria-disabled-can-set-selected-expected.txt
+++ b/LayoutTests/accessibility/mac/dynamic-aria-disabled-can-set-selected-expected.txt
@@ -1,0 +1,14 @@
+This test ensures we properly report whether AXSelected is settable after dynamic changes.
+
+PASS: accessibilityController.accessibleElementById('radio').isAttributeSettable('AXSelected') === true
+PASS: accessibilityController.accessibleElementById('tree').isAttributeSettable('AXSelected') === true
+PASS: accessibilityController.accessibleElementById('treeitem').isAttributeSettable('AXSelected') === true
+PASS: accessibilityController.accessibleElementById('radio').isAttributeSettable('AXSelected') === false
+PASS: accessibilityController.accessibleElementById('tree').isAttributeSettable('AXSelected') === false
+PASS: accessibilityController.accessibleElementById('treeitem').isAttributeSettable('AXSelected') === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Radio
+Tree item

--- a/LayoutTests/accessibility/mac/dynamic-aria-disabled-can-set-selected.html
+++ b/LayoutTests/accessibility/mac/dynamic-aria-disabled-can-set-selected.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="radio" role="menuitemradio" aria-checked="true">Radio</div>
+
+<ul id="tree" role="tree">
+    <li id="treeitem" role="treeitem">Tree item</li>
+</ul>
+
+<script>
+var output = "This test ensures we properly report whether AXSelected is settable after dynamic changes.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += expect("accessibilityController.accessibleElementById('radio').isAttributeSettable('AXSelected')", "true");
+    output += expect("accessibilityController.accessibleElementById('tree').isAttributeSettable('AXSelected')", "true");
+    output += expect("accessibilityController.accessibleElementById('treeitem').isAttributeSettable('AXSelected')", "true");
+
+    document.getElementById("radio").setAttribute("aria-disabled", "true")
+    document.getElementById("tree").setAttribute("aria-disabled", "true")
+    setTimeout(async function() {
+        output += await expectAsync("accessibilityController.accessibleElementById('radio').isAttributeSettable('AXSelected')", "false");
+        output += await expectAsync("accessibilityController.accessibleElementById('tree').isAttributeSettable('AXSelected')", "false");
+        output += await expectAsync("accessibilityController.accessibleElementById('treeitem').isAttributeSettable('AXSelected')", "false");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -4594,7 +4594,7 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::ColumnIndexRange });
             break;
         case AXNotification::DisabledStateChanged:
-            tree->updatePropertiesForSelfAndDescendants(notification.first.get(), { { AXPropertyName::CanSetFocusAttribute, AXPropertyName::IsEnabled } });
+            tree->updatePropertiesForSelfAndDescendants(notification.first.get(), { { AXPropertyName::CanSetFocusAttribute, AXPropertyName::CanSetSelectedAttribute, AXPropertyName::IsEnabled } });
             break;
         case AXNotification::ExpandedChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::IsExpanded });

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -639,6 +639,9 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
         case AXPropertyName::CanSetFocusAttribute:
             propertyMap.set(AXPropertyName::CanSetFocusAttribute, axObject.canSetFocusAttribute());
             break;
+        case AXPropertyName::CanSetSelectedAttribute:
+            propertyMap.set(AXPropertyName::CanSetSelectedAttribute, axObject.canSetSelectedAttribute());
+            break;
         case AXPropertyName::CanSetValueAttribute:
             propertyMap.set(AXPropertyName::CanSetValueAttribute, axObject.canSetValueAttribute());
             break;


### PR DESCRIPTION
#### 417e6ae394e17923da56161b8af4fc84730562f9
<pre>
AX: AXPropertyName::CanSetSelectedAttribute is not updated when element enabled state changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=285006">https://bugs.webkit.org/show_bug.cgi?id=285006</a>
<a href="https://rdar.apple.com/141800770">rdar://141800770</a>

Reviewed by Chris Fleizach.

When an element&apos;s enabled state changes, all descendants need to re-compute whether they can set AXSelected
(AXPropertyName::CanSetSelectedAttribute).

* LayoutTests/accessibility/dynamic-aria-disabled-can-set-selected-expected.txt: Added.
* LayoutTests/accessibility/dynamic-aria-disabled-can-set-selected.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::updateIsolatedTree):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):

Canonical link: <a href="https://commits.webkit.org/288181@main">https://commits.webkit.org/288181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1685fa16b11ec5d8856841bbd8a34be09722f6a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86603 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33078 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84152 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63958 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21677 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1198 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74653 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44242 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28830 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31498 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88036 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9288 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6622 "Found 1 new test failure: inspector/worker/resources-in-subworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72325 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9473 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70472 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71547 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17846 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15670 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14589 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9239 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14775 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9079 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12605 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->