### PR TITLE
AX: Remove unnecessary properties AXPropertyName::ColumnHeader and AXPropertyName::IsTableColumn

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -125,7 +125,6 @@ accessibility/AccessibilityScrollView.cpp
 accessibility/AccessibilitySlider.cpp
 accessibility/AccessibilityTable.cpp
 accessibility/AccessibilityTableCell.cpp
-accessibility/AccessibilityTableColumn.cpp
 accessibility/AccessibilityTableRow.cpp
 accessibility/AccessibilityTree.cpp
 accessibility/AccessibilityTreeItem.cpp

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -507,6 +507,22 @@ unsigned AXCoreObject::tableLevel() const
     return level;
 }
 
+AXCoreObject* AXCoreObject::columnHeader()
+{
+    if (!isTableColumn())
+        return nullptr;
+
+    RefPtr parent = parentObject();
+    if (!parent || !parent->isTable() || !parent->isExposable())
+        return nullptr;
+
+    for (const auto& cell : unignoredChildren()) {
+        if (cell->roleValue() == AccessibilityRole::ColumnHeader)
+            return cell.ptr();
+    }
+    return nullptr;
+}
+
 AXCoreObject::AccessibilityChildrenVector AXCoreObject::columnHeaders()
 {
     AccessibilityChildrenVector headers;

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -877,9 +877,9 @@ public:
     virtual int axRowIndex() const = 0;
 
     // Table column support.
-    virtual bool isTableColumn() const = 0;
+    bool isTableColumn() const { return roleValue() == AccessibilityRole::Column; }
     virtual unsigned columnIndex() const = 0;
-    virtual AXCoreObject* columnHeader() = 0;
+    AXCoreObject* columnHeader();
 
     // Table row support.
     virtual bool isTableRow() const = 0;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -706,9 +706,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXPropertyName property)
     case AXPropertyName::Columns:
         stream << "Columns";
         break;
-    case AXPropertyName::ColumnHeader:
-        stream << "ColumnHeader";
-        break;
     case AXPropertyName::ColumnIndex:
         stream << "ColumnIndex";
         break;
@@ -968,9 +965,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXPropertyName property)
         break;
     case AXPropertyName::IsTable:
         stream << "IsTable";
-        break;
-    case AXPropertyName::IsTableColumn:
-        stream << "IsTableColumn";
         break;
     case AXPropertyName::IsTableRow:
         stream << "IsTableRow";

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -160,9 +160,7 @@ public:
     int axRowIndex() const override { return -1; }
 
     // Table column support.
-    bool isTableColumn() const override { return false; }
     unsigned columnIndex() const override { return 0; }
-    AccessibilityObject* columnHeader() override { return nullptr; }
 
     // Table row support.
     bool isTableRow() const override { return false; }

--- a/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
@@ -64,19 +64,6 @@ LayoutRect AccessibilityTableColumn::elementRect() const
     return columnRect;
 }
 
-AccessibilityObject* AccessibilityTableColumn::columnHeader()
-{
-    auto* parentTable = dynamicDowncast<AccessibilityTable>(m_parent.get());
-    if (!parentTable || !parentTable->isExposable())
-        return nullptr;
-
-    for (const auto& cell : unignoredChildren()) {
-        if (cell->roleValue() == AccessibilityRole::ColumnHeader)
-            return &downcast<AccessibilityObject>(cell.get());
-    }
-    return nullptr;
-}
-
 void AccessibilityTableColumn::setColumnIndex(unsigned columnIndex)
 {
     if (m_columnIndex == columnIndex)

--- a/Source/WebCore/accessibility/AccessibilityTableColumn.h
+++ b/Source/WebCore/accessibility/AccessibilityTableColumn.h
@@ -39,8 +39,6 @@ public:
     static Ref<AccessibilityTableColumn> create(AXID);
     virtual ~AccessibilityTableColumn();
 
-    AccessibilityObject* columnHeader() final;
-
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::Column; }
 
     void setColumnIndex(unsigned);
@@ -55,7 +53,6 @@ private:
     explicit AccessibilityTableColumn(AXID);
     
     bool computeIsIgnored() const final;
-    bool isTableColumn() const final { return true; }
 
     bool isAccessibilityTableColumnInstance() const final { return true; }
     unsigned m_columnIndex;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -302,11 +302,9 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
         setProperty(AXPropertyName::RowGroupAncestorID, object.rowGroupAncestorID());
     }
 
-    if (object.isTableColumn()) {
-        setProperty(AXPropertyName::IsTableColumn, true);
+    if (object.isTableColumn())
         setProperty(AXPropertyName::ColumnIndex, object.columnIndex());
-        setObjectProperty(AXPropertyName::ColumnHeader, object.columnHeader());
-    } else if (object.isTableRow()) {
+    else if (object.isTableRow()) {
         setProperty(AXPropertyName::IsTableRow, true);
         setProperty(AXPropertyName::RowIndex, object.rowIndex());
     }
@@ -412,8 +410,13 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     }
 
     if (object.isWidget()) {
-        setProperty(AXPropertyName::IsWidget, true);
-        setProperty(AXPropertyName::IsPlugin, object.isPlugin());
+        if (object.isPlugin()) {
+            // Plugins are a subclass of widget, so we only need to cache IsPlugin, and we implicitly know
+            // this is also a widget (see AXIsolatedObject::isWidget).
+            setProperty(AXPropertyName::IsPlugin, true);
+        } else
+            setProperty(AXPropertyName::IsWidget, true);
+
         setProperty(AXPropertyName::IsVisible, object.isVisible());
     }
 
@@ -556,9 +559,6 @@ void AXIsolatedObject::setProperty(AXPropertyName propertyName, AXPropertyValueV
             return;
         case AXPropertyName::IsNonLayerSVGObject:
             setPropertyFlag(AXPropertyFlag::IsNonLayerSVGObject, std::get<bool>(value));
-            return;
-        case AXPropertyName::IsTableColumn:
-            setPropertyFlag(AXPropertyFlag::IsTableColumn, std::get<bool>(value));
             return;
         case AXPropertyName::IsTableRow:
             setPropertyFlag(AXPropertyFlag::IsTableRow, std::get<bool>(value));
@@ -1162,8 +1162,6 @@ bool AXIsolatedObject::boolAttributeValue(AXPropertyName propertyName) const
         return hasPropertyFlag(AXPropertyFlag::IsKeyboardFocusable);
     case AXPropertyName::IsNonLayerSVGObject:
         return hasPropertyFlag(AXPropertyFlag::IsNonLayerSVGObject);
-    case AXPropertyName::IsTableColumn:
-        return hasPropertyFlag(AXPropertyFlag::IsTableColumn);
     case AXPropertyName::IsTableRow:
         return hasPropertyFlag(AXPropertyFlag::IsTableRow);
     case AXPropertyName::SupportsCheckedState:

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -199,9 +199,7 @@ private:
     std::optional<AXID> rowGroupAncestorID() const final { return propertyValue<Markable<AXID>>(AXPropertyName::RowGroupAncestorID); }
 
     // Table column support.
-    bool isTableColumn() const final { return boolAttributeValue(AXPropertyName::IsTableColumn); }
     unsigned columnIndex() const final { return unsignedAttributeValue(AXPropertyName::ColumnIndex); }
-    AXIsolatedObject* columnHeader() final { return objectAttributeValue(AXPropertyName::ColumnHeader); }
 
     // Table row support.
     bool isTableRow() const final { return boolAttributeValue(AXPropertyName::IsTableRow); }
@@ -510,7 +508,11 @@ private:
     Path elementPath() const final { return pathAttributeValue(AXPropertyName::Path); };
     bool supportsPath() const final { return boolAttributeValue(AXPropertyName::SupportsPath); }
 
-    bool isWidget() const final { return boolAttributeValue(AXPropertyName::IsWidget); }
+    bool isWidget() const final
+    {
+        // Plugins are a widget subclass.
+        return boolAttributeValue(AXPropertyName::IsPlugin) || boolAttributeValue(AXPropertyName::IsWidget);
+    }
     Widget* widget() const final;
     PlatformWidget platformWidget() const final;
     Widget* widgetForAttachmentView() const final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -71,14 +71,13 @@ enum class AXPropertyFlag : uint32_t {
     IsInlineText                                  = 1 << 10,
     IsKeyboardFocusable                           = 1 << 11,
     IsNonLayerSVGObject                           = 1 << 12,
-    IsTableColumn                                 = 1 << 13,
-    IsTableRow                                    = 1 << 14,
-    SupportsCheckedState                          = 1 << 15,
-    SupportsDragging                              = 1 << 16,
-    SupportsExpanded                              = 1 << 17,
-    SupportsPath                                  = 1 << 18,
-    SupportsPosInSet                              = 1 << 19,
-    SupportsSetSize                               = 1 << 20
+    IsTableRow                                    = 1 << 13,
+    SupportsCheckedState                          = 1 << 14,
+    SupportsDragging                              = 1 << 15,
+    SupportsExpanded                              = 1 << 16,
+    SupportsPath                                  = 1 << 17,
+    SupportsPosInSet                              = 1 << 18,
+    SupportsSetSize                               = 1 << 19
 };
 
 enum class AXPropertyName : uint16_t {
@@ -114,7 +113,6 @@ enum class AXPropertyName : uint16_t {
     CellSlots,
     ColorValue,
     Columns,
-    ColumnHeader,
     ColumnIndex,
     ColumnIndexRange,
     CurrentState,
@@ -203,7 +201,6 @@ enum class AXPropertyName : uint16_t {
     IsSelected,
     IsSelectedOptionActive,
     IsTable,
-    IsTableColumn,
     IsTableRow,
     IsTree,
     IsTreeItem,


### PR DESCRIPTION
#### a587bbdcbff17f05d8d5a7a5707a0074f513642a
<pre>
AX: Remove unnecessary properties AXPropertyName::ColumnHeader and AXPropertyName::IsTableColumn
<a href="https://bugs.webkit.org/show_bug.cgi?id=285075">https://bugs.webkit.org/show_bug.cgi?id=285075</a>
<a href="https://rdar.apple.com/141892269">rdar://141892269</a>

Reviewed by Chris Fleizach.

AXPropertyName::ColumnHeader can be syntheized on-demand with already cached information on the secondary thread, so we shouldn&apos;t
eagerly cache it. Removing this property saves memory.

AXPropertyName::IsTableColumn can be expressed in terms of roleValue(), so we don&apos;t need to cache it as its own property.
This also lets us make AXCoreObject::isTableColumn() non-virtual, enabling more compiler optimizations.

This patch also stops caching AXPropertyName::IsWidget == true for objects that are isPlugin(), saving a bit of memory.
Plugins are a subclass of widget, so we don&apos;t need to cache both. AXIsolatedObject::isWidget() now checks for both
AXPropertyName::IsWidget and AXPropertyName::IsPlugin.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::columnHeader):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityTableColumn.cpp:
(WebCore::AccessibilityTableColumn::columnHeader): Deleted.
* Source/WebCore/accessibility/AccessibilityTableColumn.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:

Canonical link: <a href="https://commits.webkit.org/288234@main">https://commits.webkit.org/288234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b161623acda67260fbdb2e8c6d9b12ebceddfe01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87232 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33236 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64052 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21791 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1316 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44331 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28957 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32167 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72516 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29576 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88561 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6749 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72445 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70593 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71664 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17873 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15789 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14700 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9435 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14924 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9301 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12779 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->