### PR TITLE
Cleanup some localMainFrame/localTopDocument usage

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7374,12 +7374,25 @@ Document& Document::topDocument() const
         Document* localMainDocument = nullptr;
         if (RefPtr localMainFrame = this->localMainFrame())
             localMainDocument = localMainFrame->document();
+#if !LOG_DISABLED
+        if (!localMainDocument && settings().siteIsolationEnabled())
+            LOG_ERROR("Document::topDocument() - Grabbing main frame directly, the Page's main frame is not a LocalFrame, therefore we're about to lie about which Document is the top document");
+#endif
         return localMainDocument ? *localMainDocument : const_cast<Document&>(*this);
     }
 
     Document* document = const_cast<Document*>(this);
     while (HTMLFrameOwnerElement* element = document->ownerElement())
         document = &element->document();
+#if !LOG_DISABLED
+    if (settings().siteIsolationEnabled()) {
+        Document* localMainDocument = nullptr;
+        if (RefPtr localMainFrame = this->localMainFrame())
+            localMainDocument = localMainFrame->document();
+        if (localMainDocument != document)
+            LOG_ERROR("Document::topDocument() - Walking frame owner elements, the Page's main frame is not a LocalFrame, therefore we're about to lie about which Document is the top document");
+    }
+#endif
     return *document;
 }
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1226,6 +1226,8 @@ public:
     Ref<Document> protectedTopDocument() const { return topDocument(); }
     WEBCORE_EXPORT bool isTopDocument() const;
 
+    WEBCORE_EXPORT RefPtr<Document> localTopDocument() const;
+
     ScriptRunner* scriptRunnerIfExists() { return m_scriptRunner.get(); }
     inline ScriptRunner& scriptRunner();
     Ref<ScriptRunner> protectedScriptRunner();

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -192,11 +192,10 @@ ReplacementFragment::ReplacementFragment(RefPtr<DocumentFragment>&& inputFragmen
     }
 
     Ref page = createPageForSanitizingWebContent();
-    RefPtr localMainFrame = page->localMainFrame();
-    if (!localMainFrame)
+    RefPtr stagingDocument = page->localTopDocument();
+    if (!stagingDocument)
         return;
 
-    RefPtr stagingDocument { localMainFrame->document() };
     ASSERT(stagingDocument->body());
 
     ComputedStyleExtractor computedStyleOfEditableRoot(editableRoot.get());

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -525,12 +525,10 @@ static std::optional<MarkupAndArchive> extractMarkupAndArchive(SharedBuffer& buf
 static String sanitizeMarkupWithArchive(LocalFrame& frame, Document& destinationDocument, MarkupAndArchive& markupAndArchive, MSOListQuirks msoListQuirks, const std::function<bool(const String)>& canShowMIMETypeAsHTML)
 {
     Ref page = createPageForSanitizingWebContent();
-    RefPtr localMainFrame = page->localMainFrame();
-    if (!localMainFrame)
+    RefPtr stagingDocument = page->localTopDocument();
+    if (!stagingDocument)
         return String();
 
-    Document* stagingDocument = localMainFrame->document();
-    ASSERT(stagingDocument);
     auto fragment = createFragmentFromMarkup(*stagingDocument, markupAndArchive.markup, markupAndArchive.mainResource->url().string(), { });
 
     if (shouldReplaceRichContentWithAttachments()) {

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -228,12 +228,9 @@ Ref<Page> createPageForSanitizingWebContent()
 String sanitizeMarkup(const String& rawHTML, MSOListQuirks msoListQuirks, std::optional<Function<void(DocumentFragment&)>> fragmentSanitizer)
 {
     Ref page = createPageForSanitizingWebContent();
-    RefPtr localMainFrame = page->localMainFrame();
-    if (!localMainFrame)
+    RefPtr stagingDocument = page->localTopDocument();
+    if (!stagingDocument)
         return String();
-
-    RefPtr stagingDocument = localMainFrame->document();
-    ASSERT(stagingDocument);
 
     auto fragment = createFragmentFromMarkup(*stagingDocument, rawHTML, emptyString(), { });
 

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -471,10 +471,6 @@ std::optional<PrivateClickMeasurement> HTMLAnchorElement::parsePrivateClickMeasu
     if (!page || !document().settings().privateClickMeasurementEnabled() || !UserGestureIndicator::processingUserGesture())
         return std::nullopt;
 
-    RefPtr localMainFrame = page->localMainFrame();
-    if (!localMainFrame)
-        return std::nullopt;
-
     if (auto pcm = parsePrivateClickMeasurementForSKAdNetwork(hrefURL))
         return pcm;
 
@@ -508,14 +504,13 @@ std::optional<PrivateClickMeasurement> HTMLAnchorElement::parsePrivateClickMeasu
         return std::nullopt;
     }
 
-    RegistrableDomain mainDocumentRegistrableDomain;
-    if (auto mainDocument = localMainFrame->document())
-        mainDocumentRegistrableDomain = RegistrableDomain { mainDocument->url() };
-    else {
+    auto& mainURL = page->mainFrameURL();
+    if (mainURL.isEmpty()) {
         protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, "Could not find a main document to use as source site for Private Click Measurement."_s);
         return std::nullopt;
     }
 
+    RegistrableDomain mainDocumentRegistrableDomain = RegistrableDomain { mainURL };
     if (mainDocumentRegistrableDomain.matches(destinationURL)) {
         protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, "attributiondestination can not be the same site as the current website."_s);
         return std::nullopt;

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -326,10 +326,7 @@ void InspectorDOMAgent::didCreateFrontendAndBackend(Inspector::FrontendRouter*, 
     m_domEditor = makeUnique<DOMEditor>(*m_history);
 
     m_instrumentingAgents.setPersistentDOMAgent(this);
-    RefPtr localMainFrame = m_inspectedPage.localMainFrame();
-    if (!localMainFrame)
-        return;
-    m_document = localMainFrame->document();
+    m_document = m_inspectedPage.localTopDocument();
 
     // Force a layout so that we can collect additional information from the layout process.
     relayoutDocument();

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -440,11 +440,14 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::navigate(const Stri
     RefPtr localMainFrame = m_inspectedPage.localMainFrame();
     if (!localMainFrame)
         return { };
+    RefPtr localTopDocument = m_inspectedPage.localTopDocument();
+    if (!localTopDocument)
+        return { };
 
-    UserGestureIndicator indicator { IsProcessingUserGesture::Yes, localMainFrame->document() };
+    UserGestureIndicator indicator { IsProcessingUserGesture::Yes, localTopDocument.get() };
 
-    ResourceRequest resourceRequest { localMainFrame->document()->completeURL(url) };
-    FrameLoadRequest frameLoadRequest { *localMainFrame->document(), localMainFrame->document()->securityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), InitiatedByMainFrame::Unknown };
+    ResourceRequest resourceRequest { localTopDocument->completeURL(url) };
+    FrameLoadRequest frameLoadRequest { *localTopDocument, localTopDocument->securityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), InitiatedByMainFrame::Unknown };
     frameLoadRequest.disableNavigationToInvalidURL();
     localMainFrame->loader().changeLocation(WTFMove(frameLoadRequest));
 
@@ -1175,11 +1178,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorPageAgent::setEmulatedMedia(co
     // FIXME: Schedule a rendering update instead of synchronously updating the layout.
     m_inspectedPage.updateStyleAfterChangeInEnvironment();
 
-    RefPtr localMainFrame = m_inspectedPage.localMainFrame();
-    if (!localMainFrame)
-        return { };
-
-    RefPtr document = localMainFrame->document();
+    RefPtr document = m_inspectedPage.localTopDocument();
     if (!document)
         return { };
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1209,10 +1209,9 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
             bool sameOriginRequest = false;
             Ref requestedOrigin = SecurityOrigin::create(url);
             if (type == CachedResource::Type::MainResource) {
-                RefPtr localMainFrame = page->localMainFrame();
                 if (frame->isMainFrame())
                     sameOriginRequest = true;
-                else if (RefPtr topDocument = localMainFrame ? localMainFrame->document() : nullptr)
+                else if (RefPtr topDocument = page->localTopDocument())
                     sameOriginRequest = topDocument->protectedSecurityOrigin()->isSameSchemeHostPort(requestedOrigin.get());
             } else if (RefPtr document = this->document()) {
                 sameOriginRequest = document->protectedTopOrigin()->isSameSchemeHostPort(requestedOrigin.get())

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -239,11 +239,11 @@ void Chrome::runModal()
     // JavaScript that runs within the nested event loop must not be run in the context of the
     // script that called showModalDialog. Null out entryScope to break the connection.
 
-    RefPtr localMainFrame = m_page->localMainFrame();
-    if (!localMainFrame)
+    RefPtr localTopDocument = m_page->localTopDocument();
+    if (!localTopDocument)
         return;
 
-    SetForScope entryScopeNullifier { localMainFrame->document()->vm().entryScope, nullptr };
+    SetForScope entryScopeNullifier { localTopDocument->vm().entryScope, nullptr };
 
     TimerBase::fireTimersInNestedEventLoop();
     m_client->runModal();

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -329,11 +329,11 @@ std::optional<std::pair<RenderLayer&, GraphicsLayer&>> InteractionRegionOverlay:
         HitTestRequest::Type::AllowChildFrameContent
     };
     HitTestResult result(m_mouseLocationInContentCoordinates);
-    RefPtr localMainFrame = page->localMainFrame();
-    if (!localMainFrame)
+    RefPtr localTopDocument = page->localTopDocument();
+    if (!localTopDocument)
         return std::nullopt;
 
-    localMainFrame->document()->hitTest(hitType, result);
+    localTopDocument->hitTest(hitType, result);
 
     RefPtr hitNode = result.innerNode();
     if (!hitNode || !hitNode->renderer())

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -623,10 +623,10 @@ bool FocusController::advanceFocusInDocumentOrder(FocusDirection direction, Keyb
         }
 
         // Chrome doesn't want focus, so we should wrap focus.
-        RefPtr localMainFrame = m_page->localMainFrame();
-        if (!localMainFrame)
+        RefPtr localTopDocument = m_page->localTopDocument();
+        if (!localTopDocument)
             return false;
-        element = findFocusableElementAcrossFocusScope(direction, FocusNavigationScope::scopeOf(*localMainFrame->protectedDocument()), nullptr, event);
+        element = findFocusableElementAcrossFocusScope(direction, FocusNavigationScope::scopeOf(*localTopDocument), nullptr, event);
 
         if (!element)
             return false;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -376,7 +376,10 @@ public:
     EditorClient& editorClient() { return m_editorClient.get(); }
 
     WEBCORE_EXPORT RefPtr<LocalFrame> localMainFrame();
-    RefPtr<const LocalFrame> localMainFrame() const;
+    WEBCORE_EXPORT RefPtr<const LocalFrame> localMainFrame() const;
+    WEBCORE_EXPORT RefPtr<Document> localTopDocument();
+    WEBCORE_EXPORT RefPtr<Document> localTopDocument() const;
+
     Frame& mainFrame() { return m_mainFrame.get(); }
     const Frame& mainFrame() const { return m_mainFrame.get(); }
     WEBCORE_EXPORT Ref<Frame> protectedMainFrame() const;

--- a/Source/WebCore/page/PageDebuggable.cpp
+++ b/Source/WebCore/page/PageDebuggable.cpp
@@ -61,14 +61,11 @@ String PageDebuggable::name() const
         if (!page)
             return;
 
-        RefPtr localMainFrame = page->localMainFrame();
-        if (!localMainFrame)
+        RefPtr localTopDocument = page->localTopDocument();
+        if (!localTopDocument)
             return;
 
-        if (!localMainFrame->document())
-            return;
-
-        name = localMainFrame->document()->title().isolatedCopy();
+        name = localTopDocument->title().isolatedCopy();
     });
     return name;
 }
@@ -81,14 +78,7 @@ String PageDebuggable::url() const
         if (!page)
             return;
 
-        RefPtr localMainFrame = page->localMainFrame();
-        if (!localMainFrame)
-            return;
-
-        if (!localMainFrame->document())
-            return;
-
-        url = localMainFrame->document()->url().string().isolatedCopy();
+        url = page->mainFrameURL().string().isolatedCopy();
         if (url.isEmpty())
             url = "about:blank"_s;
     });

--- a/Source/WebCore/page/PerformanceMonitor.cpp
+++ b/Source/WebCore/page/PerformanceMonitor.cpp
@@ -156,15 +156,7 @@ void PerformanceMonitor::activityStateChanged(OptionSet<ActivityState> oldState,
 enum class ReportingReason { HighCPUUsage, HighMemoryUsage };
 static void reportPageOverPostLoadResourceThreshold(Page& page, ReportingReason reason)
 {
-    RefPtr localMainFrame = page.localMainFrame();
-    if (!localMainFrame)
-        return;
-
-    auto* document = localMainFrame->document();
-    if (!document)
-        return;
-
-    RegistrableDomain registrableDomain { document->url() };
+    RegistrableDomain registrableDomain { page.mainFrameURL() };
     if (registrableDomain.isEmpty())
         return;
 

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -476,16 +476,30 @@ void SettingsBase::storageBlockingPolicyChanged()
 
 void SettingsBase::backgroundShouldExtendBeyondPageChanged()
 {
-    RefPtr localMainFrame = m_page->localMainFrame();
-    if (m_page && localMainFrame)
-        localMainFrame->view()->updateExtendBackgroundIfNecessary();
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    RefPtr localMainFrame = page->localMainFrame();
+    if (!localMainFrame)
+        return;
+
+    if (RefPtr view = localMainFrame->view())
+        view->updateExtendBackgroundIfNecessary();
 }
 
 void SettingsBase::scrollingPerformanceTestingEnabledChanged()
 {
-    RefPtr localMainFrame = m_page->localMainFrame();
-    if (m_page && localMainFrame && localMainFrame->view())
-        localMainFrame->view()->setScrollingPerformanceTestingEnabled(m_page->settings().scrollingPerformanceTestingEnabled());
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    RefPtr localMainFrame = page->localMainFrame();
+    if (!localMainFrame)
+        return;
+
+    if (RefPtr view = localMainFrame->view())
+        view->setScrollingPerformanceTestingEnabled(page->settings().scrollingPerformanceTestingEnabled());
 }
 
 void SettingsBase::hiddenPageDOMTimerThrottlingStateChanged()

--- a/Source/WebCore/page/mac/PageMac.mm
+++ b/Source/WebCore/page/mac/PageMac.mm
@@ -73,11 +73,10 @@ void Page::platformInitialize()
             WTFLogAlways("%u live pages:", numPages);
 
             Page::forEachPage([](Page& page) {
-                RefPtr localMainFrame = page.localMainFrame();
-                if (!localMainFrame)
+                RefPtr localTopDocument = page.localTopDocument();
+                if (!localTopDocument)
                     return;
-                const auto* mainFrameDocument = localMainFrame->document();
-                WTFLogAlways("Page %p with main document %p %s", &page, mainFrameDocument, mainFrameDocument ? mainFrameDocument->url().string().utf8().data() : "");
+                WTFLogAlways("Page %p with main document %p %s", &page, localTopDocument.get(), localTopDocument ? localTopDocument->url().string().utf8().data() : "");
             });
 
             WTFLogAlways("%u live documents:", Document::allDocuments().size());

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -28,6 +28,7 @@
 #include "ScrollingCoordinator.h"
 
 #include "Document.h"
+#include "DocumentClasses.h"
 #include "EventNames.h"
 #include "GraphicsLayer.h"
 #include "LocalFrame.h"
@@ -341,11 +342,8 @@ void ScrollingCoordinator::updateSynchronousScrollingReasons(LocalFrameView& fra
     if (hasVisibleSlowRepaintViewportConstrainedObjects(frameView))
         newSynchronousScrollingReasons.add(SynchronousScrollingReason::HasNonLayerViewportConstrainedObjects);
 
-    Ref localFrame = frameView.frame();
-    RefPtr localMainFrame = localFrame->localMainFrame();
-    if (localMainFrame
-        && localMainFrame->document()
-        && localFrame->document()->isImageDocument())
+    RefPtr page = frameView.frame().protectedPage();
+    if (page && page->topDocumentHasDocumentClass(DocumentClass::Image))
         newSynchronousScrollingReasons.add(SynchronousScrollingReason::IsImageDocument);
 
     setSynchronousScrollingReasons(frameView.scrollingNodeID(), newSynchronousScrollingReasons);

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -433,13 +433,13 @@ bool SVGImage::isAnimating() const
 
 void SVGImage::reportApproximateMemoryCost() const
 {
-    RefPtr localMainFrame = m_page->localMainFrame();
-    if (!localMainFrame)
+    RefPtr localTopDocument = m_page->localTopDocument();
+    if (!localTopDocument)
         return;
-    RefPtr document = localMainFrame->document();
+
     size_t decodedImageMemoryCost = 0;
 
-    for (RefPtr<Node> node = document; node; node = NodeTraversal::next(*node))
+    for (RefPtr<Node> node = localTopDocument; node; node = NodeTraversal::next(*node))
         decodedImageMemoryCost += node->approximateMemoryCost();
 
     JSC::VM& vm = commonVM();

--- a/Source/WebCore/testing/InternalSettings.cpp
+++ b/Source/WebCore/testing/InternalSettings.cpp
@@ -516,11 +516,18 @@ ExceptionOr<void> InternalSettings::setUseElevatedUserInterfaceLevel(bool useEle
 
 ExceptionOr<void> InternalSettings::setAllowUnclampedScrollPosition(bool allowUnclamped)
 {
-    RefPtr localMainFrame = m_page->localMainFrame();
-    if (!m_page || !localMainFrame || !localMainFrame->view())
+    if (!m_page)
         return Exception { ExceptionCode::InvalidAccessError };
 
-    localMainFrame->view()->setAllowsUnclampedScrollPositionForTesting(allowUnclamped);
+    RefPtr localMainFrame = m_page->localMainFrame();
+    if (!localMainFrame)
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    RefPtr view = localMainFrame->view();
+    if (!view)
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    view->setAllowsUnclampedScrollPositionForTesting(allowUnclamped);
     return { };
 }
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -67,7 +67,7 @@ static ThreadSafeWeakHashSet<ServiceWorkerThreadProxy>& allServiceWorkerThreadPr
 
 ServiceWorkerThreadProxy::ServiceWorkerThreadProxy(Ref<Page>&& page, ServiceWorkerContextData&& contextData, ServiceWorkerData&& workerData, String&& userAgent, WorkerThreadMode workerThreadMode, CacheStorageProvider& cacheStorageProvider, std::unique_ptr<NotificationClient>&& notificationClient)
     : m_page(WTFMove(page))
-    , m_document(*m_page->localMainFrame()->document())
+    , m_document(*m_page->localTopDocument())
 #if ENABLE(REMOTE_INSPECTOR)
     , m_remoteDebuggable(ServiceWorkerDebuggable::create(*this, contextData))
 #endif

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -99,7 +99,7 @@ bool SharedWorkerThreadProxy::hasInstances()
 
 SharedWorkerThreadProxy::SharedWorkerThreadProxy(Ref<Page>&& page, SharedWorkerIdentifier sharedWorkerIdentifier, const ClientOrigin& clientOrigin, WorkerFetchResult&& workerFetchResult, WorkerOptions&& workerOptions, WorkerInitializationData&& initializationData, CacheStorageProvider& cacheStorageProvider)
     : m_page(WTFMove(page))
-    , m_document(*m_page->localMainFrame()->document())
+    , m_document(*m_page->localTopDocument())
     , m_contextIdentifier(*initializationData.clientIdentifier)
     , m_workerThread(SharedWorkerThread::create(sharedWorkerIdentifier, generateWorkerParameters(workerFetchResult, WTFMove(workerOptions), WTFMove(initializationData), m_document), WTFMove(workerFetchResult.script), *this, *this, *this, *this, WorkerThreadStartMode::Normal, clientOrigin.topOrigin.securityOrigin(), m_document->idbConnectionProxy(), m_document->socketProvider(), JSC::RuntimeFlags::createAllEnabled()))
     , m_cacheStorageProvider(cacheStorageProvider)

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -325,10 +325,8 @@ void NetworkProcessConnection::broadcastConsoleMessage(MessageSource source, Mes
     FAST_RETURN_IF_NO_FRONTENDS(void());
 
     Page::forEachPage([&] (auto& page) {
-        if (RefPtr localMainFrame = page.localMainFrame()) {
-            if (RefPtr document = localMainFrame->document())
-                document->addConsoleMessage(source, level, message);
-        }
+        if (RefPtr localTopDocument = page.localTopDocument())
+            localTopDocument->addConsoleMessage(source, level, message);
     });
 }
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -125,7 +125,7 @@ void WebLoaderStrategy::loadResource(LocalFrame& frame, CachedResource& resource
 {
     if (resource.type() != CachedResource::Type::MainResource || !frame.isMainFrame()) {
         if (RefPtr localMainFrame = frame.localMainFrame()) {
-            if (auto* document = localMainFrame->document()) {
+            if (RefPtr document = localMainFrame->document()) {
                 if (document && document->loader())
                     request.setIsAppInitiated(document->loader()->lastNavigationWasAppInitiated());
             }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -666,11 +666,11 @@ void WebChromeClient::invalidateRootView(const IntRect&)
 void WebChromeClient::invalidateContentsAndRootView(const IntRect& rect)
 {
     auto page = protectedPage();
-    RefPtr localMainFrame = page->corePage()->localMainFrame();
-    if (!localMainFrame)
+    RefPtr corePage = page->protectedCorePage();
+    if (!corePage)
         return;
 
-    if (RefPtr document = localMainFrame->document()) {
+    if (RefPtr document = corePage->localTopDocument()) {
         if (document->printing())
             return;
     }
@@ -681,11 +681,11 @@ void WebChromeClient::invalidateContentsAndRootView(const IntRect& rect)
 void WebChromeClient::invalidateContentsForSlowScroll(const IntRect& rect)
 {
     auto page = protectedPage();
-    RefPtr localMainFrame = page->corePage()->localMainFrame();
-    if (!localMainFrame)
+    RefPtr corePage = page->protectedCorePage();
+    if (!corePage)
         return;
 
-    if (RefPtr document = localMainFrame->document()) {
+    if (RefPtr document = corePage->localTopDocument()) {
         if (document->printing())
             return;
     }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -738,6 +738,7 @@ public:
     WebCore::FrameView* mainFrameView() const; // May return nullptr.
     WebCore::LocalFrameView* localMainFrameView() const; // May return nullptr.
     RefPtr<WebCore::LocalFrame> localMainFrame() const;
+    RefPtr<WebCore::Document> localTopDocument() const;
 
     void createRemoteSubframe(WebCore::FrameIdentifier parentID, WebCore::FrameIdentifier newChildID, const String& newChildFrameName);
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -128,8 +128,7 @@ void WebPage::platformInitializeAccessibility()
     // Get the pid for the starting process.
     pid_t pid = legacyPresentingApplicationPID();
     createMockAccessibilityElement(pid);
-    RefPtr localMainFrame = m_page->localMainFrame();
-    if (localMainFrame)
+    if (m_page->localMainFrame())
         accessibilityTransferRemoteToken(accessibilityRemoteTokenData());
 
     // Close Mach connection to Launch Services.


### PR DESCRIPTION
#### ce9f6de6dbe34aef669f0af3535ef95e272ccd4d
<pre>
Cleanup some localMainFrame/localTopDocument usage
<a href="https://rdar.apple.com/141858346">rdar://141858346</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=285056">https://bugs.webkit.org/show_bug.cgi?id=285056</a>

Reviewed by Alex Christensen.

This patch does the following:
- Logs an error whenever `Document::topDocument()` returns the incorrect Document as a fallback
- Introduces some obviously missing null checks
- Uses a safer/easier `localTopDocument` accessor instead of `localMainFrame-&gt;document()`
- Avoids localTopDocument and localMainFrame altogether in some cases where Page already has the data
- Other assorted cleanup and refactoring

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::topDocument const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplacementFragment::ReplacementFragment):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::sanitizeMarkupWithArchive):
* Source/WebCore/editing/markup.cpp:
(WebCore::sanitizeMarkup):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::parsePrivateClickMeasurement const):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::didCreateFrontendAndBackend):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::navigate):
(WebCore::InspectorPageAgent::setEmulatedMedia):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::runModal):
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::InteractionRegionOverlay::activeLayer const):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::advanceFocusInDocumentOrder):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::disabledAdaptations const):
(WebCore::Page::setOverrideViewportArguments):
(WebCore::Page::accessibilityTreeData const):
(WebCore::Page::showAllPlugins const):
(WebCore::Page::setPageScaleFactor):
(WebCore::Page::pageCount const):
(WebCore::Page::prioritizeVisibleResources):
(WebCore::Page::themeColor const):
(WebCore::Page::localTopDocument):
(WebCore::Page::localTopDocument const):
(WebCore::Page::proofreadingSessionSuggestionTextRectsInRootViewCoordinates const):
(WebCore::Page::updateTextVisibilityForActiveWritingToolsSession):
(WebCore::Page::textPreviewDataForActiveWritingToolsSession):
(WebCore::Page::decorateTextReplacementsForActiveWritingToolsSession):
(WebCore::Page::setSelectionForActiveWritingToolsSession):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageDebuggable.cpp:
(WebCore::PageDebuggable::name const):
(WebCore::PageDebuggable::url const):
* Source/WebCore/page/PerformanceMonitor.cpp:
(WebCore::reportPageOverPostLoadResourceThreshold):
* Source/WebCore/page/SettingsBase.cpp:
(WebCore::SettingsBase::backgroundShouldExtendBeyondPageChanged):
(WebCore::SettingsBase::scrollingPerformanceTestingEnabledChanged):
* Source/WebCore/page/mac/PageMac.mm:
(WebCore::Page::platformInitialize):
* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
(WebCore::ScrollingCoordinator::updateSynchronousScrollingReasons):
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::reportApproximateMemoryCost const):
* Source/WebCore/testing/InternalSettings.cpp:
(WebCore::InternalSettings::setAllowUnclampedScrollPosition):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::ServiceWorkerThreadProxy):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::SharedWorkerThreadProxy::SharedWorkerThreadProxy):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::broadcastConsoleMessage):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::loadResource):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::invalidateContentsAndRootView):
(WebKit::WebChromeClient::invalidateContentsForSlowScroll):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::shouldDispatchSyntheticMouseEventsWhenModifyingSelection const):
(WebKit::WebPage::tryRestoreScrollPosition):
(WebKit::WebPage::drawRect):
(WebKit::WebPage::viewportPropertiesDidChange):
(WebKit::WebPage::dispatchWheelEventWithoutScrolling):
(WebKit::WebPage::setCurrentHistoryItemForReattach):
(WebKit::WebPage::updatePotentialTapSecurityOrigin):
(WebKit::WebPage::touchEvent):
(WebKit::WebPage::setNeedsDOMWindowResizeEvent):
(WebKit::WebPage::runJavaScript):
(WebKit::WebPage::performDragControllerAction):
(WebKit::WebPage::didStartDrag):
(WebKit::WebPage::dragCancelled):
(WebKit::WebPage::setCustomTextEncodingName):
(WebKit::WebPage::drawToPDF):
(WebKit::WebPage::drawCompositedToPDF):
(WebKit::WebPage::localTopDocument const):
(WebKit::WebPage::characterIndexForPointAsync):
(WebKit::WebPage::updateWebsitePolicies):
(WebKit::WebPage::extendIncrementalRenderingSuppression):
(WebKit::WebPage::stopExtendingIncrementalRenderingSuppression):
(WebKit::WebPage::setScrollPinningBehavior):
(WebKit::WebPage::setScrollbarOverlayStyle):
(WebKit::WebPage::wasLoadedWithDataTransferFromPrevalentResource):
(WebKit::WebPage::simulateDeviceOrientationChange):
(WebKit::WebPage::attachmentElementWithIdentifier const):
(WebKit::WebPage::lastNavigationWasAppInitiated):
(WebKit::WebPage::generateTestReport):
(WebKit::WebPage::useRedirectionForCurrentNavigation):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::platformInitializeAccessibility):

Canonical link: <a href="https://commits.webkit.org/288238@main">https://commits.webkit.org/288238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10ae8e6b2d24650914d6f6c9f997d8dc0a114d71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82199 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33261 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84305 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64064 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21805 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44342 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1230 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28972 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32302 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72533 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88688 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6765 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72455 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71673 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17876 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15802 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9459 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14941 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9333 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12798 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11102 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->