### PR TITLE
AX: AXProperty::SupportsDragging isn't updated when the draggable attribute changes

### DIFF
--- a/LayoutTests/accessibility/mac/supports-grabbed-after-dynamic-change-expected.txt
+++ b/LayoutTests/accessibility/mac/supports-grabbed-after-dynamic-change-expected.txt
@@ -1,0 +1,15 @@
+This test ensures that we report whether an object supports AXGrabbed correctly after dynamic page changes.
+
+PASS: axInput1.isAttributeSupported('AXGrabbed') === false
+PASS: axInput2.isAttributeSupported('AXGrabbed') === false
+PASS: axInput1.isAttributeSupported('AXGrabbed') === true
+PASS: axInput1.isAttributeSupported('AXGrabbed') === false
+PASS: axInput1.isAttributeSupported('AXGrabbed') === true
+PASS: axInput2.isAttributeSupported('AXGrabbed') === true
+PASS: axInput2.isAttributeSupported('AXGrabbed') === false
+PASS: axInput2.isAttributeSupported('AXGrabbed') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/supports-grabbed-after-dynamic-change.html
+++ b/LayoutTests/accessibility/mac/supports-grabbed-after-dynamic-change.html
@@ -1,0 +1,48 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input id="input1" type="text" />
+<input id="input2" type="text" />
+
+<script>
+var output = "This test ensures that we report whether an object supports AXGrabbed correctly after dynamic page changes.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var input1 = document.getElementById("input1");
+    var axInput1 = accessibilityController.accessibleElementById("input1");
+    var input2 = document.getElementById("input2");
+    var axInput2 = accessibilityController.accessibleElementById("input2");
+
+    output += expect("axInput1.isAttributeSupported('AXGrabbed')", "false");
+    output += expect("axInput2.isAttributeSupported('AXGrabbed')", "false");
+
+    input1.setAttribute("draggable", "true");
+    setTimeout(async function() {
+        output += await expectAsync("axInput1.isAttributeSupported('AXGrabbed')", "true");
+        input1.removeAttribute("draggable");
+        output += await expectAsync("axInput1.isAttributeSupported('AXGrabbed')", "false");
+        input1.setAttribute("draggable", "false");
+        output += await expectAsync("axInput1.isAttributeSupported('AXGrabbed')", "true");
+
+        input2.setAttribute("aria-grabbed", "false");
+        output += await expectAsync("axInput2.isAttributeSupported('AXGrabbed')", "true");
+        input2.removeAttribute("aria-grabbed");
+        output += await expectAsync("axInput2.isAttributeSupported('AXGrabbed')", "false");
+        input2.setAttribute("aria-grabbed", "true");
+        output += await expectAsync("axInput2.isAttributeSupported('AXGrabbed')", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2757,6 +2757,8 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
         }
     }
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    else if (attrName == draggableAttr)
+        postNotification(get(*element), AXNotification::DraggableStateChanged);
     else if (attrName == langAttr)
         updateIsolatedTree(get(*element), AXNotification::LanguageChanged);
     else if (attrName == nameAttr)
@@ -4617,6 +4619,9 @@ void AXObjectCache::updateIsolatedTree(const Vector<std::pair<Ref<AccessibilityO
             break;
         case AXNotification::DisabledStateChanged:
             tree->updatePropertiesForSelfAndDescendants(notification.first.get(), { { AXProperty::CanSetFocusAttribute, AXProperty::CanSetSelectedAttribute, AXProperty::IsEnabled } });
+            break;
+        case AXNotification::DraggableStateChanged:
+            tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::SupportsDragging });
             break;
         case AXNotification::ExpandedChanged:
             tree->queueNodeUpdate(notification.first->objectID(), { AXProperty::IsExpanded });

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -175,6 +175,7 @@ protected:
     macro(DatetimeChanged) \
     macro(DescribedByChanged) \
     macro(DisabledStateChanged) \
+    macro(DraggableStateChanged) \
     macro(DropEffectChanged) \
     macro(ExtendedDescriptionChanged) \
     macro(FlowToChanged) \

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -926,6 +926,12 @@ Vector<String> AccessibilityNodeObject::determineDropEffects() const
     if (!webkitdropzone.isEmpty())
         return Vector<String> { webkitdropzone };
 
+    // FIXME: We should return drop effects for elements with `dragenter` and `dragover` event handlers.
+    // dropzone and webkitdropzone used to serve this purpose, but are deprecated in favor of the
+    // aforementioned event handlers.
+    //
+    // https://html.spec.whatwg.org/dev/obsolete.html:
+    // "dropzone on all elements: Use script to handle the dragenter and dragover events instead."
     return { };
 }
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -181,6 +181,7 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
     // Don't cache ID when logging is disabled because we don't expect non-test AX clients to actually request it.
     setProperty(AXProperty::IdentifierAttribute, object.identifierAttribute().isolatedCopy());
 #endif
+    // FIXME: We never update AXProperty::SupportsDropping.
     setProperty(AXProperty::SupportsDropping, object.supportsDropping());
     setProperty(AXProperty::SupportsDragging, object.supportsDragging());
     setProperty(AXProperty::IsGrabbed, object.isGrabbed());

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -777,6 +777,9 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
         case AXProperty::SupportsExpanded:
             propertyMap.set(AXProperty::SupportsExpanded, axObject.supportsExpanded());
             break;
+        case AXProperty::SupportsDragging:
+            propertyMap.set(AXProperty::SupportsDragging, axObject.supportsDragging());
+            break;
         case AXProperty::SupportsPosInSet:
             propertyMap.set(AXProperty::SupportsPosInSet, axObject.supportsPosInSet());
             break;


### PR DESCRIPTION
#### 3e77b719af8b3ad479b5c878377e9a11ba808ab2
<pre>
AX: AXProperty::SupportsDragging isn&apos;t updated when the draggable attribute changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=285088">https://bugs.webkit.org/show_bug.cgi?id=285088</a>
<a href="https://rdar.apple.com/141922026">rdar://141922026</a>

Reviewed by Chris Fleizach.

With this commit, we update AXProperty::SupportsDragging when the draggable attribute changes.

* LayoutTests/accessibility/mac/supports-grabbed-after-dynamic-change-expected.txt: Added.
* LayoutTests/accessibility/mac/supports-grabbed-after-dynamic-change.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::updateIsolatedTree):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::determineDropEffects const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):

Canonical link: <a href="https://commits.webkit.org/288260@main">https://commits.webkit.org/288260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83796baed8a840b075a7868b5bed24b73f04f7ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87355 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33284 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64080 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21824 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44358 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28995 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32325 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72553 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88711 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9529 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6786 "Found 1 new test failure: http/wpt/mediarecorder/MediaRecorder-video-h264-profiles.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72471 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9755 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71689 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17885 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15820 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14848 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/881 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9482 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14968 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9356 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12822 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11125 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->