### PR TITLE
Support x86_64 in IPInt

### DIFF
--- a/Source/JavaScriptCore/offlineasm/arm64.rb
+++ b/Source/JavaScriptCore/offlineasm/arm64.rb
@@ -584,7 +584,7 @@ class Sequence
                 /^ci/, /^ti/, "addis", "subis", "mulis", "smulli", "leai", "loadf", "storef", "loadlinkacqi", "storecondreli",
                 /^atomic[a-z]+i$/
                 size = 4
-            when "loadp", "storep", "loadq", "storeq", "loadd", "stored", "lshiftp", "lshiftq", "negp", "negq", "rshiftp", "rshiftq",
+            when "loadp", "storep", "loadq", "storeq", "loadqinc", "loadd", "stored", "lshiftp", "lshiftq", "negp", "negq", "rshiftp", "rshiftq",
                 "urshiftp", "urshiftq", "addp", "addq", "mulp", "mulq", "andp", "andq", "orp", "orq", "subp", "subq", "xorp", "xorq", "addd",
                 "divd", "subd", "muld", "sqrtd", /^bp/, /^bq/, /^btp/, /^btq/, /^cp/, /^cq/, /^tp/, /^tq/, /^bd/,
                 "jmp", "call", "leap", "leaq", "loadlinkacqq", "storecondrelq", /^atomic[a-z]+q$/, "loadv", "storev"
@@ -1011,6 +1011,8 @@ class Instruction
             emitARM64Access("ldr", "ldur", operands[1], operands[0], :ptr)
         when "loadq"
             emitARM64Access("ldr", "ldur", operands[1], operands[0], :quad)
+        when "loadqinc"
+            $asm.puts "ldr #{operands[1].arm64Operand(:quad)}, #{operands[0].arm64Operand(:quad)}, #{operands[2].value}"
         when "storei"
             emitARM64Unflipped("str", operands, :word)
         when "storep"

--- a/Source/JavaScriptCore/offlineasm/instructions.rb
+++ b/Source/JavaScriptCore/offlineasm/instructions.rb
@@ -411,6 +411,7 @@ ARM64_INSTRUCTIONS =
      "pcrtoaddr",   # Address from PC relative offset - adr instruction
      "globaladdr",
      "notq",
+     "loadqinc",
      "loadlinkacqb",
      "loadlinkacqh",
      "loadlinkacqi",

--- a/Source/JavaScriptCore/offlineasm/x86.rb
+++ b/Source/JavaScriptCore/offlineasm/x86.rb
@@ -1293,8 +1293,8 @@ class Instruction
         when "popv"
             operands.each {
                 | op |
-                $asm.puts "movdqu (%esp), #{op.x86Operand(:vector)}"
-                $asm.puts "add $16, %esp"
+                $asm.puts "movdqu (%rsp), #{op.x86Operand(:vector)}"
+                $asm.puts "add $16, %rsp"
             }
         when "push"
             operands.each {
@@ -1304,8 +1304,8 @@ class Instruction
         when "pushv"
             operands.each {
                 | op |
-                $asm.puts "sub $16, %esp"
-                $asm.puts "movdqu #{op.x86Operand(:vector)}, (%esp)"
+                $asm.puts "sub $16, %rsp"
+                $asm.puts "movdqu #{op.x86Operand(:vector)}, (%rsp)"
             }
         when "move"
             handleMove

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -1017,7 +1017,7 @@ WASM_IPINT_EXTERN_CPP_DECL(prepare_call_indirect, CallFrame* callFrame, Wasm::Fu
 
     EncodedJSValue* calleeReturn = std::bit_cast<EncodedJSValue*>(functionIndex);
     EncodedJSValue boxedCallee = CalleeBits::encodeNullCallee();
-    if (!function.m_function.boxedWasmCalleeLoadLocation)
+    if (function.m_function.boxedWasmCalleeLoadLocation)
         boxedCallee = CalleeBits::encodeBoxedNativeCallee(reinterpret_cast<void*>(*function.m_function.boxedWasmCalleeLoadLocation));
     else
         boxedCallee = CalleeBits::encodeNativeCallee(

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -298,7 +298,7 @@ void FuncRefTable::setFunction(uint32_t index, WebAssemblyFunctionBase* function
     slot.m_function = function->importableFunction();
     if (!slot.m_function.targetInstance) {
         // This is a JS function.
-        ASSERT(slot.m_function.boxedWasmCalleeLoadLocation == &Wasm::NullWasmCallee);
+        ASSERT(!*slot.m_function.boxedWasmCalleeLoadLocation);
         slot.m_protectedJSCallee = adoptRef(*new WasmToJSCallee(FunctionSpaceIndex(index), { nullptr, nullptr }));
         slot.m_boxedProtectedJSCallee = CalleeBits::encodeNativeCallee(slot.m_protectedJSCallee.get());
         slot.m_function.boxedWasmCalleeLoadLocation = &slot.m_boxedProtectedJSCallee;

--- a/Tools/lldb/debug_ipint.py
+++ b/Tools/lldb/debug_ipint.py
@@ -15,6 +15,10 @@ if ARCH == 'arm64':
     PC_REG = 'x26'
     MC_REG = 'x25'
     PL_REG = 'x6'
+elif ARCH == 'x64':
+    PC_REG = 'r13'
+    MC_REG = 'r12'
+    PL_REG = 'r10'
 
 # Read all instruction opcodes from InPlaceInterpreter64.asm
 


### PR DESCRIPTION
#### 55d789ff3bf87148459a5bf12aa2b2c5ab547d56
<pre>
Support x86_64 in IPInt
<a href="https://bugs.webkit.org/show_bug.cgi?id=285022">https://bugs.webkit.org/show_bug.cgi?id=285022</a>
<a href="https://rdar.apple.com/141823156">rdar://141823156</a>

Reviewed by Yusuke Suzuki.

Previously, IPInt was not tested on x86_64 systems. This patch fixes a variety of issues
in IPInt on x86_64, mainly register conflicts during calls and fixing loading the address
of labels. This allows IPInt to run on x86_64 systems.

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/offlineasm/x86.rb:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addReturnData):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addArguments):
(JSC::Wasm::gprToIndex):
(JSC::Wasm::IPIntGenerator::addCallCommonData):
(JSC::Wasm::IPIntGenerator::addTailCallCommonData):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmTable.cpp:
(JSC::Wasm::FuncRefTable::setFunction):
* Tools/lldb/debug_ipint.py:

Canonical link: <a href="https://commits.webkit.org/288261@main">https://commits.webkit.org/288261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6f722ab87af8b16315a8530345927e71fc904c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36348 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87413 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9827 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/87413 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21874 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74870 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/87413 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29051 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32383 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75267 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88769 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81335 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9587 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6847 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72520 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71738 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15873 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14883 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/942 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12770 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9540 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15061 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103748 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9414 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25167 "Found 3 new JSC stress test failures: stress/json-stringify-inspector-check.js.no-llint, stress/substring-global-atom-cache.js.lockdown, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12880 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11184 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->