### PR TITLE
Surface exceptions from URLPattern::ConstructorStringParser

### DIFF
--- a/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.cpp
@@ -199,7 +199,7 @@ void URLPatternConstructorStringParser::changeState(URLPatternConstructorStringP
     m_tokenIncrement = 0;
 }
 
-void URLPatternConstructorStringParser::updateState(ScriptExecutionContext& context)
+ExceptionOr<void> URLPatternConstructorStringParser::updateState(ScriptExecutionContext& context)
 {
     switch (m_state) {
     case URLPatternConstructorStringParserState::Init:
@@ -214,7 +214,7 @@ void URLPatternConstructorStringParser::updateState(ScriptExecutionContext& cont
         if (isNonSpecialPatternChararacter(m_tokenIndex, ':')) {
             auto maybeMatchesSpecialSchemeProtocol = computeProtocolMatchSpecialSchemeFlag(context);
             if (maybeMatchesSpecialSchemeProtocol.hasException())
-                break; // FIXME: Return exceptions.
+                return maybeMatchesSpecialSchemeProtocol.releaseException();
             auto nextState = URLPatternConstructorStringParserState::Pathname;
             auto skip = 1;
             if (isAuthoritySlashesNext()) {
@@ -298,9 +298,11 @@ void URLPatternConstructorStringParser::updateState(ScriptExecutionContext& cont
     default:
         break;
     }
+
+    return { };
 }
 
-void URLPatternConstructorStringParser::performParse(ScriptExecutionContext& context)
+ExceptionOr<void> URLPatternConstructorStringParser::performParse(ScriptExecutionContext& context)
 {
     while (m_tokenIndex < m_tokenList.size()) {
         m_tokenIncrement = 1;
@@ -344,11 +346,16 @@ void URLPatternConstructorStringParser::performParse(ScriptExecutionContext& con
             }
         }
 
-        updateState(context);
+        auto maybeException = updateState(context);
+        if (maybeException.hasException())
+            return maybeException.releaseException();
+
         m_tokenIndex += m_tokenIncrement;
     }
     if (!m_result.hostname.isNull() && m_result.port.isNull())
         m_result.port = emptyString();
+
+    return { };
 }
 
 // https://urlpattern.spec.whatwg.org/#parse-a-constructor-string
@@ -359,7 +366,9 @@ ExceptionOr<URLPatternInit> URLPatternConstructorStringParser::parse(ScriptExecu
         return maybeTokenList.releaseException();
     m_tokenList = maybeTokenList.releaseReturnValue();
 
-    performParse(context);
+    auto maybeParseException = performParse(context);
+    if (maybeParseException.hasException())
+        return maybeParseException.releaseException();
 
     return URLPatternInit { m_result };
 }

--- a/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.h
@@ -48,7 +48,7 @@ public:
     ExceptionOr<URLPatternInit> parse(ScriptExecutionContext&);
 
 private:
-    void performParse(ScriptExecutionContext&);
+    ExceptionOr<void> performParse(ScriptExecutionContext&);
     void rewind();
     const URLPatternUtilities::Token& getSafeToken(size_t index) const;
     bool isNonSpecialPatternChararacter(size_t index, char value) const;
@@ -56,7 +56,7 @@ private:
     bool isAuthoritySlashesNext() const;
     String makeComponentString() const;
     void changeState(URLPatternConstructorStringParserState, size_t skip);
-    void updateState(ScriptExecutionContext&);
+    ExceptionOr<void> updateState(ScriptExecutionContext&);
     ExceptionOr<void> computeProtocolMatchSpecialSchemeFlag(ScriptExecutionContext&);
 
     StringView m_input;


### PR DESCRIPTION
#### ed925cc9f744efcc32d6f4acd42739407847e2e6
<pre>
Surface exceptions from URLPattern::ConstructorStringParser
<a href="https://bugs.webkit.org/show_bug.cgi?id=285122">https://bugs.webkit.org/show_bug.cgi?id=285122</a>
<a href="https://rdar.apple.com/141970678">rdar://141970678</a>

Reviewed by NOBODY (OOPS!).

URLPattern::ConstructorStringParser needs to return exceptions from compiling a protocol component when invoking function computeProtocolMatchSpecialSchemeFlag. See spec: <a href="https://urlpattern.spec.whatwg.org/#compute-protocol-matches-a-special-scheme-flag">https://urlpattern.spec.whatwg.org/#compute-protocol-matches-a-special-scheme-flag</a>

* Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.cpp:
(WebCore::URLPatternConstructorStringParser::updateState):
(WebCore::URLPatternConstructorStringParser::performParse):
(WebCore::URLPatternConstructorStringParser::parse):
* Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed925cc9f744efcc32d6f4acd42739407847e2e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87439 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33368 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84412 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64146 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21897 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1428 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74892 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44424 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1330 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29073 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32409 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72623 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88795 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6870 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72542 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9839 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70706 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71760 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15897 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14904 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/968 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9566 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15087 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9440 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12906 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->