### PR TITLE
imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault.html is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.traverseTo() in an iframe with same-document preventDefault in its parent assert_unreached: navigate event should not fire in the iframe, because the traversal was cancelled in the top window Reached unreachable code
+PASS navigation.traverseTo() in an iframe with same-document preventDefault in its parent
 

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
@@ -164,15 +164,6 @@ public:
     WEBCORE_EXPORT void reject(Exception, RejectAsHandled = RejectAsHandled::No);
     WEBCORE_EXPORT void reject(ExceptionCode, const String& = { }, RejectAsHandled = RejectAsHandled::No);
 
-    bool wasRejected() const
-    {
-        auto* lexicalGlobalObject = globalObject();
-        ASSERT(lexicalGlobalObject);
-
-        ASSERT(deferred());
-        return deferred()->status(lexicalGlobalObject->vm()) == JSC::JSPromise::Status::Rejected;
-    }
-
     template<typename Callback>
     void resolveWithCallback(Callback callback)
     {

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -41,6 +41,7 @@ class SerializedScriptValue;
 
 enum class ShouldTreatAsContinuingLoad : uint8_t;
 
+struct NavigationAPIMethodTracker;
 struct StringWithDirection;
 
 class HistoryController final : public CanMakeCheckedPtr<HistoryController> {
@@ -99,7 +100,7 @@ private:
     friend class Page;
     bool shouldStopLoadingForHistoryItem(HistoryItem&) const;
     void goToItem(HistoryItem&, FrameLoadType, ShouldTreatAsContinuingLoad);
-    void goToItemForNavigationAPI(HistoryItem&, FrameLoadType, const String& targetNavigationEntryKey);
+    void goToItemForNavigationAPI(HistoryItem&, FrameLoadType, LocalFrame& triggeringFrame, NavigationAPIMethodTracker*);
 
     void initializeItem(HistoryItem&, RefPtr<DocumentLoader>);
     Ref<HistoryItem> createItem(HistoryItemClient&);

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -389,7 +389,8 @@ public:
         auto completionHandler = std::exchange(m_completionHandler, nullptr);
 
         Ref rootFrame = localFrame->rootFrame();
-        page->goToItemForNavigationAPI(rootFrame, *historyItem, FrameLoadType::IndexedBackForward, m_key);
+        RefPtr upcomingTraverseMethodTracker = localFrame->window()->navigation().upcomingTraverseMethodTracker(m_key);
+        page->goToItemForNavigationAPI(rootFrame, *historyItem, FrameLoadType::IndexedBackForward, *localFrame, upcomingTraverseMethodTracker.get());
 
         completionHandler(ScheduleHistoryNavigationResult::Completed);
     }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -941,12 +941,12 @@ void Page::goToItem(LocalFrame& frame, HistoryItem& item, FrameLoadType type, Sh
     frame.loader().checkedHistory()->goToItem(item, type, shouldTreatAsContinuingLoad);
 }
 
-void Page::goToItemForNavigationAPI(LocalFrame& frame, HistoryItem& item, FrameLoadType type, const String& targetNavigationEntryKey)
+void Page::goToItemForNavigationAPI(LocalFrame& frame, HistoryItem& item, FrameLoadType type, LocalFrame& triggeringFrame, NavigationAPIMethodTracker* tracker)
 {
     ASSERT(frame.isRootFrame());
     if (frame.loader().checkedHistory()->shouldStopLoadingForHistoryItem(item))
         frame.protectedLoader()->stopAllLoadersAndCheckCompleteness();
-    frame.loader().checkedHistory()->goToItemForNavigationAPI(item, type, targetNavigationEntryKey);
+    frame.loader().checkedHistory()->goToItemForNavigationAPI(item, type, triggeringFrame, tracker);
 }
 
 void Page::setGroupName(const String& name)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -213,6 +213,7 @@ struct AXTreeData;
 struct ApplePayAMSUIRequest;
 struct AttributedString;
 struct CharacterRange;
+struct NavigationAPIMethodTracker;
 struct ProcessSyncData;
 struct SimpleRange;
 struct TextRecognitionResult;
@@ -411,7 +412,7 @@ public:
     void setOpenedByDOMWithOpener(bool value) { m_openedByDOMWithOpener = value; }
 
     WEBCORE_EXPORT void goToItem(LocalFrame& rootFrame, HistoryItem&, FrameLoadType, ShouldTreatAsContinuingLoad);
-    void goToItemForNavigationAPI(LocalFrame& rootFrame, HistoryItem&, FrameLoadType, const String& targetNavigationEntryKey);
+    void goToItemForNavigationAPI(LocalFrame& rootFrame, HistoryItem&, FrameLoadType, LocalFrame& triggeringFrame, NavigationAPIMethodTracker*);
 
     WEBCORE_EXPORT void setGroupName(const String&);
     WEBCORE_EXPORT const String& groupName() const;


### PR DESCRIPTION
#### c1305a23bb3a86fbaa930c27caa4b3a4eb2b5222
<pre>
imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=285045">https://bugs.webkit.org/show_bug.cgi?id=285045</a>

Reviewed by Rob Buis.

When doing same-document navigations using the Navigation API, several frames can be
navigated. If the navigation in a parent frame gets aborted (e.g. by the JS calling
`preventDefault()` on the navigate event), we should not proceed with navigations in
subframes and we should reject the finished promise for the overall navigation.

I attempted to implement this in an earlier PR but the logic was flawed and would
prevent us from passing this test. To detect in the navigation in a frame failed,
I used to rely on the Navigation object&apos;s apiMethodTracker finished promise being
rejected or not. However, when `Navigation.traverseTo()` is called in a subframe
and the JS abort the navigation in a parent frame, the parent frame&apos;s navigation
object doesn&apos;t have a apiMethodTracker (the subframe does). As a result, we were
unable to detect that the navigation had been aborted. To make this more robust,
I added a `registerAbortHandler()` member function to Navigation so we can easily
track if the navigation in a given frame was aborted or not, without relying on
the apiMethodTracker&apos;s finished promise.

I also pass the apiMethodTracker to goToItemForNavigationAPI(), so we can
properly reject its finished promise if the navigation is aborted by another
frame. This is expected by the test.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigation-traverseTo-in-iframe-same-document-preventDefault-expected.txt:
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
(WebCore::DeferredPromise::wasRejected const): Deleted.
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::goToItemForNavigationAPI):
* Source/WebCore/loader/HistoryController.h:
* Source/WebCore/loader/NavigationScheduler.cpp:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::rejectFinishedPromise):
(WebCore::Navigation::registerAbortHandler):
(WebCore::Navigation::abortOngoingNavigation):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::goToItemForNavigationAPI):
* Source/WebCore/page/Page.h:

Canonical link: <a href="https://commits.webkit.org/288374@main">https://commits.webkit.org/288374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96214900ba87400f5d83799f70751bd524b47299

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86689 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33155 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64006 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21734 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1261 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74715 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44287 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28894 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31583 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72487 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88121 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9364 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6684 "Found 1 new test failure: http/wpt/mediarecorder/record-96KHz-sources.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72388 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71608 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15732 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14642 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/774 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12821 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9320 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14852 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9163 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12685 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10967 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->