### PR TITLE
Stop using static_cast for AudioProcessor subclasses

### DIFF
--- a/Source/WebCore/Modules/webaudio/BiquadDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/BiquadDSPKernel.h
@@ -60,7 +60,7 @@ public:
 
 private:
     Biquad m_biquad;
-    BiquadProcessor* biquadProcessor() { return static_cast<BiquadProcessor*>(processor()); }
+    BiquadProcessor* biquadProcessor() { return downcast<BiquadProcessor>(processor()); }
 
     // To prevent audio glitches when parameters are changed,
     // dezippering is used to slowly change the parameters.

--- a/Source/WebCore/Modules/webaudio/BiquadFilterNode.h
+++ b/Source/WebCore/Modules/webaudio/BiquadFilterNode.h
@@ -52,7 +52,7 @@ public:
 private:
     explicit BiquadFilterNode(BaseAudioContext&);
 
-    BiquadProcessor* biquadProcessor() { return static_cast<BiquadProcessor*>(processor()); }
+    BiquadProcessor* biquadProcessor() { return downcast<BiquadProcessor>(processor()); }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/BiquadProcessor.h
+++ b/Source/WebCore/Modules/webaudio/BiquadProcessor.h
@@ -70,6 +70,8 @@ public:
     bool shouldUseARate() const { return m_shouldUseARate; }
 
 private:
+    Type processorType() const final { return Type::Biquad; }
+
     BiquadFilterType m_type { BiquadFilterType::Lowpass };
 
     Ref<AudioParam> m_parameter1;
@@ -87,3 +89,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::BiquadProcessor) \
+    static bool isType(const WebCore::AudioProcessor& processor) { return processor.processorType() == WebCore::AudioProcessor::Type::Biquad; } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/webaudio/DelayDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/DelayDSPKernel.h
@@ -64,7 +64,7 @@ private:
     // Temporary buffer used to hold the second sample for interpolation if needed.
     AudioFloatArray m_tempBuffer;
 
-    DelayProcessor* delayProcessor() { return static_cast<DelayProcessor*>(processor()); }
+    DelayProcessor* delayProcessor() { return downcast<DelayProcessor>(processor()); }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/DelayNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DelayNode.cpp
@@ -69,7 +69,7 @@ ExceptionOr<Ref<DelayNode>> DelayNode::create(BaseAudioContext& context, const D
 
 AudioParam& DelayNode::delayTime()
 {
-    return static_cast<DelayProcessor&>(*m_processor).delayTime();
+    return downcast<DelayProcessor>(*m_processor).delayTime();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/DelayProcessor.h
+++ b/Source/WebCore/Modules/webaudio/DelayProcessor.h
@@ -46,7 +46,13 @@ public:
     double maxDelayTime() { return delayTime().maxValue(); }
 
 private:
+    Type processorType() const final { return Type::Delay; }
+
     Ref<AudioParam> m_delayTime;
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::DelayProcessor) \
+    static bool isType(const WebCore::AudioProcessor& processor) { return processor.processorType() == WebCore::AudioProcessor::Type::Delay; } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/webaudio/IIRDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/IIRDSPKernel.h
@@ -41,7 +41,7 @@ public:
     void getFrequencyResponse(unsigned length, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse);
 
 private:
-    IIRProcessor* iirProcessor() { return static_cast<IIRProcessor*>(processor()); }
+    IIRProcessor* iirProcessor() { return downcast<IIRProcessor>(processor()); }
 
     // AudioDSPKernel
     void process(std::span<const float> source, std::span<float> destination) final;

--- a/Source/WebCore/Modules/webaudio/IIRFilterNode.h
+++ b/Source/WebCore/Modules/webaudio/IIRFilterNode.h
@@ -43,7 +43,7 @@ public:
 private:
     IIRFilterNode(BaseAudioContext&, const Vector<double>& feedforward, const Vector<double>& feedback, bool isFilterStable);
 
-    IIRProcessor* iirProcessor() { return static_cast<IIRProcessor*>(processor()); }
+    IIRProcessor* iirProcessor() { return downcast<IIRProcessor>(processor()); }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/IIRProcessor.h
+++ b/Source/WebCore/Modules/webaudio/IIRProcessor.h
@@ -51,6 +51,8 @@ public:
     bool isFilterStable() const { return m_isFilterStable; }
 
 private:
+    Type processorType() const final { return Type::IIR; }
+
     Vector<double> m_feedforward;
     Vector<double> m_feedback;
     bool m_isFilterStable;
@@ -59,3 +61,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::IIRProcessor) \
+    static bool isType(const WebCore::AudioProcessor& processor) { return processor.processorType() == WebCore::AudioProcessor::Type::IIR; } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h
@@ -60,8 +60,8 @@ private:
 
     bool requiresTailProcessing() const final;
 
-    WaveShaperProcessor* waveShaperProcessor() { return static_cast<WaveShaperProcessor*>(processor()); }
-    const WaveShaperProcessor* waveShaperProcessor() const { return static_cast<const WaveShaperProcessor*>(processor()); }
+    WaveShaperProcessor* waveShaperProcessor() { return downcast<WaveShaperProcessor>(processor()); }
+    const WaveShaperProcessor* waveShaperProcessor() const { return downcast<WaveShaperProcessor>(processor()); }
 
     // Oversampling.
     std::unique_ptr<AudioFloatArray> m_tempBuffer;

--- a/Source/WebCore/Modules/webaudio/WaveShaperNode.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperNode.h
@@ -53,8 +53,8 @@ private:
 
     bool propagatesSilence() const final;
 
-    WaveShaperProcessor* waveShaperProcessor() { return static_cast<WaveShaperProcessor*>(processor()); }
-    const WaveShaperProcessor* waveShaperProcessor() const { return static_cast<const WaveShaperProcessor*>(processor()); }
+    WaveShaperProcessor* waveShaperProcessor() { return downcast<WaveShaperProcessor>(processor()); }
+    const WaveShaperProcessor* waveShaperProcessor() const { return downcast<WaveShaperProcessor>(processor()); }
 };
 
 String convertEnumerationToString(WebCore::OverSampleType); // in JSOverSampleType.cpp

--- a/Source/WebCore/Modules/webaudio/WaveShaperProcessor.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperProcessor.h
@@ -65,6 +65,8 @@ public:
     Lock& processLock() const WTF_RETURNS_LOCK(m_processLock) { return m_processLock; }
 
 private:
+    Type processorType() const final { return Type::WaveShaper; }
+
     // m_curve represents the non-linear shaping curve.
     RefPtr<Float32Array> m_curve WTF_GUARDED_BY_LOCK(m_processLock);
 
@@ -75,3 +77,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WaveShaperProcessor) \
+    static bool isType(const WebCore::AudioProcessor& processor) { return processor.processorType() == WebCore::AudioProcessor::Type::WaveShaper; } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/platform/audio/AudioProcessor.h
+++ b/Source/WebCore/platform/audio/AudioProcessor.h
@@ -79,6 +79,9 @@ public:
     virtual double latencyTime() const = 0;
     virtual bool requiresTailProcessing() const = 0;
 
+    enum class Type : uint8_t { Biquad, Delay, IIR, WaveShaper };
+    virtual Type processorType() const = 0;
+
 protected:
     bool m_initialized;
     unsigned m_numberOfChannels;


### PR DESCRIPTION
#### 13a5f1418626f5b784e5189d86d49e8605cf1c56
<pre>
Stop using static_cast for AudioProcessor subclasses
<a href="https://bugs.webkit.org/show_bug.cgi?id=285019">https://bugs.webkit.org/show_bug.cgi?id=285019</a>

Reviewed by Darin Adler.

Stop using static_cast for AudioProcessor subclasses
and use downcast instead.

* Source/WebCore/Modules/webaudio/BiquadDSPKernel.h:
* Source/WebCore/Modules/webaudio/BiquadFilterNode.h:
* Source/WebCore/Modules/webaudio/BiquadProcessor.h:
(isType):
* Source/WebCore/Modules/webaudio/DelayDSPKernel.h:
* Source/WebCore/Modules/webaudio/DelayNode.cpp:
(WebCore::DelayNode::delayTime):
* Source/WebCore/Modules/webaudio/DelayProcessor.h:
(isType):
* Source/WebCore/Modules/webaudio/IIRDSPKernel.h:
* Source/WebCore/Modules/webaudio/IIRFilterNode.h:
* Source/WebCore/Modules/webaudio/IIRProcessor.h:
(isType):
* Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h:
* Source/WebCore/Modules/webaudio/WaveShaperNode.h:
* Source/WebCore/Modules/webaudio/WaveShaperProcessor.h:
(isType):
* Source/WebCore/platform/audio/AudioDSPKernelProcessor.h:

Canonical link: <a href="https://commits.webkit.org/288169@main">https://commits.webkit.org/288169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec28a50f15171dde509dafb3be6442bc2f61819e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82050 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86607 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33082 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9403 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63961 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21681 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74655 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44245 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1098 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28832 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31502 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88040 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9292 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6624 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72330 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70474 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15676 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12717 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9243 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/14779 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9083 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12609 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10891 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->