### PR TITLE
Add throttler to limit the ResourceMonitor activity.

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1556,6 +1556,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/ResourceLoaderTypes.h
     loader/ResourceMonitor.h
     loader/ResourceMonitorChecker.h
+    loader/ResourceMonitorThrottler.h
     loader/ResourceTimingInformation.h
     loader/ShouldTreatAsContinuingLoad.h
     loader/SubframeLoader.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2026,6 +2026,7 @@ loader/ResourceLoadStatistics.cpp
 loader/ResourceLoader.cpp
 loader/ResourceMonitor.cpp
 loader/ResourceMonitorChecker.cpp
+loader/ResourceMonitorThrottler.cpp
 loader/ResourceTiming.cpp
 loader/ResourceTimingInformation.cpp
 loader/ServerTiming.cpp

--- a/Source/WebCore/loader/LocalFrameLoaderClient.cpp
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.cpp
@@ -46,4 +46,10 @@ void LocalFrameLoaderClient::deref() const
     m_loader->deref();
 }
 
+#if ENABLE(CONTENT_EXTENSIONS)
+void LocalFrameLoaderClient::didExceedNetworkUsageThreshold()
+{
+}
+#endif
+
 } // namespace WebCore

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -389,6 +389,10 @@ public:
 
     virtual RefPtr<HistoryItem> createHistoryItemTree(bool clipAtTarget, BackForwardItemIdentifier) const = 0;
 
+#if ENABLE(CONTENT_EXTENSIONS)
+    virtual void didExceedNetworkUsageThreshold();
+#endif
+
 protected:
     explicit LocalFrameLoaderClient(FrameLoader&);
 

--- a/Source/WebCore/loader/ResourceMonitor.cpp
+++ b/Source/WebCore/loader/ResourceMonitor.cpp
@@ -128,7 +128,14 @@ void ResourceMonitor::checkNetworkUsageExcessIfNecessary()
 
     if (m_networkUsage.hasOverflowed() || m_networkUsage >= m_networkUsageThreshold) {
         m_networkUsageExceed = true;
-        protectedFrame()->networkUsageDidExceedThreshold();
+
+        Ref frame = m_frame.get();
+
+        // If the frame has sticky user activation, don't do offloading.
+        if (RefPtr protectedWindow = frame->window(); protectedWindow && protectedWindow->hasStickyActivation())
+            return;
+
+        frame->loader().client().didExceedNetworkUsageThreshold();
     }
 }
 

--- a/Source/WebCore/loader/ResourceMonitorThrottler.cpp
+++ b/Source/WebCore/loader/ResourceMonitorThrottler.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ResourceMonitorThrottler.h"
+
+#include <wtf/CryptographicallyRandomNumber.h>
+#include <wtf/Seconds.h>
+#include <wtf/StdLibExtras.h>
+
+#if ENABLE(CONTENT_EXTENSIONS)
+
+#define RESOURCEMONITOR_RELEASE_LOG(fmt, ...) RELEASE_LOG(ResourceLoading, "%p - ResourceMonitorThrottler::" fmt, this, ##__VA_ARGS__)
+
+namespace WebCore {
+
+static constexpr size_t defaultThrottleAccessCount = 5;
+static constexpr Seconds defaultThrottleDuration = 24_h;
+static constexpr size_t defaultMaxHosts = 100;
+
+ResourceMonitorThrottler::ResourceMonitorThrottler()
+    : ResourceMonitorThrottler(defaultThrottleAccessCount, defaultThrottleDuration, defaultMaxHosts)
+{
+}
+
+ResourceMonitorThrottler::ResourceMonitorThrottler(size_t count, Seconds duration, size_t maxHosts)
+    : m_config { count, duration, maxHosts }
+{
+    ASSERT(maxHosts >= 1);
+    RESOURCEMONITOR_RELEASE_LOG("Initialized with count: %zu, duration: %.f, maxHosts: %zu", count, duration.value(), maxHosts);
+}
+
+auto ResourceMonitorThrottler::throttlerForHost(const String& host) -> AccessThrottler&
+{
+    return m_throttlersByHost.ensure(host, [] {
+        return AccessThrottler { };
+    }).iterator->value;
+}
+
+void ResourceMonitorThrottler::removeOldestThrottler()
+{
+    auto oldest = ApproximateTime::infinity();
+    String oldestKey;
+
+    for (auto it : m_throttlersByHost) {
+        auto time = it.value.newestAccessTime();
+        if (time < oldest) {
+            oldest = time;
+            oldestKey = it.key;
+        }
+    }
+    ASSERT(!oldestKey.isNull());
+    m_throttlersByHost.remove(oldestKey);
+}
+
+bool ResourceMonitorThrottler::tryAccess(const String& host, ApproximateTime time)
+{
+    if (host.isEmpty())
+        return false;
+
+    auto& throttler = throttlerForHost(host);
+    auto result = throttler.tryAccessAndUpdateHistory(time, m_config);
+
+    if (m_throttlersByHost.size() > m_config.maxHosts) {
+        // Update and remove all expired access times. If no entry in throttler, remove it.
+        m_throttlersByHost.removeIf([&](auto& it) -> bool {
+            return it.value.tryExpire(time, m_config);
+        });
+
+        // If there are still too many hosts, then remove oldest one.
+        while (m_throttlersByHost.size() > m_config.maxHosts)
+            removeOldestThrottler();
+    }
+    ASSERT(m_throttlersByHost.size() <= m_config.maxHosts);
+
+    return result;
+}
+
+bool ResourceMonitorThrottler::AccessThrottler::tryAccessAndUpdateHistory(ApproximateTime time, const Config& config)
+{
+    tryExpire(time, config);
+    if (m_accessTimes.size() >= config.count)
+        return false;
+
+    m_accessTimes.enqueue(time);
+    if (m_newestAccessTime < time)
+        m_newestAccessTime = time;
+
+    return true;
+}
+
+ApproximateTime ResourceMonitorThrottler::AccessThrottler::oldestAccessTime() const
+{
+    return m_accessTimes.peek();
+}
+
+bool ResourceMonitorThrottler::AccessThrottler::tryExpire(ApproximateTime time, const Config& config)
+{
+    auto expirationTime = time - config.duration;
+
+    while (!m_accessTimes.isEmpty()) {
+        if (oldestAccessTime() > expirationTime)
+            return false;
+
+        m_accessTimes.dequeue();
+    }
+    // Tell caller that the queue is empty.
+    return true;
+}
+
+} // namespace WebCore
+
+#undef RESOURCEMONITOR_RELEASE_LOG
+
+#endif

--- a/Source/WebCore/loader/ResourceMonitorThrottler.h
+++ b/Source/WebCore/loader/ResourceMonitorThrottler.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ApproximateTime.h>
+#include <wtf/HashMap.h>
+#include <wtf/PriorityQueue.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+class ResourceMonitorThrottler final {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    WEBCORE_EXPORT ResourceMonitorThrottler();
+    WEBCORE_EXPORT ResourceMonitorThrottler(size_t count, Seconds duration, size_t maxHosts);
+
+    WEBCORE_EXPORT bool tryAccess(const String& host, ApproximateTime = ApproximateTime::now());
+
+private:
+    struct Config {
+        size_t count;
+        Seconds duration;
+        size_t maxHosts;
+    };
+
+    class AccessThrottler final {
+    public:
+        AccessThrottler() = default;
+
+        bool tryAccessAndUpdateHistory(ApproximateTime, const Config&);
+        bool tryExpire(ApproximateTime, const Config&);
+        ApproximateTime oldestAccessTime() const;
+        ApproximateTime newestAccessTime() const { return m_newestAccessTime; }
+
+    private:
+        void removeExpired(ApproximateTime);
+
+        PriorityQueue<ApproximateTime> m_accessTimes;
+        ApproximateTime m_newestAccessTime { -ApproximateTime::infinity() };
+    };
+
+    AccessThrottler& throttlerForHost(const String& host);
+    void removeExpiredThrottler();
+    void removeOldestThrottler();
+
+    Config m_config;
+    HashMap<String, AccessThrottler> m_throttlersByHost;
+};
+
+}

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -332,7 +332,7 @@ public:
     WEBCORE_EXPORT void setScrollingMode(ScrollbarMode);
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    void networkUsageDidExceedThreshold();
+    WEBCORE_EXPORT void showResourceMonitoringError();
 #endif
 
 protected:
@@ -356,10 +356,6 @@ private:
     void reinitializeDocumentSecurityContext() final;
     FrameLoaderClient& loaderClient() final;
     void documentURLForConsoleLog(CompletionHandler<void(const URL&)>&&) final;
-
-#if ENABLE(CONTENT_EXTENSIONS)
-    void showResourceMonitoringError(String&& htmlContent);
-#endif
 
     WeakHashSet<FrameDestructionObserver> m_destructionObservers;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -15873,6 +15873,14 @@ void WebPageProxy::setPresentingApplicationAuditToken(const audit_token_t& prese
 }
 #endif
 
+#if ENABLE(CONTENT_EXTENSIONS)
+void WebPageProxy::shouldOffloadIFrameForHost(const String& host, CompletionHandler<void(bool)>&& completionHandler) const
+{
+    bool wasGranted = protectedWebsiteDataStore()->resourceMonitorThrottler().tryAccess(host);
+    completionHandler(wasGranted);
+}
+#endif
+
 } // namespace WebKit
 
 #undef WEBPAGEPROXY_RELEASE_LOG

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3288,6 +3288,11 @@ private:
     bool hasValidOpeningAppLinkActivity() const;
 #endif
 
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    void shouldOffloadIFrameForHost(const String& host, CompletionHandler<void(bool)>&&) const;
+#endif
+
     UniqueRef<Internals> m_internals;
     Identifier m_identifier;
     WebCore::PageIdentifier m_webPageID;

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -671,4 +671,8 @@ messages -> WebPageProxy {
     HasActiveNowPlayingSessionChanged(bool hasActiveNowPlayingSessionChanged)
 
     SetAllowsLayoutViewportHeightExpansion(bool newValue)
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    ShouldOffloadIFrameForHost(String host) -> (bool wasGranted)
+#endif
 }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -69,6 +69,10 @@
 #include <WebCore/SoupNetworkProxySettings.h>
 #endif
 
+#if ENABLE(CONTENT_EXTENSIONS)
+#include <WebCore/ResourceMonitorThrottler.h>
+#endif
+
 namespace API {
 class Data;
 class DownloadClient;
@@ -490,6 +494,10 @@ public:
     bool builtInNotificationsEnabled() const;
 #endif
 
+#if ENABLE(CONTENT_EXTENSIONS)
+    WebCore::ResourceMonitorThrottler& resourceMonitorThrottler() { return m_resourceMonitorThrottler; }
+#endif
+
 private:
     enum class ForceReinitialization : bool { No, Yes };
 #if ENABLE(APP_BOUND_DOMAINS)
@@ -630,6 +638,10 @@ private:
 #endif
     bool m_storageSiteValidationEnabled { false };
     HashSet<URL> m_persistedSiteURLs;
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    WebCore::ResourceMonitorThrottler m_resourceMonitorThrottler;
+#endif
 };
 
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -289,6 +289,10 @@ private:
 
     bool siteIsolationEnabled() const;
 
+#if ENABLE(CONTENT_EXTENSIONS)
+    void didExceedNetworkUsageThreshold();
+#endif
+
 #if ENABLE(PDF_PLUGIN)
     RefPtr<PluginView> m_pluginView;
     bool m_hasSentResponseToPluginView { false };

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -217,6 +217,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/PathTests.cpp
         Tests/WebCore/PublicSuffix.cpp
         Tests/WebCore/RenderStyleChange.cpp
+        Tests/WebCore/ResourceMonitor.cpp
         Tests/WebCore/SecurityOrigin.cpp
         Tests/WebCore/SharedBuffer.cpp
         Tests/WebCore/SharedBufferTest.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1276,6 +1276,7 @@
 		E5AA42F2259128AE00410A3D /* UserInterfaceIdiomUpdate.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5AA42F1259128AE00410A3D /* UserInterfaceIdiomUpdate.mm */; };
 		E5AA8D1D25151CC60051CC45 /* DateInputTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E5AA8D1C25151CC60051CC45 /* DateInputTests.mm */; };
 		E720BDD72D08B42A0093E680 /* web-extension-with-parent-directory.zip in Copy Resources */ = {isa = PBXBuildFile; fileRef = E720BDD62D08B42A0093E680 /* web-extension-with-parent-directory.zip */; };
+		EB1F62972D19E07E000B3A04 /* ResourceMonitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB1F62962D19E07E000B3A04 /* ResourceMonitor.cpp */; };
 		EB7067FC2CCC0E9900A94073 /* MixedContentChecker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB6836D32CC967E00073A8E5 /* MixedContentChecker.cpp */; };
 		EB9AD8C727646E7400D893A4 /* PushDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB9AD8C627646E7300D893A4 /* PushDatabase.cpp */; };
 		EBA75C49275ED7C700D6D31C /* PushMessageCrypto.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EBA75C48275ED7BE00D6D31C /* PushMessageCrypto.cpp */; };
@@ -3661,6 +3662,7 @@
 		E5F67D662B637F9200CC30DE /* AdaptiveImageGlyph.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AdaptiveImageGlyph.mm; sourceTree = "<group>"; };
 		E720BDD62D08B42A0093E680 /* web-extension-with-parent-directory.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = "web-extension-with-parent-directory.zip"; sourceTree = "<group>"; };
 		EB0E04122B7C228D00EFFB94 /* ProcessInfo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ProcessInfo.mm; sourceTree = "<group>"; };
+		EB1F62962D19E07E000B3A04 /* ResourceMonitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ResourceMonitor.cpp; sourceTree = "<group>"; };
 		EB230D3D245E722E00C66AD1 /* IDBCheckpointWAL.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = IDBCheckpointWAL.html; sourceTree = "<group>"; };
 		EB230D3E245E726300C66AD1 /* IDBCheckpointWAL.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = IDBCheckpointWAL.mm; sourceTree = "<group>"; };
 		EB4D320727C045430081A8E4 /* TestNotificationProvider.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestNotificationProvider.cpp; sourceTree = "<group>"; };
@@ -4744,6 +4746,7 @@
 				EBA75C48275ED7BE00D6D31C /* PushMessageCrypto.cpp */,
 				6B4E861B2220A5520022F389 /* RegistrableDomain.cpp */,
 				D84FAD9829FAC1D0008D338F /* RenderStyleChange.cpp */,
+				EB1F62962D19E07E000B3A04 /* ResourceMonitor.cpp */,
 				F418BE141F71B7DC001970E6 /* RoundedRectTests.cpp */,
 				4181C62C255A891100AEB0FF /* RTCRtpSFrameTransformerTests.cpp */,
 				CDCFA7A91E45122F00C2433D /* SampleMap.cpp */,
@@ -7189,6 +7192,7 @@
 				D84FAD9A29FAC1D0008D338F /* RenderStyleChange.cpp in Sources */,
 				7CCE7F0E1A411AE600447C4C /* ResizeReversePaginatedWebView.cpp in Sources */,
 				7CCE7F0F1A411AE600447C4C /* ResizeWindowAfterCrash.cpp in Sources */,
+				EB1F62972D19E07E000B3A04 /* ResourceMonitor.cpp in Sources */,
 				512C4C9E20EAA40D004945EA /* ResponsivenessTimerCrash.mm in Sources */,
 				83B6DE6F1EE75221001E792F /* RestoreSessionState.cpp in Sources */,
 				7CCE7F111A411AE600447C4C /* RestoreSessionStateContainingFormData.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/ResourceMonitor.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ResourceMonitor.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(CONTENT_EXTENSIONS)
+
+#include "Utilities.h"
+#include <WebCore/ResourceMonitorThrottler.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+class ResouceMonitorTest : public testing::Test {
+public:
+    void SetUp() override
+    {
+        m_reference = ApproximateTime::now();
+    }
+
+protected:
+    ApproximateTime m_reference;
+
+    ApproximateTime now()
+    {
+        auto t = m_reference;
+        m_reference += 1_ms;
+        return t;
+    }
+
+    ApproximateTime later(Seconds delta)
+    {
+        m_reference += delta;
+        return m_reference;
+    }
+};
+
+TEST_F(ResouceMonitorTest, ThrottlerBasic)
+{
+    ResourceMonitorThrottler throttler { /* size */ 2, /* duration */ 1_s, /* maxHosts */ 1 };
+
+    auto host = "example.com"_s;
+
+    // first access must be okay.
+    EXPECT_TRUE(throttler.tryAccess(host, now()));
+    // second one is alse okay.
+    EXPECT_TRUE(throttler.tryAccess(host, now()));
+    // but third one is not okay because size is 2.
+    EXPECT_FALSE(throttler.tryAccess(host, now()));
+
+    // after duration, it should be okay.
+    EXPECT_TRUE(throttler.tryAccess(host, later(1_s)));
+}
+
+TEST_F(ResouceMonitorTest, ThrottlerMaxHosts)
+{
+    ResourceMonitorThrottler throttler { /* size */ 2, /* duration */ 1_s, /* maxHosts */ 2 };
+
+    auto host1 = "h1.example.com"_s;
+    auto host2 = "h2.example.com"_s;
+    auto host3 = "h3.example.com"_s;
+
+    // make host1 inaccessible.
+    EXPECT_TRUE(throttler.tryAccess(host1, now()));
+    EXPECT_TRUE(throttler.tryAccess(host1, now()));
+    EXPECT_FALSE(throttler.tryAccess(host1, now()));
+
+    // host2 is accessible and still host1 is not.
+    EXPECT_TRUE(throttler.tryAccess(host2, now()));
+    EXPECT_FALSE(throttler.tryAccess(host1, now()));
+
+    // host3 is accessible and host1 is now also accessible because of the max host.
+    EXPECT_TRUE(throttler.tryAccess(host3, now()));
+    EXPECT_TRUE(throttler.tryAccess(host1, now()));
+}
+
+TEST_F(ResouceMonitorTest, ThrottlerLeastRecentAccessedHostWillBeRemoved)
+{
+    ResourceMonitorThrottler throttler { /* size */ 2, /* duration */ 1_s, /* maxHosts */ 2 };
+
+    auto host1 = "h1.example.com"_s;
+    auto host2 = "h2.example.com"_s;
+    auto host3 = "h3.example.com"_s;
+
+    // host1 is the oldest access.
+    EXPECT_TRUE(throttler.tryAccess(host1, now()));
+
+    // make host2 inaccessible
+    EXPECT_TRUE(throttler.tryAccess(host2, now()));
+    EXPECT_TRUE(throttler.tryAccess(host2, now()));
+    EXPECT_FALSE(throttler.tryAccess(host2, now()));
+
+    // make host1 inaccessible and this is the most recent access.
+    EXPECT_TRUE(throttler.tryAccess(host1, now()));
+    EXPECT_FALSE(throttler.tryAccess(host1, now()));
+
+    // host3 is accessible. In this access, lest recent host is removed.
+    EXPECT_TRUE(throttler.tryAccess(host3, now()));
+    // host1 is the oldest, but recent than host2. Still it is blocked.
+    EXPECT_FALSE(throttler.tryAccess(host1, now()));
+    // host2 is the least recent access and removed in host3 access. So it is accessible.
+    EXPECT_TRUE(throttler.tryAccess(host2, now()));
+}
+
+TEST_F(ResouceMonitorTest, ThrottlerEmptyHostname)
+{
+    ResourceMonitorThrottler throttler { /* size */ 2, /* duration */ 1_s, /* maxHosts */ 2 };
+
+    auto emptyHost = ""_s;
+
+    // Accessing with an empty hostname should not crash.
+    EXPECT_FALSE(throttler.tryAccess(emptyHost, now()));
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(CONTENT_EXTENSIONS)


### PR DESCRIPTION
#### 69f96c73ab392b6e7969da02996ce934f7951757
<pre>
Add throttler to limit the ResourceMonitor activity.
<a href="https://bugs.webkit.org/show_bug.cgi?id=285107">https://bugs.webkit.org/show_bug.cgi?id=285107</a>
<a href="https://rdar.apple.com/141840417">rdar://141840417</a>

Reviewed by Chris Dumez.

When ResourceMonitor detects large resource usage in a iframe, currently the decision is in
action immediately. In this patch, add throttler to limit the execution of the decision.

- Moving the action from LocalFrame to LocalFrameLoaderClient.
- Ask WebPageProxy for the decision.
- Add ResourceMonitorThrottler to limit the action.
- Place the throttler in ResourceMonitorManager for the global decision.
- Send the result to WebPage if the decision is ongoing.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/LocalFrameLoaderClient.cpp:
(WebCore::LocalFrameLoaderClient::didExceedNetworkUsageThreshold):
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebCore/loader/ResourceMonitor.cpp:
(WebCore::ResourceMonitor::checkNetworkUsageExcessIfNecessary):
* Source/WebCore/loader/ResourceMonitorThrottler.cpp: Added.
(WebCore::ResourceMonitorThrottler::ResourceMonitorThrottler):
(WebCore::ResourceMonitorThrottler::throttlerForHost):
(WebCore::ResourceMonitorThrottler::removeOldestThrottler):
(WebCore::ResourceMonitorThrottler::tryAccess):
(WebCore::ResourceMonitorThrottler::AccessThrottler::tryAccessAndUpdateHistory):
(WebCore::ResourceMonitorThrottler::AccessThrottler::oldestAccessTime const):
(WebCore::ResourceMonitorThrottler::AccessThrottler::tryExpire):
* Source/WebCore/loader/ResourceMonitorThrottler.h: Added.
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::showResourceMonitoringError):
(WebCore::LocalFrame::networkUsageDidExceedThreshold): Deleted.
* Source/WebCore/page/LocalFrame.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::shouldOffloadIFrameForHost):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::resourceMonitorThrottler):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::didExceedNetworkUsageThreshold):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/ResourceMonitor.cpp: Added.
(TestWebKitAPI::ResouceMonitorTest::now):
(TestWebKitAPI::ResouceMonitorTest::later):
(TestWebKitAPI::TEST_F(ResouceMonitorTest, ThrottlerBasic)):
(TestWebKitAPI::TEST_F(ResouceMonitorTest, ThrottlerMaxHosts)):
(TestWebKitAPI::TEST_F(ResouceMonitorTest, ThrottlerLeastRecentAccessedHostWillBeRemoved)):
(TestWebKitAPI::TEST_F(ResouceMonitorTest, ThrottlerEmptyHostname)):

Canonical link: <a href="https://commits.webkit.org/288427@main">https://commits.webkit.org/288427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6f1d6dd1bab34394f0afafa3e901b41034a9c59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88306 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/34239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10776 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/64763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/34239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75643 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/45047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2033 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29841 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33283 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30557 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89676 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10489 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7549 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10716 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71460 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/72427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17945 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16620 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15351 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10443 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/15924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/10301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/13771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/12072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->