### PR TITLE
"Look Up" and "Search Web" should appear in the edit menu for selected text

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -89,6 +89,8 @@ class WebMouseEvent;
 class WebWheelEvent;
 enum class SelectionEndpoint : bool;
 enum class SelectionWasFlipped : bool;
+struct DocumentEditingContextRequest;
+struct DocumentEditingContext;
 struct EditorState;
 struct WebHitTestResultData;
 
@@ -181,6 +183,7 @@ public:
 
     virtual String fullDocumentString() const { return { }; }
     virtual String selectionString() const = 0;
+    virtual std::pair<String, String> stringsBeforeAndAfterSelection(int /* characterCount */) const { return { }; }
     virtual bool existingSelectionContainsPoint(const WebCore::FloatPoint&) const = 0;
     virtual WebCore::FloatRect rectForSelectionInRootView(PDFSelection *) const = 0;
 
@@ -324,6 +327,7 @@ public:
     virtual SelectionWasFlipped moveSelectionEndpoint(WebCore::FloatPoint /* pointInRootView */, SelectionEndpoint);
     virtual SelectionEndpoint extendInitialSelection(WebCore::FloatPoint /* pointInRootView */, WebCore::TextGranularity);
     virtual CursorContext cursorContext(WebCore::FloatPoint /* pointInRootView */) const { return { }; }
+    virtual DocumentEditingContext documentEditingContext(DocumentEditingContextRequest&&) const;
 #endif
 
     bool populateEditorStateIfNeeded(EditorState&) const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -28,6 +28,7 @@
 
 #if ENABLE(PDF_PLUGIN)
 
+#import "DocumentEditingContext.h"
 #import "EditorState.h"
 #import "GestureTypes.h"
 #import "Logging.h"
@@ -1291,6 +1292,11 @@ SelectionWasFlipped PDFPluginBase::moveSelectionEndpoint(FloatPoint, SelectionEn
 SelectionEndpoint PDFPluginBase::extendInitialSelection(FloatPoint pointInRootView, TextGranularity)
 {
     return SelectionEndpoint::Start;
+}
+
+DocumentEditingContext PDFPluginBase::documentEditingContext(DocumentEditingContextRequest&&) const
+{
+    return { };
 }
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -70,6 +70,8 @@ class PDFPresentationController;
 class WebFrame;
 class WebMouseEvent;
 struct EditorState;
+struct DocumentEditingContextRequest;
+struct DocumentEditingContext;
 struct PDFContextMenu;
 struct PDFContextMenuItem;
 
@@ -402,6 +404,7 @@ private:
 
     String fullDocumentString() const override;
     String selectionString() const override;
+    std::pair<String, String> stringsBeforeAndAfterSelection(int characterCount) const override;
     bool existingSelectionContainsPoint(const WebCore::FloatPoint&) const override;
     WebCore::FloatRect rectForSelectionInRootView(PDFSelection *) const override;
 
@@ -589,6 +592,7 @@ private:
     SelectionEndpoint extendInitialSelection(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity) final;
     bool platformPopulateEditorStateIfNeeded(EditorState&) const final;
     CursorContext cursorContext(WebCore::FloatPoint pointInRootView) const final;
+    DocumentEditingContext documentEditingContext(DocumentEditingContextRequest&&) const final;
 
 #if HAVE(PDFDOCUMENT_SELECTION_WITH_GRANULARITY)
     PDFSelection *selectionAtPoint(WebCore::FloatPoint pointInPage, PDFPage *, WebCore::TextGranularity) const;

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(PDF_PLUGIN)
 
+#include "DocumentEditingContext.h"
 #include "FrameInfoData.h"
 #include "PDFPlugin.h"
 #include "UnifiedPDFPlugin.h"
@@ -687,6 +688,14 @@ String PluginView::selectionString() const
     return protectedPlugin()->selectionString();
 }
 
+std::pair<String, String> PluginView::stringsBeforeAndAfterSelection(int characterCount) const
+{
+    if (!m_isInitialized)
+        return { };
+
+    return protectedPlugin()->stringsBeforeAndAfterSelection(characterCount);
+}
+
 void PluginView::handleEvent(Event& event)
 {
     if (!m_isInitialized)
@@ -1137,6 +1146,11 @@ SelectionWasFlipped PluginView::moveSelectionEndpoint(FloatPoint pointInRootView
 SelectionEndpoint PluginView::extendInitialSelection(FloatPoint pointInRootView, TextGranularity granularity)
 {
     return protectedPlugin()->extendInitialSelection(pointInRootView, granularity);
+}
+
+DocumentEditingContext PluginView::documentEditingContext(DocumentEditingContextRequest&& request) const
+{
+    return protectedPlugin()->documentEditingContext(WTFMove(request));
 }
 
 void PluginView::clearSelection()

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -61,6 +61,8 @@ class WebFrame;
 class WebPage;
 enum class SelectionEndpoint : bool;
 enum class SelectionWasFlipped : bool;
+struct DocumentEditingContextRequest;
+struct DocumentEditingContext;
 struct EditorState;
 struct FrameInfoData;
 struct WebHitTestResultData;
@@ -106,6 +108,7 @@ public:
     SelectionWasFlipped moveSelectionEndpoint(WebCore::FloatPoint pointInRootView, SelectionEndpoint);
     SelectionEndpoint extendInitialSelection(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity);
     CursorContext cursorContext(WebCore::FloatPoint pointInRootView) const;
+    DocumentEditingContext documentEditingContext(DocumentEditingContextRequest&&) const;
 #endif
 
     bool populateEditorStateIfNeeded(EditorState&) const;
@@ -130,6 +133,7 @@ public:
 
     String fullDocumentString() const;
     String selectionString() const;
+    std::pair<String, String> stringsBeforeAndAfterSelection(int characterCount) const;
 
     RefPtr<WebCore::FragmentedSharedBuffer> liveResourceData() const;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm
@@ -150,27 +150,6 @@ static UIWKDocumentRequest *makeRequest(UIWKDocumentRequestFlags flags, UITextGr
 
 @implementation TestWKWebView (SynchronousDocumentContext)
 
-- (UIWKDocumentContext *)synchronouslyRequestDocumentContext:(UIWKDocumentRequest *)request
-{
-    __block bool finished = false;
-    __block RetainPtr<id> result;
-    [self.textInputContentView requestDocumentContext:request completionHandler:^(UIWKDocumentContext *context) {
-        result = context;
-        finished = true;
-    }];
-    TestWebKitAPI::Util::run(&finished);
-
-#if USE(BROWSERENGINEKIT)
-    if (RetainPtr context = dynamic_objc_cast<BETextDocumentContext>(result.get()))
-        return [context _uikitDocumentContext];
-#endif
-
-    if (RetainPtr context = dynamic_objc_cast<UIWKDocumentContext>(result.get()))
-        return context.autorelease();
-
-    return nil;
-}
-
 - (UITextPlaceholder *)synchronouslyInsertTextPlaceholderWithSize:(CGSize)size
 {
     __block bool finished = false;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -35,6 +35,8 @@
 @class _WKActivatedElementInfo;
 @class _WKTextInputContext;
 @class UITextSuggestion;
+@class UIWKDocumentContext;
+@class UIWKDocumentRequest;
 @protocol UITextInputInternal;
 @protocol UITextInputMultiDocument;
 @protocol UITextInputPrivate;
@@ -99,6 +101,9 @@ class Color;
 - (void)moveSelectionToEndOfParagraph;
 - (void)extendSelectionToEndOfParagraph;
 - (void)insertTextSuggestion:(UITextSuggestion *)textSuggestion;
+#if HAVE(UI_WK_DOCUMENT_CONTEXT)
+- (UIWKDocumentContext *)synchronouslyRequestDocumentContext:(UIWKDocumentRequest *)request;
+#endif
 #endif // PLATFORM(IOS_FAMILY)
 
 @property (nonatomic, readonly) CGImageRef snapshotAfterScreenUpdates;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -284,6 +284,31 @@ static NSString *overrideBundleIdentifier(id, SEL)
     [self.textInputContentView insertTextSuggestion:textSuggestion];
 }
 
+#if HAVE(UI_WK_DOCUMENT_CONTEXT)
+
+- (UIWKDocumentContext *)synchronouslyRequestDocumentContext:(UIWKDocumentRequest *)request
+{
+    __block bool finished = false;
+    __block RetainPtr<id> result;
+    [self.textInputContentView requestDocumentContext:request completionHandler:^(UIWKDocumentContext *context) {
+        result = context;
+        finished = true;
+    }];
+    TestWebKitAPI::Util::run(&finished);
+
+#if USE(BROWSERENGINEKIT)
+    if (RetainPtr context = dynamic_objc_cast<BETextDocumentContext>(result.get()))
+        return [context _uikitDocumentContext];
+#endif
+
+    if (RetainPtr context = dynamic_objc_cast<UIWKDocumentContext>(result.get()))
+        return context.autorelease();
+
+    return nil;
+}
+
+#endif // HAVE(UI_WK_DOCUMENT_CONTEXT)
+
 #if USE(BROWSERENGINEKIT)
 
 - (id<BETextInput>)asyncTextInput


### PR DESCRIPTION
#### f778680e9ba45d5bbcd17b16dd4e32886370e73e
<pre>
&quot;Look Up&quot; and &quot;Search Web&quot; should appear in the edit menu for selected text
<a href="https://bugs.webkit.org/show_bug.cgi?id=285086">https://bugs.webkit.org/show_bug.cgi?id=285086</a>
<a href="https://rdar.apple.com/141917634">rdar://141917634</a>

Reviewed by Abrar Rahman Protyasha.

Add support for a few more text services: &quot;Look Up&quot; and &quot;Search Web&quot;, through the edit menu for
selected text in PDFs when Unified PDF is enabled. See below for more details.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::stringsBeforeAndAfterSelection const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::documentEditingContext const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::stringsBeforeAndAfterSelection const):

Add a new helper method to surface text (i.e. a given number of characters) around the current
selection, as a `std::pair` representing text before and after (respectively).

(WebKit::UnifiedPDFPlugin::documentEditingContext const):

Add a helper method to return a document editing context for the given request. This only surfaces
selected text at the moment, but can be fleshed out in the future if needed.

* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::stringsBeforeAndAfterSelection const):
(WebKit::PluginView::documentEditingContext const):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::getSelectionContext):

Implement this for the unified PDF plugin in terms of the new `stringsBeforeAndAfterSelection`
helper method. Look Up uses this to obtain text context around the selection string.

(WebKit::WebPage::requestDocumentEditingContext):

Add very basic support for document editing contexts in PDFs — DataDetectorsUI uses a Reveal item
derived from the document editing context to determine whether or not they should populate the edit
menu with &quot;Look Up&quot; and &quot;Search Web&quot;. We currently return an empty document editing context, which
causes this to fail.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm:
(-[TestWKWebView synchronouslyRequestDocumentContext:]): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):

Add a new API test to exercise this change by simulating the &quot;Look Up&quot; action from API.

* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[WKWebView synchronouslyRequestDocumentContext:]):

Move this testing helper out of the test file and into `TestWKWebView`, for use in Unified PDF
tests as well.

Canonical link: <a href="https://commits.webkit.org/288247@main">https://commits.webkit.org/288247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a6c7b1035dc05941de08339605d5317c213b098

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87360 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33289 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84333 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64083 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21833 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44361 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1256 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28998 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32330 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88716 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9534 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6792 "Found 1 new test failure: http/wpt/mediarecorder/record-96KHz-sources.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72474 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71692 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17880 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15826 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/14849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/886 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9487 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14977 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9361 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12827 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11130 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->