### PR TITLE
[iOS] [SelectionHonorsOverflowScrolling] Selection rects are sometimes offset after switching back to a tab

### DIFF
--- a/LayoutTests/editing/selection/ios/selection-after-reparenting-view-and-becoming-first-responder-expected.txt
+++ b/LayoutTests/editing/selection/ios/selection-after-reparenting-view-and-becoming-first-responder-expected.txt
@@ -1,0 +1,16 @@
+Select me
+
+Verifies that the selection appears in the right location after the view becomes first responder, after being reparented
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS selectionRectsBefore.length is 1
+PASS selectionRectsAfter.length is 1
+PASS selectionRectsBefore[0].top is selectionRectsAfter[0].top
+PASS selectionRectsBefore[0].left is selectionRectsAfter[0].left
+PASS selectionRectsBefore[0].width is selectionRectsAfter[0].width
+PASS selectionRectsBefore[0].height is selectionRectsAfter[0].height
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/selection-after-reparenting-view-and-becoming-first-responder.html
+++ b/LayoutTests/editing/selection/ios/selection-after-reparenting-view-and-becoming-first-responder.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true SelectionHonorsOverflowScrolling=true contentInset.top=100 ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 16px;
+    font-family: system-ui;
+    margin: 0;
+}
+
+.target {
+    text-align: center;
+    font-size: 40px;
+    line-height: 40px;
+}
+
+.target > span {
+    border: 1px solid orange;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the selection appears in the right location after the view becomes first responder, after being reparented");
+
+    await UIHelper.longPressElement(document.querySelector(".target > span"));
+    selectionRectsBefore = await UIHelper.waitForSelectionToAppear();
+
+    await UIHelper.removeViewFromWindow();
+    await new Promise(resolve => {
+        testRunner.runUIScript(`
+            uiController.addViewToWindow();
+            uiController.becomeFirstResponder()
+        `, resolve);
+    });
+
+    selectionRectsAfter = await UIHelper.waitForSelectionToAppear();
+
+    shouldBe("selectionRectsBefore.length", "1");
+    shouldBe("selectionRectsAfter.length", "1");
+    shouldBe("selectionRectsBefore[0].top", "selectionRectsAfter[0].top");
+    shouldBe("selectionRectsBefore[0].left", "selectionRectsAfter[0].left");
+    shouldBe("selectionRectsBefore[0].width", "selectionRectsAfter[0].width");
+    shouldBe("selectionRectsBefore[0].height", "selectionRectsAfter[0].height");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <p class="target"><span>Select</span> me</p>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h
@@ -56,6 +56,7 @@
 - (void)selectAll:(id)sender;
 - (void)translate:(NSString *)text fromRect:(CGRect)presentationRect;
 - (void)prepareToMoveSelectionContainer:(UIView *)newContainer;
+- (void)setNeedsSelectionUpdate;
 
 - (void)willBeginDragLift;
 - (void)didConcludeDrop;

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
@@ -236,6 +236,13 @@ private:
 #endif // HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
 }
 
+- (void)setNeedsSelectionUpdate
+{
+#if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
+    [self.textSelectionDisplayInteraction setNeedsSelectionUpdate];
+#endif
+}
+
 - (void)activateSelection
 {
 #if USE(BROWSERENGINEKIT)


### PR DESCRIPTION
#### 2aa41ea14b83de5fc8af2827129307dd821a5233
<pre>
[iOS] [SelectionHonorsOverflowScrolling] Selection rects are sometimes offset after switching back to a tab
<a href="https://bugs.webkit.org/show_bug.cgi?id=285072">https://bugs.webkit.org/show_bug.cgi?id=285072</a>
<a href="https://rdar.apple.com/141885834">rdar://141885834</a>

Reviewed by Abrar Rahman Protyasha.

When `SelectionHonorsOverflowScrolling` is enabled, it&apos;s possible to get the text selection
highlight view into a state where it&apos;s in the wrong place after switching away and then back to a
tab in Safari. When performing this workflow (switching from web view A to B, and then back to A)…

1.  Safari removes A from the view hierarchy, replacing it with B. Underlying compositing views
    (one of which may contain selection views) are also removed from the view hierarchy in the
    process. The text interaction is also deactivated, as a result of the view no longer being
    parented.

2.  When switching back, Safari reinserts A in the view hierarchy, and immediately proceeds to call
    `-becomeFirstResponder` on the web view. In `-[WKContentView becomeFirstResponderForWebView]`,
    this causes us to activate the selection right away, which leads to UIKit regenerating
    selection highlight views by mapping from `WKContentView` coordinates to selection container
    coordinates. However, when `SelectionHonorsOverflowScrolling` is enabled, the selection is in a
    compositing view that still hasn&apos;t been reparented in the view hierarchy at this point, so the
    coordinate space mapping produces an incorrect result.

3.  After the first presentation update that follows, the compositing views are reinserted. However,
    because the text selection display interaction is already active and UIKit has already laid out
    selection rects, we bail early on updating native selection views because we think we&apos;re already
    up to date.

Consequently, the selection ends up being offset until the next selection change (or any other
layout change that forces the selection display interaction to update again). To fix this, we simply
defer the selection activation until the next presentation update (when the layer tree is up to
date), and also call `-setNeedsSelectionUpdate` to ensure that UIKit lays out selection views using
up-to-date selection geometry.

* LayoutTests/editing/selection/ios/selection-after-reparenting-view-and-becoming-first-responder-expected.txt: Added.
* LayoutTests/editing/selection/ios/selection-after-reparenting-view-and-becoming-first-responder.html: Added.

Add a layout test to exercise the bug, by simulating switching away and then back to a tab in
Safari and verifying that the selection highlight rect appears in the same place.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView becomeFirstResponderForWebView]):

See above for more details.

(-[WKContentView _shouldActivateSelectionAfterBecomingFirstResponder]):
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.h:
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper setNeedsSelectionUpdate]):

Add a helper method to call `-setNeedsSelectionUpdate` on the underlying text selection display
interaction.

Canonical link: <a href="https://commits.webkit.org/288232@main">https://commits.webkit.org/288232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e87001c5b37f173d5eeef2e7531ab63360b63f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87183 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33225 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64047 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21782 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85246 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74770 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44326 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28951 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32112 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72508 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88520 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72435 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71654 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17872 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15780 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14694 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9421 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14915 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9285 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12767 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->