### PR TITLE
AX: AXPropertyName::IsGrabbed is not updated when non-aria-grabbed drags happen

### DIFF
--- a/LayoutTests/accessibility/gtk/aria-drag-and-drop-expected.txt
+++ b/LayoutTests/accessibility/gtk/aria-drag-and-drop-expected.txt
@@ -5,35 +5,35 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 test1
 	ariaDropEffects:
-	ariaIsGrabbed: false
+	isGrabbed: false
 	has grabbed attribute: false
 test2
 	ariaDropEffects:
-	ariaIsGrabbed: false
+	isGrabbed: false
 	has grabbed attribute: false
 test3
 	ariaDropEffects:
-	ariaIsGrabbed: true
+	isGrabbed: true
 	has grabbed attribute: true
 test4
 	ariaDropEffects:
-	ariaIsGrabbed: false
+	isGrabbed: false
 	has grabbed attribute: true
 test5
 	ariaDropEffects: copy
-	ariaIsGrabbed: false
+	isGrabbed: false
 	has grabbed attribute: false
 test6
 	ariaDropEffects: move
-	ariaIsGrabbed: false
+	isGrabbed: false
 	has grabbed attribute: false
 test7
 	ariaDropEffects: copy move
-	ariaIsGrabbed: false
+	isGrabbed: false
 	has grabbed attribute: false
 test8
 	ariaDropEffects: none
-	ariaIsGrabbed: false
+	isGrabbed: false
 	has grabbed attribute: false
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/gtk/aria-drag-and-drop.html
+++ b/LayoutTests/accessibility/gtk/aria-drag-and-drop.html
@@ -33,7 +33,7 @@
         for (var i = 1; i <= 8; i++) {
             var axElement = accessibilityController.accessibleElementById("test" + i);
             debug("test" + i + "\n\tariaDropEffects: " + axElement.ariaDropEffects +
-			       "\n\tariaIsGrabbed: " + axElement.ariaIsGrabbed +
+			       "\n\tisGrabbed: " + axElement.isGrabbed +
 			       "\n\thas grabbed attribute: " + hasGrabbedAttribute(axElement));
         }
 

--- a/LayoutTests/accessibility/mac/aria-drag-drop-expected.txt
+++ b/LayoutTests/accessibility/mac/aria-drag-drop-expected.txt
@@ -1,16 +1,16 @@
 This tests that the ARIA drag and drop attributes work as intended.
 
 PASS: dropeffectDiv.ariaDropEffects === 'copy,move'
-PASS: initiallyGrabbedDiv.ariaIsGrabbed === true
-PASS: initiallyUngrabbedDiv.ariaIsGrabbed === false
+PASS: initiallyGrabbedDiv.isGrabbed === true
+PASS: initiallyUngrabbedDiv.isGrabbed === false
 PASS: initiallyGrabbedDiv.isAttributeSettable('AXGrabbed') === true
 PASS: initiallyUngrabbedDiv.isAttributeSettable('AXGrabbed') === true
-PASS: displayContentsDiv.ariaIsGrabbed === true
+PASS: displayContentsDiv.isGrabbed === true
 PASS: displayContentsDiv.isAttributeSettable('AXGrabbed') === true
 PASS: displayContentsDiv.ariaDropEffects === 'copy,move'
 
 Setting aria-grabbed false for element #initially-grabbed-div.
-PASS: initiallyGrabbedDiv.ariaIsGrabbed === false
+PASS: initiallyGrabbedDiv.isGrabbed === false
 
 Setting aria-dropeffect of #dropeffect-div to 'move'.
 PASS: dropeffectDiv.ariaDropEffects === 'move'

--- a/LayoutTests/accessibility/mac/aria-drag-drop.html
+++ b/LayoutTests/accessibility/mac/aria-drag-drop.html
@@ -23,20 +23,20 @@ if (window.accessibilityController) {
     var initiallyGrabbedDiv = accessibilityController.accessibleElementById("initially-grabbed-div");
     var initiallyUngrabbedDiv = accessibilityController.accessibleElementById("initially-ungrabbed-div");
     var displayContentsDiv = accessibilityController.accessibleElementById("display-contents-div");
-    testOutput += expect("initiallyGrabbedDiv.ariaIsGrabbed", "true");
-    testOutput += expect("initiallyUngrabbedDiv.ariaIsGrabbed", "false");
+    testOutput += expect("initiallyGrabbedDiv.isGrabbed", "true");
+    testOutput += expect("initiallyUngrabbedDiv.isGrabbed", "false");
     testOutput += expect("initiallyGrabbedDiv.isAttributeSettable('AXGrabbed')", "true");
     testOutput += expect("initiallyUngrabbedDiv.isAttributeSettable('AXGrabbed')", "true");
 
-    testOutput += expect("displayContentsDiv.ariaIsGrabbed", "true");
+    testOutput += expect("displayContentsDiv.isGrabbed", "true");
     testOutput += expect("displayContentsDiv.isAttributeSettable('AXGrabbed')", "true");
     testOutput += expect("displayContentsDiv.ariaDropEffects", "'copy,move'");
 
     testOutput += "\nSetting aria-grabbed false for element #initially-grabbed-div.\n";
     document.getElementById("initially-grabbed-div").setAttribute("aria-grabbed", "false");
     setTimeout(async function() {
-        await waitFor(() => !initiallyGrabbedDiv.ariaIsGrabbed);
-        testOutput += expect("initiallyGrabbedDiv.ariaIsGrabbed", "false");
+        await waitFor(() => !initiallyGrabbedDiv.isGrabbed);
+        testOutput += expect("initiallyGrabbedDiv.isGrabbed", "false");
 
         testOutput += "\nSetting aria-dropeffect of #dropeffect-div to 'move'.\n";
         document.getElementById("dropeffect-div").setAttribute("aria-dropeffect", "move");

--- a/LayoutTests/accessibility/mac/dynamic-drag-expected.txt
+++ b/LayoutTests/accessibility/mac/dynamic-drag-expected.txt
@@ -1,0 +1,14 @@
+This test ensures we properly report isGrabbed state to assistive technologies.
+
+PASS: accessibilityController.accessibleElementById('input1').isGrabbed === false
+PASS: accessibilityController.accessibleElementById('input2').isGrabbed === false
+PASS: accessibilityController.accessibleElementById('input1').isGrabbed === true
+PASS: accessibilityController.accessibleElementById('input1').isGrabbed === false
+PASS: accessibilityController.accessibleElementById('input2').isGrabbed === true
+PASS: accessibilityController.accessibleElementById('input2').isGrabbed === false
+PASS: accessibilityController.accessibleElementById('input1').isGrabbed === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/dynamic-drag.html
+++ b/LayoutTests/accessibility/mac/dynamic-drag.html
@@ -1,0 +1,50 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input id="input1" type="text" draggable="true" />
+<input id="input2" type="text" draggable="true" />
+
+<script>
+var output = "This test ensures we properly report isGrabbed state to assistive technologies.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += expect("accessibilityController.accessibleElementById('input1').isGrabbed", "false");
+    output += expect("accessibilityController.accessibleElementById('input2').isGrabbed", "false");
+
+    startDrag("input1");
+    setTimeout(async function() {
+        output += await expectAsync("accessibilityController.accessibleElementById('input1').isGrabbed", "true");
+        stopDrag();
+        startDrag("input2");
+        output += await expectAsync("accessibilityController.accessibleElementById('input1').isGrabbed", "false");
+        output += await expectAsync("accessibilityController.accessibleElementById('input2').isGrabbed", "true");
+        startDrag("input1");
+        output += await expectAsync("accessibilityController.accessibleElementById('input2').isGrabbed", "false");
+        output += await expectAsync("accessibilityController.accessibleElementById('input1').isGrabbed", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+
+function startDrag(id) {
+    const element = document.getElementById(id);
+    const centerY = element.offsetTop + element.offsetHeight / 2;
+    const centerX = element.offsetLeft + element.offsetWidth / 2;
+    eventSender.mouseMoveTo(centerX, centerY);
+    eventSender.mouseDown();
+    eventSender.mouseMoveTo(centerX + 100, centerY + 100)
+}
+function stopDrag() { eventSender.mouseUp(); }
+
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -897,6 +897,8 @@ accessibility/range-input-increment-decrement-fires-input-event.html [ WontFix ]
 # Default ARIA for custom elements are not yet enabled
 accessibility/custom-elements/ [ Skip ]
 
+accessibility/mac/dynamic-drag.html [ Skip ]
+
 accessibility/display-contents/role-row-headers.html [ Skip ]
 
 # Missing AccessibilityUIElement::dateTimeValue() implementation.

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1287,6 +1287,23 @@ static bool isClickEvent(const AtomString& eventType)
 }
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
+void AXObjectCache::onDragElementChanged(Element* oldElement, Element* newElement)
+{
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    if (oldElement == newElement)
+        return;
+
+    if (oldElement)
+        postNotification(get(*oldElement), AXNotification::GrabbedStateChanged);
+
+    if (newElement)
+        postNotification(get(*newElement), AXNotification::GrabbedStateChanged);
+#else
+    UNUSED_PARAM(oldElement);
+    UNUSED_PARAM(newElement);
+#endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+}
+
 void AXObjectCache::onEventListenerAdded(Node& node, const AtomString& eventType)
 {
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -357,6 +357,7 @@ public:
     void childrenChanged(Node*, Element* newChild = nullptr);
     void childrenChanged(RenderObject*, RenderObject* newChild = nullptr);
     void childrenChanged(AccessibilityObject*);
+    void onDragElementChanged(Element* oldElement, Element* newElement);
     void onEventListenerAdded(Node&, const AtomString& eventType);
     void onEventListenerRemoved(Node&, const AtomString& eventType);
     void onExpandedChanged(HTMLDetailsElement&);

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -384,6 +384,7 @@ private:
 #if ENABLE(DRAG_SUPPORT)
     static DragState& dragState();
     static const Seconds TextDragDelay;
+    void setDragStateSource(Element*) const;
     SimpleRange createSimpleRangeFromDragStartSelection() const;
     std::optional<WeakSimpleRange> getWeakSimpleRangeFromSelection(const VisibleSelection&) const;
 #endif

--- a/Tools/DumpRenderTree/AccessibilityUIElement.cpp
+++ b/Tools/DumpRenderTree/AccessibilityUIElement.cpp
@@ -1177,9 +1177,9 @@ static JSValueRef domIdentifierCallback(JSContextRef context, JSObjectRef thisOb
     return JSValueMakeString(context, domIdentifier.get());
 }
 
-static JSValueRef getARIAIsGrabbedCallback(JSContextRef context, JSObjectRef thisObject, JSStringRef propertyName, JSValueRef* exception)
+static JSValueRef getIsGrabbedCallback(JSContextRef context, JSObjectRef thisObject, JSStringRef propertyName, JSValueRef* exception)
 {
-    return JSValueMakeBoolean(context, toAXElement(thisObject)->ariaIsGrabbed());
+    return JSValueMakeBoolean(context, toAXElement(thisObject)->isGrabbed());
 }
 
 static JSValueRef getIsValidCallback(JSContextRef context, JSObjectRef thisObject, JSStringRef propertyName, JSValueRef* exception)
@@ -2012,7 +2012,7 @@ JSClassRef AccessibilityUIElement::getJSClass()
         { "liveRegionRelevant", getLiveRegionRelevantCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "liveRegionStatus", getLiveRegionStatusCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "orientation", getOrientationCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
-        { "ariaIsGrabbed", getARIAIsGrabbedCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
+        { "isGrabbed", getIsGrabbedCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "ariaDropEffects", getARIADropEffectsCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "classList", getClassListCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "domIdentifier", domIdentifierCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },

--- a/Tools/DumpRenderTree/AccessibilityUIElement.h
+++ b/Tools/DumpRenderTree/AccessibilityUIElement.h
@@ -219,8 +219,8 @@ public:
     JSRetainPtr<JSStringRef> customContent() const;
 #endif
 
-    // ARIA Drag and Drop
-    bool ariaIsGrabbed() const;
+    // Drag and drop
+    bool isGrabbed() const;
     // A space concatentated string of all the drop effects.
     JSRetainPtr<JSStringRef> ariaDropEffects() const;
     

--- a/Tools/DumpRenderTree/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/DumpRenderTree/ios/AccessibilityUIElementIOS.mm
@@ -948,7 +948,7 @@ int AccessibilityUIElement::hierarchicalLevel() const
     return 0;
 }
 
-bool AccessibilityUIElement::ariaIsGrabbed() const
+bool AccessibilityUIElement::isGrabbed() const
 {
     return false;
 }

--- a/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
@@ -984,7 +984,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::classList() const
     return nullptr;
 }
 
-bool AccessibilityUIElement::ariaIsGrabbed() const
+bool AccessibilityUIElement::isGrabbed() const
 {
     return boolAttributeValue(NSAccessibilityGrabbedAttribute);
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -290,8 +290,8 @@ public:
     RefPtr<AccessibilityUIElement> ownerElementAtIndex(unsigned);
     RefPtr<AccessibilityUIElement> ariaOwnsElementAtIndex(unsigned);
 
-    // ARIA Drag and Drop
-    bool ariaIsGrabbed() const;
+    // Drag and drop
+    bool isGrabbed() const;
     // A space concatentated string of all the drop effects.
     JSRetainPtr<JSStringRef> ariaDropEffects() const;
     

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -116,7 +116,7 @@ interface AccessibilityUIElement {
     readonly attribute boolean isOffScreen;
     readonly attribute boolean isValid;
     readonly attribute long hierarchicalLevel;
-    readonly attribute boolean ariaIsGrabbed;
+    readonly attribute boolean isGrabbed;
     readonly attribute DOMString ariaDropEffects;
     readonly attribute DOMString classList;
     readonly attribute DOMString embeddedImageDescription;

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -1163,7 +1163,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::speakAs()
     return JSStringCreateWithCharacters(nullptr, 0);
 }
 
-bool AccessibilityUIElement::ariaIsGrabbed() const
+bool AccessibilityUIElement::isGrabbed() const
 {
     m_element->updateBackingStore();
     return m_element->attributes().get("grabbed"_s) == "true"_s;

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
@@ -748,7 +748,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::speakAs()
     return [[[m_element accessibilitySpeechHint] componentsJoinedByString:@", "] createJSStringRef];
 }
 
-bool AccessibilityUIElement::ariaIsGrabbed() const
+bool AccessibilityUIElement::isGrabbed() const
 {
     return false;
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -1374,7 +1374,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::speakAs()
     return nullptr;
 }
 
-bool AccessibilityUIElement::ariaIsGrabbed() const
+bool AccessibilityUIElement::isGrabbed() const
 {
     return boolAttributeValueNS(NSAccessibilityGrabbedAttribute);
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp
@@ -496,7 +496,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::speakAs()
     return nullptr;
 }
 
-bool AccessibilityUIElement::ariaIsGrabbed() const
+bool AccessibilityUIElement::isGrabbed() const
 {
     notImplemented();
     return false;

--- a/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
@@ -496,7 +496,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::speakAs()
     return nullptr;
 }
 
-bool AccessibilityUIElement::ariaIsGrabbed() const
+bool AccessibilityUIElement::isGrabbed() const
 {
     notImplemented();
     return false;


### PR DESCRIPTION
#### 050c5b45835674a04049e64ceb07ad7958acb4be
<pre>
AX: AXPropertyName::IsGrabbed is not updated when non-aria-grabbed drags happen
<a href="https://bugs.webkit.org/show_bug.cgi?id=285070">https://bugs.webkit.org/show_bug.cgi?id=285070</a>
<a href="https://rdar.apple.com/141880722">rdar://141880722</a>

Reviewed by Chris Fleizach.

With this commit, we now AXPropertyName::IsGrabbed when drags happen via pointing device or JavaScript.

AccessibilityUIElement::ariaIsGrabbed is renamed to isGrabbed, as this state is not ARIA-only.

* LayoutTests/accessibility/gtk/aria-drag-and-drop-expected.txt:
* LayoutTests/accessibility/gtk/aria-drag-and-drop.html:
* LayoutTests/accessibility/mac/aria-drag-drop-expected.txt:
* LayoutTests/accessibility/mac/aria-drag-drop.html:
* LayoutTests/accessibility/mac/dynamic-drag-expected.txt: Added.
* LayoutTests/accessibility/mac/dynamic-drag.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onDragElementChanged):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMousePressEvent):
(WebCore::EventHandler::setDragStateSource const):
(WebCore::EventHandler::dragSourceEndedAt):
(WebCore::EventHandler::updateDragStateAfterEditDragIfNeeded):
(WebCore::EventHandler::handleDrag):
* Source/WebCore/page/EventHandler.h:
* Tools/DumpRenderTree/AccessibilityUIElement.cpp:
(getIsGrabbedCallback):
(AccessibilityUIElement::getJSClass):
(getARIAIsGrabbedCallback): Deleted.
* Tools/DumpRenderTree/AccessibilityUIElement.h:
* Tools/DumpRenderTree/ios/AccessibilityUIElementIOS.mm:
(AccessibilityUIElement::isGrabbed const):
(AccessibilityUIElement::ariaIsGrabbed const): Deleted.
* Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm:
(AccessibilityUIElement::isGrabbed const):
(AccessibilityUIElement::ariaIsGrabbed const): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp:
(WTR::AccessibilityUIElement::isGrabbed const):
(WTR::AccessibilityUIElement::ariaIsGrabbed const): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
(WTR::AccessibilityUIElement::isGrabbed const):
(WTR::AccessibilityUIElement::ariaIsGrabbed const): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElement::isGrabbed const):
(WTR::AccessibilityUIElement::ariaIsGrabbed const): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp:
(WTR::AccessibilityUIElement::isGrabbed const):
(WTR::AccessibilityUIElement::ariaIsGrabbed const): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp:
(WTR::AccessibilityUIElement::isGrabbed const):
(WTR::AccessibilityUIElement::ariaIsGrabbed const): Deleted.

Canonical link: <a href="https://commits.webkit.org/288235@main">https://commits.webkit.org/288235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/788c54cddaad2f32cdf1453d85fdbf3174e11b97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87027 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33216 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64043 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21778 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44322 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1202 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28945 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31968 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72503 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88427 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72430 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71649 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17874 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15775 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14688 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9406 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14906 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9265 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12757 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11050 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->