### PR TITLE
Introduce a CompactVariant for efficient variants of pointers and types smaller than 56 bits

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -220,6 +220,9 @@
 		ADF2CE671E39F106006889DB /* MemoryFootprintCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ADF2CE651E39F106006889DB /* MemoryFootprintCocoa.cpp */; };
 		BC05ACA62CEA70E500750CB1 /* VariantListOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = BC05ACA52CEA70E500750CB1 /* VariantListOperations.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC5267672C2726D600E422DD /* MakeString.h in Headers */ = {isa = PBXBuildFile; fileRef = BC5267662C2726D600E422DD /* MakeString.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BCE0DFA72D1865B9003F0349 /* CompactVariant.h in Headers */ = {isa = PBXBuildFile; fileRef = BCE0DFA62D1865B9003F0349 /* CompactVariant.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BCE0DFA92D1865C4003F0349 /* CompactVariantOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = BCE0DFA82D1865C4003F0349 /* CompactVariantOperations.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BCE0DFAB2D18670B003F0349 /* VariantExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = BCE0DFAA2D18670B003F0349 /* VariantExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCEA08042CCFDB33000AC148 /* VariantList.h in Headers */ = {isa = PBXBuildFile; fileRef = BCEA08032CCFDB33000AC148 /* VariantList.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C2BCFC401F61D13000C9222C /* Language.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2BCFC3E1F61D13000C9222C /* Language.cpp */; };
 		C2BCFC421F61D61600C9222C /* LanguageCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2BCFC411F61D61600C9222C /* LanguageCF.cpp */; };
@@ -1572,6 +1575,9 @@
 		ADF2CE651E39F106006889DB /* MemoryFootprintCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryFootprintCocoa.cpp; sourceTree = "<group>"; };
 		BC05ACA52CEA70E500750CB1 /* VariantListOperations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VariantListOperations.h; sourceTree = "<group>"; };
 		BC5267662C2726D600E422DD /* MakeString.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MakeString.h; sourceTree = "<group>"; };
+		BCE0DFA62D1865B9003F0349 /* CompactVariant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompactVariant.h; sourceTree = "<group>"; };
+		BCE0DFA82D1865C4003F0349 /* CompactVariantOperations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompactVariantOperations.h; sourceTree = "<group>"; };
+		BCE0DFAA2D18670B003F0349 /* VariantExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VariantExtras.h; sourceTree = "<group>"; };
 		BCEA08032CCFDB33000AC148 /* VariantList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VariantList.h; sourceTree = "<group>"; };
 		C2BCFC3E1F61D13000C9222C /* Language.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Language.cpp; sourceTree = "<group>"; };
 		C2BCFC3F1F61D13000C9222C /* Language.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Language.h; sourceTree = "<group>"; };
@@ -2188,6 +2194,8 @@
 				FF895F10282AB96400E7BAE8 /* CompactRefPtr.h */,
 				E38020DB2401C0930037CA9E /* CompactRefPtrTuple.h */,
 				9B96E9B324FF77B8001756C3 /* CompactUniquePtrTuple.h */,
+				BCE0DFA62D1865B9003F0349 /* CompactVariant.h */,
+				BCE0DFA82D1865C4003F0349 /* CompactVariantOperations.h */,
 				0F8F2B8F172E00F0007DBDA5 /* CompilationThread.cpp */,
 				0F8F2B90172E00F0007DBDA5 /* CompilationThread.h */,
 				A8A47270151A825A004123FF /* Compiler.h */,
@@ -2585,6 +2593,7 @@
 				7AFEC6B01EB22B5900DADE36 /* UUID.cpp */,
 				7AFEC6AE1EB22AC600DADE36 /* UUID.h */,
 				A8A4736F151A825B004123FF /* ValueCheck.h */,
+				BCE0DFAA2D18670B003F0349 /* VariantExtras.h */,
 				BCEA08032CCFDB33000AC148 /* VariantList.h */,
 				BC05ACA52CEA70E500750CB1 /* VariantListOperations.h */,
 				0F95B63420CB53C100479635 /* Vector.cpp */,
@@ -3279,6 +3288,8 @@
 				FF895F11282AB96400E7BAE8 /* CompactRefPtr.h in Headers */,
 				DD3DC93927A4BF8E007E5B61 /* CompactRefPtrTuple.h in Headers */,
 				DD3DC93527A4BF8E007E5B61 /* CompactUniquePtrTuple.h in Headers */,
+				BCE0DFA72D1865B9003F0349 /* CompactVariant.h in Headers */,
+				BCE0DFA92D1865C4003F0349 /* CompactVariantOperations.h in Headers */,
 				DD3DC90727A4BF8E007E5B61 /* CompilationThread.h in Headers */,
 				DD3DC99927A4BF8E007E5B61 /* Compiler.h in Headers */,
 				DD3DC8A227A4BF8E007E5B61 /* CompletionHandler.h in Headers */,
@@ -3701,6 +3712,7 @@
 				DDF306F527C086CC006A526F /* utils.h in Headers */,
 				DD3DC8C227A4BF8E007E5B61 /* UUID.h in Headers */,
 				DD3DC86D27A4BF8E007E5B61 /* ValueCheck.h in Headers */,
+				BCE0DFAB2D18670B003F0349 /* VariantExtras.h in Headers */,
 				BCEA08042CCFDB33000AC148 /* VariantList.h in Headers */,
 				BC05ACA62CEA70E500750CB1 /* VariantListOperations.h in Headers */,
 				DD3DC90B27A4BF8E007E5B61 /* Vector.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -47,6 +47,8 @@ set(WTF_PUBLIC_HEADERS
     CompactRefPtr.h
     CompactRefPtrTuple.h
     CompactUniquePtrTuple.h
+    CompactVariant.h
+    CompactVariantOperations.h
     CompilationThread.h
     Compiler.h
     CompletionHandler.h
@@ -352,6 +354,7 @@ set(WTF_PUBLIC_HEADERS
     UniqueRefVector.h
     VMTags.h
     ValueCheck.h
+    VariantExtras.h
     VariantList.h
     VariantListOperations.h
     Vector.h

--- a/Source/WTF/wtf/CompactVariant.h
+++ b/Source/WTF/wtf/CompactVariant.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/CompactVariantOperations.h>
+
+namespace WTF {
+
+// A `CompactVariant` acts like a `std::variant` with the following differences:
+// - All alternatives must be pointers, smart pointers, have size of 56 bits or fewer, or be specialized for `CompactVariantTraits`.
+// - Can only contain 254 or fewer alternatives.
+// - Has a more limited API, only offering `holds_alternative()` for type checking and `switchOn()` for value access.
+
+template<CompactVariantCapable V> class CompactVariant {
+    static_assert(std::variant_size_v<V> < 255);
+    using Variant = V;
+    using Index = uint8_t;
+    using Storage = uint64_t;
+    using Operations = CompactVariantOperations<V>;
+public:
+    template<typename U> constexpr CompactVariant(U&& value)
+        requires std::constructible_from<V, U> && (!std::same_as<std::remove_cvref_t<U>, CompactVariant>)
+    {
+        m_data = Operations::template encode<typename VariantBestMatch<V, U>::type>(std::forward<U>(value));
+    }
+
+    template<typename T, typename... Args> explicit constexpr CompactVariant(std::in_place_type_t<T>, Args&&... args)
+        requires std::constructible_from<V, T>
+    {
+        m_data = Operations::template encodeFromArguments<T>(std::forward<Args>(args)...);
+    }
+
+    template<size_t I, typename... Args> explicit constexpr CompactVariant(std::in_place_index_t<I>, Args&&... args)
+        requires std::constructible_from<V, std::variant_alternative_t<I, V>>
+    {
+        m_data = Operations::template encodeFromArguments<std::variant_alternative_t<I, V>>(std::forward<Args>(args)...);
+    }
+
+    CompactVariant(const CompactVariant& other)
+    {
+        Operations::copy(m_data, other.m_data);
+    }
+
+    CompactVariant& operator=(const CompactVariant& other)
+    {
+        if (m_data == &other.m_data)
+            return *this;
+
+        Operations::destruct(m_data);
+        Operations::copy(m_data, other.m_data);
+
+        return *this;
+    }
+
+    CompactVariant(CompactVariant&& other)
+    {
+        Operations::move(m_data, other.m_data);
+
+        // Set `other` to the "moved from" state.
+        other.m_data = Operations::movedFromDataValue;
+    }
+
+    CompactVariant& operator=(CompactVariant&& other)
+    {
+        if (m_data == &other.m_data)
+            return *this;
+
+        Operations::destruct(m_data);
+        Operations::move(m_data, other.m_data);
+
+        // Set `other` to the "moved from" state.
+        other.m_data = Operations::movedFromDataValue;
+
+        return *this;
+    }
+
+    template<typename U> CompactVariant& operator=(U&& value)
+        requires std::constructible_from<V, U> && (!std::same_as<std::remove_cvref_t<U>, CompactVariant>)
+    {
+        Operations::destruct(m_data);
+        m_data = Operations::template encode<typename VariantBestMatch<V, U>::type>(std::forward<U>(value));
+
+        return *this;
+    }
+
+    ~CompactVariant()
+    {
+        Operations::destruct(m_data);
+    }
+
+    template<typename T, typename... Args> void emplace(Args&&... args)
+    {
+        Operations::destruct(m_data);
+        m_data = Operations::template encodeFromArguments<T>(std::forward<Args>(args)...);
+    }
+
+    template<size_t I, typename... Args> void emplace(Args&&... args)
+    {
+        Operations::destruct(m_data);
+        m_data = Operations::template encodeFromArguments<std::variant_alternative_t<I, V>>(std::forward<Args>(args)...);
+    }
+
+    constexpr Index index() const
+    {
+        return Operations::decodedIndex(m_data);
+    }
+
+    constexpr bool valueless_by_move() const
+    {
+        return m_data == Operations::movedFromDataValue;
+    }
+
+    template<typename T> constexpr bool holds_alternative() const
+    {
+        static_assert(alternativeIndexV<T, Variant> <= std::variant_size_v<Variant>);
+        return index() == alternativeIndexV<T, Variant>;
+    }
+
+    template<size_t I> constexpr bool holds_alternative() const
+    {
+        static_assert(I <= std::variant_size_v<Variant>);
+        return index() == I;
+    }
+
+    template<typename... F> decltype(auto) switchOn(F&&... f) const
+    {
+        return Operations::constPayloadForData(m_data, std::forward<F>(f)...);
+    }
+
+    bool operator==(const CompactVariant& other) const
+    {
+        if (index() != other.index())
+            return false;
+
+        return typeForIndex<V>(index(), [&]<typename T>() {
+            return Operations::template equal<T>(m_data, other.m_data);
+        });
+    }
+
+private:
+    // FIXME: Use a smaller data type if values are small enough / empty.
+    Storage m_data;
+};
+
+} // namespace WTF

--- a/Source/WTF/wtf/CompactVariantOperations.h
+++ b/Source/WTF/wtf/CompactVariantOperations.h
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <bit>
+#include <concepts>
+#include <functional>
+#include <type_traits>
+#include <variant>
+#include <wtf/GetPtr.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/VariantExtras.h>
+
+namespace WTF {
+
+template<typename T> struct CompactVariantTraits {
+   static constexpr bool hasAlternativeRepresentation = false;
+
+   /* 
+       If `hasAlternativeRepresentation` is set to `true`, you must also implement the following functions.
+
+           static constexpr uint64_t encode(T& value) { ... }
+           static constexpr T& decode(uint64_t value) { ... }
+   */
+};
+
+template<typename T> concept CompactVariantAlternativeSmallEnough = sizeof(T) <= 4;
+template<typename T> concept CompactVariantAlternativePointer =
+       std::is_pointer_v<T>
+   ||  IsSmartPtr<T>::value;
+
+template<typename T> concept  CompactVariantAlternative =
+       CompactVariantAlternativePointer<T>
+    || CompactVariantAlternativeSmallEnough<T>
+    || CompactVariantTraits<T>::hasAlternativeRepresentation;
+
+template<typename>       struct CompactVariantCheck;
+template<typename... Ts> struct CompactVariantCheck<std::variant<Ts...>> : std::integral_constant<bool, all<CompactVariantAlternative<Ts>...>> { };
+
+template<typename T> concept CompactVariantCapable = CompactVariantCheck<T>::value;
+
+template<CompactVariantCapable V> struct CompactVariantOperations {
+    using Variant = V;
+    using Index = uint8_t;
+    using Storage = uint64_t;
+    static constexpr Storage movedFromDataValue = std::numeric_limits<Storage>::max();
+    static constexpr Storage totalSize = sizeof(Storage) * 8;
+    static constexpr Storage indexSize = sizeof(Index) * 8;
+    static constexpr Storage indexShift = totalSize - indexSize;
+    static constexpr Storage payloadSize = totalSize - indexSize;
+    static constexpr Storage payloadMask = (1ULL << payloadSize) - 1;
+    static_assert(payloadSize + indexSize <= totalSize);
+
+    template<typename... F> static decltype(auto) payloadForData(Storage data, F&&... f)
+    {
+        auto visitor = makeVisitor(std::forward<F>(f)...);
+        return typeForIndex<Variant>(decodedIndex(data), [&]<typename T>() {
+            return decodedPayload<T>(data, visitor);
+        });
+    }
+
+    template<typename... F> static decltype(auto) constPayloadForData(Storage data, F&&... f)
+    {
+        auto visitor = makeVisitor(std::forward<F>(f)...);
+        return typeForIndex<Variant>(decodedIndex(data), [&]<typename T>() {
+            return decodedConstPayload<T>(data, visitor);
+        });
+    }
+
+    static void destruct(Storage data)
+    {
+        if (data == movedFromDataValue)
+            return;
+
+        payloadForData(data, [&]<typename T>(T& value) {
+            if constexpr (!std::is_trivially_destructible_v<T>)
+                value.~T();
+        });
+    }
+
+    static void copy(Storage& to, Storage from)
+    {
+        if (from == movedFromDataValue) {
+            to = from;
+            return;
+        }
+
+        payloadForData(from, [&]<typename T>(T& value) {
+            Storage data = 0;
+            new (NotNull, &data) T(value);
+            to = data | encodedIndex(alternativeIndexV<T, Variant>);
+        });
+    }
+
+    static void move(Storage& to, Storage from)
+    {
+        if (from == movedFromDataValue) {
+            to = from;
+            return;
+        }
+
+        payloadForData(from, [&]<typename T>(T& value) {
+            Storage data = 0;
+            new (NotNull, &data) T(WTFMove(value));
+            to = data | encodedIndex(alternativeIndexV<T, Variant>);
+        });
+    }
+
+    template<typename T> static bool equal(Storage a, Storage b)
+    {
+        Storage maskedA = a & payloadMask;
+        Storage maskedB = b & payloadMask;
+
+        if constexpr (CompactVariantTraits<T>::hasAlternativeRepresentation)
+            return CompactVariantTraits<T>::decode(maskedA) == CompactVariantTraits<T>::decode(maskedB);
+        else
+            return *std::launder(reinterpret_cast<T*>(&maskedA)) == *std::launder(reinterpret_cast<T*>(&maskedB));
+    }
+
+    // Index coding
+
+    static constexpr Storage encodedIndex(Index index)
+    {
+        return static_cast<Storage>(index) << indexShift;
+    }
+
+    static constexpr Index decodedIndex(Storage value)
+    {
+        return static_cast<Index>(static_cast<uint8_t>(value >> indexShift));
+    }
+
+    // Payload coding
+
+    template<typename T, typename U> static constexpr Storage encodedPayload(U&& payload)
+    {
+        Storage data = 0;
+
+        if constexpr (CompactVariantTraits<T>::hasAlternativeRepresentation)
+            data = CompactVariantTraits<T>::encode(std::forward<U>(payload));
+        else
+            new (NotNull, &data) T(std::forward<U>(payload));
+
+        return data;
+    }
+
+    template<typename T, typename... Args> static constexpr Storage encodedPayloadFromArguments(Args&&... arguments)
+    {
+        Storage data = 0;
+
+        if constexpr (CompactVariantTraits<T>::hasAlternativeRepresentation)
+            data = CompactVariantTraits<T>::encodeFromArguments(std::forward<Args>(arguments)...);
+        else
+            new (NotNull, &data) T(std::forward<Args>(arguments)...);
+
+        return data;
+    }
+
+    template<typename T, typename F> static constexpr void decodedPayload(Storage value, F&& f)
+    {
+        Storage maskedData = value & payloadMask;
+
+        if constexpr (CompactVariantTraits<T>::hasAlternativeRepresentation) {
+            T decodedData = CompactVariantTraits<T>::decode(maskedData);
+            f(decodedData);
+        } else {
+            T& decodedData = *std::launder(reinterpret_cast<T*>(&maskedData));
+            f(decodedData);
+        }
+    }
+
+    template<typename T, typename F> static constexpr void decodedConstPayload(Storage value, F&& f)
+    {
+        Storage maskedData = value & payloadMask;
+
+        if constexpr (CompactVariantTraits<T>::hasAlternativeRepresentation) {
+            T decodedData = CompactVariantTraits<T>::decode(maskedData);
+            f(std::as_const(decodedData));
+        } else {
+            T& decodedData = *std::launder(reinterpret_cast<T*>(&maskedData));
+            f(std::as_const(decodedData));
+        }
+    }
+
+    // Coding
+
+    template<typename T, typename U> static Storage encode(U&& argument)
+    {
+        return encodedPayload<T>(std::forward<U>(argument)) | encodedIndex(alternativeIndexV<T, Variant>);
+    }
+
+    template<typename T, typename... Args> static Storage encodeFromArguments(Args&&... arguments)
+    {
+        return encodedPayloadFromArguments<T>(std::forward<Args>(arguments)...) | encodedIndex(alternativeIndexV<T, Variant>);
+    }
+};
+
+} // namespace WTF

--- a/Source/WTF/wtf/VariantExtras.h
+++ b/Source/WTF/wtf/VariantExtras.h
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <variant>
+#include <wtf/StdLibExtras.h>
+#include <wtf/VectorTraits.h>
+
+namespace WTF {
+
+// MARK: - Utility concepts/traits for std::variant.
+
+template<typename>       struct VariantAllAlternativesCanCopyWithMemcpyHelper;
+template<typename... Ts> struct VariantAllAlternativesCanCopyWithMemcpyHelper<std::variant<Ts...>> : std::integral_constant<bool, all<VectorTraits<Ts>::canCopyWithMemcpy...>> { };
+template<typename V>     concept VariantAllAlternativesCanCopyWithMemcpy = VariantAllAlternativesCanCopyWithMemcpyHelper<V>::value;
+
+template<typename>       struct VariantAllAlternativesCanMoveWithMemcpyHelper;
+template<typename... Ts> struct VariantAllAlternativesCanMoveWithMemcpyHelper<std::variant<Ts...>> : std::integral_constant<bool, all<VectorTraits<Ts>::canMoveWithMemcpy...>> { };
+template<typename V>     concept VariantAllAlternativesCanMoveWithMemcpy = VariantAllAlternativesCanMoveWithMemcpyHelper<V>::value;
+
+// MARK: - Best match for std::variant construction.
+
+// `VariantBestMatch` picks the type `T` from `Ts...` in `std::variant<Ts...>` that will be used when the
+// `std::variant<Ts...>` is constructed from type `Arg`. Implementation based off of libc++.
+
+struct VariantNoNarrowingCheck {
+    template<typename D, typename S> using apply = std::type_identity_t<D>;
+};
+struct VariantNarrowingCheck {
+    template<typename D> static auto test(D(&&)[1]) -> std::type_identity_t<D>;
+    template<typename D, typename S> using apply = decltype(test<D>({ std::declval<S>() }));
+};
+template<typename D, typename S> using VariantCheckForNarrowing = typename std::conditional_t<std::is_arithmetic_v<D>, VariantNarrowingCheck, VariantNoNarrowingCheck>::template apply<D, S>;
+template<typename T, size_t I> struct VariantOverload {
+    template<typename U> auto operator()(T, U&&) const -> VariantCheckForNarrowing<T, U>;
+};
+template<typename... Bases> struct VariantAllOverloads : Bases... {
+    void operator()() const;
+    using Bases::operator()...;
+};
+template<typename Seq>   struct VariantMakeOverloadsImpl;
+template<size_t... I> struct VariantMakeOverloadsImpl<std::index_sequence<I...> > {
+    template<typename... Ts> using apply = VariantAllOverloads<VariantOverload<Ts, I>...>;
+};
+template<typename... Ts> using VariantMakeOverloads = typename VariantMakeOverloadsImpl<std::make_index_sequence<sizeof...(Ts)> >::template apply<Ts...>;
+template<typename T, typename... Ts> using VariantBestMatchImpl = typename std::invoke_result_t<VariantMakeOverloads<Ts...>, T, T>;
+
+template<typename V, typename Arg>     struct VariantBestMatch;
+template<typename Arg, typename... Ts> struct VariantBestMatch<std::variant<Ts...>, Arg> {
+    using type = VariantBestMatchImpl<Arg, Ts...>;
+};
+
+// MARK: - Type switching for std::variant
+
+// Calls a zero argument functor with a template argument corresponding to the index's mapped type.
+//
+// e.g.
+//   using Variant = std::variant<int, float>;
+//
+//   Variant foo = 5;
+//   typeForIndex<Variant>(foo.index(), /* index will be 0 for first parameter, <int> */
+//       []<typename T>() {
+//           if constexpr (std::is_same_v<T, int>) {
+//               print("we got an int");  <--- this will get called
+//           } else if constexpr (std::is_same_v<T, float>) {
+//               print("we got an float");  <--- this will NOT get called
+//           }
+//       }
+//   );
+
+template<typename V, typename IndexType = size_t, typename... F> constexpr auto typeForIndex(IndexType index, F&&... f) -> decltype(visitTypeForIndex<V>(index, makeVisitor(std::forward<F>(f)...)));
+
+template<typename V, size_t I = 0, typename IndexType = size_t, typename F> constexpr ALWAYS_INLINE decltype(auto) visitTypeForIndex(IndexType index, F&& f)
+{
+    constexpr auto size = std::variant_size_v<V>;
+
+    // To implement dispatch for variants, this recursively looping switch will work for
+    // variants with any number of alternatives, with variants with greater than 32 recursing
+    // and starting the switch at 32 (and so on).
+
+#define WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT 32
+#define WTF_VARIANT_EXTRAS_VISIT_CASE(N, D) \
+        I + N:                                                                                      \
+        {                                                                                           \
+            if constexpr (I + N < size) {                                                           \
+                return f.template operator()<std::variant_alternative_t<I + N, V>>();               \
+            } else {                                                                                \
+                WTF_UNREACHABLE();                                                                  \
+            }                                                                                       \
+        }                                                                                           \
+
+    switch (index) {
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(0, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(1, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(2, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(3, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(4, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(5, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(6, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(7, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(8, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(9, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(10, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(11, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(12, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(13, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(14, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(15, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(16, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(17, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(18, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(19, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(20, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(21, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(22, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(23, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(24, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(25, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(26, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(27, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(28, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(29, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(30, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    case WTF_VARIANT_EXTRAS_VISIT_CASE(31, WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT)
+    }
+
+    constexpr auto nextI = std::min(I + WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT, size);
+
+    if constexpr (nextI < size)
+        return visitTypeForIndex<V, nextI>(index, std::forward<F>(f));
+
+    WTF_UNREACHABLE();
+
+#undef WTF_VARIANT_EXTRAS_VISIT_CASE_COUNT
+#undef WTF_VARIANT_EXTRAS_VISIT_CASE
+}
+
+template<typename V, typename IndexType, typename... F> constexpr auto typeForIndex(IndexType index, F&&... f) -> decltype(visitTypeForIndex<V>(index, makeVisitor(std::forward<F>(f)...)))
+{
+    return visitTypeForIndex<V>(index, makeVisitor(std::forward<F>(f)...));
+}
+
+} // namespace WTF

--- a/Source/WTF/wtf/VariantList.h
+++ b/Source/WTF/wtf/VariantList.h
@@ -46,7 +46,7 @@ template<typename V, size_t inlineCapacity> class VariantList : private VectorBu
     using Base = VectorBuffer<std::byte, inlineCapacity, VectorBufferMalloc>;
 public:
     using Variant = V;
-    using Tag = VariantListTag;
+    using Index = VariantListIndex;
     using Operations = VariantListOperations<Variant>;
     using Proxy = VariantListProxy<Variant>;
     using Sizer = VariantListSizer<Variant>;
@@ -71,7 +71,7 @@ public:
     ~VariantList();
 
     bool operator==(const VariantList&) const
-        requires VariantAllowsEqualityOperator<V>;
+        requires std::equality_comparable<Variant>;
 
     bool isEmpty() const { return m_size == 0; }
 
@@ -79,7 +79,7 @@ public:
     size_t capacityInBytes() const { return static_cast<size_t>(capacity()); }
 
     template<typename Arg> void append(Arg&&)
-        requires VariantAllowsConstructionOfArg<V, std::decay_t<Arg>>;
+        requires std::constructible_from<Variant, Arg>;
 
     void append(const Variant&);
     void append(Variant&&);
@@ -123,7 +123,7 @@ private:
     std::span<const std::byte> spanFromSizeToSize() const { return std::span(buffer(), sizeInBytes()).subspan(sizeInBytes()); }
 
     template<typename Arg> void appendImpl(Arg&&)
-        requires VariantAllowsConstructionOfArg<V, std::decay_t<Arg>>;
+        requires std::constructible_from<V, Arg>;
 
     void reserveCapacity(size_t newCapacityInBytes);
     void expandCapacity(size_t newMinCapacityInBytes);
@@ -256,14 +256,14 @@ template<typename V, size_t inlineCapacity> VariantList<V, inlineCapacity>::~Var
     Operations::destruct(spanToSize());
 }
 
-template<typename V, size_t inlineCapacity> bool VariantList<V, inlineCapacity>::operator==(const VariantList<V, inlineCapacity>& other) const requires VariantAllowsEqualityOperator<V>
+template<typename V, size_t inlineCapacity> bool VariantList<V, inlineCapacity>::operator==(const VariantList<V, inlineCapacity>& other) const requires std::equality_comparable<V>
 {
     return Operations::compare(spanToSize(), other.spanToSize());
 }
 
-template<typename V, size_t inlineCapacity> template<typename Arg> void VariantList<V, inlineCapacity>::appendImpl(Arg&& arg) requires VariantAllowsConstructionOfArg<V, std::decay_t<Arg>>
+template<typename V, size_t inlineCapacity> template<typename Arg> void VariantList<V, inlineCapacity>::appendImpl(Arg&& arg) requires std::constructible_from<V, Arg>
 {
-    using T = std::decay_t<Arg>;
+    using T = typename VariantBestMatch<V, Arg>::type;
 
     auto remainingBuffer = spanFromSizeToCapacity();
     auto newSizeInBytes = m_size + Operations::template sizeRequiredToWriteAt<T>(remainingBuffer.data());
@@ -273,11 +273,11 @@ template<typename V, size_t inlineCapacity> template<typename Arg> void VariantL
         return appendImpl(std::forward<Arg>(arg));
     }
 
-    Operations::write(std::forward<Arg>(arg), remainingBuffer);
+    Operations::template write<T>(std::forward<Arg>(arg), remainingBuffer);
     m_size = newSizeInBytes;
 }
 
-template<typename V, size_t inlineCapacity> template<typename Arg> void VariantList<V, inlineCapacity>::append(Arg&& arg) requires VariantAllowsConstructionOfArg<V, std::decay_t<Arg>>
+template<typename V, size_t inlineCapacity> template<typename Arg> void VariantList<V, inlineCapacity>::append(Arg&& arg) requires std::constructible_from<V, Arg>
 {
     appendImpl(std::forward<Arg>(arg));
 }

--- a/Source/WTF/wtf/VariantListOperations.h
+++ b/Source/WTF/wtf/VariantListOperations.h
@@ -26,15 +26,13 @@
 
 #include <array>
 #include <span>
-#include <variant>
-#include <wtf/StdLibExtras.h>
-#include <wtf/VectorTraits.h>
+#include <wtf/VariantExtras.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF {
 
-using VariantListTag = unsigned;
+using VariantListIndex = unsigned;
 
 struct VariantListItemMetadata {
     size_t size;      // sizeof(T)
@@ -43,26 +41,10 @@ struct VariantListItemMetadata {
 
 // Utility concepts for constraining VariantList based on the underlying std::variant.
 
-template<typename V, typename Arg>
-concept VariantAllowsConstructionOfArg = requires(Arg&& arg) { V(std::forward<Arg>(arg)); };
-
-template<typename V>
-concept VariantAllowsEqualityOperator = requires(const V& a, const V& b) { { a == b } -> std::convertible_to<bool>; };
-
 template<typename> struct VariantListItemMetadataTable;
 template<typename... Ts> struct VariantListItemMetadataTable<std::variant<Ts...>> {
     static constexpr auto table = std::array { VariantListItemMetadata { sizeof(Ts), alignof(Ts) }... };
 };
-
-template<typename>       struct VariantAllAlternativesCanCopyWithMemcpyHelper;
-template<typename... Ts> struct VariantAllAlternativesCanCopyWithMemcpyHelper<std::variant<Ts...>> : std::integral_constant<bool, all<VectorTraits<Ts>::canCopyWithMemcpy...>> { };
-template<typename V>
-concept VariantAllAlternativesCanCopyWithMemcpy = VariantAllAlternativesCanCopyWithMemcpyHelper<V>::value;
-
-template<typename>       struct VariantAllAlternativesCanMoveWithMemcpyHelper;
-template<typename... Ts> struct VariantAllAlternativesCanMoveWithMemcpyHelper<std::variant<Ts...>> : std::integral_constant<bool, all<VectorTraits<Ts>::canMoveWithMemcpy...>> { };
-template<typename V>
-concept VariantAllAlternativesCanMoveWithMemcpy = VariantAllAlternativesCanMoveWithMemcpyHelper<V>::value;
 
 template<typename Variant> struct VariantListOperations {
     // MARK: - Value alignment.
@@ -73,41 +55,23 @@ template<typename Variant> struct VariantListOperations {
     template<typename T> static std::span<std::byte> alignBufferForValue(std::span<std::byte>);
     template<typename T> static std::span<const std::byte> alignBufferForValue(std::span<const std::byte>);
 
-    // MARK: - Tag reading & writing
+    // MARK: - Index reading & writing
 
-    static VariantListTag readTag(std::span<std::byte>);
-    static VariantListTag readTag(std::span<const std::byte>);
-    static std::span<std::byte> writeTag(VariantListTag, std::span<std::byte>);
+    static VariantListIndex readIndex(std::span<std::byte>);
+    static VariantListIndex readIndex(std::span<const std::byte>);
+    static std::span<std::byte> writeIndex(VariantListIndex, std::span<std::byte>);
 
     // MARK: - Value reading & writing
 
     template<typename T> static T& readValue(std::span<std::byte>);
     template<typename T> static const T& readValue(std::span<const std::byte>);
-    template<typename T> static std::span<std::byte> writeValue(T&&, std::span<std::byte>);
+    template<typename T, typename U> static std::span<std::byte> writeValue(U&&, std::span<std::byte>);
 
-    // MARK: - Value+Tag writing
+    // MARK: - Value+Index writing
 
     template<typename T> static size_t sizeRequiredToWriteAt(std::byte* buffer);
     template<typename T> static size_t sizeRequiredToWriteAt(const std::byte* buffer);
-    template<typename T> static std::span<std::byte> write(T&&, std::span<std::byte> buffer);
-
-    // MARK: - Type switching
-
-    // Calls a zero argument functor with a template argument corresponding to the tag's mapped type.
-    //
-    // e.g.
-    //   typeForTag(0, /* tag for first parameter, <int> */
-    //       []<typename T>() {
-    //           if constexpr (std::is_same_v<T, int>) {
-    //               print("we got an int");  <--- this will get called
-    //           } else if constexpr (std::is_same_v<T, float>) {
-    //               print("we got an float");  <--- this will NOT get called
-    //           }
-    //       }
-    //   );
-
-    template<size_t I = 0, typename F> static constexpr ALWAYS_INLINE decltype(auto) visitTypeForTag(VariantListTag, F&&);
-    template<typename... F> static constexpr auto typeForTag(VariantListTag tag, F&&... f) -> decltype(visitTypeForTag(tag, makeVisitor(std::forward<F>(f)...)));
+    template<typename T, typename U> static std::span<std::byte> write(U&&, std::span<std::byte> buffer);
 
     // MARK: - Value visiting.
 
@@ -116,20 +80,20 @@ template<typename Variant> struct VariantListOperations {
 
     // MARK: - Value iteration.
 
-    // Returns a new span with the start position updated to the start of the next tag.
+    // Returns a new span with the start position updated to the start of the next index.
     //
-    // Requires the type of the element to already be known. Useful for internal cases where `typeForTag` is already
+    // Requires the type of the element to already be known. Useful for internal cases where `typeForIndex` is already
     // being called.
     template<typename T> static std::span<std::byte> nextKnownType(std::span<std::byte>);
     template<typename T> static std::span<const std::byte> nextKnownType(std::span<const std::byte>);
 
-    // Returns a new span with the start position updated to the start of the next tag.
+    // Returns a new span with the start position updated to the start of the next index.
     //
-    // Uses constexpr metadata table to lookup size and alignment information for the next element by tag. Used by
-    // external iterators to avoid duplicate calls to `typeForTag()`.
+    // Uses constexpr metadata table to lookup size and alignment information for the next element by index. Used by
+    // external iterators to avoid duplicate calls to `typeForIndex()`.
     static std::span<std::byte> next(std::span<std::byte>);
     static std::span<const std::byte> next(std::span<const std::byte>);
-    static constexpr VariantListItemMetadata lookupMetadataByTag(VariantListTag);
+    static constexpr VariantListItemMetadata lookupMetadataByIndex(VariantListIndex);
 
     // MARK: - List operations.
 
@@ -159,124 +123,52 @@ template<typename V> template<typename T> std::span<const std::byte> VariantList
     return alignBufferForValue(buffer, alignof(T));
 }
 
-template<typename V> auto VariantListOperations<V>::readTag(std::span<std::byte> buffer) -> VariantListTag
+template<typename V> auto VariantListOperations<V>::readIndex(std::span<std::byte> buffer) -> VariantListIndex
 {
-    VariantListTag value;
-    memcpy(&value, buffer.data(), sizeof(VariantListTag));
+    VariantListIndex value;
+    memcpy(&value, buffer.data(), sizeof(VariantListIndex));
     return value;
 }
 
-template<typename V> auto VariantListOperations<V>::readTag(std::span<const std::byte> buffer) -> VariantListTag
+template<typename V> auto VariantListOperations<V>::readIndex(std::span<const std::byte> buffer) -> VariantListIndex
 {
-    VariantListTag value;
-    memcpy(&value, buffer.data(), sizeof(VariantListTag));
+    VariantListIndex value;
+    memcpy(&value, buffer.data(), sizeof(VariantListIndex));
     return value;
 }
 
-template<typename V> auto VariantListOperations<V>::writeTag(VariantListTag tag, std::span<std::byte> buffer) -> std::span<std::byte>
+template<typename V> auto VariantListOperations<V>::writeIndex(VariantListIndex index, std::span<std::byte> buffer) -> std::span<std::byte>
 {
-    memcpy(buffer.data(), &tag, sizeof(VariantListTag));
-    return buffer.subspan(sizeof(VariantListTag));
+    memcpy(buffer.data(), &index, sizeof(VariantListIndex));
+    return buffer.subspan(sizeof(VariantListIndex));
 }
 
 template<typename V> template<typename T> T& VariantListOperations<V>::readValue(std::span<std::byte> buffer)
 {
-    constexpr auto tagFromType = alternativeIndexV<T, V>;
-    ASSERT_UNUSED(tagFromType, tagFromType == readTag(buffer));
+    constexpr auto indexFromType = alternativeIndexV<T, V>;
+    ASSERT_UNUSED(indexFromType, indexFromType == readIndex(buffer));
 
-    return reinterpretCastSpanStartTo<T>(alignBufferForValue<T>(buffer.subspan(sizeof(VariantListTag))));
+    return reinterpretCastSpanStartTo<T>(alignBufferForValue<T>(buffer.subspan(sizeof(VariantListIndex))));
 }
 
 template<typename V> template<typename T> const T& VariantListOperations<V>::readValue(std::span<const std::byte> buffer)
 {
-    constexpr auto tagFromType = alternativeIndexV<T, V>;
-    ASSERT_UNUSED(tagFromType, tagFromType == readTag(buffer));
+    constexpr auto indexFromType = alternativeIndexV<T, V>;
+    ASSERT_UNUSED(indexFromType, indexFromType == readIndex(buffer));
 
-    return reinterpretCastSpanStartTo<T>(alignBufferForValue<T>(buffer.subspan(sizeof(VariantListTag))));
+    return reinterpretCastSpanStartTo<T>(alignBufferForValue<T>(buffer.subspan(sizeof(VariantListIndex))));
 }
 
-template<typename V> template<typename Arg> auto VariantListOperations<V>::writeValue(Arg&& value, std::span<std::byte> buffer) -> std::span<std::byte>
+template<typename V> template<typename T, typename U> auto VariantListOperations<V>::writeValue(U&& value, std::span<std::byte> buffer) -> std::span<std::byte>
 {
-    using T = std::decay_t<Arg>;
-
-    new (NotNull, buffer.data()) T(std::forward<Arg>(value));
+    new (NotNull, buffer.data()) T(std::forward<U>(value));
     return buffer.subspan(sizeof(T));
-}
-
-template<typename V> template<size_t I, typename F> constexpr ALWAYS_INLINE decltype(auto) VariantListOperations<V>::visitTypeForTag(VariantListTag tag, F&& f)
-{
-    constexpr auto size = std::variant_size_v<V>;
-
-    // To implement dispatch for variants, this recursively looping switch will work for
-    // variants with any number of alternatives, with variants with greater than 32 recursing
-    // and starting the switch at 32 (and so on).
-
-#define WTF_VARIANT_LIST_VISIT_CASE_COUNT 32
-#define WTF_VARIANT_LIST_VISIT_CASE(N, D) \
-        case I + N:                                                                                 \
-        {                                                                                           \
-            if constexpr (I + N < size) {                                                           \
-                return f.template operator()<std::variant_alternative_t<I + N, V>>();               \
-            } else {                                                                                \
-                WTF_UNREACHABLE();                                                                  \
-            }                                                                                       \
-        }                                                                                           \
-
-    switch (tag) {
-        WTF_VARIANT_LIST_VISIT_CASE(0, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(1, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(2, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(3, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(4, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(5, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(6, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(7, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(8, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(9, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(10, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(11, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(12, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(13, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(14, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(15, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(16, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(17, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(18, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(19, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(20, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(21, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(22, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(23, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(24, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(25, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(26, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(27, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(28, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(29, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(30, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-        WTF_VARIANT_LIST_VISIT_CASE(31, WTF_VARIANT_LIST_VISIT_CASE_COUNT)
-    }
-
-    constexpr auto nextI = std::min(I + WTF_VARIANT_LIST_VISIT_CASE_COUNT, size);
-
-    if constexpr (nextI < size)
-        return visitTypeForTag<nextI>(tag, std::forward<F>(f));
-
-    WTF_UNREACHABLE();
-
-#undef WTF_VARIANT_LIST_VISIT_CASE_COUNT
-#undef WTF_VARIANT_LIST_VISIT_CASE
-}
-
-template<typename V> template<typename... F> constexpr auto VariantListOperations<V>::typeForTag(VariantListTag tag, F&&... f) -> decltype(visitTypeForTag(tag, makeVisitor(std::forward<F>(f)...)))
-{
-    return visitTypeForTag(tag, makeVisitor(std::forward<F>(f)...));
 }
 
 template<typename V> template<typename... F> auto VariantListOperations<V>::visitValue(std::span<std::byte> buffer, F&& ...f)
 {
     auto visitor = makeVisitor(std::forward<F>(f)...);
-    return typeForTag(readTag(buffer), [&]<typename T>() {
+    return typeForIndex<V>(readIndex(buffer), [&]<typename T>() {
         return std::invoke(visitor, readValue<T>(buffer));
     });
 }
@@ -284,66 +176,65 @@ template<typename V> template<typename... F> auto VariantListOperations<V>::visi
 template<typename V> template<typename... F> auto VariantListOperations<V>::visitValue(std::span<const std::byte> buffer, F&& ...f)
 {
     auto visitor = makeVisitor(std::forward<F>(f)...);
-    return typeForTag(readTag(buffer), [&]<typename T>() {
+    return typeForIndex<V>(readIndex(buffer), [&]<typename T>() {
         return std::invoke(visitor, readValue<T>(buffer));
     });
 }
 
 template<typename V> template<typename T> std::span<std::byte> VariantListOperations<V>::nextKnownType(std::span<std::byte> buffer)
 {
-    return alignBufferForValue<T>(buffer.subspan(sizeof(VariantListTag))).subspan(sizeof(T));
+    return alignBufferForValue<T>(buffer.subspan(sizeof(VariantListIndex))).subspan(sizeof(T));
 }
 
 template<typename V> template<typename T> std::span<const std::byte> VariantListOperations<V>::nextKnownType(std::span<const std::byte> buffer)
 {
-    return alignBufferForValue<T>(buffer.subspan(sizeof(VariantListTag))).subspan(sizeof(T));
+    return alignBufferForValue<T>(buffer.subspan(sizeof(VariantListIndex))).subspan(sizeof(T));
 }
 
-template<typename V> constexpr VariantListItemMetadata VariantListOperations<V>::lookupMetadataByTag(VariantListTag tag)
+template<typename V> constexpr VariantListItemMetadata VariantListOperations<V>::lookupMetadataByIndex(VariantListIndex index)
 {
     constexpr auto table = VariantListItemMetadataTable<V> { };
-    return table.table[tag];
+    return table.table[index];
 }
 template<typename V> std::span<std::byte> VariantListOperations<V>::next(std::span<std::byte> buffer)
 {
-    auto metadata = lookupMetadataByTag(readTag(buffer));
-    return alignBufferForValue(buffer.subspan(sizeof(VariantListTag)), metadata.alignment).subspan(metadata.size);
+    auto metadata = lookupMetadataByIndex(readIndex(buffer));
+    return alignBufferForValue(buffer.subspan(sizeof(VariantListIndex)), metadata.alignment).subspan(metadata.size);
 }
 
 template<typename V> std::span<const std::byte> VariantListOperations<V>::next(std::span<const std::byte> buffer)
 {
-    auto metadata = lookupMetadataByTag(readTag(buffer));
-    return alignBufferForValue(buffer.subspan(sizeof(VariantListTag)), metadata.alignment).subspan(metadata.size);
+    auto metadata = lookupMetadataByIndex(readIndex(buffer));
+    return alignBufferForValue(buffer.subspan(sizeof(VariantListIndex)), metadata.alignment).subspan(metadata.size);
 }
 
 // MARK: - Value appending
 
 template<typename V> template<typename T> size_t VariantListOperations<V>::sizeRequiredToWriteAt(std::byte* buffer)
 {
-    auto* bufferPlusTag = buffer + sizeof(VariantListTag);
-    auto* bufferPlusTagPlusAlignment = alignedBytes(bufferPlusTag, alignof(T));
-    auto* bufferPlusTagPlusAlignmentPlusValue = bufferPlusTagPlusAlignment + sizeof(T);
+    auto* bufferPlusIndex = buffer + sizeof(VariantListIndex);
+    auto* bufferPlusIndexPlusAlignment = alignedBytes(bufferPlusIndex, alignof(T));
+    auto* bufferPlusIndexPlusAlignmentPlusValue = bufferPlusIndexPlusAlignment + sizeof(T);
 
-    return bufferPlusTagPlusAlignmentPlusValue - buffer;
+    return bufferPlusIndexPlusAlignmentPlusValue - buffer;
 }
 
 template<typename V> template<typename T> size_t VariantListOperations<V>::sizeRequiredToWriteAt(const std::byte* buffer)
 {
-    auto* bufferPlusTag = buffer + sizeof(VariantListTag);
-    auto* bufferPlusTagPlusAlignment = alignedBytes(bufferPlusTag, alignof(T));
-    auto* bufferPlusTagPlusAlignmentPlusValue = bufferPlusTagPlusAlignment + sizeof(T);
+    auto* bufferPlusIndex = buffer + sizeof(VariantListIndex);
+    auto* bufferPlusIndexPlusAlignment = alignedBytes(bufferPlusIndex, alignof(T));
+    auto* bufferPlusIndexPlusAlignmentPlusValue = bufferPlusIndexPlusAlignment + sizeof(T);
 
-    return bufferPlusTagPlusAlignmentPlusValue - buffer;
+    return bufferPlusIndexPlusAlignmentPlusValue - buffer;
 }
 
-template<typename V> template<typename Arg> std::span<std::byte> VariantListOperations<V>::write(Arg&& value, std::span<std::byte> buffer)
+template<typename V> template<typename T, typename U> std::span<std::byte> VariantListOperations<V>::write(U&& value, std::span<std::byte> buffer)
 {
-    using T = std::decay_t<Arg>;
-    static constexpr VariantListTag tagValue = alternativeIndexV<T, V>;
+    static constexpr VariantListIndex indexValue = alternativeIndexV<T, V>;
 
-    buffer = writeTag(tagValue, buffer);
+    buffer = writeIndex(indexValue, buffer);
     buffer = alignBufferForValue<T>(buffer);
-    buffer = writeValue(std::forward<Arg>(value), buffer);
+    buffer = writeValue<T>(std::forward<U>(value), buffer);
 
     return buffer;
 }
@@ -358,12 +249,12 @@ template<typename V> bool VariantListOperations<V>::compare(std::span<const std:
         return false;
 
     while (true) {
-        auto tagA = readTag(bufferA);
-        auto tagB = readTag(bufferB);
-        if (tagA != tagB)
+        auto indexA = readIndex(bufferA);
+        auto indexB = readIndex(bufferB);
+        if (indexA != indexB)
             return false;
 
-        bool equal = typeForTag(tagA, [&]<typename T>() {
+        bool equal = typeForIndex<V>(indexA, [&]<typename T>() {
             if (readValue<T>(bufferA) != readValue<T>(bufferB))
                 return false;
 
@@ -401,13 +292,13 @@ template<typename V> void VariantListOperations<V>::copy(std::span<std::byte> ne
         memcpySpan(newBuffer, oldBuffer);
     else {
         while (!oldBuffer.empty()) {
-            // Copy tag.
-            memcpySpan(newBuffer.first(sizeof(VariantListTag)), oldBuffer.first(sizeof(VariantListTag)));
+            // Copy index.
+            memcpySpan(newBuffer.first(sizeof(VariantListIndex)), oldBuffer.first(sizeof(VariantListIndex)));
 
             // Copy value.
             visitValue(oldBuffer, [&]<typename T>(const T& value) {
-                oldBuffer = alignBufferForValue<T>(oldBuffer.subspan(sizeof(VariantListTag)));
-                newBuffer = alignBufferForValue<T>(newBuffer.subspan(sizeof(VariantListTag)));
+                oldBuffer = alignBufferForValue<T>(oldBuffer.subspan(sizeof(VariantListIndex)));
+                newBuffer = alignBufferForValue<T>(newBuffer.subspan(sizeof(VariantListIndex)));
 
                 if constexpr (VectorTraits<T>::canCopyWithMemcpy) {
                     memcpySpan(newBuffer.first(sizeof(T)), oldBuffer.first(sizeof(T)));
@@ -428,13 +319,13 @@ template<typename V> void VariantListOperations<V>::move(std::span<std::byte> ne
         memcpySpan(newBuffer, oldBuffer);
     else {
         while (!oldBuffer.empty()) {
-            // Move tag.
-            memcpySpan(newBuffer.first(sizeof(VariantListTag)), oldBuffer.first(sizeof(VariantListTag)));
+            // Move index.
+            memcpySpan(newBuffer.first(sizeof(VariantListIndex)), oldBuffer.first(sizeof(VariantListIndex)));
 
             // Move value.
             visitValue(oldBuffer, [&]<typename T>(T& value) {
-                oldBuffer = alignBufferForValue<T>(oldBuffer.subspan(sizeof(VariantListTag)));
-                newBuffer = alignBufferForValue<T>(newBuffer.subspan(sizeof(VariantListTag)));
+                oldBuffer = alignBufferForValue<T>(oldBuffer.subspan(sizeof(VariantListIndex)));
+                newBuffer = alignBufferForValue<T>(newBuffer.subspan(sizeof(VariantListIndex)));
 
                 if constexpr (VectorTraits<T>::canMoveWithMemcpy) {
                     memcpySpan(newBuffer.first(sizeof(T)), oldBuffer.first(sizeof(T)));
@@ -465,40 +356,39 @@ template<typename V> struct VariantListProxy {
 
     template<typename T> bool holds_alternative() const
     {
-        return alternativeIndexV<T, Variant> == Operations::readTag(buffer);
+        return Operations::readIndex(buffer) == alternativeIndexV<T, Variant>;
     }
 
-    template<typename... F> auto visit(F&& ...f) const
+    template<size_t I> bool holds_alternative() const
+    {
+        static_assert(I <= std::variant_size_v<Variant>);
+        return Operations::readIndex(buffer) == I;
+    }
+
+    template<typename... F> auto switchOn(F&& ...f) const
     {
         return Operations::visitValue(buffer, std::forward<F>(f)...);
     }
 
     Variant asVariant() const
     {
-        return visit([](const auto& alternative) -> Variant { return alternative; });
+        return switchOn([](const auto& alternative) -> Variant { return alternative; });
     }
 
     bool operator==(const VariantListProxy& other) const
     {
-        auto tag = Operations::readTag(buffer);
-        auto otherTag = Operations::readTag(other.buffer);
-        if (tag != otherTag)
+        auto index = Operations::readIndex(buffer);
+        auto otherIndex = Operations::readIndex(other.buffer);
+        if (index != otherIndex)
             return false;
 
-        return Operations::typeForTag(tag, [&]<typename T>() {
+        return typeForIndex<V>(index, [&]<typename T>() {
             return Operations::template readValue<T>(buffer) == Operations::template readValue<T>(other.buffer);
         });
     }
 
     std::span<const std::byte> buffer;
 };
-
-// Overload WTF::switchOn to allow it to be used with a `VariantListProxy`
-template<class V, class... F> ALWAYS_INLINE auto switchOn(V&& v, F&&... f) -> decltype(v.visit(std::forward<F>(f)...))
-{
-    return v.visit(std::forward<F>(f)...);
-}
-
 
 // The `VariantListSizer` can be used to emulate adding elements, by type, to a `VariantList`
 // in order to calculate the exact size requirements. This can then be passed to a `VariantList`
@@ -510,16 +400,16 @@ template<typename V> struct VariantListSizer {
 
     // Emulate appending a value of type `Arg` to the VariantList.
     template<typename Arg> void append()
-        requires VariantAllowsConstructionOfArg<V, std::decay_t<Arg>>
+        requires std::constructible_from<V, Arg>
     {
-        using T = std::decay_t<Arg>;
+        using T = typename VariantBestMatch<V, Arg>::type;
 
         unsigned currentOffset = size;
-        unsigned currentOffsetPlusTag = currentOffset + sizeof(VariantListTag);
-        unsigned currentOffsetPlusTagPlusAlignment = (currentOffsetPlusTag - 1u + alignof(T)) & -alignof(T);
-        unsigned currentOffsetPlusTagPlusAlignmentPlusSize = currentOffsetPlusTagPlusAlignment + sizeof(T);
+        unsigned currentOffsetPlusIndex = currentOffset + sizeof(VariantListIndex);
+        unsigned currentOffsetPlusIndexPlusAlignment = (currentOffsetPlusIndex - 1u + alignof(T)) & -alignof(T);
+        unsigned currentOffsetPlusIndexPlusAlignmentPlusSize = currentOffsetPlusIndexPlusAlignment + sizeof(T);
 
-        size = currentOffsetPlusTagPlusAlignmentPlusSize;
+        size = currentOffsetPlusIndexPlusAlignmentPlusSize;
     }
 };
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1183,6 +1183,7 @@
 		BC575BD9126F58E2006F0F12 /* PlatformUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC575BBF126F5752006F0F12 /* PlatformUtilities.cpp */; };
 		BC575BE0126F590D006F0F12 /* PlatformUtilitiesMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = BC131884117114B600B69727 /* PlatformUtilitiesMac.mm */; };
 		BCB68042126FBFF100642A61 /* DocumentStartUserScriptAlertCrash_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCB68041126FBFF100642A61 /* DocumentStartUserScriptAlertCrash_Bundle.cpp */; };
+		BCE0DFB72D188ADC003F0349 /* CompactVariant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCE0DFB62D188ADC003F0349 /* CompactVariant.cpp */; };
 		BCEA080E2CD00F5C000AC148 /* VariantList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCEA080D2CD00F5C000AC148 /* VariantList.cpp */; };
 		C0BD669F131D3CFF00E18F2A /* ResponsivenessTimerDoesntFireEarly_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0BD669E131D3CFF00E18F2A /* ResponsivenessTimerDoesntFireEarly_Bundle.cpp */; };
 		C0C5D3C61459912900A802A6 /* GetBackingScaleFactor_Bundle.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0C5D3BD14598B6F00A802A6 /* GetBackingScaleFactor_Bundle.mm */; };
@@ -3404,6 +3405,7 @@
 		BCBD372E125ABBE600D2C29F /* icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon.png; sourceTree = "<group>"; };
 		BCBD3760125ABCFE00D2C29F /* FrameMIMETypePNG.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FrameMIMETypePNG.cpp; sourceTree = "<group>"; };
 		BCC8B95A12611F4700DE46A4 /* FailedLoad.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FailedLoad.cpp; sourceTree = "<group>"; };
+		BCE0DFB62D188ADC003F0349 /* CompactVariant.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CompactVariant.cpp; sourceTree = "<group>"; };
 		BCEA080D2CD00F5C000AC148 /* VariantList.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = VariantList.cpp; sourceTree = "<group>"; };
 		C02B77F1126612140026BF0F /* SpacebarScrolling.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpacebarScrolling.cpp; sourceTree = "<group>"; };
 		C02B7853126613AE0026BF0F /* Carbon.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Carbon.framework; sourceTree = SDKROOT; };
@@ -5655,6 +5657,7 @@
 				FF5D0CB3283221AD00F3278A /* CompactRefPtr.cpp */,
 				E302BDA92404B92300865277 /* CompactRefPtrTuple.cpp */,
 				9B0C051824FDFB7000F2FE31 /* CompactUniquePtrTuple.cpp */,
+				BCE0DFB62D188ADC003F0349 /* CompactVariant.cpp */,
 				7BB8BDDC28F0781A00129836 /* CompletionHandlerTests.cpp */,
 				0F30CB5B1FCE1792004B5323 /* ConcurrentPtrHashSet.cpp */,
 				0FEAE3671B7D19CB00CE17F2 /* Condition.cpp */,
@@ -6748,6 +6751,7 @@
 				FF5D0CB4283221AD00F3278A /* CompactRefPtr.cpp in Sources */,
 				E302BDAA2404B92400865277 /* CompactRefPtrTuple.cpp in Sources */,
 				9B0C051924FDFB7D00F2FE31 /* CompactUniquePtrTuple.cpp in Sources */,
+				BCE0DFB72D188ADC003F0349 /* CompactVariant.cpp in Sources */,
 				7BB8BDE428F0781A00129836 /* CompletionHandlerTests.cpp in Sources */,
 				0F30CB5C1FCE1796004B5323 /* ConcurrentPtrHashSet.cpp in Sources */,
 				7C83DEC31D0A590C00FEBCF3 /* Condition.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/CompactVariant.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompactVariant.cpp
@@ -1,0 +1,527 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "LifecycleLogger.h"
+#include "MoveOnly.h"
+#include "RefLogger.h"
+#include <wtf/CompactVariant.h>
+#include <wtf/GetPtr.h>
+
+namespace TestWebKitAPI {
+
+struct EmptyStruct {
+    constexpr bool operator==(const EmptyStruct&) const = default;
+};
+
+struct SmallEnoughStruct {
+    float value { 0 };
+
+    constexpr bool operator==(const SmallEnoughStruct&) const = default;
+    constexpr bool operator==(float other) const { return value == other; };
+};
+
+struct TooBigStruct {
+    double value { 0 };
+
+    constexpr bool operator==(const TooBigStruct&) const = default;
+    constexpr bool operator==(double other) const { return value == other; };
+};
+
+} // namespace TestWebKitAPI
+
+namespace WTF {
+
+// Treat LifecycleLogger as smart pointer to allow its use in CompactVariant.
+template<> struct IsSmartPtr<TestWebKitAPI::LifecycleLogger> {
+    static constexpr bool value = true;
+};
+
+template<> struct CompactVariantTraits<TestWebKitAPI::TooBigStruct> {
+   static constexpr bool hasAlternativeRepresentation = true;
+
+   static constexpr uint64_t encodeFromArguments(double value)
+   {
+       return static_cast<uint64_t>(std::bit_cast<uint32_t>(static_cast<float>(value)));
+   }
+
+   static constexpr uint64_t encode(TestWebKitAPI::TooBigStruct&& value)
+   {
+       return static_cast<uint64_t>(std::bit_cast<uint32_t>(static_cast<float>(value.value)));
+   }
+
+   static constexpr TestWebKitAPI::TooBigStruct decode(uint64_t value)
+   {
+       return { std::bit_cast<float>(static_cast<uint32_t>(value)) };
+   }
+};
+
+} // namespace WTF
+
+namespace TestWebKitAPI {
+
+TEST(WTF_CompactVariant, Pointers)
+{
+    int testInt = 1;
+    float testFloat = 2.0f;
+
+    WTF::CompactVariant<std::variant<int*, float*>> variant = &testInt;
+    EXPECT_TRUE(variant.holds_alternative<int*>());
+    EXPECT_FALSE(variant.holds_alternative<float*>());
+
+    WTF::switchOn(variant,
+        [&](int* const& value)   { EXPECT_EQ(*value, 1); },
+        [&](float* const& value) { FAIL(); }
+    );
+
+    variant = &testFloat;
+    EXPECT_FALSE(variant.holds_alternative<int*>());
+    EXPECT_TRUE(variant.holds_alternative<float*>());
+
+    WTF::switchOn(variant,
+        [&](int* const& value)   { FAIL(); },
+        [&](float* const& value) { EXPECT_EQ(*value, 2.0f); }
+    );
+}
+
+TEST(WTF_CompactVariant, SmartPointers)
+{
+    {
+        RefLogger testRefLogger("testRefLogger");
+        Ref<RefLogger> ref(testRefLogger);
+
+        WTF::CompactVariant<std::variant<Ref<RefLogger>, std::unique_ptr<double>>> variant { std::in_place_type<Ref<RefLogger>>, WTFMove(ref) };
+
+        EXPECT_TRUE(variant.holds_alternative<Ref<RefLogger>>());
+        EXPECT_FALSE(variant.holds_alternative<std::unique_ptr<double>>());
+
+        WTF::switchOn(variant,
+            [&](const Ref<RefLogger>&)          { SUCCEED(); },
+            [&](const std::unique_ptr<double>&) { FAIL(); }
+        );
+
+        variant = std::make_unique<double>(2.0);
+        EXPECT_FALSE(variant.holds_alternative<Ref<RefLogger>>());
+        EXPECT_TRUE(variant.holds_alternative<std::unique_ptr<double>>());
+
+        WTF::switchOn(variant,
+            [&](const Ref<RefLogger>&)                { FAIL(); },
+            [&](const std::unique_ptr<double>& value) { EXPECT_EQ(*value, 2.0);  }
+        );
+    }
+    ASSERT_STREQ("ref(testRefLogger) deref(testRefLogger) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, SmallScalars)
+{
+    float testFloat = 2.0f;
+
+    WTF::CompactVariant<std::variant<int*, float*, float>> variant = 3.0f;
+    EXPECT_FALSE(variant.holds_alternative<int*>());
+    EXPECT_FALSE(variant.holds_alternative<float*>());
+    EXPECT_TRUE(variant.holds_alternative<float>());
+
+    WTF::switchOn(variant,
+        [&](int* const& value)   { FAIL(); },
+        [&](float* const& value) { FAIL(); },
+        [&](const float& value)  { EXPECT_EQ(value, 3.0f); }
+    );
+
+    variant = &testFloat;
+    EXPECT_FALSE(variant.holds_alternative<int*>());
+    EXPECT_TRUE(variant.holds_alternative<float*>());
+    EXPECT_FALSE(variant.holds_alternative<float>());
+
+    WTF::switchOn(variant,
+        [&](int* const& value)   { FAIL(); },
+        [&](float* const& value) { EXPECT_EQ(*value, 2.0f); },
+        [&](const float& value)  { FAIL(); }
+    );
+}
+
+TEST(WTF_CompactVariant, EmptyStruct)
+{
+    float testFloat = 2.0f;
+
+    WTF::CompactVariant<std::variant<int*, float*, EmptyStruct>> variant = EmptyStruct { };
+    EXPECT_FALSE(variant.holds_alternative<int*>());
+    EXPECT_FALSE(variant.holds_alternative<float*>());
+    EXPECT_TRUE(variant.holds_alternative<EmptyStruct>());
+
+    WTF::switchOn(variant,
+        [&](int* const& value)   { FAIL(); },
+        [&](float* const& value) { FAIL(); },
+        [&](const EmptyStruct&)  { SUCCEED(); }
+    );
+
+    variant = &testFloat;
+    EXPECT_FALSE(variant.holds_alternative<int*>());
+    EXPECT_TRUE(variant.holds_alternative<float*>());
+    EXPECT_FALSE(variant.holds_alternative<EmptyStruct>());
+
+    WTF::switchOn(variant,
+        [&](int* const& value)   { FAIL(); },
+        [&](float* const& value) { EXPECT_EQ(*value, 2.0f); },
+        [&](const EmptyStruct&)  { FAIL(); }
+    );
+}
+
+TEST(WTF_CompactVariant, SmallEnoughStruct)
+{
+    float testFloat = 2.0f;
+
+    WTF::CompactVariant<std::variant<int*, float*, SmallEnoughStruct>> variant = SmallEnoughStruct { 3.0f };
+    EXPECT_FALSE(variant.holds_alternative<int*>());
+    EXPECT_FALSE(variant.holds_alternative<float*>());
+    EXPECT_TRUE(variant.holds_alternative<SmallEnoughStruct>());
+
+    WTF::switchOn(variant,
+        [&](int* const& value)              { FAIL(); },
+        [&](float* const& value)            { FAIL(); },
+        [&](const SmallEnoughStruct& value) { EXPECT_EQ(value.value, 3.0f); }
+    );
+
+    variant = &testFloat;
+    EXPECT_FALSE(variant.holds_alternative<int*>());
+    EXPECT_TRUE(variant.holds_alternative<float*>());
+    EXPECT_FALSE(variant.holds_alternative<SmallEnoughStruct>());
+
+    WTF::switchOn(variant,
+        [&](int* const& value)        { FAIL(); },
+        [&](float* const& value)      { EXPECT_EQ(*value, 2.0f); },
+        [&](const SmallEnoughStruct&) { FAIL(); }
+    );
+}
+
+TEST(WTF_CompactVariant, TooBigStruct)
+{
+    float testFloat = 2.0f;
+
+    WTF::CompactVariant<std::variant<int*, float*, TooBigStruct>> variant = TooBigStruct { 4.0 };
+    EXPECT_FALSE(variant.holds_alternative<int*>());
+    EXPECT_FALSE(variant.holds_alternative<float*>());
+    EXPECT_TRUE(variant.holds_alternative<TooBigStruct>());
+
+    WTF::switchOn(variant,
+        [&](int* const& value)        { FAIL(); },
+        [&](float* const& value)      { FAIL(); },
+        [&](const TooBigStruct value) { EXPECT_EQ(value.value, 4.0); }
+    );
+
+    variant = &testFloat;
+    EXPECT_FALSE(variant.holds_alternative<int*>());
+    EXPECT_TRUE(variant.holds_alternative<float*>());
+    EXPECT_FALSE(variant.holds_alternative<TooBigStruct>());
+
+    WTF::switchOn(variant,
+        [&](int* const& value)   { FAIL(); },
+        [&](float* const& value) { EXPECT_EQ(*value, 2.0f); },
+        [&](const TooBigStruct)  { FAIL(); }
+    );
+}
+
+TEST(WTF_CompactVariant, MoveOnlyStruct)
+{
+    float testFloat = 2.0f;
+
+    WTF::CompactVariant<std::variant<int*, float*, MoveOnly>> variant = MoveOnly { 5u };
+    EXPECT_FALSE(variant.holds_alternative<int*>());
+    EXPECT_FALSE(variant.holds_alternative<float*>());
+    EXPECT_TRUE(variant.holds_alternative<MoveOnly>());
+
+    WTF::switchOn(variant,
+        [&](int* const& value)      { FAIL(); },
+        [&](float* const& value)    { FAIL(); },
+        [&](const MoveOnly& value)  { EXPECT_EQ(value.value(), 5u); }
+    );
+
+    variant = &testFloat;
+    EXPECT_FALSE(variant.holds_alternative<int*>());
+    EXPECT_TRUE(variant.holds_alternative<float*>());
+    EXPECT_FALSE(variant.holds_alternative<MoveOnly>());
+
+    WTF::switchOn(variant,
+        [&](int* const& value)   { FAIL(); },
+        [&](float* const& value) { EXPECT_EQ(*value, 2.0f); },
+        [&](const MoveOnly&)     { FAIL(); }
+    );
+
+    variant = MoveOnly { 6u };
+    EXPECT_FALSE(variant.holds_alternative<int*>());
+    EXPECT_FALSE(variant.holds_alternative<float*>());
+    EXPECT_TRUE(variant.holds_alternative<MoveOnly>());
+
+    WTF::switchOn(variant,
+        [&](int* const& value)     { FAIL(); },
+        [&](float* const& value)   { FAIL(); },
+        [&](const MoveOnly& value) { EXPECT_EQ(value.value(), 6u); }
+    );
+}
+
+TEST(WTF_CompactVariant, ValuelessByMove)
+{
+    int testInt = 1;
+    WTF::CompactVariant<std::variant<int*, float*>> variant = &testInt;
+    EXPECT_FALSE(variant.valueless_by_move());
+
+    WTF::CompactVariant<std::variant<int*, float*>> other = WTFMove(variant);
+    EXPECT_FALSE(other.valueless_by_move());
+    EXPECT_TRUE(variant.valueless_by_move());
+
+    // Test copying the "valueless_by_move" variant.
+    WTF::CompactVariant<std::variant<int*, float*>> copy = variant;
+    EXPECT_TRUE(variant.valueless_by_move());
+    EXPECT_TRUE(copy.valueless_by_move());
+
+    // Test re-moving the "valueless_by_move" variant.
+    WTF::CompactVariant<std::variant<int*, float*>> moved = WTFMove(variant);
+    EXPECT_TRUE(variant.valueless_by_move());
+    EXPECT_TRUE(moved.valueless_by_move());
+}
+
+TEST(WTF_CompactVariant, ArgumentAssignment)
+{
+    {
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant = LifecycleLogger("compact");
+
+        ASSERT_STREQ("construct(compact) move-construct(compact) destruct(<default>) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) ", takeLogStr().c_str());
+}
+
+
+TEST(WTF_CompactVariant, ArgumentConstruct)
+{
+    {
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { LifecycleLogger("compact") };
+
+        ASSERT_STREQ("construct(compact) move-construct(compact) destruct(<default>) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, ArgumentConstructInPlaceType)
+{
+    {
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { std::in_place_type<LifecycleLogger>, "compact" };
+
+        ASSERT_STREQ("construct(compact) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, ArgumentConstructInPlaceIndex)
+{
+    {
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { std::in_place_index<1>, "compact" };
+
+        ASSERT_STREQ("construct(compact) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, ArgumentMoveConstruct)
+{
+    {
+        LifecycleLogger lifecycleLogger("compact");
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { WTFMove(lifecycleLogger) };
+
+        ASSERT_STREQ("construct(compact) move-construct(compact) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) destruct(<default>) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, ArgumentCopyConstruct)
+{
+    {
+        LifecycleLogger lifecycleLogger("compact");
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { lifecycleLogger };
+
+        ASSERT_STREQ("construct(compact) copy-construct(compact) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) destruct(compact) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, ArgumentMoveAssignment)
+{
+    {
+        LifecycleLogger lifecycleLogger("compact");
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant = WTFMove(lifecycleLogger);
+
+        ASSERT_STREQ("construct(compact) move-construct(compact) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) destruct(<default>) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, ArgumentCopyAssignment)
+{
+    {
+        LifecycleLogger lifecycleLogger("compact");
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant = lifecycleLogger;
+
+        ASSERT_STREQ("construct(compact) copy-construct(compact) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) destruct(compact) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, CopyConstruct)
+{
+    {
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { std::in_place_type<LifecycleLogger>, "compact" };
+
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> other { variant };
+
+        ASSERT_STREQ("construct(compact) copy-construct(compact) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) destruct(compact) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, CopyAssignment)
+{
+    {
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { std::in_place_type<LifecycleLogger>, "compact" };
+
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> other = variant;
+
+        ASSERT_STREQ("construct(compact) copy-construct(compact) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) destruct(compact) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, MoveConstruct)
+{
+    {
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { std::in_place_type<LifecycleLogger>, "compact" };
+
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> other { WTFMove(variant) };
+
+        ASSERT_STREQ("construct(compact) move-construct(compact) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, MoveAssignment)
+{
+    {
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { std::in_place_type<LifecycleLogger>, "compact" };
+
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> other = WTFMove(variant);
+
+        ASSERT_STREQ("construct(compact) move-construct(compact) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, ConstructThenReassign)
+{
+    {
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { std::in_place_type<LifecycleLogger>, "compact" };
+
+        variant = 1.0f;
+
+        ASSERT_STREQ("construct(compact) destruct(compact) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, ArgumentReassignment)
+{
+    {
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { 1.0f };
+
+        variant = LifecycleLogger { "compact" };
+
+        ASSERT_STREQ("construct(compact) move-construct(compact) destruct(<default>) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, ArgumentCopyReassignment)
+{
+    {
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { 1.0f };
+
+        LifecycleLogger lifecycleLogger { "compact" };
+        variant = lifecycleLogger;
+
+        ASSERT_STREQ("construct(compact) copy-construct(compact) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) destruct(compact) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, ArgumentMoveReassignment)
+{
+    {
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { 1.0f };
+
+        LifecycleLogger lifecycleLogger { "compact" };
+        variant = WTFMove(lifecycleLogger);
+
+        ASSERT_STREQ("construct(compact) move-construct(compact) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(<default>) destruct(compact) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, EmplaceType)
+{
+    {
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { 1.0f };
+
+        variant.emplace<LifecycleLogger>("compact");
+
+        ASSERT_STREQ("construct(compact) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, EmplaceIndex)
+{
+    {
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { 1.0f };
+
+        variant.emplace<1>("compact");
+
+        ASSERT_STREQ("construct(compact) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) ", takeLogStr().c_str());
+}
+
+TEST(WTF_CompactVariant, SwitchOn)
+{
+    // `switchOn` should not cause any lifecycle events.
+    {
+        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { std::in_place_type<LifecycleLogger>, "compact" };
+
+        WTF::switchOn(variant,
+            [&](const float&) { },
+            [&](const LifecycleLogger&) { }
+        );
+
+        ASSERT_STREQ("construct(compact) ", takeLogStr().c_str());
+    }
+    ASSERT_STREQ("destruct(compact) ", takeLogStr().c_str());
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/LifecycleLogger.h
+++ b/Tools/TestWebKitAPI/Tests/WTF/LifecycleLogger.h
@@ -40,7 +40,11 @@ struct LifecycleLogger {
 
     void setName(const char*);
 
+    const char* get() const { return name; }
+
     const char* name { "<default>" };
+
+    bool operator==(const LifecycleLogger&) const = default;
 };
 
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/VariantList.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/VariantList.cpp
@@ -42,7 +42,7 @@ TEST(WTF_VariantList, Basic)
     for (auto proxy : variantList) {
         EXPECT_TRUE(proxy.holds_alternative<int>());
 
-        proxy.visit(
+        WTF::switchOn(proxy,
             [&](int value) { EXPECT_EQ(0, value); },
             [&](float) { FAIL(); }
         );
@@ -75,7 +75,7 @@ TEST(WTF_VariantList, Basic_InlineCapacity)
     for (auto proxy : variantList) {
         EXPECT_TRUE(proxy.holds_alternative<int>());
 
-        proxy.visit(
+        WTF::switchOn(proxy,
             [&](int value) { EXPECT_EQ(0, value); },
             [&](float) { FAIL(); }
         );
@@ -108,7 +108,7 @@ TEST(WTF_VariantList, MoveOnly)
     for (auto proxy : variantList) {
         EXPECT_TRUE(proxy.holds_alternative<MoveOnly>());
 
-        proxy.visit(
+        WTF::switchOn(proxy,
             [&](int) { FAIL(); },
             [&](const MoveOnly& value) { EXPECT_EQ(iterations, value.value()); },
             [&](float) { FAIL(); }
@@ -151,7 +151,7 @@ TEST(WTF_VariantList, MoveWithItems)
     unsigned iterations = 0;
 
     for (auto proxy : moved) {
-        proxy.visit(
+        WTF::switchOn(proxy,
             [&](int value) { EXPECT_EQ(0, value); },
             [&](const MoveOnly& value) { EXPECT_EQ(1u, value.value()); },
             [&](float value) { EXPECT_EQ(2.0f, value); }
@@ -174,7 +174,7 @@ TEST(WTF_VariantList, CopyWithItems)
     unsigned iterations = 0;
 
     for (auto proxy : variantList) {
-        proxy.visit(
+        WTF::switchOn(proxy,
             [&](int value) { EXPECT_EQ(0, value); },
             [&](float value) { EXPECT_EQ(1.0f, value); }
         );
@@ -187,7 +187,7 @@ TEST(WTF_VariantList, CopyWithItems)
     iterations = 0;
 
     for (auto proxy : copied) {
-        proxy.visit(
+        WTF::switchOn(proxy,
             [&](int value) { EXPECT_EQ(0, value); },
             [&](float value) { EXPECT_EQ(1.0f, value); }
         );


### PR DESCRIPTION
#### dc904eb4098bab9698ede556c0f2cc6b9955d9ab
<pre>
Introduce a CompactVariant for efficient variants of pointers and types smaller than 56 bits
<a href="https://bugs.webkit.org/show_bug.cgi?id=285099">https://bugs.webkit.org/show_bug.cgi?id=285099</a>

Reviewed by Darin Adler.

Adds `WTF::CompactVariant`.

A `WTF::CompactVariant` acts like a `std::variant` with the following differences:
- All alternatives must be pointers, smart pointers, have size of 56 bits or fewer,
  or be specialized for `CompactVariantTraits`.
- It can only contain 254 or fewer alternatives.
- Has a more limited API, only offering `holds_alternative()` for type checking and
  `switchOn()` for value access.

Factors out a few share helpers from VariantList into a VariantExtras.h file.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/CompactVariant.h: Added.
* Source/WTF/wtf/CompactVariantOperations.h: Added.
* Source/WTF/wtf/VariantExtras.h: Added.
* Source/WTF/wtf/VariantList.h:
* Source/WTF/wtf/VariantListOperations.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/CompactVariant.cpp: Added.
* Tools/TestWebKitAPI/Tests/WTF/LifecycleLogger.h:

Canonical link: <a href="https://commits.webkit.org/288271@main">https://commits.webkit.org/288271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca9a0b2ceaabf7f9d5f3378724fe8966e46e3af9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82335 "26 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87467 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33396 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84440 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9882 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/64169 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21920 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44447 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1358 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29100 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32437 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75323 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72649 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88823 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81389 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6900 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/72570 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71787 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17887 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15922 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14931 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9594 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15115 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103802 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9468 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25193 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12934 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11238 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->