### PR TITLE
URLPattern constructor should support std::nullopt for URLPatternInput arguments.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -293,9 +293,9 @@ FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js:
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
-FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
-FAIL Pattern: [] Inputs: [{}] Not implemented.
-FAIL Pattern: [] Inputs: [] Not implemented.
+FAIL Pattern: [] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
+PASS Pattern: [] Inputs: [{}]
+FAIL Pattern: [] Inputs: [] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -293,9 +293,9 @@ FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js:
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
-FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
-FAIL Pattern: [] Inputs: [{}] Not implemented.
-FAIL Pattern: [] Inputs: [] Not implemented.
+FAIL Pattern: [] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
+PASS Pattern: [] Inputs: [{}]
+FAIL Pattern: [] Inputs: [] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -293,9 +293,9 @@ FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js:
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
-FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
-FAIL Pattern: [] Inputs: [{}] Not implemented.
-FAIL Pattern: [] Inputs: [] Not implemented.
+FAIL Pattern: [] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
+PASS Pattern: [] Inputs: [{}]
+FAIL Pattern: [] Inputs: [] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -293,9 +293,9 @@ FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js:
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
-FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
-FAIL Pattern: [] Inputs: [{}] Not implemented.
-FAIL Pattern: [] Inputs: [] Not implemented.
+FAIL Pattern: [] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
+PASS Pattern: [] Inputs: [{}]
+FAIL Pattern: [] Inputs: [] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -293,9 +293,9 @@ FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js:
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
-FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
-FAIL Pattern: [] Inputs: [{}] Not implemented.
-FAIL Pattern: [] Inputs: [] Not implemented.
+FAIL Pattern: [] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
+PASS Pattern: [] Inputs: [{}]
+FAIL Pattern: [] Inputs: [] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -293,9 +293,9 @@ FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js:
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
-FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
-FAIL Pattern: [] Inputs: [{}] Not implemented.
-FAIL Pattern: [] Inputs: [] Not implemented.
+FAIL Pattern: [] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
+PASS Pattern: [] Inputs: [{}]
+FAIL Pattern: [] Inputs: [] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -293,9 +293,9 @@ FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js:
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
-FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
-FAIL Pattern: [] Inputs: [{}] Not implemented.
-FAIL Pattern: [] Inputs: [] Not implemented.
+FAIL Pattern: [] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
+PASS Pattern: [] Inputs: [{}]
+FAIL Pattern: [] Inputs: [] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -293,9 +293,9 @@ FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js:
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
-FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
-FAIL Pattern: [] Inputs: [{}] Not implemented.
-FAIL Pattern: [] Inputs: [] Not implemented.
+FAIL Pattern: [] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
+PASS Pattern: [] Inputs: [{}]
+FAIL Pattern: [] Inputs: [] assert_equals: test() result expected true but got false
 PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]

--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -258,8 +258,13 @@ ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context,
 ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context, std::optional<URLPatternInput>&& input, URLPatternOptions&& options)
 {
     if (!input) {
-        // FIXME: File a bug to URLPattern owners to tell them that spec does not mention supporting empty URLPattern objects. Spec and test cases have diverged!
-        return Exception { ExceptionCode::NotSupportedError, "Not implemented."_s };
+        Ref result = adoptRef(*new URLPattern);
+
+        auto maybeCompileException = result->compileAllComponents(context, URLPatternInit::emptyInit(), WTFMove(options));
+        if (maybeCompileException.hasException())
+            return maybeCompileException.releaseException();
+
+        return result;
     }
 
     return create(context, WTFMove(*input), String { }, WTFMove(options));
@@ -270,10 +275,7 @@ URLPattern::~URLPattern() = default;
 // https://urlpattern.spec.whatwg.org/#dom-urlpattern-test
 ExceptionOr<bool> URLPattern::test(ScriptExecutionContext& context, std::optional<URLPatternInput>&& input, String&& baseURL) const
 {
-    if (!input)
-        return Exception { ExceptionCode::NotSupportedError };
-
-    auto maybeResult = match(context, WTFMove(*input), WTFMove(baseURL));
+    auto maybeResult = match(context, input ? WTFMove(*input) : URLPatternInit::emptyInit(), WTFMove(baseURL));
     if (maybeResult.hasException())
         return maybeResult.releaseException();
 
@@ -284,10 +286,7 @@ ExceptionOr<bool> URLPattern::test(ScriptExecutionContext& context, std::optiona
 // https://urlpattern.spec.whatwg.org/#dom-urlpattern-exec
 ExceptionOr<std::optional<URLPatternResult>> URLPattern::exec(ScriptExecutionContext& context, std::optional<URLPatternInput>&& input, String&& baseURL) const
 {
-    if (!input)
-        return Exception { ExceptionCode::NotSupportedError };
-
-    return match(context, WTFMove(*input), WTFMove(baseURL));
+    return match(context, input ? WTFMove(*input) : URLPatternInit::emptyInit(), WTFMove(baseURL));
 }
 
 ExceptionOr<void> URLPattern::compileAllComponents(ScriptExecutionContext& context, URLPatternInit&& processedInit, const URLPatternOptions& options)

--- a/Source/WebCore/Modules/url-pattern/URLPatternInit.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternInit.h
@@ -39,6 +39,12 @@ struct URLPatternInit {
     String search;
     String hash;
     String baseURL;
+
+    static URLPatternInit emptyInit()
+    {
+        // baseURL is not guaranteed to be an argument so it is null string instead of wildcard.
+        return URLPatternInit { "*"_s, "*"_s, "*"_s, "*"_s, "*"_s, "*"_s, "*"_s, "*"_s, String { } };
+    }
 };
 
 }


### PR DESCRIPTION
#### 46c5ccc4804919dd764cd1d6f05bf26166da9824
<pre>
URLPattern constructor should support std::nullopt for URLPatternInput arguments.
<a href="https://bugs.webkit.org/show_bug.cgi?id=285117">https://bugs.webkit.org/show_bug.cgi?id=285117</a>
<a href="https://rdar.apple.com/141965965">rdar://141965965</a> (URLPattern constructor should support std::nullopt for URLPatternInput arguments.)

Reviewed by NOBODY (OOPS!).

We are currently failing these three test cases in the imported wpt/w3c because this is not implemented.

FAIL Pattern: [] Inputs: [&quot;<a href="https://example.com/&quot">https://example.com/&quot</a>;] Not implemented.
FAIL Pattern: [] Inputs: [{}] Not implemented.
FAIL Pattern: [] Inputs: [] Not implemented.

 Combined changes:
 * LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
 * LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
 * LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
 * LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
 * LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
 * LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
 * LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
 * LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
 * Source/WebCore/Modules/url-pattern/URLPattern.cpp:
 (WebCore::URLPattern::create):
 (WebCore::URLPattern::test const):
 (WebCore::URLPattern::exec const):
 * Source/WebCore/Modules/url-pattern/URLPatternInit.h:
 (WebCore::URLPatternInit::emptyInit):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46c5ccc4804919dd764cd1d6f05bf26166da9824

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87431 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33360 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64139 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21890 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44417 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29066 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32401 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72614 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29690 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88787 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9605 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6862 "Found 1 new test failure: http/wpt/mediarecorder/record-96KHz-sources.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72535 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70699 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71753 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15890 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14897 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/960 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9558 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15079 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9432 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12898 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->