### PR TITLE
Implement CSP hash reporting for scripts

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6184,9 +6184,6 @@ imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.
 
 imported/w3c/web-platform-tests/import-maps/ [ DumpJSConsoleLogInStdErr ]
 
-# Imported tests that are timing out because the feature is not yet implemented.
-imported/w3c/web-platform-tests/content-security-policy/report-hash [ Skip ]
-
 # WebKit2 Only
 fullscreen/fullscreen-enter-bottom-padding-animation.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/default-src.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/default-src.https.window-expected.txt
@@ -1,12 +1,10 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Reporting endpoints received hash for same-origin CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/default-src.https.window.html is not found. Reached unreachable code
-FAIL Reporting endpoints received hash for same-origin no-CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/default-src.https.window.html is not found. Reached unreachable code
-TIMEOUT Reporting endpoints received hash for cross-origin CORS script. Test timed out
-NOTRUN Reporting endpoints received no hash for cross-origin no-CORS script.
-NOTRUN Reporting endpoints received the right hash for same-origin CORS script with integrity.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha256.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha512.
-NOTRUN Reporting endpoints received no report for CORS stylesheet.
+PASS Reporting endpoints received hash for same-origin CORS script.
+PASS Reporting endpoints received hash for same-origin no-CORS script.
+PASS Reporting endpoints received hash for cross-origin CORS script.
+PASS Reporting endpoints received no hash for cross-origin no-CORS script.
+PASS Reporting endpoints received the right hash for same-origin CORS script with integrity.
+PASS Reporting endpoints received no report for failed integrity check with sha256.
+PASS Reporting endpoints received no report for failed integrity check with sha512.
+PASS Reporting endpoints received no report for CORS stylesheet.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/default-src.https.window.js.sub.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/default-src.https.window.js.sub.headers
@@ -1,3 +1,3 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy: default-src 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy: default-src 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha256-1XF/E08XndkoxwN6eIa5J89hYn3OVZ/UyB8BrU5jgzk="

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/multiple-policies.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/multiple-policies.https.sub-expected.txt
@@ -1,12 +1,10 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Reporting endpoints received hash for same-origin CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/multiple-policies.https.sub.html is not found. Reached unreachable code
-FAIL Reporting endpoints received hash for same-origin no-CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/multiple-policies.https.sub.html is not found. Reached unreachable code
-TIMEOUT Reporting endpoints received hash for cross-origin CORS script. Test timed out
-NOTRUN Reporting endpoints received no hash for cross-origin no-CORS script.
-NOTRUN Reporting endpoints received the right hash for same-origin CORS script with integrity.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha256.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha512.
-NOTRUN Reporting endpoints received no report for CORS stylesheet.
+PASS Reporting endpoints received hash for same-origin CORS script.
+PASS Reporting endpoints received hash for same-origin no-CORS script.
+PASS Reporting endpoints received hash for cross-origin CORS script.
+PASS Reporting endpoints received no hash for cross-origin no-CORS script.
+PASS Reporting endpoints received the right hash for same-origin CORS script with integrity.
+PASS Reporting endpoints received no report for failed integrity check with sha256.
+PASS Reporting endpoints received no report for failed integrity check with sha512.
+PASS Reporting endpoints received no report for CORS stylesheet.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/multiple-policies.https.sub.html.sub.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/multiple-policies.https.sub.html.sub.headers
@@ -1,7 +1,7 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy: script-src-elem 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy: script-src-elem 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
 Reporting-Endpoints: csp-endpoint2="/reporting/resources/report.py?reportID={{$id2:uuid()}}"
-Content-Security-Policy: script-src-elem 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha512'; report-to csp-endpoint2
+Content-Security-Policy: script-src-elem 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha512'; report-to csp-endpoint2
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha256-1XF/E08XndkoxwN6eIa5J89hYn3OVZ/UyB8BrU5jgzk="
 Server-Timing: uuid2;desc="{{$id2}}",hash2;desc="sha512-hG4x56V5IhUUepZdYU/lX7UOQJ2M7f6ud2EI7os4JV3OwXSZ002P3zkb9tXQkjpOO8UbtjuEufvdcU67Qt2tlw=="
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-default-src.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-default-src.https.window-expected.txt
@@ -1,12 +1,10 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Reporting endpoints received hash for same-origin CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/reportonly-default-src.https.window.html is not found. Reached unreachable code
-FAIL Reporting endpoints received hash for same-origin no-CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/reportonly-default-src.https.window.html is not found. Reached unreachable code
-TIMEOUT Reporting endpoints received hash for cross-origin CORS script. Test timed out
-NOTRUN Reporting endpoints received no hash for cross-origin no-CORS script.
-NOTRUN Reporting endpoints received the right hash for same-origin CORS script with integrity.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha256.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha512.
-NOTRUN Reporting endpoints received no report for CORS stylesheet.
+PASS Reporting endpoints received hash for same-origin CORS script.
+PASS Reporting endpoints received hash for same-origin no-CORS script.
+PASS Reporting endpoints received hash for cross-origin CORS script.
+PASS Reporting endpoints received no hash for cross-origin no-CORS script.
+PASS Reporting endpoints received the right hash for same-origin CORS script with integrity.
+PASS Reporting endpoints received no report for failed integrity check with sha256.
+PASS Reporting endpoints received no report for failed integrity check with sha512.
+PASS Reporting endpoints received no report for CORS stylesheet.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-default-src.https.window.js.sub.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-default-src.https.window.js.sub.headers
@@ -1,3 +1,3 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy-Report-Only: default-src 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy-Report-Only: default-src 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha256-1XF/E08XndkoxwN6eIa5J89hYn3OVZ/UyB8BrU5jgzk="

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src-elem.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src-elem.https.window-expected.txt
@@ -1,12 +1,10 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Reporting endpoints received hash for same-origin CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/reportonly-script-src-elem.https.window.html is not found. Reached unreachable code
-FAIL Reporting endpoints received hash for same-origin no-CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/reportonly-script-src-elem.https.window.html is not found. Reached unreachable code
-TIMEOUT Reporting endpoints received hash for cross-origin CORS script. Test timed out
-NOTRUN Reporting endpoints received no hash for cross-origin no-CORS script.
-NOTRUN Reporting endpoints received the right hash for same-origin CORS script with integrity.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha256.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha512.
-NOTRUN Reporting endpoints received no report for CORS stylesheet.
+PASS Reporting endpoints received hash for same-origin CORS script.
+PASS Reporting endpoints received hash for same-origin no-CORS script.
+PASS Reporting endpoints received hash for cross-origin CORS script.
+PASS Reporting endpoints received no hash for cross-origin no-CORS script.
+PASS Reporting endpoints received the right hash for same-origin CORS script with integrity.
+PASS Reporting endpoints received no report for failed integrity check with sha256.
+PASS Reporting endpoints received no report for failed integrity check with sha512.
+PASS Reporting endpoints received no report for CORS stylesheet.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src-elem.https.window.js.sub.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src-elem.https.window.js.sub.headers
@@ -1,3 +1,3 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy-Report-Only: script-src-elem 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy-Report-Only: script-src-elem 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha256-1XF/E08XndkoxwN6eIa5J89hYn3OVZ/UyB8BrU5jgzk="

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src-none.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src-none.https.window-expected.txt
@@ -1,12 +1,10 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Reporting endpoints received hash for same-origin CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/reportonly-script-src-none.https.window.html is not found. Reached unreachable code
-FAIL Reporting endpoints received hash for same-origin no-CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/reportonly-script-src-none.https.window.html is not found. Reached unreachable code
-TIMEOUT Reporting endpoints received hash for cross-origin CORS script. Test timed out
-NOTRUN Reporting endpoints received no hash for cross-origin no-CORS script.
-NOTRUN Reporting endpoints received the right hash for same-origin CORS script with integrity.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha256.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha512.
-NOTRUN Reporting endpoints received no report for CORS stylesheet.
+PASS Reporting endpoints received hash for same-origin CORS script.
+PASS Reporting endpoints received hash for same-origin no-CORS script.
+PASS Reporting endpoints received hash for cross-origin CORS script.
+PASS Reporting endpoints received no hash for cross-origin no-CORS script.
+PASS Reporting endpoints received the right hash for same-origin CORS script with integrity.
+PASS Reporting endpoints received no report for failed integrity check with sha256.
+PASS Reporting endpoints received no report for failed integrity check with sha512.
+PASS Reporting endpoints received no report for CORS stylesheet.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src-none.https.window.js.sub.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src-none.https.window.js.sub.headers
@@ -1,4 +1,4 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy-Report-Only: script-src 'none' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy-Report-Only: script-src 'none' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha256-1XF/E08XndkoxwN6eIa5J89hYn3OVZ/UyB8BrU5jgzk="
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src.https.window-expected.txt
@@ -1,12 +1,10 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Reporting endpoints received hash for same-origin CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/reportonly-script-src.https.window.html is not found. Reached unreachable code
-FAIL Reporting endpoints received hash for same-origin no-CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/reportonly-script-src.https.window.html is not found. Reached unreachable code
-TIMEOUT Reporting endpoints received hash for cross-origin CORS script. Test timed out
-NOTRUN Reporting endpoints received no hash for cross-origin no-CORS script.
-NOTRUN Reporting endpoints received the right hash for same-origin CORS script with integrity.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha256.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha512.
-NOTRUN Reporting endpoints received no report for CORS stylesheet.
+PASS Reporting endpoints received hash for same-origin CORS script.
+PASS Reporting endpoints received hash for same-origin no-CORS script.
+PASS Reporting endpoints received hash for cross-origin CORS script.
+PASS Reporting endpoints received no hash for cross-origin no-CORS script.
+PASS Reporting endpoints received the right hash for same-origin CORS script with integrity.
+PASS Reporting endpoints received no report for failed integrity check with sha256.
+PASS Reporting endpoints received no report for failed integrity check with sha512.
+PASS Reporting endpoints received no report for CORS stylesheet.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src.https.window.js.sub.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src.https.window.js.sub.headers
@@ -1,3 +1,3 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy-Report-Only: script-src 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy-Report-Only: script-src 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha256-1XF/E08XndkoxwN6eIa5J89hYn3OVZ/UyB8BrU5jgzk="

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/resources/report-hash-test-runner.sub.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/resources/report-hash-test-runner.sub.js
@@ -9,7 +9,7 @@ function find_server_timing(name) {
 }
 
 const ORIGIN = "https://{{host}}:{{ports[https][0]}}";
-const REMOTE_ORIGIN = "https://{{hosts[alt][www]}}:{{ports[https][0]}}";
+const REMOTE_ORIGIN = "https://{{hosts[alt][]}}:{{ports[https][0]}}";
 const endpoint = `${ORIGIN}/reporting/resources/report.py`;
 const id = find_server_timing("uuid");
 const id2 = find_server_timing("uuid2");
@@ -49,6 +49,7 @@ function report_hash_test(url, populate_script_attributes, expected_hash, expect
       script.src = unique_subresource_url;
       populate_script_attributes(script);
       script.addEventListener('load', resolve);
+      script.addEventListener('error', resolve);
       document.head.appendChild(script);
     });
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src-elem.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src-elem.https.window-expected.txt
@@ -1,12 +1,10 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Reporting endpoints received hash for same-origin CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/script-src-elem.https.window.html is not found. Reached unreachable code
-FAIL Reporting endpoints received hash for same-origin no-CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/script-src-elem.https.window.html is not found. Reached unreachable code
-TIMEOUT Reporting endpoints received hash for cross-origin CORS script. Test timed out
-NOTRUN Reporting endpoints received no hash for cross-origin no-CORS script.
-NOTRUN Reporting endpoints received the right hash for same-origin CORS script with integrity.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha256.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha512.
-NOTRUN Reporting endpoints received no report for CORS stylesheet.
+PASS Reporting endpoints received hash for same-origin CORS script.
+PASS Reporting endpoints received hash for same-origin no-CORS script.
+PASS Reporting endpoints received hash for cross-origin CORS script.
+PASS Reporting endpoints received no hash for cross-origin no-CORS script.
+PASS Reporting endpoints received the right hash for same-origin CORS script with integrity.
+PASS Reporting endpoints received no report for failed integrity check with sha256.
+PASS Reporting endpoints received no report for failed integrity check with sha512.
+PASS Reporting endpoints received no report for CORS stylesheet.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src-elem.https.window.js.sub.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src-elem.https.window.js.sub.headers
@@ -1,3 +1,3 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy: script-src-elem 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy: script-src-elem 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha256-1XF/E08XndkoxwN6eIa5J89hYn3OVZ/UyB8BrU5jgzk="

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src-sha512.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src-sha512.https.window-expected.txt
@@ -1,12 +1,10 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Reporting endpoints received hash for same-origin CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/script-src-sha512.https.window.html is not found. Reached unreachable code
-FAIL Reporting endpoints received hash for same-origin no-CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/script-src-sha512.https.window.html is not found. Reached unreachable code
-TIMEOUT Reporting endpoints received hash for cross-origin CORS script. Test timed out
-NOTRUN Reporting endpoints received no hash for cross-origin no-CORS script.
-NOTRUN Reporting endpoints received the right hash for same-origin CORS script with integrity.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha256.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha512.
-NOTRUN Reporting endpoints received no report for CORS stylesheet.
+PASS Reporting endpoints received hash for same-origin CORS script.
+PASS Reporting endpoints received hash for same-origin no-CORS script.
+PASS Reporting endpoints received hash for cross-origin CORS script.
+PASS Reporting endpoints received no hash for cross-origin no-CORS script.
+PASS Reporting endpoints received the right hash for same-origin CORS script with integrity.
+PASS Reporting endpoints received no report for failed integrity check with sha256.
+PASS Reporting endpoints received no report for failed integrity check with sha512.
+PASS Reporting endpoints received no report for CORS stylesheet.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src-sha512.https.window.js.sub.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src-sha512.https.window.js.sub.headers
@@ -1,3 +1,3 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy: script-src 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha512' 'report-sha384' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy: script-src 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha512' 'report-sha384' 'report-sha256'; report-to csp-endpoint
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha512-hG4x56V5IhUUepZdYU/lX7UOQJ2M7f6ud2EI7os4JV3OwXSZ002P3zkb9tXQkjpOO8UbtjuEufvdcU67Qt2tlw=="

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src.https.window-expected.txt
@@ -1,12 +1,10 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Reporting endpoints received hash for same-origin CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/script-src.https.window.html is not found. Reached unreachable code
-FAIL Reporting endpoints received hash for same-origin no-CORS script. assert_unreached: A report of csp-hash from https://localhost:9443/content-security-policy/report-hash/script-src.https.window.html is not found. Reached unreachable code
-TIMEOUT Reporting endpoints received hash for cross-origin CORS script. Test timed out
-NOTRUN Reporting endpoints received no hash for cross-origin no-CORS script.
-NOTRUN Reporting endpoints received the right hash for same-origin CORS script with integrity.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha256.
-NOTRUN Reporting endpoints received no report for failed integrity check with sha512.
-NOTRUN Reporting endpoints received no report for CORS stylesheet.
+PASS Reporting endpoints received hash for same-origin CORS script.
+PASS Reporting endpoints received hash for same-origin no-CORS script.
+PASS Reporting endpoints received hash for cross-origin CORS script.
+PASS Reporting endpoints received no hash for cross-origin no-CORS script.
+PASS Reporting endpoints received the right hash for same-origin CORS script with integrity.
+PASS Reporting endpoints received no report for failed integrity check with sha256.
+PASS Reporting endpoints received no report for failed integrity check with sha512.
+PASS Reporting endpoints received no report for CORS stylesheet.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src.https.window.js.sub.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src.https.window.js.sub.headers
@@ -1,3 +1,3 @@
 Reporting-Endpoints: csp-endpoint="/reporting/resources/report.py?reportID={{$id:uuid()}}"
-Content-Security-Policy: script-src 'self' {{hosts[alt][www]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
+Content-Security-Policy: script-src 'self' {{hosts[alt][]}}:{{ports[https][0]}} 'unsafe-inline' 'report-sha256'; report-to csp-endpoint
 Server-Timing: uuid;desc="{{$id}}",hash;desc="sha256-1XF/E08XndkoxwN6eIa5J89hYn3OVZ/UyB8BrU5jgzk="

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -860,6 +860,9 @@ webkit.org/b/246719 imported/w3c/web-platform-tests/reporting/generateTestReport
 webkit.org/b/246719 imported/w3c/web-platform-tests/reporting/cross-origin-report-no-credentials.https.sub.html [ Failure ]
 webkit.org/b/246719 imported/w3c/web-platform-tests/reporting/cross-origin-reports-isolated.https.sub.html [ Failure ]
 
+# Reports are not being sent, potentially due to issues with WebKitLegacy and https-based WPT
+webkit.org/b/285098 imported/w3c/web-platform-tests/content-security-policy/report-hash/ [ Failure ]
+
 # WebKitLegacy is flaky on reporting API
 webkit.org/b/246350 imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-sends-reports-on-violation.https.sub.html [ Pass Failure ]
 webkit.org/b/246350 imported/w3c/web-platform-tests/content-security-policy/reporting-api/report-to-directive-allowed-in-meta.https.sub.html [ Pass Failure DumpJSConsoleLogInStdErr ]

--- a/Source/WebCore/Modules/reporting/ViolationReportType.h
+++ b/Source/WebCore/Modules/reporting/ViolationReportType.h
@@ -30,6 +30,7 @@ namespace WebCore {
 enum class ViolationReportType : uint8_t {
     COEPInheritenceViolation, // https://html.spec.whatwg.org/multipage/origin.html#queue-a-cross-origin-embedder-policy-inheritance-violation
     CORPViolation, // https://fetch.spec.whatwg.org/#queue-a-cross-origin-embedder-policy-corp-violation-report
+    CSPHashReport,
     ContentSecurityPolicy,
     CrossOriginOpenerPolicy,
     Deprecation, // https://wicg.github.io/deprecation-reporting/

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -185,6 +185,7 @@ void PingLoader::sendViolationReport(LocalFrame& frame, const URL& reportURL, Re
         break;
     case ViolationReportType::COEPInheritenceViolation:
     case ViolationReportType::CORPViolation:
+    case ViolationReportType::CSPHashReport:
     case ViolationReportType::CrossOriginOpenerPolicy:
     case ViolationReportType::Deprecation:
     case ViolationReportType::StandardReportingAPIViolation:

--- a/Source/WebCore/loader/SubresourceIntegrity.cpp
+++ b/Source/WebCore/loader/SubresourceIntegrity.cpp
@@ -29,6 +29,7 @@
 #include "CachedResource.h"
 #include "ResourceCryptographicDigest.h"
 #include "SharedBuffer.h"
+#include "SubresourceLoader.h"
 #include <wtf/text/MakeString.h>
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringParsingBuffer.h>
@@ -159,6 +160,89 @@ static Vector<EncodedResourceCryptographicDigest> strongestMetadataFromSet(Vecto
     }
 
     return result;
+}
+
+static Ref<FormData> createReportFormData(const String& type, const URL& url, const String& userAgent, const Function<void(JSON::Object&)>& populateBody)
+{
+    auto body = JSON::Object::create();
+    populateBody(body);
+
+    // https://www.w3.org/TR/reporting-1/#queue-report, step 2.3.1.
+    auto reportObject = JSON::Object::create();
+    reportObject->setObject("body"_s, WTFMove(body));
+    reportObject->setString("type"_s, type);
+    reportObject->setString("user_agent"_s, userAgent);
+    // The spec allows user agents to delay report sending, in order to reduce impact on the user and potential overhead. See https://www.w3.org/TR/reporting-1/#delivery
+    // Currently we're not taking advantage of that, so setting the `age` to 0 to indicate immediate delivery.
+    reportObject->setInteger("age"_s, 0);
+    reportObject->setInteger("attempts"_s, 0);
+    if (url.isValid())
+        reportObject->setString("url"_s, url.strippedForUseAsReferrer().string);
+
+    auto reportList = JSON::Array::create();
+    reportList->pushObject(reportObject);
+
+    return FormData::create(reportList->toJSONString().utf8());
+}
+
+static String addHashPrefix(ResourceCryptographicDigest::Algorithm algorithm, StringView hash)
+{
+    switch (algorithm) {
+    case ResourceCryptographicDigest::Algorithm::SHA256:
+        return makeString("sha256-"_s, hash);
+    case ResourceCryptographicDigest::Algorithm::SHA384:
+        return makeString("sha384-"_s, hash);
+    case ResourceCryptographicDigest::Algorithm::SHA512:
+        return makeString("sha512-"_s, hash);
+    }
+    ASSERT_NOT_REACHED();
+    return String();
+}
+
+static std::optional<ResourceCryptographicDigest::Algorithm> findStrongestAlgorithm(HashAlgorithmSet algorithmSet)
+{
+    for (int i = ResourceCryptographicDigest::algorithmCount - 1; i >= 0; --i) {
+        uint8_t algorithm = (1 << i);
+        if (algorithmSet & algorithm)
+            return static_cast<ResourceCryptographicDigest::Algorithm>(algorithm);
+    }
+    return std::nullopt;
+}
+
+void reportHashesIfNeeded(const CachedResource& resource)
+{
+    if (!resource.loader() || !resource.loader()->frame() || !resource.loader()->frame()->document())
+        return;
+
+    RefPtr document = resource.loader()->frame()->document();
+    auto csp = document->checkedContentSecurityPolicy();
+    URL documentURL = document->url();
+
+    auto& hashesToReport = csp->hashesToReport();
+    if (hashesToReport.isEmpty())
+        return;
+
+    bool canExposeHashes = isResponseEligible(resource);
+    for (auto& [algorithmSet, fixedEndpoints] : hashesToReport) {
+        auto hashAlgorithm = findStrongestAlgorithm(algorithmSet);
+        if (!hashAlgorithm)
+            return;
+
+        String hash = ""_s;
+        if (canExposeHashes)
+            hash = addHashPrefix(hashAlgorithm.value(), base64EncodeToString(resource.cryptographicDigest(hashAlgorithm.value()).value));
+        Ref report = createReportFormData("csp-hash"_s, documentURL, document->httpUserAgent(), [&](auto& body) {
+            body.setString("documentURL"_s, documentURL.strippedForUseAsReferrer().string);
+            body.setString("subresourceURL"_s, resource.url().strippedForUseAsReferrer().string);
+            body.setString("hash"_s, hash);
+            body.setString("type"_s, "subresource"_s);
+            body.setString("destination"_s, "script"_s);
+        });
+        Vector<String> endpoints;
+        for (auto endpoint : fixedEndpoints)
+            endpoints.append(endpoint);
+        document->sendReportToEndpoints(documentURL, { }, WTFMove(endpoints), WTFMove(report), ViolationReportType::CSPHashReport);
+    }
 }
 
 bool matchIntegrityMetadataSlow(const CachedResource& resource, const String& integrityMetadataList)

--- a/Source/WebCore/loader/SubresourceIntegrity.h
+++ b/Source/WebCore/loader/SubresourceIntegrity.h
@@ -35,14 +35,18 @@ namespace WebCore {
 class CachedResource;
 
 bool matchIntegrityMetadataSlow(const CachedResource&, const String& integrityMetadata);
+void reportHashesIfNeeded(const CachedResource&);
 String integrityMismatchDescription(const CachedResource&, const String& integrityMetadata);
 std::optional<Vector<EncodedResourceCryptographicDigest>> parseIntegrityMetadata(const String& integrityMetadata);
 
 inline bool matchIntegrityMetadata(const CachedResource& resource, const String& integrityMetadata)
 {
-    if (LIKELY(integrityMetadata.isEmpty()))
+    if (LIKELY(integrityMetadata.isEmpty() && !resource.isHashReportingNeeded()))
         return true;
-    return matchIntegrityMetadataSlow(resource, integrityMetadata);
+    bool result = matchIntegrityMetadataSlow(resource, integrityMetadata);
+    if (result)
+        reportHashesIfNeeded(resource);
+    return result;
 }
 
 }

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -197,7 +197,7 @@ public:
     void setLoading(bool b) { m_loading = b; }
     virtual bool stillNeedsLoad() const { return false; }
 
-    SubresourceLoader* loader() { return m_loader.get(); }
+    SubresourceLoader* loader() const { return m_loader.get(); }
 
     bool isImage() const { return type() == Type::ImageResource; }
     // FIXME: CachedRawResource could be a main resource, an audio/video resource, or a raw XHR/icon resource.
@@ -322,6 +322,9 @@ public:
 
     ResourceCryptographicDigest cryptographicDigest(ResourceCryptographicDigest::Algorithm) const;
 
+    void setIsHashReportingNeeded() { m_isHashReportingNeeded = true; }
+    bool isHashReportingNeeded() const { return m_isHashReportingNeeded; }
+
 protected:
     // CachedResource constructor that may be used when the CachedResource can already be filled with response data.
     CachedResource(const URL&, Type, PAL::SessionID, const CookieJar*);
@@ -436,6 +439,7 @@ private:
     bool m_hasUnknownEncoding : 1;
     bool m_switchingClientsToRevalidatedResource : 1 { false };
     bool m_ignoreForRequestCount : 1;
+    bool m_isHashReportingNeeded : 1 { false };
 
 #if ASSERT_ENABLED
     bool m_deleted { false };

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -1189,4 +1189,16 @@ void ContentSecurityPolicy::setInsecureNavigationRequestsToUpgrade(UncheckedKeyH
     m_insecureNavigationRequestsToUpgrade = WTFMove(insecureNavigationRequests);
 }
 
+const HashAlgorithmSetCollection& ContentSecurityPolicy::hashesToReport()
+{
+    if (m_hashesToReport.isEmpty()) {
+        Vector<std::pair<HashAlgorithmSet, FixedVector<String>>> hashesToReport;
+        for (auto& policy : m_policies) {
+            if (auto hash = policy->reportHash())
+                hashesToReport.append(std::make_pair(hash, policy->reportToTokens()));
+        }
+        m_hashesToReport = WTFMove(hashesToReport);
+    }
+    return m_hashesToReport;
+}
 }

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -33,6 +33,7 @@
 #include "SecurityOriginHash.h"
 #include <functional>
 #include <wtf/CheckedPtr.h>
+#include <wtf/FixedVector.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
@@ -86,6 +87,9 @@ enum class AllowTrustedTypePolicy : uint8_t {
     DisallowedName,
     DisallowedDuplicateName,
 };
+
+using HashAlgorithmSet = uint8_t;
+using HashAlgorithmSetCollection = FixedVector<std::pair<HashAlgorithmSet, FixedVector<String>>>;
 
 class ContentSecurityPolicy final : public CanMakeThreadSafeCheckedPtr<ContentSecurityPolicy> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ContentSecurityPolicy, WEBCORE_EXPORT);
@@ -230,6 +234,7 @@ public:
     const String& webAssemblyErrorMessage() const { return m_lastPolicyWebAssemblyDisabledErrorMessage; }
 
     ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension() const { return m_contentSecurityPolicyModeForExtension; }
+    const HashAlgorithmSetCollection& hashesToReport();
 
 private:
     void logToConsole(const String& message, const String& contextURL = String(), const OrdinalNumber& contextLine = OrdinalNumber::beforeFirst(), const OrdinalNumber& contextColumn = OrdinalNumber::beforeFirst(), JSC::JSGlobalObject* = nullptr) const;
@@ -290,6 +295,7 @@ private:
     mutable std::optional<ContentSecurityPolicyResponseHeaders> m_cachedResponseHeaders;
     bool m_isHeaderDelivered { false };
     ContentSecurityPolicyModeForExtension m_contentSecurityPolicyModeForExtension { ContentSecurityPolicyModeForExtension::None };
+    HashAlgorithmSetCollection m_hashesToReport;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -776,4 +776,18 @@ bool ContentSecurityPolicyDirectiveList::shouldReportSample(const String& violat
     return directive && directive->shouldReportSample();
 }
 
+const ContentSecurityPolicySourceListDirective* ContentSecurityPolicyDirectiveList::hashReportDirectiveForScript() const
+{
+    auto* directive = this->operativeDirectiveScript(m_scriptSrcElem.get(), ContentSecurityPolicyDirectiveNames::scriptSrcElem);
+    if (!directive || !directive->reportHash())
+        return nullptr;
+    return directive;
+}
+
+HashAlgorithmSet ContentSecurityPolicyDirectiveList::reportHash() const
+{
+    auto* directive = hashReportDirectiveForScript();
+    return directive ? directive->reportHash() : 0;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
@@ -89,6 +89,7 @@ public:
     const String& webAssemblyDisabledErrorMessage() const { return m_webAssemblyDisabledErrorMessage; }
     bool isReportOnly() const { return m_reportOnly; }
     bool shouldReportSample(const String&) const;
+    HashAlgorithmSet reportHash() const;
     const Vector<String>& reportToTokens() const { return m_reportToTokens; }
     const Vector<String>& reportURIs() const { return m_reportURIs; }
 
@@ -112,6 +113,8 @@ private:
     void applySandboxPolicy(ParsedDirective&&);
     void setUpgradeInsecureRequests(ParsedDirective&&);
     void setBlockAllMixedContentEnabled(ParsedDirective&&);
+
+    const ContentSecurityPolicySourceListDirective* hashReportDirectiveForScript() const;
 
     template <class CSPDirectiveType>
     void setCSPDirective(ParsedDirective&&, std::unique_ptr<CSPDirectiveType>&);

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -336,6 +336,21 @@ template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::
         return source;
     }
 
+    if (skipExactlyIgnoringASCIICase(buffer, "'report-sha256'"_s) && extensionModeAllowsKeywordsForDirective(m_contentSecurityPolicyModeForExtension, m_directiveName)) {
+        m_reportHash |= static_cast<HashAlgorithmSet>(ResourceCryptographicDigest::Algorithm::SHA256);
+        return source;
+    }
+
+    if (skipExactlyIgnoringASCIICase(buffer, "'report-sha384'"_s) && extensionModeAllowsKeywordsForDirective(m_contentSecurityPolicyModeForExtension, m_directiveName)) {
+        m_reportHash |= static_cast<HashAlgorithmSet>(ResourceCryptographicDigest::Algorithm::SHA384);
+        return source;
+    }
+
+    if (skipExactlyIgnoringASCIICase(buffer, "'report-sha512'"_s) && extensionModeAllowsKeywordsForDirective(m_contentSecurityPolicyModeForExtension, m_directiveName)) {
+        m_reportHash |= static_cast<HashAlgorithmSet>(ResourceCryptographicDigest::Algorithm::SHA512);
+        return source;
+    }
+
     if (m_allowNonParserInsertedScripts)
         return source;
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.h
@@ -60,6 +60,8 @@ public:
     bool allowUnsafeHashes() const { return m_allowUnsafeHashes; }
     bool shouldReportSample() const { return m_reportSample; }
 
+    HashAlgorithmSet reportHash() const { return m_reportHash; }
+
 private:
     struct Host {
         StringView value;
@@ -103,6 +105,7 @@ private:
     bool m_allowNonParserInsertedScripts { false };
     bool m_allowUnsafeHashes { false };
     bool m_reportSample { false };
+    HashAlgorithmSet m_reportHash { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.h
@@ -50,6 +50,7 @@ public:
     bool allowWasmEval() const { return m_sourceList.allowWasmEval(); }
     bool allowNonParserInsertedScripts() const { return m_sourceList.allowNonParserInsertedScripts(); }
     bool shouldReportSample() const { return m_sourceList.shouldReportSample(); }
+    HashAlgorithmSet reportHash() const { return m_sourceList.reportHash(); }
 
     OptionSet<ContentSecurityPolicyHashAlgorithm> hashAlgorithmsUsed() const { return m_sourceList.hashAlgorithmsUsed(); }
 


### PR DESCRIPTION
#### 70d6fcb9fc882b766302bdb5116a50f05414383b
<pre>
Implement CSP hash reporting for scripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=285292">https://bugs.webkit.org/show_bug.cgi?id=285292</a>

Reviewed by Darin Adler.

CSP was recently added new `report-sha256`, `report-sha384` and `report-sha512` keywords - <a href="https://github.com/w3c/webappsec-csp/pull/693/files">https://github.com/w3c/webappsec-csp/pull/693/files</a>

These new keywords trigger a new reporting type &quot;hash-report&quot;.
It reports hashes for (same-origin or CORS enabled) scripts that are loaded in the context of the document (regardless of their &quot;integrity&quot; attribute), and sends reports about them.

Those reports enable developers to:

* Create inventory of the scripts running on their page. (critical for PCI-DSS v4 - context.)
* Have certainty that they can enable SRI or CSP hash-based enforcement without breaking their sites. The current PR only covers external scripts. We may want to extend the feature in the future to cover inline scripts, evals, event handlers and javascript URLs.

This PR implements that feature.

* LayoutTests/TestExpectations: Stop skipping the relevant tests.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/default-src.https.window-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/default-src.https.window.js.sub.headers: Avoid domains.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/multiple-policies.https.sub-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/multiple-policies.https.sub.html.sub.headers: Avoid domains.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-default-src.https.window-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-default-src.https.window.js.sub.headers: Avoid domains.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src-elem.https.window-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src-elem.https.window.js.sub.headers: Avoid domains.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src-none.https.window-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src-none.https.window.js.sub.headers: Avoid domains.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src.https.window-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/reportonly-script-src.https.window.js.sub.headers: Avoid domains.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/resources/report-hash-test-runner.sub.js:
(report_hash_test): Avoid domains and add error handling.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src-elem.https.window-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src-elem.https.window.js.sub.headers: Avoid domains.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src-sha512.https.window-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src-sha512.https.window.js.sub.headers: Avoid domains.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src.https.window-expected.txt: progression.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/report-hash/script-src.https.window.js.sub.headers: Avoid domains.
* LayoutTests/platform/mac-wk1/TestExpectations: Expect failures on wk1 - <a href="https://bugs.webkit.org/show_bug.cgi?id=285098.">https://bugs.webkit.org/show_bug.cgi?id=285098.</a>
* Source/WebCore/Modules/reporting/ViolationReportType.h: Add
  CSPHashReport type.
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::notifyFinished): rename
matchIntegrityMetadata call.
* Source/WebCore/dom/LoadableClassicScript.cpp:
(WebCore::LoadableNonModuleScriptBase::notifyFinished): rename
matchIntegrityMetadata call.
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::setCSSStyleSheet): rename
matchIntegrityMetadata call.
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::didFinishLoading): rename
matchIntegrityMetadata call.
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::sendViolationReport): Handle CSPHashReport.
* Source/WebCore/loader/SubresourceIntegrity.cpp:
(WebCore::createReportFormData): Create a report.
(WebCore::addHashPrefix): Add a prefix to the reported value, based on
the algorithm enum value.
(WebCore::findStrongestAlgorithm): Get the strongest algorithm is
a HashAlgorithmSet.
(WebCore::reportHashesIfNeeded): Potentially report hashes for a resource.
(WebCore::matchIntegrityMetadataSlow): implements the
matchIntegrityMetadata logic.
* Source/WebCore/loader/SubresourceIntegrity.h:
(WebCore::matchIntegrityMetadata): Adjust condition and call hash
reporting.
* Source/WebCore/loader/cache/CachedResource.h:
(WebCore::CachedResource::loader const): Make it a const.
(WebCore::CachedResource::setIsHashReportingNeeded): Setter for
isHashReportingNeeded.
(WebCore::CachedResource::isHashReportingNeeded const): Getter for
isHashReportingNeeded.
(WebCore::CachedResource::loader): Deleted.
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource): Set
isHashReportingNeeded on the resource.
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::hashesToReport): Get the hashes to
report from the different CSP policies.
* Source/WebCore/page/csp/ContentSecurityPolicy.h: Define
  HashAlgorithmSet and HashAlgorithmSetCollection.
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::ContentSecurityPolicyDirectiveList::hashReportDirectiveForScript const): Get the directives for script hash reporting.
(WebCore::ContentSecurityPolicyDirectiveList::reportHash const): Return
the HashAlgorithmSet for the script reporting directive.
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h: Add
  reportHash and hashReportDirectiveForScript.
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp:
(WebCore::ContentSecurityPolicySourceList::parseSource): Parse the hash
reporting keywords and set the appropriate algorithms in the
HashAlgorithmSet.
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.h: Add
  a HashAlgorithmSet.
(WebCore::ContentSecurityPolicySourceList::reportHash const): Getter for
the HashAlgorithmSet.
* Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.h:
(WebCore::ContentSecurityPolicySourceListDirective::reportHash const):
Pipe the HashAlgorithmSet from the sourceList.

Canonical link: <a href="https://commits.webkit.org/288506@main">https://commits.webkit.org/288506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/687543b022ebfd4e63ad4a63e106fd33b1552324

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34550 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65001 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22736 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2383 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45288 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2287 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30122 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33598 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89990 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10807 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73436 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71728 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72651 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17981 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16883 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15598 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2131 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10759 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16231 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10605 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14081 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->