### PR TITLE
AX: Update generateRemoteToken to return a vector

### DIFF
--- a/Source/WebCore/accessibility/AXRemoteFrame.h
+++ b/Source/WebCore/accessibility/AXRemoteFrame.h
@@ -37,7 +37,7 @@ public:
 
 #if PLATFORM(COCOA)
     void initializePlatformElementWithRemoteToken(std::span<const uint8_t>, int);
-    std::span<const uint8_t> generateRemoteToken() const;
+    Vector<uint8_t> generateRemoteToken() const;
     RetainPtr<id> remoteFramePlatformElement() const final { return m_remoteFramePlatformElement; }
     pid_t processIdentifier() const { return m_processIdentifier; }
     std::optional<FrameIdentifier> frameID() const { return m_frameID; }

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -1009,7 +1009,7 @@ PlatformRoleMap createPlatformRoleMap();
 String roleToPlatformString(AccessibilityRole);
 
 #if PLATFORM(IOS_FAMILY)
-WEBCORE_EXPORT NSData* newAccessibilityRemoteToken(NSString *);
+WEBCORE_EXPORT RetainPtr<NSData> newAccessibilityRemoteToken(NSString *);
 #endif
 } // namespace Accessibility
 

--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -41,6 +41,7 @@
 #import <wtf/SoftLinking.h>
 #import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/WTFString.h>
 
@@ -189,9 +190,11 @@ static RetainPtr<NSDictionary> unarchivedTokenForData(RetainPtr<NSData> tokenDat
 
 #endif
 
-std::span<const uint8_t> AXRemoteFrame::generateRemoteToken() const
+Vector<uint8_t> AXRemoteFrame::generateRemoteToken() const
 {
-    return span(Accessibility::newAccessibilityRemoteToken([[NSUUID UUID] UUIDString]));
+    if (RetainPtr data = Accessibility::newAccessibilityRemoteToken([[NSUUID UUID] UUIDString]))
+        return makeVector(data.get());
+    return { };
 }
 
 void AXRemoteFrame::initializePlatformElementWithRemoteToken(std::span<const uint8_t> token, int processIdentifier)
@@ -342,7 +345,7 @@ RetainPtr<NSAttributedString> attributedStringCreate(Node& node, StringView text
 
 namespace Accessibility {
 
-NSData *newAccessibilityRemoteToken(NSString *uuidString)
+RetainPtr<NSData> newAccessibilityRemoteToken(NSString *uuidString)
 {
     if (!uuidString)
         return nil;

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -48,6 +48,7 @@
 #import "TextDecorationPainter.h"
 #import "TextIterator.h"
 #import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/cocoa/VectorCocoa.h>
 
 #if PLATFORM(MAC)
 
@@ -655,15 +656,15 @@ RetainPtr<NSAttributedString> attributedStringCreate(Node& node, StringView text
     return string;
 }
 
-std::span<const uint8_t> AXRemoteFrame::generateRemoteToken() const
+Vector<uint8_t> AXRemoteFrame::generateRemoteToken() const
 {
     if (auto* parent = parentObject()) {
         // We use the parent's wrapper so that the remote frame acts as a pass through for the remote token bridge.
         NSData *data = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:parent->wrapper()];
-        return span(data);
+        return makeVector(data);
     }
 
-    return std::span<const uint8_t> { };
+    return { };
 }
 
 void AXRemoteFrame::initializePlatformElementWithRemoteToken(std::span<const uint8_t> token, int processIdentifier)

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -78,6 +78,7 @@
 #import <wtf/UUID.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/TextStream.h>
 #import <wtf/threads/BinarySemaphore.h>
@@ -868,15 +869,16 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
 - (void)_accessibilityRegisterUIProcessTokens
 {
     auto uuid = [NSUUID UUID];
-    NSData *remoteElementToken = WebCore::Accessibility::newAccessibilityRemoteToken(uuid.UUIDString);
+    if (RetainPtr remoteElementToken = WebCore::Accessibility::newAccessibilityRemoteToken(uuid.UUIDString)) {
+        // Store information about the WebProcess that can later be retrieved by the iOS Accessibility runtime.
+        if (_page->legacyMainFrameProcess().state() == WebKit::WebProcessProxy::State::Running) {
+            [self _updateRemoteAccessibilityRegistration:YES];
+            storeAccessibilityRemoteConnectionInformation(self, _page->legacyMainFrameProcess().processID(), uuid);
 
-    // Store information about the WebProcess that can later be retrieved by the iOS Accessibility runtime.
-    if (_page->legacyMainFrameProcess().state() == WebKit::WebProcessProxy::State::Running) {
-        [self _updateRemoteAccessibilityRegistration:YES];
-        storeAccessibilityRemoteConnectionInformation(self, _page->legacyMainFrameProcess().processID(), uuid);
+            auto elementToken = makeVector(remoteElementToken.get());
+            _page->registerUIProcessAccessibilityTokens(elementToken, elementToken);
+        }
 
-        auto elementToken = span(remoteElementToken);
-        _page->registerUIProcessAccessibilityTokens(elementToken, elementToken);
     }
 }
 


### PR DESCRIPTION
#### b8e7cf92b349613e123e257d7fe98632f768b2cf
<pre>
AX: Update generateRemoteToken to return a vector
<a href="https://bugs.webkit.org/show_bug.cgi?id=285118">https://bugs.webkit.org/show_bug.cgi?id=285118</a>
<a href="https://rdar.apple.com/problem/141965781">rdar://problem/141965781</a>

Reviewed by Wenson Hsieh.

We need the lifetime of the token generated from `generateRemoteToken` to persist while
we are passing it around, to avoid a UAF. To make this safer, let&apos;s make
`newAccessibilityRemoteToken` return a `RetainPtr&lt;NSData&gt;` and `generateRemoteToken`
return a `Vector`, rather than an intermediate `span`.

* Source/WebCore/accessibility/AXRemoteFrame.h:
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
(WebCore::AXRemoteFrame::generateRemoteToken const):
(WebCore::Accessibility::newAccessibilityRemoteToken):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AXRemoteFrame::generateRemoteToken const):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _accessibilityRegisterUIProcessTokens]):

Canonical link: <a href="https://commits.webkit.org/288273@main">https://commits.webkit.org/288273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbef30500ace3087d18807e12144bd17b8c33956

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33356 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84400 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64137 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21887 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44415 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1320 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29060 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32397 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72613 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88783 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9601 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6858 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72532 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71750 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17889 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15885 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14892 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/956 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9554 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15075 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9428 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->