### PR TITLE
[Yarr] Improve processing of \s* and related simple Character Class atoms

### DIFF
--- a/JSTests/microbenchmarks/regexp-greedy-whitespace.js
+++ b/JSTests/microbenchmarks/regexp-greedy-whitespace.js
@@ -1,0 +1,165 @@
+// With verbose set to false, this test is successful if there is no output.  Set verbose to true to see expected matches.
+let verbose = false;
+
+function arrayToString(arr)
+{
+    let str = '';
+    arr.forEach(function(v, index) {
+        if (typeof v == "string")
+            str += "\"" + v + "\"";
+        else
+            str += v;
+
+        if (index != (arr.length - 1))
+            str += ',';
+      });
+  return str;
+}
+
+function objectToString(obj)
+{
+    let str = "";
+
+    firstEntry = true;
+
+    for (const [key, value] of Object.entries(obj)) {
+        if (!firstEntry)
+            str += ", ";
+
+        str += key + ": " + dumpValue(value);
+
+        firstEntry = false;
+    }
+    
+    return "{ " + str + " }";
+}
+
+function dumpValue(v)
+{
+    if (v === null)
+        return "<null>";
+
+    if (v === undefined)
+        return "<undefined>";
+
+    if (typeof v == "string")
+        return "\"" + v + "\"";
+
+    let str = "";
+
+    if (v.length)
+        str += arrayToString(v);
+
+    if (v.groups) {
+        groupStr = objectToString(v.groups);
+
+        if (str.length) {
+            if ( groupStr.length)
+                str += ", " + groupStr;
+        } else
+            str = groupStr;
+    }
+
+    return "[ " + str + " ]";
+}
+
+function compareArray(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected is null, actual is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected is not null, actual is null");
+        return false;
+    }
+
+    if (expected.length !== actual.length) {
+        print("### expected.length: " + expected.length + ", actual.length: " + actual.length);
+        return false;
+    }
+
+    for (var i = 0; i < expected.length; i++) {
+        if (expected[i] !== actual[i]) {
+            print("### expected[" + i + "]: \"" + expected[i] + "\" !== actual[" + i + "]: \"" + actual[i] + "\"");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function compareGroups(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected group is null, actual group is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected group is not null, actual group is null");
+        return false;
+    }
+
+    for (const key in expected) {
+        if (expected[key] !== actual[key]) {
+            print("### expected." + key + ": " + dumpValue(expected[key]) + " !== actual." + key + ": " + dumpValue(actual[key]));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+let testNumber = 0;
+
+function testRegExp(re, str, exp, groups)
+{
+    testNumber++;
+
+    if (groups)
+        exp.groups = groups;
+
+    let actual = re.exec(str);
+
+    let result = compareArray(exp, actual);;
+
+    if (exp && exp.groups) {
+        if (!compareGroups(exp.groups, actual.groups))
+            result = false;
+    }
+
+    if (result) {
+        if (verbose)
+            print(re.toString() + ".exec(" + dumpValue(str) + "), passed ", dumpValue(exp));
+    } else
+        print(re.toString() + ".exec(" + dumpValue(str) + "), FAILED test #" + testNumber + ", Expected ", dumpValue(exp), " got ", dumpValue(actual));
+}
+
+function testRegExpSyntaxError(reString, flags, expError)
+{
+    testNumber++;
+
+
+    try {
+        let re = new RegExp(reString, flags);
+        print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\", but it didn't");
+    } catch (e) {
+        if (e != expError)
+            print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\" got \"" + e + "\"");
+        else if (verbose)
+            print("/" + reString + "/" + flags + " passed, it threw \"" + expError + "\" as expected");
+    }
+}
+
+for (i = 0; i < 500000; i++) {
+    testRegExp(/\s+$/, "XYZ                     \t     ", ["                     \t     "]);
+    testRegExp(/\s+$/, "    \u1234                     \t     ", ["                     \t     "]);
+}

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -2596,6 +2596,9 @@ void CharacterClass::copyOnly8BitCharacterData(const CharacterClass& other)
             m_rangesUnicode.append(CharacterRange(range.begin, std::min<char32_t>(range.end, 0xff)));
     }
 
+    m_table = other.m_table;
+    m_tableInverted = other.m_tableInverted;
+
     if (m_matches.isEmpty() && m_matchesUnicode.isEmpty()
         && m_ranges.size() == 1 && m_rangesUnicode.size() == 1
         && !m_ranges[0].begin && m_rangesUnicode[0].end == 0xff

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -85,6 +85,8 @@ inline CharacterClassWidths& operator|=(CharacterClassWidths& lhs, CharacterClas
 struct CharacterClass {
     WTF_MAKE_TZONE_ALLOCATED(CharacterClass);
 public:
+    using Table = const char*;
+
     // All CharacterClass instances have to have the full set of matches and ranges,
     // they may have an optional m_table for faster lookups (which must match the
     // specified matches and ranges)
@@ -95,7 +97,7 @@ public:
     {
     }
 
-    CharacterClass(const char* table, bool inverted)
+    CharacterClass(Table table, bool inverted)
         : m_table(table)
         , m_characterWidths(CharacterClassWidths::Unknown)
         , m_tableInverted(inverted)
@@ -144,7 +146,7 @@ public:
     Vector<char32_t> m_matchesUnicode;
     Vector<CharacterRange> m_rangesUnicode;
 
-    const char* m_table;
+    Table m_table;
     CharacterClassWidths m_characterWidths;
     bool m_tableInverted : 1;
     bool m_anyCharacter : 1;

--- a/Source/JavaScriptCore/yarr/create_regex_tables
+++ b/Source/JavaScriptCore/yarr/create_regex_tables
@@ -31,8 +31,8 @@ types = {
     "wordUnicodeIgnoreCaseChar": { "UseTable" : False, "data": ['_', ('0', '9'), ('A', 'Z'), ('a', 'z'), 0x017f, 0x212a]},
     "nonwordchar": { "UseTable" : True, "Inverse": "wordchar", "data": ['`', (0, ord('0') - 1), (ord('9') + 1, ord('A') - 1), (ord('Z') + 1, ord('_') - 1), (ord('z') + 1, 0x10ffff)]},
     "nonwordUnicodeIgnoreCaseChar": { "UseTable" : False, "Inverse": "wordUnicodeIgnoreCaseChar", "data": ['`', (0, ord('0') - 1), (ord('9') + 1, ord('A') - 1), (ord('Z') + 1, ord('_') - 1), (ord('z') + 1, 0x017e), (0x0180, 0x2129), (0x212b, 0x10ffff)]},
-    "newline": { "UseTable" : False, "data": ['\n', '\r', 0x2028, 0x2029]},
-    "spaces": { "UseTable" : True, "data": [' ', ('\t', '\r'), 0xa0, 0x1680, 0x2028, 0x2029, 0x202f, 0x205f, 0x3000, (0x2000, 0x200a), 0xfeff]},
+    "newline": { "UseTable" : False, "data": ['\n', '\r', (0x2028, 0x2029)]},
+    "spaces": { "UseTable" : True, "data": [' ', ('\t', '\r'), 0xa0, 0x1680, 0x202f, 0x205f, 0x3000, (0x2000, 0x200a), (0x2028, 0x2029), 0xfeff]},
     "nonspaces": { "UseTable" : True, "Inverse": "spaces", "data": [(0, ord('\t') - 1), (ord('\r') + 1, ord(' ') - 1), (ord(' ') + 1, 0x009f), (0x00a1, 0x167f), (0x1681, 0x1fff), (0x200b, 0x2027), (0x202a, 0x202e), (0x2030, 0x205e), (0x2060, 0x2fff), (0x3001, 0xfefe), (0xff00, 0x10ffff)]},
     "digits": { "UseTable" : False, "data": [('0', '9')]},
     "nondigits": { "UseTable" : False, "Inverse": "digits", "data": [(0, ord('0') - 1), (ord('9') + 1, 0x10ffff)] }


### PR DESCRIPTION
#### 33a069473f47b0242c67a1a4f9ae3a0ad249480d
<pre>
[Yarr] Improve processing of \s* and related simple Character Class atoms
<a href="https://bugs.webkit.org/show_bug.cgi?id=285121">https://bugs.webkit.org/show_bug.cgi?id=285121</a>
<a href="https://rdar.apple.com/141967884">rdar://141967884</a>

Reviewed by Yusuke Suzuki.

This has three fixes to improve the processing of simple character classes like \s or [abc].

1. Added code to YarrGenerator::matchCharacterClass() and related methods to generate a single
   branch instead of a branch over a branch.  e.g
     Before:
       &lt;112&gt; 0x11aabce30:    b.eq     0x11aabce38 -&gt; &lt;120&gt;
       &lt;116&gt; 0x11aabce34:    b        0x11aabce44 -&gt; &lt;132&gt;
       &lt;120&gt; 0x11aabce38:    ...
     After:
       &lt;112&gt; 0x11aabce30:    b.ne     0x11aabce38 -&gt; &lt;128&gt;
       &lt;126&gt; 0x11aabce38:    ...
   Part of this change can be used for future branch over branch elimination.
2. Fixed an issue in CharacterClass::copyOnly8BitCharacterData() where we didn&apos;t copy the table
   data.  This applies to the built-in whitespace and word classes.
3. Made a minor fix in the whitespace character class generation to turn the separate characters
   0x2028, 0x2029 into the range 0x2028..0x2029.

Added a micro benchmark to measure the perf improvement of \s+ for both 8 bit and 16 bit string.
The speedup for that micro benchmark is:
                              Baseline            NoBrAroundBr

regexp-greedy-whitespace  60.3322+-0.5647   ^   51.9861+-1.1278    ^ definitely 1.1605x faster

&lt;geometric&gt;               60.3322+-0.5647   ^   51.9861+-1.1278    ^ definitely 1.1605x faster

* JSTests/microbenchmarks/regexp-greedy-whitespace.js: Added.
(arrayToString):
(objectToString):
(dumpValue):
(compareArray):
(compareGroups):
(testRegExp):
(testRegExpSyntaxError):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClass::copyOnly8BitCharacterData):
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::CharacterClass::CharacterClass):
* Source/JavaScriptCore/yarr/create_regex_tables:

Canonical link: <a href="https://commits.webkit.org/288284@main">https://commits.webkit.org/288284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51d500c579630fc697b28b81a944f350059598c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87483 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33412 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9899 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64181 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21932 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74932 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44459 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1369 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29115 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32453 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75339 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72660 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88839 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81405 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6915 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72582 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71799 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17891 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15935 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14944 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1014 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9610 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15131 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103818 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9484 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25195 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12950 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11254 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->