### PR TITLE
Support baseURL field in URLPattern constructor

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -201,8 +201,8 @@ FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.co
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
-FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["/foo"] Inputs: undefined
+PASS Pattern: ["example.com/foo"] Inputs: undefined
 FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
@@ -219,14 +219,14 @@ FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/
 PASS Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"]
 FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
 PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
-FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
 FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] assert_equals: test() result expected true but got false
@@ -268,9 +268,7 @@ FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:tex
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -201,8 +201,8 @@ FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.co
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
-FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["/foo"] Inputs: undefined
+PASS Pattern: ["example.com/foo"] Inputs: undefined
 FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
@@ -219,14 +219,14 @@ FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/
 PASS Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"]
 FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
 PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
-FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
 FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] assert_equals: test() result expected true but got false
@@ -268,9 +268,7 @@ FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:tex
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -201,8 +201,8 @@ FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.co
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
-FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["/foo"] Inputs: undefined
+PASS Pattern: ["example.com/foo"] Inputs: undefined
 FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
@@ -219,14 +219,14 @@ FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/
 PASS Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"]
 FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
 PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
-FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
 FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] assert_equals: test() result expected true but got false
@@ -268,9 +268,7 @@ FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:tex
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -201,8 +201,8 @@ FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.co
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
-FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["/foo"] Inputs: undefined
+PASS Pattern: ["example.com/foo"] Inputs: undefined
 FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
@@ -219,14 +219,14 @@ FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/
 PASS Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"]
 FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
 PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
-FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
 FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] assert_equals: test() result expected true but got false
@@ -268,9 +268,7 @@ FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:tex
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -201,8 +201,8 @@ FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.co
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
-FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["/foo"] Inputs: undefined
+PASS Pattern: ["example.com/foo"] Inputs: undefined
 FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
@@ -219,14 +219,14 @@ FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/
 PASS Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"]
 FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
 PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
-FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
 FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] assert_equals: test() result expected true but got false
@@ -268,9 +268,7 @@ FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:tex
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -201,8 +201,8 @@ FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.co
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
-FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["/foo"] Inputs: undefined
+PASS Pattern: ["example.com/foo"] Inputs: undefined
 FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
@@ -219,14 +219,14 @@ FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/
 PASS Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"]
 FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
 PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
-FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
 FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] assert_equals: test() result expected true but got false
@@ -268,9 +268,7 @@ FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:tex
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -201,8 +201,8 @@ FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.co
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
-FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["/foo"] Inputs: undefined
+PASS Pattern: ["example.com/foo"] Inputs: undefined
 FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
@@ -219,14 +219,14 @@ FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/
 PASS Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"]
 FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
 PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
-FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
 FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] assert_equals: test() result expected true but got false
@@ -268,9 +268,7 @@ FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:tex
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -201,8 +201,8 @@ FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.co
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
-FAIL Pattern: ["/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: ["example.com/foo"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["/foo"] Inputs: undefined
+PASS Pattern: ["example.com/foo"] Inputs: undefined
 FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
@@ -219,14 +219,14 @@ FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/
 PASS Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"]
 FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
 PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
-FAIL Pattern: ["data:foobar"] Inputs: ["data:foobar"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
 FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
 FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] assert_equals: test() result expected true but got false
@@ -268,9 +268,7 @@ FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:tex
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" threw object "NotSupportedError: Not implemented." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]

--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -200,27 +200,22 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
     return result;
 }
 
-ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context, URLPatternInput&&, String&& baseURL, URLPatternOptions&&)
-{
-    UNUSED_PARAM(baseURL);
-    UNUSED_PARAM(context);
-
-    return Exception { ExceptionCode::NotSupportedError, "Not implemented."_s };
-}
-
-ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context, std::optional<URLPatternInput>&& input, URLPatternOptions&& options)
+// https://urlpattern.spec.whatwg.org/#url-pattern-create
+ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context, URLPatternInput&& input, String&& baseURL, URLPatternOptions&& options)
 {
     URLPatternInit init;
 
-    if (!input)
-        return Exception { ExceptionCode::NotSupportedError, "Not implemented."_s };
-    if (std::holds_alternative<String>(*input) && !std::get<String>(*input).isNull()) {
-        auto maybeInit = URLPatternConstructorStringParser(WTFMove(std::get<String>(*input))).parse(context);
+    if (std::holds_alternative<String>(input) && !std::get<String>(input).isNull()) {
+        auto maybeInit = URLPatternConstructorStringParser(WTFMove(std::get<String>(input))).parse(context);
         if (maybeInit.hasException())
             return maybeInit.releaseException();
         init = maybeInit.releaseReturnValue();
-    } else if (std::holds_alternative<URLPatternInit>(*input))
-        init = std::get<URLPatternInit>(*input);
+
+        if (baseURL.isNull() && init.protocol.isEmpty())
+            return Exception { ExceptionCode::TypeError, "Relative constructor string must have additional baseURL argument."_s };
+        init.baseURL = WTFMove(baseURL);
+    } else if (std::holds_alternative<URLPatternInit>(input))
+        init = std::get<URLPatternInit>(input);
 
     auto maybeProcessedInit = processInit(WTFMove(init), BaseURLStringType::Pattern);
 
@@ -259,8 +254,20 @@ ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context,
     return result;
 }
 
+// https://urlpattern.spec.whatwg.org/#urlpattern-initialize
+ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context, std::optional<URLPatternInput>&& input, URLPatternOptions&& options)
+{
+    if (!input) {
+        // FIXME: File a bug to URLPattern owners to tell them that spec does not mention supporting empty URLPattern objects. Spec and test cases have diverged!
+        return Exception { ExceptionCode::NotSupportedError, "Not implemented."_s };
+    }
+
+    return create(context, WTFMove(*input), String { }, WTFMove(options));
+}
+
 URLPattern::~URLPattern() = default;
 
+// https://urlpattern.spec.whatwg.org/#dom-urlpattern-test
 ExceptionOr<bool> URLPattern::test(ScriptExecutionContext& context, std::optional<URLPatternInput>&& input, String&& baseURL) const
 {
     if (!input)
@@ -274,6 +281,7 @@ ExceptionOr<bool> URLPattern::test(ScriptExecutionContext& context, std::optiona
 
 }
 
+// https://urlpattern.spec.whatwg.org/#dom-urlpattern-exec
 ExceptionOr<std::optional<URLPatternResult>> URLPattern::exec(ScriptExecutionContext& context, std::optional<URLPatternInput>&& input, String&& baseURL) const
 {
     if (!input)


### PR DESCRIPTION
#### 79f1cff6211b3ce60ffa3b517d55fbcc43446d45
<pre>
Support baseURL field in URLPattern constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=285110">https://bugs.webkit.org/show_bug.cgi?id=285110</a>
<a href="https://rdar.apple.com/141962318">rdar://141962318</a>

Reviewed by Chris Dumez.

URLPattern constructor does not currently support baseURL.
Spec: <a href="https://urlpattern.spec.whatwg.org/#url-pattern-create">https://urlpattern.spec.whatwg.org/#url-pattern-create</a>

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::URLPattern::create):

Canonical link: <a href="https://commits.webkit.org/288262@main">https://commits.webkit.org/288262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d21102b971031f66ae66534f252f82cdcfd9a605

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87419 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33348 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64129 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21878 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1408 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74871 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44407 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1310 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29052 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32389 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72604 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88775 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6851 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72523 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71741 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15876 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14884 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12771 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9546 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15067 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9420 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12886 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11190 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->