### PR TITLE
[Site Isolation] Discard uncached back items for navigated over isolated iframes

### DIFF
--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -140,4 +140,13 @@ Ref<FrameState> WebBackForwardListFrameItem::copyFrameStateWithChildren()
     return frameState;
 }
 
+bool WebBackForwardListFrameItem::hasAncestorFrame(FrameIdentifier frameID)
+{
+    for (RefPtr ancestor = m_parent.get(); ancestor; ancestor = ancestor->m_parent.get()) {
+        if (ancestor->frameID() == frameID)
+            return true;
+    }
+    return false;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -53,6 +53,8 @@ public:
 
     WebBackForwardListFrameItem* parent() const { return m_parent.get(); }
     RefPtr<WebBackForwardListFrameItem> protectedParent() const { return m_parent.get(); }
+    void setParent(WebBackForwardListFrameItem* parent) { m_parent = parent; }
+    bool hasAncestorFrame(WebCore::FrameIdentifier);
 
     WebBackForwardListFrameItem& rootFrame();
     WebBackForwardListFrameItem* childItemForFrameID(WebCore::FrameIdentifier);

--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -246,6 +246,19 @@ Ref<WebBackForwardListFrameItem> WebBackForwardListItem::protectedRootFrameItem(
     return m_rootFrameItem.get();
 }
 
+void WebBackForwardListItem::setParentFromItem(WebBackForwardListItem* previousItem)
+{
+    if (!previousItem || !m_isRemoteFrameNavigation)
+        return;
+
+    auto frameID = m_rootFrameItem->frameID();
+    if (!frameID)
+        return;
+
+    if (RefPtr previousFrameItem = previousItem->rootFrameItem().childItemForFrameID(*frameID))
+        m_rootFrameItem->setParent(previousFrameItem->protectedParent().get());
+}
+
 #if !LOG_DISABLED
 String WebBackForwardListItem::loggingString()
 {

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -104,6 +104,8 @@ public:
     void setIsRemoteFrameNavigation(bool isRemoteFrameNavigation) { m_isRemoteFrameNavigation = isRemoteFrameNavigation; }
     bool isRemoteFrameNavigation() const { return m_isRemoteFrameNavigation; }
 
+    void setParentFromItem(WebBackForwardListItem*);
+
     void setWasRestoredFromSession();
 
 #if !LOG_DISABLED

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -121,6 +121,18 @@ void WebBackForwardList::addItem(Ref<WebBackForwardListItem>&& newItem)
             m_entries.removeLast();
         }
 
+        if (auto frameID = newItem->rootFrameItem().frameID()) {
+            while (m_entries.size()) {
+                Ref lastEntry = m_entries.last();
+                if (!lastEntry->isRemoteFrameNavigation() || !lastEntry->rootFrameItem().hasAncestorFrame(*frameID))
+                    break;
+                didRemoveItem(lastEntry);
+                removedItems.append(WTFMove(lastEntry));
+                m_entries.removeLast();
+                setProvisionalOrCurrentIndex(*provisionalOrCurrentIndex() - 1);
+            }
+        }
+
         // Toss the first item if the list is getting too big, as long as we're not using it
         // (or even if we are, if we only want 1 entry).
         if (m_entries.size() >= DefaultCapacity && (*provisionalOrCurrentIndex())) {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9407,6 +9407,7 @@ void WebPageProxy::backForwardAddItemShared(IPC::Connection& connection, FrameId
     item->setIsRemoteFrameNavigation(isRemoteFrameNavigation);
     if (loadedWebArchive == LoadedWebArchive::Yes)
         item->setDataStoreForWebArchive(process->websiteDataStore());
+    item->setParentFromItem(m_backForwardList->protectedCurrentItem().get());
     protectedBackForwardList()->addItem(WTFMove(item));
 }
 


### PR DESCRIPTION
#### d521cb41c396151b0331a98b8e559ce715fad9f6
<pre>
[Site Isolation] Discard uncached back items for navigated over isolated iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=285096">https://bugs.webkit.org/show_bug.cgi?id=285096</a>
<a href="https://rdar.apple.com/141934328">rdar://141934328</a>

Reviewed by Pascoe.

When storing session history for an uncached site isolated iframe, any navigation of an ancestor frame
invalidates the history state for all of its descendants. This is because navigating back will require
the ancestor to reload its children, and the previously stored state will have changed.

To fix this, when a new back/forward item is added, all prior items with an ancestor that navigated
should be discarded. I also needed to add logic to associate the state from the current back/forward item
to be set as the parent of the state committed by the site-isolated web process.

No change in behavior with site isolation disabled.

* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::hasAncestorFrame):
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
(WebKit::WebBackForwardListFrameItem::setParent):
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::setParentFromItem):
* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::addItem):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::backForwardAddItemShared):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, DiscardUncachedBackItemForNavigatedOverIframe)):

Canonical link: <a href="https://commits.webkit.org/288281@main">https://commits.webkit.org/288281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cd526e5b3336669b42c25af7469d901d103c4b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87384 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33313 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64105 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21853 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44383 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1284 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29023 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32354 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88740 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72497 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71715 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15851 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14866 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/912 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12784 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9511 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15027 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9385 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12851 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11154 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->