### PR TITLE
[JSC] Remove explicit memory shrink at incremental sweeper end

### DIFF
--- a/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
+++ b/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
@@ -31,18 +31,6 @@
 #include "MarkedBlockInlines.h"
 #include <wtf/SystemTracing.h>
 
-#if !USE(SYSTEM_MALLOC)
-#include <bmalloc/BPlatform.h>
-#if BUSE(LIBPAS)
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-#include <bmalloc/pas_debug_spectrum.h>
-#include <bmalloc/pas_fd_stream.h>
-#include <bmalloc/pas_heap_lock.h>
-#include <bmalloc/pas_thread_local_cache.h>
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-#endif
-#endif
-
 namespace JSC {
 
 static constexpr Seconds sweepTimeSlice = 10_ms;
@@ -98,15 +86,6 @@ void IncrementalSweeper::doSweep(VM& vm, MonotonicTime deadline, SweepTrigger tr
     if (trigger == SweepTrigger::OpportunisticTask)
         m_lastOpportunisticTaskDidFinishSweeping = true;
 
-#if !USE(SYSTEM_MALLOC)
-#if BUSE(LIBPAS)
-    pas_thread_local_cache_flush_deallocation_log(pas_thread_local_cache_try_get(), pas_lock_is_not_held);
-#endif
-#endif
-    if (m_shouldFreeFastMallocMemoryAfterSweeping) {
-        WTF::releaseFastMallocFreeMemory();
-        m_shouldFreeFastMallocMemoryAfterSweeping = false;
-    }
     cancelTimer();
 }
 

--- a/Source/JavaScriptCore/heap/IncrementalSweeper.h
+++ b/Source/JavaScriptCore/heap/IncrementalSweeper.h
@@ -38,7 +38,6 @@ public:
     JS_EXPORT_PRIVATE explicit IncrementalSweeper(Heap*);
 
     JS_EXPORT_PRIVATE void startSweeping(Heap&);
-    void freeFastMallocMemoryAfterSweeping() { m_shouldFreeFastMallocMemoryAfterSweeping = true; }
 
     void doWorkUntil(VM&, MonotonicTime deadline);
     void doWork(VM&) final;
@@ -52,7 +51,6 @@ private:
     
     BlockDirectory* m_currentDirectory;
     bool m_lastOpportunisticTaskDidFinishSweeping { false };
-    bool m_shouldFreeFastMallocMemoryAfterSweeping { false };
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### 740dbe11bd403320976619217a5643dcfe22d338
<pre>
[JSC] Remove explicit memory shrink at incremental sweeper end
<a href="https://bugs.webkit.org/show_bug.cgi?id=285073">https://bugs.webkit.org/show_bug.cgi?id=285073</a>
<a href="https://rdar.apple.com/141886889">rdar://141886889</a>

Reviewed by Keith Miller and Justin Michaud.

This is not showing any memory benefit since libpas scavenger runs well
reliably and collect memory anyway. Rather, these explicit running could
cause inefficient memory collection even we would like to use some of
memory just after this. Let&apos;s not do this explicit collection and let
libpas scavenger to decide.

* Source/JavaScriptCore/heap/IncrementalSweeper.cpp:
(JSC::IncrementalSweeper::doSweep):

Canonical link: <a href="https://commits.webkit.org/288229@main">https://commits.webkit.org/288229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88f6e45674549ae4b1f26d412ddc24ddacbb0a35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87106 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33221 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9651 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64046 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-images/object-fit-fill-svg-005p.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21781 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44325 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28948 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32052 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75157 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72506 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29566 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88473 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81229 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6736 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72434 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71653 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15778 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14691 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12752 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9415 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14910 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103641 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9277 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25148 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12763 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->