### PR TITLE
Reduce use of memcpy() in WebCore/PAL/pal/text

### DIFF
--- a/Source/WTF/wtf/text/StringBuffer.h
+++ b/Source/WTF/wtf/text/StringBuffer.h
@@ -70,6 +70,7 @@ public:
 
     unsigned length() const { return m_length; }
     CharType* characters() { return m_data; }
+    std::span<CharType> span() { return unsafeMakeSpan(m_data, m_length); }
 
     CharType& operator[](unsigned i) { RELEASE_ASSERT(i < m_length); return m_data[i]; }
 

--- a/Source/WebCore/PAL/pal/text/TextCodecASCIIFastPath.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecASCIIFastPath.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/ASCIIFastPath.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -34,12 +35,12 @@ namespace PAL {
 
 template<size_t size> struct UCharByteFiller;
 template<> struct UCharByteFiller<4> {
-    static void copy(LChar* destination, const uint8_t* source)
+    static void copy(std::span<LChar> destination, std::span<const uint8_t> source)
     {
-        memcpy(destination, source, 4);
+        memcpySpan(destination, source.first(4));
     }
     
-    static void copy(UChar* destination, const uint8_t* source)
+    static void copy(std::span<UChar> destination, std::span<const uint8_t> source)
     {
         destination[0] = source[0];
         destination[1] = source[1];
@@ -48,12 +49,12 @@ template<> struct UCharByteFiller<4> {
     }
 };
 template<> struct UCharByteFiller<8> {
-    static void copy(LChar* destination, const uint8_t* source)
+    static void copy(std::span<LChar> destination, std::span<const uint8_t> source)
     {
-        memcpy(destination, source, 8);
+        memcpySpan(destination, source.first(8));
     }
 
-    static void copy(UChar* destination, const uint8_t* source)
+    static void copy(std::span<UChar> destination, std::span<const uint8_t> source)
     {
         destination[0] = source[0];
         destination[1] = source[1];
@@ -66,12 +67,12 @@ template<> struct UCharByteFiller<8> {
     }
 };
 
-inline void copyASCIIMachineWord(LChar* destination, const uint8_t* source)
+inline void copyASCIIMachineWord(std::span<LChar> destination, std::span<const uint8_t> source)
 {
     UCharByteFiller<sizeof(WTF::MachineWord)>::copy(destination, source);
 }
 
-inline void copyASCIIMachineWord(UChar* destination, const uint8_t* source)
+inline void copyASCIIMachineWord(std::span<UChar> destination, std::span<const uint8_t> source)
 {
     UCharByteFiller<sizeof(WTF::MachineWord)>::copy(destination, source);
 }

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.h
@@ -46,8 +46,8 @@ private:
     String decode(std::span<const uint8_t>, bool flush, bool stopOnError, bool& sawError) final;
     Vector<uint8_t> encode(StringView, UnencodableHandling) const final;
 
-    bool handlePartialSequence(LChar*& destination, std::span<const uint8_t>& source, bool flush);
-    void handlePartialSequence(UChar*& destination, std::span<const uint8_t>& source, bool flush, bool stopOnError, bool& sawError);
+    bool handlePartialSequence(std::span<LChar>& destination, std::span<const uint8_t>& source, bool flush);
+    void handlePartialSequence(std::span<UChar>& destination, std::span<const uint8_t>& source, bool flush, bool stopOnError, bool& sawError);
     void consumePartialSequenceByte();
 
     int m_partialSequenceSize { 0 };


### PR DESCRIPTION
#### f099fb617a268053ded3526772d184770070ae1c
<pre>
Reduce use of memcpy() in WebCore/PAL/pal/text
<a href="https://bugs.webkit.org/show_bug.cgi?id=285116">https://bugs.webkit.org/show_bug.cgi?id=285116</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/text/StringBuffer.h:
(WTF::StringBuffer::span):
* Source/WebCore/PAL/pal/text/TextCodecASCIIFastPath.h:
(PAL::UCharByteFiller&lt;4&gt;::copy):
(PAL::UCharByteFiller&lt;8&gt;::copy):
(PAL::copyASCIIMachineWord):
* Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp:
(PAL::TextCodecLatin1::decode):
* Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp:
(PAL::appendCharacter):
(PAL::TextCodecUTF8::handlePartialSequence):
(PAL::TextCodecUTF8::decode):
* Source/WebCore/PAL/pal/text/TextCodecUTF8.h:

Canonical link: <a href="https://commits.webkit.org/288291@main">https://commits.webkit.org/288291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a21ceca38499d377dd72a7285c8736dd421b6979

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87501 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33430 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64199 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21950 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44477 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29131 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32471 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75357 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72678 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88857 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81423 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6933 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72601 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9901 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70762 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71818 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15953 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14960 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1042 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12786 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9628 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15149 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103836 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9502 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25197 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12968 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11272 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->