### PR TITLE
AX: AXIsolatedTree::m_selectedTextMarkerRange is not initialized when the tree is created, causing accessibility/textarea-insertion-point-line-number.html to fail in ITM

### DIFF
--- a/LayoutTests/accessibility/textarea-insertion-point-line-number.html
+++ b/LayoutTests/accessibility/textarea-insertion-point-line-number.html
@@ -35,7 +35,7 @@ if (window.accessibilityController) {
         for (currentLine = 0; currentLine < 3; currentLine++) {
             area1.selectionStart = currentLine * 7;
             area1.selectionEnd = currentLine * 7;
-            output += expect("area1AXUIElement.insertionPointLineNumber", "currentLine");
+            output += await expectAsync("area1AXUIElement.insertionPointLineNumber", "currentLine");
         }
 
         // area2 is an empty textarea so the insertion point line number should be 0.

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -223,6 +223,13 @@ String AXTextMarker::debugDescription() const
     );
 }
 
+AXTextMarkerRange::AXTextMarkerRange(const VisibleSelection& selection)
+    : m_start(selection.visibleStart())
+    , m_end(selection.visibleEnd())
+{
+    ASSERT(isMainThread());
+}
+
 AXTextMarkerRange::AXTextMarkerRange(const VisiblePositionRange& range)
     : m_start(range.start)
     , m_end(range.end)

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -253,6 +253,7 @@ class AXTextMarkerRange {
 public:
     // Constructors.
     AXTextMarkerRange(const VisiblePositionRange&);
+    AXTextMarkerRange(const VisibleSelection&);
     AXTextMarkerRange(const std::optional<SimpleRange>&);
     AXTextMarkerRange(const AXTextMarker&, const AXTextMarker&);
     AXTextMarkerRange(AXTextMarker&&, AXTextMarker&&);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -168,7 +168,7 @@ Ref<AXIsolatedTree> AXIsolatedTree::create(AXObjectCache& axObjectCache)
     auto* axFocus = axObjectCache.focusedObjectForPage(document.page());
     if (axFocus)
         tree->setFocusedNodeID(axFocus->objectID());
-
+    tree->setSelectedTextMarkerRange(document.selection().selection());
     tree->updateLoadingProgress(axObjectCache.loadingProgress());
 
     const auto relations = axObjectCache.relations();


### PR DESCRIPTION
#### a29ef3b109619cc942baf10a3e19d4e35725fe63
<pre>
AX: AXIsolatedTree::m_selectedTextMarkerRange is not initialized when the tree is created, causing accessibility/textarea-insertion-point-line-number.html to fail in ITM
<a href="https://bugs.webkit.org/show_bug.cgi?id=285068">https://bugs.webkit.org/show_bug.cgi?id=285068</a>
<a href="https://rdar.apple.com/141876835">rdar://141876835</a>

Reviewed by Chris Fleizach.

When creating an AXIsolatedTree, we didn&apos;t sync the current frame selection into AXIsolatedTree::m_selectedTextMarkerRange,
meaning it would be wrong until it changed again. This commit syncs the frame selection when creating the tree, ensuring
m_selectedTextMarkerRange is right from the start.

* LayoutTests/accessibility/textarea-insertion-point-line-number.html:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::create):

Canonical link: <a href="https://commits.webkit.org/288225@main">https://commits.webkit.org/288225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/974ac9e005d43e2a841f7894364ee08c6f2f0d10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86964 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33204 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64037 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21770 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74758 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44316 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28939 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31869 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72495 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88344 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72423 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71642 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17871 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15767 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14682 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9388 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14897 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9244 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12744 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11035 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->