### PR TITLE
Reduce use of memcpy() in WebCore/Modules

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp
@@ -30,6 +30,7 @@
 
 #include "SFrameUtils.h"
 #include <wtf/Algorithms.h>
+#include <wtf/StdLibExtras.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -39,10 +40,10 @@ namespace WebCore {
 static constexpr unsigned AES_CM_128_HMAC_SHA256_NONCE_SIZE = 12;
 #endif
 
-static inline void writeUInt64(uint8_t* data, uint64_t value, uint8_t valueLength)
+static inline void writeUInt64(std::span<uint8_t> data, uint64_t value, uint8_t valueLength)
 {
     for (unsigned i = 0; i < valueLength; ++i)
-        *data++ = (value >> ((valueLength - 1 - i) * 8)) & 0xff;
+        data[i] = (value >> ((valueLength - 1 - i) * 8)) & 0xff;
 }
 
 static inline uint64_t readUInt64(std::span<const uint8_t> data)
@@ -310,17 +311,17 @@ RTCRtpSFrameTransformer::TransformResult RTCRtpSFrameTransformer::encryptFrame(s
     if (prefixBufferSpan.size())
         memcpySpan(transformedData.mutableSpan(), prefixBufferSpan);
 
-    auto* newDataPointer = transformedData.data() + prefixBufferSpan.size();
+    auto newDataSpan = transformedData.mutableSpan().subspan(prefixBufferSpan.size());
     // Fill header.
     size_t headerSize = 1;
-    *newDataPointer = computeFirstHeaderByte(m_keyId, m_counter);
+    newDataSpan[0] = computeFirstHeaderByte(m_keyId, m_counter);
     if (m_keyId >= 8) {
         auto keyIdLength = lengthOfUInt64(m_keyId);
-        writeUInt64(newDataPointer + headerSize, m_keyId, keyIdLength);
+        writeUInt64(newDataSpan.subspan(headerSize), m_keyId, keyIdLength);
         headerSize += keyIdLength;
     }
     auto counterLength = lengthOfUInt64(m_counter);
-    writeUInt64(newDataPointer + headerSize, m_counter, counterLength);
+    writeUInt64(newDataSpan.subspan(headerSize), m_counter, counterLength);
     headerSize += counterLength;
 
     ASSERT(headerSize < MaxHeaderSize);
@@ -332,11 +333,11 @@ RTCRtpSFrameTransformer::TransformResult RTCRtpSFrameTransformer::encryptFrame(s
     if (encryptedData.hasException())
         return makeUnexpected(ErrorInformation { Error::Other, encryptedData.exception().message(), 0 });
 
-    std::memcpy(newDataPointer + headerSize, encryptedData.returnValue().data(), data.size());
+    memcpySpan(newDataSpan.subspan(headerSize), encryptedData.returnValue().span().first(data.size()));
 
     // Fill signature
-    auto signature = computeEncryptedDataSignature(iv, std::span { newDataPointer, headerSize }, std::span { newDataPointer + headerSize, data.size() }, m_authenticationKey);
-    std::memcpy(newDataPointer + data.size() + headerSize, signature.data(), m_authenticationSize);
+    auto signature = computeEncryptedDataSignature(iv, newDataSpan.first(headerSize), newDataSpan.subspan(headerSize, data.size()), m_authenticationKey);
+    memcpySpan(newDataSpan.subspan(data.size() + headerSize), signature.span().first(m_authenticationSize));
 
     if (m_compatibilityMode == CompatibilityMode::H264)
         toRbsp(transformedData, prefixBufferSpan.size());

--- a/Source/WebCore/Modules/mediastream/SFrameUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/SFrameUtils.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEB_RTC)
 
 #include <wtf/Function.h>
+#include <wtf/StdLibExtras.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -139,7 +140,7 @@ SFrameCompatibilityPrefixBuffer computeH264PrefixBuffer(std::span<const uint8_t>
     Vector<uint8_t> buffer(spsPpsLength + 2);
 IGNORE_GCC_WARNINGS_BEGIN("restrict")
     // https://bugs.webkit.org/show_bug.cgi?id=246862
-    std::memcpy(buffer.data(), frameData.data(), spsPpsLength);
+    memcpySpan(buffer.mutableSpan(), frameData.first(spsPpsLength));
 IGNORE_GCC_WARNINGS_END
     buffer[spsPpsLength] = 0x25;
     buffer[spsPpsLength + 1] = 0xb8;


### PR DESCRIPTION
#### 2dd4425a68528f4103dcf51dc49ba18964f73213
<pre>
Reduce use of memcpy() in WebCore/Modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=285055">https://bugs.webkit.org/show_bug.cgi?id=285055</a>

Reviewed by Geoffrey Garen and Darin Adler.

* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp:
(WebCore::writeUInt64):
(WebCore::RTCRtpSFrameTransformer::encryptFrame):
* Source/WebCore/Modules/mediastream/SFrameUtils.cpp:
(WebCore::computeH264PrefixBuffer):
* Source/WebCore/Modules/mediastream/STUNMessageParsing.cpp:
(WebCore::WebRTC::extractSTUNOrTURNMessages):
(WebCore::WebRTC::extractDataMessages):
* Source/WebCore/Modules/push-api/PushMessageCrypto.cpp:
(WebCore::PushCrypto::decryptAES128GCMPayload):
(WebCore::PushCrypto::computeAESGCMPaddingLength):
(WebCore::PushCrypto::decryptAESGCMPayload):
* Source/WebCore/Modules/push-api/cocoa/PushCryptoCocoa.cpp:
(WebCore::PushCrypto::computeP256DHSharedSecret):

Canonical link: <a href="https://commits.webkit.org/288227@main">https://commits.webkit.org/288227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0815e944d08d7f21c3ec8003ec589bc97084f7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87009 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33214 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9618 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64042 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21777 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44321 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28944 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31952 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72502 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88415 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6730 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72429 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9650 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71648 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15774 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14687 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12750 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9403 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14905 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9261 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12756 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11048 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->