### PR TITLE
Range.getClientRects should take surrogate pairs into account

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/range-client-rects-surrogate-indexing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/range-client-rects-surrogate-indexing-expected.txt
@@ -1,0 +1,5 @@
+🌠a🌠
+🌠a🌠
+
+PASS Range.getClientRects should correct indexing into trailing surrogates
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/range-client-rects-surrogate-indexing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/range-client-rects-surrogate-indexing.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Range.getClientRects should correct indexing into trailing surrogates</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view-1/#dom-range-getclientrects">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="surrogates">🌠a🌠</div>
+<span id="surrogate">🌠a</span><span id="surrogate2">🌠</span>
+<script>
+  test(function () {
+    const surrogates = document.getElementById("surrogates");
+    const surrogate = document.getElementById("surrogate");
+    const surrogate2 = document.getElementById("surrogate2");
+
+    // test range with one container
+    fullrange = document.createRange();
+    fullrange.setStart(surrogates.firstChild, 0);
+    fullrange.setEnd(surrogates.firstChild, 5);
+
+    range = document.createRange();
+    range.setStart(surrogates.firstChild, 1);
+    range.setEnd(surrogates.firstChild, 5);
+
+    assert_equals(range.getClientRects()[0].width, fullrange.getClientRects()[0].width);
+
+    range.setStart(surrogates.firstChild, 0);
+    range.setEnd(surrogates.firstChild, 4);
+
+    assert_equals(range.getClientRects()[0].width, fullrange.getClientRects()[0].width);
+
+    range.setStart(surrogates.firstChild, 1);
+    range.setEnd(surrogates.firstChild, 4);
+
+    assert_equals(range.getClientRects()[0].width, fullrange.getClientRects()[0].width);
+
+    // test range with two containers
+    fullrange.setStart(surrogate.firstChild, 0);
+    fullrange.setEnd(surrogate2.firstChild, 2);
+
+    range.setStart(surrogate.firstChild, 1);
+    range.setEnd(surrogate2.firstChild, 2);
+
+    assert_equals(range.getClientRects()[0].width, fullrange.getClientRects()[0].width);
+    assert_equals(range.getClientRects()[1].width, fullrange.getClientRects()[1].width);
+
+    range.setStart(surrogate.firstChild, 0);
+    range.setEnd(surrogate2.firstChild, 1);
+
+    assert_equals(range.getClientRects()[0].width, fullrange.getClientRects()[0].width);
+    assert_equals(range.getClientRects()[1].width, fullrange.getClientRects()[1].width);
+
+    range.setStart(surrogate.firstChild, 1);
+    range.setEnd(surrogate2.firstChild, 1);
+
+    assert_equals(range.getClientRects()[0].width, fullrange.getClientRects()[0].width);
+    assert_equals(range.getClientRects()[1].width, fullrange.getClientRects()[1].width);
+  }, "Range.getClientRects should correct indexing into trailing surrogates")
+</script>

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2282,6 +2282,11 @@ static Vector<FloatRect> absoluteRectsForRangeInText(const SimpleRange& range, T
         return { };
 
     auto offsetRange = characterDataOffsetRange(range, node);
+    // Move to surrogate pair start for Range start and past surrogate pair end for Range end in case the trailing surrogate is indexed.
+    if (offsetRange.start < node.data().length() && offsetRange.start && U16_IS_TRAIL(node.data()[offsetRange.start]) && U16_IS_LEAD(node.data()[offsetRange.start - 1]))
+        offsetRange.start--;
+    if (offsetRange.end < node.data().length() && offsetRange.end && U16_IS_TRAIL(node.data()[offsetRange.end]) && U16_IS_LEAD(node.data()[offsetRange.end - 1]))
+        offsetRange.end++;
     auto textQuads = renderer->absoluteQuadsForRange(offsetRange.start, offsetRange.end, behavior);
 
     if (behavior.contains(RenderObject::BoundingRectBehavior::RespectClipping)) {


### PR DESCRIPTION
#### 7d8be0b05d9ea1a501cb3b152033ffb86a6046f6
<pre>
Range.getClientRects should take surrogate pairs into account
<a href="https://bugs.webkit.org/show_bug.cgi?id=285023">https://bugs.webkit.org/show_bug.cgi?id=285023</a>

Reviewed by Ryosuke Niwa.

Add logic to move to surrogate pair start for Range start and past surrogate pair end for Range end in case the trailing surrogate is indexed [1].

[1] <a href="https://drafts.csswg.org/cssom-view-1/#dom-range-getclientrects">https://drafts.csswg.org/cssom-view-1/#dom-range-getclientrects</a>

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/range-client-rects-surrogate-indexing-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/range-client-rects-surrogate-indexing.html: Added.
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::absoluteRectsForRangeInText):

Canonical link: <a href="https://commits.webkit.org/288589@main">https://commits.webkit.org/288589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e77ee3f86e3655b03127b8d21660cc7299d1e5e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88809 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34745 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85822 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65137 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22973 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86783 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76087 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45426 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30300 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33794 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31047 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90187 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7951 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73574 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72797 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18022 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17062 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15764 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2326 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10954 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16426 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10802 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14277 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->