### PR TITLE
[JSC] Optimize `Array#at` in DFG/FTL

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-at-in-bounds-contiguous-neg.js
+++ b/JSTests/microbenchmarks/array-prototype-at-in-bounds-contiguous-neg.js
@@ -1,0 +1,21 @@
+function test(array) {
+    var result;
+    for (let i = 0; i < 1e6; i++) {
+        result = array.at(-3);
+    }
+    return result;
+}
+
+noInline(test);
+
+var array = [
+    { value: 12 }, { value: 4 }, { value: 4 }, { value: 66 }, { value: 56 },
+    { value: 44 }, { value: 44 }, { value: 38 }, { value: 65 }, { value: 89 },
+    { value: 2 }, { value: 45 }, { value: 789 }, { value: 56 }, { value: 432 },
+    { value: 677 }, { value: 2234 }, { value: 77 }, { value: 3457 }, { value: 133 },
+    { value: 6544 }, { value: 76 }, { value: 17 }, { value: 322 }, { value: 34 }
+];
+var result = test(array);
+if (result.value != 17)
+    throw "Bad result: " + JSON.stringify(result);
+

--- a/JSTests/microbenchmarks/array-prototype-at-in-bounds-contiguous.js
+++ b/JSTests/microbenchmarks/array-prototype-at-in-bounds-contiguous.js
@@ -1,0 +1,21 @@
+function test(array) {
+    var result;
+    for (let i = 0; i < 1e6; i++) {
+        result = array.at(4);
+    }
+    return result;
+}
+
+noInline(test);
+
+var array = [
+    { value: 12 }, { value: 4 }, { value: 4 }, { value: 66 }, { value: 56 },
+    { value: 44 }, { value: 44 }, { value: 38 }, { value: 65 }, { value: 89 },
+    { value: 2 }, { value: 45 }, { value: 789 }, { value: 56 }, { value: 432 },
+    { value: 677 }, { value: 2234 }, { value: 77 }, { value: 3457 }, { value: 133 },
+    { value: 6544 }, { value: 76 }, { value: 17 }, { value: 322 }, { value: 34 }
+];
+var result = test(array);
+if (result.value != 56)
+    throw "Bad result: " + JSON.stringify(result);
+

--- a/JSTests/microbenchmarks/array-prototype-at-in-bounds-double-neg.js
+++ b/JSTests/microbenchmarks/array-prototype-at-in-bounds-double-neg.js
@@ -1,0 +1,15 @@
+function test(array) {
+    var result;
+    for (let i = 0; i < 1e6; i++) {
+        result = array.at(-4);
+    }
+    return result;
+}
+
+noInline(test);
+
+var array = [12.5, 4.5, 4.5, 66.5, 56.5, 44.5, 44.5, 38.5, 65.5, 89.5, 2.5, 45.5, 789.5, 56.5, 432.5, 677.5, 2234.5, 77.5, 3457.5, 133.5, 6544.5, 76.5, 17.5, 322.5, 34.5];
+var result = test(array);
+if (result != 76.5)
+    throw "Bad result: " + result;
+

--- a/JSTests/microbenchmarks/array-prototype-at-in-bounds-double.js
+++ b/JSTests/microbenchmarks/array-prototype-at-in-bounds-double.js
@@ -1,0 +1,15 @@
+function test(array) {
+    var result;
+    for (let i = 0; i < 1e6; i++) {
+        result = array.at(4);
+    }
+    return result;
+}
+
+noInline(test);
+
+var array = [12.5, 4.5, 4.5, 66.5, 56.5, 44.5, 44.5, 38.5, 65.5, 89.5, 2.5, 45.5, 789.5, 56.5, 432.5, 677.5, 2234.5, 77.5, 3457.5, 133.5, 6544.5, 76.5, 17.5, 322.5, 34.5];
+var result = test(array);
+if (result != 56.5)
+    throw "Bad result: " + result;
+

--- a/JSTests/microbenchmarks/array-prototype-at-in-bounds-int32-neg.js
+++ b/JSTests/microbenchmarks/array-prototype-at-in-bounds-int32-neg.js
@@ -1,0 +1,15 @@
+function test(array) {
+    var result;
+    for (let i = 0; i < 1e6; i++) {
+        result = array.at(-4);
+    }
+    return result;
+}
+
+noInline(test);
+
+var array = [12,4,4,66,56,44,44,38,65,89,2,45,789,56,432,677,2234,77,3457,133,6544,76,17,322,34];
+var result = test(array);
+if (result != 76)
+    throw "Bad result: " + result;
+

--- a/JSTests/microbenchmarks/array-prototype-at-in-bounds-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-at-in-bounds-int32.js
@@ -1,0 +1,15 @@
+function test(array) {
+    var result;
+    for (let i = 0; i < 1e6; i++) {
+        result = array.at(4);
+    }
+    return result;
+}
+
+noInline(test);
+
+var array = [12,4,4,66,56,44,44,38,65,89,2,45,789,56,432,677,2234,77,3457,133,6544,76,17,322,34];
+var result = test(array);
+if (result != 56)
+    throw "Bad result: " + result;
+

--- a/JSTests/microbenchmarks/array-prototype-at-out-of-bounds-contiguous-neg.js
+++ b/JSTests/microbenchmarks/array-prototype-at-out-of-bounds-contiguous-neg.js
@@ -1,0 +1,21 @@
+function test(array) {
+    var result;
+    for (let i = 0; i < 1e6; i++) {
+        result = array.at(-1000);
+    }
+    return result;
+}
+
+noInline(test);
+
+var array = [
+    { value: 12 }, { value: 4 }, { value: 4 }, { value: 66 }, { value: 56 },
+    { value: 44 }, { value: 44 }, { value: 38 }, { value: 65 }, { value: 89 },
+    { value: 2 }, { value: 45 }, { value: 789 }, { value: 56 }, { value: 432 },
+    { value: 677 }, { value: 2234 }, { value: 77 }, { value: 3457 }, { value: 133 },
+    { value: 6544 }, { value: 76 }, { value: 17 }, { value: 322 }, { value: 34 }
+];
+var result = test(array);
+if (result !== undefined)
+    throw "Bad result: " + JSON.stringify(result);
+

--- a/JSTests/microbenchmarks/array-prototype-at-out-of-bounds-contiguous.js
+++ b/JSTests/microbenchmarks/array-prototype-at-out-of-bounds-contiguous.js
@@ -1,0 +1,21 @@
+function test(array) {
+    var result;
+    for (let i = 0; i < 1e6; i++) {
+        result = array.at(1000);
+    }
+    return result;
+}
+
+noInline(test);
+
+var array = [
+    { value: 12 }, { value: 4 }, { value: 4 }, { value: 66 }, { value: 56 },
+    { value: 44 }, { value: 44 }, { value: 38 }, { value: 65 }, { value: 89 },
+    { value: 2 }, { value: 45 }, { value: 789 }, { value: 56 }, { value: 432 },
+    { value: 677 }, { value: 2234 }, { value: 77 }, { value: 3457 }, { value: 133 },
+    { value: 6544 }, { value: 76 }, { value: 17 }, { value: 322 }, { value: 34 }
+];
+var result = test(array);
+if (result !== undefined)
+    throw "Bad result: " + JSON.stringify(result);
+

--- a/JSTests/microbenchmarks/array-prototype-at-out-of-bounds-double-neg.js
+++ b/JSTests/microbenchmarks/array-prototype-at-out-of-bounds-double-neg.js
@@ -1,0 +1,15 @@
+function test(array) {
+    var result;
+    for (let i = 0; i < 1e6; i++) {
+        result = array.at(-1000);
+    }
+    return result;
+}
+
+noInline(test);
+
+var array = [12.5, 4.5, 4.5, 66.5, 56.5, 44.5, 44.5, 38.5, 65.5, 89.5, 2.5, 45.5, 789.5, 56.5, 432.5, 677.5, 2234.5, 77.5, 3457.5, 133.5, 6544.5, 76.5, 17.5, 322.5, 34.5];
+var result = test(array);
+if (result !== undefined)
+    throw "Bad result: " + result;
+

--- a/JSTests/microbenchmarks/array-prototype-at-out-of-bounds-double.js
+++ b/JSTests/microbenchmarks/array-prototype-at-out-of-bounds-double.js
@@ -1,0 +1,15 @@
+function test(array) {
+    var result;
+    for (let i = 0; i < 1e6; i++) {
+        result = array.at(1000);
+    }
+    return result;
+}
+
+noInline(test);
+
+var array = [12.5, 4.5, 4.5, 66.5, 56.5, 44.5, 44.5, 38.5, 65.5, 89.5, 2.5, 45.5, 789.5, 56.5, 432.5, 677.5, 2234.5, 77.5, 3457.5, 133.5, 6544.5, 76.5, 17.5, 322.5, 34.5];
+var result = test(array);
+if (result !== undefined)
+    throw "Bad result: " + result;
+

--- a/JSTests/microbenchmarks/array-prototype-at-out-of-bounds-int32-neg.js
+++ b/JSTests/microbenchmarks/array-prototype-at-out-of-bounds-int32-neg.js
@@ -1,0 +1,15 @@
+function test(array) {
+    var result;
+    for (let i = 0; i < 1e6; i++) {
+        result = array.at(-1000);
+    }
+    return result;
+}
+
+noInline(test);
+
+var array = [12,4,4,66,56,44,44,38,65,89,2,45,789,56,432,677,2234,77,3457,133,6544,76,17,322,34];
+var result = test(array);
+if (result !== undefined)
+    throw "Bad result: " + result;
+

--- a/JSTests/microbenchmarks/array-prototype-at-out-of-bounds-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-at-out-of-bounds-int32.js
@@ -1,0 +1,15 @@
+function test(array) {
+    var result;
+    for (let i = 0; i < 1e6; i++) {
+        result = array.at(1000);
+    }
+    return result;
+}
+
+noInline(test);
+
+var array = [12,4,4,66,56,44,44,38,65,89,2,45,789,56,432,677,2234,77,3457,133,6544,76,17,322,34];
+var result = test(array);
+if (result !== undefined)
+    throw "Bad result: " + result;
+

--- a/JSTests/stress/array-prototype-at-out-of-bounds-contiguous.js
+++ b/JSTests/stress/array-prototype-at-out-of-bounds-contiguous.js
@@ -1,0 +1,26 @@
+function shouldBe(actual, expected) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error('bad value: ' + JSON.stringify(actual));
+}
+
+function test(array, index) {
+    return array.at(index);
+}
+noInline(test);
+
+var array = [
+    { value: 12 }, { value: 4 }, { value: 4 }, { value: 66 }, { value: 56 },
+    { value: 44 }, { value: 44 }, { value: 38 }, { value: 65 }, { value: 89 },
+    { value: 2 }, { value: 45 }, { value: 789 }, { value: 56 }, { value: 432 },
+    { value: 677 }, { value: 2234 }, { value: 77 }, { value: 3457 }, { value: 133 },
+    { value: 6544 }, { value: 76 }, { value: 17 }, { value: 322 }, { value: 34 }
+];
+for (var i = 0; i < 1e4; ++i) {
+    shouldBe(test(array, 0), { value: 12 });
+    shouldBe(test(array, 1), { value: 4 });
+    shouldBe(test(array, 3), { value: 66 });
+    shouldBe(test(array, -2), { value: 322 });
+    shouldBe(test(array, 42), undefined);
+    shouldBe(test(array, -40), undefined);
+}
+

--- a/JSTests/stress/array-prototype-at-out-of-bounds-double.js
+++ b/JSTests/stress/array-prototype-at-out-of-bounds-double.js
@@ -1,0 +1,20 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(array, index) {
+    return array.at(index);
+}
+noInline(test);
+
+var array = [12.5, 4.5, 4.5, 66.5, 56.5, 44.5, 44.5, 38.5, 65.5, 89.5, 2.5, 45.5, 789.5, 56.5, 432.5, 677.5, 2234.5, 77.5, 3457.5, 133.5, 6544.5, 76.5, 17.5, 322.5, 34.5];
+for (var i = 0; i < 1e4; ++i) {
+    shouldBe(test(array, 0), 12.5);
+    shouldBe(test(array, 1), 4.5);
+    shouldBe(test(array, 3), 66.5);
+    shouldBe(test(array, -2), 322.5);
+    shouldBe(test(array, 42), undefined);
+    shouldBe(test(array, -40), undefined);
+}
+

--- a/JSTests/stress/array-prototype-at-out-of-bounds-int32.js
+++ b/JSTests/stress/array-prototype-at-out-of-bounds-int32.js
@@ -1,0 +1,20 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(array, index) {
+    return array.at(index);
+}
+noInline(test);
+
+var array = [12, 4, 4, 66, 56, 44, 44, 38, 65, 89, 2, 45, 789, 56, 432, 677, 2234, 77, 3457, 133, 6544, 76, 17, 322, 34];
+for (var i = 0; i < 1e4; ++i) {
+    shouldBe(test(array, 0), 12);
+    shouldBe(test(array, 1), 4);
+    shouldBe(test(array, 3), 66);
+    shouldBe(test(array, -2), 322);
+    shouldBe(test(array, 42), undefined);
+    shouldBe(test(array, -40), undefined);
+}
+

--- a/Source/JavaScriptCore/builtins/ArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayPrototype.js
@@ -441,20 +441,6 @@ function flatMap(callback)
     return @flatIntoArrayWithCallback(result, array, length, 0, callback, thisArg);
 }
 
-function at(index)
-{
-    "use strict";
-
-    var array = @toObject(this, "Array.prototype.at requires that |this| not be null or undefined");
-    var length = @toLength(array.length);
-
-    var k = @toIntegerOrInfinity(index);
-    if (k < 0)
-        k += length;
-
-    return (k >= 0 && k < length) ? array[k] : @undefined;
-}
-
 function toSpliced(start, deleteCount /*, ...items */)
 {
     "use strict"

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -506,6 +506,7 @@ private:
             break;
         }
 
+        case ArrayAt:
         case EnumeratorGetByVal:
         case GetByVal:
         case GetByValMegamorphic: {
@@ -513,7 +514,7 @@ private:
             m_graph.varArgChild(node, 1)->mergeFlags(NodeBytecodeUsesAsArrayIndex);
             break;
         }
-            
+
         case NewTypedArray:
         case NewArrayWithSize:
         case NewArrayWithConstantSize:

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -139,6 +139,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         case CheckArray:
         case CheckArrayOrEmpty:
             break;
+        case ArrayAt:
         case EnumeratorNextUpdateIndexAndMode:
         case EnumeratorGetByVal:
         case EnumeratorPutByVal:
@@ -989,6 +990,12 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case EnumeratorGetByVal: {
         clobberTop();
         return;
+    }
+
+    case ArrayAt: {
+        ASSERT(node->arrayMode().type() == Array::Int32 || node->arrayMode().type() == Array::Double || node->arrayMode().type() == Array::Contiguous);
+
+        FALLTHROUGH;
     }
         
     case GetByVal:

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -562,6 +562,9 @@ bool doesGC(Graph& graph, Node* node)
             return true;
         return false;
 
+    case ArrayAt:
+        return false;
+
     case ResolveRope:
         return true;
 

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1105,6 +1105,28 @@ private:
             break;
         }
 
+        case ArrayAt: {
+            blessArrayOperation(m_graph.varArgChild(node, 0), m_graph.varArgChild(node, 1), m_graph.varArgChild(node, 2));
+            fixEdge<KnownCellUse>(m_graph.varArgChild(node, 0));
+            fixEdge<Int32Use>(m_graph.varArgChild(node, 1));
+            ArrayMode arrayMode = node->arrayMode();
+            switch (arrayMode.type()) {
+            case Array::Double:
+                if (!arrayMode.isOutOfBounds()
+                    || (arrayMode.isOutOfBoundsSaneChain() && !(node->flags() & NodeBytecodeUsesAsOther)))
+                    node->setResult(NodeResultDouble);
+                break;
+            case Array::Contiguous:
+            case Array::Int32: {
+                break;
+            }
+            default:
+                RELEASE_ASSERT_NOT_REACHED();
+                break;
+            }
+            break;
+        }
+
         case EnumeratorGetByVal: {
             fixEdge<KnownInt32Use>(m_graph.varArgChild(node, 3));
             fixEdge<KnownInt32Use>(m_graph.varArgChild(node, 4));

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -2013,6 +2013,7 @@ public:
         case GetInternalField:
         case GetFromArguments:
         case GetArgument:
+        case ArrayAt:
         case ArrayPop:
         case ArrayPush:
         case ArraySplice:
@@ -2209,6 +2210,7 @@ public:
         case GetTypedArrayLengthAsInt52:
         case HasIndexedProperty:
         case EnumeratorNextUpdateIndexAndMode:
+        case ArrayAt:
         case ArrayIndexOf:
             return true;
         default:
@@ -2550,6 +2552,7 @@ public:
         case CheckArrayOrEmpty:
         case Arrayify:
         case ArrayifyToStructure:
+        case ArrayAt:
         case ArrayPush:
         case ArrayPop:
         case ArrayIndexOf:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -255,6 +255,7 @@ namespace JSC { namespace DFG {
     macro(CheckArrayOrEmpty, NodeMustGenerate) \
     macro(GetPrivateName, NodeResultJS | NodeMustGenerate) \
     macro(GetPrivateNameById, NodeResultJS | NodeMustGenerate) \
+    macro(ArrayAt, NodeResultJS | NodeHasVarArgs | NodeMustGenerate) \
     /* This checks if the edge is a typed array and if it is detached. */ \
     macro(CheckDetached, NodeMustGenerate) \
     macro(Arrayify, NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -556,6 +556,7 @@ private:
             break;
         }
 
+        case ArrayAt:
         case GetByVal:
         case AtomicsAdd:
         case AtomicsAnd:
@@ -1528,7 +1529,8 @@ private:
         case AtomicsStore:
         case AtomicsSub:
         case AtomicsXor:
-        case StringAt: {
+        case StringAt:
+        case ArrayAt: {
             m_dependentNodes.append(m_currentNode);
             break;
         }

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -402,6 +402,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case GetUndetachedTypeArrayLength:
     case GetTypedArrayLengthAsInt52:
     case GetVectorLength:
+    case ArrayAt:
     case ArrayPop:
     case StringAt:
     case StringCharAt:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1795,6 +1795,7 @@ public:
     void compileNumberIsNaN(Node*);
     void compileToIntegerOrInfinity(Node*);
     void compileToLength(Node*);
+    void compileArrayAt(Node*, const ScopedLambda<std::tuple<JSValueRegs, DataFormat>(DataFormat preferredFormat, bool needsFlush)>& prefix);
 
     template<typename JSClass, typename Operation>
     void compileCreateInternalFieldObject(Node*, Operation);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2783,6 +2783,11 @@ void SpeculativeJIT::compile(Node* node)
         compileRecordRegExpCachedResult(node);
         break;
     }
+
+    case ArrayAt: {
+        DFG_CRASH(m_graph, node, "ArrayAt only used in 64-bit DFG");
+        break;
+    }
         
     case ArrayPush: {
         compileArrayPush(node);

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -417,6 +417,7 @@ inline CapabilityLevel canCompile(Node* node)
     case CheckNotJSCast:
     case CallDOM:
     case CallDOMGetter:
+    case ArrayAt:
     case ArraySlice:
     case ArraySplice:
     case ArrayIndexOf:

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -52,6 +52,7 @@ namespace JSC {
     macro(CoshIntrinsic) \
     macro(SinhIntrinsic) \
     macro(TanhIntrinsic) \
+    macro(ArrayAtIntrinsic) \
     macro(ArrayPushIntrinsic) \
     macro(ArrayPopIntrinsic) \
     macro(ArraySliceIntrinsic) \


### PR DESCRIPTION
#### 8db8cb832a122e2873b961ecae67c5084155c43d
<pre>
[JSC] Optimize `Array#at` in DFG/FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=285095">https://bugs.webkit.org/show_bug.cgi?id=285095</a>

Reviewed by NOBODY (OOPS!).

This patch optimize `Array#at` in DFG/FTL using same approach as
`GetByVal` and `StringAt`.

                                                  TipOfTree                  Patched

array-prototype-at-out-of-bounds-contiguous
                                                1.2855+-0.0333     ^      0.9349+-0.0073        ^ definitely 1.3750x faster
array-prototype-at-in-bounds-contiguous         1.4921+-0.0096     ^      0.9417+-0.0087        ^ definitely 1.5844x faster
array-prototype-at-in-bounds-contiguous-neg
                                                1.7482+-0.0216     ^      0.9724+-0.0266        ^ definitely 1.7979x faster
array-prototype-at-out-of-bounds-contiguous-neg
                                                1.3912+-0.0463     ^      0.9658+-0.0137        ^ definitely 1.4404x faster
array-prototype-at-in-bounds-double-neg         1.7896+-0.1390     ^      0.9218+-0.0887        ^ definitely 1.9415x faster
array-prototype-at-out-of-bounds-double-neg
                                                1.3934+-0.0361     ^      0.9822+-0.0199        ^ definitely 1.4187x faster
array-prototype-at-in-bounds-int32              1.5240+-0.0864     ^      0.9183+-0.0177        ^ definitely 1.6597x faster
array-prototype-at-in-bounds-int32-neg          1.7369+-0.0131     ^      0.9576+-0.0080        ^ definitely 1.8138x faster
array-prototype-at-out-of-bounds-int32          1.2567+-0.0136     ^      0.9449+-0.0090        ^ definitely 1.3299x faster
array-prototype-at-out-of-bounds-int32-neg
                                                1.3925+-0.0366     ^      0.9708+-0.0226        ^ definitely 1.4344x faster
array-prototype-at-out-of-bounds-double         1.3008+-0.1358     ^      0.9612+-0.0058        ^ definitely 1.3533x faster
array-prototype-at-in-bounds-double             1.5088+-0.0320     ^      0.9846+-0.0260        ^ definitely 1.5325x faster

* JSTests/microbenchmarks/array-prototype-at-in-bounds-contiguous-neg.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-at-in-bounds-contiguous.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-at-in-bounds-double-neg.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-at-in-bounds-double.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-at-in-bounds-int32-neg.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-at-in-bounds-int32.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-at-out-of-bounds-contiguous-neg.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-at-out-of-bounds-contiguous.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-at-out-of-bounds-double-neg.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-at-out-of-bounds-double.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-at-out-of-bounds-int32-neg.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-at-out-of-bounds-int32.js: Added.
(test):
* JSTests/stress/array-prototype-at-out-of-bounds-contiguous.js: Added.
(shouldBe):
(test):
(i.shouldBe.test):
* JSTests/stress/array-prototype-at-out-of-bounds-double.js: Added.
(shouldBe):
(test):
* JSTests/stress/array-prototype-at-out-of-bounds-int32.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/builtins/ArrayPrototype.js:
(at): Deleted.
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::hasHeapPrediction):
(JSC::DFG::Node::hasStorageChild const):
(JSC::DFG::Node::hasArrayMode):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileGetByVal):
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileGetByValImpl):
(JSC::FTL::DFG::LowerDFGToB3::compileArrayAt):
(JSC::FTL::DFG::LowerDFGToB3::compileArrayPush):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::ArrayPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/Intrinsic.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8db8cb832a122e2873b961ecae67c5084155c43d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90127 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36034 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66131 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23949 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77228 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46397 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31456 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35107 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77946 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74352 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91500 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84023 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74616 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73039 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73736 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18125 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16577 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4345 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12270 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17723 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106413 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12106 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25686 "Found 11 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-many-args.js.layout-no-llint, stress/json-stringify-inspector-check.js.no-llint, stress/regexp-escape-oom.js.default, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.default-wasm, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.wasm-eager, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.wasm-no-cjit ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15602 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->