### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebAudio code

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -44,8 +44,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(AudioBuffer);
@@ -359,13 +357,11 @@ void AudioBuffer::applyNoiseIfNeeded()
         return;
 
     for (auto& channel : m_channels)
-        AudioUtilities::applyNoise(channel->data(), channel->length(), m_noiseInjectionMultiplier);
+        AudioUtilities::applyNoise(channel->typedMutableSpan(), m_noiseInjectionMultiplier);
 
     m_noiseInjectionMultiplier = 0;
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -40,8 +40,6 @@
 #include <algorithm>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(AudioBufferSourceNode);
@@ -53,7 +51,7 @@ constexpr double DefaultGrainDuration = 0.020; // 20ms
 // to minimize linear interpolation aliasing.
 const double MaxRate = 1024;
 
-static float computeSampleUsingLinearInterpolation(const float* source, unsigned readIndex, unsigned readIndex2, float interpolationFactor)
+static float computeSampleUsingLinearInterpolation(std::span<const float> source, unsigned readIndex, unsigned readIndex2, float interpolationFactor)
 {
     if (readIndex == readIndex2 && readIndex >= 1) {
         // We're at the end of the buffer, so just linearly extrapolate from the last two samples.
@@ -365,7 +363,7 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus* bus, unsigned destination
                 auto destination = m_destinationChannels[i];
                 auto source = m_sourceChannels[i];
 
-                destination[writeIndex] = computeSampleUsingLinearInterpolation(source.data(), readIndex, readIndex2, interpolationFactor);
+                destination[writeIndex] = computeSampleUsingLinearInterpolation(source, readIndex, readIndex2, interpolationFactor);
             }
 
             writeIndex++;
@@ -404,7 +402,7 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus* bus, unsigned destination
                 auto destination = m_destinationChannels[i];
                 auto source = m_sourceChannels[i];
 
-                destination[writeIndex] = computeSampleUsingLinearInterpolation(source.data(), readIndex, readIndex2, interpolationFactor);
+                destination[writeIndex] = computeSampleUsingLinearInterpolation(source, readIndex, readIndex2, interpolationFactor);
             }
             writeIndex++;
 
@@ -639,7 +637,5 @@ float AudioBufferSourceNode::noiseInjectionMultiplier() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webaudio/AudioListener.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioListener.cpp
@@ -137,58 +137,58 @@ void AudioListener::updateDirtyState()
     m_isUpVectorDirty = lastUpVector != m_lastUpVector;
 }
 
-const float* AudioListener::positionXValues(size_t framesToProcess)
+std::span<const float> AudioListener::positionXValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_positionXValues.data();
+    return m_positionXValues.span();
 }
 
-const float* AudioListener::positionYValues(size_t framesToProcess)
+std::span<const float> AudioListener::positionYValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_positionYValues.data();
+    return m_positionYValues.span();
 }
 
-const float* AudioListener::positionZValues(size_t framesToProcess)
+std::span<const float> AudioListener::positionZValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_positionZValues.data();
+    return m_positionZValues.span();
 }
 
-const float* AudioListener::forwardXValues(size_t framesToProcess)
+std::span<const float> AudioListener::forwardXValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_forwardXValues.data();
+    return m_forwardXValues.span();
 }
 
-const float* AudioListener::forwardYValues(size_t framesToProcess)
+std::span<const float> AudioListener::forwardYValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_forwardYValues.data();
+    return m_forwardYValues.span();
 }
 
-const float* AudioListener::forwardZValues(size_t framesToProcess)
+std::span<const float> AudioListener::forwardZValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_forwardZValues.data();
+    return m_forwardZValues.span();
 }
 
-const float* AudioListener::upXValues(size_t framesToProcess)
+std::span<const float> AudioListener::upXValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_upXValues.data();
+    return m_upXValues.span();
 }
 
-const float* AudioListener::upYValues(size_t framesToProcess)
+std::span<const float> AudioListener::upYValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_upYValues.data();
+    return m_upYValues.span();
 }
 
-const float* AudioListener::upZValues(size_t framesToProcess)
+std::span<const float> AudioListener::upZValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_upZValues.data();
+    return m_upZValues.span();
 }
 
 ExceptionOr<void> AudioListener::setPosition(float x, float y, float z)

--- a/Source/WebCore/Modules/webaudio/AudioListener.h
+++ b/Source/WebCore/Modules/webaudio/AudioListener.h
@@ -73,17 +73,17 @@ public:
     bool hasSampleAccurateValues() const;
     bool shouldUseARate() const;
 
-    const float* positionXValues(size_t framesToProcess);
-    const float* positionYValues(size_t framesToProcess);
-    const float* positionZValues(size_t framesToProcess);
+    std::span<const float> positionXValues(size_t framesToProcess);
+    std::span<const float> positionYValues(size_t framesToProcess);
+    std::span<const float> positionZValues(size_t framesToProcess);
 
-    const float* forwardXValues(size_t framesToProcess);
-    const float* forwardYValues(size_t framesToProcess);
-    const float* forwardZValues(size_t framesToProcess);
+    std::span<const float> forwardXValues(size_t framesToProcess);
+    std::span<const float> forwardYValues(size_t framesToProcess);
+    std::span<const float> forwardZValues(size_t framesToProcess);
 
-    const float* upXValues(size_t framesToProcess);
-    const float* upYValues(size_t framesToProcess);
-    const float* upZValues(size_t framesToProcess);
+    std::span<const float> upXValues(size_t framesToProcess);
+    std::span<const float> upYValues(size_t framesToProcess);
+    std::span<const float> upZValues(size_t framesToProcess);
 
     void updateValuesIfNeeded(size_t framesToProcess);
 

--- a/Source/WebCore/Modules/webaudio/AudioNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNode.cpp
@@ -45,15 +45,13 @@
 #include <stdio.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(AudioNode);
 
 String convertEnumerationToString(AudioNode::NodeType enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 21> values {
         MAKE_STATIC_STRING_IMPL("NodeTypeDestination"),
         MAKE_STATIC_STRING_IMPL("NodeTypeOscillator"),
         MAKE_STATIC_STRING_IMPL("NodeTypeAudioBufferSource"),
@@ -772,7 +770,5 @@ WTFLogChannel& AudioNode::logChannel() const
 #endif
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webaudio/AudioParam.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParam.cpp
@@ -39,8 +39,6 @@
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static void replaceNaNValues(std::span<float> values, float defaultValue)
@@ -396,7 +394,5 @@ WTFLogChannel& AudioParam::logChannel() const
     
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp
@@ -37,14 +37,12 @@
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
-static void fillWithValue(float* values, float value, unsigned endFrame, unsigned& writeIndex)
+static void fillWithValue(std::span<float> values, float value, unsigned endFrame, unsigned& writeIndex)
 {
     if (writeIndex < endFrame) {
-        std::fill_n(values + writeIndex, endFrame - writeIndex, value);
+        std::ranges::fill(values.subspan(writeIndex).first(endFrame - writeIndex), value);
         writeIndex = endFrame;
     }
 }
@@ -288,7 +286,7 @@ ExceptionOr<void> AudioParamTimeline::cancelAndHoldAtTime(Seconds cancelTime)
                 // compute the new end value now instead of doing when running
                 // the timeline.
                 auto newDuration = cancelTime - cancelledEvent.time();
-                float endValue = valueCurveAtTime(cancelTime, cancelledEvent.time(), cancelledEvent.duration(), cancelledEvent.curve().data(), cancelledEvent.curve().size());
+                float endValue = valueCurveAtTime(cancelTime, cancelledEvent.time(), cancelledEvent.duration(), cancelledEvent.curve().span(), cancelledEvent.curve().size());
 
                 // Replace the existing SetValueCurve with this new one that is identical except for the duration.
                 newEvent = ParamEvent { eventType, cancelledEvent.value(), cancelledEvent.time(), cancelledEvent.timeConstant(), newDuration, Vector<float> { cancelledEvent.curve() }, cancelledEvent.curvePointsPerSecond(), endValue, std::nullopt };
@@ -407,7 +405,7 @@ float AudioParamTimeline::valuesForFrameRangeImpl(size_t startFrame, size_t endF
 
         size_t fillToFrame = fillToEndFrame - startFrame;
         fillToFrame = std::min(fillToFrame, values.size());
-        fillWithValue(values.data(), defaultValue, fillToFrame, writeIndex);
+        fillWithValue(values, defaultValue, fillToFrame, writeIndex);
 
         currentFrame += fillToFrame;
     }
@@ -470,9 +468,9 @@ float AudioParamTimeline::valuesForFrameRangeImpl(size_t startFrame, size_t endF
 
         // First handle linear and exponential ramps which require looking ahead to the next event.
         if (nextEventType == ParamEvent::LinearRampToValue)
-            processLinearRamp(currentState, values.data(), currentFrame, value, writeIndex);
+            processLinearRamp(currentState, values, currentFrame, value, writeIndex);
         else if (nextEventType == ParamEvent::ExponentialRampToValue)
-            processExponentialRamp(currentState, values.data(), currentFrame, value, writeIndex);
+            processExponentialRamp(currentState, values, currentFrame, value, writeIndex);
         else {
             // Handle event types not requiring looking ahead to the next event.
             switch (event->type()) {
@@ -483,16 +481,16 @@ float AudioParamTimeline::valuesForFrameRangeImpl(size_t startFrame, size_t endF
 
                 // Simply stay at a constant value.
                 value = event->value();
-                fillWithValue(values.data(), value, fillToFrame, writeIndex);
+                fillWithValue(values, value, fillToFrame, writeIndex);
                 break;
             case ParamEvent::CancelValues:
-                processCancelValues(currentState, values.data(), currentFrame, value, writeIndex);
+                processCancelValues(currentState, values, currentFrame, value, writeIndex);
                 break;
             case ParamEvent::SetTarget:
-                processSetTarget(currentState, values.data(), currentFrame, value, writeIndex);
+                processSetTarget(currentState, values, currentFrame, value, writeIndex);
                 break;
             case ParamEvent::SetValueCurve:
-                processSetValueCurve(currentState, values.data(), currentFrame, value, writeIndex);
+                processSetValueCurve(currentState, values, currentFrame, value, writeIndex);
                 break;
             case ParamEvent::LastType:
                 ASSERT_NOT_REACHED();
@@ -507,12 +505,12 @@ float AudioParamTimeline::valuesForFrameRangeImpl(size_t startFrame, size_t endF
 
     // If there's any time left after processing the last event then just propagate the last value
     // to the end of the values buffer.
-    fillWithValue(values.data(), value, values.size(), writeIndex);
+    fillWithValue(values, value, values.size(), writeIndex);
 
     return value;
 }
 
-void AudioParamTimeline::processLinearRamp(const AutomationState& currentState, float* values, size_t& currentFrame, float& value, unsigned& writeIndex)
+void AudioParamTimeline::processLinearRamp(const AutomationState& currentState, std::span<float> values, size_t& currentFrame, float& value, unsigned& writeIndex)
 {
     auto deltaTime = currentState.time2 - currentState.time1;
     float valueDelta = currentState.value2 - currentState.value1;
@@ -533,10 +531,10 @@ void AudioParamTimeline::processLinearRamp(const AutomationState& currentState, 
         values[writeIndex + 1] = 1;
         values[writeIndex + 2] = 2;
         values[writeIndex + 3] = 3;
-        VectorMath::multiplyByScalar(values + writeIndex, currentState.samplingPeriod, values + writeIndex, 4);
-        VectorMath::addScalar(values + writeIndex, currentFrame * currentState.samplingPeriod - currentState.time1.value(), values + writeIndex, 4);
-        VectorMath::multiplyByScalar(values + writeIndex, k * valueDelta, values + writeIndex, 4);
-        VectorMath::addScalar(values + writeIndex, currentState.value1, values + writeIndex, 4);
+        VectorMath::multiplyByScalar(values.subspan(writeIndex).data(), currentState.samplingPeriod, values.subspan(writeIndex).data(), 4);
+        VectorMath::addScalar(values.subspan(writeIndex).data(), currentFrame * currentState.samplingPeriod - currentState.time1.value(), values.subspan(writeIndex).data(), 4);
+        VectorMath::multiplyByScalar(values.subspan(writeIndex).data(), k * valueDelta, values.subspan(writeIndex).data(), 4);
+        VectorMath::addScalar(values.subspan(writeIndex).data(), currentState.value1, values.subspan(writeIndex).data(), 4);
 
         float inc = 4 * currentState.samplingPeriod * k * valueDelta;
 
@@ -548,7 +546,7 @@ void AudioParamTimeline::processLinearRamp(const AutomationState& currentState, 
         // Process 4 loop steps.
         writeIndex += 4;
         for (; writeIndex < fillToFrameTrunc; writeIndex += 4)
-            VectorMath::addScalar(values + writeIndex - 4, inc, values + writeIndex, 4);
+            VectorMath::addScalar(values.subspan(writeIndex - 4).data(), inc, values.subspan(writeIndex).data(), 4);
     }
     // Update |value| with the last value computed so that the .value attribute of the AudioParam gets
     // the correct linear ramp value, in case the following loop doesn't execute.
@@ -564,7 +562,7 @@ void AudioParamTimeline::processLinearRamp(const AutomationState& currentState, 
     }
 }
 
-void AudioParamTimeline::processExponentialRamp(const AutomationState& currentState, float* values, size_t& currentFrame, float& value, unsigned& writeIndex)
+void AudioParamTimeline::processExponentialRamp(const AutomationState& currentState, std::span<float> values, size_t& currentFrame, float& value, unsigned& writeIndex)
 {
     if (!currentState.value1 || currentState.value1 * currentState.value2 < 0) {
         // Per the specification:
@@ -594,7 +592,7 @@ void AudioParamTimeline::processExponentialRamp(const AutomationState& currentSt
         value /= multiplier;
 }
 
-void AudioParamTimeline::processCancelValues(const AutomationState& currentState, float* values, size_t& currentFrame, float& value, unsigned& writeIndex)
+void AudioParamTimeline::processCancelValues(const AutomationState& currentState, std::span<float> values, size_t& currentFrame, float& value, unsigned& writeIndex)
 {
     // If the previous event was a SetTarget or ExponentialRamp
     // event, the current value is one sample behind. Update
@@ -620,7 +618,7 @@ void AudioParamTimeline::processCancelValues(const AutomationState& currentState
     currentFrame = currentState.fillToEndFrame;
 }
 
-void AudioParamTimeline::processSetTarget(const AutomationState& currentState, float* values, size_t& currentFrame, float& value, unsigned& writeIndex)
+void AudioParamTimeline::processSetTarget(const AutomationState& currentState, std::span<float> values, size_t& currentFrame, float& value, unsigned& writeIndex)
 {
     // Exponential approach to target value with given time constant.
     float target = currentState.event->value();
@@ -671,13 +669,13 @@ void AudioParamTimeline::processSetTarget(const AutomationState& currentState, f
 
         // Process 4 loop steps.
         unsigned fillToFrameTrunc = writeIndex + ((currentState.fillToFrame - writeIndex) / 4) * 4;
-        const float cVector[4] = { 0, c0, c1, c2 };
+        const std::array<float, 4> cArray { 0, c0, c1, c2 };
 
         for (; writeIndex < fillToFrameTrunc; writeIndex += 4) {
             delta = target - value;
 
-            VectorMath::multiplyByScalar(&cVector[0], delta, &values[writeIndex], 4);
-            VectorMath::addScalar(&values[writeIndex], value, &values[writeIndex], 4);
+            VectorMath::multiplyByScalar(cArray.data(), delta, values.subspan(writeIndex).data(), cArray.size());
+            VectorMath::addScalar(values.subspan(writeIndex).data(), value, values.subspan(writeIndex).data(), 4);
 
             value += delta * c3;
         }
@@ -697,9 +695,9 @@ void AudioParamTimeline::processSetTarget(const AutomationState& currentState, f
     currentFrame = currentState.fillToEndFrame;
 }
 
-void AudioParamTimeline::processSetValueCurve(const AutomationState& currentState, float* values, size_t& currentFrame, float& value, unsigned& writeIndex)
+void AudioParamTimeline::processSetValueCurve(const AutomationState& currentState, std::span<float> values, size_t& currentFrame, float& value, unsigned& writeIndex)
 {
-    auto* curveData = currentState.event->curve().data();
+    auto curveData = currentState.event->curve().span();
     unsigned numberOfCurvePoints = currentState.event->curve().size();
     float curveEndValue = currentState.event->curveEndValue();
     size_t fillToEndFrame = currentState.fillToEndFrame;
@@ -709,7 +707,7 @@ void AudioParamTimeline::processSetValueCurve(const AutomationState& currentStat
     auto duration = currentState.event->duration();
     double curvePointsPerFrame = currentState.event->curvePointsPerSecond() * currentState.samplingPeriod;
 
-    if (!curveData || !numberOfCurvePoints || duration <= 0_s || currentState.sampleRate <= 0) {
+    if (!curveData.data() || !numberOfCurvePoints || duration <= 0_s || currentState.sampleRate <= 0) {
         // Error condition - simply propagate previous value.
         currentFrame = fillToEndFrame;
         fillWithValue(values, value, fillToFrame, writeIndex);
@@ -842,7 +840,7 @@ float AudioParamTimeline::exponentialRampAtTime(Seconds t, float value1, Seconds
     return value1 * pow(value2 / value1, (t - time1).value() / (time2 - time1).value());
 }
 
-float AudioParamTimeline::valueCurveAtTime(Seconds t, Seconds time1, Seconds duration, const float* curveData, size_t curveLength)
+float AudioParamTimeline::valueCurveAtTime(Seconds t, Seconds time1, Seconds duration, std::span<const float> curveData, size_t curveLength)
 {
     double curveIndex = (curveLength - 1) / duration.value() * (t - time1).value();
     size_t k = std::min(static_cast<size_t>(curveIndex), curveLength - 1);
@@ -1054,7 +1052,5 @@ bool AudioParamTimeline::hasValues(size_t startFrame, double sampleRate) const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webaudio/AudioParamTimeline.h
+++ b/Source/WebCore/Modules/webaudio/AudioParamTimeline.h
@@ -196,15 +196,15 @@ private:
     float valuesForFrameRangeImpl(size_t startFrame, size_t endFrame, float defaultValue, std::span<float> values, double sampleRate, double controlRate) WTF_REQUIRES_LOCK(m_eventsLock);
     float linearRampAtTime(Seconds t, float value1, Seconds time1, float value2, Seconds time2);
     float exponentialRampAtTime(Seconds t, float value1, Seconds time1, float value2, Seconds time2);
-    float valueCurveAtTime(Seconds t, Seconds time1, Seconds duration, const float* curveData, size_t curveLength);
+    float valueCurveAtTime(Seconds t, Seconds time1, Seconds duration, std::span<const float> curveData, size_t curveLength);
     void handleCancelValues(ParamEvent&, ParamEvent* nextEvent, float& value2, Seconds& time2, ParamEvent::Type& nextEventType);
     bool isEventCurrent(const ParamEvent&, const ParamEvent* nextEvent, size_t currentFrame, double sampleRate) const;
 
-    void processLinearRamp(const AutomationState&, float* values, size_t& currentFrame, float& value, unsigned& writeIndex);
-    void processExponentialRamp(const AutomationState&, float* values, size_t& currentFrame, float& value, unsigned& writeIndex);
-    void processCancelValues(const AutomationState&, float* values, size_t& currentFrame, float& value, unsigned& writeIndex) WTF_REQUIRES_LOCK(m_eventsLock);
-    void processSetTarget(const AutomationState&, float* values, size_t& currentFrame, float& value, unsigned& writeIndex);
-    void processSetValueCurve(const AutomationState&, float* values, size_t& currentFrame, float& value, unsigned& writeIndex);
+    void processLinearRamp(const AutomationState&, std::span<float> values, size_t& currentFrame, float& value, unsigned& writeIndex);
+    void processExponentialRamp(const AutomationState&, std::span<float> values, size_t& currentFrame, float& value, unsigned& writeIndex);
+    void processCancelValues(const AutomationState&, std::span<float> values, size_t& currentFrame, float& value, unsigned& writeIndex) WTF_REQUIRES_LOCK(m_eventsLock);
+    void processSetTarget(const AutomationState&, std::span<float> values, size_t& currentFrame, float& value, unsigned& writeIndex);
+    void processSetValueCurve(const AutomationState&, std::span<float> values, size_t& currentFrame, float& value, unsigned& writeIndex);
     void processSetTargetFollowedByRamp(int eventIndex, ParamEvent*&, ParamEvent::Type nextEventType, size_t currentFrame, double samplingPeriod, double controlRate, float& value) WTF_REQUIRES_LOCK(m_eventsLock);
 
     Vector<ParamEvent> m_events WTF_GUARDED_BY_LOCK(m_eventsLock);

--- a/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.cpp
@@ -44,8 +44,6 @@
 #include "ScriptController.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(AudioScheduledSourceNode);
@@ -210,7 +208,5 @@ void AudioScheduledSourceNode::finish()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -222,7 +222,7 @@ void AudioWorkletNode::process(size_t framesToProcess)
             if (auto& input = m_inputs[inputIndex]) {
                 for (unsigned channelIndex = 0; channelIndex < input->numberOfChannels(); ++channelIndex) {
                     auto* channel = input->channel(channelIndex);
-                    AudioUtilities::applyNoise(channel->mutableData(), channel->length(), 0.01);
+                    AudioUtilities::applyNoise(channel->mutableSpan(), 0.01);
                 }
             }
         }

--- a/Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp
@@ -45,8 +45,6 @@
 #include <arm_neon.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BiquadDSPKernel);
@@ -212,9 +210,9 @@ void BiquadDSPKernel::process(std::span<const float> source, std::span<float> de
     m_biquad.process(source, destination);
 }
 
-void BiquadDSPKernel::getFrequencyResponse(unsigned nFrequencies, const float* frequencyHz, float* magResponse, float* phaseResponse)
+void BiquadDSPKernel::getFrequencyResponse(unsigned nFrequencies, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse)
 {
-    bool isGood = nFrequencies > 0 && frequencyHz && magResponse && phaseResponse;
+    bool isGood = nFrequencies > 0 && frequencyHz.data() && magResponse.data() && phaseResponse.data();
     ASSERT(isGood);
     if (!isGood)
         return;
@@ -228,7 +226,7 @@ void BiquadDSPKernel::getFrequencyResponse(unsigned nFrequencies, const float* f
     for (unsigned k = 0; k < nFrequencies; ++k)
         frequency[k] = frequencyHz[k] / nyquist;
 
-    m_biquad.getFrequencyResponse(nFrequencies, frequency.data(), magResponse, phaseResponse);
+    m_biquad.getFrequencyResponse(nFrequencies, frequency.span(), magResponse, phaseResponse);
 }
 
 double BiquadDSPKernel::tailTime() const
@@ -267,7 +265,5 @@ bool BiquadDSPKernel::requiresTailProcessing() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webaudio/BiquadDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/BiquadDSPKernel.h
@@ -49,7 +49,7 @@ public:
 
     // Get the magnitude and phase response of the filter at the given
     // set of frequencies (in Hz). The phase response is in radians.
-    void getFrequencyResponse(unsigned nFrequencies, const float* frequencyHz, float* magResponse, float* phaseResponse);
+    void getFrequencyResponse(unsigned nFrequencies, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse);
 
     double tailTime() const override;
     double latencyTime() const override;

--- a/Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp
@@ -79,7 +79,7 @@ ExceptionOr<void> BiquadFilterNode::getFrequencyResponse(const Ref<Float32Array>
         return Exception { ExceptionCode::InvalidAccessError, "The arrays passed as arguments must have the same length"_s };
 
     if (length)
-        biquadProcessor()->getFrequencyResponse(length, frequencyHz->data(), magResponse->data(), phaseResponse->data());
+        biquadProcessor()->getFrequencyResponse(length, frequencyHz->typedSpan(), magResponse->typedMutableSpan(), phaseResponse->typedMutableSpan());
     return { };
 }
 

--- a/Source/WebCore/Modules/webaudio/BiquadProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadProcessor.cpp
@@ -129,7 +129,7 @@ void BiquadProcessor::setType(BiquadFilterType type)
     }
 }
 
-void BiquadProcessor::getFrequencyResponse(unsigned nFrequencies, const float* frequencyHz, float* magResponse, float* phaseResponse)
+void BiquadProcessor::getFrequencyResponse(unsigned nFrequencies, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse)
 {
     // Compute the frequency response on a separate temporary kernel
     // to avoid interfering with the processing running in the audio

--- a/Source/WebCore/Modules/webaudio/BiquadProcessor.h
+++ b/Source/WebCore/Modules/webaudio/BiquadProcessor.h
@@ -52,7 +52,7 @@ public:
 
     // Get the magnitude and phase response of the filter at the given
     // set of frequencies (in Hz). The phase response is in radians.
-    void getFrequencyResponse(unsigned nFrequencies, const float* frequencyHz, float* magResponse, float* phaseResponse);
+    void getFrequencyResponse(unsigned nFrequencies, std::span<const float> frequencyHz, std::span<float> magResponse, std::span<float> phaseResponse);
 
     void checkForDirtyCoefficients();
     

--- a/Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp
@@ -33,9 +33,8 @@
 #include "AudioParam.h"
 #include "AudioUtilities.h"
 #include "ConstantSourceOptions.h"
+#include <algorithm>
 #include <wtf/TZoneMallocInlines.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -97,8 +96,8 @@ void ConstantSourceNode::process(size_t framesToProcess)
     if (!value)
         outputBus.zero();
     else {
-        float* dest = outputBus.channel(0)->mutableData();
-        std::fill_n(dest + quantumFrameOffset, nonSilentFramesToProcess, value);
+        auto destination = outputBus.channel(0)->mutableSpan();
+        std::ranges::fill(destination.subspan(quantumFrameOffset).first(nonSilentFramesToProcess), value);
         outputBus.clearSilentFlag();
     }
 }
@@ -109,7 +108,5 @@ bool ConstantSourceNode::propagatesSilence() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp
@@ -34,8 +34,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DelayDSPKernel);
@@ -250,7 +248,5 @@ bool DelayDSPKernel::requiresTailProcessing() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webaudio/IIRDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/IIRDSPKernel.cpp
@@ -29,8 +29,6 @@
 #include "IIRDSPKernel.h"
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IIRDSPKernel);
@@ -78,7 +76,5 @@ bool IIRDSPKernel::requiresTailProcessing() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp
@@ -46,8 +46,6 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/threads/BinarySemaphore.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(OfflineAudioDestinationNode);
@@ -201,7 +199,5 @@ auto OfflineAudioDestinationNode::renderOnAudioThread() -> RenderResult
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webaudio/OscillatorNode.h
+++ b/Source/WebCore/Modules/webaudio/OscillatorNode.h
@@ -60,8 +60,8 @@ private:
     // Returns true if there are sample-accurate timeline parameter changes.
     bool calculateSampleAccuratePhaseIncrements(size_t framesToProcess) WTF_REQUIRES_LOCK(m_processLock);
 
-    double processARate(int, float* destP, double virtualReadIndex, float* phaseIncrements) WTF_REQUIRES_LOCK(m_processLock);
-    double processKRate(int, float* destP, double virtualReadIndex) WTF_REQUIRES_LOCK(m_processLock);
+    double processARate(int, std::span<float> destP, double virtualReadIndex, std::span<float> phaseIncrements) WTF_REQUIRES_LOCK(m_processLock);
+    double processKRate(int, std::span<float> destP, double virtualReadIndex) WTF_REQUIRES_LOCK(m_processLock);
 
     bool propagatesSilence() const final;
 

--- a/Source/WebCore/Modules/webaudio/PannerNode.cpp
+++ b/Source/WebCore/Modules/webaudio/PannerNode.cpp
@@ -40,8 +40,6 @@
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(PannerNode);
@@ -205,17 +203,17 @@ void PannerNode::processSampleAccurateValues(AudioBus* destination, const AudioB
     m_orientationZ->calculateSampleAccurateValues(std::span { orientationZ }.first(framesToProcess));
 
     // Get the automation values from the listener.
-    const float* listenerX = listener().positionXValues(AudioUtilities::renderQuantumSize);
-    const float* listenerY = listener().positionYValues(AudioUtilities::renderQuantumSize);
-    const float* listenerZ = listener().positionZValues(AudioUtilities::renderQuantumSize);
+    auto listenerX = listener().positionXValues(AudioUtilities::renderQuantumSize);
+    auto listenerY = listener().positionYValues(AudioUtilities::renderQuantumSize);
+    auto listenerZ = listener().positionZValues(AudioUtilities::renderQuantumSize);
 
-    const float* forwardX = listener().forwardXValues(AudioUtilities::renderQuantumSize);
-    const float* forwardY = listener().forwardYValues(AudioUtilities::renderQuantumSize);
-    const float* forwardZ = listener().forwardZValues(AudioUtilities::renderQuantumSize);
+    auto forwardX = listener().forwardXValues(AudioUtilities::renderQuantumSize);
+    auto forwardY = listener().forwardYValues(AudioUtilities::renderQuantumSize);
+    auto forwardZ = listener().forwardZValues(AudioUtilities::renderQuantumSize);
 
-    const float* upX = listener().upXValues(AudioUtilities::renderQuantumSize);
-    const float* upY = listener().upYValues(AudioUtilities::renderQuantumSize);
-    const float* upZ = listener().upZValues(AudioUtilities::renderQuantumSize);
+    auto upX = listener().upXValues(AudioUtilities::renderQuantumSize);
+    auto upY = listener().upYValues(AudioUtilities::renderQuantumSize);
+    auto upZ = listener().upZValues(AudioUtilities::renderQuantumSize);
 
     // Compute the azimuth, elevation, and total gains for each position.
     std::array<double, AudioUtilities::renderQuantumSize> azimuth;
@@ -593,7 +591,5 @@ void PannerNode::invalidateCachedPropertiesIfNecessary()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/Modules/webaudio/PeriodicWave.h
+++ b/Source/WebCore/Modules/webaudio/PeriodicWave.h
@@ -61,7 +61,7 @@ public:
     // at this fundamental frequency. The lower wave is the next range containing fewer partials than the higher wave.
     // Interpolation between these two tables can be made according to tableInterpolationFactor.
     // Where values from 0 -> 1 interpolate between lower -> higher.
-    void waveDataForFundamentalFrequency(float, float* &lowerWaveData, float* &higherWaveData, float& tableInterpolationFactor);
+    void waveDataForFundamentalFrequency(float, std::span<float>& lowerWaveData, std::span<float>& higherWaveData, float& tableInterpolationFactor);
 
     // Returns the scalar multiplier to the oscillator frequency to calculate wave table phase increment.
     float rateScale() const { return m_rateScale; }
@@ -99,7 +99,7 @@ private:
     unsigned numberOfPartialsForRange(unsigned rangeIndex) const;
 
     // Creates tables based on numberOfComponents Fourier coefficients.
-    void createBandLimitedTables(const float* real, const float* imag, unsigned numberOfComponents, ShouldDisableNormalization = ShouldDisableNormalization::No);
+    void createBandLimitedTables(std::span<const float> real, std::span<const float> imag, ShouldDisableNormalization = ShouldDisableNormalization::No);
     Vector<std::unique_ptr<AudioFloatArray>> m_bandLimitedTables;
 };
 

--- a/Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp
@@ -41,8 +41,6 @@
 #include <wtf/MainThread.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(ScriptProcessorNode);
@@ -303,7 +301,5 @@ bool ScriptProcessorNode::virtualHasPendingActivity() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/AudioUtilities.cpp
+++ b/Source/WebCore/platform/audio/AudioUtilities.cpp
@@ -80,7 +80,7 @@ size_t timeToSampleFrame(double time, double sampleRate, SampleFrameRounding rou
     return static_cast<size_t>(frame);
 }
 
-void applyNoise(float* values, size_t numberOfElementsToProcess, float standardDeviation)
+void applyNoise(std::span<float> values, float standardDeviation)
 {
     std::random_device device;
     std::mt19937 generator(device());
@@ -96,11 +96,11 @@ void applyNoise(float* values, size_t numberOfElementsToProcess, float standardD
     std::array<float, maximumTableSize> multipliers;
     multipliers.fill(std::numeric_limits<float>::infinity());
 
-    for (size_t i = 0; i < numberOfElementsToProcess; ++i) {
-        auto& multiplier = multipliers[DefaultHash<double>::hash(values[i]) % tableSize];
+    for (auto& value : values) {
+        auto& multiplier = multipliers[DefaultHash<double>::hash(value) % tableSize];
         if (std::isinf(multiplier))
             multiplier = distribution(generator);
-        values[i] *= multiplier;
+        value *= multiplier;
     }
 }
 

--- a/Source/WebCore/platform/audio/AudioUtilities.h
+++ b/Source/WebCore/platform/audio/AudioUtilities.h
@@ -64,7 +64,7 @@ inline float decibelsToLinear(float decibels)
     return powf(10, 0.05f * decibels);
 }
 
-void applyNoise(float* values, size_t numberOfElementsToProcess, float standardDeviation);
+void applyNoise(std::span<float> values, float standardDeviation);
 
 } // AudioUtilites
 

--- a/Source/WebCore/platform/audio/Biquad.cpp
+++ b/Source/WebCore/platform/audio/Biquad.cpp
@@ -558,7 +558,7 @@ void Biquad::setBandpassParams(size_t index, double frequency, double Q)
     }
 }
 
-void Biquad::getFrequencyResponse(unsigned nFrequencies, const float* frequency, float* magResponse, float* phaseResponse)
+void Biquad::getFrequencyResponse(unsigned nFrequencies, std::span<const float> frequency, std::span<float> magResponse, std::span<float> phaseResponse)
 {
     // Evaluate the Z-transform of the filter at given normalized
     // frequency from 0 to 1. (1 corresponds to the Nyquist

--- a/Source/WebCore/platform/audio/Biquad.h
+++ b/Source/WebCore/platform/audio/Biquad.h
@@ -69,7 +69,7 @@ public:
     // Filter response at a set of n frequencies. The magnitude and
     // phase response are returned in magResponse and phaseResponse.
     // The phase response is in radians.
-    void getFrequencyResponse(unsigned nFrequencies, const float* frequency, float* magResponse, float* phaseResponse);
+    void getFrequencyResponse(unsigned nFrequencies, std::span<const float> frequency, std::span<float> magResponse, std::span<float> phaseResponse);
 
     // Compute tail frame based on the filter coefficents at index
     // |coefIndex|. The tail frame is the frame number where the


### PR DESCRIPTION
#### 49bd9c733d704d6e7db0e6cef17d4d4587dd5cdc
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebAudio code
<a href="https://bugs.webkit.org/show_bug.cgi?id=285076">https://bugs.webkit.org/show_bug.cgi?id=285076</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
(WebCore::AudioBuffer::applyNoiseIfNeeded):
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::computeSampleUsingLinearInterpolation):
(WebCore::AudioBufferSourceNode::renderFromBuffer):
* Source/WebCore/Modules/webaudio/AudioListener.cpp:
(WebCore::AudioListener::positionXValues):
(WebCore::AudioListener::positionYValues):
(WebCore::AudioListener::positionZValues):
(WebCore::AudioListener::forwardXValues):
(WebCore::AudioListener::forwardYValues):
(WebCore::AudioListener::forwardZValues):
(WebCore::AudioListener::upXValues):
(WebCore::AudioListener::upYValues):
(WebCore::AudioListener::upZValues):
* Source/WebCore/Modules/webaudio/AudioListener.h:
* Source/WebCore/Modules/webaudio/AudioNode.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/Modules/webaudio/AudioParam.cpp:
* Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp:
(WebCore::fillWithValue):
(WebCore::AudioParamTimeline::cancelAndHoldAtTime):
(WebCore::AudioParamTimeline::valuesForFrameRangeImpl):
(WebCore::AudioParamTimeline::processLinearRamp):
(WebCore::AudioParamTimeline::processExponentialRamp):
(WebCore::AudioParamTimeline::processCancelValues):
(WebCore::AudioParamTimeline::processSetTarget):
(WebCore::AudioParamTimeline::processSetValueCurve):
(WebCore::AudioParamTimeline::valueCurveAtTime):
* Source/WebCore/Modules/webaudio/AudioParamTimeline.h:
* Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.cpp:
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::process):
* Source/WebCore/Modules/webaudio/BiquadDSPKernel.cpp:
(WebCore::BiquadDSPKernel::getFrequencyResponse):
* Source/WebCore/Modules/webaudio/BiquadDSPKernel.h:
* Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp:
(WebCore::BiquadFilterNode::getFrequencyResponse):
* Source/WebCore/Modules/webaudio/BiquadProcessor.cpp:
(WebCore::BiquadProcessor::getFrequencyResponse):
* Source/WebCore/Modules/webaudio/BiquadProcessor.h:
* Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp:
(WebCore::ConstantSourceNode::process):
* Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp:
* Source/WebCore/Modules/webaudio/IIRDSPKernel.cpp:
* Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp:
* Source/WebCore/Modules/webaudio/OscillatorNode.cpp:
(WebCore::doInterpolation):
(WebCore::OscillatorNode::processARate):
(WebCore::OscillatorNode::processKRate):
(WebCore::OscillatorNode::process):
* Source/WebCore/Modules/webaudio/OscillatorNode.h:
* Source/WebCore/Modules/webaudio/PannerNode.cpp:
(WebCore::PannerNode::processSampleAccurateValues):
* Source/WebCore/Modules/webaudio/PeriodicWave.cpp:
(WebCore::PeriodicWave::create):
(WebCore::PeriodicWave::waveDataForFundamentalFrequency):
(WebCore::PeriodicWave::createBandLimitedTables):
(WebCore::PeriodicWave::generateBasicWaveform):
* Source/WebCore/Modules/webaudio/PeriodicWave.h:
* Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp:
(WebCore::RealtimeAnalyser::doFFTAnalysisIfNecessary):
(WebCore::RealtimeAnalyser::getByteFrequencyData):
(WebCore::RealtimeAnalyser::getFloatTimeDomainData):
(WebCore::RealtimeAnalyser::getByteTimeDomainData):
* Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp:
* Source/WebCore/platform/audio/AudioUtilities.cpp:
(WebCore::AudioUtilities::applyNoise):
* Source/WebCore/platform/audio/AudioUtilities.h:
* Source/WebCore/platform/audio/Biquad.cpp:
(WebCore::Biquad::getFrequencyResponse):
* Source/WebCore/platform/audio/Biquad.h:

Canonical link: <a href="https://commits.webkit.org/288248@main">https://commits.webkit.org/288248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4136f8461f6ba149599170dfee9e8fea353fe48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87338 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33267 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64067 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21810 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44345 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28976 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32308 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72537 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88694 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6769 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72458 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9737 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71676 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15806 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/864 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12761 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9465 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14947 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9339 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12804 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11108 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->