### PR TITLE
[WTF] Add more LIFETIME_BOUND attributes to iterator, span and inner pointer methods

### DIFF
--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -80,7 +80,7 @@ String errorDescriptionForValue(JSGlobalObject* globalObject, JSValue v)
     return v.toString(globalObject)->value(globalObject);
 }
     
-static StringView clampErrorMessage(const String& originalMessage)
+static StringView clampErrorMessage(const String& originalMessage LIFETIME_BOUND)
 {
     // Hopefully this is sufficiently long. Note, this is the length of the string not the number of bytes used.
     constexpr unsigned maxLength = 2 * KB;

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -241,10 +241,12 @@
 /* LIFETIME_BOUND */
 
 #if !defined(LIFETIME_BOUND) && defined(__cplusplus)
-#if defined(__has_cpp_attribute) && __has_cpp_attribute(clang::lifetimebound)
+#if __has_cpp_attribute(clang::lifetimebound)
 #define LIFETIME_BOUND [[clang::lifetimebound]]
-#elif COMPILER_HAS_ATTRIBUTE(lifetimebound)
-#define LIFETIME_BOUND __attribute__((lifetimebound))
+#elif __has_cpp_attribute(msvc::lifetimebound)
+#define LIFETIME_BOUND [[msvc::lifetimebound]]
+#elif __has_cpp_attribute(lifetimebound)
+#define LIFETIME_BOUND [[lifetimebound]]
 #endif
 #endif
 

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -269,8 +269,8 @@ public:
     std::span<uint8_t> leakHandle() { return m_fileData.leakSpan(); }
     explicit operator bool() const { return !!m_fileData; }
     size_t size() const { return m_fileData.span().size(); }
-    std::span<const uint8_t> span() const { return m_fileData.span(); }
-    std::span<uint8_t> mutableSpan() { return m_fileData.mutableSpan(); }
+    std::span<const uint8_t> span() const LIFETIME_BOUND { return m_fileData.span(); }
+    std::span<uint8_t> mutableSpan() LIFETIME_BOUND { return m_fileData.mutableSpan(); }
 #elif OS(WINDOWS)
     const Win32Handle& fileMapping() const { return m_fileMapping; }
     explicit operator bool() const { return !!m_fileData.data(); }

--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -137,27 +137,27 @@ public:
     bool isEmpty() const { return m_storage ? m_storage->isEmpty() : true; }
     size_t byteSize() const { return m_storage ? m_storage->byteSize() : 0; }
 
-    iterator begin() { return m_storage ? m_storage->begin() : nullptr; }
-    iterator end() { return m_storage ? m_storage->end() : nullptr; }
+    iterator begin() LIFETIME_BOUND { return m_storage ? m_storage->begin() : nullptr; }
+    iterator end() LIFETIME_BOUND { return m_storage ? m_storage->end() : nullptr; }
 
-    const_iterator begin() const { return const_cast<FixedVector*>(this)->begin(); }
-    const_iterator end() const { return const_cast<FixedVector*>(this)->end(); }
+    const_iterator begin() const LIFETIME_BOUND { return const_cast<FixedVector*>(this)->begin(); }
+    const_iterator end() const LIFETIME_BOUND { return const_cast<FixedVector*>(this)->end(); }
 
-    reverse_iterator rbegin() { return m_storage ? m_storage->rbegin() : reverse_iterator(nullptr); }
-    reverse_iterator rend() { return m_storage ? m_storage->rend() : reverse_iterator(nullptr); }
-    const_reverse_iterator rbegin() const { return m_storage ? m_storage->rbegin() : const_reverse_iterator(nullptr); }
-    const_reverse_iterator rend() const { return m_storage ? m_storage->rend() : const_reverse_iterator(nullptr); }
+    reverse_iterator rbegin() LIFETIME_BOUND { return m_storage ? m_storage->rbegin() : reverse_iterator(nullptr); }
+    reverse_iterator rend() LIFETIME_BOUND { return m_storage ? m_storage->rend() : reverse_iterator(nullptr); }
+    const_reverse_iterator rbegin() const LIFETIME_BOUND { return m_storage ? m_storage->rbegin() : const_reverse_iterator(nullptr); }
+    const_reverse_iterator rend() const LIFETIME_BOUND { return m_storage ? m_storage->rend() : const_reverse_iterator(nullptr); }
 
-    T& at(size_t i) { return m_storage->at(i); }
-    const T& at(size_t i) const { return m_storage->at(i); }
+    T& at(size_t i) LIFETIME_BOUND { return m_storage->at(i); }
+    const T& at(size_t i) const LIFETIME_BOUND { return m_storage->at(i); }
 
-    T& operator[](size_t i) { return m_storage->at(i); }
-    const T& operator[](size_t i) const { return m_storage->at(i); }
+    T& operator[](size_t i) LIFETIME_BOUND { return m_storage->at(i); }
+    const T& operator[](size_t i) const LIFETIME_BOUND { return m_storage->at(i); }
 
-    T& first() { return (*this)[0]; }
-    const T& first() const { return (*this)[0]; }
-    T& last() { return (*this)[size() - 1]; }
-    const T& last() const { return (*this)[size() - 1]; }
+    T& first() LIFETIME_BOUND { return (*this)[0]; }
+    const T& first() const LIFETIME_BOUND { return (*this)[0]; }
+    T& last() LIFETIME_BOUND { return (*this)[size() - 1]; }
+    const T& last() const LIFETIME_BOUND { return (*this)[size() - 1]; }
 
     void clear() { m_storage = nullptr; }
 
@@ -192,17 +192,17 @@ public:
 
     static constexpr ptrdiff_t offsetOfStorage() { return OBJECT_OFFSETOF(FixedVector, m_storage); }
 
-    Storage* storage() { return m_storage.get(); }
+    Storage* storage() LIFETIME_BOUND { return m_storage.get(); }
 
-    std::span<const T> span() const { return m_storage ? m_storage->span() : std::span<const T> { }; }
-    std::span<T> mutableSpan() { return m_storage ? m_storage->span() : std::span<T> { }; }
+    std::span<const T> span() const LIFETIME_BOUND { return m_storage ? m_storage->span() : std::span<const T> { }; }
+    std::span<T> mutableSpan() LIFETIME_BOUND { return m_storage ? m_storage->span() : std::span<T> { }; }
 
     Vector<T> subvector(size_t offset, size_t length = std::dynamic_extent) const
     {
         return { span().subspan(offset, length) };
     }
 
-    std::span<const T> subspan(size_t offset, size_t length = std::dynamic_extent) const
+    std::span<const T> subspan(size_t offset, size_t length = std::dynamic_extent) const LIFETIME_BOUND
     {
         return span().subspan(offset, length);
     }

--- a/Source/WTF/wtf/MallocSpan.h
+++ b/Source/WTF/wtf/MallocSpan.h
@@ -73,16 +73,16 @@ public:
 
     size_t sizeInBytes() const { return m_span.size_bytes(); }
 
-    std::span<const T> span() const { return spanConstCast<const T>(m_span); }
-    std::span<T> mutableSpan() { return m_span; }
+    std::span<const T> span() const LIFETIME_BOUND { return spanConstCast<const T>(m_span); }
+    std::span<T> mutableSpan() LIFETIME_BOUND { return m_span; }
     std::span<T> leakSpan() WARN_UNUSED_RETURN { return std::exchange(m_span, std::span<T>()); }
 
-    T& operator[](size_t i) { return m_span[i]; }
-    const T& operator[](size_t i) const { return m_span[i]; }
+    T& operator[](size_t i) LIFETIME_BOUND { return m_span[i]; }
+    const T& operator[](size_t i) const LIFETIME_BOUND { return m_span[i]; }
 
     explicit operator bool() const
     {
-        return m_span.data();
+        return !!m_span.data();
     }
 
     bool operator!() const

--- a/Source/WTF/wtf/StackShot.h
+++ b/Source/WTF/wtf/StackShot.h
@@ -71,10 +71,10 @@ public:
         *this = other;
     }
     
-    void** array() const { return m_array.get(); }
+    void** array() const LIFETIME_BOUND { return m_array.get(); }
     size_t size() const { return m_size; }
 
-    std::span<void*> span() const { return unsafeMakeSpan(m_array.get(), m_size); }
+    std::span<void*> span() const LIFETIME_BOUND { return unsafeMakeSpan(m_array.get(), m_size); }
     
     explicit operator bool() const { return !!m_array; }
     

--- a/Source/WTF/wtf/TrailingArray.h
+++ b/Source/WTF/wtf/TrailingArray.h
@@ -124,44 +124,44 @@ public:
     bool isEmpty() const { return !size(); }
     unsigned byteSize() const { return size() * sizeof(T); }
 
-    pointer data() { return std::bit_cast<T*>(std::bit_cast<uint8_t*>(static_cast<Derived*>(this)) + offsetOfData()); }
-    const_pointer data() const { return std::bit_cast<const T*>(std::bit_cast<const uint8_t*>(static_cast<const Derived*>(this)) + offsetOfData()); }
-    std::span<T> span() { return { data(), size() }; }
-    std::span<const T> span() const { return { data(), size() }; }
+    pointer data() LIFETIME_BOUND { return std::bit_cast<T*>(std::bit_cast<uint8_t*>(static_cast<Derived*>(this)) + offsetOfData()); }
+    const_pointer data() const LIFETIME_BOUND { return std::bit_cast<const T*>(std::bit_cast<const uint8_t*>(static_cast<const Derived*>(this)) + offsetOfData()); }
+    std::span<T> span() LIFETIME_BOUND { return { data(), size() }; }
+    std::span<const T> span() const LIFETIME_BOUND { return { data(), size() }; }
 
-    iterator begin() { return data(); }
-    iterator end() { return data() + size(); }
-    const_iterator begin() const { return cbegin(); }
-    const_iterator end() const { return cend(); }
-    const_iterator cbegin() const { return data(); }
-    const_iterator cend() const { return data() + size(); }
+    iterator begin() LIFETIME_BOUND { return data(); }
+    iterator end() LIFETIME_BOUND { return data() + size(); }
+    const_iterator begin() const LIFETIME_BOUND { return cbegin(); }
+    const_iterator end() const LIFETIME_BOUND { return cend(); }
+    const_iterator cbegin() const LIFETIME_BOUND { return data(); }
+    const_iterator cend() const LIFETIME_BOUND { return data() + size(); }
 
-    reverse_iterator rbegin() { return reverse_iterator(end()); }
-    reverse_iterator rend() { return reverse_iterator(begin()); }
-    const_reverse_iterator rbegin() const { return crbegin(); }
-    const_reverse_iterator rend() const { return crend(); }
-    const_reverse_iterator crbegin() const { return const_reverse_iterator(end()); }
-    const_reverse_iterator crend() const { return const_reverse_iterator(begin()); }
+    reverse_iterator rbegin() LIFETIME_BOUND { return reverse_iterator(end()); }
+    reverse_iterator rend() LIFETIME_BOUND { return reverse_iterator(begin()); }
+    const_reverse_iterator rbegin() const LIFETIME_BOUND { return crbegin(); }
+    const_reverse_iterator rend() const LIFETIME_BOUND { return crend(); }
+    const_reverse_iterator crbegin() const LIFETIME_BOUND { return const_reverse_iterator(end()); }
+    const_reverse_iterator crend() const LIFETIME_BOUND { return const_reverse_iterator(begin()); }
 
-    reference at(unsigned i)
+    reference at(unsigned i) LIFETIME_BOUND
     {
         RELEASE_ASSERT(i < size());
         return begin()[i];
     }
 
-    const_reference at(unsigned i) const
+    const_reference at(unsigned i) const LIFETIME_BOUND
     {
         RELEASE_ASSERT(i < size());
         return begin()[i];
     }
 
-    reference operator[](unsigned i) { return at(i); }
-    const_reference operator[](unsigned i) const { return at(i); }
+    reference operator[](unsigned i) LIFETIME_BOUND { return at(i); }
+    const_reference operator[](unsigned i) const LIFETIME_BOUND { return at(i); }
 
-    T& first() { return (*this)[0]; }
-    const T& first() const { return (*this)[0]; }
-    T& last() { return (*this)[size() - 1]; }
-    const T& last() const { return (*this)[size() - 1]; }
+    T& first() LIFETIME_BOUND { return (*this)[0]; }
+    const T& first() const LIFETIME_BOUND { return (*this)[0]; }
+    T& last() LIFETIME_BOUND { return (*this)[size() - 1]; }
+    const T& last() const LIFETIME_BOUND { return (*this)[size() - 1]; }
 
     void fill(const T& val)
     {

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -1335,7 +1335,7 @@ Vector<KeyValuePair<String, String>> differingQueryParameters(const URL& firstUR
     return differingQueryParameters;
 }
 
-static StringView substringIgnoringQueryAndFragments(const URL& url)
+static StringView substringIgnoringQueryAndFragments(const URL& url LIFETIME_BOUND)
 {
     if (!url.isValid())
         return StringView(url.string());

--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -95,7 +95,7 @@ public:
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!isHashTableDeletedValue());
     }
 
-    std::span<const uint8_t, 16> span() const
+    std::span<const uint8_t, 16> span() const LIFETIME_BOUND
     {
         return asByteSpan<UInt128, 16>(m_data);
     }

--- a/Source/WTF/wtf/persistence/PersistentEncoder.h
+++ b/Source/WTF/wtf/persistence/PersistentEncoder.h
@@ -70,9 +70,9 @@ public:
     WTF_EXPORT_PRIVATE Encoder& operator<<(float);
     WTF_EXPORT_PRIVATE Encoder& operator<<(double);
 
-    const uint8_t* buffer() const { return m_buffer.data(); }
+    const uint8_t* buffer() const LIFETIME_BOUND { return m_buffer.data(); }
     size_t bufferSize() const { return m_buffer.size(); }
-    std::span<const uint8_t> span() const { return m_buffer.span(); }
+    std::span<const uint8_t> span() const LIFETIME_BOUND { return m_buffer.span(); }
 
     WTF_EXPORT_PRIVATE static void updateChecksumForData(SHA1&, std::span<const uint8_t>);
     template <typename Type> static void updateChecksumForNumber(SHA1&, Type);

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -85,9 +85,9 @@ public:
     UChar operator[](unsigned i) const;
 
     bool is8Bit() const;
-    std::span<const LChar> span8() const { return span<LChar>(); }
-    std::span<const UChar> span16() const { return span<UChar>(); }
-    template<typename CharacterType> std::span<const CharacterType> span() const;
+    std::span<const LChar> span8() const LIFETIME_BOUND { return span<LChar>(); }
+    std::span<const UChar> span16() const LIFETIME_BOUND { return span<UChar>(); }
+    template<typename CharacterType> std::span<const CharacterType> span() const LIFETIME_BOUND;
     
     unsigned capacity() const;
     WTF_EXPORT_PRIVATE void reserveCapacity(unsigned newCapacity);

--- a/Source/WTF/wtf/text/StringConcatenateNumbers.h
+++ b/Source/WTF/wtf/text/StringConcatenateNumbers.h
@@ -81,7 +81,7 @@ public:
     template<typename CharacterType> void writeTo(std::span<CharacterType> destination) const { StringImpl::copyCharacters(destination.data(), span()); }
 
 private:
-    std::span<const LChar> span() const { return byteCast<LChar>(std::span { m_buffer }).first(m_length); }
+    std::span<const LChar> span() const LIFETIME_BOUND { return byteCast<LChar>(std::span { m_buffer }).first(m_length); }
 
     NumberToStringBuffer m_buffer;
     unsigned m_length;
@@ -105,8 +105,8 @@ public:
     }
 
     unsigned length() const { return m_length; }
-    const LChar* buffer() const { return byteCast<LChar>(&m_buffer[0]); }
-    std::span<const LChar> span() const { return byteCast<LChar>(std::span { m_buffer }).first(m_length); }
+    const LChar* buffer() const LIFETIME_BOUND { return byteCast<LChar>(&m_buffer[0]); }
+    std::span<const LChar> span() const LIFETIME_BOUND { return byteCast<LChar>(std::span { m_buffer }).first(m_length); }
 
 private:
     NumberToStringBuffer m_buffer;
@@ -139,8 +139,8 @@ public:
     } 
 
     unsigned length() const { return m_length; }
-    const LChar* buffer() const { return byteCast<LChar>(&m_buffer[0]); }
-    std::span<const LChar> span() const { return byteCast<LChar>(std::span { m_buffer }).first(m_length); }
+    const LChar* buffer() const LIFETIME_BOUND { return byteCast<LChar>(&m_buffer[0]); }
+    std::span<const LChar> span() const LIFETIME_BOUND { return byteCast<LChar>(std::span { m_buffer }).first(m_length); }
 
 private:
     NumberToCSSStringBuffer m_buffer;

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -309,10 +309,10 @@ public:
     bool isEmpty() const { return !m_length; }
 
     bool is8Bit() const { return m_hashAndFlags & s_hashFlag8BitBuffer; }
-    ALWAYS_INLINE std::span<const LChar> span8() const { ASSERT(is8Bit()); return { m_data8, length() }; }
-    ALWAYS_INLINE std::span<const UChar> span16() const { ASSERT(!is8Bit() || isEmpty()); return { m_data16, length() }; }
+    ALWAYS_INLINE std::span<const LChar> span8() const LIFETIME_BOUND { ASSERT(is8Bit()); return { m_data8, length() }; }
+    ALWAYS_INLINE std::span<const UChar> span16() const LIFETIME_BOUND { ASSERT(!is8Bit() || isEmpty()); return { m_data16, length() }; }
 
-    template<typename CharacterType> std::span<const CharacterType> span() const;
+    template<typename CharacterType> std::span<const CharacterType> span() const LIFETIME_BOUND;
 
     size_t cost() const;
     size_t costDuringGC();

--- a/Source/WTF/wtf/text/StringParsingBuffer.h
+++ b/Source/WTF/wtf/text/StringParsingBuffer.h
@@ -39,14 +39,14 @@ public:
 
     constexpr StringParsingBuffer() = default;
 
-    constexpr StringParsingBuffer(std::span<const CharacterType> characters)
+    constexpr StringParsingBuffer(std::span<const CharacterType> characters LIFETIME_BOUND)
         : m_data { characters }
     {
         ASSERT(m_data.data() || m_data.empty());
     }
 
-    constexpr auto position() const { return m_data.data(); }
-    constexpr auto end() const { return m_data.data() + m_data.size(); }
+    constexpr auto position() const LIFETIME_BOUND { return m_data.data(); }
+    constexpr auto end() const LIFETIME_BOUND { return m_data.data() + m_data.size(); }
 
     constexpr bool hasCharactersRemaining() const { return !m_data.empty(); }
     constexpr bool atEnd() const { return m_data.empty(); }
@@ -59,7 +59,7 @@ public:
         m_data = { position, m_data.data() + m_data.size() };
     }
 
-    StringView stringViewOfCharactersRemaining() const { return span(); }
+    StringView stringViewOfCharactersRemaining() const LIFETIME_BOUND { return span(); }
 
     CharacterType consume()
     {
@@ -69,9 +69,9 @@ public:
         return character;
     }
 
-    std::span<const CharacterType> span() const { return m_data; }
+    std::span<const CharacterType> span() const LIFETIME_BOUND { return m_data; }
 
-    std::span<const CharacterType> consume(size_t count)
+    std::span<const CharacterType> consume(size_t count) LIFETIME_BOUND
     {
         ASSERT(count <= lengthRemaining());
         auto result = m_data;

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -62,14 +62,14 @@ public:
     StringView& operator=(const StringView&);
 #endif
 
-    StringView(const AtomString&);
-    StringView(const String&);
-    StringView(const StringImpl&);
-    StringView(const StringImpl*);
-    StringView(std::span<const LChar>);
-    StringView(std::span<const UChar>);
-    StringView(std::span<const char>); // FIXME: Consider dropping this overload. Callers should pass LChars/UChars instead.
-    StringView(const void*, unsigned length, bool is8bit);
+    StringView(const AtomString& string LIFETIME_BOUND);
+    StringView(const String& string LIFETIME_BOUND);
+    StringView(const StringImpl& string LIFETIME_BOUND);
+    StringView(const StringImpl* string LIFETIME_BOUND);
+    StringView(std::span<const LChar> span LIFETIME_BOUND);
+    StringView(std::span<const UChar> span LIFETIME_BOUND);
+    StringView(std::span<const char> span LIFETIME_BOUND); // FIXME: Consider dropping this overload. Callers should pass LChars/UChars instead.
+    StringView(const void* string LIFETIME_BOUND, unsigned length, bool is8bit);
     StringView(ASCIILiteral);
 
     ALWAYS_INLINE static StringView fromLatin1(const char* characters) { return StringView { characters }; }
@@ -93,10 +93,10 @@ public:
     GraphemeClusters graphemeClusters() const;
 
     bool is8Bit() const;
-    const void* rawCharacters() const { return m_characters; }
-    std::span<const LChar> span8() const;
-    std::span<const UChar> span16() const;
-    template<typename CharacterType> std::span<const CharacterType> span() const;
+    const void* rawCharacters() const LIFETIME_BOUND { return m_characters; }
+    std::span<const LChar> span8() const LIFETIME_BOUND;
+    std::span<const UChar> span16() const LIFETIME_BOUND;
+    template<typename CharacterType> std::span<const CharacterType> span() const LIFETIME_BOUND;
 
     unsigned hash() const;
 
@@ -514,10 +514,10 @@ class StringView::UpconvertedCharactersWithSize {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit UpconvertedCharactersWithSize(StringView);
-    operator const UChar*() const { return m_characters.data(); }
-    const UChar* get() const { return m_characters.data(); }
-    operator std::span<const UChar>() const { return m_characters; }
-    std::span<const UChar> span() const { return m_characters; }
+    operator const UChar*() const LIFETIME_BOUND { return m_characters.data(); }
+    const UChar* get() const LIFETIME_BOUND { return m_characters.data(); }
+    operator std::span<const UChar>() const LIFETIME_BOUND { return m_characters; }
+    std::span<const UChar> span() const LIFETIME_BOUND { return m_characters; }
 
 private:
     Vector<UChar, N> m_upconvertedCharacters;
@@ -792,11 +792,11 @@ inline bool equalIgnoringASCIICase(StringView a, ASCIILiteral b)
 class StringView::SplitResult {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    SplitResult(StringView, UChar separator, bool allowEmptyEntries);
+    SplitResult(StringView view LIFETIME_BOUND, UChar separator, bool allowEmptyEntries);
 
     class Iterator;
-    Iterator begin() const;
-    Iterator end() const;
+    Iterator begin() const LIFETIME_BOUND;
+    Iterator end() const LIFETIME_BOUND;
 
 private:
     StringView m_string;
@@ -807,11 +807,11 @@ private:
 class StringView::GraphemeClusters {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit GraphemeClusters(StringView);
+    explicit GraphemeClusters(StringView view LIFETIME_BOUND);
 
     class Iterator;
-    Iterator begin() const;
-    Iterator end() const;
+    Iterator begin() const LIFETIME_BOUND;
+    Iterator end() const LIFETIME_BOUND;
 
 private:
     StringView m_stringView;
@@ -820,12 +820,12 @@ private:
 class StringView::CodePoints {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit CodePoints(StringView);
+    explicit CodePoints(StringView view LIFETIME_BOUND);
 
     class Iterator;
-    Iterator begin() const;
-    Iterator end() const;
-    Iterator codePointAt(unsigned index) const;
+    Iterator begin() const LIFETIME_BOUND;
+    Iterator end() const LIFETIME_BOUND;
+    Iterator codePointAt(unsigned index) const LIFETIME_BOUND;
 
 private:
     StringView m_stringView;
@@ -834,11 +834,11 @@ private:
 class StringView::CodeUnits {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit CodeUnits(StringView);
+    explicit CodeUnits(StringView view LIFETIME_BOUND);
 
     class Iterator;
-    Iterator begin() const;
-    Iterator end() const;
+    Iterator begin() const LIFETIME_BOUND;
+    Iterator end() const LIFETIME_BOUND;
 
 private:
     StringView m_stringView;
@@ -878,7 +878,7 @@ class StringView::GraphemeClusters::Iterator {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     Iterator() = delete;
-    WTF_EXPORT_PRIVATE Iterator(StringView, unsigned index);
+    WTF_EXPORT_PRIVATE Iterator(StringView view LIFETIME_BOUND, unsigned index);
     WTF_EXPORT_PRIVATE ~Iterator();
 
     Iterator(const Iterator&) = delete;
@@ -901,7 +901,7 @@ class StringView::CodePoints::Iterator {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     using iterator_category = std::forward_iterator_tag;
-    Iterator(StringView, unsigned index);
+    Iterator(StringView view LIFETIME_BOUND, unsigned index);
 
     char32_t operator*() const;
     Iterator& operator++();
@@ -920,7 +920,7 @@ private:
 class StringView::CodeUnits::Iterator {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    Iterator(StringView, unsigned index);
+    Iterator(StringView view LIFETIME_BOUND, unsigned index);
 
     UChar operator*() const;
     Iterator& operator++();

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -39,12 +39,12 @@ struct ListMarkerTextContent {
         return textWithSuffix.isEmpty();
     }
 
-    StringView textWithoutSuffix() const
+    StringView textWithoutSuffix() const LIFETIME_BOUND
     {
         return StringView { textWithSuffix }.left(textWithoutSuffixLength);
     }
 
-    StringView suffix() const
+    StringView suffix() const LIFETIME_BOUND
     {
         return StringView { textWithSuffix }.substring(textWithoutSuffixLength);
     }


### PR DESCRIPTION
#### 4f842d8d9a8e1f9610635c931ff9ac31c36ca186
<pre>
[WTF] Add more LIFETIME_BOUND attributes to iterator, span and inner pointer methods
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=285113">https://bugs.webkit.org/show_bug.cgi?id=285113</a>&gt;
&lt;<a href="https://rdar.apple.com/141961625">rdar://141961625</a>&gt;

Reviewed by Geoffrey Garen.

Add more LIFETIME_BOUND attributes to WTF classes unless otherwise noted
below.  Also fix the LIFETIME_BOUND attribute for gcc and MSVC++.

* Source/JavaScriptCore/runtime/ExceptionHelpers.cpp:
(JSC::clampErrorMessage):

* Source/WTF/wtf/Compiler.h:
(LIFETIME_BOUND):
- Fix attribute for gcc, and add attribute for MSVC++.

* Source/WTF/wtf/FileSystem.h:
(WTF::MappedFileData::span):
(WTF::MappedFileData::mutableSpan):
* Source/WTF/wtf/FixedVector.h:
(WTF::FixedVector::begin):
(WTF::FixedVector::end):
(WTF::FixedVector::begin const):
(WTF::FixedVector::end const):
(WTF::FixedVector::rbegin):
(WTF::FixedVector::rend):
(WTF::FixedVector::rbegin const):
(WTF::FixedVector::rend const):
(WTF::FixedVector::at):
(WTF::FixedVector::at const):
(WTF::FixedVector::operator[]):
(WTF::FixedVector::operator[] const):
(WTF::FixedVector::first):
(WTF::FixedVector::first const):
(WTF::FixedVector::last):
(WTF::FixedVector::last const):
(WTF::FixedVector::storage):
(WTF::FixedVector::span const):
(WTF::FixedVector::mutableSpan):
(WTF::FixedVector::subspan const):
* Source/WTF/wtf/MallocSpan.h:
(WTF::MallocSpan::span const):
(WTF::MallocSpan::mutableSpan):
(WTF::MallocSpan::operator[]):
(WTF::MallocSpan::operator[] const):
(WTF::MallocSpan::operator bool const):
- Add !! to match other pointer -&gt; bool conversions.
* Source/WTF/wtf/StackShot.h:
(WTF::StackShot::array const):
(WTF::StackShot::span const):
* Source/WTF/wtf/TrailingArray.h:
(WTF::TrailingArray::data):
(WTF::TrailingArray::data const):
(WTF::TrailingArray::span):
(WTF::TrailingArray::span const):
(WTF::TrailingArray::begin):
(WTF::TrailingArray::end):
(WTF::TrailingArray::begin const):
(WTF::TrailingArray::end const):
(WTF::TrailingArray::cbegin const):
(WTF::TrailingArray::cend const):
(WTF::TrailingArray::rbegin):
(WTF::TrailingArray::rend):
(WTF::TrailingArray::rbegin const):
(WTF::TrailingArray::rend const):
(WTF::TrailingArray::crbegin const):
(WTF::TrailingArray::crend const):
(WTF::TrailingArray::at):
(WTF::TrailingArray::at const):
(WTF::TrailingArray::operator[]):
(WTF::TrailingArray::operator[] const):
(WTF::TrailingArray::first):
(WTF::TrailingArray::first const):
(WTF::TrailingArray::last):
(WTF::TrailingArray::last const):
* Source/WTF/wtf/URL.cpp:
(WTF::substringIgnoringQueryAndFragments):
* Source/WTF/wtf/UUID.h:
(WTF::UUID::span const):
* Source/WTF/wtf/persistence/PersistentEncoder.h:
(WTF::Persistence::Encoder::buffer const):
(WTF::Persistence::Encoder::span const):
* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::span8 const):
(WTF::StringBuilder::span16 const):
(WTF::StringBuilder::span const):
* Source/WTF/wtf/text/StringConcatenateNumbers.h:
(WTF::StringTypeAdapter::span const):
(WTF::FormattedNumber::span const):
(WTF::FormattedNumber::buffer const):
(WTF::FormattedNumber::span const):
(WTF::FormattedCSSNumber::buffer const):
(WTF::FormattedCSSNumber::span const):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::span8 const):
(WTF::StringImpl::span16 const):
(WTF::StringImpl::span const):
* Source/WTF/wtf/text/StringParsingBuffer.h:
(WTF::StringParsingBuffer::StringParsingBuffer):
(WTF::StringParsingBuffer::position const):
(WTF::StringParsingBuffer::end const):
(WTF::StringParsingBuffer::stringViewOfCharactersRemaining const):
(WTF::StringParsingBuffer::span const):
(WTF::StringParsingBuffer::consume):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::StringView):
(WTF::StringView::rawCharacters const):
(WTF::StringView::span8 const):
(WTF::StringView::span16 const):
(WTF::StringView::span const):
(WTF::StringView::UpconvertedCharactersWithSize::operator const UChar* const):
(WTF::StringView::UpconvertedCharactersWithSize::get const):
(WTF::StringView::UpconvertedCharactersWithSize::operator std::span&lt;const UChar&gt; const):
(WTF::StringView::UpconvertedCharactersWithSize::span const):
(WTF::StringView::SplitResult::SplitResult):
(WTF::StringView::SplitResult::begin const):
(WTF::StringView::SplitResult::end const):
(WTF::StringView::GraphemeClusters::GraphemeClusters):
(WTF::StringView::GraphemeClusters::begin const):
(WTF::StringView::GraphemeClusters::end const):
(WTF::StringView::CodePoints::CodePoints):
(WTF::StringView::CodePoints::begin const):
(WTF::StringView::CodePoints::end const):
(WTF::StringView::CodePoints::codePointAt const):
(WTF::StringView::CodeUnits::CodeUnits):
(WTF::StringView::CodeUnits::begin const):
(WTF::StringView::CodeUnits::end const):
(WTF::StringView::GraphemeClusters::Iterator::Iterator):
(WTF::StringView::CodePoints::Iterator::Iterator):
(WTF::StringView::CodeUnits::Iterator::Iterator):

* Source/WebCore/rendering/RenderListMarker.h:
(WebCore::ListMarkerTextContent::textWithoutSuffix const):
(WebCore::ListMarkerTextContent::suffix const):

Canonical link: <a href="https://commits.webkit.org/288278@main">https://commits.webkit.org/288278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b5e965c9a2b9f17bf99e06a525cd9a8c6f1cd99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82288 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87420 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33349 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64134 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21882 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74875 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44412 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1314 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29056 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32390 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75274 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72607 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88776 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81342 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6853 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72526 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71744 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15880 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14887 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/949 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12780 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9547 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15068 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103755 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9421 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25171 "Found 3 new JSC stress test failures: stress/json-stringify-inspector-check.js.no-llint, stress/substring-global-atom-cache.js.lockdown, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12887 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11191 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->