### PR TITLE
Further reduce use of memcmp()

### DIFF
--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
@@ -31,6 +31,7 @@
 #include "JSCJSValueInlines.h"
 #include "Parser.h"
 #include <wtf/NeverDestroyed.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -93,11 +94,11 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
     RELEASE_ASSERT(!view.isNull());
     RELEASE_ASSERT(view.is8Bit());
     auto characters = view.span8();
-    const char* regularFunctionBegin = "(function (";
-    const char* asyncFunctionBegin = "(async function (";
+    auto regularFunctionBegin = "(function ("_span;
+    auto asyncFunctionBegin = "(async function ("_span;
     RELEASE_ASSERT(view.length() >= strlen("(function (){})"));
-    bool isAsyncFunction = view.length() >= strlen("(async function (){})") && !memcmp(characters.data(), asyncFunctionBegin, strlen(asyncFunctionBegin));
-    RELEASE_ASSERT(isAsyncFunction || !memcmp(characters.data(), regularFunctionBegin, strlen(regularFunctionBegin)));
+    bool isAsyncFunction = view.length() >= strlen("(async function (){})") && spanHasPrefix(characters, asyncFunctionBegin);
+    RELEASE_ASSERT(isAsyncFunction || spanHasPrefix(characters, regularFunctionBegin));
 
     unsigned asyncOffset = isAsyncFunction ? strlen("async ") : 0;
     unsigned parametersStart = strlen("function (") + asyncOffset;
@@ -166,11 +167,11 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
             ++endColumn;
 
         if (!isInStrictContext && (characters[i] == '"' || characters[i] == '\'')) {
-            const unsigned useStrictLength = strlen("use strict");
-            if (i + 1 + useStrictLength < view.length()) {
-                if (!memcmp(characters.data() + i + 1, "use strict", useStrictLength)) {
+            const auto useStrict = "use strict"_span;
+            if (i + 1 + useStrict.size() < view.length()) {
+                if (spanHasPrefix(characters.subspan(i + 1), useStrict)) {
                     isInStrictContext = true;
-                    i += 1 + useStrictLength;
+                    i += 1 + useStrict.size();
                 }
             }
         }

--- a/Source/JavaScriptCore/fuzzilli/Fuzzilli.cpp
+++ b/Source/JavaScriptCore/fuzzilli/Fuzzilli.cpp
@@ -26,6 +26,7 @@
 #include <wtf/Compiler.h>
 #include <wtf/DataLog.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/StdLibExtras.h>
 
 #if ENABLE(FUZZILLI)
 
@@ -133,12 +134,12 @@ void Fuzzilli::flushReprl(int32_t result)
 
 void Fuzzilli::initializeReprl()
 {
-    char helo[] = "HELO";
+    std::array<char, 4> helo { 'H', 'E', 'L', 'O' };
 
-    WRITE_TO_FUZZILLI(helo, 4);
-    READ_FROM_FUZZILLI(helo, 4);
+    WRITE_TO_FUZZILLI(helo.data(), helo.size());
+    READ_FROM_FUZZILLI(helo.data(), helo.size());
 
-    RELEASE_ASSERT_WITH_MESSAGE(!memcmp(helo, "HELO", 4), "[REPRL] Invalid response from parent");
+    RELEASE_ASSERT_WITH_MESSAGE(equalSpans(helo, "HELO"_span), "[REPRL] Invalid response from parent");
 
     // Mmap the data input buffer.
     reprlInputData = static_cast<char*>(mmap(0, REPRL_MAX_DATA_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, REPRL_DRFD, 0));

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -899,6 +899,28 @@ bool equalSpans(std::span<T, TExtent> a, std::span<U, UExtent> b)
 }
 
 template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
+bool spanHasPrefix(std::span<T, TExtent> span, std::span<U, UExtent> prefix)
+{
+    static_assert(sizeof(T) == sizeof(U));
+    static_assert(std::has_unique_object_representations_v<T>);
+    static_assert(std::has_unique_object_representations_v<U>);
+    if (span.size() < prefix.size())
+        return false;
+    return !memcmp(span.data(), prefix.data(), prefix.size_bytes());
+}
+
+template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
+bool spanHasSuffix(std::span<T, TExtent> span, std::span<U, UExtent> suffix)
+{
+    static_assert(sizeof(T) == sizeof(U));
+    static_assert(std::has_unique_object_representations_v<T>);
+    static_assert(std::has_unique_object_representations_v<U>);
+    if (span.size() < suffix.size())
+        return false;
+    return !memcmp(span.last(suffix.size()).data(), suffix.data(), suffix.size_bytes());
+}
+
+template<typename T, std::size_t TExtent, typename U, std::size_t UExtent>
 int compareSpans(std::span<T, TExtent> a, std::span<U, UExtent> b)
 {
     static_assert(sizeof(T) == sizeof(U));
@@ -1247,6 +1269,8 @@ using WTF::safeCast;
 using WTF::secureMemsetSpan;
 using WTF::singleElementSpan;
 using WTF::spanConstCast;
+using WTF::spanHasPrefix;
+using WTF::spanHasSuffix;
 using WTF::spanReinterpretCast;
 using WTF::toTwosComplement;
 using WTF::tryBinarySearch;

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -454,7 +454,7 @@ static inline bool isSecondLevelDomainNameAllowedByTLDRules(std::span<const UCha
 #define CHECK_RULES_IF_SUFFIX_MATCHES(suffix, function) \
     { \
         static constexpr size_t suffixLength = suffix.size(); \
-        if (buffer.size() > suffixLength && equalSpans(buffer.last(suffixLength), std::span { suffix })) \
+        if (spanHasSuffix(buffer, std::span { suffix })) \
             return isSecondLevelDomainNameAllowedByTLDRules(buffer.first(buffer.size() - suffixLength), function); \
     }
 

--- a/Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp
@@ -302,13 +302,13 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier id
     index += bytesUsedToEncodedLength(keyData[index]); // Read length
     if (keyData.size() < index + sizeof(IdEcPublicKey))
         return nullptr;
-    if (!equalSpans(keyData.subspan(index, sizeof(IdEcPublicKey)), std::span { IdEcPublicKey }))
+    if (!spanHasPrefix(keyData.subspan(index), std::span { IdEcPublicKey }))
         return nullptr;
     index += std::size(IdEcPublicKey); // Read id-ecPublicKey
     auto oid = getOID(curve);
     if (keyData.size() < index + oid.size())
         return nullptr;
-    if (!equalSpans(keyData.subspan(index, oid.size()), oid))
+    if (!spanHasPrefix(keyData.subspan(index), oid))
         return nullptr;
     index += oid.size() + 1; // Read named curve OID, BIT STRING
     if (keyData.size() < index + 1)
@@ -392,13 +392,13 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier i
     index += bytesUsedToEncodedLength(keyData[index]); // Read length
     if (keyData.size() < index + sizeof(IdEcPublicKey))
         return nullptr;
-    if (!equalSpans(keyData.subspan(index, sizeof(IdEcPublicKey)), std::span { IdEcPublicKey }))
+    if (!spanHasPrefix(keyData.subspan(index), std::span { IdEcPublicKey }))
         return nullptr;
     index += std::size(IdEcPublicKey); // Read id-ecPublicKey
     auto oid = getOID(curve);
     if (keyData.size() < index + oid.size())
         return nullptr;
-    if (!equalSpans(keyData.subspan(index, oid.size()), oid))
+    if (!spanHasPrefix(keyData.subspan(index), oid))
         return nullptr;
     index += oid.size() + 1; // Read named curve OID, OCTET STRING
     if (keyData.size() < index + 1)

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -104,13 +104,6 @@ bool isCustomPropertyName(StringView propertyName)
     return propertyName.length() > 2 && propertyName.characterAt(0) == '-' && propertyName.characterAt(1) == '-';
 }
 
-static bool hasPrefix(std::span<const char> string, std::span<const LChar> prefix)
-{
-    if (string.size() < prefix.size())
-        return false;
-    return equalSpans(string.first(prefix.size()), prefix);
-}
-
 template<typename CharacterType> static CSSPropertyID cssPropertyID(std::span<const CharacterType> characters)
 {
     char buffer[maxCSSPropertyNameLength];
@@ -126,10 +119,10 @@ template<typename CharacterType> static CSSPropertyID cssPropertyID(std::span<co
 // FIXME: Remove this mechanism entirely once we can do it without breaking the web.
 static bool isAppleLegacyCSSValueKeyword(std::span<const char> characters)
 {
-    return hasPrefix(characters.subspan(1), "apple-"_span)
-        && !hasPrefix(characters.subspan(7), "system"_span)
-        && !hasPrefix(characters.subspan(7), "pay"_span)
-        && !hasPrefix(characters.subspan(7), "wireless"_span);
+    return spanHasPrefix(characters.subspan(1), "apple-"_span)
+        && !spanHasPrefix(characters.subspan(7), "system"_span)
+        && !spanHasPrefix(characters.subspan(7), "pay"_span)
+        && !spanHasPrefix(characters.subspan(7), "wireless"_span);
 }
 
 template<typename CharacterType> static CSSValueID cssValueKeywordID(std::span<const CharacterType> characters)

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -307,7 +307,7 @@ private:
 
         struct A : ContainerTag<HTMLAnchorElement, PermittedParents::FlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::a;
-            static constexpr CharacterType tagNameCharacters[] = { 'a' };
+            static constexpr std::array<CharacterType, 1> tagNameCharacters { 'a' };
 
             static RefPtr<HTMLElement> parseChild(ContainerNode& parent, HTMLFastPathParser& self)
             {
@@ -321,7 +321,7 @@ private:
 
         struct AWithPhrasingContent : ContainsPhrasingContentTag<HTMLAnchorElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::a;
-            static constexpr CharacterType tagNameCharacters[] = { 'a' };
+            static constexpr std::array<CharacterType, 1> tagNameCharacters { 'a' };
 
             static RefPtr<HTMLElement> parseChild(ContainerNode& parent, HTMLFastPathParser& self)
             {
@@ -335,7 +335,7 @@ private:
 
         struct B : ContainsPhrasingContentTag<HTMLElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::b;
-            static constexpr CharacterType tagNameCharacters[] = { 'b' };
+            static constexpr std::array<CharacterType, 1> tagNameCharacters { 'b' };
 
             static Ref<HTMLElement> create(Document& document)
             {
@@ -345,27 +345,27 @@ private:
 
         struct Br : VoidTag<HTMLBRElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::br;
-            static constexpr CharacterType tagNameCharacters[] = { 'b', 'r' };
+            static constexpr std::array<CharacterType, 2> tagNameCharacters { 'b', 'r' };
         };
 
         struct Button : ContainsPhrasingContentTag<HTMLButtonElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::button;
-            static constexpr CharacterType tagNameCharacters[] = { 'b', 'u', 't', 't', 'o', 'n' };
+            static constexpr std::array<CharacterType, 6> tagNameCharacters { 'b', 'u', 't', 't', 'o', 'n' };
         };
 
         struct Div : ContainerTag<HTMLDivElement, PermittedParents::FlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::div;
-            static constexpr CharacterType tagNameCharacters[] = { 'd', 'i', 'v' };
+            static constexpr std::array<CharacterType, 3> tagNameCharacters { 'd', 'i', 'v' };
         };
 
         struct Body : ContainerTag<HTMLBodyElement, PermittedParents::Special> {
             static constexpr ElementName tagName = ElementNames::HTML::body;
-            static constexpr CharacterType tagNameCharacters[] = { 'b', 'o', 'd', 'y' };
+            static constexpr std::array<CharacterType, 4> tagNameCharacters { 'b', 'o', 'd', 'y' };
         };
 
         struct Footer : ContainerTag<HTMLElement, PermittedParents::FlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::footer;
-            static constexpr CharacterType tagNameCharacters[] = { 'f', 'o', 'o', 't', 'e', 'r' };
+            static constexpr std::array<CharacterType, 6> tagNameCharacters { 'f', 'o', 'o', 't', 'e', 'r' };
 
             static Ref<HTMLElement> create(Document& document)
             {
@@ -375,7 +375,7 @@ private:
 
         struct I : ContainsPhrasingContentTag<HTMLElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::i;
-            static constexpr CharacterType tagNameCharacters[] = { 'i' };
+            static constexpr std::array<CharacterType, 1> tagNameCharacters { 'i' };
 
             static Ref<HTMLElement> create(Document& document)
             {
@@ -385,7 +385,7 @@ private:
 
         struct Input : VoidTag<HTMLInputElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::input;
-            static constexpr CharacterType tagNameCharacters[] = { 'i', 'n', 'p', 'u', 't' };
+            static constexpr std::array<CharacterType, 5> tagNameCharacters { 'i', 'n', 'p', 'u', 't' };
 
             static Ref<HTMLInputElement> create(Document& document)
             {
@@ -395,17 +395,17 @@ private:
 
         struct Li : ContainerTag<HTMLLIElement, PermittedParents::FlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::li;
-            static constexpr CharacterType tagNameCharacters[] = { 'l', 'i' };
+            static constexpr std::array<CharacterType, 2> tagNameCharacters { 'l', 'i' };
         };
 
         struct Label : ContainsPhrasingContentTag<HTMLLabelElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::label;
-            static constexpr CharacterType tagNameCharacters[] = { 'l', 'a', 'b', 'e', 'l' };
+            static constexpr std::array<CharacterType, 5> tagNameCharacters { 'l', 'a', 'b', 'e', 'l' };
         };
 
         struct Option : ContainerTag<HTMLOptionElement, PermittedParents::Special> {
             static constexpr ElementName tagName = ElementNames::HTML::option;
-            static constexpr CharacterType tagNameCharacters[] = { 'o', 'p', 't', 'i', 'o', 'n' };
+            static constexpr std::array<CharacterType, 6> tagNameCharacters { 'o', 'p', 't', 'i', 'o', 'n' };
 
             static RefPtr<HTMLElement> parseChild(ContainerNode&, HTMLFastPathParser& self)
             {
@@ -416,7 +416,7 @@ private:
 
         struct Ol : ContainerTag<HTMLOListElement, PermittedParents::FlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::ol;
-            static constexpr CharacterType tagNameCharacters[] = { 'o', 'l' };
+            static constexpr std::array<CharacterType, 2> tagNameCharacters { 'o', 'l' };
 
             static RefPtr<HTMLElement> parseChild(ContainerNode& parent, HTMLFastPathParser& self)
             {
@@ -426,12 +426,12 @@ private:
 
         struct P : ContainsPhrasingContentTag<HTMLParagraphElement, PermittedParents::FlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::p;
-            static constexpr CharacterType tagNameCharacters[] = { 'p' };
+            static constexpr std::array<CharacterType, 1> tagNameCharacters { 'p' };
         };
 
         struct Select : ContainerTag<HTMLSelectElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::select;
-            static constexpr CharacterType tagNameCharacters[] = { 's', 'e', 'l', 'e', 'c', 't' };
+            static constexpr std::array<CharacterType, 6> tagNameCharacters { 's', 'e', 'l', 'e', 'c', 't' };
 
             static RefPtr<HTMLElement> parseChild(ContainerNode& parent, HTMLFastPathParser& self)
             {
@@ -441,12 +441,12 @@ private:
 
         struct Span : ContainsPhrasingContentTag<HTMLSpanElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::span;
-            static constexpr CharacterType tagNameCharacters[] = { 's', 'p', 'a', 'n' };
+            static constexpr std::array<CharacterType, 4> tagNameCharacters { 's', 'p', 'a', 'n' };
         };
 
         struct Strong : ContainsPhrasingContentTag<HTMLElement, PermittedParents::PhrasingOrFlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::strong;
-            static constexpr CharacterType tagNameCharacters[] = { 's', 't', 'r', 'o', 'n', 'g' };
+            static constexpr std::array<CharacterType, 6> tagNameCharacters { 's', 't', 'r', 'o', 'n', 'g' };
 
             static Ref<HTMLElement> create(Document& document)
             {
@@ -456,7 +456,7 @@ private:
 
         struct Ul : ContainerTag<HTMLUListElement, PermittedParents::FlowContent> {
             static constexpr ElementName tagName = ElementNames::HTML::ul;
-            static constexpr CharacterType tagNameCharacters[] = { 'u', 'l' };
+            static constexpr std::array<CharacterType, 2> tagNameCharacters { 'u', 'l' };
 
             static RefPtr<HTMLElement> parseChild(ContainerNode& parent, HTMLFastPathParser& self)
             {
@@ -930,8 +930,8 @@ private:
         ASSERT(*m_parsingBuffer == '/');
         m_parsingBuffer.advance();
 
-        if (UNLIKELY(!skipCharactersExactly(m_parsingBuffer, Tag::tagNameCharacters))) {
-            if (UNLIKELY(!skipLettersExactlyIgnoringASCIICase(m_parsingBuffer, Tag::tagNameCharacters)))
+        if (UNLIKELY(!skipCharactersExactly(m_parsingBuffer, std::span { Tag::tagNameCharacters }))) {
+            if (UNLIKELY(!skipLettersExactlyIgnoringASCIICase(m_parsingBuffer, std::span { Tag::tagNameCharacters })))
                 return didFail(HTMLFastPathResult::FailedEndTagNameMismatch, element);
         }
         skipWhile<isASCIIWhitespace>(m_parsingBuffer);

--- a/Source/WebCore/html/parser/ParsingUtilities.h
+++ b/Source/WebCore/html/parser/ParsingUtilities.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/StringCommon.h>
 #include <wtf/text/StringParsingBuffer.h>
 
@@ -233,36 +234,24 @@ template<typename CharacterType> bool skipExactlyIgnoringASCIICase(StringParsing
     return true;
 }
 
-template<typename CharacterType, unsigned characterCount> bool skipLettersExactlyIgnoringASCIICase(StringParsingBuffer<CharacterType>& buffer, const CharacterType(&letters)[characterCount])
+template<typename CharacterType, std::size_t Extent> bool skipLettersExactlyIgnoringASCIICase(StringParsingBuffer<CharacterType>& buffer, std::span<const CharacterType, Extent> letters)
 {
-    if (buffer.lengthRemaining() < characterCount)
+    if (buffer.lengthRemaining() < letters.size())
         return false;
-    for (unsigned i = 0; i < characterCount; ++i) {
+    for (unsigned i = 0; i < letters.size(); ++i) {
         ASSERT(isASCIIAlpha(letters[i]));
         if (!isASCIIAlphaCaselessEqual(buffer.position()[i], static_cast<char>(letters[i])))
             return false;
     }
-    buffer += characterCount;
+    buffer += letters.size();
     return true;
 }
 
-template<typename CharacterType, unsigned characterCount> constexpr bool skipCharactersExactly(const CharacterType*& ptr, const CharacterType* end, const CharacterType(&str)[characterCount])
+template<typename CharacterType, std::size_t Extent> constexpr bool skipCharactersExactly(StringParsingBuffer<CharacterType>& buffer, std::span<const CharacterType, Extent> string)
 {
-    if (end - ptr < characterCount)
+    if (!spanHasPrefix(buffer.span(), string))
         return false;
-    if (memcmp(str, ptr, sizeof(CharacterType) * characterCount))
-        return false;
-    ptr += characterCount;
-    return true;
-}
-
-template<typename CharacterType, unsigned characterCount> constexpr bool skipCharactersExactly(StringParsingBuffer<CharacterType>& buffer, const CharacterType(&str)[characterCount])
-{
-    if (buffer.lengthRemaining() < characterCount)
-        return false;
-    if (memcmp(str, buffer.position(), sizeof(CharacterType) * characterCount))
-        return false;
-    buffer += characterCount;
+    buffer += string.size();
     return true;
 }
 

--- a/Source/WebCore/html/track/DataCue.cpp
+++ b/Source/WebCore/html/track/DataCue.cpp
@@ -125,8 +125,6 @@ bool DataCue::cueContentsMatch(const TextTrackCue& cue) const
     RefPtr<ArrayBuffer> otherData = dataCue->data();
     if ((otherData && !m_data) || (!otherData && m_data))
         return false;
-    if (m_data && m_data->byteLength() != otherData->byteLength())
-        return false;
     if (m_data && m_data->data() && !equalSpans(m_data->span(), otherData->span()))
         return false;
 

--- a/Source/WebCore/loader/TextResourceDecoder.cpp
+++ b/Source/WebCore/loader/TextResourceDecoder.cpp
@@ -469,7 +469,7 @@ bool TextResourceDecoder::checkForCSSCharset(std::span<const uint8_t> data, bool
     data = m_buffer.span();
 
     static constexpr std::array<uint8_t, 10> charsetPrefix { '@', 'c', 'h', 'a', 'r', 's', 'e', 't', ' ', '"' };
-    if (equalSpans(data.first(10), std::span { charsetPrefix })) {
+    if (spanHasPrefix(data, std::span { charsetPrefix })) {
         data = data.subspan(10);
 
         size_t index = 0;
@@ -524,7 +524,7 @@ bool TextResourceDecoder::checkForHeadCharset(std::span<const uint8_t> data, boo
     static constexpr std::array<uint8_t, 5> xmlPrefix { '<', '?', 'x', 'm', 'l' };
     static constexpr std::array<uint8_t, 6> xmlPrefixLittleEndian { '<', 0, '?', 0, 'x', 0 };
     static constexpr std::array<uint8_t, 6> xmlPrefixBigEndian { 0, '<', 0, '?', 0, 'x' };
-    if (equalSpans(bufferData.first(5), std::span { xmlPrefix })) {
+    if (spanHasPrefix(bufferData, std::span { xmlPrefix })) {
         auto xmlDeclarationEnd = bufferData;
         while (!xmlDeclarationEnd.empty() && xmlDeclarationEnd[0] != '>')
             xmlDeclarationEnd = xmlDeclarationEnd.subspan(1);
@@ -536,10 +536,10 @@ bool TextResourceDecoder::checkForHeadCharset(std::span<const uint8_t> data, boo
         if (pos != -1)
             setEncoding(findTextEncoding(bufferData.subspan(pos, len)), EncodingFromXMLHeader);
         // continue looking for a charset - it may be specified in an HTTP-Equiv meta
-    } else if (equalSpans(bufferData.first(6), std::span { xmlPrefixLittleEndian })) {
+    } else if (spanHasPrefix(bufferData, std::span { xmlPrefixLittleEndian })) {
         setEncoding(PAL::UTF16LittleEndianEncoding(), AutoDetectedEncoding);
         return true;
-    } else if (equalSpans(bufferData.first(6), std::span { xmlPrefixBigEndian })) {
+    } else if (spanHasPrefix(bufferData, std::span { xmlPrefixBigEndian })) {
         setEncoding(PAL::UTF16BigEndianEncoding(), AutoDetectedEncoding);
         return true;
     }

--- a/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
@@ -69,10 +69,10 @@ template<typename CharacterType> static URL makeManifestURL(const URL& manifestU
     return url;
 }
 
-template<typename CharacterType> static constexpr CharacterType cacheManifestIdentifier[] = { 'C', 'A', 'C', 'H', 'E', ' ', 'M', 'A', 'N', 'I', 'F', 'E', 'S', 'T' };
-template<typename CharacterType> static constexpr CharacterType cacheModeIdentifier[] = { 'C', 'A', 'C', 'H', 'E' };
-template<typename CharacterType> static constexpr CharacterType fallbackModeIdentifier[] = { 'F', 'A', 'L', 'L', 'B', 'A', 'C', 'K' };
-template<typename CharacterType> static constexpr CharacterType networkModeIdentifier[] = { 'N', 'E', 'T', 'W', 'O', 'R', 'K' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 14> cacheManifestIdentifier { 'C', 'A', 'C', 'H', 'E', ' ', 'M', 'A', 'N', 'I', 'F', 'E', 'S', 'T' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 5> cacheModeIdentifier { 'C', 'A', 'C', 'H', 'E' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 8> fallbackModeIdentifier { 'F', 'A', 'L', 'L', 'B', 'A', 'C', 'K' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 7> networkModeIdentifier { 'N', 'E', 'T', 'W', 'O', 'R', 'K' };
 
 std::optional<ApplicationCacheManifest> parseApplicationCacheManifest(const URL& manifestURL, const String& manifestMIMEType, std::span<const uint8_t> data)
 {
@@ -89,7 +89,7 @@ std::optional<ApplicationCacheManifest> parseApplicationCacheManifest(const URL&
         // Look for the magic signature: "^\xFEFF?CACHE MANIFEST[ \t]?" (the BOM is removed by TextResourceDecoder).
         // Example: "CACHE MANIFEST #comment" is a valid signature.
         // Example: "CACHE MANIFEST;V2" is not.
-        if (!skipCharactersExactly(buffer, cacheManifestIdentifier<CharacterType>))
+        if (!skipCharactersExactly(buffer, std::span { cacheManifestIdentifier<CharacterType> }))
             return std::nullopt;
     
         if (buffer.hasCharactersRemaining() && !isManifestWhitespaceOrNewline(*buffer))
@@ -122,15 +122,15 @@ std::optional<ApplicationCacheManifest> parseApplicationCacheManifest(const URL&
             StringParsingBuffer lineBuffer(std::span(lineStart, lineEnd + 1));
 
             if (lineBuffer[lineBuffer.lengthRemaining() - 1] == ':') {
-                if (skipCharactersExactly(lineBuffer, cacheModeIdentifier<CharacterType>) && lineBuffer.lengthRemaining() == 1) {
+                if (skipCharactersExactly(lineBuffer, std::span { cacheModeIdentifier<CharacterType> }) && lineBuffer.lengthRemaining() == 1) {
                     mode = ApplicationCacheParserMode::Explicit;
                     continue;
                 }
-                if (skipCharactersExactly(lineBuffer, fallbackModeIdentifier<CharacterType>) && lineBuffer.lengthRemaining() == 1) {
+                if (skipCharactersExactly(lineBuffer, std::span { fallbackModeIdentifier<CharacterType> }) && lineBuffer.lengthRemaining() == 1) {
                     mode = ApplicationCacheParserMode::Fallback;
                     continue;
                 }
-                if (skipCharactersExactly(lineBuffer, networkModeIdentifier<CharacterType>) && lineBuffer.lengthRemaining() == 1) {
+                if (skipCharactersExactly(lineBuffer, std::span { networkModeIdentifier<CharacterType> }) && lineBuffer.lengthRemaining() == 1) {
                     mode = ApplicationCacheParserMode::OnlineAllowlist;
                     continue;
                 }

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -363,7 +363,7 @@ bool FragmentedSharedBuffer::startsWith(std::span<const uint8_t> prefix) const
     size_t remaining = prefix.size();
     for (auto& segment : m_segments) {
         size_t amountToCompareThisTime = std::min(remaining, segment.segment->size());
-        if (!equalSpans(prefix.first(amountToCompareThisTime), segment.segment->span().first(amountToCompareThisTime)))
+        if (!spanHasPrefix(segment.segment->span(), prefix.first(amountToCompareThisTime)))
             return false;
         remaining -= amountToCompareThisTime;
         if (!remaining)

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
@@ -163,7 +163,7 @@ static std::pair<unsigned, unsigned> extractKeyidsLocationFromCencInitData(const
             return keyIdsMap;
 
         // 12 = BMFF box header + Full box header.
-        if (equalSpans(data.subspan(index + 12, ClearKey::cencSystemId.size()), std::span { ClearKey::cencSystemId })) {
+        if (spanHasPrefix(data.subspan(index + 12), std::span { ClearKey::cencSystemId })) {
             foundPssh = true;
             break;
         }

--- a/Source/WebCore/platform/image-decoders/ScalableImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/ScalableImageDecoder.cpp
@@ -65,38 +65,37 @@ namespace {
 #if !PLATFORM(COCOA)
 static bool matchesGIFSignature(std::span<const uint8_t> contents)
 {
-    auto start = contents.first(6);
-    return equalSpans(start, "GIF87a"_span) || equalSpans(start, "GIF89a"_span);
+    return spanHasPrefix(contents, "GIF87a"_span) || spanHasPrefix(contents, "GIF89a"_span);
 }
 
 static bool matchesPNGSignature(std::span<const uint8_t> contents)
 {
-    return equalSpans(contents.first(8), unsafeMakeSpan("\x89\x50\x4E\x47\x0D\x0A\x1A\x0A", 8));
+    return spanHasPrefix(contents, unsafeMakeSpan("\x89\x50\x4E\x47\x0D\x0A\x1A\x0A", 8));
 }
 
 static bool matchesJPEGSignature(std::span<const uint8_t> contents)
 {
-    return equalSpans(contents.first(3), unsafeMakeSpan("\xFF\xD8\xFF", 3));
+    return spanHasPrefix(contents, unsafeMakeSpan("\xFF\xD8\xFF", 3));
 }
 
 static bool matchesBMPSignature(std::span<const uint8_t> contents)
 {
-    return equalSpans(contents.first(2), "BM"_span);
+    return spanHasPrefix(contents, "BM"_span);
 }
 
 static bool matchesICOSignature(std::span<const uint8_t> contents)
 {
-    return equalSpans(contents.first(4), unsafeMakeSpan("\x00\x00\x01\x00", 4));
+    return spanHasPrefix(contents, unsafeMakeSpan("\x00\x00\x01\x00", 4));
 }
 
 static bool matchesCURSignature(std::span<const uint8_t> contents)
 {
-    return equalSpans(contents.first(4), unsafeMakeSpan("\x00\x00\x02\x00", 4));
+    return spanHasPrefix(contents, unsafeMakeSpan("\x00\x00\x02\x00", 4));
 }
 
 static bool matchesWebPSignature(std::span<const uint8_t> contents)
 {
-    return equalSpans(contents.first(4), "RIFF"_span) && equalSpans(contents.subspan(8, 6), "WEBPVP"_span);
+    return spanHasPrefix(contents, "RIFF"_span) && spanHasPrefix(contents.subspan(8), "WEBPVP"_span);
 }
 #endif
 
@@ -112,7 +111,7 @@ static bool matchesAVIFSignature(std::span<const uint8_t> contents, FragmentedSh
     return uti == "public.avif"_s || uti == "public.avis"_s;
 #else
     UNUSED_PARAM(data);
-    return equalSpans(contents.subspan(4, 4), unsafeMakeSpan("\x66\x74\x79\x70", 4));
+    return spanHasPrefix(contents.subspan(4), unsafeMakeSpan("\x66\x74\x79\x70", 4));
 #endif
 }
 #endif // USE(AVIF)

--- a/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp
@@ -321,7 +321,7 @@ ICOImageDecoder::ImageType ICOImageDecoder::imageTypeAtIndex(size_t index)
     const uint32_t imageOffset = m_dirEntries[index].m_imageOffset;
     if ((imageOffset > m_data->size()) || ((m_data->size() - imageOffset) < 4))
         return Unknown;
-    return equalSpans(m_data->span().subspan(imageOffset, 4), unsafeMakeSpan("\x89PNG", 4)) ? PNG : BMP;
+    return spanHasPrefix(m_data->span().subspan(imageOffset), unsafeMakeSpan("\x89PNG", 4)) ? PNG : BMP;
 }
 
 }

--- a/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp
@@ -565,7 +565,7 @@ void PNGImageDecoder::decode(bool onlySize, unsigned haltAtFrame, bool allDataRe
 
 void PNGImageDecoder::readChunks(png_unknown_chunkp chunk)
 {
-    if (chunk->size == 8 && equalSpans(span(chunk->name).first(4), "acTL"_span)) {
+    if (chunk->size == 8 && spanHasPrefix(span(chunk->name), "acTL"_span)) {
         if (m_hasInfo || m_isAnimated)
             return;
 
@@ -585,7 +585,7 @@ void PNGImageDecoder::readChunks(png_unknown_chunkp chunk)
             return;
 
         m_frameBufferCache.resize(m_frameCount);
-    } else if (chunk->size == 26 && equalSpans(span(chunk->name).first(4), "fcTL"_span)) {
+    } else if (chunk->size == 26 && spanHasPrefix(span(chunk->name), "fcTL"_span)) {
         if (m_hasInfo && !m_isAnimated)
             return;
 
@@ -652,7 +652,7 @@ void PNGImageDecoder::readChunks(png_unknown_chunkp chunk)
             fallbackNotAnimated();
             return;
         }
-    } else if (chunk->size >= 4 && equalSpans(span(chunk->name).first(4), "fdAT"_span)) {
+    } else if (chunk->size >= 4 && spanHasPrefix(span(chunk->name), "fdAT"_span)) {
         if (!m_frameInfo || !m_isAnimated)
             return;
 

--- a/Source/WebCore/svg/SVGPreserveAspectRatioValue.cpp
+++ b/Source/WebCore/svg/SVGPreserveAspectRatioValue.cpp
@@ -82,9 +82,9 @@ bool SVGPreserveAspectRatioValue::parse(StringParsingBuffer<UChar>& buffer, bool
     return parseInternal(buffer, validate);
 }
 
-template<typename CharacterType> static constexpr CharacterType noneDesc[] =  {'n', 'o', 'n', 'e'};
-template<typename CharacterType> static constexpr CharacterType meetDesc[] =  {'m', 'e', 'e', 't'};
-template<typename CharacterType> static constexpr CharacterType sliceDesc[] =  {'s', 'l', 'i', 'c', 'e'};
+template<typename CharacterType> static constexpr std::array<CharacterType, 4> noneDesc  { 'n', 'o', 'n', 'e' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 4> meetDesc  { 'm', 'e', 'e', 't' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 5> sliceDesc  { 's', 'l', 'i', 'c', 'e' };
 
 template<typename CharacterType> bool SVGPreserveAspectRatioValue::parseInternal(StringParsingBuffer<CharacterType>& buffer, bool validate)
 {
@@ -98,7 +98,7 @@ template<typename CharacterType> bool SVGPreserveAspectRatioValue::parseInternal
         return false;
 
     if (*buffer == 'n') {
-        if (!skipCharactersExactly(buffer, noneDesc<CharacterType>)) {
+        if (!skipCharactersExactly(buffer, std::span { noneDesc<CharacterType> })) {
             LOG_ERROR("Skipped to parse except for *none* value.");
             return false;
         }
@@ -157,13 +157,13 @@ template<typename CharacterType> bool SVGPreserveAspectRatioValue::parseInternal
 
     if (buffer.hasCharactersRemaining()) {
         if (*buffer == 'm') {
-            if (!skipCharactersExactly(buffer, meetDesc<CharacterType>)) {
+            if (!skipCharactersExactly(buffer, std::span { meetDesc<CharacterType> })) {
                 LOG_ERROR("Skipped to parse except for *meet* or *slice* value.");
                 return false;
             }
             skipOptionalSVGSpaces(buffer);
         } else if (*buffer == 's') {
-            if (!skipCharactersExactly(buffer, sliceDesc<CharacterType>)) {
+            if (!skipCharactersExactly(buffer, std::span { sliceDesc<CharacterType> })) {
                 LOG_ERROR("Skipped to parse except for *meet* or *slice* value.");
                 return false;
             }

--- a/Source/WebCore/svg/SVGTransformable.cpp
+++ b/Source/WebCore/svg/SVGTransformable.cpp
@@ -162,12 +162,12 @@ std::optional<SVGTransformValue> SVGTransformable::parseTransformValue(SVGTransf
     return parseTransformValueGeneric(type, buffer);
 }
 
-template<typename CharacterType> static constexpr CharacterType skewXDesc[] =  {'s', 'k', 'e', 'w', 'X'};
-template<typename CharacterType> static constexpr CharacterType skewYDesc[] =  {'s', 'k', 'e', 'w', 'Y'};
-template<typename CharacterType> static constexpr CharacterType scaleDesc[] =  {'s', 'c', 'a', 'l', 'e'};
-template<typename CharacterType> static constexpr CharacterType translateDesc[] =  {'t', 'r', 'a', 'n', 's', 'l', 'a', 't', 'e'};
-template<typename CharacterType> static constexpr CharacterType rotateDesc[] =  {'r', 'o', 't', 'a', 't', 'e'};
-template<typename CharacterType> static constexpr CharacterType matrixDesc[] =  {'m', 'a', 't', 'r', 'i', 'x'};
+template<typename CharacterType> static constexpr std::array<CharacterType, 5> skewXDesc  { 's', 'k', 'e', 'w', 'X' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 5> skewYDesc  { 's', 'k', 'e', 'w', 'Y' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 5> scaleDesc  { 's', 'c', 'a', 'l', 'e' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 9> translateDesc  { 't', 'r', 'a', 'n', 's', 'l', 'a', 't', 'e' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 6> rotateDesc  { 'r', 'o', 't', 'a', 't', 'e' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 6> matrixDesc  { 'm', 'a', 't', 'r', 'i', 'x' };
 
 template<typename CharacterType> static std::optional<SVGTransformValue::SVGTransformType> parseTransformTypeGeneric(StringParsingBuffer<CharacterType>& buffer)
 {
@@ -175,20 +175,20 @@ template<typename CharacterType> static std::optional<SVGTransformValue::SVGTran
         return std::nullopt;
 
     if (*buffer == 's') {
-        if (skipCharactersExactly(buffer, skewXDesc<CharacterType>))
+        if (skipCharactersExactly(buffer, std::span { skewXDesc<CharacterType> }))
             return SVGTransformValue::SVG_TRANSFORM_SKEWX;
-        if (skipCharactersExactly(buffer, skewYDesc<CharacterType>))
+        if (skipCharactersExactly(buffer, std::span { skewYDesc<CharacterType> }))
             return SVGTransformValue::SVG_TRANSFORM_SKEWY;
-        if (skipCharactersExactly(buffer, scaleDesc<CharacterType>))
+        if (skipCharactersExactly(buffer, std::span { scaleDesc<CharacterType> }))
             return SVGTransformValue::SVG_TRANSFORM_SCALE;
         return std::nullopt;
     }
 
-    if (skipCharactersExactly(buffer, translateDesc<CharacterType>))
+    if (skipCharactersExactly(buffer, std::span { translateDesc<CharacterType> }))
         return SVGTransformValue::SVG_TRANSFORM_TRANSLATE;
-    if (skipCharactersExactly(buffer, rotateDesc<CharacterType>))
+    if (skipCharactersExactly(buffer, std::span { rotateDesc<CharacterType> }))
         return SVGTransformValue::SVG_TRANSFORM_ROTATE;
-    if (skipCharactersExactly(buffer, matrixDesc<CharacterType>))
+    if (skipCharactersExactly(buffer, std::span { matrixDesc<CharacterType> }))
         return SVGTransformValue::SVG_TRANSFORM_MATRIX;
 
     return std::nullopt;

--- a/Source/WebCore/svg/SVGViewSpec.cpp
+++ b/Source/WebCore/svg/SVGViewSpec.cpp
@@ -67,12 +67,12 @@ void SVGViewSpec::reset()
     SVGZoomAndPan::reset();
 }
 
-template<typename CharacterType> static constexpr CharacterType svgViewSpec[] = {'s', 'v', 'g', 'V', 'i', 'e', 'w'};
-template<typename CharacterType> static constexpr CharacterType viewBoxSpec[] = {'v', 'i', 'e', 'w', 'B', 'o', 'x'};
-template<typename CharacterType> static constexpr CharacterType preserveAspectRatioSpec[] = {'p', 'r', 'e', 's', 'e', 'r', 'v', 'e', 'A', 's', 'p', 'e', 'c', 't', 'R', 'a', 't', 'i', 'o'};
-template<typename CharacterType> static constexpr CharacterType transformSpec[] = {'t', 'r', 'a', 'n', 's', 'f', 'o', 'r', 'm'};
-template<typename CharacterType> static constexpr CharacterType zoomAndPanSpec[] = {'z', 'o', 'o', 'm', 'A', 'n', 'd', 'P', 'a', 'n'};
-template<typename CharacterType> static constexpr CharacterType viewTargetSpec[] =  {'v', 'i', 'e', 'w', 'T', 'a', 'r', 'g', 'e', 't'};
+template<typename CharacterType> static constexpr std::array<CharacterType, 7> svgViewSpec { 's', 'v', 'g', 'V', 'i', 'e', 'w' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 7> viewBoxSpec { 'v', 'i', 'e', 'w', 'B', 'o', 'x' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 19> preserveAspectRatioSpec { 'p', 'r', 'e', 's', 'e', 'r', 'v', 'e', 'A', 's', 'p', 'e', 'c', 't', 'R', 'a', 't', 'i', 'o' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 9> transformSpec { 't', 'r', 'a', 'n', 's', 'f', 'o', 'r', 'm' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 10> zoomAndPanSpec { 'z', 'o', 'o', 'm', 'A', 'n', 'd', 'P', 'a', 'n' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 10> viewTargetSpec  { 'v', 'i', 'e', 'w', 'T', 'a', 'r', 'g', 'e', 't' };
 
 bool SVGViewSpec::parseViewSpec(StringView string)
 {
@@ -80,7 +80,7 @@ bool SVGViewSpec::parseViewSpec(StringView string)
         if (buffer.atEnd() || !m_contextElement)
             return false;
 
-        if (!skipCharactersExactly(buffer, svgViewSpec<CharacterType>))
+        if (!skipCharactersExactly(buffer, std::span { svgViewSpec<CharacterType> }))
             return false;
 
         if (!skipExactly(buffer, '('))
@@ -88,7 +88,7 @@ bool SVGViewSpec::parseViewSpec(StringView string)
 
         while (buffer.hasCharactersRemaining() && *buffer != ')') {
             if (*buffer == 'v') {
-                if (skipCharactersExactly(buffer, viewBoxSpec<CharacterType>)) {
+                if (skipCharactersExactly(buffer, std::span { viewBoxSpec<CharacterType> })) {
                     if (!skipExactly(buffer, '('))
                         return false;
                     auto viewBox = SVGFitToViewBox::parseViewBox(buffer, false);
@@ -97,7 +97,7 @@ bool SVGViewSpec::parseViewSpec(StringView string)
                     setViewBox(WTFMove(*viewBox));
                     if (!skipExactly(buffer, ')'))
                         return false;
-                } else if (skipCharactersExactly(buffer, viewTargetSpec<CharacterType>)) {
+                } else if (skipCharactersExactly(buffer, std::span { viewTargetSpec<CharacterType> })) {
                     if (!skipExactly(buffer, '('))
                         return false;
                     auto viewTargetStart = buffer.position();
@@ -109,7 +109,7 @@ bool SVGViewSpec::parseViewSpec(StringView string)
                 } else
                     return false;
             } else if (*buffer == 'z') {
-                if (!skipCharactersExactly(buffer, zoomAndPanSpec<CharacterType>))
+                if (!skipCharactersExactly(buffer, std::span { zoomAndPanSpec<CharacterType> }))
                     return false;
                 if (!skipExactly(buffer, '('))
                     return false;
@@ -120,7 +120,7 @@ bool SVGViewSpec::parseViewSpec(StringView string)
                 if (!skipExactly(buffer, ')'))
                     return false;
             } else if (*buffer == 'p') {
-                if (!skipCharactersExactly(buffer, preserveAspectRatioSpec<CharacterType>))
+                if (!skipCharactersExactly(buffer, std::span { preserveAspectRatioSpec<CharacterType> }))
                     return false;
                 if (!skipExactly(buffer, '('))
                     return false;
@@ -131,7 +131,7 @@ bool SVGViewSpec::parseViewSpec(StringView string)
                 if (!skipExactly(buffer, ')'))
                     return false;
             } else if (*buffer == 't') {
-                if (!skipCharactersExactly(buffer, transformSpec<CharacterType>))
+                if (!skipCharactersExactly(buffer, std::span { transformSpec<CharacterType> }))
                     return false;
                 if (!skipExactly(buffer, '('))
                     return false;

--- a/Source/WebCore/svg/SVGZoomAndPan.cpp
+++ b/Source/WebCore/svg/SVGZoomAndPan.cpp
@@ -26,15 +26,15 @@
 
 namespace WebCore {
 
-template<typename CharacterType> static constexpr CharacterType disable[] = { 'd', 'i', 's', 'a', 'b', 'l', 'e' };
-template<typename CharacterType> static constexpr CharacterType magnify[] = { 'm', 'a', 'g', 'n', 'i', 'f', 'y' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 7> disable { 'd', 'i', 's', 'a', 'b', 'l', 'e' };
+template<typename CharacterType> static constexpr std::array<CharacterType, 7> magnify { 'm', 'a', 'g', 'n', 'i', 'f', 'y' };
 
 template<typename CharacterType> static std::optional<SVGZoomAndPanType> parseZoomAndPanGeneric(StringParsingBuffer<CharacterType>& buffer)
 {
-    if (skipCharactersExactly(buffer, disable<CharacterType>))
+    if (skipCharactersExactly(buffer, std::span { disable<CharacterType> }))
         return SVGZoomAndPanDisable;
 
-    if (skipCharactersExactly(buffer, magnify<CharacterType>))
+    if (skipCharactersExactly(buffer, std::span { magnify<CharacterType> }))
         return SVGZoomAndPanMagnify;
 
     return std::nullopt;

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -489,7 +489,7 @@ static bool tryApplyCachedSandbox(const SandboxInfo& info)
         return false;
     if (cachedSandboxHeader.headerSize != info.header.length())
         return false;
-    if (!equalSpans(sandboxHeader.first(info.header.length()), info.header.span()))
+    if (!spanHasPrefix(sandboxHeader, info.header.span()))
         return false;
 
     SandboxProfile profile { };

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
@@ -220,7 +220,7 @@ void CtapHidDriver::continueAfterChannelAllocated(std::optional<FidoHidMessage>&
     auto payload = message->getMessagePayload();
     ASSERT(payload.size() == kHidInitResponseSize);
     // Restart the transaction in the next run loop when nonce mismatches.
-    if (!equalSpans(payload.span().first(m_nonce.size()), m_nonce.span())) {
+    if (!spanHasPrefix(payload.span(), m_nonce.span())) {
         m_state = State::Idle;
         RunLoop::main().dispatch([weakThis = WeakPtr { *this }, data = WTFMove(m_requestData), callback = WTFMove(m_responseCallback)]() mutable {
             if (!weakThis)

--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -31,6 +31,7 @@
 #include "Encoder.h"
 #include "StreamConnectionEncoder.h"
 #include "Test.h"
+#include <wtf/StdLibExtras.h>
 
 namespace TestWebKitAPI {
 
@@ -594,14 +595,14 @@ TYPED_TEST_P(ArgumentCoderSpanTest, SimpleSpan)
         ASSERT_TRUE(!!span);
         ASSERT_EQ(data8.size(), span->size());
         ASSERT_EQ(data8.size() * sizeof(uint8_t), span->size_bytes());
-        ASSERT_EQ(memcmp(data8.data(), span->data(), span->size_bytes()), 0);
+        ASSERT_TRUE(equalSpans(std::span { data8 }, *span));
     }
     {
         auto span = decoder->template decode<std::span<const uint32_t>>();
         ASSERT_TRUE(!!span);
         ASSERT_EQ(data32.size(), span->size());
         ASSERT_EQ(data32.size() * sizeof(uint32_t), span->size_bytes());
-        ASSERT_EQ(memcmp(data32.data(), span->data(), span->size_bytes()), 0);
+        ASSERT_TRUE(equalSpans(std::span { data32 }, *span));
     }
     {
         auto span = decoder->template decode<std::span<const uint64_t>>();


### PR DESCRIPTION
#### e3bc80970566b176f6f2e02c0ffbf3323c0eb19e
<pre>
Further reduce use of memcmp()
<a href="https://bugs.webkit.org/show_bug.cgi?id=285060">https://bugs.webkit.org/show_bug.cgi?id=285060</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/API/JSValue.mm:
(createStructHandlerMap):
* Source/JavaScriptCore/builtins/BuiltinExecutables.cpp:
(JSC::BuiltinExecutables::createExecutable):
* Source/JavaScriptCore/fuzzilli/Fuzzilli.cpp:
(Fuzzilli::initializeReprl):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::parseContainerElement):
* Source/WebCore/html/parser/ParsingUtilities.h:
(WebCore::skipLettersExactlyIgnoringASCIICase):
(WebCore::skipCharactersExactly):
* Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp:
(WebCore::parseApplicationCacheManifest):
* Source/WebCore/svg/SVGPreserveAspectRatioValue.cpp:
(WebCore::SVGPreserveAspectRatioValue::parseInternal):
* Source/WebCore/svg/SVGTransformable.cpp:
(WebCore::parseTransformTypeGeneric):
* Source/WebCore/svg/SVGViewSpec.cpp:
(WebCore::SVGViewSpec::parseViewSpec):
* Source/WebCore/svg/SVGZoomAndPan.cpp:
(WebCore::parseZoomAndPanGeneric):
* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp:
(TestWebKitAPI::TYPED_TEST_P):

Canonical link: <a href="https://commits.webkit.org/288228@main">https://commits.webkit.org/288228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41234d87fdc2a4ef8be80d4b5e0e3822dfc1ae51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36197 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87147 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33224 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84281 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9662 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/87147 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21783 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1307 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74769 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/87147 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28950 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32097 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75158 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72507 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88509 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81230 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6737 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72436 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9674 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71655 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15779 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14693 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12751 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9419 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14914 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103642 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9283 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25149 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12766 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->