### PR TITLE
AX: Rename AXPropertyName to AXProperty

### DIFF
--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -621,602 +621,602 @@ WTF::TextStream& operator<<(WTF::TextStream& stream, const AXPropertyMap& map)
     return stream;
 }
 
-TextStream& operator<<(WTF::TextStream& stream, AXPropertyName property)
+TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
 {
     switch (property) {
-    case AXPropertyName::ARIATreeRows:
+    case AXProperty::ARIATreeRows:
         stream << "ARIATreeRows";
         break;
 #if !ENABLE(AX_THREAD_TEXT_APIS)
-    case AXPropertyName::AttributedText:
+    case AXProperty::AttributedText:
         stream << "AttributedText";
         break;
 #endif // !ENABLE(AX_THREAD_TEXT_APIS)
-    case AXPropertyName::AXColumnCount:
+    case AXProperty::AXColumnCount:
         stream << "AXColumnCount";
         break;
-    case AXPropertyName::AXColumnIndex:
+    case AXProperty::AXColumnIndex:
         stream << "AXColumnIndex";
         break;
-    case AXPropertyName::AXRowCount:
+    case AXProperty::AXRowCount:
         stream << "AXRowCount";
         break;
-    case AXPropertyName::AXRowIndex:
+    case AXProperty::AXRowIndex:
         stream << "AXRowIndex";
         break;
-    case AXPropertyName::AccessKey:
+    case AXProperty::AccessKey:
         stream << "AccessKey";
         break;
-    case AXPropertyName::AccessibilityText:
+    case AXProperty::AccessibilityText:
         stream << "AccessibilityText";
         break;
-    case AXPropertyName::ActionVerb:
+    case AXProperty::ActionVerb:
         stream << "ActionVerb";
         break;
-    case AXPropertyName::AncestorFlags:
+    case AXProperty::AncestorFlags:
         stream << "AncestorFlags";
         break;
-    case AXPropertyName::AutoCompleteValue:
+    case AXProperty::AutoCompleteValue:
         stream << "AutoCompleteValue";
         break;
-    case AXPropertyName::BackgroundColor:
+    case AXProperty::BackgroundColor:
         stream << "BackgroundColor";
         break;
-    case AXPropertyName::BlockquoteLevel:
+    case AXProperty::BlockquoteLevel:
         stream << "BlockquoteLevel";
         break;
-    case AXPropertyName::BrailleLabel:
+    case AXProperty::BrailleLabel:
         stream << "BrailleLabel";
         break;
-    case AXPropertyName::BrailleRoleDescription:
+    case AXProperty::BrailleRoleDescription:
         stream << "BrailleRoleDescription";
         break;
-    case AXPropertyName::ButtonState:
+    case AXProperty::ButtonState:
         stream << "ButtonState";
         break;
-    case AXPropertyName::CanBeMultilineTextField:
+    case AXProperty::CanBeMultilineTextField:
         stream << "CanBeMultilineTextField";
         break;
-    case AXPropertyName::CanSetFocusAttribute:
+    case AXProperty::CanSetFocusAttribute:
         stream << "CanSetFocusAttribute";
         break;
-    case AXPropertyName::CanSetSelectedAttribute:
+    case AXProperty::CanSetSelectedAttribute:
         stream << "CanSetSelectedAttribute";
         break;
-    case AXPropertyName::CanSetValueAttribute:
+    case AXProperty::CanSetValueAttribute:
         stream << "CanSetValueAttribute";
         break;
 #if PLATFORM(MAC)
-    case AXPropertyName::CaretBrowsingEnabled:
+    case AXProperty::CaretBrowsingEnabled:
         stream << "CaretBrowsingEnabled";
         break;
 #endif
-    case AXPropertyName::Cells:
+    case AXProperty::Cells:
         stream << "Cells";
         break;
-    case AXPropertyName::CellScope:
+    case AXProperty::CellScope:
         stream << "CellScope";
         break;
-    case AXPropertyName::CellSlots:
+    case AXProperty::CellSlots:
         stream << "CellSlots";
         break;
-    case AXPropertyName::ColorValue:
+    case AXProperty::ColorValue:
         stream << "ColorValue";
         break;
-    case AXPropertyName::Columns:
+    case AXProperty::Columns:
         stream << "Columns";
         break;
-    case AXPropertyName::ColumnIndex:
+    case AXProperty::ColumnIndex:
         stream << "ColumnIndex";
         break;
-    case AXPropertyName::ColumnIndexRange:
+    case AXProperty::ColumnIndexRange:
         stream << "ColumnIndexRange";
         break;
-    case AXPropertyName::CurrentState:
+    case AXProperty::CurrentState:
         stream << "CurrentState";
         break;
-    case AXPropertyName::DateTimeComponentsType:
+    case AXProperty::DateTimeComponentsType:
         stream << "DateTimeComponentsType";
         break;
-    case AXPropertyName::DateTimeValue:
+    case AXProperty::DateTimeValue:
         stream << "DateTimeValue";
         break;
-    case AXPropertyName::DatetimeAttributeValue:
+    case AXProperty::DatetimeAttributeValue:
         stream << "DatetimeAttributeValue";
         break;
-    case AXPropertyName::DecrementButton:
+    case AXProperty::DecrementButton:
         stream << "DecrementButton";
         break;
-    case AXPropertyName::Description:
+    case AXProperty::Description:
         stream << "Description";
         break;
-    case AXPropertyName::DisclosedByRow:
+    case AXProperty::DisclosedByRow:
         stream << "DisclosedByRow";
         break;
-    case AXPropertyName::DisclosedRows:
+    case AXProperty::DisclosedRows:
         stream << "DisclosedRows";
         break;
-    case AXPropertyName::DocumentEncoding:
+    case AXProperty::DocumentEncoding:
         stream << "DocumentEncoding";
         break;
-    case AXPropertyName::DocumentLinks:
+    case AXProperty::DocumentLinks:
         stream << "DocumentLinks";
         break;
-    case AXPropertyName::DocumentURI:
+    case AXProperty::DocumentURI:
         stream << "DocumentURI";
         break;
-    case AXPropertyName::EmbeddedImageDescription:
+    case AXProperty::EmbeddedImageDescription:
         stream << "EmbeddedImageDescription";
         break;
-    case AXPropertyName::EmitTextAfterBehavior:
+    case AXProperty::EmitTextAfterBehavior:
         stream << "EmitTextAfterBehavior";
         break;
-    case AXPropertyName::ExpandedTextValue:
+    case AXProperty::ExpandedTextValue:
         stream << "ExpandedTextValue";
         break;
-    case AXPropertyName::ExtendedDescription:
+    case AXProperty::ExtendedDescription:
         stream << "ExtendedDescription";
         break;
 #if PLATFORM(COCOA)
-    case AXPropertyName::Font:
+    case AXProperty::Font:
         stream << "Font";
         break;
 #endif // PLATFORM(COCOA)
-    case AXPropertyName::TextColor:
+    case AXProperty::TextColor:
         stream << "TextColor";
         break;
-    case AXPropertyName::HasApplePDFAnnotationAttribute:
+    case AXProperty::HasApplePDFAnnotationAttribute:
         stream << "HasApplePDFAnnotationAttribute";
         break;
-    case AXPropertyName::HasBodyTag:
+    case AXProperty::HasBodyTag:
         stream << "HasBodyTag";
         break;
-    case AXPropertyName::HasBoldFont:
+    case AXProperty::HasBoldFont:
         stream << "HasBoldFont";
         break;
-    case AXPropertyName::HasClickHandler:
+    case AXProperty::HasClickHandler:
         stream << "HasClickHandler";
         break;
-    case AXPropertyName::HasHighlighting:
+    case AXProperty::HasHighlighting:
         stream << "HasHighlighting";
         break;
-    case AXPropertyName::HasItalicFont:
+    case AXProperty::HasItalicFont:
         stream << "HasItalicFont";
         break;
-    case AXPropertyName::HasLinethrough:
+    case AXProperty::HasLinethrough:
         stream << "HasLinethrough";
         break;
-    case AXPropertyName::HasMarkTag:
+    case AXProperty::HasMarkTag:
         stream << "HasMarkTag";
         break;
-    case AXPropertyName::HasPlainText:
+    case AXProperty::HasPlainText:
         stream << "HasPlainText";
         break;
-    case AXPropertyName::HasRemoteFrameChild:
+    case AXProperty::HasRemoteFrameChild:
         stream << "HasRemoteFrameChild";
         break;
-    case AXPropertyName::IsSubscript:
+    case AXProperty::IsSubscript:
         stream << "IsSubscript";
         break;
-    case AXPropertyName::IsSuperscript:
+    case AXProperty::IsSuperscript:
         stream << "IsSuperscript";
         break;
-    case AXPropertyName::HasTextShadow:
+    case AXProperty::HasTextShadow:
         stream << "HasTextShadow";
         break;
-    case AXPropertyName::HasUnderline:
+    case AXProperty::HasUnderline:
         stream << "HasUnderline";
         break;
-    case AXPropertyName::HeaderContainer:
+    case AXProperty::HeaderContainer:
         stream << "HeaderContainer";
         break;
-    case AXPropertyName::HeadingLevel:
+    case AXProperty::HeadingLevel:
         stream << "HeadingLevel";
         break;
-    case AXPropertyName::HierarchicalLevel:
+    case AXProperty::HierarchicalLevel:
         stream << "HierarchicalLevel";
         break;
-    case AXPropertyName::HorizontalScrollBar:
+    case AXProperty::HorizontalScrollBar:
         stream << "HorizontalScrollBar";
         break;
-    case AXPropertyName::IdentifierAttribute:
+    case AXProperty::IdentifierAttribute:
         stream << "IdentifierAttribute";
         break;
-    case AXPropertyName::IncrementButton:
+    case AXProperty::IncrementButton:
         stream << "IncrementButton";
         break;
-    case AXPropertyName::InitialFrameRect:
+    case AXProperty::InitialFrameRect:
         stream << "InitialFrameRect";
         break;
-    case AXPropertyName::InnerHTML:
+    case AXProperty::InnerHTML:
         stream << "InnerHTML";
         break;
-    case AXPropertyName::InternalLinkElement:
+    case AXProperty::InternalLinkElement:
         stream << "InternalLinkElement";
         break;
-    case AXPropertyName::InsideLink:
+    case AXProperty::InsideLink:
         stream << "InsideLink";
         break;
-    case AXPropertyName::InvalidStatus:
+    case AXProperty::InvalidStatus:
         stream << "InvalidStatus";
         break;
-    case AXPropertyName::IsGrabbed:
+    case AXProperty::IsGrabbed:
         stream << "IsGrabbed";
         break;
-    case AXPropertyName::IsARIATreeGridRow:
+    case AXProperty::IsARIATreeGridRow:
         stream << "IsARIATreeGridRow";
         break;
-    case AXPropertyName::IsAttachment:
+    case AXProperty::IsAttachment:
         stream << "IsAttachment";
         break;
-    case AXPropertyName::IsBusy:
+    case AXProperty::IsBusy:
         stream << "IsBusy";
         break;
-    case AXPropertyName::IsChecked:
+    case AXProperty::IsChecked:
         stream << "IsChecked";
         break;
-    case AXPropertyName::IsColumnHeader:
+    case AXProperty::IsColumnHeader:
         stream << "IsColumnHeader";
         break;
-    case AXPropertyName::IsEnabled:
+    case AXProperty::IsEnabled:
         stream << "IsEnabled";
         break;
-    case AXPropertyName::IsExpanded:
+    case AXProperty::IsExpanded:
         stream << "IsExpanded";
         break;
-    case AXPropertyName::IsExposable:
+    case AXProperty::IsExposable:
         stream << "IsExposable";
         break;
-    case AXPropertyName::IsExposedTableCell:
+    case AXProperty::IsExposedTableCell:
         stream << "IsExposedTableCell";
         break;
-    case AXPropertyName::IsFieldset:
+    case AXProperty::IsFieldset:
         stream << "IsFieldset";
         break;
-    case AXPropertyName::IsFileUploadButton:
+    case AXProperty::IsFileUploadButton:
         stream << "IsFileUploadButton";
         break;
-    case AXPropertyName::IsIgnored:
+    case AXProperty::IsIgnored:
         stream << "IsIgnored";
         break;
-    case AXPropertyName::IsIndeterminate:
+    case AXProperty::IsIndeterminate:
         stream << "IsIndeterminate";
         break;
-    case AXPropertyName::IsInlineText:
+    case AXProperty::IsInlineText:
         stream << "IsInlineText";
         break;
-    case AXPropertyName::IsRadioInput:
+    case AXProperty::IsRadioInput:
         stream << "IsRadioInput";
         break;
-    case AXPropertyName::IsInputImage:
+    case AXProperty::IsInputImage:
         stream << "IsInputImage";
         break;
-    case AXPropertyName::IsKeyboardFocusable:
+    case AXProperty::IsKeyboardFocusable:
         stream << "IsKeyboardFocusable";
         break;
-    case AXPropertyName::IsListBox:
+    case AXProperty::IsListBox:
         stream << "IsListBox";
         break;
-    case AXPropertyName::IsMathElement:
+    case AXProperty::IsMathElement:
         stream << "IsMathElement";
         break;
-    case AXPropertyName::IsMathFraction:
+    case AXProperty::IsMathFraction:
         stream << "IsMathFraction";
         break;
-    case AXPropertyName::IsMathFenced:
+    case AXProperty::IsMathFenced:
         stream << "IsMathFenced";
         break;
-    case AXPropertyName::IsMathSubscriptSuperscript:
+    case AXProperty::IsMathSubscriptSuperscript:
         stream << "IsMathSubscriptSuperscript";
         break;
-    case AXPropertyName::IsMathRow:
+    case AXProperty::IsMathRow:
         stream << "IsMathRow";
         break;
-    case AXPropertyName::IsMathUnderOver:
+    case AXProperty::IsMathUnderOver:
         stream << "IsMathUnderOver";
         break;
-    case AXPropertyName::IsMathRoot:
+    case AXProperty::IsMathRoot:
         stream << "IsMathRoot";
         break;
-    case AXPropertyName::IsMathSquareRoot:
+    case AXProperty::IsMathSquareRoot:
         stream << "IsMathSquareRoot";
         break;
-    case AXPropertyName::IsMathTable:
+    case AXProperty::IsMathTable:
         stream << "IsMathTable";
         break;
-    case AXPropertyName::IsMathTableRow:
+    case AXProperty::IsMathTableRow:
         stream << "IsMathTableRow";
         break;
-    case AXPropertyName::IsMathTableCell:
+    case AXProperty::IsMathTableCell:
         stream << "IsMathTableCell";
         break;
-    case AXPropertyName::IsMathMultiscript:
+    case AXProperty::IsMathMultiscript:
         stream << "IsMathMultiscript";
         break;
-    case AXPropertyName::IsMathToken:
+    case AXProperty::IsMathToken:
         stream << "IsMathToken";
         break;
-    case AXPropertyName::IsMultiSelectable:
+    case AXProperty::IsMultiSelectable:
         stream << "IsMultiSelectable";
         break;
-    case AXPropertyName::IsNonLayerSVGObject:
+    case AXProperty::IsNonLayerSVGObject:
         stream << "IsNonLayerSVGObject";
         break;
-    case AXPropertyName::IsPlugin:
+    case AXProperty::IsPlugin:
         stream << "IsPlugin";
         break;
-    case AXPropertyName::IsPressed:
+    case AXProperty::IsPressed:
         stream << "IsPressed";
         break;
-    case AXPropertyName::IsRequired:
+    case AXProperty::IsRequired:
         stream << "IsRequired";
         break;
-    case AXPropertyName::IsRowHeader:
+    case AXProperty::IsRowHeader:
         stream << "IsRowHeader";
         break;
-    case AXPropertyName::IsSecureField:
+    case AXProperty::IsSecureField:
         stream << "IsSecureField";
         break;
-    case AXPropertyName::IsSelected:
+    case AXProperty::IsSelected:
         stream << "IsSelected";
         break;
-    case AXPropertyName::IsSelectedOptionActive:
+    case AXProperty::IsSelectedOptionActive:
         stream << "IsSelectedOptionActive";
         break;
-    case AXPropertyName::IsTable:
+    case AXProperty::IsTable:
         stream << "IsTable";
         break;
-    case AXPropertyName::IsTableRow:
+    case AXProperty::IsTableRow:
         stream << "IsTableRow";
         break;
-    case AXPropertyName::IsTree:
+    case AXProperty::IsTree:
         stream << "IsTree";
         break;
-    case AXPropertyName::IsTreeItem:
+    case AXProperty::IsTreeItem:
         stream << "IsTreeItem";
         break;
-    case AXPropertyName::IsValueAutofillAvailable:
+    case AXProperty::IsValueAutofillAvailable:
         stream << "IsValueAutofillAvailable";
         break;
-    case AXPropertyName::IsVisible:
+    case AXProperty::IsVisible:
         stream << "IsVisible";
         break;
-    case AXPropertyName::IsWidget:
+    case AXProperty::IsWidget:
         stream << "IsWidget";
         break;
-    case AXPropertyName::KeyShortcuts:
+    case AXProperty::KeyShortcuts:
         stream << "KeyShortcuts";
         break;
-    case AXPropertyName::Language:
+    case AXProperty::Language:
         stream << "Language";
         break;
-    case AXPropertyName::LinethroughColor:
+    case AXProperty::LinethroughColor:
         stream << "LinethroughColor";
         break;
-    case AXPropertyName::LiveRegionAtomic:
+    case AXProperty::LiveRegionAtomic:
         stream << "LiveRegionAtomic";
         break;
-    case AXPropertyName::LiveRegionRelevant:
+    case AXProperty::LiveRegionRelevant:
         stream << "LiveRegionRelevant";
         break;
-    case AXPropertyName::LiveRegionStatus:
+    case AXProperty::LiveRegionStatus:
         stream << "LiveRegionStatus";
         break;
-    case AXPropertyName::LocalizedActionVerb:
+    case AXProperty::LocalizedActionVerb:
         stream << "LocalizedActionVerb";
         break;
-    case AXPropertyName::MathFencedOpenString:
+    case AXProperty::MathFencedOpenString:
         stream << "MathFencedOpenString";
         break;
-    case AXPropertyName::MathFencedCloseString:
+    case AXProperty::MathFencedCloseString:
         stream << "MathFencedCloseString";
         break;
-    case AXPropertyName::MathLineThickness:
+    case AXProperty::MathLineThickness:
         stream << "MathLineThickness";
         break;
-    case AXPropertyName::MathPrescripts:
+    case AXProperty::MathPrescripts:
         stream << "MathPrescripts";
         break;
-    case AXPropertyName::MathPostscripts:
+    case AXProperty::MathPostscripts:
         stream << "MathPostscripts";
         break;
-    case AXPropertyName::MathRadicand:
+    case AXProperty::MathRadicand:
         stream << "MathRadicand";
         break;
-    case AXPropertyName::MathRootIndexObject:
+    case AXProperty::MathRootIndexObject:
         stream << "MathRootIndexObject";
         break;
-    case AXPropertyName::MathUnderObject:
+    case AXProperty::MathUnderObject:
         stream << "MathUnderObject";
         break;
-    case AXPropertyName::MathOverObject:
+    case AXProperty::MathOverObject:
         stream << "MathOverObject";
         break;
-    case AXPropertyName::MathNumeratorObject:
+    case AXProperty::MathNumeratorObject:
         stream << "MathNumeratorObject";
         break;
-    case AXPropertyName::MathDenominatorObject:
+    case AXProperty::MathDenominatorObject:
         stream << "MathDenominatorObject";
         break;
-    case AXPropertyName::MathBaseObject:
+    case AXProperty::MathBaseObject:
         stream << "MathBaseObject";
         break;
-    case AXPropertyName::MathSubscriptObject:
+    case AXProperty::MathSubscriptObject:
         stream << "MathSubscriptObject";
         break;
-    case AXPropertyName::MathSuperscriptObject:
+    case AXProperty::MathSuperscriptObject:
         stream << "MathSuperscriptObject";
         break;
-    case AXPropertyName::MaxValueForRange:
+    case AXProperty::MaxValueForRange:
         stream << "MaxValueForRange";
         break;
-    case AXPropertyName::MinValueForRange:
+    case AXProperty::MinValueForRange:
         stream << "MinValueForRange";
         break;
-    case AXPropertyName::NameAttribute:
+    case AXProperty::NameAttribute:
         stream << "NameAttribute";
         break;
-    case AXPropertyName::Orientation:
+    case AXProperty::Orientation:
         stream << "Orientation";
         break;
-    case AXPropertyName::OuterHTML:
+    case AXProperty::OuterHTML:
         stream << "OuterHTML";
         break;
-    case AXPropertyName::Path:
+    case AXProperty::Path:
         stream << "Path";
         break;
-    case AXPropertyName::PlaceholderValue:
+    case AXProperty::PlaceholderValue:
         stream << "PlaceholderValue";
         break;
-    case AXPropertyName::PopupValue:
+    case AXProperty::PopupValue:
         stream << "PopupValue";
         break;
-    case AXPropertyName::PosInSet:
+    case AXProperty::PosInSet:
         stream << "PosInSet";
         break;
-    case AXPropertyName::PreventKeyboardDOMEventDispatch:
+    case AXProperty::PreventKeyboardDOMEventDispatch:
         stream << "PreventKeyboardDOMEventDispatch";
         break;
-    case AXPropertyName::RadioButtonGroup:
+    case AXProperty::RadioButtonGroup:
         stream << "RadioButtonGroup";
         break;
-    case AXPropertyName::RelativeFrame:
+    case AXProperty::RelativeFrame:
         stream << "RelativeFrame";
         break;
-    case AXPropertyName::RemoteFrameOffset:
+    case AXProperty::RemoteFrameOffset:
         stream << "RemoteFrameOffset";
         break;
-    case AXPropertyName::RemoteFramePlatformElement:
+    case AXProperty::RemoteFramePlatformElement:
         stream << "RemoteFramePlatformElement";
         break;
-    case AXPropertyName::RolePlatformString:
+    case AXProperty::RolePlatformString:
         stream << "RolePlatformString";
         break;
-    case AXPropertyName::RoleDescription:
+    case AXProperty::RoleDescription:
         stream << "RoleDescription";
         break;
-    case AXPropertyName::Rows:
+    case AXProperty::Rows:
         stream << "Rows";
         break;
-    case AXPropertyName::RowGroupAncestorID:
+    case AXProperty::RowGroupAncestorID:
         stream << "RowGroupAncestorID";
         break;
-    case AXPropertyName::RowHeader:
+    case AXProperty::RowHeader:
         stream << "RowHeader";
         break;
-    case AXPropertyName::RowHeaders:
+    case AXProperty::RowHeaders:
         stream << "RowHeaders";
         break;
-    case AXPropertyName::RowIndex:
+    case AXProperty::RowIndex:
         stream << "RowIndex";
         break;
-    case AXPropertyName::RowIndexRange:
+    case AXProperty::RowIndexRange:
         stream << "RowIndexRange";
         break;
-    case AXPropertyName::ScreenRelativePosition:
+    case AXProperty::ScreenRelativePosition:
         stream << "ScreenRelativePosition";
         break;
-    case AXPropertyName::SelectedChildren:
+    case AXProperty::SelectedChildren:
         stream << "SelectedChildren";
         break;
-    case AXPropertyName::SelectedTextRange:
+    case AXProperty::SelectedTextRange:
         stream << "SelectedTextRange";
         break;
-    case AXPropertyName::SetSize:
+    case AXProperty::SetSize:
         stream << "SetSize";
         break;
-    case AXPropertyName::SortDirection:
+    case AXProperty::SortDirection:
         stream << "SortDirection";
         break;
-    case AXPropertyName::SpeechHint:
+    case AXProperty::SpeechHint:
         stream << "SpeechHint";
         break;
-    case AXPropertyName::StringValue:
+    case AXProperty::StringValue:
         stream << "StringValue";
         break;
-    case AXPropertyName::SubrolePlatformString:
+    case AXProperty::SubrolePlatformString:
         stream << "SubrolePlatformString";
         break;
-    case AXPropertyName::SupportsDragging:
+    case AXProperty::SupportsDragging:
         stream << "SupportsDragging";
         break;
-    case AXPropertyName::SupportsDropping:
+    case AXProperty::SupportsDropping:
         stream << "SupportsDropping";
         break;
-    case AXPropertyName::SupportsARIAOwns:
+    case AXProperty::SupportsARIAOwns:
         stream << "SupportsARIAOwns";
         break;
-    case AXPropertyName::SupportsCheckedState:
+    case AXProperty::SupportsCheckedState:
         stream << "SupportsCheckedState";
         break;
-    case AXPropertyName::SupportsCurrent:
+    case AXProperty::SupportsCurrent:
         stream << "SupportsCurrent";
         break;
-    case AXPropertyName::SupportsDatetimeAttribute:
+    case AXProperty::SupportsDatetimeAttribute:
         stream << "SupportsDatetimeAttribute";
         break;
-    case AXPropertyName::SupportsExpanded:
+    case AXProperty::SupportsExpanded:
         stream << "SupportsExpanded";
         break;
-    case AXPropertyName::SupportsExpandedTextValue:
+    case AXProperty::SupportsExpandedTextValue:
         stream << "SupportsExpandedTextValue";
         break;
-    case AXPropertyName::SupportsKeyShortcuts:
+    case AXProperty::SupportsKeyShortcuts:
         stream << "SupportsKeyShortcuts";
         break;
-    case AXPropertyName::SupportsPath:
+    case AXProperty::SupportsPath:
         stream << "SupportsPath";
         break;
-    case AXPropertyName::SupportsPosInSet:
+    case AXProperty::SupportsPosInSet:
         stream << "SupportsPosInSet";
         break;
-    case AXPropertyName::SupportsRangeValue:
+    case AXProperty::SupportsRangeValue:
         stream << "SupportsRangeValue";
         break;
-    case AXPropertyName::SupportsSetSize:
+    case AXProperty::SupportsSetSize:
         stream << "SupportsSetSize";
         break;
 #if !ENABLE(AX_THREAD_TEXT_APIS)
-    case AXPropertyName::TextContent:
+    case AXProperty::TextContent:
         stream << "TextContent";
         break;
 #endif // !ENABLE(AX_THREAD_TEXT_APIS)
-    case AXPropertyName::TextInputMarkedTextMarkerRange:
+    case AXProperty::TextInputMarkedTextMarkerRange:
         stream << "TextInputMarkedTextMarkerRange";
         break;
 #if ENABLE(AX_THREAD_TEXT_APIS)
-    case AXPropertyName::TextRuns:
+    case AXProperty::TextRuns:
         stream << "TextRuns";
         break;
 #endif
-    case AXPropertyName::Title:
+    case AXProperty::Title:
         stream << "Title";
         break;
-    case AXPropertyName::TitleAttributeValue:
+    case AXProperty::TitleAttributeValue:
         stream << "TitleAttributeValue";
         break;
-    case AXPropertyName::URL:
+    case AXProperty::URL:
         stream << "URL";
         break;
-    case AXPropertyName::UnderlineColor:
+    case AXProperty::UnderlineColor:
         stream << "UnderlineColor";
         break;
-    case AXPropertyName::ValueAutofillButtonType:
+    case AXProperty::ValueAutofillButtonType:
         stream << "ValueAutofillButtonType";
         break;
-    case AXPropertyName::ValueDescription:
+    case AXProperty::ValueDescription:
         stream << "ValueDescription";
         break;
-    case AXPropertyName::ValueForRange:
+    case AXProperty::ValueForRange:
         stream << "ValueForRange";
         break;
-    case AXPropertyName::VerticalScrollBar:
+    case AXProperty::VerticalScrollBar:
         stream << "VerticalScrollBar";
         break;
-    case AXPropertyName::VisibleChildren:
+    case AXProperty::VisibleChildren:
         stream << "VisibleChildren";
         break;
-    case AXPropertyName::VisibleRows:
+    case AXProperty::VisibleRows:
         stream << "VisibleRows";
         break;
     }

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1311,7 +1311,7 @@ void AXObjectCache::onEventListenerAdded(Node& node, const AtomString& eventType
         return;
 
     if (RefPtr tree = AXIsolatedTree::treeForPageID(m_pageID))
-        tree->updateNodeProperties(get(node), { AXPropertyName::HasClickHandler });
+        tree->updateNodeProperties(get(node), { AXProperty::HasClickHandler });
 #else
     UNUSED_PARAM(node);
     UNUSED_PARAM(eventType);
@@ -1325,7 +1325,7 @@ void AXObjectCache::onEventListenerRemoved(Node& node, const AtomString& eventTy
         return;
 
     if (RefPtr tree = AXIsolatedTree::treeForPageID(m_pageID))
-        tree->updateNodeProperties(get(node), { AXPropertyName::HasClickHandler });
+        tree->updateNodeProperties(get(node), { AXProperty::HasClickHandler });
 #else
     UNUSED_PARAM(node);
     UNUSED_PARAM(eventType);
@@ -1489,7 +1489,7 @@ void AXObjectCache::handleRecomputeCellSlots(AccessibilityTable& axTable)
 void AXObjectCache::onRemoteFrameInitialized(AXRemoteFrame& remoteFrame)
 {
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    updateIsolatedTree(remoteFrame, AXPropertyName::RemoteFramePlatformElement);
+    updateIsolatedTree(remoteFrame, AXProperty::RemoteFramePlatformElement);
 #else
     UNUSED_PARAM(remoteFrame);
 #endif
@@ -1886,7 +1886,7 @@ void AXObjectCache::onInertOrVisibilityChange(RenderElement& renderer)
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     if (RefPtr tree = AXIsolatedTree::treeForPageID(m_pageID))
-        tree->updatePropertiesForSelfAndDescendants(*axObject, { AXPropertyName::IsIgnored });
+        tree->updatePropertiesForSelfAndDescendants(*axObject, { AXProperty::IsIgnored });
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
 #else // !ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
@@ -2010,30 +2010,30 @@ void AXObjectCache::onStyleChange(RenderText& renderText, StyleDifference differ
         return;
 
     if (!oldStyle->fontCascadeEqual(newStyle))
-        tree->queueNodeUpdate(object->objectID(), { AXPropertyName::Font });
+        tree->queueNodeUpdate(object->objectID(), { AXProperty::Font });
 
     if (oldStyle->visitedDependentColor(CSSPropertyColor) != newStyle.visitedDependentColor(CSSPropertyColor))
-        tree->queueNodeUpdate(object->objectID(), { AXPropertyName::TextColor });
+        tree->queueNodeUpdate(object->objectID(), { AXProperty::TextColor });
 
     if (oldStyle->visitedDependentColor(CSSPropertyBackgroundColor) != newStyle.visitedDependentColor(CSSPropertyBackgroundColor))
-        tree->queueNodeUpdate(object->objectID(), { AXPropertyName::BackgroundColor });
+        tree->queueNodeUpdate(object->objectID(), { AXProperty::BackgroundColor });
 
     if (oldStyle->verticalAlign() != newStyle.verticalAlign())
-        tree->queueNodeUpdate(object->objectID(), { { AXPropertyName::IsSuperscript, AXPropertyName::IsSubscript } });
+        tree->queueNodeUpdate(object->objectID(), { { AXProperty::IsSuperscript, AXProperty::IsSubscript } });
 
     if (!!oldStyle->textShadow() != !!newStyle.textShadow())
-        tree->queueNodeUpdate(object->objectID(), { AXPropertyName::HasTextShadow });
+        tree->queueNodeUpdate(object->objectID(), { AXProperty::HasTextShadow });
 
     auto oldDecor = oldStyle->textDecorationsInEffect();
     auto newDecor = newStyle.textDecorationsInEffect();
     if ((oldDecor & TextDecorationLine::Underline) != (newDecor & TextDecorationLine::Underline))
-        tree->queueNodeUpdate(object->objectID(), { AXPropertyName::HasUnderline });
+        tree->queueNodeUpdate(object->objectID(), { AXProperty::HasUnderline });
 
     if ((oldDecor & TextDecorationLine::LineThrough) != (newDecor & TextDecorationLine::LineThrough))
-        tree->queueNodeUpdate(object->objectID(), { AXPropertyName::HasLinethrough });
+        tree->queueNodeUpdate(object->objectID(), { AXProperty::HasLinethrough });
 
     if (oldStyle->textDecorationColor() != newStyle.textDecorationColor())
-        tree->queueNodeUpdate(object->objectID(), { { AXPropertyName::LinethroughColor, AXPropertyName::UnderlineColor } });
+        tree->queueNodeUpdate(object->objectID(), { { AXProperty::LinethroughColor, AXProperty::UnderlineColor } });
 #else
     UNUSED_PARAM(renderText);
     UNUSED_PARAM(difference);
@@ -2919,7 +2919,7 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     else if (attrName == aria_ownsAttr) {
         if (oldValue.isEmpty() || newValue.isEmpty())
-            updateIsolatedTree(get(*element), AXPropertyName::SupportsARIAOwns);
+            updateIsolatedTree(get(*element), AXProperty::SupportsARIAOwns);
     } else if (attrName == aria_braillelabelAttr)
         postNotification(element, AXNotification::BrailleLabelChanged);
     else if (attrName == aria_brailleroledescriptionAttr)
@@ -4480,7 +4480,7 @@ void AXObjectCache::performDeferredCacheUpdate(ForceLayout forceLayout)
                 // m_deferredRegenerateIsolatedTree is only set when we change the active modal, which effects the ignored
                 // status of every object on the page. With ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE), this means we only have
                 // to re-compute is-ignored for every object, rather than re-compute all objects entirely as when this flag is off.
-                tree->updatePropertiesForSelfAndDescendants(*webArea, { AXPropertyName::IsIgnored });
+                tree->updatePropertiesForSelfAndDescendants(*webArea, { AXProperty::IsIgnored });
 #else
                 tree->generateSubtree(*webArea);
 #endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
@@ -4576,142 +4576,142 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
 
         switch (notification.second) {
         case AXNotification::AccessKeyChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::AccessKey });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::AccessKey });
             break;
         case AXNotification::AutofillTypeChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::ValueAutofillButtonType });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::ValueAutofillButtonType });
             break;
         case AXNotification::ARIAColumnIndexChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::AXColumnIndex });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::AXColumnIndex });
             break;
         case AXNotification::ARIARowIndexChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::AXRowIndex });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::AXRowIndex });
             break;
         case AXNotification::BrailleLabelChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::BrailleLabel });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::BrailleLabel });
             break;
         case AXNotification::BrailleRoleDescriptionChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::BrailleRoleDescription });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::BrailleRoleDescription });
             break;
         case AXNotification::CellSlotsChanged:
             ASSERT(notification.first->isTable());
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::CellSlots });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::CellSlots });
             break;
         case AXNotification::CheckedStateChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::IsChecked });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::IsChecked });
             break;
         case AXNotification::CurrentStateChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::CurrentState });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::CurrentState });
             break;
         case AXNotification::ColumnCountChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::AXColumnCount });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::AXColumnCount });
             break;
         case AXNotification::ColumnIndexChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::ColumnIndexRange, AXPropertyName::ColumnIndex } });
+            tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::ColumnIndexRange, AXProperty::ColumnIndex } });
             break;
         case AXNotification::ColumnSpanChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::ColumnIndexRange });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::ColumnIndexRange });
             break;
         case AXNotification::DatetimeChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::DatetimeAttributeValue });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::DatetimeAttributeValue });
             break;
         case AXNotification::DisabledStateChanged:
-            tree->updatePropertiesForSelfAndDescendants(notification.first.get(), { { AXPropertyName::CanSetFocusAttribute, AXPropertyName::CanSetSelectedAttribute, AXPropertyName::IsEnabled } });
+            tree->updatePropertiesForSelfAndDescendants(notification.first.get(), { { AXProperty::CanSetFocusAttribute, AXProperty::CanSetSelectedAttribute, AXProperty::IsEnabled } });
             break;
         case AXNotification::ExpandedChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::IsExpanded });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::IsExpanded });
             break;
         case AXNotification::ExtendedDescriptionChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::AccessibilityText, AXPropertyName::ExtendedDescription } });
+            tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::AccessibilityText, AXProperty::ExtendedDescription } });
             break;
         case AXNotification::FocusableStateChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::CanSetFocusAttribute });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::CanSetFocusAttribute });
             break;
         case AXNotification::MaximumValueChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::MaxValueForRange, AXPropertyName::ValueForRange } });
+            tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::MaxValueForRange, AXProperty::ValueForRange } });
             break;
         case AXNotification::MenuListItemSelected: {
             RefPtr ancestor = Accessibility::findAncestor<AccessibilityObject>(notification.first.get(), false, [] (const auto& object) {
                 return object.isMenu() || object.isMenuBar();
             });
             if (ancestor) {
-                tree->queueNodeUpdate(ancestor->objectID(), { AXPropertyName::SelectedChildren });
-                tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::IsSelected });
+                tree->queueNodeUpdate(ancestor->objectID(), { AXProperty::SelectedChildren });
+                tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::IsSelected });
             }
             break;
         }
         case AXNotification::MinimumValueChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::MinValueForRange, AXPropertyName::ValueForRange } });
+            tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::MinValueForRange, AXProperty::ValueForRange } });
             break;
         case AXNotification::NameChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::NameAttribute });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::NameAttribute });
             break;
         case AXNotification::OrientationChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::Orientation });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::Orientation });
             break;
         case AXNotification::PositionInSetChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::PosInSet, AXPropertyName::SupportsPosInSet } });
+            tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::PosInSet, AXProperty::SupportsPosInSet } });
             break;
         case AXNotification::PopoverTargetChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::SupportsExpanded, AXPropertyName::IsExpanded } });
+            tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::SupportsExpanded, AXProperty::IsExpanded } });
             break;
         case AXNotification::SelectedTextChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::SelectedTextRange });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::SelectedTextRange });
             break;
         case AXNotification::SortDirectionChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::SortDirection });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::SortDirection });
             break;
         case AXNotification::IdAttributeChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::IdentifierAttribute });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::IdentifierAttribute });
             break;
         case AXNotification::ReadOnlyStatusChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::CanSetValueAttribute });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::CanSetValueAttribute });
             break;
         case AXNotification::RequiredStatusChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::IsRequired });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::IsRequired });
             break;
         case AXNotification::RoleDescriptionChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::RoleDescription });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::RoleDescription });
             break;
         case AXNotification::RowIndexChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::RowIndexRange, AXPropertyName::RowIndex } });
+            tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::RowIndexRange, AXProperty::RowIndex } });
             break;
         case AXNotification::RowSpanChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::RowIndexRange });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::RowIndexRange });
             break;
         case AXNotification::CellScopeChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::CellScope, AXPropertyName::IsColumnHeader, AXPropertyName::IsRowHeader } });
+            tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::CellScope, AXProperty::IsColumnHeader, AXProperty::IsRowHeader } });
             break;
         //  FIXME: Contrary to the name "AXSelectedCellsChanged", this notification can be posted on a cell
         //  who has changed selected state, not just on table or grid who has changed its selected cells.
         case AXNotification::SelectedCellsChanged:
         case AXNotification::SelectedStateChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::IsSelected });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::IsSelected });
             break;
         case AXNotification::SetSizeChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::SetSize, AXPropertyName::SupportsSetSize } });
+            tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::SetSize, AXProperty::SupportsSetSize } });
             break;
         case AXNotification::TextCompositionChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::TextInputMarkedTextMarkerRange });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::TextInputMarkedTextMarkerRange });
             break;
         case AXNotification::TextUnderElementChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::AccessibilityText, AXPropertyName::Title } });
+            tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::AccessibilityText, AXProperty::Title } });
             if (notification.first->isAccessibilityLabelInstance() || notification.first->roleValue() == AccessibilityRole::TextField)
-                tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::StringValue });
+                tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::StringValue });
             break;
 #if ENABLE(AX_THREAD_TEXT_APIS)
         case AXNotification::TextRunsChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::TextRuns });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::TextRuns });
             break;
 #endif
         case AXNotification::URLChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { { AXPropertyName::URL, AXPropertyName::InternalLinkElement } });
+            tree->queueNodeUpdate(notification.first->objectID(), { { AXProperty::URL, AXProperty::InternalLinkElement } });
             break;
         case AXNotification::KeyShortcutsChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::KeyShortcuts });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::KeyShortcuts });
             break;
         case AXNotification::VisibilityChanged:
-            tree->queueNodeUpdate(notification.first->objectID(), { AXPropertyName::IsVisible });
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::IsVisible });
             break;
         case AXNotification::ActiveDescendantChanged:
         case AXNotification::RoleChanged:
@@ -4756,13 +4756,13 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
     }
 }
 
-void AXObjectCache::updateIsolatedTree(AccessibilityObject* axObject, AXPropertyName property) const
+void AXObjectCache::updateIsolatedTree(AccessibilityObject* axObject, AXProperty property) const
 {
     if (axObject)
         updateIsolatedTree(*axObject, property);
 }
 
-void AXObjectCache::updateIsolatedTree(AccessibilityObject& axObject, AXPropertyName property) const
+void AXObjectCache::updateIsolatedTree(AccessibilityObject& axObject, AXProperty property) const
 {
     if (RefPtr tree = AXIsolatedTree::treeForPageID(m_pageID))
         tree->queueNodeUpdate(axObject.objectID(), { property });

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -626,8 +626,8 @@ private:
     void updateIsolatedTree(AccessibilityObject&, AXNotification);
     void updateIsolatedTree(AccessibilityObject*, AXNotification);
     void updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityObject>, AXNotification>>&);
-    void updateIsolatedTree(AccessibilityObject*, AXPropertyName) const;
-    void updateIsolatedTree(AccessibilityObject&, AXPropertyName) const;
+    void updateIsolatedTree(AccessibilityObject*, AXProperty) const;
+    void updateIsolatedTree(AccessibilityObject&, AXProperty) const;
     void startUpdateTreeSnapshotTimer();
 #endif
 

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -238,7 +238,7 @@ RetainPtr<NSMutableAttributedString> AXCoreObject::createAttributedString(String
     }
 
     // FIXME: Computing block-quote level is an ancestry walk, so ideally we would just combine that with the
-    // ancestry walk we do above, but we currently cache this as its own property (AXPropertyName::BlockquoteLevel)
+    // ancestry walk we do above, but we currently cache this as its own property (AXProperty::BlockquoteLevel)
     // so just use that for now.
     attributedStringSetBlockquoteLevel(string.get(), *this, range);
     attributedStringSetExpandedText(string.get(), *this, range);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -106,13 +106,13 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
             m_propertyMap.reserveInitialCapacity(sizeToReserve);
 
         // These properties are cached for all objects, ignored and unignored.
-        setProperty(AXPropertyName::HasClickHandler, object.hasClickHandler());
+        setProperty(AXProperty::HasClickHandler, object.hasClickHandler());
         auto tag = object.tagName();
         if (tag == bodyTag)
-            setProperty(AXPropertyName::HasBodyTag, true);
+            setProperty(AXProperty::HasBodyTag, true);
 #if ENABLE(AX_THREAD_TEXT_APIS)
         else if (tag == markTag)
-            setProperty(AXPropertyName::HasMarkTag, true);
+            setProperty(AXProperty::HasMarkTag, true);
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
     };
 
@@ -121,7 +121,7 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     if (object.includeIgnoredInCoreTree()) {
         bool isIgnored = object.isIgnored();
-        setProperty(AXPropertyName::IsIgnored, isIgnored);
+        setProperty(AXProperty::IsIgnored, isIgnored);
         // Maintain full properties for objects meeting this criteria:
         //   - Unconnected objects, which are involved in relations or outgoing notifications
         //   - Static text. We sometimes ignore static text (e.g. because it descends from a text field),
@@ -140,73 +140,73 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
 #endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
 
     if (object.ancestorFlagsAreInitialized())
-        setProperty(AXPropertyName::AncestorFlags, object.ancestorFlags());
+        setProperty(AXProperty::AncestorFlags, object.ancestorFlags());
     else
-        setProperty(AXPropertyName::AncestorFlags, object.computeAncestorFlagsWithTraversal());
+        setProperty(AXProperty::AncestorFlags, object.computeAncestorFlagsWithTraversal());
 
-    setProperty(AXPropertyName::IsAttachment, object.isAttachment());
-    setProperty(AXPropertyName::IsBusy, object.isBusy());
-    setProperty(AXPropertyName::IsEnabled, object.isEnabled());
-    setProperty(AXPropertyName::IsExpanded, object.isExpanded());
-    setProperty(AXPropertyName::IsFileUploadButton, object.isFileUploadButton());
-    setProperty(AXPropertyName::IsIndeterminate, object.isIndeterminate());
-    setProperty(AXPropertyName::IsInlineText, object.isInlineText());
-    setProperty(AXPropertyName::IsInputImage, object.isInputImage());
-    setProperty(AXPropertyName::IsMultiSelectable, object.isMultiSelectable());
-    setProperty(AXPropertyName::IsRequired, object.isRequired());
-    setProperty(AXPropertyName::IsSecureField, object.isSecureField());
-    setProperty(AXPropertyName::IsSelected, object.isSelected());
-    setProperty(AXPropertyName::InsideLink, object.insideLink());
-    setProperty(AXPropertyName::IsValueAutofillAvailable, object.isValueAutofillAvailable());
-    setProperty(AXPropertyName::RoleDescription, object.roleDescription().isolatedCopy());
-    setProperty(AXPropertyName::RolePlatformString, object.rolePlatformString().isolatedCopy());
-    setProperty(AXPropertyName::SubrolePlatformString, object.subrolePlatformString().isolatedCopy());
-    setProperty(AXPropertyName::CanSetFocusAttribute, object.canSetFocusAttribute());
-    setProperty(AXPropertyName::CanSetValueAttribute, object.canSetValueAttribute());
-    setProperty(AXPropertyName::CanSetSelectedAttribute, object.canSetSelectedAttribute());
-    setProperty(AXPropertyName::BlockquoteLevel, object.blockquoteLevel());
-    setProperty(AXPropertyName::HeadingLevel, object.headingLevel());
-    setProperty(AXPropertyName::ValueDescription, object.valueDescription().isolatedCopy());
-    setProperty(AXPropertyName::ValueForRange, object.valueForRange());
-    setProperty(AXPropertyName::MaxValueForRange, object.maxValueForRange());
-    setProperty(AXPropertyName::MinValueForRange, object.minValueForRange());
-    setProperty(AXPropertyName::SupportsARIAOwns, object.supportsARIAOwns());
-    setProperty(AXPropertyName::PopupValue, object.popupValue().isolatedCopy());
-    setProperty(AXPropertyName::InvalidStatus, object.invalidStatus().isolatedCopy());
-    setProperty(AXPropertyName::SupportsExpanded, object.supportsExpanded());
-    setProperty(AXPropertyName::SortDirection, static_cast<int>(object.sortDirection()));
-    setProperty(AXPropertyName::SupportsRangeValue, object.supportsRangeValue());
+    setProperty(AXProperty::IsAttachment, object.isAttachment());
+    setProperty(AXProperty::IsBusy, object.isBusy());
+    setProperty(AXProperty::IsEnabled, object.isEnabled());
+    setProperty(AXProperty::IsExpanded, object.isExpanded());
+    setProperty(AXProperty::IsFileUploadButton, object.isFileUploadButton());
+    setProperty(AXProperty::IsIndeterminate, object.isIndeterminate());
+    setProperty(AXProperty::IsInlineText, object.isInlineText());
+    setProperty(AXProperty::IsInputImage, object.isInputImage());
+    setProperty(AXProperty::IsMultiSelectable, object.isMultiSelectable());
+    setProperty(AXProperty::IsRequired, object.isRequired());
+    setProperty(AXProperty::IsSecureField, object.isSecureField());
+    setProperty(AXProperty::IsSelected, object.isSelected());
+    setProperty(AXProperty::InsideLink, object.insideLink());
+    setProperty(AXProperty::IsValueAutofillAvailable, object.isValueAutofillAvailable());
+    setProperty(AXProperty::RoleDescription, object.roleDescription().isolatedCopy());
+    setProperty(AXProperty::RolePlatformString, object.rolePlatformString().isolatedCopy());
+    setProperty(AXProperty::SubrolePlatformString, object.subrolePlatformString().isolatedCopy());
+    setProperty(AXProperty::CanSetFocusAttribute, object.canSetFocusAttribute());
+    setProperty(AXProperty::CanSetValueAttribute, object.canSetValueAttribute());
+    setProperty(AXProperty::CanSetSelectedAttribute, object.canSetSelectedAttribute());
+    setProperty(AXProperty::BlockquoteLevel, object.blockquoteLevel());
+    setProperty(AXProperty::HeadingLevel, object.headingLevel());
+    setProperty(AXProperty::ValueDescription, object.valueDescription().isolatedCopy());
+    setProperty(AXProperty::ValueForRange, object.valueForRange());
+    setProperty(AXProperty::MaxValueForRange, object.maxValueForRange());
+    setProperty(AXProperty::MinValueForRange, object.minValueForRange());
+    setProperty(AXProperty::SupportsARIAOwns, object.supportsARIAOwns());
+    setProperty(AXProperty::PopupValue, object.popupValue().isolatedCopy());
+    setProperty(AXProperty::InvalidStatus, object.invalidStatus().isolatedCopy());
+    setProperty(AXProperty::SupportsExpanded, object.supportsExpanded());
+    setProperty(AXProperty::SortDirection, static_cast<int>(object.sortDirection()));
+    setProperty(AXProperty::SupportsRangeValue, object.supportsRangeValue());
 #if !LOG_DISABLED
     // Eagerly cache ID when logging is enabled so that we can log isolated objects without constant deadlocks.
     // Don't cache ID when logging is disabled because we don't expect non-test AX clients to actually request it.
-    setProperty(AXPropertyName::IdentifierAttribute, object.identifierAttribute().isolatedCopy());
+    setProperty(AXProperty::IdentifierAttribute, object.identifierAttribute().isolatedCopy());
 #endif
-    setProperty(AXPropertyName::SupportsDropping, object.supportsDropping());
-    setProperty(AXPropertyName::SupportsDragging, object.supportsDragging());
-    setProperty(AXPropertyName::IsGrabbed, object.isGrabbed());
-    setProperty(AXPropertyName::PlaceholderValue, object.placeholderValue().isolatedCopy());
-    setProperty(AXPropertyName::ValueAutofillButtonType, static_cast<int>(object.valueAutofillButtonType()));
-    setProperty(AXPropertyName::URL, std::make_shared<URL>(object.url().isolatedCopy()));
-    setProperty(AXPropertyName::AccessKey, object.accessKey().isolatedCopy());
-    setProperty(AXPropertyName::AutoCompleteValue, object.autoCompleteValue().isolatedCopy());
-    setProperty(AXPropertyName::ColorValue, object.colorValue());
-    setProperty(AXPropertyName::Orientation, static_cast<int>(object.orientation()));
-    setProperty(AXPropertyName::HierarchicalLevel, object.hierarchicalLevel());
-    setProperty(AXPropertyName::Language, object.language().isolatedCopy());
-    setProperty(AXPropertyName::LiveRegionStatus, object.liveRegionStatus().isolatedCopy());
-    setProperty(AXPropertyName::LiveRegionRelevant, object.liveRegionRelevant().isolatedCopy());
-    setProperty(AXPropertyName::LiveRegionAtomic, object.liveRegionAtomic());
-    setProperty(AXPropertyName::HasHighlighting, object.hasHighlighting());
-    setProperty(AXPropertyName::HasBoldFont, object.hasBoldFont());
-    setProperty(AXPropertyName::HasItalicFont, object.hasItalicFont());
-    setProperty(AXPropertyName::HasPlainText, object.hasPlainText());
+    setProperty(AXProperty::SupportsDropping, object.supportsDropping());
+    setProperty(AXProperty::SupportsDragging, object.supportsDragging());
+    setProperty(AXProperty::IsGrabbed, object.isGrabbed());
+    setProperty(AXProperty::PlaceholderValue, object.placeholderValue().isolatedCopy());
+    setProperty(AXProperty::ValueAutofillButtonType, static_cast<int>(object.valueAutofillButtonType()));
+    setProperty(AXProperty::URL, std::make_shared<URL>(object.url().isolatedCopy()));
+    setProperty(AXProperty::AccessKey, object.accessKey().isolatedCopy());
+    setProperty(AXProperty::AutoCompleteValue, object.autoCompleteValue().isolatedCopy());
+    setProperty(AXProperty::ColorValue, object.colorValue());
+    setProperty(AXProperty::Orientation, static_cast<int>(object.orientation()));
+    setProperty(AXProperty::HierarchicalLevel, object.hierarchicalLevel());
+    setProperty(AXProperty::Language, object.language().isolatedCopy());
+    setProperty(AXProperty::LiveRegionStatus, object.liveRegionStatus().isolatedCopy());
+    setProperty(AXProperty::LiveRegionRelevant, object.liveRegionRelevant().isolatedCopy());
+    setProperty(AXProperty::LiveRegionAtomic, object.liveRegionAtomic());
+    setProperty(AXProperty::HasHighlighting, object.hasHighlighting());
+    setProperty(AXProperty::HasBoldFont, object.hasBoldFont());
+    setProperty(AXProperty::HasItalicFont, object.hasItalicFont());
+    setProperty(AXProperty::HasPlainText, object.hasPlainText());
 #if !ENABLE(AX_THREAD_TEXT_APIS)
-    setProperty(AXPropertyName::HasUnderline, object.hasUnderline());
+    setProperty(AXProperty::HasUnderline, object.hasUnderline());
 #endif
-    setProperty(AXPropertyName::IsKeyboardFocusable, object.isKeyboardFocusable());
-    setProperty(AXPropertyName::BrailleRoleDescription, object.brailleRoleDescription().isolatedCopy());
-    setProperty(AXPropertyName::BrailleLabel, object.brailleLabel().isolatedCopy());
-    setProperty(AXPropertyName::IsNonLayerSVGObject, object.isNonLayerSVGObject());
+    setProperty(AXProperty::IsKeyboardFocusable, object.isKeyboardFocusable());
+    setProperty(AXProperty::BrailleRoleDescription, object.brailleRoleDescription().isolatedCopy());
+    setProperty(AXProperty::BrailleLabel, object.brailleLabel().isolatedCopy());
+    setProperty(AXProperty::IsNonLayerSVGObject, object.isNonLayerSVGObject());
 
     bool isWebArea = axObject->isWebArea();
     bool isScrollArea = axObject->isScrollView();
@@ -214,182 +214,182 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
         // Eagerly cache the screen relative position for the root. AXIsolatedObject::screenRelativePosition()
         // of non-root objects depend on the root object's screen relative position, so make sure it's there
         // from the start. We keep this up-to-date via AXIsolatedTree::updateRootScreenRelativePosition().
-        setProperty(AXPropertyName::ScreenRelativePosition, axObject->screenRelativePosition());
+        setProperty(AXProperty::ScreenRelativePosition, axObject->screenRelativePosition());
         // FIXME: We never update this property, e.g. when the iframe is moved in the hosting web content process.
-        setProperty(AXPropertyName::RemoteFrameOffset, object.remoteFrameOffset());
+        setProperty(AXProperty::RemoteFrameOffset, object.remoteFrameOffset());
     }
 
     RefPtr geometryManager = tree()->geometryManager();
     std::optional frame = geometryManager ? geometryManager->cachedRectForID(object.objectID()) : std::nullopt;
     if (frame)
-        setProperty(AXPropertyName::RelativeFrame, WTFMove(*frame));
+        setProperty(AXProperty::RelativeFrame, WTFMove(*frame));
     else if (isScrollArea || isWebArea || object.isScrollbar()) {
         // The GeometryManager does not have a relative frame for ScrollViews, WebAreas, or scrollbars yet. We need to get it from the
         // live object so that we don't need to hit the main thread in the case a request comes in while the whole isolated tree is being built.
-        setProperty(AXPropertyName::RelativeFrame, enclosingIntRect(object.relativeFrame()));
+        setProperty(AXProperty::RelativeFrame, enclosingIntRect(object.relativeFrame()));
     } else if (!object.renderer() && object.node() && is<AccessibilityNodeObject>(object)) {
         // The frame of node-only AX objects is made up of their children.
         m_getsGeometryFromChildren = true;
     } else if (object.isMenuListPopup()) {
         // AccessibilityMenuListPopup's elementRect is hardcoded to return an empty rect, so preserve that behavior.
-        setProperty(AXPropertyName::RelativeFrame, IntRect());
+        setProperty(AXProperty::RelativeFrame, IntRect());
     } else
-        setProperty(AXPropertyName::InitialFrameRect, object.frameRect());
+        setProperty(AXProperty::InitialFrameRect, object.frameRect());
 
     if (object.supportsPath()) {
-        setProperty(AXPropertyName::SupportsPath, true);
-        setProperty(AXPropertyName::Path, std::make_shared<Path>(object.elementPath()));
+        setProperty(AXProperty::SupportsPath, true);
+        setProperty(AXProperty::Path, std::make_shared<Path>(object.elementPath()));
     }
 
     if (object.supportsKeyShortcuts()) {
-        setProperty(AXPropertyName::SupportsKeyShortcuts, true);
-        setProperty(AXPropertyName::KeyShortcuts, object.keyShortcuts().isolatedCopy());
+        setProperty(AXProperty::SupportsKeyShortcuts, true);
+        setProperty(AXProperty::KeyShortcuts, object.keyShortcuts().isolatedCopy());
     }
 
     if (object.supportsCurrent()) {
-        setProperty(AXPropertyName::SupportsCurrent, true);
-        setProperty(AXPropertyName::CurrentState, static_cast<int>(object.currentState()));
+        setProperty(AXProperty::SupportsCurrent, true);
+        setProperty(AXProperty::CurrentState, static_cast<int>(object.currentState()));
     }
 
     if (object.supportsSetSize()) {
-        setProperty(AXPropertyName::SupportsSetSize, true);
-        setProperty(AXPropertyName::SetSize, object.setSize());
+        setProperty(AXProperty::SupportsSetSize, true);
+        setProperty(AXProperty::SetSize, object.setSize());
     }
 
     if (object.supportsPosInSet()) {
-        setProperty(AXPropertyName::SupportsPosInSet, true);
-        setProperty(AXPropertyName::PosInSet, object.posInSet());
+        setProperty(AXProperty::SupportsPosInSet, true);
+        setProperty(AXProperty::PosInSet, object.posInSet());
     }
 
     if (object.supportsExpandedTextValue()) {
-        setProperty(AXPropertyName::SupportsExpandedTextValue, true);
-        setProperty(AXPropertyName::ExpandedTextValue, object.expandedTextValue().isolatedCopy());
+        setProperty(AXProperty::SupportsExpandedTextValue, true);
+        setProperty(AXProperty::ExpandedTextValue, object.expandedTextValue().isolatedCopy());
     }
 
     if (object.supportsDatetimeAttribute()) {
-        setProperty(AXPropertyName::SupportsDatetimeAttribute, true);
-        setProperty(AXPropertyName::DatetimeAttributeValue, object.datetimeAttributeValue().isolatedCopy());
+        setProperty(AXProperty::SupportsDatetimeAttribute, true);
+        setProperty(AXProperty::DatetimeAttributeValue, object.datetimeAttributeValue().isolatedCopy());
     }
 
     if (object.supportsCheckedState()) {
-        setProperty(AXPropertyName::SupportsCheckedState, true);
-        setProperty(AXPropertyName::IsChecked, object.isChecked());
-        setProperty(AXPropertyName::ButtonState, object.checkboxOrRadioValue());
+        setProperty(AXProperty::SupportsCheckedState, true);
+        setProperty(AXProperty::IsChecked, object.isChecked());
+        setProperty(AXProperty::ButtonState, object.checkboxOrRadioValue());
     }
 
     if (object.isTable()) {
-        setProperty(AXPropertyName::IsTable, true);
-        setProperty(AXPropertyName::IsExposable, object.isExposable());
-        setObjectVectorProperty(AXPropertyName::Columns, object.columns());
-        setObjectVectorProperty(AXPropertyName::Rows, object.rows());
-        setObjectVectorProperty(AXPropertyName::Cells, object.cells());
-        setObjectVectorProperty(AXPropertyName::VisibleRows, object.visibleRows());
-        setObjectProperty(AXPropertyName::HeaderContainer, object.headerContainer());
-        setProperty(AXPropertyName::AXColumnCount, object.axColumnCount());
-        setProperty(AXPropertyName::AXRowCount, object.axRowCount());
-        setProperty(AXPropertyName::CellSlots, object.cellSlots());
+        setProperty(AXProperty::IsTable, true);
+        setProperty(AXProperty::IsExposable, object.isExposable());
+        setObjectVectorProperty(AXProperty::Columns, object.columns());
+        setObjectVectorProperty(AXProperty::Rows, object.rows());
+        setObjectVectorProperty(AXProperty::Cells, object.cells());
+        setObjectVectorProperty(AXProperty::VisibleRows, object.visibleRows());
+        setObjectProperty(AXProperty::HeaderContainer, object.headerContainer());
+        setProperty(AXProperty::AXColumnCount, object.axColumnCount());
+        setProperty(AXProperty::AXRowCount, object.axRowCount());
+        setProperty(AXProperty::CellSlots, object.cellSlots());
     }
 
     if (object.isExposedTableCell()) {
-        setProperty(AXPropertyName::IsExposedTableCell, true);
-        setProperty(AXPropertyName::ColumnIndexRange, object.columnIndexRange());
-        setProperty(AXPropertyName::RowIndexRange, object.rowIndexRange());
-        setProperty(AXPropertyName::AXColumnIndex, object.axColumnIndex());
-        setProperty(AXPropertyName::AXRowIndex, object.axRowIndex());
-        setProperty(AXPropertyName::IsColumnHeader, object.isColumnHeader());
-        setProperty(AXPropertyName::IsRowHeader, object.isRowHeader());
-        setProperty(AXPropertyName::CellScope, object.cellScope().isolatedCopy());
-        setProperty(AXPropertyName::RowGroupAncestorID, object.rowGroupAncestorID());
+        setProperty(AXProperty::IsExposedTableCell, true);
+        setProperty(AXProperty::ColumnIndexRange, object.columnIndexRange());
+        setProperty(AXProperty::RowIndexRange, object.rowIndexRange());
+        setProperty(AXProperty::AXColumnIndex, object.axColumnIndex());
+        setProperty(AXProperty::AXRowIndex, object.axRowIndex());
+        setProperty(AXProperty::IsColumnHeader, object.isColumnHeader());
+        setProperty(AXProperty::IsRowHeader, object.isRowHeader());
+        setProperty(AXProperty::CellScope, object.cellScope().isolatedCopy());
+        setProperty(AXProperty::RowGroupAncestorID, object.rowGroupAncestorID());
     }
 
     if (object.isTableColumn())
-        setProperty(AXPropertyName::ColumnIndex, object.columnIndex());
+        setProperty(AXProperty::ColumnIndex, object.columnIndex());
     else if (object.isTableRow()) {
-        setProperty(AXPropertyName::IsTableRow, true);
-        setProperty(AXPropertyName::RowIndex, object.rowIndex());
+        setProperty(AXProperty::IsTableRow, true);
+        setProperty(AXProperty::RowIndex, object.rowIndex());
     }
 
     if (object.isARIATreeGridRow()) {
-        setProperty(AXPropertyName::IsARIATreeGridRow, true);
-        setObjectVectorProperty(AXPropertyName::DisclosedRows, object.disclosedRows());
-        setObjectProperty(AXPropertyName::DisclosedByRow, object.disclosedByRow());
+        setProperty(AXProperty::IsARIATreeGridRow, true);
+        setObjectVectorProperty(AXProperty::DisclosedRows, object.disclosedRows());
+        setObjectProperty(AXProperty::DisclosedByRow, object.disclosedByRow());
     }
 
     if (object.isARIATreeGridRow() || object.isTableRow())
-        setObjectProperty(AXPropertyName::RowHeader, object.rowHeader());
+        setObjectProperty(AXProperty::RowHeader, object.rowHeader());
 
     if (object.isTreeItem()) {
-        setProperty(AXPropertyName::IsTreeItem, true);
-        setObjectVectorProperty(AXPropertyName::DisclosedRows, object.disclosedRows());
+        setProperty(AXProperty::IsTreeItem, true);
+        setObjectVectorProperty(AXProperty::DisclosedRows, object.disclosedRows());
     }
 
     if (object.isTree()) {
-        setProperty(AXPropertyName::IsTree, true);
-        setObjectVectorProperty(AXPropertyName::ARIATreeRows, object.ariaTreeRows());
+        setProperty(AXProperty::IsTree, true);
+        setObjectVectorProperty(AXProperty::ARIATreeRows, object.ariaTreeRows());
     }
 
     if (object.isRadioButton()) {
-        setProperty(AXPropertyName::NameAttribute, object.nameAttribute().isolatedCopy());
+        setProperty(AXProperty::NameAttribute, object.nameAttribute().isolatedCopy());
         // FIXME: This property doesn't get updated when a page changes dynamically.
-        setObjectVectorProperty(AXPropertyName::RadioButtonGroup, object.radioButtonGroup());
-        setProperty(AXPropertyName::IsRadioInput, object.isRadioInput());
+        setObjectVectorProperty(AXProperty::RadioButtonGroup, object.radioButtonGroup());
+        setProperty(AXProperty::IsRadioInput, object.isRadioInput());
     }
 
     if (auto selectedChildren = object.selectedChildren())
-        setObjectVectorProperty(AXPropertyName::SelectedChildren, *selectedChildren);
+        setObjectVectorProperty(AXProperty::SelectedChildren, *selectedChildren);
 
     if (object.isImage())
-        setProperty(AXPropertyName::EmbeddedImageDescription, object.embeddedImageDescription().isolatedCopy());
+        setProperty(AXProperty::EmbeddedImageDescription, object.embeddedImageDescription().isolatedCopy());
 
     // On macOS, we only advertise support for the visible children attribute for lists and listboxes.
     if (object.isList() || object.isListBox())
-        setObjectVectorProperty(AXPropertyName::VisibleChildren, object.visibleChildren());
+        setObjectVectorProperty(AXProperty::VisibleChildren, object.visibleChildren());
 
     if (object.isDateTime()) {
-        setProperty(AXPropertyName::DateTimeValue, object.dateTimeValue().isolatedCopy());
-        setProperty(AXPropertyName::DateTimeComponentsType, object.dateTimeComponentsType());
+        setProperty(AXProperty::DateTimeValue, object.dateTimeValue().isolatedCopy());
+        setProperty(AXProperty::DateTimeComponentsType, object.dateTimeComponentsType());
     }
 
     if (object.isSpinButton()) {
-        setObjectProperty(AXPropertyName::DecrementButton, object.decrementButton());
-        setObjectProperty(AXPropertyName::IncrementButton, object.incrementButton());
+        setObjectProperty(AXProperty::DecrementButton, object.decrementButton());
+        setObjectProperty(AXProperty::IncrementButton, object.incrementButton());
     }
 
     if (object.isMathElement()) {
-        setProperty(AXPropertyName::IsMathElement, true);
-        setProperty(AXPropertyName::IsMathFraction, object.isMathFraction());
-        setProperty(AXPropertyName::IsMathFenced, object.isMathFenced());
-        setProperty(AXPropertyName::IsMathSubscriptSuperscript, object.isMathSubscriptSuperscript());
-        setProperty(AXPropertyName::IsMathRow, object.isMathRow());
-        setProperty(AXPropertyName::IsMathUnderOver, object.isMathUnderOver());
-        setProperty(AXPropertyName::IsMathTable, object.isMathTable());
-        setProperty(AXPropertyName::IsMathTableRow, object.isMathTableRow());
-        setProperty(AXPropertyName::IsMathTableCell, object.isMathTableCell());
-        setProperty(AXPropertyName::IsMathMultiscript, object.isMathMultiscript());
-        setProperty(AXPropertyName::IsMathToken, object.isMathToken());
-        setProperty(AXPropertyName::MathFencedOpenString, object.mathFencedOpenString().isolatedCopy());
-        setProperty(AXPropertyName::MathFencedCloseString, object.mathFencedCloseString().isolatedCopy());
-        setProperty(AXPropertyName::MathLineThickness, object.mathLineThickness());
+        setProperty(AXProperty::IsMathElement, true);
+        setProperty(AXProperty::IsMathFraction, object.isMathFraction());
+        setProperty(AXProperty::IsMathFenced, object.isMathFenced());
+        setProperty(AXProperty::IsMathSubscriptSuperscript, object.isMathSubscriptSuperscript());
+        setProperty(AXProperty::IsMathRow, object.isMathRow());
+        setProperty(AXProperty::IsMathUnderOver, object.isMathUnderOver());
+        setProperty(AXProperty::IsMathTable, object.isMathTable());
+        setProperty(AXProperty::IsMathTableRow, object.isMathTableRow());
+        setProperty(AXProperty::IsMathTableCell, object.isMathTableCell());
+        setProperty(AXProperty::IsMathMultiscript, object.isMathMultiscript());
+        setProperty(AXProperty::IsMathToken, object.isMathToken());
+        setProperty(AXProperty::MathFencedOpenString, object.mathFencedOpenString().isolatedCopy());
+        setProperty(AXProperty::MathFencedCloseString, object.mathFencedCloseString().isolatedCopy());
+        setProperty(AXProperty::MathLineThickness, object.mathLineThickness());
 
         bool isMathRoot = object.isMathRoot();
-        setProperty(AXPropertyName::IsMathRoot, isMathRoot);
-        setProperty(AXPropertyName::IsMathSquareRoot, object.isMathSquareRoot());
+        setProperty(AXProperty::IsMathRoot, isMathRoot);
+        setProperty(AXProperty::IsMathSquareRoot, object.isMathSquareRoot());
         if (isMathRoot) {
             if (auto radicand = object.mathRadicand())
-                setObjectVectorProperty(AXPropertyName::MathRadicand, *radicand);
+                setObjectVectorProperty(AXProperty::MathRadicand, *radicand);
 
-            setObjectProperty(AXPropertyName::MathRootIndexObject, object.mathRootIndexObject());
+            setObjectProperty(AXProperty::MathRootIndexObject, object.mathRootIndexObject());
         }
 
-        setObjectProperty(AXPropertyName::MathUnderObject, object.mathUnderObject());
-        setObjectProperty(AXPropertyName::MathOverObject, object.mathOverObject());
-        setObjectProperty(AXPropertyName::MathNumeratorObject, object.mathNumeratorObject());
-        setObjectProperty(AXPropertyName::MathDenominatorObject, object.mathDenominatorObject());
-        setObjectProperty(AXPropertyName::MathBaseObject, object.mathBaseObject());
-        setObjectProperty(AXPropertyName::MathSubscriptObject, object.mathSubscriptObject());
-        setObjectProperty(AXPropertyName::MathSuperscriptObject, object.mathSuperscriptObject());
-        setMathscripts(AXPropertyName::MathPrescripts, object);
-        setMathscripts(AXPropertyName::MathPostscripts, object);
+        setObjectProperty(AXProperty::MathUnderObject, object.mathUnderObject());
+        setObjectProperty(AXProperty::MathOverObject, object.mathOverObject());
+        setObjectProperty(AXProperty::MathNumeratorObject, object.mathNumeratorObject());
+        setObjectProperty(AXProperty::MathDenominatorObject, object.mathDenominatorObject());
+        setObjectProperty(AXProperty::MathBaseObject, object.mathBaseObject());
+        setObjectProperty(AXProperty::MathSubscriptObject, object.mathSubscriptObject());
+        setObjectProperty(AXProperty::MathSuperscriptObject, object.mathSuperscriptObject());
+        setMathscripts(AXProperty::MathPrescripts, object);
+        setMathscripts(AXProperty::MathPostscripts, object);
     }
 
     Vector<AccessibilityText> texts;
@@ -397,56 +397,56 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     auto axTextValue = texts.map([] (const auto& text) -> AccessibilityText {
         return { text.text.isolatedCopy(), text.textSource };
     });
-    setProperty(AXPropertyName::AccessibilityText, axTextValue);
+    setProperty(AXProperty::AccessibilityText, axTextValue);
 
     if (isScrollArea) {
-        setObjectProperty(AXPropertyName::VerticalScrollBar, object.scrollBar(AccessibilityOrientation::Vertical));
-        setObjectProperty(AXPropertyName::HorizontalScrollBar, object.scrollBar(AccessibilityOrientation::Horizontal));
-        setProperty(AXPropertyName::HasRemoteFrameChild, object.hasRemoteFrameChild());
+        setObjectProperty(AXProperty::VerticalScrollBar, object.scrollBar(AccessibilityOrientation::Vertical));
+        setObjectProperty(AXProperty::HorizontalScrollBar, object.scrollBar(AccessibilityOrientation::Horizontal));
+        setProperty(AXProperty::HasRemoteFrameChild, object.hasRemoteFrameChild());
     } else if (isWebArea && !tree()->isEmptyContentTree()) {
         // We expose DocumentLinks only for the web area objects when the tree is not an empty content tree. This property is expensive and makes no sense in an empty content tree.
         // FIXME: compute DocumentLinks on the AX thread instead of caching it.
-        setObjectVectorProperty(AXPropertyName::DocumentLinks, object.documentLinks());
+        setObjectVectorProperty(AXProperty::DocumentLinks, object.documentLinks());
     }
 
     if (object.isWidget()) {
         if (object.isPlugin()) {
             // Plugins are a subclass of widget, so we only need to cache IsPlugin, and we implicitly know
             // this is also a widget (see AXIsolatedObject::isWidget).
-            setProperty(AXPropertyName::IsPlugin, true);
+            setProperty(AXProperty::IsPlugin, true);
         } else
-            setProperty(AXPropertyName::IsWidget, true);
+            setProperty(AXProperty::IsWidget, true);
 
-        setProperty(AXPropertyName::IsVisible, object.isVisible());
+        setProperty(AXProperty::IsVisible, object.isVisible());
     }
 
     auto descriptor = object.title();
     if (descriptor.length())
-        setProperty(AXPropertyName::Title, descriptor.isolatedCopy());
+        setProperty(AXProperty::Title, descriptor.isolatedCopy());
 
     descriptor = object.description();
     if (descriptor.length())
-        setProperty(AXPropertyName::Description, descriptor.isolatedCopy());
+        setProperty(AXProperty::Description, descriptor.isolatedCopy());
 
     descriptor = object.extendedDescription();
     if (descriptor.length())
-        setProperty(AXPropertyName::ExtendedDescription, descriptor.isolatedCopy());
+        setProperty(AXProperty::ExtendedDescription, descriptor.isolatedCopy());
 
     if (object.isTextControl()) {
         // FIXME: We don't keep this property up-to-date, and we can probably just compute it using
         // AXIsolatedObject::selectedTextMarkerRange() (which does stay up-to-date).
-        setProperty(AXPropertyName::SelectedTextRange, object.selectedTextRange());
+        setProperty(AXProperty::SelectedTextRange, object.selectedTextRange());
 
         auto range = object.textInputMarkedTextMarkerRange();
         if (auto characterRange = range.characterRange(); range && characterRange)
-            setProperty(AXPropertyName::TextInputMarkedTextMarkerRange, std::pair<Markable<AXID>, CharacterRange>(range.start().objectID(), *characterRange));
+            setProperty(AXProperty::TextInputMarkedTextMarkerRange, std::pair<Markable<AXID>, CharacterRange>(range.start().objectID(), *characterRange));
 
-        setProperty(AXPropertyName::CanBeMultilineTextField, canBeMultilineTextField(object));
+        setProperty(AXProperty::CanBeMultilineTextField, canBeMultilineTextField(object));
     }
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
-    setProperty(AXPropertyName::TextRuns, object.textRuns());
-    setProperty(AXPropertyName::EmitTextAfterBehavior, object.emitTextAfterBehavior());
+    setProperty(AXProperty::TextRuns, object.textRuns());
+    setProperty(AXProperty::EmitTextAfterBehavior, object.emitTextAfterBehavior());
 #endif
 
     // These properties are only needed on the AXCoreObject interface due to their use in ATSPI,
@@ -454,16 +454,16 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
 #if USE(ATSPI)
     // We cache IsVisible on all platforms just for Widgets above. In ATSPI, this should be cached on all objects.
     if (!object.isWidget())
-        setProperty(AXPropertyName::IsVisible, object.isVisible());
+        setProperty(AXProperty::IsVisible, object.isVisible());
 
-    setProperty(AXPropertyName::ActionVerb, object.actionVerb().isolatedCopy());
-    setProperty(AXPropertyName::IsFieldset, object.isFieldset());
-    setProperty(AXPropertyName::IsPressed, object.isPressed());
-    setProperty(AXPropertyName::IsSelectedOptionActive, object.isSelectedOptionActive());
-    setProperty(AXPropertyName::LocalizedActionVerb, object.localizedActionVerb().isolatedCopy());
+    setProperty(AXProperty::ActionVerb, object.actionVerb().isolatedCopy());
+    setProperty(AXProperty::IsFieldset, object.isFieldset());
+    setProperty(AXProperty::IsPressed, object.isPressed());
+    setProperty(AXProperty::IsSelectedOptionActive, object.isSelectedOptionActive());
+    setProperty(AXProperty::LocalizedActionVerb, object.localizedActionVerb().isolatedCopy());
 #endif
 
-    setObjectProperty(AXPropertyName::InternalLinkElement, object.internalLinkElement());
+    setObjectProperty(AXProperty::InternalLinkElement, object.internalLinkElement());
 
     initializePlatformProperties(axObject);
 }
@@ -489,12 +489,12 @@ AccessibilityObject* AXIsolatedObject::associatedAXObject() const
     return axObjectCache ? axObjectCache->objectForID(objectID()) : nullptr;
 }
 
-void AXIsolatedObject::setMathscripts(AXPropertyName propertyName, AccessibilityObject& object)
+void AXIsolatedObject::setMathscripts(AXProperty propertyName, AccessibilityObject& object)
 {
     AccessibilityMathMultiscriptPairs pairs;
-    if (propertyName == AXPropertyName::MathPrescripts)
+    if (propertyName == AXProperty::MathPrescripts)
         object.mathPrescripts(pairs);
-    else if (propertyName == AXPropertyName::MathPostscripts)
+    else if (propertyName == AXProperty::MathPostscripts)
         object.mathPostscripts(pairs);
     
     size_t mathSize = pairs.size();
@@ -507,78 +507,78 @@ void AXIsolatedObject::setMathscripts(AXPropertyName propertyName, Accessibility
     setProperty(propertyName, WTFMove(idPairs));
 }
 
-void AXIsolatedObject::setObjectProperty(AXPropertyName propertyName, AXCoreObject* object)
+void AXIsolatedObject::setObjectProperty(AXProperty propertyName, AXCoreObject* object)
 {
     setProperty(propertyName, object ? Markable { object->objectID() } : std::nullopt);
 }
 
-void AXIsolatedObject::setObjectVectorProperty(AXPropertyName propertyName, const AccessibilityChildrenVector& objects)
+void AXIsolatedObject::setObjectVectorProperty(AXProperty propertyName, const AccessibilityChildrenVector& objects)
 {
     setProperty(propertyName, axIDs(objects));
 }
 
-void AXIsolatedObject::setProperty(AXPropertyName propertyName, AXPropertyValueVariant&& value)
+void AXIsolatedObject::setProperty(AXProperty propertyName, AXPropertyValueVariant&& value)
 {
     if (std::holds_alternative<bool>(value)) {
         switch (propertyName) {
-        case AXPropertyName::CanSetFocusAttribute:
+        case AXProperty::CanSetFocusAttribute:
             setPropertyFlag(AXPropertyFlag::CanSetFocusAttribute, std::get<bool>(value));
             return;
-        case AXPropertyName::CanSetSelectedAttribute:
+        case AXProperty::CanSetSelectedAttribute:
             setPropertyFlag(AXPropertyFlag::CanSetSelectedAttribute, std::get<bool>(value));
             return;
-        case AXPropertyName::CanSetValueAttribute:
+        case AXProperty::CanSetValueAttribute:
             setPropertyFlag(AXPropertyFlag::CanSetValueAttribute, std::get<bool>(value));
             return;
-        case AXPropertyName::HasBoldFont:
+        case AXProperty::HasBoldFont:
             setPropertyFlag(AXPropertyFlag::HasBoldFont, std::get<bool>(value));
             return;
-        case AXPropertyName::HasItalicFont:
+        case AXProperty::HasItalicFont:
             setPropertyFlag(AXPropertyFlag::HasItalicFont, std::get<bool>(value));
             return;
-        case AXPropertyName::HasPlainText:
+        case AXProperty::HasPlainText:
             setPropertyFlag(AXPropertyFlag::HasPlainText, std::get<bool>(value));
             return;
-        case AXPropertyName::IsEnabled:
+        case AXProperty::IsEnabled:
             setPropertyFlag(AXPropertyFlag::IsEnabled, std::get<bool>(value));
             return;
-        case AXPropertyName::IsExposedTableCell:
+        case AXProperty::IsExposedTableCell:
             setPropertyFlag(AXPropertyFlag::IsExposedTableCell, std::get<bool>(value));
             return;
-        case AXPropertyName::IsGrabbed:
+        case AXProperty::IsGrabbed:
             setPropertyFlag(AXPropertyFlag::IsGrabbed, std::get<bool>(value));
             return;
-        case AXPropertyName::IsIgnored:
+        case AXProperty::IsIgnored:
             setPropertyFlag(AXPropertyFlag::IsIgnored, std::get<bool>(value));
             return;
-        case AXPropertyName::IsInlineText:
+        case AXProperty::IsInlineText:
             setPropertyFlag(AXPropertyFlag::IsInlineText, std::get<bool>(value));
             return;
-        case AXPropertyName::IsKeyboardFocusable:
+        case AXProperty::IsKeyboardFocusable:
             setPropertyFlag(AXPropertyFlag::IsKeyboardFocusable, std::get<bool>(value));
             return;
-        case AXPropertyName::IsNonLayerSVGObject:
+        case AXProperty::IsNonLayerSVGObject:
             setPropertyFlag(AXPropertyFlag::IsNonLayerSVGObject, std::get<bool>(value));
             return;
-        case AXPropertyName::IsTableRow:
+        case AXProperty::IsTableRow:
             setPropertyFlag(AXPropertyFlag::IsTableRow, std::get<bool>(value));
             return;
-        case AXPropertyName::SupportsCheckedState:
+        case AXProperty::SupportsCheckedState:
             setPropertyFlag(AXPropertyFlag::SupportsCheckedState, std::get<bool>(value));
             return;
-        case AXPropertyName::SupportsDragging:
+        case AXProperty::SupportsDragging:
             setPropertyFlag(AXPropertyFlag::SupportsDragging, std::get<bool>(value));
             return;
-        case AXPropertyName::SupportsExpanded:
+        case AXProperty::SupportsExpanded:
             setPropertyFlag(AXPropertyFlag::SupportsExpanded, std::get<bool>(value));
             return;
-        case AXPropertyName::SupportsPath:
+        case AXProperty::SupportsPath:
             setPropertyFlag(AXPropertyFlag::SupportsPath, std::get<bool>(value));
             return;
-        case AXPropertyName::SupportsPosInSet:
+        case AXProperty::SupportsPosInSet:
             setPropertyFlag(AXPropertyFlag::SupportsPosInSet, std::get<bool>(value));
             return;
-        case AXPropertyName::SupportsSetSize:
+        case AXProperty::SupportsSetSize:
             setPropertyFlag(AXPropertyFlag::SupportsSetSize, std::get<bool>(value));
             return;
         default:
@@ -591,7 +591,7 @@ void AXIsolatedObject::setProperty(AXPropertyName propertyName, AXPropertyValueV
         [](Markable<AXID> typedValue) { return !typedValue; },
         [&](String& typedValue) {
             // We use a null stringValue to indicate when the string value is different than the text content.
-            if (propertyName == AXPropertyName::StringValue)
+            if (propertyName == AXProperty::StringValue)
                 return typedValue == emptyString(); // Only compares empty, not null
             return typedValue.isEmpty(); // null or empty
         },
@@ -714,8 +714,8 @@ void AXIsolatedObject::updateChildrenIfNecessary()
 
 std::optional<AXCoreObject::AccessibilityChildrenVector> AXIsolatedObject::selectedChildren()
 {
-    if (m_propertyMap.contains(AXPropertyName::SelectedChildren))
-        return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXPropertyName::SelectedChildren));
+    if (m_propertyMap.contains(AXProperty::SelectedChildren))
+        return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::SelectedChildren));
     return std::nullopt;
 }
 
@@ -753,8 +753,8 @@ bool AXIsolatedObject::isDetachedFromParent()
 
 AXIsolatedObject* AXIsolatedObject::cellForColumnAndRow(unsigned columnIndex, unsigned rowIndex)
 {
-    // AXPropertyName::CellSlots can be big, so make sure not to copy it.
-    auto cellSlotsIterator = m_propertyMap.find(AXPropertyName::CellSlots);
+    // AXProperty::CellSlots can be big, so make sure not to copy it.
+    auto cellSlotsIterator = m_propertyMap.find(AXProperty::CellSlots);
     if (cellSlotsIterator == m_propertyMap.end())
         return nullptr;
 
@@ -771,7 +771,7 @@ AXIsolatedObject* AXIsolatedObject::cellForColumnAndRow(unsigned columnIndex, un
 
 void AXIsolatedObject::accessibilityText(Vector<AccessibilityText>& texts) const
 {
-    texts = vectorAttributeValue<AccessibilityText>(AXPropertyName::AccessibilityText);
+    texts = vectorAttributeValue<AccessibilityText>(AXProperty::AccessibilityText);
 }
 
 void AXIsolatedObject::insertMathPairs(Vector<std::pair<Markable<AXID>, Markable<AXID>>>& isolatedPairs, AccessibilityMathMultiscriptPairs& pairs)
@@ -788,21 +788,21 @@ void AXIsolatedObject::insertMathPairs(Vector<std::pair<Markable<AXID>, Markable
 
 void AXIsolatedObject::mathPrescripts(AccessibilityMathMultiscriptPairs& pairs)
 {
-    auto isolatedPairs = vectorAttributeValue<std::pair<Markable<AXID>, Markable<AXID>>>(AXPropertyName::MathPrescripts);
+    auto isolatedPairs = vectorAttributeValue<std::pair<Markable<AXID>, Markable<AXID>>>(AXProperty::MathPrescripts);
     insertMathPairs(isolatedPairs, pairs);
 }
 
 void AXIsolatedObject::mathPostscripts(AccessibilityMathMultiscriptPairs& pairs)
 {
-    auto isolatedPairs = vectorAttributeValue<std::pair<Markable<AXID>, Markable<AXID>>>(AXPropertyName::MathPostscripts);
+    auto isolatedPairs = vectorAttributeValue<std::pair<Markable<AXID>, Markable<AXID>>>(AXProperty::MathPostscripts);
     insertMathPairs(isolatedPairs, pairs);
 }
 
 std::optional<AXCoreObject::AccessibilityChildrenVector> AXIsolatedObject::mathRadicand()
 {
-    if (m_propertyMap.contains(AXPropertyName::MathRadicand)) {
+    if (m_propertyMap.contains(AXProperty::MathRadicand)) {
         Vector<Ref<AXCoreObject>> radicand;
-        fillChildrenVectorForProperty(AXPropertyName::MathRadicand, radicand);
+        fillChildrenVectorForProperty(AXProperty::MathRadicand, radicand);
         return { radicand };
     }
     return std::nullopt;
@@ -824,7 +824,7 @@ AXIsolatedObject* AXIsolatedObject::focusedUIElement() const
     
 AXIsolatedObject* AXIsolatedObject::scrollBar(AccessibilityOrientation orientation)
 {
-    return objectAttributeValue(orientation == AccessibilityOrientation::Vertical ? AXPropertyName::VerticalScrollBar : AXPropertyName::HorizontalScrollBar);
+    return objectAttributeValue(orientation == AccessibilityOrientation::Vertical ? AXProperty::VerticalScrollBar : AXProperty::HorizontalScrollBar);
 }
 
 void AXIsolatedObject::setARIAGrabbed(bool value)
@@ -971,7 +971,7 @@ void AXIsolatedObject::setSelectedTextRange(CharacterRange&& range)
 
 SRGBA<uint8_t> AXIsolatedObject::colorValue() const
 {
-    return colorAttributeValue(AXPropertyName::ColorValue).toColorTypeLossy<SRGBA<uint8_t>>();
+    return colorAttributeValue(AXProperty::ColorValue).toColorTypeLossy<SRGBA<uint8_t>>();
 }
 
 AXIsolatedObject* AXIsolatedObject::accessibilityHitTest(const IntPoint& point) const
@@ -989,7 +989,7 @@ AXIsolatedObject* AXIsolatedObject::accessibilityHitTest(const IntPoint& point) 
     return tree()->objectForID(axID);
 }
 
-IntPoint AXIsolatedObject::intPointAttributeValue(AXPropertyName propertyName) const
+IntPoint AXIsolatedObject::intPointAttributeValue(AXProperty propertyName) const
 {
     auto value = m_propertyMap.get(propertyName);
     return WTF::switchOn(value,
@@ -998,7 +998,7 @@ IntPoint AXIsolatedObject::intPointAttributeValue(AXPropertyName propertyName) c
     );
 }
 
-AXIsolatedObject* AXIsolatedObject::objectAttributeValue(AXPropertyName propertyName) const
+AXIsolatedObject* AXIsolatedObject::objectAttributeValue(AXProperty propertyName) const
 {
     auto value = m_propertyMap.get(propertyName);
     auto axID = WTF::switchOn(value,
@@ -1010,7 +1010,7 @@ AXIsolatedObject* AXIsolatedObject::objectAttributeValue(AXPropertyName property
 }
 
 template<typename T>
-T AXIsolatedObject::rectAttributeValue(AXPropertyName propertyName) const
+T AXIsolatedObject::rectAttributeValue(AXProperty propertyName) const
 {
     auto value = m_propertyMap.get(propertyName);
     return WTF::switchOn(value,
@@ -1020,7 +1020,7 @@ T AXIsolatedObject::rectAttributeValue(AXPropertyName propertyName) const
 }
 
 template<typename T>
-Vector<T> AXIsolatedObject::vectorAttributeValue(AXPropertyName propertyName) const
+Vector<T> AXIsolatedObject::vectorAttributeValue(AXProperty propertyName) const
 {
     auto value = m_propertyMap.get(propertyName);
     return WTF::switchOn(value,
@@ -1030,7 +1030,7 @@ Vector<T> AXIsolatedObject::vectorAttributeValue(AXPropertyName propertyName) co
 }
 
 template<typename T>
-OptionSet<T> AXIsolatedObject::optionSetAttributeValue(AXPropertyName propertyName) const
+OptionSet<T> AXIsolatedObject::optionSetAttributeValue(AXProperty propertyName) const
 {
     auto value = m_propertyMap.get(propertyName);
     return WTF::switchOn(value,
@@ -1039,7 +1039,7 @@ OptionSet<T> AXIsolatedObject::optionSetAttributeValue(AXPropertyName propertyNa
     );
 }
 
-std::pair<unsigned, unsigned> AXIsolatedObject::indexRangePairAttributeValue(AXPropertyName propertyName) const
+std::pair<unsigned, unsigned> AXIsolatedObject::indexRangePairAttributeValue(AXProperty propertyName) const
 {
     auto value = m_propertyMap.get(propertyName);
     return WTF::switchOn(value,
@@ -1049,7 +1049,7 @@ std::pair<unsigned, unsigned> AXIsolatedObject::indexRangePairAttributeValue(AXP
 }
 
 template<typename T>
-std::optional<T> AXIsolatedObject::optionalAttributeValue(AXPropertyName propertyName) const
+std::optional<T> AXIsolatedObject::optionalAttributeValue(AXProperty propertyName) const
 {
     auto it = m_propertyMap.find(propertyName);
     if (it == m_propertyMap.end())
@@ -1064,7 +1064,7 @@ std::optional<T> AXIsolatedObject::optionalAttributeValue(AXPropertyName propert
     );
 }
 
-uint64_t AXIsolatedObject::uint64AttributeValue(AXPropertyName propertyName) const
+uint64_t AXIsolatedObject::uint64AttributeValue(AXProperty propertyName) const
 {
     auto value = m_propertyMap.get(propertyName);
     return WTF::switchOn(value,
@@ -1073,7 +1073,7 @@ uint64_t AXIsolatedObject::uint64AttributeValue(AXPropertyName propertyName) con
     );
 }
 
-URL AXIsolatedObject::urlAttributeValue(AXPropertyName propertyName) const
+URL AXIsolatedObject::urlAttributeValue(AXProperty propertyName) const
 {
     auto value = m_propertyMap.get(propertyName);
     return WTF::switchOn(value,
@@ -1085,7 +1085,7 @@ URL AXIsolatedObject::urlAttributeValue(AXPropertyName propertyName) const
     );
 }
 
-Path AXIsolatedObject::pathAttributeValue(AXPropertyName propertyName) const
+Path AXIsolatedObject::pathAttributeValue(AXProperty propertyName) const
 {
     auto value = m_propertyMap.get(propertyName);
     return WTF::switchOn(value,
@@ -1097,7 +1097,7 @@ Path AXIsolatedObject::pathAttributeValue(AXPropertyName propertyName) const
     );
 }
 
-Color AXIsolatedObject::colorAttributeValue(AXPropertyName propertyName) const
+Color AXIsolatedObject::colorAttributeValue(AXProperty propertyName) const
 {
     auto value = m_propertyMap.get(propertyName);
     return WTF::switchOn(value,
@@ -1106,7 +1106,7 @@ Color AXIsolatedObject::colorAttributeValue(AXPropertyName propertyName) const
     );
 }
 
-float AXIsolatedObject::floatAttributeValue(AXPropertyName propertyName) const
+float AXIsolatedObject::floatAttributeValue(AXProperty propertyName) const
 {
     auto value = m_propertyMap.get(propertyName);
     return WTF::switchOn(value,
@@ -1115,7 +1115,7 @@ float AXIsolatedObject::floatAttributeValue(AXPropertyName propertyName) const
     );
 }
 
-double AXIsolatedObject::doubleAttributeValue(AXPropertyName propertyName) const
+double AXIsolatedObject::doubleAttributeValue(AXProperty propertyName) const
 {
     auto value = m_propertyMap.get(propertyName);
     return WTF::switchOn(value,
@@ -1124,7 +1124,7 @@ double AXIsolatedObject::doubleAttributeValue(AXPropertyName propertyName) const
     );
 }
 
-unsigned AXIsolatedObject::unsignedAttributeValue(AXPropertyName propertyName) const
+unsigned AXIsolatedObject::unsignedAttributeValue(AXProperty propertyName) const
 {
     auto value = m_propertyMap.get(propertyName);
     return WTF::switchOn(value,
@@ -1133,48 +1133,48 @@ unsigned AXIsolatedObject::unsignedAttributeValue(AXPropertyName propertyName) c
     );
 }
 
-bool AXIsolatedObject::boolAttributeValue(AXPropertyName propertyName) const
+bool AXIsolatedObject::boolAttributeValue(AXProperty propertyName) const
 {
     switch (propertyName) {
-    case AXPropertyName::CanSetFocusAttribute:
+    case AXProperty::CanSetFocusAttribute:
         return hasPropertyFlag(AXPropertyFlag::CanSetFocusAttribute);
-    case AXPropertyName::CanSetSelectedAttribute:
+    case AXProperty::CanSetSelectedAttribute:
         return hasPropertyFlag(AXPropertyFlag::CanSetSelectedAttribute);
-    case AXPropertyName::CanSetValueAttribute:
+    case AXProperty::CanSetValueAttribute:
         return hasPropertyFlag(AXPropertyFlag::CanSetValueAttribute);
-    case AXPropertyName::HasBoldFont:
+    case AXProperty::HasBoldFont:
         return hasPropertyFlag(AXPropertyFlag::HasBoldFont);
-    case AXPropertyName::HasItalicFont:
+    case AXProperty::HasItalicFont:
         return hasPropertyFlag(AXPropertyFlag::HasItalicFont);
-    case AXPropertyName::HasPlainText:
+    case AXProperty::HasPlainText:
         return hasPropertyFlag(AXPropertyFlag::HasPlainText);
-    case AXPropertyName::IsEnabled:
+    case AXProperty::IsEnabled:
         return hasPropertyFlag(AXPropertyFlag::IsEnabled);
-    case AXPropertyName::IsExposedTableCell:
+    case AXProperty::IsExposedTableCell:
         return hasPropertyFlag(AXPropertyFlag::IsExposedTableCell);
-    case AXPropertyName::IsGrabbed:
+    case AXProperty::IsGrabbed:
         return hasPropertyFlag(AXPropertyFlag::IsGrabbed);
-    case AXPropertyName::IsIgnored:
+    case AXProperty::IsIgnored:
         return hasPropertyFlag(AXPropertyFlag::IsIgnored);
-    case AXPropertyName::IsInlineText:
+    case AXProperty::IsInlineText:
         return hasPropertyFlag(AXPropertyFlag::IsInlineText);
-    case AXPropertyName::IsKeyboardFocusable:
+    case AXProperty::IsKeyboardFocusable:
         return hasPropertyFlag(AXPropertyFlag::IsKeyboardFocusable);
-    case AXPropertyName::IsNonLayerSVGObject:
+    case AXProperty::IsNonLayerSVGObject:
         return hasPropertyFlag(AXPropertyFlag::IsNonLayerSVGObject);
-    case AXPropertyName::IsTableRow:
+    case AXProperty::IsTableRow:
         return hasPropertyFlag(AXPropertyFlag::IsTableRow);
-    case AXPropertyName::SupportsCheckedState:
+    case AXProperty::SupportsCheckedState:
         return hasPropertyFlag(AXPropertyFlag::SupportsCheckedState);
-    case AXPropertyName::SupportsDragging:
+    case AXProperty::SupportsDragging:
         return hasPropertyFlag(AXPropertyFlag::SupportsDragging);
-    case AXPropertyName::SupportsExpanded:
+    case AXProperty::SupportsExpanded:
         return hasPropertyFlag(AXPropertyFlag::SupportsExpanded);
-    case AXPropertyName::SupportsPath:
+    case AXProperty::SupportsPath:
         return hasPropertyFlag(AXPropertyFlag::SupportsPath);
-    case AXPropertyName::SupportsPosInSet:
+    case AXProperty::SupportsPosInSet:
         return hasPropertyFlag(AXPropertyFlag::SupportsPosInSet);
-    case AXPropertyName::SupportsSetSize:
+    case AXProperty::SupportsSetSize:
         return hasPropertyFlag(AXPropertyFlag::SupportsSetSize);
     default:
         break;
@@ -1187,7 +1187,7 @@ bool AXIsolatedObject::boolAttributeValue(AXPropertyName propertyName) const
     );
 }
 
-String AXIsolatedObject::stringAttributeValue(AXPropertyName propertyName) const
+String AXIsolatedObject::stringAttributeValue(AXProperty propertyName) const
 {
     auto value = m_propertyMap.get(propertyName);
     return WTF::switchOn(value,
@@ -1196,7 +1196,7 @@ String AXIsolatedObject::stringAttributeValue(AXPropertyName propertyName) const
     );
 }
 
-String AXIsolatedObject::stringAttributeValueNullIfMissing(AXPropertyName propertyName) const
+String AXIsolatedObject::stringAttributeValueNullIfMissing(AXProperty propertyName) const
 {
     auto value = m_propertyMap.get(propertyName);
     return WTF::switchOn(value,
@@ -1205,7 +1205,7 @@ String AXIsolatedObject::stringAttributeValueNullIfMissing(AXPropertyName proper
     );
 }
 
-int AXIsolatedObject::intAttributeValue(AXPropertyName propertyName) const
+int AXIsolatedObject::intAttributeValue(AXProperty propertyName) const
 {
     auto value = m_propertyMap.get(propertyName);
     return WTF::switchOn(value,
@@ -1217,7 +1217,7 @@ int AXIsolatedObject::intAttributeValue(AXPropertyName propertyName) const
 #if ENABLE(AX_THREAD_TEXT_APIS)
 const AXTextRuns* AXIsolatedObject::textRuns() const
 {
-    auto entry = m_propertyMap.find(AXPropertyName::TextRuns);
+    auto entry = m_propertyMap.find(AXProperty::TextRuns);
     if (entry == m_propertyMap.end())
         return nullptr;
     return WTF::switchOn(entry->value,
@@ -1228,7 +1228,7 @@ const AXTextRuns* AXIsolatedObject::textRuns() const
 #endif
 
 template<typename T>
-T AXIsolatedObject::getOrRetrievePropertyValue(AXPropertyName propertyName)
+T AXIsolatedObject::getOrRetrievePropertyValue(AXProperty propertyName)
 {
     if (m_propertyMap.contains(propertyName))
         return propertyValue<T>(propertyName);
@@ -1240,10 +1240,10 @@ T AXIsolatedObject::getOrRetrievePropertyValue(AXPropertyName propertyName)
 
         AXPropertyValueVariant value;
         switch (propertyName) {
-        case AXPropertyName::InnerHTML:
+        case AXProperty::InnerHTML:
             value = axObject->innerHTML().isolatedCopy();
             break;
-        case AXPropertyName::OuterHTML:
+        case AXProperty::OuterHTML:
             value = axObject->outerHTML().isolatedCopy();
             break;
         default:
@@ -1257,7 +1257,7 @@ T AXIsolatedObject::getOrRetrievePropertyValue(AXPropertyName propertyName)
     return propertyValue<T>(propertyName);
 }
 
-void AXIsolatedObject::fillChildrenVectorForProperty(AXPropertyName propertyName, AccessibilityChildrenVector& children) const
+void AXIsolatedObject::fillChildrenVectorForProperty(AXProperty propertyName, AccessibilityChildrenVector& children) const
 {
     Vector<AXID> childIDs = vectorAttributeValue<AXID>(propertyName);
     children.reserveCapacity(childIDs.size());
@@ -1400,16 +1400,16 @@ LayoutRect AXIsolatedObject::elementRect() const
 IntPoint AXIsolatedObject::remoteFrameOffset() const
 {
     RefPtr root = tree()->rootNode();
-    return root ? root->propertyValue<IntPoint>(AXPropertyName::RemoteFrameOffset) : IntPoint();
+    return root ? root->propertyValue<IntPoint>(AXProperty::RemoteFrameOffset) : IntPoint();
 }
 
 FloatPoint AXIsolatedObject::screenRelativePosition() const
 {
-    if (auto point = optionalAttributeValue<FloatPoint>(AXPropertyName::ScreenRelativePosition))
+    if (auto point = optionalAttributeValue<FloatPoint>(AXProperty::ScreenRelativePosition))
         return *point;
 
     if (RefPtr rootNode = tree()->rootNode()) {
-        auto rootPoint = rootNode->propertyValue<FloatPoint>(AXPropertyName::ScreenRelativePosition);
+        auto rootPoint = rootNode->propertyValue<FloatPoint>(AXProperty::ScreenRelativePosition);
         auto rootRelativeFrame = rootNode->relativeFrame();
         auto relativeFrame = this->relativeFrame();
         // Relative frames are top-left origin, but screen relative positions are bottom-left origin.
@@ -1427,7 +1427,7 @@ FloatRect AXIsolatedObject::relativeFrame() const
 {
     FloatRect relativeFrame;
 
-    if (auto cachedRelativeFrame = optionalAttributeValue<IntRect>(AXPropertyName::RelativeFrame)) {
+    if (auto cachedRelativeFrame = optionalAttributeValue<IntRect>(AXProperty::RelativeFrame)) {
         // We should not have cached a relative frame for elements that get their geometry from their children.
         ASSERT(!m_getsGeometryFromChildren);
         relativeFrame = *cachedRelativeFrame;
@@ -1460,7 +1460,7 @@ FloatRect AXIsolatedObject::relativeFrame() const
         auto* ancestor = Accessibility::findAncestor<AXIsolatedObject>(*this, false, [] (const auto& object) {
             return object.hasCachedRelativeFrame();
         });
-        relativeFrame = rectAttributeValue<FloatRect>(AXPropertyName::InitialFrameRect);
+        relativeFrame = rectAttributeValue<FloatRect>(AXProperty::InitialFrameRect);
         if (ancestor && relativeFrame.location() == FloatPoint())
             relativeFrame.setLocation(ancestor->relativeFrame().location());
     }
@@ -1549,7 +1549,7 @@ bool AXIsolatedObject::isNativeTextControl() const
 
 int AXIsolatedObject::insertionPointLineNumber() const
 {
-    if (!boolAttributeValue(AXPropertyName::CanBeMultilineTextField))
+    if (!boolAttributeValue(AXProperty::CanBeMultilineTextField))
         return 0;
 
     auto selectedMarkerRange = selectedTextMarkerRange();
@@ -1577,7 +1577,7 @@ int AXIsolatedObject::insertionPointLineNumber() const
 String AXIsolatedObject::identifierAttribute() const
 {
 #if !LOG_DISABLED
-    return stringAttributeValue(AXPropertyName::IdentifierAttribute);
+    return stringAttributeValue(AXProperty::IdentifierAttribute);
 #else
     return Accessibility::retrieveValueFromMainThread<String>([this] () -> String {
         if (auto* object = associatedAXObject())
@@ -1799,7 +1799,7 @@ bool AXIsolatedObject::isPressed() const
 #if PLATFORM(MAC)
     ASSERT_NOT_REACHED();
 #endif
-    return boolAttributeValue(AXPropertyName::IsPressed);
+    return boolAttributeValue(AXProperty::IsPressed);
 }
 
 bool AXIsolatedObject::isSelectedOptionActive() const
@@ -1854,7 +1854,7 @@ bool AXIsolatedObject::hasSameFontColor(AXCoreObject& otherObject)
 
         if (!thisText || !otherText)
             return false;
-        return thisText->colorAttributeValue(AXPropertyName::TextColor) == otherText->colorAttributeValue(AXPropertyName::TextColor);
+        return thisText->colorAttributeValue(AXProperty::TextColor) == otherText->colorAttributeValue(AXProperty::TextColor);
     }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
@@ -1897,7 +1897,7 @@ bool AXIsolatedObject::hasSameStyle(AXCoreObject& otherObject)
 
 AXTextMarkerRange AXIsolatedObject::textInputMarkedTextMarkerRange() const
 {
-    auto value = optionalAttributeValue<std::pair<Markable<AXID>, CharacterRange>>(AXPropertyName::TextInputMarkedTextMarkerRange);
+    auto value = optionalAttributeValue<std::pair<Markable<AXID>, CharacterRange>>(AXProperty::TextInputMarkedTextMarkerRange);
     if (!value)
         return { };
 
@@ -1980,15 +1980,15 @@ String AXIsolatedObject::titleAttributeValue() const
 {
     AXTRACE("AXIsolatedObject::titleAttributeValue"_s);
 
-    if (m_propertyMap.contains(AXPropertyName::TitleAttributeValue))
-        return propertyValue<String>(AXPropertyName::TitleAttributeValue);
+    if (m_propertyMap.contains(AXProperty::TitleAttributeValue))
+        return propertyValue<String>(AXProperty::TitleAttributeValue);
     return AXCoreObject::titleAttributeValue();
 }
 
 String AXIsolatedObject::stringValue() const
 {
-    if (m_propertyMap.contains(AXPropertyName::StringValue))
-        return stringAttributeValue(AXPropertyName::StringValue);
+    if (m_propertyMap.contains(AXProperty::StringValue))
+        return stringAttributeValue(AXProperty::StringValue);
     if (auto value = platformStringValue())
         return *value;
     return { };
@@ -2090,7 +2090,7 @@ AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::relatedObjects(AXRel
 
 OptionSet<AXAncestorFlag> AXIsolatedObject::ancestorFlags() const
 {
-    auto value = m_propertyMap.get(AXPropertyName::AncestorFlags);
+    auto value = m_propertyMap.get(AXProperty::AncestorFlags);
     return WTF::switchOn(value,
         [] (OptionSet<AXAncestorFlag>& typedValue) -> OptionSet<AXAncestorFlag> { return typedValue; },
         [] (auto&) { return OptionSet<AXAncestorFlag>(); }
@@ -2099,12 +2099,12 @@ OptionSet<AXAncestorFlag> AXIsolatedObject::ancestorFlags() const
 
 String AXIsolatedObject::innerHTML() const
 {
-    return const_cast<AXIsolatedObject*>(this)->getOrRetrievePropertyValue<String>(AXPropertyName::InnerHTML);
+    return const_cast<AXIsolatedObject*>(this)->getOrRetrievePropertyValue<String>(AXProperty::InnerHTML);
 }
 
 String AXIsolatedObject::outerHTML() const
 {
-    return const_cast<AXIsolatedObject*>(this)->getOrRetrievePropertyValue<String>(AXPropertyName::OuterHTML);
+    return const_cast<AXIsolatedObject*>(this)->getOrRetrievePropertyValue<String>(AXProperty::OuterHTML);
 }
 
 AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::rowHeaders()

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -60,12 +60,12 @@ public:
 
     void attachPlatformWrapper(AccessibilityObjectWrapper*);
     bool isDetached() const final;
-    bool isTable() const final { return boolAttributeValue(AXPropertyName::IsTable); }
-    bool isExposable() const final { return boolAttributeValue(AXPropertyName::IsExposable); }
-    bool hasClickHandler() const final { return boolAttributeValue(AXPropertyName::HasClickHandler); }
+    bool isTable() const final { return boolAttributeValue(AXProperty::IsTable); }
+    bool isExposable() const final { return boolAttributeValue(AXProperty::IsExposable); }
+    bool hasClickHandler() const final { return boolAttributeValue(AXProperty::HasClickHandler); }
 
-    bool hasBodyTag() const final { return boolAttributeValue(AXPropertyName::HasBodyTag); }
-    bool hasMarkTag() const final { return boolAttributeValue(AXPropertyName::HasMarkTag); }
+    bool hasBodyTag() const final { return boolAttributeValue(AXProperty::HasBodyTag); }
+    bool hasMarkTag() const final { return boolAttributeValue(AXProperty::HasMarkTag); }
 
     const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) final;
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
@@ -77,7 +77,7 @@ public:
 #endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     AXIsolatedObject* clickableSelfOrAncestor(ClickHandlerFilter filter = ClickHandlerFilter::ExcludeBody) const final { return Accessibility::clickableSelfOrAncestor(*this, filter); };
     AXIsolatedObject* editableAncestor() const final { return Accessibility::editableAncestor(*this); };
-    bool canSetFocusAttribute() const final { return boolAttributeValue(AXPropertyName::CanSetFocusAttribute); }
+    bool canSetFocusAttribute() const final { return boolAttributeValue(AXProperty::CanSetFocusAttribute); }
     AttributedStringStyle stylesForAttributedString() const final;
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
@@ -87,7 +87,7 @@ public:
         const auto* runs = textRuns();
         return runs && runs->size();
     }
-    TextEmissionBehavior emitTextAfterBehavior() const final { return propertyValue<TextEmissionBehavior>(AXPropertyName::EmitTextAfterBehavior); }
+    TextEmissionBehavior emitTextAfterBehavior() const final { return propertyValue<TextEmissionBehavior>(AXProperty::EmitTextAfterBehavior); }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
     AXTextMarkerRange textMarkerRange() const final;
@@ -109,9 +109,9 @@ private:
     void initializeProperties(const Ref<AccessibilityObject>&);
     void initializePlatformProperties(const Ref<const AccessibilityObject>&);
 
-    void setProperty(AXPropertyName, AXPropertyValueVariant&&);
-    void setObjectProperty(AXPropertyName, AXCoreObject*);
-    void setObjectVectorProperty(AXPropertyName, const AccessibilityChildrenVector&);
+    void setProperty(AXProperty, AXPropertyValueVariant&&);
+    void setObjectProperty(AXProperty, AXCoreObject*);
+    void setObjectVectorProperty(AXProperty, const AccessibilityChildrenVector&);
 
     void setPropertyFlag(AXPropertyFlag, bool);
     bool hasPropertyFlag(AXPropertyFlag) const;
@@ -119,33 +119,33 @@ private:
     static bool canBeMultilineTextField(AccessibilityObject&);
 
     // FIXME: consolidate all AttributeValue retrieval in a single template method.
-    bool boolAttributeValue(AXPropertyName) const;
-    String stringAttributeValue(AXPropertyName) const;
-    String stringAttributeValueNullIfMissing(AXPropertyName) const;
-    int intAttributeValue(AXPropertyName) const;
-    unsigned unsignedAttributeValue(AXPropertyName) const;
-    double doubleAttributeValue(AXPropertyName) const;
-    float floatAttributeValue(AXPropertyName) const;
-    AXIsolatedObject* objectAttributeValue(AXPropertyName) const;
-    IntPoint intPointAttributeValue(AXPropertyName) const;
-    Color colorAttributeValue(AXPropertyName) const;
-    URL urlAttributeValue(AXPropertyName) const;
-    uint64_t uint64AttributeValue(AXPropertyName) const;
-    Path pathAttributeValue(AXPropertyName) const;
-    std::pair<unsigned, unsigned> indexRangePairAttributeValue(AXPropertyName) const;
-    template<typename T> T rectAttributeValue(AXPropertyName) const;
-    template<typename T> Vector<T> vectorAttributeValue(AXPropertyName) const;
-    template<typename T> OptionSet<T> optionSetAttributeValue(AXPropertyName) const;
-    template<typename T> std::optional<T> optionalAttributeValue(AXPropertyName) const;
-    template<typename T> T propertyValue(AXPropertyName) const;
+    bool boolAttributeValue(AXProperty) const;
+    String stringAttributeValue(AXProperty) const;
+    String stringAttributeValueNullIfMissing(AXProperty) const;
+    int intAttributeValue(AXProperty) const;
+    unsigned unsignedAttributeValue(AXProperty) const;
+    double doubleAttributeValue(AXProperty) const;
+    float floatAttributeValue(AXProperty) const;
+    AXIsolatedObject* objectAttributeValue(AXProperty) const;
+    IntPoint intPointAttributeValue(AXProperty) const;
+    Color colorAttributeValue(AXProperty) const;
+    URL urlAttributeValue(AXProperty) const;
+    uint64_t uint64AttributeValue(AXProperty) const;
+    Path pathAttributeValue(AXProperty) const;
+    std::pair<unsigned, unsigned> indexRangePairAttributeValue(AXProperty) const;
+    template<typename T> T rectAttributeValue(AXProperty) const;
+    template<typename T> Vector<T> vectorAttributeValue(AXProperty) const;
+    template<typename T> OptionSet<T> optionSetAttributeValue(AXProperty) const;
+    template<typename T> std::optional<T> optionalAttributeValue(AXProperty) const;
+    template<typename T> T propertyValue(AXProperty) const;
 
     // The following method performs a lazy caching of the given property.
     // If the property is already in m_propertyMap, returns the existing value.
     // If not, retrieves the property from the main thread and cache it for later use.
-    template<typename T> T getOrRetrievePropertyValue(AXPropertyName);
+    template<typename T> T getOrRetrievePropertyValue(AXProperty);
 
-    void fillChildrenVectorForProperty(AXPropertyName, AccessibilityChildrenVector&) const;
-    void setMathscripts(AXPropertyName, AccessibilityObject&);
+    void fillChildrenVectorForProperty(AXProperty, AccessibilityChildrenVector&) const;
+    void setMathscripts(AXProperty, AccessibilityObject&);
     void insertMathPairs(Vector<std::pair<Markable<AXID>, Markable<AXID>>>&, AccessibilityMathMultiscriptPairs&);
     template<typename U> void performFunctionOnMainThreadAndWait(U&& lambda) const
     {
@@ -163,202 +163,202 @@ private:
     }
 
     // Attribute retrieval overrides.
-    bool isSecureField() const final { return boolAttributeValue(AXPropertyName::IsSecureField); }
-    bool isAttachment() const final { return boolAttributeValue(AXPropertyName::IsAttachment); }
-    bool isInputImage() const final { return boolAttributeValue(AXPropertyName::IsInputImage); }
-    bool isRadioInput() const final { return boolAttributeValue(AXPropertyName::IsRadioInput); }
+    bool isSecureField() const final { return boolAttributeValue(AXProperty::IsSecureField); }
+    bool isAttachment() const final { return boolAttributeValue(AXProperty::IsAttachment); }
+    bool isInputImage() const final { return boolAttributeValue(AXProperty::IsInputImage); }
+    bool isRadioInput() const final { return boolAttributeValue(AXProperty::IsRadioInput); }
 
-    bool isKeyboardFocusable() const final { return boolAttributeValue(AXPropertyName::IsKeyboardFocusable); }
+    bool isKeyboardFocusable() const final { return boolAttributeValue(AXProperty::IsKeyboardFocusable); }
     
     // Table support.
     AXIsolatedObject* exposedTableAncestor(bool includeSelf = false) const final { return Accessibility::exposedTableAncestor(*this, includeSelf); }
-    AccessibilityChildrenVector columns() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXPropertyName::Columns)); }
-    AccessibilityChildrenVector rows() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXPropertyName::Rows)); }
+    AccessibilityChildrenVector columns() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::Columns)); }
+    AccessibilityChildrenVector rows() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::Rows)); }
     unsigned columnCount() final { return static_cast<unsigned>(columns().size()); }
     unsigned rowCount() final { return static_cast<unsigned>(rows().size()); }
-    AccessibilityChildrenVector cells() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXPropertyName::Cells)); }
+    AccessibilityChildrenVector cells() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::Cells)); }
     AXIsolatedObject* cellForColumnAndRow(unsigned, unsigned) final;
     AccessibilityChildrenVector rowHeaders() final;
-    AccessibilityChildrenVector visibleRows() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXPropertyName::VisibleRows)); }
-    AXIsolatedObject* headerContainer() final { return objectAttributeValue(AXPropertyName::HeaderContainer); }
-    int axColumnCount() const final { return intAttributeValue(AXPropertyName::AXColumnCount); }
-    int axRowCount() const final { return intAttributeValue(AXPropertyName::AXRowCount); }
+    AccessibilityChildrenVector visibleRows() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::VisibleRows)); }
+    AXIsolatedObject* headerContainer() final { return objectAttributeValue(AXProperty::HeaderContainer); }
+    int axColumnCount() const final { return intAttributeValue(AXProperty::AXColumnCount); }
+    int axRowCount() const final { return intAttributeValue(AXProperty::AXRowCount); }
 
     // Table cell support.
     bool isTableCell() const final;
-    bool isExposedTableCell() const final { return boolAttributeValue(AXPropertyName::IsExposedTableCell); }
+    bool isExposedTableCell() const final { return boolAttributeValue(AXProperty::IsExposedTableCell); }
     // Returns the start location and row span of the cell.
-    std::pair<unsigned, unsigned> rowIndexRange() const final { return indexRangePairAttributeValue(AXPropertyName::RowIndexRange); }
+    std::pair<unsigned, unsigned> rowIndexRange() const final { return indexRangePairAttributeValue(AXProperty::RowIndexRange); }
     // Returns the start location and column span of the cell.
-    std::pair<unsigned, unsigned> columnIndexRange() const final { return indexRangePairAttributeValue(AXPropertyName::ColumnIndexRange); }
-    int axColumnIndex() const final { return intAttributeValue(AXPropertyName::AXColumnIndex); }
-    int axRowIndex() const final { return intAttributeValue(AXPropertyName::AXRowIndex); }
-    bool isColumnHeader() const final { return boolAttributeValue(AXPropertyName::IsColumnHeader); }
-    bool isRowHeader() const final { return boolAttributeValue(AXPropertyName::IsRowHeader); }
-    String cellScope() const final { return stringAttributeValue(AXPropertyName::CellScope); }
-    std::optional<AXID> rowGroupAncestorID() const final { return propertyValue<Markable<AXID>>(AXPropertyName::RowGroupAncestorID); }
+    std::pair<unsigned, unsigned> columnIndexRange() const final { return indexRangePairAttributeValue(AXProperty::ColumnIndexRange); }
+    int axColumnIndex() const final { return intAttributeValue(AXProperty::AXColumnIndex); }
+    int axRowIndex() const final { return intAttributeValue(AXProperty::AXRowIndex); }
+    bool isColumnHeader() const final { return boolAttributeValue(AXProperty::IsColumnHeader); }
+    bool isRowHeader() const final { return boolAttributeValue(AXProperty::IsRowHeader); }
+    String cellScope() const final { return stringAttributeValue(AXProperty::CellScope); }
+    std::optional<AXID> rowGroupAncestorID() const final { return propertyValue<Markable<AXID>>(AXProperty::RowGroupAncestorID); }
 
     // Table column support.
-    unsigned columnIndex() const final { return unsignedAttributeValue(AXPropertyName::ColumnIndex); }
+    unsigned columnIndex() const final { return unsignedAttributeValue(AXProperty::ColumnIndex); }
 
     // Table row support.
-    bool isTableRow() const final { return boolAttributeValue(AXPropertyName::IsTableRow); }
-    unsigned rowIndex() const final { return unsignedAttributeValue(AXPropertyName::RowIndex); }
-    AXIsolatedObject* rowHeader() final { return objectAttributeValue(AXPropertyName::RowHeader); };
+    bool isTableRow() const final { return boolAttributeValue(AXProperty::IsTableRow); }
+    unsigned rowIndex() const final { return unsignedAttributeValue(AXProperty::RowIndex); }
+    AXIsolatedObject* rowHeader() final { return objectAttributeValue(AXProperty::RowHeader); };
 
     // ARIA tree/grid row support.
-    bool isARIATreeGridRow() const final { return boolAttributeValue(AXPropertyName::IsARIATreeGridRow); }
-    AccessibilityChildrenVector disclosedRows() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXPropertyName::DisclosedRows)); }
-    AXIsolatedObject* disclosedByRow() const final { return objectAttributeValue(AXPropertyName::DisclosedByRow); }
+    bool isARIATreeGridRow() const final { return boolAttributeValue(AXProperty::IsARIATreeGridRow); }
+    AccessibilityChildrenVector disclosedRows() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::DisclosedRows)); }
+    AXIsolatedObject* disclosedByRow() const final { return objectAttributeValue(AXProperty::DisclosedByRow); }
 
-    bool isFieldset() const final { return boolAttributeValue(AXPropertyName::IsFieldset); }
-    bool isChecked() const final { return boolAttributeValue(AXPropertyName::IsChecked); }
-    bool isEnabled() const final { return boolAttributeValue(AXPropertyName::IsEnabled); }
-    bool isSelected() const final { return boolAttributeValue(AXPropertyName::IsSelected); }
+    bool isFieldset() const final { return boolAttributeValue(AXProperty::IsFieldset); }
+    bool isChecked() const final { return boolAttributeValue(AXProperty::IsChecked); }
+    bool isEnabled() const final { return boolAttributeValue(AXProperty::IsEnabled); }
+    bool isSelected() const final { return boolAttributeValue(AXProperty::IsSelected); }
     bool isFocused() const final { return tree()->focusedNodeID() == objectID(); }
-    bool isMultiSelectable() const final { return boolAttributeValue(AXPropertyName::IsMultiSelectable); }
-    InsideLink insideLink() const final { return propertyValue<InsideLink>(AXPropertyName::InsideLink); }
-    bool isRequired() const final { return boolAttributeValue(AXPropertyName::IsRequired); }
-    bool isExpanded() const final { return boolAttributeValue(AXPropertyName::IsExpanded); }
-    bool isFileUploadButton() const final { return boolAttributeValue(AXPropertyName::IsFileUploadButton); }
+    bool isMultiSelectable() const final { return boolAttributeValue(AXProperty::IsMultiSelectable); }
+    InsideLink insideLink() const final { return propertyValue<InsideLink>(AXProperty::InsideLink); }
+    bool isRequired() const final { return boolAttributeValue(AXProperty::IsRequired); }
+    bool isExpanded() const final { return boolAttributeValue(AXProperty::IsExpanded); }
+    bool isFileUploadButton() const final { return boolAttributeValue(AXProperty::IsFileUploadButton); }
     FloatPoint screenRelativePosition() const final;
     IntPoint remoteFrameOffset() const final;
     FloatRect relativeFrame() const final;
-    bool hasCachedRelativeFrame() const { return optionalAttributeValue<IntRect>(AXPropertyName::RelativeFrame).has_value(); }
+    bool hasCachedRelativeFrame() const { return optionalAttributeValue<IntRect>(AXProperty::RelativeFrame).has_value(); }
 #if PLATFORM(MAC)
     FloatRect primaryScreenRect() const final;
 #endif
     IntSize size() const final { return snappedIntRect(LayoutRect(relativeFrame())).size(); }
     FloatRect relativeFrameFromChildren() const;
-    WallTime dateTimeValue() const final { return propertyValue<WallTime>(AXPropertyName::DateTimeValue); }
-    DateComponentsType dateTimeComponentsType() const final { return propertyValue<DateComponentsType>(AXPropertyName::DateTimeComponentsType); }
-    bool supportsDatetimeAttribute() const final { return boolAttributeValue(AXPropertyName::SupportsDatetimeAttribute); }
-    String datetimeAttributeValue() const final { return stringAttributeValue(AXPropertyName::DatetimeAttributeValue); }
-    bool canSetValueAttribute() const final { return boolAttributeValue(AXPropertyName::CanSetValueAttribute); }
-    bool canSetSelectedAttribute() const final { return boolAttributeValue(AXPropertyName::CanSetSelectedAttribute); }
+    WallTime dateTimeValue() const final { return propertyValue<WallTime>(AXProperty::DateTimeValue); }
+    DateComponentsType dateTimeComponentsType() const final { return propertyValue<DateComponentsType>(AXProperty::DateTimeComponentsType); }
+    bool supportsDatetimeAttribute() const final { return boolAttributeValue(AXProperty::SupportsDatetimeAttribute); }
+    String datetimeAttributeValue() const final { return stringAttributeValue(AXProperty::DatetimeAttributeValue); }
+    bool canSetValueAttribute() const final { return boolAttributeValue(AXProperty::CanSetValueAttribute); }
+    bool canSetSelectedAttribute() const final { return boolAttributeValue(AXProperty::CanSetSelectedAttribute); }
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
-    bool isIgnored() const final { return boolAttributeValue(AXPropertyName::IsIgnored); }
+    bool isIgnored() const final { return boolAttributeValue(AXProperty::IsIgnored); }
 #else
     // When not including ignored objects in the core tree, we should never create an isolated object from
     // an ignored live object, so we can hardcode this to false.
     bool isIgnored() const final { return false; }
 #endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
-    unsigned blockquoteLevel() const final { return unsignedAttributeValue(AXPropertyName::BlockquoteLevel); }
-    unsigned headingLevel() const final { return unsignedAttributeValue(AXPropertyName::HeadingLevel); }
-    AccessibilityButtonState checkboxOrRadioValue() const final { return propertyValue<AccessibilityButtonState>(AXPropertyName::ButtonState); }
-    String valueDescription() const final { return stringAttributeValue(AXPropertyName::ValueDescription); }
-    float valueForRange() const final { return floatAttributeValue(AXPropertyName::ValueForRange); }
-    float maxValueForRange() const final { return floatAttributeValue(AXPropertyName::MaxValueForRange); }
-    float minValueForRange() const final { return floatAttributeValue(AXPropertyName::MinValueForRange); }
+    unsigned blockquoteLevel() const final { return unsignedAttributeValue(AXProperty::BlockquoteLevel); }
+    unsigned headingLevel() const final { return unsignedAttributeValue(AXProperty::HeadingLevel); }
+    AccessibilityButtonState checkboxOrRadioValue() const final { return propertyValue<AccessibilityButtonState>(AXProperty::ButtonState); }
+    String valueDescription() const final { return stringAttributeValue(AXProperty::ValueDescription); }
+    float valueForRange() const final { return floatAttributeValue(AXProperty::ValueForRange); }
+    float maxValueForRange() const final { return floatAttributeValue(AXProperty::MaxValueForRange); }
+    float minValueForRange() const final { return floatAttributeValue(AXProperty::MinValueForRange); }
     int layoutCount() const final;
     double loadingProgress() const final { return tree()->loadingProgress(); }
-    bool supportsARIAOwns() const final { return boolAttributeValue(AXPropertyName::SupportsARIAOwns); }
-    String popupValue() const final { return stringAttributeValue(AXPropertyName::PopupValue); }
+    bool supportsARIAOwns() const final { return boolAttributeValue(AXProperty::SupportsARIAOwns); }
+    String popupValue() const final { return stringAttributeValue(AXProperty::PopupValue); }
     bool pressedIsPresent() const final;
-    String invalidStatus() const final { return stringAttributeValue(AXPropertyName::InvalidStatus); }
-    bool supportsExpanded() const final { return boolAttributeValue(AXPropertyName::SupportsExpanded); }
-    AccessibilitySortDirection sortDirection() const final { return static_cast<AccessibilitySortDirection>(intAttributeValue(AXPropertyName::SortDirection)); }
-    bool supportsRangeValue() const final { return boolAttributeValue(AXPropertyName::SupportsRangeValue); }
+    String invalidStatus() const final { return stringAttributeValue(AXProperty::InvalidStatus); }
+    bool supportsExpanded() const final { return boolAttributeValue(AXProperty::SupportsExpanded); }
+    AccessibilitySortDirection sortDirection() const final { return static_cast<AccessibilitySortDirection>(intAttributeValue(AXProperty::SortDirection)); }
+    bool supportsRangeValue() const final { return boolAttributeValue(AXProperty::SupportsRangeValue); }
     String identifierAttribute() const final;
     String linkRelValue() const final;
     Vector<String> classList() const final;
-    AccessibilityCurrentState currentState() const final { return static_cast<AccessibilityCurrentState>(intAttributeValue(AXPropertyName::CurrentState)); }
-    bool supportsCurrent() const final { return boolAttributeValue(AXPropertyName::SupportsCurrent); }
-    bool supportsKeyShortcuts() const final { return boolAttributeValue(AXPropertyName::SupportsKeyShortcuts); }
-    String keyShortcuts() const final { return stringAttributeValue(AXPropertyName::KeyShortcuts); }
-    bool supportsSetSize() const final { return boolAttributeValue(AXPropertyName::SupportsSetSize); }
-    bool supportsPosInSet() const final { return boolAttributeValue(AXPropertyName::SupportsPosInSet); }
-    int setSize() const final { return intAttributeValue(AXPropertyName::SetSize); }
-    int posInSet() const final { return intAttributeValue(AXPropertyName::PosInSet); }
-    bool supportsDropping() const final { return boolAttributeValue(AXPropertyName::SupportsDropping); }
-    bool supportsDragging() const final { return boolAttributeValue(AXPropertyName::SupportsDragging); }
-    bool isGrabbed() final { return boolAttributeValue(AXPropertyName::IsGrabbed); }
+    AccessibilityCurrentState currentState() const final { return static_cast<AccessibilityCurrentState>(intAttributeValue(AXProperty::CurrentState)); }
+    bool supportsCurrent() const final { return boolAttributeValue(AXProperty::SupportsCurrent); }
+    bool supportsKeyShortcuts() const final { return boolAttributeValue(AXProperty::SupportsKeyShortcuts); }
+    String keyShortcuts() const final { return stringAttributeValue(AXProperty::KeyShortcuts); }
+    bool supportsSetSize() const final { return boolAttributeValue(AXProperty::SupportsSetSize); }
+    bool supportsPosInSet() const final { return boolAttributeValue(AXProperty::SupportsPosInSet); }
+    int setSize() const final { return intAttributeValue(AXProperty::SetSize); }
+    int posInSet() const final { return intAttributeValue(AXProperty::PosInSet); }
+    bool supportsDropping() const final { return boolAttributeValue(AXProperty::SupportsDropping); }
+    bool supportsDragging() const final { return boolAttributeValue(AXProperty::SupportsDragging); }
+    bool isGrabbed() final { return boolAttributeValue(AXProperty::IsGrabbed); }
     Vector<String> determineDropEffects() const final;
     AXIsolatedObject* accessibilityHitTest(const IntPoint&) const final;
     AXIsolatedObject* focusedUIElement() const final;
-    AXIsolatedObject* internalLinkElement() const final { return objectAttributeValue(AXPropertyName::InternalLinkElement); }
-    AccessibilityChildrenVector radioButtonGroup() const final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXPropertyName::RadioButtonGroup)); }
+    AXIsolatedObject* internalLinkElement() const final { return objectAttributeValue(AXProperty::InternalLinkElement); }
+    AccessibilityChildrenVector radioButtonGroup() const final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::RadioButtonGroup)); }
     AXIsolatedObject* scrollBar(AccessibilityOrientation) final;
-    const String placeholderValue() const final { return stringAttributeValue(AXPropertyName::PlaceholderValue); }
-    String expandedTextValue() const final { return stringAttributeValue(AXPropertyName::ExpandedTextValue); }
-    bool supportsExpandedTextValue() const final { return boolAttributeValue(AXPropertyName::SupportsExpandedTextValue); }
+    const String placeholderValue() const final { return stringAttributeValue(AXProperty::PlaceholderValue); }
+    String expandedTextValue() const final { return stringAttributeValue(AXProperty::ExpandedTextValue); }
+    bool supportsExpandedTextValue() const final { return boolAttributeValue(AXProperty::SupportsExpandedTextValue); }
     SRGBA<uint8_t> colorValue() const final;
-    String rolePlatformString() const final { return stringAttributeValue(AXPropertyName::RolePlatformString); }
-    String roleDescription() const final { return stringAttributeValue(AXPropertyName::RoleDescription); }
-    String subrolePlatformString() const final { return stringAttributeValue(AXPropertyName::SubrolePlatformString); }
+    String rolePlatformString() const final { return stringAttributeValue(AXProperty::RolePlatformString); }
+    String roleDescription() const final { return stringAttributeValue(AXProperty::RoleDescription); }
+    String subrolePlatformString() const final { return stringAttributeValue(AXProperty::SubrolePlatformString); }
     LayoutRect elementRect() const final;
     IntPoint clickPoint() final;
     void accessibilityText(Vector<AccessibilityText>& texts) const final;
-    String brailleLabel() const final { return stringAttributeValue(AXPropertyName::BrailleLabel); }
-    String brailleRoleDescription() const final { return stringAttributeValue(AXPropertyName::BrailleRoleDescription); }
-    String embeddedImageDescription() const final { return stringAttributeValue(AXPropertyName::EmbeddedImageDescription); }
+    String brailleLabel() const final { return stringAttributeValue(AXProperty::BrailleLabel); }
+    String brailleRoleDescription() const final { return stringAttributeValue(AXProperty::BrailleRoleDescription); }
+    String embeddedImageDescription() const final { return stringAttributeValue(AXProperty::EmbeddedImageDescription); }
     std::optional<AccessibilityChildrenVector> imageOverlayElements() final { return std::nullopt; }
-    String extendedDescription() const final { return stringAttributeValue(AXPropertyName::ExtendedDescription); }
+    String extendedDescription() const final { return stringAttributeValue(AXProperty::ExtendedDescription); }
     String computedRoleString() const final;
-    bool isValueAutofillAvailable() const final { return boolAttributeValue(AXPropertyName::IsValueAutofillAvailable); }
-    AutoFillButtonType valueAutofillButtonType() const final { return static_cast<AutoFillButtonType>(intAttributeValue(AXPropertyName::ValueAutofillButtonType)); }
-    AccessibilityChildrenVector ariaTreeRows() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXPropertyName::ARIATreeRows)); }
-    URL url() const final { return urlAttributeValue(AXPropertyName::URL); }
-    String accessKey() const final { return stringAttributeValueNullIfMissing(AXPropertyName::AccessKey); }
-    String localizedActionVerb() const final { return stringAttributeValue(AXPropertyName::LocalizedActionVerb); }
-    String actionVerb() const final { return stringAttributeValue(AXPropertyName::ActionVerb); }
-    String autoCompleteValue() const final { return stringAttributeValue(AXPropertyName::AutoCompleteValue); }
-    bool isMathElement() const final { return boolAttributeValue(AXPropertyName::IsMathElement); }
-    bool isMathFraction() const final { return boolAttributeValue(AXPropertyName::IsMathFraction); }
-    bool isMathFenced() const final { return boolAttributeValue(AXPropertyName::IsMathFenced); }
-    bool isMathSubscriptSuperscript() const final { return boolAttributeValue(AXPropertyName::IsMathSubscriptSuperscript); }
-    bool isMathRow() const final { return boolAttributeValue(AXPropertyName::IsMathRow); }
-    bool isMathUnderOver() const final { return boolAttributeValue(AXPropertyName::IsMathUnderOver); }
-    bool isMathRoot() const final { return boolAttributeValue(AXPropertyName::IsMathRoot); }
-    bool isMathSquareRoot() const final { return boolAttributeValue(AXPropertyName::IsMathSquareRoot); }
-    bool isMathTable() const final { return boolAttributeValue(AXPropertyName::IsMathTable); }
-    bool isMathTableRow() const final { return boolAttributeValue(AXPropertyName::IsMathTableRow); }
-    bool isMathTableCell() const final { return boolAttributeValue(AXPropertyName::IsMathTableCell); }
-    bool isMathMultiscript() const final { return boolAttributeValue(AXPropertyName::IsMathMultiscript); }
-    bool isMathToken() const final { return boolAttributeValue(AXPropertyName::IsMathToken); }
+    bool isValueAutofillAvailable() const final { return boolAttributeValue(AXProperty::IsValueAutofillAvailable); }
+    AutoFillButtonType valueAutofillButtonType() const final { return static_cast<AutoFillButtonType>(intAttributeValue(AXProperty::ValueAutofillButtonType)); }
+    AccessibilityChildrenVector ariaTreeRows() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::ARIATreeRows)); }
+    URL url() const final { return urlAttributeValue(AXProperty::URL); }
+    String accessKey() const final { return stringAttributeValueNullIfMissing(AXProperty::AccessKey); }
+    String localizedActionVerb() const final { return stringAttributeValue(AXProperty::LocalizedActionVerb); }
+    String actionVerb() const final { return stringAttributeValue(AXProperty::ActionVerb); }
+    String autoCompleteValue() const final { return stringAttributeValue(AXProperty::AutoCompleteValue); }
+    bool isMathElement() const final { return boolAttributeValue(AXProperty::IsMathElement); }
+    bool isMathFraction() const final { return boolAttributeValue(AXProperty::IsMathFraction); }
+    bool isMathFenced() const final { return boolAttributeValue(AXProperty::IsMathFenced); }
+    bool isMathSubscriptSuperscript() const final { return boolAttributeValue(AXProperty::IsMathSubscriptSuperscript); }
+    bool isMathRow() const final { return boolAttributeValue(AXProperty::IsMathRow); }
+    bool isMathUnderOver() const final { return boolAttributeValue(AXProperty::IsMathUnderOver); }
+    bool isMathRoot() const final { return boolAttributeValue(AXProperty::IsMathRoot); }
+    bool isMathSquareRoot() const final { return boolAttributeValue(AXProperty::IsMathSquareRoot); }
+    bool isMathTable() const final { return boolAttributeValue(AXProperty::IsMathTable); }
+    bool isMathTableRow() const final { return boolAttributeValue(AXProperty::IsMathTableRow); }
+    bool isMathTableCell() const final { return boolAttributeValue(AXProperty::IsMathTableCell); }
+    bool isMathMultiscript() const final { return boolAttributeValue(AXProperty::IsMathMultiscript); }
+    bool isMathToken() const final { return boolAttributeValue(AXProperty::IsMathToken); }
     std::optional<AccessibilityChildrenVector> mathRadicand() final;
-    AXIsolatedObject* mathRootIndexObject() final { return objectAttributeValue(AXPropertyName::MathRootIndexObject); }
-    AXIsolatedObject* mathUnderObject() final { return objectAttributeValue(AXPropertyName::MathUnderObject); }
-    AXIsolatedObject* mathOverObject() final { return objectAttributeValue(AXPropertyName::MathOverObject); }
-    AXIsolatedObject* mathNumeratorObject() final { return objectAttributeValue(AXPropertyName::MathNumeratorObject); }
-    AXIsolatedObject* mathDenominatorObject() final { return objectAttributeValue(AXPropertyName::MathDenominatorObject); }
-    AXIsolatedObject* mathBaseObject() final { return objectAttributeValue(AXPropertyName::MathBaseObject); }
-    AXIsolatedObject* mathSubscriptObject() final { return objectAttributeValue(AXPropertyName::MathSubscriptObject); }
-    AXIsolatedObject* mathSuperscriptObject() final { return objectAttributeValue(AXPropertyName::MathSuperscriptObject); }
-    String mathFencedOpenString() const final { return stringAttributeValue(AXPropertyName::MathFencedOpenString); }
-    String mathFencedCloseString() const final { return stringAttributeValue(AXPropertyName::MathFencedCloseString); }
-    int mathLineThickness() const final { return intAttributeValue(AXPropertyName::MathLineThickness); }
+    AXIsolatedObject* mathRootIndexObject() final { return objectAttributeValue(AXProperty::MathRootIndexObject); }
+    AXIsolatedObject* mathUnderObject() final { return objectAttributeValue(AXProperty::MathUnderObject); }
+    AXIsolatedObject* mathOverObject() final { return objectAttributeValue(AXProperty::MathOverObject); }
+    AXIsolatedObject* mathNumeratorObject() final { return objectAttributeValue(AXProperty::MathNumeratorObject); }
+    AXIsolatedObject* mathDenominatorObject() final { return objectAttributeValue(AXProperty::MathDenominatorObject); }
+    AXIsolatedObject* mathBaseObject() final { return objectAttributeValue(AXProperty::MathBaseObject); }
+    AXIsolatedObject* mathSubscriptObject() final { return objectAttributeValue(AXProperty::MathSubscriptObject); }
+    AXIsolatedObject* mathSuperscriptObject() final { return objectAttributeValue(AXProperty::MathSuperscriptObject); }
+    String mathFencedOpenString() const final { return stringAttributeValue(AXProperty::MathFencedOpenString); }
+    String mathFencedCloseString() const final { return stringAttributeValue(AXProperty::MathFencedCloseString); }
+    int mathLineThickness() const final { return intAttributeValue(AXProperty::MathLineThickness); }
     void mathPrescripts(AccessibilityMathMultiscriptPairs&) final;
     void mathPostscripts(AccessibilityMathMultiscriptPairs&) final;
 #if PLATFORM(COCOA)
-    String speechHintAttributeValue() const final { return stringAttributeValue(AXPropertyName::SpeechHint); }
+    String speechHintAttributeValue() const final { return stringAttributeValue(AXProperty::SpeechHint); }
 #endif
     bool fileUploadButtonReturnsValueInTitle() const final;
 #if PLATFORM(MAC)
-    bool caretBrowsingEnabled() const final { return boolAttributeValue(AXPropertyName::CaretBrowsingEnabled); }
+    bool caretBrowsingEnabled() const final { return boolAttributeValue(AXProperty::CaretBrowsingEnabled); }
 #endif
     AXIsolatedObject* focusableAncestor() final { return Accessibility::focusableAncestor(*this); }
     AXIsolatedObject* highestEditableAncestor() final { return Accessibility::highestEditableAncestor(*this); }
-    AccessibilityOrientation orientation() const final { return static_cast<AccessibilityOrientation>(intAttributeValue(AXPropertyName::Orientation)); }
-    unsigned hierarchicalLevel() const final { return unsignedAttributeValue(AXPropertyName::HierarchicalLevel); }
-    String language() const final { return stringAttributeValue(AXPropertyName::Language); }
+    AccessibilityOrientation orientation() const final { return static_cast<AccessibilityOrientation>(intAttributeValue(AXProperty::Orientation)); }
+    unsigned hierarchicalLevel() const final { return unsignedAttributeValue(AXProperty::HierarchicalLevel); }
+    String language() const final { return stringAttributeValue(AXProperty::Language); }
     std::optional<AccessibilityChildrenVector> selectedChildren() final;
     void setSelectedChildren(const AccessibilityChildrenVector&) final;
-    AccessibilityChildrenVector visibleChildren() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXPropertyName::VisibleChildren)); }
+    AccessibilityChildrenVector visibleChildren() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::VisibleChildren)); }
     void setChildrenIDs(Vector<AXID>&&);
     void updateChildrenIfNecessary() final;
     bool isDetachedFromParent() final;
     AXIsolatedObject* liveRegionAncestor(bool excludeIfOff = true) const final { return Accessibility::liveRegionAncestor(*this, excludeIfOff); }
-    const String liveRegionStatus() const final { return stringAttributeValue(AXPropertyName::LiveRegionStatus); }
-    const String liveRegionRelevant() const final { return stringAttributeValue(AXPropertyName::LiveRegionRelevant); }
-    bool liveRegionAtomic() const final { return boolAttributeValue(AXPropertyName::LiveRegionAtomic); }
-    bool isBusy() const final { return boolAttributeValue(AXPropertyName::IsBusy); }
-    bool isInlineText() const final { return boolAttributeValue(AXPropertyName::IsInlineText); }
+    const String liveRegionStatus() const final { return stringAttributeValue(AXProperty::LiveRegionStatus); }
+    const String liveRegionRelevant() const final { return stringAttributeValue(AXProperty::LiveRegionRelevant); }
+    bool liveRegionAtomic() const final { return boolAttributeValue(AXProperty::LiveRegionAtomic); }
+    bool isBusy() const final { return boolAttributeValue(AXProperty::IsBusy); }
+    bool isInlineText() const final { return boolAttributeValue(AXProperty::IsInlineText); }
     // Spin button support.
-    AXIsolatedObject* incrementButton() final { return objectAttributeValue(AXPropertyName::IncrementButton); }
-    AXIsolatedObject* decrementButton() final { return objectAttributeValue(AXPropertyName::DecrementButton); }
-    AccessibilityChildrenVector documentLinks() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXPropertyName::DocumentLinks)); }
-    bool supportsCheckedState() const final { return boolAttributeValue(AXPropertyName::SupportsCheckedState); }
+    AXIsolatedObject* incrementButton() final { return objectAttributeValue(AXProperty::IncrementButton); }
+    AXIsolatedObject* decrementButton() final { return objectAttributeValue(AXProperty::DecrementButton); }
+    AccessibilityChildrenVector documentLinks() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::DocumentLinks)); }
+    bool supportsCheckedState() const final { return boolAttributeValue(AXProperty::SupportsCheckedState); }
 
     String stringValue() const final;
     std::optional<String> platformStringValue() const;
@@ -369,11 +369,11 @@ private:
     AccessibilityChildrenVector findMatchingObjects(AccessibilitySearchCriteria&&) final;
 
 #if PLATFORM(COCOA)
-    bool preventKeyboardDOMEventDispatch() const final { return boolAttributeValue(AXPropertyName::PreventKeyboardDOMEventDispatch); }
+    bool preventKeyboardDOMEventDispatch() const final { return boolAttributeValue(AXProperty::PreventKeyboardDOMEventDispatch); }
 #endif
 
     // CharacterRange support.
-    CharacterRange selectedTextRange() const final { return propertyValue<CharacterRange>(AXPropertyName::SelectedTextRange); }
+    CharacterRange selectedTextRange() const final { return propertyValue<CharacterRange>(AXProperty::SelectedTextRange); }
     int insertionPointLineNumber() const final;
     CharacterRange doAXRangeForLine(unsigned) const final;
     String doAXStringForRange(const CharacterRange&) const final;
@@ -459,24 +459,24 @@ private:
     bool isNativeTextControl() const final;
     bool isMockObject() const final;
     bool isNonNativeTextControl() const final;
-    bool isIndeterminate() const final { return boolAttributeValue(AXPropertyName::IsIndeterminate); }
+    bool isIndeterminate() const final { return boolAttributeValue(AXProperty::IsIndeterminate); }
     bool isLoaded() const final { return loadingProgress() >= 1; }
     bool isOnScreen() const final;
     bool isOffScreen() const final;
     bool isPressed() const final;
-    bool isNonLayerSVGObject() const { return boolAttributeValue(AXPropertyName::IsNonLayerSVGObject); }
+    bool isNonLayerSVGObject() const { return boolAttributeValue(AXProperty::IsNonLayerSVGObject); }
     // FIXME: isVisible should be accurate for all objects, not just widgets, on COCOA.
-    bool isVisible() const final { return boolAttributeValue(AXPropertyName::IsVisible); }
+    bool isVisible() const final { return boolAttributeValue(AXProperty::IsVisible); }
     bool isSelectedOptionActive() const final;
-    bool hasBoldFont() const final { return boolAttributeValue(AXPropertyName::HasBoldFont); }
-    bool hasItalicFont() const final { return boolAttributeValue(AXPropertyName::HasItalicFont); }
+    bool hasBoldFont() const final { return boolAttributeValue(AXProperty::HasBoldFont); }
+    bool hasItalicFont() const final { return boolAttributeValue(AXProperty::HasItalicFont); }
     Vector<AXTextMarkerRange> misspellingRanges() const final;
-    bool hasPlainText() const final { return boolAttributeValue(AXPropertyName::HasPlainText); }
+    bool hasPlainText() const final { return boolAttributeValue(AXProperty::HasPlainText); }
     bool hasSameFont(AXCoreObject&) final;
     bool hasSameFontColor(AXCoreObject&) final;
     bool hasSameStyle(AXCoreObject&) final;
-    bool hasUnderline() const final { return boolAttributeValue(AXPropertyName::HasUnderline); }
-    bool hasHighlighting() const final { return boolAttributeValue(AXPropertyName::HasHighlighting); }
+    bool hasUnderline() const final { return boolAttributeValue(AXProperty::HasUnderline); }
+    bool hasHighlighting() const final { return boolAttributeValue(AXProperty::HasHighlighting); }
     AXTextMarkerRange textInputMarkedTextMarkerRange() const final;
     Element* element() const final;
     Node* node() const final;
@@ -492,8 +492,8 @@ private:
     void setAccessibleName(const AtomString&) final;
 
     String titleAttributeValue() const final;
-    String title() const final { return stringAttributeValue(AXPropertyName::Title); }
-    String description() const final { return stringAttributeValue(AXPropertyName::Description); }
+    String title() const final { return stringAttributeValue(AXProperty::Title); }
+    String description() const final { return stringAttributeValue(AXProperty::Description); }
 
     std::optional<String> textContent() const final;
 
@@ -501,22 +501,22 @@ private:
     unsigned textLength() const final;
 #if PLATFORM(COCOA)
     RetainPtr<NSAttributedString> attributedStringForTextMarkerRange(AXTextMarkerRange&&, SpellCheck) const final;
-    RetainPtr<CTFontRef> font() const final { return propertyValue<RetainPtr<CTFontRef>>(AXPropertyName::Font); }
+    RetainPtr<CTFontRef> font() const final { return propertyValue<RetainPtr<CTFontRef>>(AXProperty::Font); }
 #endif
     AXObjectCache* axObjectCache() const final;
     Element* actionElement() const final;
-    Path elementPath() const final { return pathAttributeValue(AXPropertyName::Path); };
-    bool supportsPath() const final { return boolAttributeValue(AXPropertyName::SupportsPath); }
+    Path elementPath() const final { return pathAttributeValue(AXProperty::Path); };
+    bool supportsPath() const final { return boolAttributeValue(AXProperty::SupportsPath); }
 
     bool isWidget() const final
     {
         // Plugins are a widget subclass.
-        return boolAttributeValue(AXPropertyName::IsPlugin) || boolAttributeValue(AXPropertyName::IsWidget);
+        return boolAttributeValue(AXProperty::IsPlugin) || boolAttributeValue(AXProperty::IsWidget);
     }
     Widget* widget() const final;
     PlatformWidget platformWidget() const final;
     Widget* widgetForAttachmentView() const final;
-    bool isPlugin() const final { return boolAttributeValue(AXPropertyName::IsPlugin); }
+    bool isPlugin() const final { return boolAttributeValue(AXProperty::IsPlugin); }
 
 #if PLATFORM(COCOA)
     RemoteAXObjectRef remoteParentObject() const final;
@@ -536,12 +536,12 @@ private:
     bool isInDescriptionListTerm() const final { return ancestorFlags().contains(AXAncestorFlag::IsInDescriptionListTerm); }
     bool isInCell() const final { return ancestorFlags().contains(AXAncestorFlag::IsInCell); }
 
-    String nameAttribute() const final { return stringAttributeValue(AXPropertyName::NameAttribute); }
+    String nameAttribute() const final { return stringAttributeValue(AXProperty::NameAttribute); }
 #if PLATFORM(COCOA)
-    bool hasApplePDFAnnotationAttribute() const final { return boolAttributeValue(AXPropertyName::HasApplePDFAnnotationAttribute); }
+    bool hasApplePDFAnnotationAttribute() const final { return boolAttributeValue(AXProperty::HasApplePDFAnnotationAttribute); }
     RetainPtr<id> remoteFramePlatformElement() const final;
 #endif
-    bool hasRemoteFrameChild() const final { return boolAttributeValue(AXPropertyName::HasRemoteFrameChild); }
+    bool hasRemoteFrameChild() const final { return boolAttributeValue(AXProperty::HasRemoteFrameChild); }
 
 #if PLATFORM(COCOA) && ENABLE(MODEL_ELEMENT)
     Vector<RetainPtr<id>> modelElementChildren() final;
@@ -572,7 +572,7 @@ private:
 };
 
 template<typename T>
-inline T AXIsolatedObject::propertyValue(AXPropertyName propertyName) const
+inline T AXIsolatedObject::propertyValue(AXProperty propertyName) const
 {
     auto it = m_propertyMap.find(propertyName);
     if (it == m_propertyMap.end())

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -80,11 +80,11 @@ enum class AXPropertyFlag : uint32_t {
     SupportsSetSize                               = 1 << 19
 };
 
-enum class AXPropertyName : uint16_t {
+enum class AXProperty : uint16_t {
     ARIATreeRows,
 #if !ENABLE(AX_THREAD_TEXT_APIS)
     // Rather than caching text content as property when ENABLE(AX_THREAD_TEXT_APIS), we should
-    // synthesize it on-the-fly using AXPropertyName::TextRuns.
+    // synthesize it on-the-fly using AXProperty::TextRuns.
     AttributedText,
 #endif // !ENABLE(AX_THREAD_TEXT_APIS)
     AXColumnCount,
@@ -273,7 +273,7 @@ enum class AXPropertyName : uint16_t {
     SupportsSetSize,
 #if !ENABLE(AX_THREAD_TEXT_APIS)
     // Rather than caching text content as property when ENABLE(AX_THREAD_TEXT_APIS), we should
-    // synthesize it on-the-fly using AXPropertyName::TextRuns.
+    // synthesize it on-the-fly using AXProperty::TextRuns.
     TextContent,
 #endif // !ENABLE(AX_THREAD_TEXT_APIS)
     TextInputMarkedTextMarkerRange,
@@ -291,9 +291,9 @@ enum class AXPropertyName : uint16_t {
     VisibleChildren,
     VisibleRows,
 };
-WTF::TextStream& operator<<(WTF::TextStream&, AXPropertyName);
+WTF::TextStream& operator<<(WTF::TextStream&, AXProperty);
 
-using AXPropertyNameSet = HashSet<AXPropertyName, IntHash<AXPropertyName>, WTF::StrongEnumHashTraits<AXPropertyName>>;
+using AXPropertySet = HashSet<AXProperty, IntHash<AXProperty>, WTF::StrongEnumHashTraits<AXProperty>>;
 
 // If this type is modified, the switchOn statment in AXIsolatedObject::setProperty must be updated as well.
 using AXPropertyValueVariant = std::variant<std::nullptr_t, Markable<AXID>, String, bool, int, unsigned, double, float, uint64_t, WallTime, DateComponentsType, AccessibilityButtonState, Color, std::shared_ptr<URL>, LayoutRect, FloatPoint, FloatRect, IntPoint, IntRect, std::pair<unsigned, unsigned>, Vector<AccessibilityText>, Vector<AXID>, Vector<std::pair<Markable<AXID>, Markable<AXID>>>, Vector<String>, std::shared_ptr<Path>, OptionSet<AXAncestorFlag>, InsideLink, Vector<Vector<Markable<AXID>>>, CharacterRange, std::pair<Markable<AXID>, CharacterRange>
@@ -307,7 +307,7 @@ using AXPropertyValueVariant = std::variant<std::nullptr_t, Markable<AXID>, Stri
     , TextEmissionBehavior
 #endif
 >;
-using AXPropertyMap = UncheckedKeyHashMap<AXPropertyName, AXPropertyValueVariant, IntHash<AXPropertyName>, WTF::StrongEnumHashTraits<AXPropertyName>>;
+using AXPropertyMap = UncheckedKeyHashMap<AXProperty, AXPropertyValueVariant, IntHash<AXProperty>, WTF::StrongEnumHashTraits<AXProperty>>;
 WTF::TextStream& operator<<(WTF::TextStream&, const AXPropertyMap&);
 
 struct AXPropertyChange {
@@ -316,21 +316,21 @@ struct AXPropertyChange {
 };
 
 struct NodeUpdateOptions {
-    AXPropertyNameSet properties;
+    AXPropertySet properties;
     bool shouldUpdateNode { false };
     bool shouldUpdateChildren { false };
 
-    NodeUpdateOptions(const AXPropertyNameSet& propertyNames, bool shouldUpdateNode, bool shouldUpdateChildren)
+    NodeUpdateOptions(const AXPropertySet& propertyNames, bool shouldUpdateNode, bool shouldUpdateChildren)
         : properties(propertyNames)
         , shouldUpdateNode(shouldUpdateNode)
         , shouldUpdateChildren(shouldUpdateChildren)
     { }
 
-    NodeUpdateOptions(const AXPropertyNameSet& propertyNames)
+    NodeUpdateOptions(const AXPropertySet& propertyNames)
         : properties(propertyNames)
     { }
 
-    NodeUpdateOptions(AXPropertyName propertyName)
+    NodeUpdateOptions(AXProperty propertyName)
         : properties({ propertyName })
     { }
 
@@ -384,15 +384,15 @@ public:
     enum class ResolveNodeChanges : bool { No, Yes };
     void updateChildren(AccessibilityObject&, ResolveNodeChanges = ResolveNodeChanges::Yes);
     void updateChildrenForObjects(const ListHashSet<Ref<AccessibilityObject>>&);
-    void updateNodeProperty(AccessibilityObject& object, AXPropertyName property) { updateNodeProperties(object, { property }); }
-    void updateNodeProperties(AccessibilityObject&, const AXPropertyNameSet&);
-    void updateNodeProperties(AccessibilityObject* axObject, const AXPropertyNameSet& properties)
+    void updateNodeProperty(AccessibilityObject& object, AXProperty property) { updateNodeProperties(object, { property }); }
+    void updateNodeProperties(AccessibilityObject&, const AXPropertySet&);
+    void updateNodeProperties(AccessibilityObject* axObject, const AXPropertySet& properties)
     {
         if (axObject)
             updateNodeProperties(*axObject, properties);
     }
     void updateDependentProperties(AccessibilityObject&);
-    void updatePropertiesForSelfAndDescendants(AccessibilityObject&, const AXPropertyNameSet&);
+    void updatePropertiesForSelfAndDescendants(AccessibilityObject&, const AXPropertySet&);
     void updateFrame(AXID, IntRect&&);
     void updateRootScreenRelativePosition();
     void overrideNodeProperties(AXID, AXPropertyMap&&);
@@ -439,7 +439,7 @@ public:
 
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
         objectChangedIgnoredState(object);
-        queueNodeUpdate(object.objectID(), { AXPropertyName::IsIgnored });
+        queueNodeUpdate(object.objectID(), { AXProperty::IsIgnored });
 #endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     }
     void objectBecameUnignored(const AccessibilityObject& object)
@@ -601,7 +601,7 @@ private:
     // Queued node updates used for building a new tree snapshot.
     ListHashSet<AXID> m_needsUpdateChildren;
     ListHashSet<AXID> m_needsUpdateNode;
-    UncheckedKeyHashMap<AXID, AXPropertyNameSet> m_needsPropertyUpdates;
+    UncheckedKeyHashMap<AXID, AXPropertySet> m_needsPropertyUpdates;
 };
 
 inline AXObjectCache* AXIsolatedTree::axObjectCache() const

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -36,19 +36,19 @@ namespace WebCore {
 
 void AXIsolatedObject::initializePlatformProperties(const Ref<const AccessibilityObject>& object)
 {
-    setProperty(AXPropertyName::HasApplePDFAnnotationAttribute, object->hasApplePDFAnnotationAttribute());
-    setProperty(AXPropertyName::SpeechHint, object->speechHintAttributeValue().isolatedCopy());
+    setProperty(AXProperty::HasApplePDFAnnotationAttribute, object->hasApplePDFAnnotationAttribute());
+    setProperty(AXProperty::SpeechHint, object->speechHintAttributeValue().isolatedCopy());
 #if ENABLE(AX_THREAD_TEXT_APIS)
     if (object->isStaticText()) {
         auto style = object->stylesForAttributedString();
-        setProperty(AXPropertyName::BackgroundColor, WTFMove(style.backgroundColor));
-        setProperty(AXPropertyName::Font, style.font);
-        setProperty(AXPropertyName::HasLinethrough, style.hasLinethrough());
-        setProperty(AXPropertyName::HasTextShadow, style.hasTextShadow);
-        setProperty(AXPropertyName::HasUnderline, style.hasUnderline());
-        setProperty(AXPropertyName::IsSubscript, style.isSubscript);
-        setProperty(AXPropertyName::IsSuperscript, style.isSuperscript);
-        setProperty(AXPropertyName::LinethroughColor, style.linethroughColor());
+        setProperty(AXProperty::BackgroundColor, WTFMove(style.backgroundColor));
+        setProperty(AXProperty::Font, style.font);
+        setProperty(AXProperty::HasLinethrough, style.hasLinethrough());
+        setProperty(AXProperty::HasTextShadow, style.hasTextShadow);
+        setProperty(AXProperty::HasUnderline, style.hasUnderline());
+        setProperty(AXProperty::IsSubscript, style.isSubscript);
+        setProperty(AXProperty::IsSuperscript, style.isSuperscript);
+        setProperty(AXProperty::LinethroughColor, style.linethroughColor());
         // FIXME: We're going to end up caching a lot of the same TextColor properties over and over.
         //  1. Should we implement some kind of Color interning?
         //  2. Or maybe have a "main" text color mechanism, where when we create the isolated tree, we try to compute the
@@ -59,15 +59,15 @@ void AXIsolatedObject::initializePlatformProperties(const Ref<const Accessibilit
         //         objects and uncache properties for those with the new "main" color? Not sure if this is worth it...
         //       - Only trigger the walk if font-color changes?
         // Resolve this FIXME before shipping AX_THREAD_TEXT_APIS.
-        setProperty(AXPropertyName::TextColor, WTFMove(style.textColor));
-        setProperty(AXPropertyName::UnderlineColor, style.underlineColor());
+        setProperty(AXProperty::TextColor, WTFMove(style.textColor));
+        setProperty(AXProperty::UnderlineColor, style.underlineColor());
     }
     // FIXME: Can we compute this off the main-thread with our cached text runs?
-    setProperty(AXPropertyName::StringValue, object->stringValue().isolatedCopy());
+    setProperty(AXProperty::StringValue, object->stringValue().isolatedCopy());
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
 
 #if !ENABLE(AX_THREAD_TEXT_APIS)
-    // Do not cache AXPropertyName::AttributedText or AXPropertyName::TextContent when ENABLE(AX_THREAD_TEXT_APIS).
+    // Do not cache AXProperty::AttributedText or AXProperty::TextContent when ENABLE(AX_THREAD_TEXT_APIS).
     // We should instead be synthesizing these on-the-fly using AXProperty::TextRuns.
 
     RetainPtr<NSAttributedString> attributedText;
@@ -83,28 +83,28 @@ void AXIsolatedObject::initializePlatformProperties(const Ref<const Accessibilit
                 range = object->simpleRange();
             if (range) {
                 if ((attributedText = object->attributedStringForRange(*range, SpellCheck::Yes)))
-                    setProperty(AXPropertyName::AttributedText, attributedText);
+                    setProperty(AXProperty::AttributedText, attributedText);
             }
         }
 
         // Cache the TextContent only if it is not empty and differs from the AttributedText.
         if (auto text = object->textContent()) {
             if (!attributedText || (text->length() && *text != String([attributedText string])))
-                setProperty(AXPropertyName::TextContent, text->isolatedCopy());
+                setProperty(AXProperty::TextContent, text->isolatedCopy());
         }
     }
 
     // Cache the StringValue only if it differs from the AttributedText.
     auto value = object->stringValue();
     if (!attributedText || value != String([attributedText string]))
-        setProperty(AXPropertyName::StringValue, value.isolatedCopy());
+        setProperty(AXProperty::StringValue, value.isolatedCopy());
 #endif // !ENABLE(AX_THREAD_TEXT_APIS)
 
-    setProperty(AXPropertyName::RemoteFramePlatformElement, object->remoteFramePlatformElement());
+    setProperty(AXProperty::RemoteFramePlatformElement, object->remoteFramePlatformElement());
 
     if (object->isWebArea()) {
-        setProperty(AXPropertyName::PreventKeyboardDOMEventDispatch, object->preventKeyboardDOMEventDispatch());
-        setProperty(AXPropertyName::CaretBrowsingEnabled, object->caretBrowsingEnabled());
+        setProperty(AXProperty::PreventKeyboardDOMEventDispatch, object->preventKeyboardDOMEventDispatch());
+        setProperty(AXProperty::CaretBrowsingEnabled, object->caretBrowsingEnabled());
     }
 
     if (object->isScrollView()) {
@@ -117,16 +117,16 @@ AttributedStringStyle AXIsolatedObject::stylesForAttributedString() const
 {
     return {
         font(),
-        colorAttributeValue(AXPropertyName::TextColor),
-        colorAttributeValue(AXPropertyName::BackgroundColor),
-        boolAttributeValue(AXPropertyName::IsSubscript),
-        boolAttributeValue(AXPropertyName::IsSuperscript),
-        boolAttributeValue(AXPropertyName::HasTextShadow),
+        colorAttributeValue(AXProperty::TextColor),
+        colorAttributeValue(AXProperty::BackgroundColor),
+        boolAttributeValue(AXProperty::IsSubscript),
+        boolAttributeValue(AXProperty::IsSuperscript),
+        boolAttributeValue(AXProperty::HasTextShadow),
         LineDecorationStyle(
-            boolAttributeValue(AXPropertyName::HasUnderline),
-            colorAttributeValue(AXPropertyName::UnderlineColor),
-            boolAttributeValue(AXPropertyName::HasLinethrough),
-            colorAttributeValue(AXPropertyName::LinethroughColor)
+            boolAttributeValue(AXProperty::HasUnderline),
+            colorAttributeValue(AXProperty::UnderlineColor),
+            boolAttributeValue(AXProperty::HasLinethrough),
+            colorAttributeValue(AXProperty::LinethroughColor)
         )
     };
 }
@@ -177,9 +177,9 @@ std::optional<String> AXIsolatedObject::textContent() const
     if (AXObjectCache::useAXThreadTextApis())
         return textMarkerRange().toString();
 #else
-    if (m_propertyMap.contains(AXPropertyName::TextContent))
-        return stringAttributeValue(AXPropertyName::TextContent);
-    if (auto attributedText = propertyValue<RetainPtr<NSAttributedString>>(AXPropertyName::AttributedText))
+    if (m_propertyMap.contains(AXProperty::TextContent))
+        return stringAttributeValue(AXProperty::TextContent);
+    if (auto attributedText = propertyValue<RetainPtr<NSAttributedString>>(AXProperty::AttributedText))
         return String { [attributedText string] };
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
     return { };
@@ -253,7 +253,7 @@ std::optional<String> AXIsolatedObject::platformStringValue() const
     if (AXObjectCache::useAXThreadTextApis())
         return textMarkerRange().toString();
 #else
-    if (auto attributedText = propertyValue<RetainPtr<NSAttributedString>>(AXPropertyName::AttributedText))
+    if (auto attributedText = propertyValue<RetainPtr<NSAttributedString>>(AXProperty::AttributedText))
         return [attributedText string];
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
     return { };
@@ -267,7 +267,7 @@ unsigned AXIsolatedObject::textLength() const
     if (AXObjectCache::useAXThreadTextApis())
         return textMarkerRange().toString().length();
 #else
-    if (auto attributedText = propertyValue<RetainPtr<NSAttributedString>>(AXPropertyName::AttributedText))
+    if (auto attributedText = propertyValue<RetainPtr<NSAttributedString>>(AXProperty::AttributedText))
         return [attributedText length];
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
     return 0;
@@ -275,7 +275,7 @@ unsigned AXIsolatedObject::textLength() const
 
 RetainPtr<id> AXIsolatedObject::remoteFramePlatformElement() const
 {
-    return propertyValue<RetainPtr<id>>(AXPropertyName::RemoteFramePlatformElement);
+    return propertyValue<RetainPtr<id>>(AXProperty::RemoteFramePlatformElement);
 }
 
 RetainPtr<NSAttributedString> AXIsolatedObject::attributedStringForTextMarkerRange(AXTextMarkerRange&& markerRange, SpellCheck spellCheck) const
@@ -301,7 +301,7 @@ RetainPtr<NSAttributedString> AXIsolatedObject::attributedStringForTextMarkerRan
 
     RetainPtr<NSAttributedString> attributedText = nil;
 #if !ENABLE(AX_THREAD_TEXT_APIS)
-    attributedText = propertyValue<RetainPtr<NSAttributedString>>(AXPropertyName::AttributedText);
+    attributedText = propertyValue<RetainPtr<NSAttributedString>>(AXProperty::AttributedText);
 #endif // !ENABLE(AX_THREAD_TEXT_APIS)
     if (!isConfined || !attributedText) {
         return Accessibility::retrieveValueFromMainThread<RetainPtr<NSAttributedString>>([markerRange = WTFMove(markerRange), &spellCheck, this] () mutable -> RetainPtr<NSAttributedString> {
@@ -346,7 +346,7 @@ void AXIsolatedObject::setPreventKeyboardDOMEventDispatch(bool value)
     ASSERT(!isMainThread());
     ASSERT(isWebArea());
 
-    setProperty(AXPropertyName::PreventKeyboardDOMEventDispatch, value);
+    setProperty(AXProperty::PreventKeyboardDOMEventDispatch, value);
     performFunctionOnMainThread([value] (auto* object) {
         object->setPreventKeyboardDOMEventDispatch(value);
     });
@@ -357,7 +357,7 @@ void AXIsolatedObject::setCaretBrowsingEnabled(bool value)
     ASSERT(!isMainThread());
     ASSERT(isWebArea());
 
-    setProperty(AXPropertyName::CaretBrowsingEnabled, value);
+    setProperty(AXProperty::CaretBrowsingEnabled, value);
     performFunctionOnMainThread([value] (auto* object) {
         object->setCaretBrowsingEnabled(value);
     });


### PR DESCRIPTION
#### 5592179d5613f47a4b4659f02bf9713c54086670
<pre>
AX: Rename AXPropertyName to AXProperty
<a href="https://bugs.webkit.org/show_bug.cgi?id=285083">https://bugs.webkit.org/show_bug.cgi?id=285083</a>
<a href="https://rdar.apple.com/141912978">rdar://141912978</a>

Reviewed by Chris Fleizach.

The &quot;Name&quot; suffix in AXPropertyName doesn&apos;t add much value, so changing it to AXProperty makes our code more concise.

* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onEventListenerAdded):
(WebCore::AXObjectCache::onEventListenerRemoved):
(WebCore::AXObjectCache::onRemoteFrameInitialized):
(WebCore::AXObjectCache::onInertOrVisibilityChange):
(WebCore::AXObjectCache::onStyleChange):
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::performDeferredCacheUpdate):
(WebCore::AXObjectCache::updateIsolatedTree):
(WebCore::AXObjectCache::updateIsolatedTree const):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::AXCoreObject::createAttributedString const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
(WebCore::AXIsolatedObject::setMathscripts):
(WebCore::AXIsolatedObject::setObjectProperty):
(WebCore::AXIsolatedObject::setObjectVectorProperty):
(WebCore::AXIsolatedObject::setProperty):
(WebCore::AXIsolatedObject::selectedChildren):
(WebCore::AXIsolatedObject::cellForColumnAndRow):
(WebCore::AXIsolatedObject::accessibilityText const):
(WebCore::AXIsolatedObject::mathPrescripts):
(WebCore::AXIsolatedObject::mathPostscripts):
(WebCore::AXIsolatedObject::mathRadicand):
(WebCore::AXIsolatedObject::scrollBar):
(WebCore::AXIsolatedObject::colorValue const):
(WebCore::AXIsolatedObject::intPointAttributeValue const):
(WebCore::AXIsolatedObject::objectAttributeValue const):
(WebCore::AXIsolatedObject::rectAttributeValue const):
(WebCore::AXIsolatedObject::vectorAttributeValue const):
(WebCore::AXIsolatedObject::optionSetAttributeValue const):
(WebCore::AXIsolatedObject::indexRangePairAttributeValue const):
(WebCore::AXIsolatedObject::optionalAttributeValue const):
(WebCore::AXIsolatedObject::uint64AttributeValue const):
(WebCore::AXIsolatedObject::urlAttributeValue const):
(WebCore::AXIsolatedObject::pathAttributeValue const):
(WebCore::AXIsolatedObject::colorAttributeValue const):
(WebCore::AXIsolatedObject::floatAttributeValue const):
(WebCore::AXIsolatedObject::doubleAttributeValue const):
(WebCore::AXIsolatedObject::unsignedAttributeValue const):
(WebCore::AXIsolatedObject::boolAttributeValue const):
(WebCore::AXIsolatedObject::stringAttributeValue const):
(WebCore::AXIsolatedObject::stringAttributeValueNullIfMissing const):
(WebCore::AXIsolatedObject::intAttributeValue const):
(WebCore::AXIsolatedObject::textRuns const):
(WebCore::AXIsolatedObject::getOrRetrievePropertyValue):
(WebCore::AXIsolatedObject::fillChildrenVectorForProperty const):
(WebCore::AXIsolatedObject::remoteFrameOffset const):
(WebCore::AXIsolatedObject::screenRelativePosition const):
(WebCore::AXIsolatedObject::relativeFrame const):
(WebCore::AXIsolatedObject::insertionPointLineNumber const):
(WebCore::AXIsolatedObject::identifierAttribute const):
(WebCore::AXIsolatedObject::isPressed const):
(WebCore::AXIsolatedObject::hasSameFontColor):
(WebCore::AXIsolatedObject::textInputMarkedTextMarkerRange const):
(WebCore::AXIsolatedObject::titleAttributeValue const):
(WebCore::AXIsolatedObject::stringValue const):
(WebCore::AXIsolatedObject::ancestorFlags const):
(WebCore::AXIsolatedObject::innerHTML const):
(WebCore::AXIsolatedObject::outerHTML const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
(WebCore::AXIsolatedObject::propertyValue const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::createEmptyContent):
(WebCore::AXIsolatedTree::reportLoadingProgress):
(WebCore::AXIsolatedTree::objectChangedIgnoredState):
(WebCore::AXIsolatedTree::updatePropertiesForSelfAndDescendants):
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::AXIsolatedTree::updateDependentProperties):
(WebCore::AXIsolatedTree::updateFrame):
(WebCore::AXIsolatedTree::updateRootScreenRelativePosition):
(WebCore::AXIsolatedTree::removeNode):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::NodeUpdateOptions::NodeUpdateOptions):
(WebCore::AXIsolatedTree::updateNodeProperty):
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::AXIsolatedTree::objectBecameIgnored):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::initializePlatformProperties):
(WebCore::AXIsolatedObject::stylesForAttributedString const):
(WebCore::AXIsolatedObject::textContent const):
(WebCore::AXIsolatedObject::platformStringValue const):
(WebCore::AXIsolatedObject::textLength const):
(WebCore::AXIsolatedObject::remoteFramePlatformElement const):
(WebCore::AXIsolatedObject::attributedStringForTextMarkerRange const):
(WebCore::AXIsolatedObject::setPreventKeyboardDOMEventDispatch):
(WebCore::AXIsolatedObject::setCaretBrowsingEnabled):

Canonical link: <a href="https://commits.webkit.org/288241@main">https://commits.webkit.org/288241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49c6f665af81caf671d4df2f3d52ea8dde832c63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87334 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33263 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64065 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21806 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85271 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1333 "Found 1 new test failure: compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44343 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1232 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28973 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32304 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72535 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88690 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9508 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72456 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71674 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17877 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15804 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/860 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9461 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14943 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9335 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12800 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11104 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->