### PR TITLE
SVG elements with display: contents is visually hidden

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3497,7 +3497,6 @@ webkit.org/b/186045 imported/w3c/web-platform-tests/css/css-animations/animation
 
 webkit.org/b/157477 imported/w3c/web-platform-tests/css/css-display/display-contents-dynamic-table-001-inline.html [ ImageOnlyFailure ]
 webkit.org/b/157477 imported/w3c/web-platform-tests/css/css-display/display-contents-first-letter-002.html [ ImageOnlyFailure ]
-webkit.org/b/157477 imported/w3c/web-platform-tests/css/css-display/display-contents-svg-elements.html [ ImageOnlyFailure ]
 
 ### END OF display: contents failures
 ########################################

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3500,7 +3500,6 @@ webkit.org/b/186045 imported/w3c/web-platform-tests/css/css-animations/animation
 
 webkit.org/b/157477 imported/w3c/web-platform-tests/css/css-display/display-contents-dynamic-table-001-inline.html [ ImageOnlyFailure ]
 webkit.org/b/157477 imported/w3c/web-platform-tests/css/css-display/display-contents-first-letter-002.html [ ImageOnlyFailure ]
-webkit.org/b/157477 imported/w3c/web-platform-tests/css/css-display/display-contents-svg-elements.html [ ImageOnlyFailure ]
 
 ### END OF display: contents failures
 ########################################

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-anchor-child-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-anchor-child-expected.txt
@@ -1,3 +1,4 @@
+Text
 
 PASS Loading this page should not cause a crash.
 

--- a/LayoutTests/svg/css/display-computed-expected.txt
+++ b/LayoutTests/svg/css/display-computed-expected.txt
@@ -13,5 +13,5 @@ PASS svg:g display table
 PASS svg:svg display table-cell
 PASS svg:g display table-cell
 PASS svg:svg display contents computes to none
-FAIL svg:g display contents computes to contents assert_equals: expected "contents" but got "none"
+PASS svg:g display contents computes to contents
 

--- a/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGObject.cpp
@@ -365,24 +365,26 @@ AccessibilityRole AccessibilitySVGObject::determineAccessibilityRole()
     if (m_ariaRole != AccessibilityRole::Unknown)
         return m_ariaRole;
 
+    RefPtr element = this->element();
+    if (is<SVGGElement>(element)) {
+        // https://w3c.github.io/svg-aam/#include_elements
+        // g elements are generic (like a div) unless they have a name or is focusable.
+        // Evaluated before the renderer check so display:contents <g> still exposes its role.
+        if (WebCore::hasAccNameAttribute(*element) || hasTitleOrDescriptionChild() || canSetFocusAttribute())
+            return AccessibilityRole::Group;
+        return AccessibilityRole::Generic;
+    }
+
     if (!m_renderer)
         return AccessibilityRole::Unknown;
 
     if (isAccessibilitySVGRoot())
         return AccessibilityRole::Generic;
 
-    RefPtr element = this->element();
     if (m_renderer->isRenderOrLegacyRenderSVGShape() || m_renderer->isRenderOrLegacyRenderSVGPath() || m_renderer->isRenderOrLegacyRenderSVGImage() || is<SVGUseElement>(element))
         return AccessibilityRole::Image;
     if (m_renderer->isRenderOrLegacyRenderSVGForeignObject())
         return AccessibilityRole::Generic;
-    if (is<SVGGElement>(element)) {
-        // https://w3c.github.io/svg-aam/#include_elements
-        // g elements are generic (like a div) unless they have a name or is focusable.
-        if (WebCore::hasAccNameAttribute(*element) || hasTitleOrDescriptionChild() || canSetFocusAttribute())
-            return AccessibilityRole::Group;
-        return AccessibilityRole::Generic;
-    }
     if (m_renderer->isRenderSVGInlineText())
         return AccessibilityRole::StaticText;
     if (m_renderer->isRenderSVGText())

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -816,10 +816,16 @@ static bool NODELETE hasEffectiveDisplayNoneForDisplayContents(const Element& el
 {
     using namespace ElementNames;
 
+    // According to the CSS Display spec[1], nested <svg> elements, <g>,
+    // <use>, and <tspan> elements are not rendered and their children are
+    // "hoisted". For other elements display:contents behaves as display:none.
     // https://drafts.csswg.org/css-display-3/#unbox-svg
-    // FIXME: <g>, <use> and <tspan> have special (?) behavior for display:contents in the current draft spec.
-    if (is<SVGElement>(element))
-        return true;
+    if (RefPtr svgElement = dynamicDowncast<SVGElement>(element)) {
+        bool isOutermostSVG = svgElement->isOutermostSVGSVGElement();
+        if (isOutermostSVG || (!svgElement->hasTagName(SVGNames::svgTag) && !svgElement->hasTagName(SVGNames::tspanTag) && !svgElement->hasTagName(SVGNames::gTag) && !svgElement->hasTagName(SVGNames::useTag)))
+            return true;
+        return false;
+    }
 #if ENABLE(MATHML)
     // Not sure MathML code can handle it.
     if (is<MathMLElement>(element))

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  * Copyright (C) 2004-2005 Allan Sandfeld Jensen (kde@carewolf.com)
  * Copyright (C) 2006, 2007 Nicholas Shanks (webkit@nickshanks.com)
- * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Alexey Proskuryakov <ap@webkit.org>
  * Copyright (C) 2007, 2008 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
@@ -812,10 +812,16 @@ static bool NODELETE hasEffectiveDisplayNoneForDisplayContents(const Element& el
 {
     using namespace ElementNames;
 
+    // According to the CSS Display spec[1], nested <svg> elements, <g>,
+    // <use>, and <tspan> elements are not rendered and their children are
+    // "hoisted". For other elements display:contents behaves as display:none.
     // https://drafts.csswg.org/css-display-3/#unbox-svg
-    // FIXME: <g>, <use> and <tspan> have special (?) behavior for display:contents in the current draft spec.
-    if (is<SVGElement>(element))
-        return true;
+    if (auto* svgElement = dynamicDowncast<SVGElement>(element)) {
+        bool isOutermostSVG = svgElement->isOutermostSVGSVGElement();
+        if (isOutermostSVG || (!svgElement->hasTagName(SVGNames::svgTag) && !svgElement->hasTagName(SVGNames::tspanTag) && !svgElement->hasTagName(SVGNames::gTag) && !svgElement->hasTagName(SVGNames::useTag)))
+            return true;
+        return false;
+    }
 #if ENABLE(MATHML)
     // Not sure MathML code can handle it.
     if (is<MathMLElement>(element))

--- a/Source/WebCore/svg/SVGGElement.cpp
+++ b/Source/WebCore/svg/SVGGElement.cpp
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 2004, 2005, 2007, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+* Copyright (C) 2017 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -69,6 +70,8 @@ RenderPtr<RenderElement> SVGGElement::createElementRenderer(RenderStyle&& style,
     // We still have to create renderers for the <g> & <linearGradient> element, though the
     // subtree may be hidden - we only want the resource renderers to exist so they can be
     // referenced from somewhere else.
+    if (style.display() == Style::DisplayType::Contents)
+        return nullptr;
     if (style.display() == Style::DisplayType::None)
         return createRenderer<LegacyRenderSVGHiddenContainer>(RenderObject::Type::LegacySVGHiddenContainer, *this, WTF::move(style));
     return createRenderer<LegacyRenderSVGTransformableContainer>(*this, WTF::move(style));

--- a/Source/WebCore/svg/SVGGElement.cpp
+++ b/Source/WebCore/svg/SVGGElement.cpp
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 2004, 2005, 2007, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2026 Apple Inc. All rights reserved.
+* Copyright (C) 2017 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -69,6 +70,8 @@ RenderPtr<RenderElement> SVGGElement::createElementRenderer(RenderStyle&& style,
     // We still have to create renderers for the <g> & <linearGradient> element, though the
     // subtree may be hidden - we only want the resource renderers to exist so they can be
     // referenced from somewhere else.
+    if (style.display() == Style::DisplayType::Contents)
+        return nullptr;
     if (style.display() == Style::DisplayType::None)
         return createRenderer<LegacyRenderSVGHiddenContainer>(RenderObject::Type::LegacySVGHiddenContainer, *this, WTF::move(style));
     return createRenderer<LegacyRenderSVGTransformableContainer>(*this, WTF::move(style));

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -326,6 +326,8 @@ RefPtr<SVGElement> SVGUseElement::targetClone() const
 
 RenderPtr<RenderElement> SVGUseElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
+    if (style.display() == DisplayType::Contents)
+        return nullptr;
     if (document().settings().layerBasedSVGEngineEnabled())
         return createRenderer<RenderSVGTransformableContainer>(*this, WTF::move(style));
     return createRenderer<LegacyRenderSVGTransformableContainer>(*this, WTF::move(style));

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -5,7 +5,7 @@
  * Copyright (C) 2011 Torch Mobile (Beijing) Co. Ltd. All rights reserved.
  * Copyright (C) 2012 University of Szeged
  * Copyright (C) 2012 Renata Hodovan <reni@webkit.org>
- * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2015-2019 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -325,6 +325,8 @@ RefPtr<SVGElement> SVGUseElement::targetClone() const
 
 RenderPtr<RenderElement> SVGUseElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
+    if (style.display() == Style::DisplayType::Contents)
+        return nullptr;
     if (document().settings().layerBasedSVGEngineEnabled())
         return createRenderer<RenderSVGTransformableContainer>(*this, WTF::move(style));
     return createRenderer<LegacyRenderSVGTransformableContainer>(*this, WTF::move(style));


### PR DESCRIPTION
#### efc9437044b6b399b798750f85b916b47a6589ef
<pre>
SVG elements with display: contents is visually hidden
<a href="https://bugs.webkit.org/show_bug.cgi?id=284634">https://bugs.webkit.org/show_bug.cgi?id=284634</a>
<a href="https://rdar.apple.com/141825746">rdar://141825746</a>

Reviewed by Simon Fraser and Tyler Wilcock.

This patch aligns WebKit with Blink / Chromium and Web Specification [1]:

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/829633">https://chromium-review.googlesource.com/c/chromium/src/+/829633</a>

According to the CSS Display Specification [1], nested `svg` elements, `g`,
`use`, and `tspan` elements are not rendered and their children are
&quot;hoisted&quot;. For other elements display:contents behaves as display:none.

[1] <a href="https://drafts.csswg.org/css-display-3/#unbox-svg">https://drafts.csswg.org/css-display-3/#unbox-svg</a>

* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::hasEffectiveDisplayNoneForDisplayContents):
* Source/WebCore/svg/SVGGElement.cpp:
(WebCore::SVGGElement::createElementRenderer):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::createElementRenderer):

&gt; Accessibility Specific Fix:
* Source/WebCore/accessibility/AccessibilitySVGObject.cpp:
(WebCore::AccessibilitySVGObject::determineAccessibilityRole):

AccessibilitySVGObject::determineAccessibilityRole() bailed out with
AccessibilityRole::Unknown whenever m_renderer was null, which masked
the role of display:contents SVG elements that no longer create
renderers under the unbox-svg rules. The &lt;g&gt; branch only reads from
the DOM element (aria-label/title/desc/focusability), so move it
above the renderer-null check so a display:contents &lt;g&gt; still
resolves to Group (when it carries a name) or Generic. This fixes
the &apos;g element with display: contents, as child of svg, is labelled
via title element&apos; subtest in display-contents-role-and-label.html.

* LayoutTests/TestExpectations: Progression
* LayoutTests/svg/css/display-computed-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-anchor-child-expected.txt: Rebased

Canonical link: <a href="https://commits.webkit.org/314079@main">https://commits.webkit.org/314079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edca7e8f4335e3f4e076b31c9ba65994f92d58f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121947 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eb168b4d-b1ba-48d9-a507-59eac3fb2757) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127986 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90089 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb1d65a3-6d05-414d-b4bc-e0e1707f0291) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108531 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d794a5c-a9c3-42ac-8de9-fdeab74116d4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29334 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27958 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21488 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139238 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176253 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29077 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27411 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136304 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38248 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32082 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136266 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36798 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147537 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101122 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31538 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24393 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37446 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110490 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36844 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2628 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37092 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36992 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->