### PR TITLE
Use ephemeral hash for MediaStreamTrack groupId

### DIFF
--- a/LayoutTests/http/wpt/mediastream/groupId-persistency-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/groupId-persistency-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS check groupId persistency
+

--- a/LayoutTests/http/wpt/mediastream/groupId-persistency.html
+++ b/LayoutTests/http/wpt/mediastream/groupId-persistency.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script>
+function with_iframe(url) {
+    return new Promise(function(resolve) {
+        var frame = document.createElement('iframe');
+        frame.className = 'test-iframe';
+        frame.src = url;
+        frame.onload = function() { resolve(frame); };
+        document.body.appendChild(frame);
+    });
+ }
+
+function getDeviceFromTrack(track, devices)
+{
+    let matchingDevice;
+    const settings = track.getSettings();
+    devices.forEach(device => {
+        if (device.deviceId === settings.deviceId)
+            matchingDevice = device;
+    });
+    return matchingDevice;
+}
+
+promise_test(async () => {
+    const iframe1 = await with_iframe("/");
+    const iframe2 = await with_iframe("/");
+
+    const stream1 = await iframe1.contentWindow.navigator.mediaDevices.getUserMedia({ audio: true, video: true});
+    const devices1 = await iframe1.contentWindow.navigator.mediaDevices.enumerateDevices();
+   
+    const stream2 = await iframe2.contentWindow.navigator.mediaDevices.getUserMedia({ audio: true, video: true});
+    const devices2 = await iframe2.contentWindow.navigator.mediaDevices.enumerateDevices();
+
+    const stream3 = await iframe1.contentWindow.navigator.mediaDevices.getUserMedia({ audio: true, video: true});
+    const devices3 = await iframe1.contentWindow.navigator.mediaDevices.enumerateDevices();
+
+
+    const audioDevice1 = getDeviceFromTrack(stream1.getAudioTracks()[0], devices1);
+    const audioDevice2 = getDeviceFromTrack(stream1.getAudioTracks()[0], devices2);
+    const audioDevice3 = getDeviceFromTrack(stream1.getAudioTracks()[0], devices3);
+
+    assert_equals(audioDevice1.deviceId, stream1.getAudioTracks()[0].getSettings().deviceId, "deviceId1");
+    assert_equals(audioDevice2.deviceId, stream2.getAudioTracks()[0].getSettings().deviceId, "deviceId2");
+    assert_equals(audioDevice3.deviceId, stream3.getAudioTracks()[0].getSettings().deviceId, "deviceId3");
+
+    assert_equals(audioDevice1.groupId, stream1.getAudioTracks()[0].getSettings().groupId, "groupId1");
+    assert_equals(audioDevice2.groupId, stream2.getAudioTracks()[0].getSettings().groupId, "groupId2");
+    assert_equals(audioDevice3.groupId, stream3.getAudioTracks()[0].getSettings().groupId, "groupId3");
+
+    assert_equals(stream1.getAudioTracks()[0].getCapabilities().groupId, stream1.getAudioTracks()[0].getSettings().groupId, "groupId1 capability");
+    assert_equals(stream2.getAudioTracks()[0].getCapabilities().groupId, stream2.getAudioTracks()[0].getSettings().groupId, "groupId1 capability");
+    assert_equals(stream3.getAudioTracks()[0].getCapabilities().groupId, stream3.getAudioTracks()[0].getSettings().groupId, "groupId1 capability");
+
+    assert_not_equals(audioDevice1.groupId, audioDevice2.groupId, "1 and 2");
+    assert_equals(audioDevice1.groupId, audioDevice3.groupId, "1 and 3");
+}, "check groupId persistency");
+        </script>
+    </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getUserMedia.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getUserMedia.https-expected.txt
@@ -4,8 +4,8 @@ This test checks for the presence of the navigator.mediaDevices.getUserMedia met
 
 
 PASS mediaDevices.getUserMedia() is present on navigator
-FAIL groupId is correctly supported by getUserMedia() for video devices assert_equals: expected (undefined) undefined but got (object) object "[object InputDeviceInfo]"
-FAIL groupId is correctly supported by getUserMedia() for audio devices assert_equals: expected (undefined) undefined but got (object) object "[object InputDeviceInfo]"
+PASS groupId is correctly supported by getUserMedia() for video devices
+PASS groupId is correctly supported by getUserMedia() for audio devices
 FAIL getUserMedia() supports setting none as resizeMode. assert_true: resizeMode should be supported expected true got undefined
 FAIL getUserMedia() supports setting crop-and-scale as resizeMode. assert_true: resizeMode should be supported expected true got undefined
 FAIL getUserMedia() fails with exact invalid resizeMode. assert_true: resizeMode should be supported expected true got undefined

--- a/Source/WebCore/Modules/mediastream/InputDeviceInfo.cpp
+++ b/Source/WebCore/Modules/mediastream/InputDeviceInfo.cpp
@@ -35,15 +35,15 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(InputDeviceInfo);
 
-InputDeviceInfo::InputDeviceInfo(CaptureDeviceWithCapabilities&& deviceWithCapabilities, String&& saltedDeviceId, String&& saltedGroupId)
-    : MediaDeviceInfo(deviceWithCapabilities.device.label(), WTFMove(saltedDeviceId), WTFMove(saltedGroupId), toMediaDeviceInfoKind(deviceWithCapabilities.device.type()))
+InputDeviceInfo::InputDeviceInfo(CaptureDeviceWithCapabilities&& deviceWithCapabilities)
+    : MediaDeviceInfo(deviceWithCapabilities.device.label(), deviceWithCapabilities.capabilities.deviceId(), deviceWithCapabilities.capabilities.groupId(), toMediaDeviceInfoKind(deviceWithCapabilities.device.type()))
     , m_capabilities(WTFMove(deviceWithCapabilities.capabilities))
 {
 }
 
 MediaTrackCapabilities InputDeviceInfo::getCapabilities() const
 {
-    return toMediaTrackCapabilities(m_capabilities, groupId());
+    return toMediaTrackCapabilities(m_capabilities);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/InputDeviceInfo.h
+++ b/Source/WebCore/Modules/mediastream/InputDeviceInfo.h
@@ -38,12 +38,12 @@ struct CaptureDeviceWithCapabilities;
 class InputDeviceInfo final : public MediaDeviceInfo {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(InputDeviceInfo);
 public:
-    static Ref<InputDeviceInfo> create(CaptureDeviceWithCapabilities&& device, String&& saltedDeviceId, String&& saltedGroupId) { return adoptRef(*new InputDeviceInfo(WTFMove(device), WTFMove(saltedDeviceId), WTFMove(saltedGroupId))); }
+    static Ref<InputDeviceInfo> create(CaptureDeviceWithCapabilities&& device) { return adoptRef(*new InputDeviceInfo(WTFMove(device))); }
 
     MediaTrackCapabilities getCapabilities() const;
 
 private:
-    InputDeviceInfo(CaptureDeviceWithCapabilities&&, String&& saltedDeviceId, String&& saltedGroupId);
+    explicit InputDeviceInfo(CaptureDeviceWithCapabilities&&);
 
     RealtimeMediaSourceCapabilities m_capabilities;
 };

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -95,7 +95,6 @@ public:
     MediaTrackSupportedConstraints getSupportedConstraints();
 
     String deviceIdToPersistentId(const String& deviceId) const { return m_audioOutputDeviceIdToPersistentId.get(deviceId); }
-    String hashedGroupId(const String& groupId);
 
     void willStartMediaCapture(bool microphone, bool camera);
 
@@ -131,8 +130,6 @@ private:
     Markable<UserMediaClient::DeviceChangeObserverToken> m_deviceChangeToken;
     const EventNames& m_eventNames; // Need to cache this so we can use it from GC threads.
     bool m_listeningForDeviceChanges { false };
-
-    String m_groupIdHashSalt;
 
     OptionSet<GestureAllowedRequest> m_requestTypesForCurrentGesture;
     WeakPtr<UserGestureToken> m_currentGestureToken;

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -94,13 +94,6 @@ MediaStreamTrack::MediaStreamTrack(ScriptExecutionContext& context, Ref<MediaStr
     ASSERT(isMainThread());
     ASSERT(is<Document>(context));
 
-    auto& settings = m_private->settings();
-    if (settings.supportsGroupId()) {
-        RefPtr window = downcast<Document>(context).domWindow();
-        if (RefPtr mediaDevices = window ? NavigatorMediaDevices::mediaDevices(window->navigator()) : nullptr)
-            m_groupId = mediaDevices->hashedGroupId(settings.groupId());
-    }
-
     m_isInterrupted = m_private->interrupted();
 
     if (m_private->isAudio())
@@ -283,7 +276,7 @@ MediaStreamTrack::TrackSettings MediaStreamTrack::getSettings() const
     if (settings.supportsDeviceId())
         result.deviceId = settings.deviceId();
     if (settings.supportsGroupId())
-        result.groupId = m_groupId;
+        result.groupId = settings.groupId();
     if (settings.supportsDisplaySurface() && settings.displaySurface() != DisplaySurfaceType::Invalid)
         result.displaySurface = RealtimeMediaSourceSettings::displaySurface(settings.displaySurface());
 
@@ -305,7 +298,7 @@ MediaStreamTrack::TrackSettings MediaStreamTrack::getSettings() const
 
 MediaStreamTrack::TrackCapabilities MediaStreamTrack::getCapabilities() const
 {
-    auto result = toMediaTrackCapabilities(m_private->capabilities(), m_groupId);
+    auto result = toMediaTrackCapabilities(m_private->capabilities());
 
     auto settings = m_private->settings();
     if (settings.supportsDisplaySurface() && settings.displaySurface() != DisplaySurfaceType::Invalid)

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -229,7 +229,6 @@ private:
     MediaTrackConstraints m_constraints;
 
     String m_mediaStreamId;
-    String m_groupId;
     State m_readyState { State::Live };
     bool m_muted { false };
     bool m_ended { false };

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp
@@ -107,7 +107,7 @@ static Vector<bool> powerEfficientCapabilityVector(bool powerEfficient)
     return result;
 }
 
-MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabilities& capabilities, const String& groupId)
+MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabilities& capabilities)
 {
     MediaTrackCapabilities result;
     if (capabilities.supportsWidth())
@@ -131,7 +131,7 @@ MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabil
     if (capabilities.supportsDeviceId())
         result.deviceId = capabilities.deviceId();
     if (capabilities.supportsGroupId())
-        result.groupId = groupId;
+        result.groupId = capabilities.groupId();
     if (capabilities.supportsFocusDistance())
         result.focusDistance = capabilityDoubleRange(capabilities.focusDistance());
     if (capabilities.supportsWhiteBalanceMode())

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h
@@ -56,7 +56,7 @@ struct MediaTrackCapabilities {
     std::optional<Vector<bool>> powerEfficient;
 };
 
-MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabilities&, const String& groupId);
+MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabilities&);
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -111,26 +111,26 @@ RealtimeMediaSource::RealtimeMediaSource(const CaptureDevice& device, MediaDevic
     , m_name({ device.label() })
     , m_device(device)
 {
-    initializePersistentId();
+    initializeIds();
 }
 
-RealtimeMediaSource::~RealtimeMediaSource()
-{
-}
+RealtimeMediaSource::~RealtimeMediaSource() = default;
 
 void RealtimeMediaSource::setPersistentId(const String& persistentID)
 {
     m_device.setPersistentId(persistentID);
-    initializePersistentId();
+    initializeIds();
 }
 
-void RealtimeMediaSource::initializePersistentId()
+void RealtimeMediaSource::initializeIds()
 {
     if (m_device.persistentId().isEmpty())
         m_device.setPersistentId(createVersion4UUIDString());
 
     m_hashedID = RealtimeMediaSourceCenter::hashStringWithSalt(m_device.persistentId(), m_idHashSalts.persistentDeviceSalt);
     m_ephemeralHashedID = RealtimeMediaSourceCenter::hashStringWithSalt(m_device.persistentId(), m_idHashSalts.ephemeralDeviceSalt);
+
+    m_hashedGroupId = RealtimeMediaSourceCenter::hashStringWithSalt(m_device.groupId(), m_idHashSalts.ephemeralDeviceSalt);
 }
 
 void RealtimeMediaSource::addAudioSampleObserver(AudioSampleObserver& observer)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -150,6 +150,7 @@ public:
     virtual Ref<RealtimeMediaSource> clone() { return *this; }
 
     const String& hashedId() const;
+    const String& hashedGroupId() const;
     const MediaDeviceHashSalts& deviceIDHashSalts() const;
 
     const String& persistentID() const { return m_device.persistentId(); }
@@ -366,7 +367,7 @@ private:
     virtual double observedFrameRate() const { return 0.0; }
 
     void updateHasStartedProducingData();
-    void initializePersistentId();
+    void initializeIds();
 
 #if !RELEASE_LOG_DISABLED
     RefPtr<const Logger> m_logger;
@@ -379,6 +380,7 @@ private:
     MediaDeviceHashSalts m_idHashSalts;
     String m_hashedID;
     String m_ephemeralHashedID;
+    String m_hashedGroupId;
     Type m_type;
     String m_name;
     WeakHashSet<RealtimeMediaSourceObserver> m_observers;
@@ -469,6 +471,11 @@ inline bool RealtimeMediaSource::isProducingData() const
 
 inline void RealtimeMediaSource::setIsInBackground(bool)
 {
+}
+
+inline const String& RealtimeMediaSource::hashedGroupId() const
+{
+    return m_hashedGroupId;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -131,16 +131,16 @@ void RealtimeMediaSourceCenter::getMediaStreamDevices(CompletionHandler<void(Vec
     });
 }
 
-std::optional<RealtimeMediaSourceCapabilities> RealtimeMediaSourceCenter::getCapabilities(const CaptureDevice& device)
+std::optional<RealtimeMediaSourceCapabilities> RealtimeMediaSourceCenter::getCapabilities(const CaptureDevice& device, const MediaDeviceHashSalts& hashSalts)
 {
     if (device.type() == CaptureDevice::DeviceType::Camera) {
-        auto source = videoCaptureFactory().createVideoCaptureSource({ device },  { "fake"_s, "fake"_s }, nullptr, std::nullopt);
+        auto source = videoCaptureFactory().createVideoCaptureSource(device, MediaDeviceHashSalts { hashSalts }, nullptr, std::nullopt);
         if (!source)
             return std::nullopt;
         return source.source()->capabilities();
     }
     if (device.type() == CaptureDevice::DeviceType::Microphone) {
-        auto source = audioCaptureFactory().createAudioCaptureSource({ device }, { "fake"_s, "fake"_s }, nullptr, std::nullopt);
+        auto source = audioCaptureFactory().createAudioCaptureSource(device, MediaDeviceHashSalts { hashSalts }, nullptr, std::nullopt);
         if (!source)
             return std::nullopt;
         return source.source()->capabilities();

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
@@ -79,7 +79,7 @@ public:
     void createMediaStream(Ref<const Logger>&&, NewMediaStreamHandler&&, MediaDeviceHashSalts&&, CaptureDevice&& audioDevice, CaptureDevice&& videoDevice, const MediaStreamRequest&);
 
     WEBCORE_EXPORT void getMediaStreamDevices(CompletionHandler<void(Vector<CaptureDevice>&&)>&&);
-    WEBCORE_EXPORT std::optional<RealtimeMediaSourceCapabilities> getCapabilities(const CaptureDevice&);
+    WEBCORE_EXPORT std::optional<RealtimeMediaSourceCapabilities> getCapabilities(const CaptureDevice&, const MediaDeviceHashSalts&);
 
     WEBCORE_EXPORT AudioCaptureFactory& audioCaptureFactory();
     WEBCORE_EXPORT void setAudioCaptureFactory(AudioCaptureFactory&);

--- a/Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.cpp
@@ -30,7 +30,7 @@ namespace WebCore {
 
 CaptureSourceOrError MockDisplayCaptureSourceGStreamer::create(const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier> pageIdentifier)
 {
-    auto mockSource = adoptRef(*new MockRealtimeVideoSourceGStreamer(String { device.persistentId() }, AtomString { device.label() }, MediaDeviceHashSalts { hashSalts }, pageIdentifier));
+    auto mockSource = adoptRef(*new MockRealtimeVideoSourceGStreamer(CaptureDevice { String { device.persistentId() }, CaptureDevice::DeviceType::Screen, AtomString { device.label() } }, MediaDeviceHashSalts { hashSalts }, pageIdentifier));
 
     if (constraints) {
         if (auto error = mockSource->applyConstraints(*constraints))

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.h
@@ -31,7 +31,7 @@ namespace WebCore {
 
 class MockRealtimeVideoSourceGStreamer final : public MockRealtimeVideoSource, GStreamerCapturerObserver {
 public:
-    MockRealtimeVideoSourceGStreamer(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, std::optional<PageIdentifier>);
+    MockRealtimeVideoSourceGStreamer(CaptureDevice&&, MediaDeviceHashSalts&&, std::optional<PageIdentifier>);
     ~MockRealtimeVideoSourceGStreamer();
 
     // GStreamerCapturerObserver

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -476,7 +476,7 @@ const RealtimeMediaSourceSettings& AVVideoCaptureSource::settings()
     settings.setWidth(size.width());
     settings.setHeight(size.height());
     settings.setDeviceId(hashedId());
-    settings.setGroupId(captureDevice().groupId());
+    settings.setGroupId(hashedGroupId());
     settings.setBackgroundBlur(!!device().portraitEffectActive);
 
     RealtimeMediaSourceSupportedConstraints supportedConstraints;
@@ -525,6 +525,7 @@ const RealtimeMediaSourceCapabilities& AVVideoCaptureSource::capabilities()
 
     RealtimeMediaSourceCapabilities capabilities(settings().supportedConstraints());
     capabilities.setDeviceId(hashedId());
+    capabilities.setGroupId(hashedGroupId());
 
     AVCaptureDevice *videoDevice = device();
     if ([videoDevice position] == AVCaptureDevicePositionFront)

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -262,6 +262,7 @@ const RealtimeMediaSourceCapabilities& CoreAudioCaptureSource::capabilities()
 
         RealtimeMediaSourceCapabilities capabilities(settings().supportedConstraints());
         capabilities.setDeviceId(hashedId());
+        capabilities.setGroupId(hashedGroupId());
         capabilities.setEchoCancellation(RealtimeMediaSourceCapabilities::EchoCancellation::ReadWrite);
         capabilities.setVolume({ 0.0, 1.0 });
         capabilities.setSampleRate(unit.sampleRateCapacities());
@@ -279,7 +280,7 @@ const RealtimeMediaSourceSettings& CoreAudioCaptureSource::settings()
         settings.setVolume(volume());
         settings.setSampleRate(unit.isRenderingAudio() ? unit.actualSampleRate() : sampleRate());
         settings.setDeviceId(hashedId());
-        settings.setGroupId(captureDevice().groupId());
+        settings.setGroupId(hashedGroupId());
         settings.setLabel(name());
         settings.setEchoCancellation(echoCancellation());
 

--- a/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.h
+++ b/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.h
@@ -48,12 +48,12 @@ class ImageTransferSessionVT;
 class MockRealtimeVideoSourceMac final : public MockRealtimeVideoSource {
 public:
     static Ref<MockRealtimeVideoSource> createForMockDisplayCapturer(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, std::optional<PageIdentifier>);
-    static Ref<MockRealtimeVideoSource> create(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&& salt, std::optional<PageIdentifier> pageIdentifier) { return adoptRef(*new MockRealtimeVideoSourceMac(WTFMove(deviceID), WTFMove(name), WTFMove(salt), WTFMove(pageIdentifier))); }
+    static Ref<MockRealtimeVideoSource> create(CaptureDevice&& device, MediaDeviceHashSalts&& salt, std::optional<PageIdentifier> pageIdentifier) { return adoptRef(*new MockRealtimeVideoSourceMac(WTFMove(device), WTFMove(salt), WTFMove(pageIdentifier))); }
 
     ~MockRealtimeVideoSourceMac();
 
 private:
-    MockRealtimeVideoSourceMac(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, std::optional<PageIdentifier>);
+    MockRealtimeVideoSourceMac(CaptureDevice&&, MediaDeviceHashSalts&&, std::optional<PageIdentifier>);
 
     PlatformLayer* platformLayer() const;
     void updateSampleBuffer() final;

--- a/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm
@@ -53,16 +53,16 @@
 
 namespace WebCore {
 
-CaptureSourceOrError MockRealtimeVideoSource::create(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier> pageIdentifier)
+CaptureSourceOrError MockRealtimeVideoSource::create(CaptureDevice&& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, std::optional<PageIdentifier> pageIdentifier)
 {
 #ifndef NDEBUG
-    auto device = MockRealtimeMediaSourceCenter::mockDeviceWithPersistentID(deviceID);
-    ASSERT(device);
-    if (!device)
+    auto mockDevice = MockRealtimeMediaSourceCenter::mockDeviceWithPersistentID(device.persistentId());
+    ASSERT(mockDevice);
+    if (!mockDevice)
         return CaptureSourceOrError({ "No mock camera device"_s , MediaAccessDenialReason::PermissionDenied });
 #endif
 
-    Ref<RealtimeMediaSource> source = MockRealtimeVideoSourceMac::create(WTFMove(deviceID), WTFMove(name), WTFMove(hashSalts), pageIdentifier);
+    Ref<RealtimeMediaSource> source = MockRealtimeVideoSourceMac::create(WTFMove(device), WTFMove(hashSalts), pageIdentifier);
     if (constraints) {
         if (auto error = source->applyConstraints(*constraints))
             return CaptureSourceOrError(CaptureSourceError { error->invalidConstraint });
@@ -73,11 +73,11 @@ CaptureSourceOrError MockRealtimeVideoSource::create(String&& deviceID, AtomStri
 
 Ref<MockRealtimeVideoSource> MockRealtimeVideoSourceMac::createForMockDisplayCapturer(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&& hashSalts, std::optional<PageIdentifier> pageIdentifier)
 {
-    return adoptRef(*new MockRealtimeVideoSourceMac(WTFMove(deviceID), WTFMove(name), WTFMove(hashSalts), pageIdentifier));
+    return adoptRef(*new MockRealtimeVideoSourceMac({ WTFMove(deviceID), CaptureDevice::DeviceType::Screen, WTFMove(name) }, WTFMove(hashSalts), pageIdentifier));
 }
 
-MockRealtimeVideoSourceMac::MockRealtimeVideoSourceMac(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&& hashSalts, std::optional<PageIdentifier> pageIdentifier)
-    : MockRealtimeVideoSource(WTFMove(deviceID), WTFMove(name), WTFMove(hashSalts), pageIdentifier)
+MockRealtimeVideoSourceMac::MockRealtimeVideoSourceMac(CaptureDevice&& device, MediaDeviceHashSalts&& hashSalts, std::optional<PageIdentifier> pageIdentifier)
+    : MockRealtimeVideoSource(WTFMove(device), WTFMove(hashSalts), pageIdentifier)
 {
 }
 

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
@@ -94,7 +94,7 @@ const RealtimeMediaSourceSettings& MockRealtimeAudioSource::settings()
     if (!m_currentSettings) {
         RealtimeMediaSourceSettings settings;
         settings.setDeviceId(hashedId());
-        settings.setGroupId(captureDevice().groupId());
+        settings.setGroupId(hashedGroupId());
         settings.setVolume(volume());
         settings.setEchoCancellation(echoCancellation());
         settings.setSampleRate(sampleRate());
@@ -128,6 +128,7 @@ const RealtimeMediaSourceCapabilities& MockRealtimeAudioSource::capabilities()
         RealtimeMediaSourceCapabilities capabilities(settings().supportedConstraints());
 
         capabilities.setDeviceId(hashedId());
+        capabilities.setGroupId(hashedGroupId());
         capabilities.setVolume({ 0.0, 1.0 });
         capabilities.setEchoCancellation(RealtimeMediaSourceCapabilities::EchoCancellation::ReadWrite);
         capabilities.setSampleRate({ 44100, 96000 });

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -125,7 +125,7 @@ public:
         if (mock->flags.contains(MockMediaDevice::Flag::Invalid))
             return CaptureSourceOrError({ "Invalid mock camera device"_s, MediaAccessDenialReason::PermissionDenied });
 
-        return MockRealtimeVideoSource::create(String { device.persistentId() }, AtomString { device.label() }, WTFMove(hashSalts), constraints, pageIdentifier);
+        return MockRealtimeVideoSource::create(CaptureDevice { device }, WTFMove(hashSalts), constraints, pageIdentifier);
     }
 
 private:

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
@@ -50,7 +50,7 @@ enum class VideoFrameRotation : uint16_t;
 
 class MockRealtimeVideoSource : public RealtimeVideoCaptureSource, private OrientationNotifier::Observer {
 public:
-    static CaptureSourceOrError create(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, const MediaConstraints*, std::optional<PageIdentifier>);
+    static CaptureSourceOrError create(CaptureDevice&&, MediaDeviceHashSalts&&, const MediaConstraints*, std::optional<PageIdentifier>);
     virtual ~MockRealtimeVideoSource();
 
     static void setIsInterrupted(bool);
@@ -58,7 +58,7 @@ public:
     ImageBuffer* imageBuffer();
 
 protected:
-    MockRealtimeVideoSource(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, std::optional<PageIdentifier>);
+    MockRealtimeVideoSource(CaptureDevice&&, MediaDeviceHashSalts&&, std::optional<PageIdentifier>);
 
     virtual void updateSampleBuffer() = 0;
 
@@ -107,8 +107,8 @@ private:
 
     void delaySamples(Seconds) final;
 
-    bool mockCamera() const { return std::holds_alternative<MockCameraProperties>(m_device.properties); }
-    bool mockDisplay() const { return std::holds_alternative<MockDisplayProperties>(m_device.properties); }
+    bool mockCamera() const { return std::holds_alternative<MockCameraProperties>(m_mockDevice.properties); }
+    bool mockDisplay() const { return std::holds_alternative<MockDisplayProperties>(m_mockDevice.properties); }
     bool mockScreen() const { return mockDisplayType(CaptureDevice::DeviceType::Screen); }
     bool mockWindow() const { return mockDisplayType(CaptureDevice::DeviceType::Window); }
     bool mockDisplayType(CaptureDevice::DeviceType) const;
@@ -165,7 +165,7 @@ private:
     RealtimeMediaSourceSupportedConstraints m_supportedConstraints;
     Color m_fillColor { Color::black };
     Color m_fillColorWithZoom { Color::red };
-    MockMediaDevice m_device;
+    MockMediaDevice m_mockDevice;
     std::optional<VideoPreset> m_preset;
     VideoFrameRotation m_deviceOrientation;
 

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
@@ -177,8 +177,8 @@ private:
     bool wasGrantedAudioAccess(WebCore::FrameIdentifier);
     bool wasGrantedVideoAccess(WebCore::FrameIdentifier);
 
-    void computeFilteredDeviceList(WebCore::FrameIdentifier, bool revealIdsAndLabels, CompletionHandler<void(Vector<WebCore::CaptureDeviceWithCapabilities>&&)>&&);
-    void platformGetMediaStreamDevices(bool revealIdsAndLabels, CompletionHandler<void(Vector<WebCore::CaptureDeviceWithCapabilities>&&)>&&);
+    void computeFilteredDeviceList(WebCore::FrameIdentifier, bool revealIdsAndLabels, WebCore::MediaDeviceHashSalts&&, CompletionHandler<void(Vector<WebCore::CaptureDeviceWithCapabilities>&&, WebCore::MediaDeviceHashSalts&&)>&&);
+    void platformGetMediaStreamDevices(bool revealIdsAndLabels, WebCore::MediaDeviceHashSalts&&, CompletionHandler<void(Vector<WebCore::CaptureDeviceWithCapabilities>&&, WebCore::MediaDeviceHashSalts&&)>&&);
 
     void processUserMediaPermissionRequest();
     void processUserMediaPermissionInvalidRequest(WebCore::MediaConstraintType invalidConstraint);

--- a/Source/WebKit/UIProcess/glib/UserMediaPermissionRequestManagerProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/UserMediaPermissionRequestManagerProxyGLib.cpp
@@ -39,9 +39,9 @@ void UserMediaPermissionRequestManagerProxy::platformValidateUserMediaRequestCon
     });
 }
 
-void UserMediaPermissionRequestManagerProxy::platformGetMediaStreamDevices(bool revealIdsAndLabels, CompletionHandler<void(Vector<CaptureDeviceWithCapabilities>&&)>&& completionHandler)
+void UserMediaPermissionRequestManagerProxy::platformGetMediaStreamDevices(bool revealIdsAndLabels,  MediaDeviceHashSalts&& hashSalts, CompletionHandler<void(Vector<CaptureDeviceWithCapabilities>&&)>&& completionHandler)
 {
-    m_page->legacyMainFrameProcess().protectedConnection()->sendWithAsyncReply(Messages::UserMediaCaptureManager::GetMediaStreamDevices(revealIdsAndLabels), WTFMove(completionHandler));
+    m_page->legacyMainFrameProcess().protectedConnection()->sendWithAsyncReply(Messages::UserMediaCaptureManager::GetMediaStreamDevices(revealIdsAndLabels, hashSalts), WTFMove(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp
@@ -78,14 +78,14 @@ void UserMediaCaptureManager::validateUserMediaRequestConstraints(WebCore::Media
     RealtimeMediaSourceCenter::singleton().validateRequestConstraints(WTFMove(validHandler), WTFMove(invalidHandler), request, WTFMove(deviceIdentifierHashSalts));
 }
 
-void UserMediaCaptureManager::getMediaStreamDevices(bool revealIdsAndLabels, GetMediaStreamDevicesCallback&& completionHandler)
+void UserMediaCaptureManager::getMediaStreamDevices(bool revealIdsAndLabels, WebCore::MediaDeviceHashSalts&& hashSalts, GetMediaStreamDevicesCallback&& completionHandler)
 {
-    RealtimeMediaSourceCenter::singleton().getMediaStreamDevices([completionHandler = WTFMove(completionHandler), revealIdsAndLabels](auto&& devices) mutable {
+    RealtimeMediaSourceCenter::singleton().getMediaStreamDevices([completionHandler = WTFMove(completionHandler), hashSalts = WTFMove(hashSalts), revealIdsAndLabels](auto&& devices) mutable {
         auto devicesWithCapabilities = WTF::compactMap(devices, [&](auto& device) -> std::optional<CaptureDeviceWithCapabilities> {
             RealtimeMediaSourceCapabilities deviceCapabilities;
 
             if (device.isInputDevice()) {
-                auto capabilities = RealtimeMediaSourceCenter::singleton().getCapabilities(device);
+                auto capabilities = RealtimeMediaSourceCenter::singleton().getCapabilities(device, hashSalts);
                 if (!capabilities)
                     return std::nullopt;
 

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h
@@ -68,7 +68,7 @@ private:
     ValidateUserMediaRequestConstraintsCallback m_validateUserMediaRequestConstraintsCallback;
 
     using GetMediaStreamDevicesCallback = CompletionHandler<void(Vector<WebCore::CaptureDeviceWithCapabilities>&&)>;
-    void getMediaStreamDevices(bool revealIdsAndLabels, GetMediaStreamDevicesCallback&&);
+    void retMediaStreamDevices(bool revealIdsAndLabels, WebCore::MediaDeviceHashSalts&&, GetMediaStreamDevicesCallback&&);
 
     CheckedRef<WebProcess> m_process;
 };

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.messages.in
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.messages.in
@@ -26,7 +26,7 @@
 [ExceptionForEnabledBy]
 messages -> UserMediaCaptureManager {
     ValidateUserMediaRequestConstraints(struct WebCore::MediaStreamRequest request, struct WebCore::MediaDeviceHashSalts mediaDeviceIdentifierHashSalts) -> (std::optional<WebCore::MediaConstraintType> invalidConstraint, Vector<WebCore::CaptureDevice> audioDevices, Vector<WebCore::CaptureDevice> videoDevices)
-    GetMediaStreamDevices(bool revealIdsAndLabels) -> (Vector<WebCore::CaptureDeviceWithCapabilities> devices)
+    GetMediaStreamDevices(bool revealIdsAndLabels, struct WebCore::MediaDeviceHashSalts hashSalts) -> (Vector<WebCore::CaptureDeviceWithCapabilities> devices)
 }
 
 #endif


### PR DESCRIPTION
#### 3b2d67eacbd4d42ced80436a5f072168285a5b31
<pre>
Use ephemeral hash for MediaStreamTrack groupId
<a href="https://rdar.apple.com/141814627">rdar://141814627</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=285013">https://bugs.webkit.org/show_bug.cgi?id=285013</a>

Reviewed by NOBODY (OOPS!).

We were previously relying on MediaDevices to hash per document MediaStreamck&apos;s groupIds.
We instead reuse the ephemeral hash salt which are also per document as it simplifies groupId handling.
This way, MediaStreamTrack can directly expose the groupId provided by RealtimeMediaSource.
This allows to simplify some code.
We update exposure of groupId in capabilities as done for deviceId.

* LayoutTests/http/wpt/mediastream/groupId-persistency-expected.txt: Added.
* LayoutTests/http/wpt/mediastream/groupId-persistency.html: Added.
* Source/WebCore/Modules/mediastream/InputDeviceInfo.cpp:
(WebCore::InputDeviceInfo::InputDeviceInfo):
(WebCore::InputDeviceInfo::getCapabilities const):
* Source/WebCore/Modules/mediastream/InputDeviceInfo.h:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::MediaDevices):
(WebCore::MediaDevices::exposeDevices):
(WebCore::MediaDevices::hashedGroupId): Deleted.
* Source/WebCore/Modules/mediastream/MediaDevices.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::MediaStreamTrack):
(WebCore::MediaStreamTrack::getSettings const):
(WebCore::MediaStreamTrack::getCapabilities const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp:
(WebCore::toMediaTrackCapabilities):
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::m_device):
(WebCore::RealtimeMediaSource::setPersistentId):
(WebCore::RealtimeMediaSource::initializeIds):
(WebCore::RealtimeMediaSource::~RealtimeMediaSource): Deleted.
(WebCore::RealtimeMediaSource::initializePersistentId): Deleted.
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::getCapabilities):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::settings):
(WebCore::AVVideoCaptureSource::capabilities):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::capabilities):
(WebCore::CoreAudioCaptureSource::settings):
* Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp:
(WebCore::MockRealtimeAudioSource::settings):
(WebCore::MockRealtimeAudioSource::capabilities):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::capabilities):
(WebCore::MockRealtimeVideoSource::settings):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::platformGetMediaStreamDevices):
(WebKit::UserMediaPermissionRequestManagerProxy::computeFilteredDeviceList):
(WebKit::UserMediaPermissionRequestManagerProxy::enumerateMediaDevicesForFrame):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ba532b6f276bfe62c9340c7f437af35581844f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35996 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86596 "Hash 6ba532b6 for PR 38261 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33071 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9392 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/86596 "Hash 6ba532b6 for PR 38261 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21672 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74643 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/86596 "Hash 6ba532b6 for PR 38261 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1089 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28820 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31491 "Hash 6ba532b6 for PR 38261 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29432 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88029 "Hash 6ba532b6 for PR 38261 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9281 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6615 "Found 1 new test failure: http/wpt/mediarecorder/record-96KHz-sources.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/88029 "Hash 6ba532b6 for PR 38261 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70462 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/88029 "Hash 6ba532b6 for PR 38261 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15666 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14579 "Found 1 new test failure: fast/mediastream/getDisplayMedia-max-constraints5.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/686 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9232 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14768 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9072 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10880 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->