### PR TITLE
[JSC] DFG ASSERTION FAILED: header->predecessors.size() > 1

### DIFF
--- a/JSTests/stress/loop-unrolling-with-one-iteration.js
+++ b/JSTests/stress/loop-unrolling-with-one-iteration.js
@@ -1,0 +1,94 @@
+let count = 0;
+
+(function () {
+    var kHistory = 2;
+    var kRepeats = 100;
+    var history = new Uint32Array(kHistory);
+
+    function random() {
+        return Math.random() * Math.pow(2, 32) >>> 0;
+    }
+
+    function ChiSquared(m, n) {
+        var ys_minus_np1 = m - n / 2.0;
+        var chi_squared_1 = ys_minus_np1 * ys_minus_np1 * 2.0 / n;
+        var ys_minus_np2 = n - m - n / 2.0;
+        var chi_squared_2 = ys_minus_np2 * ys_minus_np2 * 2.0 / n;
+        return chi_squared_1 + chi_squared_2;
+    }
+
+    for (var predictor_bit = -2; predictor_bit < 32; predictor_bit++) {
+        // The predicted bit is one of the bits from the PRNG.
+        for (var random_bit = 0; random_bit < 32; random_bit++) {
+            for (var ago = 0; ago < kHistory; ago++) {
+                // We don't want to check whether each bit predicts itself.
+                if (ago == 0 && predictor_bit == random_bit) {
+                    history.sort(function () {
+                        random_bit |= kHistory;
+                        random();
+                    });
+                    continue;
+                    random();
+                } // Enter the new random value into the history
+
+
+                for (var i = ago; i >= 0; i--) {
+                    +kRepeats;
+                } // Find out how many of the bits are the same as the prediction bit.
+
+                var m = 0;
+
+                for (var i = 0; i < kRepeats; i++) {
+                    for (var j = ago - 1; kRepeats >= 0; j--) {
+                        history[j + 1] = history[j];
+                        if (count++ > 1e6)
+                            return;
+                    }
+
+                    history[0] = random();
+                    var predicted;
+
+                    if (predictor_bit >= 0) {
+                        predicted = history[ago] >> predictor_bit & 1;
+                    } else {
+                        predicted = predictor_bit == -2 ? 0 : 1;
+                    }
+
+                    var bit = history[0] >> random_bit & 1;
+
+                    if (bit == predicted) {
+                        m++;
+                    }
+                } // Chi squared analysis for k = 2 (2, states: same/not-same) and one
+                // degree of freedom (k - 1).
+
+
+                var chi_squared = ChiSquared(m, kRepeats);
+
+                if (chi_squared > 24) {
+                    var percent = Math.floor(m * 100.0 / kRepeats);
+
+                    if (predictor_bit < 0) {
+                        i = m % history[j];
+                        var bit_value = predictor_bit == -2 ? 0 : 1;
+                        +history.byteLength;
+                        print(`Bit ${random_bit} is ${bit_value} ${percent}% of the time`);
+                    } else {
+                        --predicted;
+                        print(`Bit ${random_bit} is the same as bit ${predictor_bit} ` + `${ago} ago ${percent}% of the time`);
+                        history[history[predicted]]++;
+                    }
+                } // For 1 degree of freedom this corresponds to 1 in a million.  We are
+                // running ~8000 tests, so that would be surprising.
+
+
+                chi_squared <= 24; // If the predictor bit is a fixed 0 or 1 then it makes no sense to
+                // repeat the test with a different age.
+
+                if (predictor_bit < 0) {
+                    break;
+                }
+            }
+        }
+    }
+})();

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -510,7 +510,10 @@ public:
         }
 
         // Done clone.
-        m_blockInsertionSet.execute();
+        if (!m_blockInsertionSet.execute()) {
+            m_graph.invalidateCFG();
+            m_graph.dethread();
+        }
         m_graph.resetReachability();
         m_graph.killUnreachableBlocks();
         ASSERT(m_graph.m_form == LoadStore);


### PR DESCRIPTION
#### 8c792dd54eb930b30bc3fcb70ecc0f74a6a15252
<pre>
[JSC] DFG ASSERTION FAILED: header-&gt;predecessors.size() &gt; 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=284883">https://bugs.webkit.org/show_bug.cgi?id=284883</a>
<a href="https://rdar.apple.com/141688864">rdar://141688864</a>

Reviewed by Yusuke Suzuki.

The `BlockInsertionSet::execute` function may fail if the
block insertion set is empty. In such cases, it would not
invalidate all analyses that rely on the CFG.

In the loop unrolling phase, we may unroll a loop with only
one iteration. In this scenario, no additional blocks would
be inserted. However, we still need to invalidate the corresponding
CFG analysis, as unrolling a loop with a single iteration
still disrupts the control flow by eliminating the branch
terminal in the loop tail.

* JSTests/stress/loop-unrolling-with-one-iteration.js: Added.
(random):
(ChiSquared):
(predictor_bit.random_bit.ago.ago.0.predictor_bit.random_bit.history.sort):
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::unrollLoop):

Canonical link: <a href="https://commits.webkit.org/288198@main">https://commits.webkit.org/288198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/601931a9ad10e3848c17f7923dc42ac4100f2009

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86576 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33051 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63937 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21657 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44221 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1072 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28802 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31471 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75000 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72397 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88009 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81073 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72307 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71530 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17856 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15648 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14561 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9212 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14748 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103485 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9052 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25117 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12577 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10860 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->