### PR TITLE
[GLib] Print out valid tests when a specified one isn't found

### DIFF
--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -75,6 +75,18 @@ class TestRunner(object):
                 tests.append(test_path)
         return tests
 
+    def _get_all_valid_test_names(self):
+        test_paths = []
+        base_dir = self._test_programs_base_dir()
+        for test_file in os.listdir(base_dir):
+            test_path = os.path.join(base_dir, test_file)
+            if os.path.isdir(test_path):
+                test_paths.extend(self._get_tests_from_dir(test_path))
+            elif os.path.isfile(test_path) and os.access(test_path, os.X_OK):
+                test_paths.append(test_path)
+        test_dir_prefix_len = len(self._test_programs_base_dir()) + 1
+        return (path[test_dir_prefix_len:] for path in test_paths)
+
     def _get_tests(self, initial_tests):
         tests = []
         for test in initial_tests:
@@ -84,7 +96,7 @@ class TestRunner(object):
                 if not os.path.exists(test):
                     candidate = os.path.join(self._test_programs_base_dir(), test)
                     if not os.path.exists(candidate):
-                        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), test)
+                        return []
                     test = candidate
                 tests.append(test)
         if tests:
@@ -285,6 +297,7 @@ class TestRunner(object):
     def run_tests(self):
         if not self._tests:
             sys.stderr.write("ERROR: tests not found in %s.\n" % (self._test_programs_base_dir()))
+            sys.stderr.write("Valid options are: {}\n".format(", ".join(self._get_all_valid_test_names())))
             sys.stderr.flush()
             sys.exit(1)
 


### PR DESCRIPTION
#### f916bd42c1178c53e9ffe8f52dbddb3b279b8461
<pre>
[GLib] Print out valid tests when a specified one isn&apos;t found
<a href="https://bugs.webkit.org/show_bug.cgi?id=285069">https://bugs.webkit.org/show_bug.cgi?id=285069</a>

Reviewed by Michael Catanzaro.

The usage of run-*-tests isn&apos;t the most clear, this prints out
a helpful list to point you in the right direction for what
tests are available.

* Tools/glib/api_test_runner.py:
(TestRunner._get_all_valid_test_names):
(TestRunner._get_tests):
(TestRunner.run_tests):

Canonical link: <a href="https://commits.webkit.org/288233@main">https://commits.webkit.org/288233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d44f7b5c690d4d9bbb9ceab24a082e9602fdb3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86977 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33210 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9606 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64040 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21774 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1299 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44319 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1198 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28941 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31908 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88378 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9436 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6727 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72427 "Found 1 new test failure: webanimations/accelerated-web-animation-with-single-interval-and-easing-y-axis-above-1.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9643 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71646 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15771 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14684 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12754 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9397 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9253 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12751 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11043 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->