### PR TITLE
font-variant-caps: small-caps options should not apply to Japanese characters

### DIFF
--- a/Source/WTF/wtf/text/CharacterProperties.h
+++ b/Source/WTF/wtf/text/CharacterProperties.h
@@ -28,6 +28,7 @@
 #include <unicode/uchar.h>
 #include <unicode/uscript.h>
 #include <wtf/text/StringCommon.h>
+#include <wtf/text/StringView.h>
 
 namespace WTF {
 
@@ -169,6 +170,17 @@ inline bool isCombiningMark(char32_t character)
     return 0x0300 <= character && character <= 0x036F;
 }
 
+inline bool isJapaneseText(const String& str)
+{
+    StringView textView = str;
+    for (size_t i = 0; i < textView.length(); ++i) {
+        auto ch = textView[i];
+        if ((ch >= 0x4E00 && ch <= 0x9FFF) || (ch >= 0x30A0 && ch <= 0x30FF) || (ch >= 0x4E00 && ch <= 0x9FFF))
+            return true;
+    }
+    return false;
+}
+
 } // namespace WTF
 
 using WTF::isEmojiGroupCandidate;
@@ -189,3 +201,4 @@ using WTF::isEastAsianFullWidth;
 using WTF::isCJKSymbolOrPunctuation;
 using WTF::isFullwidthMiddleDotPunctuation;
 using WTF::isCombiningMark;
+using WTF::isJapaneseText;

--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -315,6 +315,10 @@ void ComplexTextController::collectComplexTextRuns()
     }();
 
     auto fontVariantCaps = m_font.fontDescription().variantCaps();
+    bool isSmallCapsVariant = fontVariantCaps == FontVariantCaps::Small || fontVariantCaps == FontVariantCaps::AllSmall;
+    if (isJapaneseText(m_run.textAsString()) && isSmallCapsVariant)
+        fontVariantCaps = FontVariantCaps::Normal;
+
     bool dontSynthesizeSmallCaps = !m_font.fontDescription().hasAutoFontSynthesisSmallCaps();
     bool engageAllSmallCapsProcessing = fontVariantCaps == FontVariantCaps::AllSmall || fontVariantCaps == FontVariantCaps::AllPetite;
     bool engageSmallCapsProcessing = engageAllSmallCapsProcessing || fontVariantCaps == FontVariantCaps::Small || fontVariantCaps == FontVariantCaps::Petite;

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -382,6 +382,11 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
     auto fontDescription = m_font->fontDescription();
     Ref primaryFont = m_font->primaryFont();
     AdvanceInternalState advanceInternalState(glyphBuffer, primaryFont, textIterator.currentIndex());
+    auto fontVariantCaps = fontDescription.variantCaps();
+    bool isSmallCapsVariant = fontVariantCaps == FontVariantCaps::Small || fontVariantCaps == FontVariantCaps::AllSmall;
+    if (isJapaneseText(run().textAsString()) && isSmallCapsVariant)
+        fontDescription.setVariantCaps(FontVariantCaps::Normal);
+
     SmallCapsState smallCapsState(fontDescription);
 
     char32_t character = 0;


### PR DESCRIPTION
#### 48e639d6e5ccb18dd22a899c96701e7f8f9d50d4
<pre>
font-variant-caps: small-caps options should not apply to Japanese characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=158522">https://bugs.webkit.org/show_bug.cgi?id=158522</a>

Reviewed by NOBODY (OOPS!).

The font-variant-caps: small-caps options should not apply to Japanese characters.
When using small-caps with Japanese text, the normal variant caps should be used for the text.

* Source/WTF/wtf/text/CharacterProperties.h:
(WTF::isJapaneseText):
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::collectComplexTextRuns):
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::advanceInternal):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48e639d6e5ccb18dd22a899c96701e7f8f9d50d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87588 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33516 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64265 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22018 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75016 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44542 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29202 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32557 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75443 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88944 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81509 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9761 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72666 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9987 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70830 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71883 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16022 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15029 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1143 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9714 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15235 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103922 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9588 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25204 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->