### PR TITLE
[JSC] Suppress Safer CPP Checking report for JSC::VM

### DIFF
--- a/Source/JavaScriptCore/API/JSContextRef.cpp
+++ b/Source/JavaScriptCore/API/JSContextRef.cpp
@@ -73,7 +73,7 @@ JSContextGroupRef JSContextGroupCreate()
 
 JSContextGroupRef JSContextGroupRetain(JSContextGroupRef group)
 {
-    toJS(group)->ref();
+    toJS(group)->refSuppressingSaferCPPChecking();
     return group;
 }
 
@@ -82,7 +82,7 @@ void JSContextGroupRelease(JSContextGroupRef group)
     VM& vm = *toJS(group);
 
     JSLockHolder locker(&vm);
-    vm.deref();
+    vm.derefSuppressingSaferCPPChecking();
 }
 
 static bool internalScriptTimeoutCallback(JSGlobalObject* globalObject, void* callbackPtr, void* callbackData)
@@ -169,7 +169,7 @@ JSGlobalContextRef JSGlobalContextRetain(JSGlobalContextRef ctx)
     JSLockHolder locker(vm);
 
     gcProtect(globalObject);
-    vm.ref();
+    vm.refSuppressingSaferCPPChecking();
     return ctx;
 }
 
@@ -182,7 +182,7 @@ void JSGlobalContextRelease(JSGlobalContextRef ctx)
     bool protectCountIsZero = vm.heap.unprotect(globalObject);
     if (protectCountIsZero)
         vm.heap.reportAbandonedObjectGraph();
-    vm.deref();
+    vm.derefSuppressingSaferCPPChecking();
 }
 
 JSObjectRef JSContextGetGlobalObject(JSContextRef ctx)

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -4394,7 +4394,7 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
         JSLockHolder locker(vm);
         // This is needed because we don't want the worker's main
         // thread to die before its compilation threads finish.
-        vm.deref();
+        vm.derefSuppressingSaferCPPChecking();
     }
 
     return result;

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -79,7 +79,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <wtf/StackPointer.h>
 #include <wtf/Stopwatch.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/UniqueArray.h>
 #include <wtf/text/AdaptiveStringSearcher.h>
@@ -287,7 +287,7 @@ private:
 enum VMIdentifierType { };
 using VMIdentifier = AtomicObjectIdentifier<VMIdentifierType>;
 
-class VM : public ThreadSafeRefCounted<VM>, public DoublyLinkedListNode<VM> {
+class VM : public ThreadSafeRefCountedWithSuppressingSaferCPPChecking<VM>, public DoublyLinkedListNode<VM> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(VM);
 public:
     // WebCore has a one-to-one mapping of threads to VMs;
@@ -1190,5 +1190,36 @@ extern "C" void SYSV_ABI sanitizeStackForVMImpl(VM*);
 JS_EXPORT_PRIVATE void sanitizeStackForVM(VM&);
 
 } // namespace JSC
+
+
+namespace WTF {
+
+// Unfortunately we have a lot of code that uses JSC::VM without locally
+// verifying its lifetime. Safer CPP checker needs to understand JSC::VM's
+// lifetime threaded from JSC entrance. Until that, we explicitly suppress
+// Ref<VM> lifetime checking by using ThreadSafeRefCountedWithSuppressingSaferCPPChecking.
+template<> struct DefaultRefDerefTraits<JSC::VM> {
+    static ALWAYS_INLINE JSC::VM* refIfNotNull(JSC::VM* ptr)
+    {
+        if (LIKELY(ptr))
+            ptr->refSuppressingSaferCPPChecking();
+        return ptr;
+    }
+
+    static ALWAYS_INLINE JSC::VM& ref(JSC::VM& ref)
+    {
+        ref.refSuppressingSaferCPPChecking();
+        return ref;
+    }
+
+    static ALWAYS_INLINE void derefIfNotNull(JSC::VM* ptr)
+    {
+        if (LIKELY(ptr))
+            ptr->derefSuppressingSaferCPPChecking();
+    }
+};
+
+} // namespace WTF
+
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -848,6 +848,7 @@
 		E336674A2722551100259122 /* Int128.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33667492722550900259122 /* Int128.cpp */; };
 		E336BD2F2BAB8A0400E8471C /* CharacterProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = E336BD2E2BAB8A0400E8471C /* CharacterProperties.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E33E83ED2C719900002FBCCD /* simdutf_impl.cpp.h in Headers */ = {isa = PBXBuildFile; fileRef = E33E83EC2C719900002FBCCD /* simdutf_impl.cpp.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E3427B2F2D1636A200919862 /* ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h in Headers */ = {isa = PBXBuildFile; fileRef = E3427B2E2D1636A200919862 /* ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E34745D32945E33700F670F2 /* simdutf_impl.h in Headers */ = {isa = PBXBuildFile; fileRef = E34745D12945E33700F670F2 /* simdutf_impl.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E35702522C9D4CEC009292DE /* simd128.h in Headers */ = {isa = PBXBuildFile; fileRef = E35702502C9D4CEC009292DE /* simd128.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3618AB92AD8C4BA00DA7E43 /* ButterflyArray.h in Headers */ = {isa = PBXBuildFile; fileRef = E3618AB82AD8C4B900DA7E43 /* ButterflyArray.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1837,6 +1838,7 @@
 		E339C163244B4E8700359DA9 /* DataRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DataRef.h; sourceTree = "<group>"; };
 		E33D5F871FBED66700BF625E /* RecursableLambda.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RecursableLambda.h; sourceTree = "<group>"; };
 		E33E83EC2C719900002FBCCD /* simdutf_impl.cpp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = simdutf_impl.cpp.h; sourceTree = "<group>"; };
+		E3427B2E2D1636A200919862 /* ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h; sourceTree = "<group>"; };
 		E34745D12945E33700F670F2 /* simdutf_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = simdutf_impl.h; sourceTree = "<group>"; };
 		E34CD0D022810A020020D299 /* Packed.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Packed.h; sourceTree = "<group>"; };
 		E3538D4C276220880075DA50 /* EmbeddedFixedVector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EmbeddedFixedVector.h; sourceTree = "<group>"; };
@@ -2544,6 +2546,7 @@
 				5311BD5B1EA822F900525281 /* ThreadMessage.cpp */,
 				5311BD591EA81A9600525281 /* ThreadMessage.h */,
 				A8A4733E151A825B004123FF /* ThreadSafeRefCounted.h */,
+				E3427B2E2D1636A200919862 /* ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h */,
 				7B2739DC2624DAAA0040F182 /* ThreadSafetyAnalysis.h */,
 				5C6552BF29423F85008CD0F3 /* ThreadSafeWeakHashSet.h */,
 				5CFF32562925A2EB001050F2 /* ThreadSafeWeakPtr.h */,
@@ -3656,6 +3659,7 @@
 				DD3DC8E227A4BF8E007E5B61 /* ThreadingPrimitives.h in Headers */,
 				DD3DC92227A4BF8E007E5B61 /* ThreadMessage.h in Headers */,
 				DD3DC96927A4BF8E007E5B61 /* ThreadSafeRefCounted.h in Headers */,
+				E3427B2F2D1636A200919862 /* ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h in Headers */,
 				DD3DC97C27A4BF8E007E5B61 /* ThreadSafetyAnalysis.h in Headers */,
 				5C6552C029423F85008CD0F3 /* ThreadSafeWeakHashSet.h in Headers */,
 				5CFF32572925A2EC001050F2 /* ThreadSafeWeakPtr.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -322,6 +322,7 @@ set(WTF_PUBLIC_HEADERS
     ThreadMessage.h
     ThreadSafetyAnalysis.h
     ThreadSafeRefCounted.h
+    ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
     ThreadSafeWeakHashSet.h
     ThreadSafeWeakPtr.h
     ThreadSanitizerSupport.h

--- a/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
+++ b/Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2007, 2008, 2010, 2013, 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2007 Justin Haygood (jhaygood@reaktix.com)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace WTF {
+
+// FIXME: Safer CPP Checking cannot perform analysis globally, and it does not work well
+// with some of lifetime model, in particular JSC::VM which is retained before entering
+// JSC world. This class is introduced to suppress these warnings since it does not use
+// ref / deref functions. Except for the function names, implementation is the copy of
+// ThreadSafeRefCounted. We would like to drop this class once Safer CPP Checking supports
+// suppression mechanism for the classes which cannot be handled well with the checker, or
+// the checker introduces a solution which works well with JSC::VM.
+class ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase {
+    WTF_MAKE_NONCOPYABLE(ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase);
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase() = default;
+
+#if CHECK_THREAD_SAFE_REF_COUNTED_LIFECYCLE
+    ~ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase();
+#endif
+
+    void refSuppressingSaferCPPChecking() const
+    {
+        applyRefDuringDestructionCheck();
+
+        ++m_refCount;
+    }
+
+    bool hasOneRef() const
+    {
+        return refCount() == 1;
+    }
+
+    unsigned refCount() const
+    {
+        return m_refCount;
+    }
+
+protected:
+    // Returns whether the pointer should be freed or not.
+    bool derefBaseWithoutDeletionCheck() const
+    {
+        ASSERT(m_refCount);
+
+        if (UNLIKELY(!--m_refCount)) {
+            // Setting m_refCount to 1 here prevents double delete within the destructor but not from another thread
+            // since such a thread could have ref'ed this object long after it had been deleted. See webkit.org/b/201576.
+            m_refCount = 1;
+#if CHECK_THREAD_SAFE_REF_COUNTED_LIFECYCLE
+            m_deletionHasBegun = true;
+#endif
+            return true;
+        }
+
+        return false;
+    }
+
+    // Returns whether the pointer should be freed or not.
+    bool derefBase() const
+    {
+        return derefBaseWithoutDeletionCheck();
+    }
+
+    void applyRefDuringDestructionCheck() const
+    {
+#if CHECK_THREAD_SAFE_REF_COUNTED_LIFECYCLE
+        if (!m_deletionHasBegun)
+            return;
+        RefCountedBase::logRefDuringDestruction(this);
+#endif
+    }
+
+private:
+    mutable std::atomic<unsigned> m_refCount { 1 };
+
+#if ASSERT_ENABLED
+    // Match the layout of RefCounted, which has flag bits for threading checks.
+    UNUSED_MEMBER_VARIABLE bool m_unused1;
+    UNUSED_MEMBER_VARIABLE bool m_unused2;
+#endif
+
+#if CHECK_THREAD_SAFE_REF_COUNTED_LIFECYCLE
+    mutable std::atomic<bool> m_deletionHasBegun { false };
+    // Match the layout of RefCounted.
+    UNUSED_MEMBER_VARIABLE bool m_unused3;
+#endif
+};
+
+#if CHECK_THREAD_SAFE_REF_COUNTED_LIFECYCLE
+inline ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase::~ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase()
+{
+    // When this ThreadSafeRefCountedWithSuppressingSaferCPPChecking object is a part of another object, derefBase() is never called on this object.
+    m_deletionHasBegun = true;
+
+    // FIXME: Test performance, then add a RELEASE_ASSERT for this too.
+    if (m_refCount != 1)
+        RefCountedBase::printRefDuringDestructionLogAndCrash(this);
+}
+#endif
+
+template<class T, DestructionThread destructionThread = DestructionThread::Any> class ThreadSafeRefCountedWithSuppressingSaferCPPChecking : public ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase {
+public:
+    void derefSuppressingSaferCPPChecking() const
+    {
+        if (!derefBase())
+            return;
+
+        if constexpr (destructionThread == DestructionThread::Any) {
+            delete static_cast<const T*>(this);
+        } else if constexpr (destructionThread == DestructionThread::Main) {
+            ensureOnMainThread([this] {
+                delete static_cast<const T*>(this);
+            });
+        } else if constexpr (destructionThread == DestructionThread::MainRunLoop) {
+            ensureOnMainRunLoop([this] {
+                delete static_cast<const T*>(this);
+            });
+        } else
+            STATIC_ASSERT_NOT_REACHED_FOR_VALUE(destructionThread, "Unexpected destructionThread enumerator value");
+    }
+
+protected:
+    ThreadSafeRefCountedWithSuppressingSaferCPPChecking() = default;
+};
+
+} // namespace WTF
+
+using WTF::ThreadSafeRefCountedWithSuppressingSaferCPPChecking;


### PR DESCRIPTION
#### 2753fb281412cc9fb004ec07c07c27c4f5c592d7
<pre>
[JSC] Suppress Safer CPP Checking report for JSC::VM
<a href="https://bugs.webkit.org/show_bug.cgi?id=285050">https://bugs.webkit.org/show_bug.cgi?id=285050</a>
<a href="https://rdar.apple.com/141847850">rdar://141847850</a>

Reviewed by Geoffrey Garen.

Safer CPP Checking cannot understand the lifetime modeling of JSC::VM:
JSC::VM is retained before entering JSC world, and inside JSC world, it
should be seen as always alive. Appropriate checking requires threading
lifetime information from the entrance of the JSC world, and it is not
done. As a result, the checker is reporting errors which is against how
JSC works.

This patch integrates a workaround class ThreadSafeRefCountedWithSuppressingSaferCPPChecking,
which uses refSuppressingSaferCPPChecking / derefSuppressingSaferCPPChecking instead of ref / deref,
so that it suppresses the checkers since checker uses ref / deref function names.
The implementation is copy of ThreadSafeRefCounted right now. But once
checker supports suppression mechanism, we will use it instead. Or once
checker understands how JSC::VM&apos;s lifetime management works, we do not
need suppression.

* Source/JavaScriptCore/API/JSContextRef.cpp:
(JSContextGroupRetain):
(JSContextGroupRelease):
(JSGlobalContextRetain):
(JSGlobalContextRelease):
* Source/JavaScriptCore/jsc.cpp:
(runJSC):
* Source/JavaScriptCore/runtime/VM.h:
(WTF::DefaultRefDerefTraits&lt;JSC::VM&gt;::refIfNotNull):
(WTF::DefaultRefDerefTraits&lt;JSC::VM&gt;::ref):
(WTF::DefaultRefDerefTraits&lt;JSC::VM&gt;::derefIfNotNull):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/ThreadSafeRefCountedWithSuppressingSaferCPPChecking.h: Added.
(WTF::ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase::refSuppressingSaferCPPChecking const):
(WTF::ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase::hasOneRef const):
(WTF::ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase::refCount const):
(WTF::ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase::derefBaseWithoutDeletionCheck const):
(WTF::ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase::derefBase const):
(WTF::ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase::applyRefDuringDestructionCheck const):
(WTF::ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase::~ThreadSafeRefCountedWithSuppressingSaferCPPCheckingBase):
(WTF::ThreadSafeRefCountedWithSuppressingSaferCPPChecking::derefSuppressingSaferCPPChecking const):

Canonical link: <a href="https://commits.webkit.org/288213@main">https://commits.webkit.org/288213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c4cad0433d0d09f241986728cb207ff824a5930

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86715 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33165 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64011 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21744 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44292 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1167 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28905 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31604 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75110 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29519 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88141 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81182 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9377 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6691 "Found 2 new test failures: http/tests/security/contentSecurityPolicy/connect-src-star-websocket-allowed.html http/wpt/mediarecorder/MediaRecorder-video-h264-profiles.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72393 "Found 7 new test failures: imported/w3c/web-platform-tests/css/css-animations/translation-animation-subpixel-offset.html imported/w3c/web-platform-tests/css/css-transforms/animation/rotate-animation-with-will-change-transform-001.html imported/w3c/web-platform-tests/css/css-transforms/animation/scale-and-rotate-both-specified-on-animation-keyframes.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-translate-em.html imported/w3c/web-platform-tests/css/css-transforms/animation/translate-percent-with-width-and-height-separate.html imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-pseudo-class-match.html imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-match-early-mutation.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9565 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71613 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15742 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14650 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12744 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9332 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14862 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103594 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9179 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25137 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12697 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10979 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->