### PR TITLE
AX: Fix failing test ax-thread-text-apis/text-marker-with-user-select-none.html

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/text-marker-with-user-select-none-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/text-marker-with-user-select-none-expected.txt
@@ -1,7 +1,7 @@
 This tests that accessibility text markers still work even when user-select:none is set.
 
 PASS: textElement.textMarkerRangeLength(textMarkerRange) === 45
-PASS: "hello test world test hello\nlink to here\ntest" == "hello test world test hello\nlink to here\ntest" === true
+PASS: text == 'hello test world test hello\nlink to here\ntest' === true
 PASS: text === 'h'
 PASS: element.isEqual(textElement.childAtIndex(0)) === true
 

--- a/LayoutTests/accessibility/ax-thread-text-apis/text-marker-with-user-select-none.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/text-marker-with-user-select-none.html
@@ -20,15 +20,13 @@ var output = "This tests that accessibility text markers still work even when us
 if (window.accessibilityController) {
     var textElement = accessibilityController.accessibleElementById("text");
     var textMarkerRange = textElement.textMarkerRangeForElement(textElement);
-    // FIXME: We don't emit newlines for either of the <br>s because they are ignored, causing this length to be wrong.
     output += expect("textElement.textMarkerRangeLength(textMarkerRange)", "45");
 
     var startMarker = textElement.startTextMarkerForTextMarkerRange(textMarkerRange);
     var endMarker = textElement.endTextMarkerForTextMarkerRange(textMarkerRange);
     textMarkerRange = textElement.textMarkerRangeForMarkers(startMarker, endMarker);
     var text = textElement.stringForTextMarkerRange(textMarkerRange);
-    // FIXME: Fails due to the missing <br> newlines mentioned above.
-    output += expect(`"${text}" == "hello test world test hello\\nlink to here\\ntest"`, "true");
+    output += expect("text == 'hello test world test hello\\nlink to here\\ntest'", "true");
 
     var nextMarker = textElement.nextTextMarker(startMarker);
     textMarkerRange = textElement.textMarkerRangeForMarkers(startMarker, nextMarker);


### PR DESCRIPTION
#### feaae839cf8dcd61f9f621ae2f2208c3d41f680c
<pre>
AX: Fix failing test ax-thread-text-apis/text-marker-with-user-select-none.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=285044">https://bugs.webkit.org/show_bug.cgi?id=285044</a>
<a href="https://rdar.apple.com/141844336">rdar://141844336</a>

Reviewed by Chris Fleizach.

ax-thread-text-apis/text-marker-with-user-select-none.html was failing because we used a template string that expanded
into invalid JS syntax, causing an &quot;unexpected EOF&quot; error.

* LayoutTests/accessibility/ax-thread-text-apis/text-marker-with-user-select-none-expected.txt:
* LayoutTests/accessibility/ax-thread-text-apis/text-marker-with-user-select-none.html:

Canonical link: <a href="https://commits.webkit.org/288205@main">https://commits.webkit.org/288205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2868e8c3fd0c2c6c4dd30fd45e98174e56340d8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86697 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33159 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64008 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21738 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74722 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44289 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1161 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28901 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31587 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88132 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9369 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72389 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71609 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17861 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15734 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14649 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9325 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/9171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12690 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10973 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->