### PR TITLE
[GStreamer][WebAudio][Quirks] Fix initial WebAudio cut on Raspberry Pi

### DIFF
--- a/Source/WebCore/platform/SourcesGStreamer.txt
+++ b/Source/WebCore/platform/SourcesGStreamer.txt
@@ -105,6 +105,7 @@ platform/gstreamer/GStreamerQuirkAmLogic.cpp
 platform/gstreamer/GStreamerQuirkBcmNexus.cpp
 platform/gstreamer/GStreamerQuirkBroadcom.cpp
 platform/gstreamer/GStreamerQuirkBroadcomBase.cpp
+platform/gstreamer/GStreamerQuirkOpenMAX.cpp
 platform/gstreamer/GStreamerQuirkRealtek.cpp
 platform/gstreamer/GStreamerQuirkRialto.cpp
 platform/gstreamer/GStreamerQuirkWesteros.cpp

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 Igalia S.L
+ * Copyright (C) 2024 Metrological Group B.V.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "GStreamerQuirkOpenMAX.h"
+
+#if USE(GSTREAMER)
+
+#include "GStreamerCommon.h"
+
+namespace WebCore {
+
+GST_DEBUG_CATEGORY_STATIC(webkit_openmax_quirks_debug);
+#define GST_CAT_DEFAULT webkit_openmax_quirks_debug
+
+GStreamerQuirkOpenMAX::GStreamerQuirkOpenMAX()
+{
+    GST_DEBUG_CATEGORY_INIT(webkit_openmax_quirks_debug, "webkitquirksopenmax", 0, "WebKit OpenMAX Quirks");
+}
+
+bool GStreamerQuirkOpenMAX::processWebAudioSilentBuffer(GstBuffer* buffer) const
+{
+    GST_TRACE("Force disabling GAP buffer flag");
+    GST_BUFFER_FLAG_UNSET(buffer, GST_BUFFER_FLAG_GAP);
+    GST_BUFFER_FLAG_UNSET(buffer, GST_BUFFER_FLAG_DROPPABLE);
+    return true;
+}
+
+#undef GST_CAT_DEFAULT
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Igalia S.L
+ * Copyright (C) 2024 Metrological Group B.V.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if USE(GSTREAMER)
+
+#include "GStreamerQuirks.h"
+
+namespace WebCore {
+
+class GStreamerQuirkOpenMAX final : public GStreamerQuirk {
+public:
+    GStreamerQuirkOpenMAX();
+    const ASCIILiteral identifier() const final { return "OpenMAX"_s; }
+
+    bool processWebAudioSilentBuffer(GstBuffer*) const final;
+};
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -31,6 +31,7 @@
 #include "GStreamerQuirkAmLogic.h"
 #include "GStreamerQuirkBcmNexus.h"
 #include "GStreamerQuirkBroadcom.h"
+#include "GStreamerQuirkOpenMAX.h"
 #include "GStreamerQuirkRealtek.h"
 #include "GStreamerQuirkRialto.h"
 #include "GStreamerQuirkWesteros.h"
@@ -79,7 +80,7 @@ GStreamerQuirksManager::GStreamerQuirksManager(bool isForTesting, bool loadQuirk
     if (quirksList) {
         StringView quirks { span(quirksList) };
         if (WTF::equalLettersIgnoringASCIICase(quirks, "help"_s)) {
-            WTFLogAlways("Supported quirks for WEBKIT_GST_QUIRKS are: amlogic, broadcom, bcmnexus, realtek, westeros");
+            gst_printerrln("Supported quirks for WEBKIT_GST_QUIRKS are: amlogic, broadcom, bcmnexus, openmax, realtek, westeros");
             return;
         }
 
@@ -91,6 +92,8 @@ GStreamerQuirksManager::GStreamerQuirksManager(bool isForTesting, bool loadQuirk
                 quirk = WTF::makeUnique<GStreamerQuirkBroadcom>();
             else if (WTF::equalLettersIgnoringASCIICase(identifier, "bcmnexus"_s))
                 quirk = WTF::makeUnique<GStreamerQuirkBcmNexus>();
+            else if (WTF::equalLettersIgnoringASCIICase(identifier, "openmax"_s))
+                quirk = WTF::makeUnique<GStreamerQuirkOpenMAX>();
             else if (WTF::equalLettersIgnoringASCIICase(identifier, "realtek"_s))
                 quirk = WTF::makeUnique<GStreamerQuirkRealtek>();
             else if (WTF::equalLettersIgnoringASCIICase(identifier, "rialto"_s))
@@ -336,6 +339,14 @@ void GStreamerQuirksManager::setupBufferingPercentageCorrection(MediaPlayerPriva
             quirk->setupBufferingPercentageCorrection(playerPrivate, currentState, newState, WTFMove(element));
             return;
         }
+    }
+}
+
+void GStreamerQuirksManager::processWebAudioSilentBuffer(GstBuffer* buffer) const
+{
+    for (const auto& quirk : m_quirks) {
+        if (quirk->processWebAudioSilentBuffer(buffer))
+            break;
     }
 }
 

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
@@ -87,6 +87,14 @@ public:
     virtual int correctBufferingPercentage(MediaPlayerPrivateGStreamer*, int originalBufferingPercentage, GstBufferingMode) const { return originalBufferingPercentage; }
     virtual void resetBufferingPercentage(MediaPlayerPrivateGStreamer*, int) const { };
     virtual void setupBufferingPercentageCorrection(MediaPlayerPrivateGStreamer*, GstState, GstState, GRefPtr<GstElement>&&) const { }
+
+    // Subclass must return true if it wants to override the default behaviour of sibling platforms.
+    virtual bool processWebAudioSilentBuffer(GstBuffer* buffer) const
+    {
+        GST_BUFFER_FLAG_SET(buffer, GST_BUFFER_FLAG_GAP);
+        GST_BUFFER_FLAG_SET(buffer, GST_BUFFER_FLAG_DROPPABLE);
+        return false;
+    }
 };
 
 class GStreamerHolePunchQuirk : public GStreamerQuirkBase {
@@ -139,6 +147,7 @@ public:
     void resetBufferingPercentage(MediaPlayerPrivateGStreamer*, int bufferingPercentage) const;
     void setupBufferingPercentageCorrection(MediaPlayerPrivateGStreamer*, GstState currentState, GstState newState, GRefPtr<GstElement>&&) const;
 
+    void processWebAudioSilentBuffer(GstBuffer*) const;
 private:
     GStreamerQuirksManager(bool, bool);
 


### PR DESCRIPTION
#### 45b9cba6ef32c10965a7d3330d5a78951a9b0137
<pre>
[GStreamer][WebAudio][Quirks] Fix initial WebAudio cut on Raspberry Pi
<a href="https://bugs.webkit.org/show_bug.cgi?id=285030">https://bugs.webkit.org/show_bug.cgi?id=285030</a>

Reviewed by Philippe Normand.

WebAudio playback eats up a portion of the start of a sound after a
silence on Raspberry Pi when using OpenMAX. This is because the silence
buffers are marked with the GAP flag by WebKitWebAudioSourceGStreamer
and that causes them not to be rendered by the audio sink. This, in
turn, causes OpenMAX (the platform media framework used on Raspbery Pi
32 bit) to cool down and when the first audible buffer arrives, it takes
a fraction of a second to warm up again and play audio back.

This patch avoids marking the buffers as GAP on these platforms, fixing
the issue. Inserting non-gap buffers periodically (even with a frequency
of one non-gap per every gap) is not enough to solve the problem, so the
only alternative is to avoid gap buffers completely.

* Source/WebCore/platform/SourcesGStreamer.txt: Added new GStreamerQuirkOpenMAX.cpp file.
* Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp:
(webKitWebAudioSrcRenderAndPushFrames): Resort to quirks to process the buffers (marking them as gap and drop there or not). Do it in-place if quirks are disabled.
* Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.cpp: Added.
(WebCore::GStreamerQuirkOpenMAX::GStreamerQuirkOpenMAX): Constructor. Initialize debug category.
(WebCore::GStreamerQuirkOpenMAX::processWebAudioSilentBuffer const): Mark the buffers as no gap and no drop.
* Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.h: Added.
* Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp:
(WebCore::GStreamerQuirksManager::GStreamerQuirksManager): Initialize OpenMAX quirk backend.
(WebCore::GStreamerQuirksManager::processWebAudioSilentBuffer const): Ask all backends to process the buffers. The backends will return true if they consider themselves as preferred, avoiding remaining backends after them to be queried.
* Source/WebCore/platform/gstreamer/GStreamerQuirks.h:
(WebCore::GStreamerQuirk::processWebAudioSilentBuffer const): Added default implementation that marks the buffers as gap and drop.

Canonical link: <a href="https://commits.webkit.org/288713@main">https://commits.webkit.org/288713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67ada814b3f3c67413a8854c0defd463408e0c3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89172 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35105 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65404 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23247 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2841 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76411 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45698 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2779 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30635 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34154 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90552 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8235 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73857 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11586 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73071 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18092 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17375 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2709 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11314 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16786 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11162 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14638 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12934 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->