### PR TITLE
[JSC] Support precise heap location analysis in CSE

### DIFF
--- a/JSTests/microbenchmarks/loop-unrolling-4.js
+++ b/JSTests/microbenchmarks/loop-unrolling-4.js
@@ -11,15 +11,14 @@ function test(s) {
     for (var i = 0; i < len; i++) {
         a[i] = s[i];
     }
-    // FIXME: why read a[0] is not eliminated but a[1] does?
     s[0] = a[0] ^ a[1];
     return s;
 }
 noInline(test);
 
 let expected;
-for (let i = 0; i < 1e5; i++) {
-    let a = [0, 0];
+for (let i = 0; i < 1e6; i++) {
+    let a = [0, 0, 0, 0];
     let res = test(a);
     if (i == 0)
         expected = res;

--- a/JSTests/microbenchmarks/loop-unrolling-5.js
+++ b/JSTests/microbenchmarks/loop-unrolling-5.js
@@ -1,0 +1,35 @@
+function assert(actual, expected) {
+    for (let i = 0; i < actual.length; i++) {
+        if (actual[i] != expected[i])
+            throw new Error("bad actual=" + actual[i] + " but expected=" + expected[i]);
+    }
+}
+
+function test(s) {
+    var a = new Array(4);
+    for (var i = 0; i < 4; i++) {
+        a[i] = s[i] & 0x80;
+    }
+
+    s[4] = a[0] ^ a[1] ^ a[2] ^ a[0] ^ a[1] ^ a[2];
+    s[5] = a[1] ^ a[2] ^ a[3] ^ a[1] ^ a[2] ^ a[3];
+    s[6] = a[2] ^ a[3] ^ a[0] ^ a[2] ^ a[3] ^ a[0];
+    s[7] = a[3] ^ a[0] ^ a[1] ^ a[3] ^ a[0] ^ a[1];
+
+    s[8] = a[0] ^ a[1] ^ a[2] ^ a[0] ^ a[1] ^ a[2];
+    s[9] = a[1] ^ a[2] ^ a[3] ^ a[1] ^ a[2] ^ a[3];
+    s[10] = a[2] ^ a[3] ^ a[0] ^ a[2] ^ a[3] ^ a[0];
+    s[11] = a[3] ^ a[0] ^ a[1] ^ a[3] ^ a[0] ^ a[1];
+
+    return s;
+}
+noInline(test);
+
+let expected;
+for (let i = 0; i < 1e6; i++) {
+    let a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    let res = test(a);
+    if (i == 0)
+        expected = res;
+    assert(res, expected);
+}

--- a/Source/JavaScriptCore/dfg/DFGCSEPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCSEPhase.cpp
@@ -115,7 +115,7 @@ public:
         m_abstractHeapStackMap.swap(other.m_abstractHeapStackMap);
         m_fallbackStackMap.swap(other.m_fallbackStackMap);
         m_heapMap.swap(other.m_heapMap);
-#if !defined(NDEBUG)
+#if ASSERT_ENABLED
         m_debugImpureData.swap(other.m_debugImpureData);
 #endif
     }
@@ -124,7 +124,7 @@ public:
     {
         const ImpureDataSlot* result = addImpl(location, node);
 
-#if !defined(NDEBUG)
+#if ASSERT_ENABLED
         auto addResult = m_debugImpureData.add(location, node);
         ASSERT(!!result == !addResult.isNewEntry);
 #endif
@@ -134,10 +134,25 @@ public:
     LazyNode get(const HeapLocation& location) const
     {
         LazyNode result = getImpl(location);
-#if !defined(NDEBUG)
+#if ASSERT_ENABLED
         ASSERT(result == m_debugImpureData.get(location));
 #endif
         return result;
+    }
+
+    void clobber(int32_t offset)
+    {
+        m_heapMap.removeIf([&](const std::unique_ptr<ImpureDataSlot>& slot) -> bool {
+            const HeapLocation& target = slot->key;
+            if (!target.hasConstantOffset() || target.constantOffset() == offset) {
+#if ASSERT_ENABLED
+                m_debugImpureData.remove(target);
+#endif
+                dataLogLnIf(DFGCSEPhaseInternal::verbose, "precise clobber remove location=", target);
+                return true;
+            }
+            return false;
+        });
     }
 
     void clobber(AbstractHeap heap, bool clobberConservatively)
@@ -165,7 +180,7 @@ public:
                 clobber(m_heapMap, heap);
             break;
         }
-#if !defined(NDEBUG)
+#if ASSERT_ENABLED
         m_debugImpureData.removeIf([heap, clobberConservatively, this](const UncheckedKeyHashMap<HeapLocation, LazyNode>::KeyValuePairType& pair) -> bool {
             switch (heap.kind()) {
             case World:
@@ -213,7 +228,7 @@ public:
         m_abstractHeapStackMap.clear();
         m_fallbackStackMap.clear();
         m_heapMap.clear();
-#if !defined(NDEBUG)
+#if ASSERT_ENABLED
         m_debugImpureData.clear();
 #endif
     }
@@ -306,7 +321,7 @@ private:
 
     Map m_heapMap;
 
-#if !defined(NDEBUG)
+#if ASSERT_ENABLED
     UncheckedKeyHashMap<HeapLocation, LazyNode> m_debugImpureData;
 #endif
 };
@@ -597,7 +612,7 @@ private:
                             m_node->setOp(PutByValAlias);
                     }
 
-                    clobberize(m_graph, m_node, *this);
+                    preciseClobberize(m_graph, m_node, *this);
                 }
             }
 
@@ -613,7 +628,9 @@ private:
             dataLogLnIf(DFGCSEPhaseInternal::verbose, "\tWrite to heap ", heap);
             m_maps.write(heap);
         }
-        
+
+        void preciseWrite(const HeapLocation&) { }
+
         void def(PureValue value)
         {
             dataLogLnIf(DFGCSEPhaseInternal::verbose, "\tDef of value ", value, " at node ", m_node->index());
@@ -687,6 +704,9 @@ public:
     
     bool run()
     {
+        SetForScope scope(m_graph.m_planStage);
+        if (m_graph.m_planStage >= PlanStage::LICMAndLater)
+            scope.set(PlanStage::InLastGlobalCSE);
 
         if (DFGCSEPhaseInternal::verbose) {
             dataLog("Graph before Global CSE:\n");
@@ -707,7 +727,7 @@ public:
             m_block = m_preOrder[i];
             m_impureData = &m_impureDataMap[m_block];
             for (unsigned nodeIndex = m_block->size(); nodeIndex--;)
-                addWrites(m_graph, m_block->at(nodeIndex), m_impureData->writes);
+                addPreciseWrites(m_graph, m_block->at(nodeIndex), m_impureData->writes, m_impureData->preciseWrites);
         }
         
         // Based on my experience doing this before, what follows might have to be made iterative.
@@ -720,7 +740,12 @@ public:
         // run it a second time. Unfortunately, we cannot assert this right now. Note that if we did
         // this, we'd have to first reset all of our state.
         // https://bugs.webkit.org/show_bug.cgi?id=145853
-        
+
+        if (DFGCSEPhaseInternal::verbose) {
+            dataLog("Graph after Global CSE:\n");
+            m_graph.dump();
+        }
+
         return changed;
     }
     
@@ -752,7 +777,7 @@ public:
                     m_node->replaceWith(m_graph, m_node->child1().node());
                     m_changed = true;
                 } else
-                    clobberize(m_graph, m_node, *this);
+                    preciseClobberize(m_graph, m_node, *this);
             }
 
             m_insertionSet.execute(m_block);
@@ -772,6 +797,38 @@ public:
         m_writesSoFar.add(heap);
     }
     
+    bool canPreciseWrite(LocationKind kind)
+    {
+        switch (kind) {
+        case IndexedPropertyJSLoc:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    bool canPreciseWrite(AbstractHeap heap)
+    {
+        switch (heap.kind()) {
+        case IndexedInt32Properties:
+        case IndexedContiguousProperties:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    bool canPreciseWrite(const HeapLocation& location)
+    {
+        return location.hasConstantOffset() && canPreciseWrite(location.kind()) && canPreciseWrite(location.heap());
+    }
+
+    void preciseWrite(const HeapLocation& location)
+    {
+        ASSERT(canPreciseWrite(location));
+        m_impureData->availableAtTail.clobber(location.constantOffset());
+    }
+
     void def(PureValue value)
     {
         // With pure values we do not have to worry about the possibility of some control flow path
@@ -902,6 +959,11 @@ public:
                     dataLog("        Clobbered.\n");
                 return nullptr;
             }
+            if (data.preciseWrites.overlaps(location)) {
+                if (DFGCSEPhaseInternal::verbose)
+                    dataLog("        PreciseClobbered.\n");
+                return nullptr;
+            }
             
             for (unsigned i = block->predecessors.size(); i--;) {
                 BasicBlock* predecessor = block->predecessors[i];
@@ -981,6 +1043,7 @@ public:
         }
         
         ClobberSet writes;
+        PreciseClobberSet preciseWrites;
         ImpureMap availableAtTail;
         bool didVisit;
     };

--- a/Source/JavaScriptCore/dfg/DFGClobberSet.cpp
+++ b/Source/JavaScriptCore/dfg/DFGClobberSet.cpp
@@ -150,6 +150,14 @@ void addWrites(Graph& graph, Node* node, ClobberSet& writeSet)
     clobberize(graph, node, noOp, addWrite, noOp);
 }
 
+void addPreciseWrites(Graph& graph, Node* node, ClobberSet& writeSet, PreciseClobberSet& preciseWriteSet)
+{
+    NoOpClobberize noOp;
+    ClobberSetAdd addWrite(writeSet);
+    PreciseClobberSetAdd addPreciseWrite(preciseWriteSet);
+    preciseClobberize(graph, node, noOp, addWrite, addPreciseWrite, noOp);
+}
+
 void addReadsAndWrites(Graph& graph, Node* node, ClobberSet& readSet, ClobberSet& writeSet)
 {
     ClobberSetAdd addRead(readSet);

--- a/Source/JavaScriptCore/dfg/DFGClobberSet.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberSet.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(DFG_JIT)
 
-#include "DFGAbstractHeap.h"
+#include "DFGHeapLocation.h"
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/PrintStream.h>
@@ -74,6 +74,25 @@ private:
     UncheckedKeyHashMap<AbstractHeap, bool> m_clobbers;
 };
 
+class PreciseClobberSet {
+public:
+    bool overlaps(const HeapLocation& location)
+    {
+        if (location.hasConstantOffset())
+            return m_clobberedOffsets.contains(location.constantOffset());
+        return false;
+    }
+
+    void add(const HeapLocation& location)
+    {
+        if (location.hasConstantOffset())
+            m_clobberedOffsets.add(location.constantOffset());
+    }
+
+private:
+    UncheckedKeyHashSet<int32_t, DefaultHash<int32_t>, WTF::SignedWithZeroKeyHashTraits<int32_t>> m_clobberedOffsets;
+};
+
 class ClobberSetAdd {
 public:
     ClobberSetAdd(ClobberSet& set)
@@ -87,6 +106,21 @@ public:
     }
 private:
     ClobberSet& m_set;
+};
+
+class PreciseClobberSetAdd {
+public:
+    PreciseClobberSetAdd(PreciseClobberSet& set)
+        : m_set(set)
+    {
+    }
+
+    void operator()(const HeapLocation& location) const
+    {
+        m_set.add(location);
+    }
+private:
+    PreciseClobberSet& m_set;
 };
 
 class ClobberSetOverlaps {
@@ -111,6 +145,7 @@ private:
 
 void addReads(Graph&, Node*, ClobberSet&);
 void addWrites(Graph&, Node*, ClobberSet&);
+void addPreciseWrites(Graph&, Node*, ClobberSet&, PreciseClobberSet&);
 void addReadsAndWrites(Graph&, Node*, ClobberSet& reads, ClobberSet& writes);
 
 ClobberSet writeSet(Graph&, Node*);

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -42,11 +42,23 @@ namespace JSC { namespace DFG {
 template<typename ReadFunctor, typename WriteFunctor, typename DefFunctor>
 void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFunctor& write, const DefFunctor& def)
 {
-    clobberize(graph, node, read, write, def, [] { });
+    clobberize(graph, node, read, write, [](const HeapLocation&) { }, def, [] { });
 }
 
 template<typename ReadFunctor, typename WriteFunctor, typename DefFunctor, typename ClobberTopFunctor>
 void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFunctor& write, const DefFunctor& def, const ClobberTopFunctor& clobberTopFunctor)
+{
+    clobberize(graph, node, read, write, [](const HeapLocation&) { }, def, clobberTopFunctor);
+}
+
+template<typename ReadFunctor, typename WriteFunctor, typename PreciseWriteFunctor, typename DefFunctor>
+void preciseClobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFunctor& write, const PreciseWriteFunctor& preciseWrite, const DefFunctor& def)
+{
+    clobberize(graph, node, read, write, preciseWrite, def, [] { });
+}
+
+template<typename ReadFunctor, typename WriteFunctor, typename PreciseWriteFunctor, typename DefFunctor, typename ClobberTopFunctor>
+void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFunctor& write, const PreciseWriteFunctor& preciseWrite, const DefFunctor& def, const ClobberTopFunctor& clobberTopFunctor)
 {
     // Some notes:
     //
@@ -129,6 +141,13 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
             clobberTopFunctor();
         read(World);
         write(Heap);
+    };
+
+    auto tryPreciseWrite = [&] (const HeapLocation& location, AbstractHeapKind kind) {
+        if (graph.m_planStage == PlanStage::InLastGlobalCSE && location.hasConstantOffset())
+            preciseWrite(location);
+        else
+            write(kind);
     };
 
     // Since Fixup can widen our ArrayModes based on profiling from other nodes we pessimistically assume
@@ -1161,8 +1180,8 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         case Array::BigUint64Array:
             clobberTop();
             return;
-            
-        case Array::Int32:
+
+        case Array::Int32: {
             if (mode.isOutOfBounds()) {
                 clobberTop();
                 return;
@@ -1170,12 +1189,14 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
             read(Butterfly_publicLength);
             read(Butterfly_vectorLength);
             read(IndexedInt32Properties);
-            write(IndexedInt32Properties);
             if (mode.mayStoreToHole())
                 write(Butterfly_publicLength);
-            def(HeapLocation(indexedPropertyLoc, IndexedInt32Properties, base, index), LazyNode(value));
+            HeapLocation location = HeapLocation(indexedPropertyLoc, IndexedInt32Properties, base, index);
+            tryPreciseWrite(location, IndexedInt32Properties);
+            def(location, LazyNode(value));
             def(HeapLocation(IndexedPropertyInt32OutOfBoundsSaneChainLoc, IndexedInt32Properties, base, index), LazyNode(value));
             return;
+        }
             
         case Array::Double:
             if (mode.isOutOfBounds()) {
@@ -1193,7 +1214,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
             def(HeapLocation(IndexedPropertyDoubleOutOfBoundsSaneChainLoc, IndexedDoubleProperties, base, index), LazyNode(value));
             return;
             
-        case Array::Contiguous:
+        case Array::Contiguous: {
             if (mode.isOutOfBounds()) {
                 clobberTop();
                 return;
@@ -1201,12 +1222,14 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
             read(Butterfly_publicLength);
             read(Butterfly_vectorLength);
             read(IndexedContiguousProperties);
-            write(IndexedContiguousProperties);
             if (mode.mayStoreToHole())
                 write(Butterfly_publicLength);
-            def(HeapLocation(indexedPropertyLoc, IndexedContiguousProperties, base, index), LazyNode(value));
+            HeapLocation location = HeapLocation(indexedPropertyLoc, IndexedContiguousProperties, base, index);
+            tryPreciseWrite(location, IndexedContiguousProperties);
+            def(location, LazyNode(value));
             def(HeapLocation(IndexedPropertyJSOutOfBoundsSaneChainLoc, IndexedContiguousProperties, base, index), LazyNode(value));
             return;
+        }
             
         case Array::ArrayStorage:
             if (node->arrayMode().isOutOfBounds()) {
@@ -2388,6 +2411,22 @@ private:
 };
 
 template<typename T>
+class PreciseWriteMethodClobberize {
+public:
+    PreciseWriteMethodClobberize(T& value)
+        : m_value(value)
+    {
+    }
+
+    void operator()(const HeapLocation& location) const
+    {
+        m_value.preciseWrite(location);
+    }
+private:
+    T& m_value;
+};
+
+template<typename T>
 class DefMethodClobberize {
 public:
     DefMethodClobberize(T& value)
@@ -2410,12 +2449,13 @@ private:
 };
 
 template<typename Adaptor>
-void clobberize(Graph& graph, Node* node, Adaptor& adaptor)
+void preciseClobberize(Graph& graph, Node* node, Adaptor& adaptor)
 {
     ReadMethodClobberize<Adaptor> read(adaptor);
     WriteMethodClobberize<Adaptor> write(adaptor);
+    PreciseWriteMethodClobberize<Adaptor> preciseWrite(adaptor);
     DefMethodClobberize<Adaptor> def(adaptor);
-    clobberize(graph, node, read, write, def);
+    preciseClobberize(graph, node, read, write, preciseWrite, def);
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGCommon.h
+++ b/Source/JavaScriptCore/dfg/DFGCommon.h
@@ -253,7 +253,8 @@ inline KillStatus killStatusForDoesKill(bool doesKill)
 enum class PlanStage {
     Initial,
     AfterFixup,
-    LICMAndLater
+    LICMAndLater,
+    InLastGlobalCSE,
 };
 
 // If possible, this will acquire a lock to make sure that if multiple threads

--- a/Source/JavaScriptCore/dfg/DFGHeapLocation.h
+++ b/Source/JavaScriptCore/dfg/DFGHeapLocation.h
@@ -169,6 +169,17 @@ public:
     {
         return m_heap.isHashTableDeletedValue();
     }
+
+    bool hasConstantOffset() const
+    {
+        return m_index && m_index.isNode() && m_index->isInt32Constant();
+    }
+
+    int32_t constantOffset() const
+    {
+        ASSERT(hasConstantOffset());
+        return m_index->asInt32();
+    }
     
     void dump(PrintStream& out) const;
     

--- a/Source/JavaScriptCore/dfg/DFGPreciseLocalClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGPreciseLocalClobberize.h
@@ -74,7 +74,9 @@ public:
         
         RELEASE_ASSERT(!heap.overlaps(Stack));
     }
-    
+
+    void preciseWrite(const HeapLocation&) { }
+
     void def(PureValue)
     {
         // PureValue defs never have anything to do with locals, so ignore this.
@@ -291,7 +293,7 @@ void preciseLocalClobberize(
 {
     PreciseLocalClobberizeAdaptor<ReadFunctor, WriteFunctor, DefFunctor>
         adaptor(graph, node, read, write, def);
-    clobberize(graph, node, adaptor);
+    preciseClobberize(graph, node, adaptor);
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -1617,11 +1617,9 @@ static void putByVal(JSGlobalObject* globalObject, JSValue baseValue, JSValue su
         uint32_t i = *index;
         if (baseValue.isObject()) {
             JSObject* object = asObject(baseValue);
-            if (object->trySetIndexQuickly(vm, i, value, arrayProfile))
+            if (object->trySetIndexQuickly<JSObject::UpdateOutOfBound::Yes>(vm, i, value, arrayProfile))
                 return;
 
-            if (arrayProfile)
-                arrayProfile->setOutOfBounds();
             scope.release();
             object->methodTable()->putByIndex(object, globalObject, i, value, ecmaMode.isStrict());
             return;

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -1354,7 +1354,7 @@ LLINT_SLOW_PATH_DECL(slow_path_put_by_val)
         uint32_t i = *index;
         if (baseValue.isObject()) {
             JSObject* object = asObject(baseValue);
-            if (!object->trySetIndexQuickly(vm, i, value, &metadata.m_arrayProfile))
+            if (!object->trySetIndexQuickly<JSObject::UpdateOutOfBound::No>(vm, i, value, &metadata.m_arrayProfile))
                 object->methodTable()->putByIndex(object, globalObject, i, value, isStrictMode);
             LLINT_END();
         }

--- a/Source/JavaScriptCore/runtime/IndexingType.h
+++ b/Source/JavaScriptCore/runtime/IndexingType.h
@@ -153,6 +153,11 @@ static const IndexingType CopyOnWriteArrayWithContiguous  = IsArray | Contiguous
     case NonArrayWithSlowPutArrayStorage:               \
     case ARRAY_WITH_ARRAY_STORAGE_INDEXING_TYPES
 
+#define ALL_COPY_ON_WRITE_INDEXING_TYPES \
+    CopyOnWriteArrayWithInt32:           \
+    case CopyOnWriteArrayWithDouble:     \
+    case CopyOnWriteArrayWithContiguous
+
 inline bool hasIndexedProperties(IndexingType indexingType)
 {
     return (indexingType & IndexingShapeMask) != NoIndexingShape;

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -274,7 +274,7 @@ public:
     ALWAYS_INLINE bool putByIndexInline(JSGlobalObject* globalObject, unsigned propertyName, JSValue value, bool shouldThrow)
     {
         VM& vm = getVM(globalObject);
-        if (trySetIndexQuickly(vm, propertyName, value))
+        if (trySetIndexQuickly<JSObject::UpdateOutOfBound::No>(vm, propertyName, value))
             return true;
         return methodTable()->putByIndex(this, globalObject, propertyName, value, shouldThrow);
     }
@@ -479,66 +479,9 @@ public:
     // Return true to indicate success
     // Use the (optional) array profile to set the m_mayBeLargeTypedArray bit when relevant
     bool trySetIndexQuicklyForTypedArray(unsigned, JSValue, ArrayProfile*);
-    bool trySetIndexQuickly(VM& vm, unsigned i, JSValue v, ArrayProfile* arrayProfile = nullptr)
-    {
-        Butterfly* butterfly = this->butterfly();
-        switch (indexingMode()) {
-        case ALL_BLANK_INDEXING_TYPES:
-            return trySetIndexQuicklyForTypedArray(i, v, arrayProfile);
-        case ALL_UNDECIDED_INDEXING_TYPES:
-            return false;
-        case ALL_WRITABLE_INT32_INDEXING_TYPES: {
-            if (i >= butterfly->vectorLength())
-                return false;
-            if (!v.isInt32()) {
-                convertInt32ToDoubleOrContiguousWhilePerformingSetIndex(vm, i, v);
-                return true;
-            }
-            FALLTHROUGH;
-        }
-        case ALL_WRITABLE_CONTIGUOUS_INDEXING_TYPES: {
-            if (i >= butterfly->vectorLength())
-                return false;
-            butterfly->contiguous().at(this, i).setWithoutWriteBarrier(v);
-            if (i >= butterfly->publicLength())
-                butterfly->setPublicLength(i + 1);
-            vm.writeBarrier(this, v);
-            return true;
-        }
-        case ALL_WRITABLE_DOUBLE_INDEXING_TYPES: {
-            if (i >= butterfly->vectorLength())
-                return false;
-            if (!v.isNumber()) {
-                convertDoubleToContiguousWhilePerformingSetIndex(vm, i, v);
-                return true;
-            }
-            double value = v.asNumber();
-            if (value != value) {
-                convertDoubleToContiguousWhilePerformingSetIndex(vm, i, v);
-                return true;
-            }
-            butterfly->contiguousDouble().at(this, i) = value;
-            if (i >= butterfly->publicLength())
-                butterfly->setPublicLength(i + 1);
-            return true;
-        }
-        case NonArrayWithArrayStorage:
-        case ArrayWithArrayStorage:
-            if (i >= butterfly->vectorLength())
-                return false;
-            setIndexQuicklyForArrayStorageIndexingType(vm, i, v);
-            return true;
-        case NonArrayWithSlowPutArrayStorage:
-        case ArrayWithSlowPutArrayStorage:
-            if (i >= butterfly->arrayStorage()->vectorLength() || !butterfly->arrayStorage()->m_vector[i])
-                return false;
-            setIndexQuicklyForArrayStorageIndexingType(vm, i, v);
-            return true;
-        default:
-            RELEASE_ASSERT(isCopyOnWrite(indexingMode()));
-            return false;
-        }
-    }
+    enum class UpdateOutOfBound { Yes, No };
+    template<UpdateOutOfBound update>
+    bool trySetIndexQuickly(VM&, unsigned, JSValue, ArrayProfile* = nullptr);
 
     void setIndexQuickly(VM& vm, unsigned i, JSValue v)
     {

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -631,6 +631,78 @@ inline bool JSObject::trySetIndexQuicklyForTypedArray(unsigned i, JSValue v, Arr
     }
 }
 
+template<JSObject::UpdateOutOfBound update>
+inline bool JSObject::trySetIndexQuickly(VM& vm, unsigned i, JSValue v, ArrayProfile* arrayProfile)
+{
+    Butterfly* butterfly = this->butterfly();
+    switch (indexingMode()) {
+    case ALL_BLANK_INDEXING_TYPES:
+        if (trySetIndexQuicklyForTypedArray(i, v, arrayProfile))
+            return true;
+        break;
+    case ALL_UNDECIDED_INDEXING_TYPES:
+        break;
+    case ALL_WRITABLE_INT32_INDEXING_TYPES: {
+        if (i >= butterfly->vectorLength())
+            break;
+        if (!v.isInt32()) {
+            convertInt32ToDoubleOrContiguousWhilePerformingSetIndex(vm, i, v);
+            return true;
+        }
+        FALLTHROUGH;
+    }
+    case ALL_WRITABLE_CONTIGUOUS_INDEXING_TYPES: {
+        if (i >= butterfly->vectorLength())
+            break;
+        butterfly->contiguous().at(this, i).setWithoutWriteBarrier(v);
+        if (i >= butterfly->publicLength())
+            butterfly->setPublicLength(i + 1);
+        vm.writeBarrier(this, v);
+        return true;
+    }
+    case ALL_WRITABLE_DOUBLE_INDEXING_TYPES: {
+        if (i >= butterfly->vectorLength())
+            break;
+        if (!v.isNumber()) {
+            convertDoubleToContiguousWhilePerformingSetIndex(vm, i, v);
+            return true;
+        }
+        double value = v.asNumber();
+        if (value != value) {
+            convertDoubleToContiguousWhilePerformingSetIndex(vm, i, v);
+            return true;
+        }
+        butterfly->contiguousDouble().at(this, i) = value;
+        if (i >= butterfly->publicLength())
+            butterfly->setPublicLength(i + 1);
+        return true;
+    }
+    case NonArrayWithArrayStorage:
+    case ArrayWithArrayStorage:
+        if (i >= butterfly->vectorLength())
+            break;
+        setIndexQuicklyForArrayStorageIndexingType(vm, i, v);
+        return true;
+    case NonArrayWithSlowPutArrayStorage:
+    case ArrayWithSlowPutArrayStorage:
+        if (i >= butterfly->arrayStorage()->vectorLength() || !butterfly->arrayStorage()->m_vector[i])
+            break;
+        setIndexQuicklyForArrayStorageIndexingType(vm, i, v);
+        return true;
+    case ALL_COPY_ON_WRITE_INDEXING_TYPES:
+        return false;
+    default:
+        RELEASE_ASSERT(isCopyOnWrite(indexingMode()));
+        break;
+    }
+
+    if constexpr (update == UpdateOutOfBound::Yes) {
+        if (arrayProfile)
+            arrayProfile->setOutOfBounds();
+    }
+    return false;
+}
+
 inline void JSObject::validatePutOwnDataProperty(VM& vm, PropertyName propertyName, JSValue value)
 {
 #if ASSERT_ENABLED

--- a/Source/WTF/wtf/SetForScope.h
+++ b/Source/WTF/wtf/SetForScope.h
@@ -71,6 +71,12 @@ public:
         m_scopedVariable = WTFMove(m_valueToRestore);
     }
 
+    template<typename U>
+    void set(U&& newValue)
+    {
+        m_scopedVariable = std::forward<U>(newValue);
+    }
+
 private:
     T& m_scopedVariable;
     T m_valueToRestore;


### PR DESCRIPTION
#### a7ad6d1e83ebee371e35dd4b62f74286558ef08e
<pre>
[JSC] Support precise heap location analysis in CSE
<a href="https://bugs.webkit.org/show_bug.cgi?id=285123">https://bugs.webkit.org/show_bug.cgi?id=285123</a>
<a href="https://rdar.apple.com/141970676">rdar://141970676</a>

Reviewed by NOBODY (OOPS!).

This patch enhances Common Subexpression Elimination (CSE) by
enabling precise heap tracking for non-typed JavaScript arrays
with constant index access. Previously, any write to an array
clobbered the entire abstract heap. Now, writes are tracked at
the per-cell level, improving CSE accuracy and reducing redundant
computations.

Benefits:
1. More precise invalidations for constant-indexed array writes.
2. Reduced recomputation, improving performance and resource efficiency.

Additionally, this patch optimizes trySetIndexQuickly by introducing
template parameter support for out-of-bound updates. Furthermore,
Copy-On-Write (COW) arrays are no longer set with the OutOfBounds
mode initially, enabling further CSE optimizations.

                            before                    after

loop-unrolling-4       31.4472+-0.1009           31.3783+-0.0931
loop-unrolling-5       35.5258+-0.1003     ^     32.7271+-0.0828        ^ definitely 1.0255x faste

* JSTests/microbenchmarks/loop-unrolling-4.js:
(test):
* JSTests/microbenchmarks/loop-unrolling-5.js: Added.
(assert):
(test):
* Source/JavaScriptCore/dfg/DFGCSEPhase.cpp:
* Source/JavaScriptCore/dfg/DFGClobberSet.cpp:
(JSC::DFG::addPreciseWrites):
* Source/JavaScriptCore/dfg/DFGClobberSet.h:
(JSC::DFG::PreciseClobberSet::overlaps):
(JSC::DFG::PreciseClobberSet::add):
(JSC::DFG::PreciseClobberSetAdd::PreciseClobberSetAdd):
(JSC::DFG::PreciseClobberSetAdd::operator() const):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
(JSC::DFG::preciseClobberize):
(JSC::DFG::PreciseWriteMethodClobberize::PreciseWriteMethodClobberize):
(JSC::DFG::PreciseWriteMethodClobberize::operator() const):
* Source/JavaScriptCore/dfg/DFGCommon.h:
* Source/JavaScriptCore/dfg/DFGHeapLocation.h:
(JSC::DFG::HeapLocation::hasConstantOffset const):
(JSC::DFG::HeapLocation::constantOffset const):
* Source/JavaScriptCore/dfg/DFGPreciseLocalClobberize.h:
(JSC::DFG::PreciseLocalClobberizeAdaptor::preciseWrite):
(JSC::DFG::preciseLocalClobberize):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::putByVal):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
* Source/JavaScriptCore/runtime/IndexingType.h:
* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::JSObject::putByIndexInline):
(JSC::JSObject::trySetIndexQuickly): Deleted.
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::trySetIndexQuickly):
* Source/WTF/wtf/SetForScope.h:
(WTF::SetForScope::set):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7ad6d1e83ebee371e35dd4b62f74286558ef08e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89808 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35720 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65918 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23737 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76951 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46191 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3285 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31163 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34795 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77632 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74153 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91183 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83711 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12008 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8912 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74386 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73511 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17874 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16315 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3456 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11960 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17400 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106104 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11794 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25612 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15288 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13540 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->