### PR TITLE
[Win] The view size shouldn't be affected by the custom device scale factor

### DIFF
--- a/Source/WebCore/PlatformWin.cmake
+++ b/Source/WebCore/PlatformWin.cmake
@@ -68,6 +68,7 @@ list(APPEND WebCore_SOURCES
 
     platform/graphics/win/DIBPixelData.cpp
     platform/graphics/win/DisplayRefreshMonitorWin.cpp
+    platform/graphics/win/FloatPointWin.cpp
     platform/graphics/win/FloatRectWin.cpp
     platform/graphics/win/FullScreenController.cpp
     platform/graphics/win/FullScreenWindow.cpp

--- a/Source/WebCore/platform/graphics/FloatPoint.h
+++ b/Source/WebCore/platform/graphics/FloatPoint.h
@@ -182,6 +182,10 @@ public:
     WEBCORE_EXPORT operator NSPoint() const;
 #endif
 
+#if PLATFORM(WIN)
+    WEBCORE_EXPORT FloatPoint(const POINT&);
+#endif
+
     WEBCORE_EXPORT FloatPoint matrixTransform(const TransformationMatrix&) const;
     WEBCORE_EXPORT FloatPoint matrixTransform(const AffineTransform&) const;
 

--- a/Source/WebCore/platform/graphics/IntRect.h
+++ b/Source/WebCore/platform/graphics/IntRect.h
@@ -228,7 +228,7 @@ public:
 
 #if USE(SKIA)
     IntRect(const SkIRect&);
-    operator SkIRect() const;
+    WEBCORE_EXPORT operator SkIRect() const;
 #endif
 
 private:

--- a/Source/WebCore/platform/graphics/win/FloatPointWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FloatPointWin.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Sony Interactive Entertainment Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FloatPoint.h"
+
+#include <windows.h>
+
+namespace WebCore {
+
+FloatPoint::FloatPoint(const POINT& p)
+    : m_x(p.x)
+    , m_y(p.y)
+{
+}
+
+}

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -145,6 +145,9 @@ struct WebPageCreationParameters {
     bool canRunModal { false };
 
     float deviceScaleFactor { 0 };
+#if USE(GRAPHICS_LAYER_WC) || USE(GRAPHICS_LAYER_TEXTURE_MAPPER)
+    float intrinsicDeviceScaleFactor { 0 };
+#endif
     float viewScaleFactor { 0 };
 
     double textZoomFactor { 1 };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -68,6 +68,9 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
     bool canRunModal;
 
     float deviceScaleFactor;
+#if USE(GRAPHICS_LAYER_WC) || USE(GRAPHICS_LAYER_TEXTURE_MAPPER)
+    float intrinsicDeviceScaleFactor;
+#endif
     float viewScaleFactor;
 
     double textZoomFactor;

--- a/Source/WebKit/Shared/win/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/win/WebEventFactory.cpp
@@ -395,9 +395,9 @@ WebMouseEvent WebEventFactory::createWebMouseEvent(HWND hWnd, UINT message, WPAR
     POINT positionPoint = point(lParam);
     POINT globalPositionPoint = positionPoint;
     ::ClientToScreen(hWnd, &globalPositionPoint);
-    IntPoint globalPosition(globalPositionPoint);
+    FloatPoint globalPosition(globalPositionPoint);
     globalPosition.scale(1 / deviceScaleFactor);
-    IntPoint position = positionPoint;
+    FloatPoint position = positionPoint;
     position.scale(1 / deviceScaleFactor);
 
     double timestamp = ::GetTickCount() * 0.001; // ::GetTickCount returns milliseconds (Chrome uses GetMessageTime() / 1000.0)
@@ -406,16 +406,16 @@ WebMouseEvent WebEventFactory::createWebMouseEvent(HWND hWnd, UINT message, WPAR
     auto modifiers = modifiersForEvent(wParam);
     auto buttons = buttonsForEvent(wParam);
 
-    return WebMouseEvent( { type, modifiers, WallTime::now() }, button, buttons, position, globalPosition, 0, 0, 0, clickCount, didActivateWebView);
+    return WebMouseEvent( { type, modifiers, WallTime::now() }, button, buttons, flooredIntPoint(position), flooredIntPoint(globalPosition), 0, 0, 0, clickCount, didActivateWebView);
 }
 
 WebWheelEvent WebEventFactory::createWebWheelEvent(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam, float deviceScaleFactor)
 {
     POINT positionPoint = point(lParam);
-    IntPoint globalPosition = positionPoint;
+    FloatPoint globalPosition = positionPoint;
     ::ScreenToClient(hWnd, &positionPoint);
     globalPosition.scale(1 / deviceScaleFactor);
-    IntPoint position = positionPoint;
+    FloatPoint position = positionPoint;
     position.scale(1 / deviceScaleFactor);
 
     WebWheelEvent::Granularity granularity = WebWheelEvent::ScrollByPixelWheelEvent;
@@ -453,7 +453,7 @@ WebWheelEvent WebEventFactory::createWebWheelEvent(HWND hWnd, UINT message, WPAR
         }
     }
 
-    return WebWheelEvent( { WebEventType::Wheel, modifiers, WallTime::now() }, position, globalPosition, FloatSize(deltaX, deltaY), FloatSize(wheelTicksX, wheelTicksY), granularity);
+    return WebWheelEvent( { WebEventType::Wheel, modifiers, WallTime::now() }, flooredIntPoint(position), flooredIntPoint(globalPosition), FloatSize(deltaX, deltaY), FloatSize(wheelTicksX, wheelTicksY), granularity);
 }
 
 static WindowsKeyNames& windowsKeyNames()

--- a/Source/WebKit/UIProcess/BackingStore.h
+++ b/Source/WebKit/UIProcess/BackingStore.h
@@ -52,8 +52,6 @@ struct UpdateInfo;
 #if USE(CAIRO) || PLATFORM(GTK)
 typedef struct _cairo cairo_t;
 using PlatformPaintContextPtr = cairo_t*;
-#elif PLATFORM(WIN)
-using PlatformPaintContextPtr = HDC;
 #elif USE(SKIA)
 using PlatformPaintContextPtr = SkCanvas*;
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11347,6 +11347,9 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.canRunBeforeUnloadConfirmPanel = m_uiClient->canRunBeforeUnloadConfirmPanel();
     parameters.canRunModal = m_canRunModal;
     parameters.deviceScaleFactor = deviceScaleFactor();
+#if USE(GRAPHICS_LAYER_WC) || USE(GRAPHICS_LAYER_TEXTURE_MAPPER)
+    parameters.intrinsicDeviceScaleFactor = intrinsicDeviceScaleFactor();
+#endif
     parameters.viewScaleFactor = m_viewScaleFactor;
     parameters.textZoomFactor = m_textZoomFactor;
     parameters.pageZoomFactor = m_pageZoomFactor;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1375,6 +1375,9 @@ public:
 #endif
     
     float deviceScaleFactor() const;
+#if USE(GRAPHICS_LAYER_WC) || USE(GRAPHICS_LAYER_TEXTURE_MAPPER)
+    float intrinsicDeviceScaleFactor() const { return m_intrinsicDeviceScaleFactor; }
+#endif
     void setIntrinsicDeviceScaleFactor(float);
     std::optional<float> customDeviceScaleFactor() const { return m_customDeviceScaleFactor; }
     void setCustomDeviceScaleFactor(float, CompletionHandler<void()>&&);

--- a/Source/WebKit/UIProcess/skia/BackingStoreSkia.cpp
+++ b/Source/WebKit/UIProcess/skia/BackingStoreSkia.cpp
@@ -33,10 +33,6 @@
 #include <skia/core/SkBitmap.h>
 #include <skia/core/SkCanvas.h>
 
-#if PLATFORM(WIN)
-#include <WebCore/BitmapInfo.h>
-#endif
-
 namespace WebKit {
 
 BackingStore::BackingStore(const WebCore::IntSize& size, float deviceScaleFactor)
@@ -54,17 +50,14 @@ BackingStore::~BackingStore() = default;
 
 void BackingStore::paint(PlatformPaintContextPtr cr, const WebCore::IntRect& rect)
 {
-#if PLATFORM(WIN)
-    SkPixmap pixmap;
-    if (m_surface->peekPixels(&pixmap)) {
-        WebCore::IntRect scaledRect = rect;
-        scaledRect.scale(m_deviceScaleFactor);
-        auto bitmapInfo = WebCore::BitmapInfo::createBottomUp({ pixmap.width(), pixmap.height() });
-        SetDIBitsToDevice(cr, 0, 0, pixmap.width(), pixmap.height(), 0, 0, 0, pixmap.height(), pixmap.addr(), &bitmapInfo, DIB_RGB_COLORS);
-    }
-#else
-    m_surface->draw(cr, rect.x(), rect.y());
-#endif
+    cr->save();
+    cr->scale(1 / m_deviceScaleFactor, 1 / m_deviceScaleFactor);
+    WebCore::IntRect scaledRect { rect };
+    scaledRect.scale(m_deviceScaleFactor);
+    cr->clipIRect(scaledRect);
+    SkSamplingOptions option { SkFilterMode::kLinear };
+    m_surface->draw(cr, 0, 0, option, nullptr);
+    cr->restore();
 }
 
 void BackingStore::incorporateUpdate(UpdateInfo&& updateInfo)

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
@@ -72,7 +72,7 @@ void DrawingAreaProxyWC::sizeDidChange()
     discardBackingStore();
     m_currentBackingStoreStateID++;
     if (m_webPageProxy)
-        send(Messages::DrawingArea::UpdateGeometryWC(m_currentBackingStoreStateID, m_size, m_webPageProxy->deviceScaleFactor()));
+        send(Messages::DrawingArea::UpdateGeometryWC(m_currentBackingStoreStateID, m_size, m_webPageProxy->deviceScaleFactor(), m_webPageProxy->intrinsicDeviceScaleFactor()));
 }
 
 void DrawingAreaProxyWC::update(uint64_t backingStoreStateID, UpdateInfo&& updateInfo)

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
@@ -367,9 +367,9 @@ void WebPopupMenuProxyWin::hidePopupMenu()
 
 void WebPopupMenuProxyWin::calculatePositionAndSize(const IntRect& rect)
 {
-    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
+    float intrinsicDeviceScaleFactor = m_webView->page()->intrinsicDeviceScaleFactor();
     IntRect rectInScreenCoords(rect);
-    rectInScreenCoords.scale(m_scaleFactor * deviceScaleFactor);
+    rectInScreenCoords.scale(m_scaleFactor * intrinsicDeviceScaleFactor);
 
     POINT location(rectInScreenCoords.location());
     if (!::ClientToScreen(m_webView->window(), &location))
@@ -378,9 +378,9 @@ void WebPopupMenuProxyWin::calculatePositionAndSize(const IntRect& rect)
 
     int itemCount = m_items.size();
     m_itemHeight = m_data.m_itemHeight;
-    int itemHeightInDevicePixel = m_itemHeight * deviceScaleFactor;
+    int itemHeightInDevicePixel = m_itemHeight * intrinsicDeviceScaleFactor;
     int naturalHeight = itemHeightInDevicePixel * itemCount;
-    int maxPopupHeightInDevicePixel = maxPopupHeight * deviceScaleFactor * m_scaleFactor;
+    int maxPopupHeightInDevicePixel = maxPopupHeight * intrinsicDeviceScaleFactor * m_scaleFactor;
     int popupHeight = std::min(maxPopupHeightInDevicePixel, naturalHeight);
     int popupWidth = m_data.m_popupWidth;
     IntRect popupRect(0, rectInScreenCoords.maxY(), popupWidth, popupHeight);
@@ -421,9 +421,9 @@ void WebPopupMenuProxyWin::calculatePositionAndSize(const IntRect& rect)
     // Check that we need room for a scrollbar
     if (popupRect.height() < naturalHeight)
         popupWidth += ScrollbarTheme::theme().scrollbarThickness(ScrollbarWidth::Thin);
-    popupWidth *= deviceScaleFactor;
-    int clientInsetLeftInDevicePixel = m_data.m_clientInsetLeft * deviceScaleFactor;
-    int clientInsetRightInDevicePixel = m_data.m_clientInsetRight * deviceScaleFactor;
+    popupWidth *= intrinsicDeviceScaleFactor;
+    int clientInsetLeftInDevicePixel = m_data.m_clientInsetLeft * intrinsicDeviceScaleFactor;
+    int clientInsetRightInDevicePixel = m_data.m_clientInsetRight * intrinsicDeviceScaleFactor;
     // The popup should be at least as wide as the control on the page
     popupWidth = std::max(rectInScreenCoords.width() - clientInsetLeftInDevicePixel - clientInsetRightInDevicePixel, popupWidth);
     popupRect.setWidth(popupWidth);
@@ -456,9 +456,9 @@ void WebPopupMenuProxyWin::invalidateItem(int index)
     if (!m_popup)
         return;
 
-    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
+    float intrinsicDeviceScaleFactor = m_webView->page()->intrinsicDeviceScaleFactor();
     IntRect damageRect(clientRect());
-    float itemHeightInDevicePixel = m_itemHeight * deviceScaleFactor;
+    float itemHeightInDevicePixel = m_itemHeight * intrinsicDeviceScaleFactor;
     damageRect.setY(itemHeightInDevicePixel * (index - m_scrollOffset));
     damageRect.setHeight(ceil(itemHeightInDevicePixel));
 
@@ -486,8 +486,8 @@ IntSize WebPopupMenuProxyWin::visibleSize() const
 
 WebCore::IntSize WebPopupMenuProxyWin::contentsSize() const
 {
-    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
-    FloatSize scaledSize(m_windowRect.width() / deviceScaleFactor, m_scrollbar ? m_scrollbar->totalSize() : m_windowRect.height() / deviceScaleFactor);
+    float intrinsicDeviceScaleFactor = m_webView->page()->intrinsicDeviceScaleFactor();
+    FloatSize scaledSize(m_windowRect.width() / intrinsicDeviceScaleFactor, m_scrollbar ? m_scrollbar->totalSize() : m_windowRect.height() / intrinsicDeviceScaleFactor);
     return expandedIntSize(scaledSize);
 }
 
@@ -524,17 +524,17 @@ void WebPopupMenuProxyWin::scrollTo(int offset)
 #endif
 
     IntRect listRect = clientRect();
-    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
+    float intrinsicDeviceScaleFactor = m_webView->page()->intrinsicDeviceScaleFactor();
     if (m_scrollbar) {
-        listRect.setWidth(listRect.width() - m_scrollbar->size().width() * deviceScaleFactor);
+        listRect.setWidth(listRect.width() - m_scrollbar->size().width() * intrinsicDeviceScaleFactor);
         if (m_data.m_isRTL)
-            listRect.setX(m_scrollbar->size().width() * deviceScaleFactor);
+            listRect.setX(m_scrollbar->size().width() * intrinsicDeviceScaleFactor);
     }
     RECT r = listRect;
-    ::ScrollWindowEx(m_popup, 0, ceil(scrolledLines * m_itemHeight * deviceScaleFactor), &r, 0, 0, 0, flags);
+    ::ScrollWindowEx(m_popup, 0, ceil(scrolledLines * m_itemHeight * intrinsicDeviceScaleFactor), &r, 0, 0, 0, flags);
     if (m_scrollbar) {
         IntRect scrollRect = m_scrollbar->frameRect();
-        scrollRect.scale(deviceScaleFactor);
+        scrollRect.scale(intrinsicDeviceScaleFactor);
         r = scrollRect;
         ::InvalidateRect(m_popup, &r, TRUE);
     }
@@ -545,7 +545,7 @@ void WebPopupMenuProxyWin::invalidateScrollbarRect(Scrollbar& scrollbar, const I
 {
     IntRect scrollRect = rect;
     scrollRect.move(scrollbar.x(), scrollbar.y());
-    scrollRect.scale(m_webView->page()->deviceScaleFactor());
+    scrollRect.scale(m_webView->page()->intrinsicDeviceScaleFactor());
     RECT r = scrollRect;
     ::InvalidateRect(m_popup, &r, false);
 }
@@ -565,8 +565,8 @@ LRESULT WebPopupMenuProxyWin::onSize(HWND hWnd, UINT message, WPARAM, LPARAM lPa
         return 0;
 
     IntSize size(LOWORD(lParam), HIWORD(lParam));
-    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
-    IntSize scaledSize(ceil(size.width() / deviceScaleFactor), ceil(size.height() / deviceScaleFactor));
+    float intrinsicDeviceScaleFactor = m_webView->page()->intrinsicDeviceScaleFactor();
+    IntSize scaledSize(ceil(size.width() / intrinsicDeviceScaleFactor), ceil(size.height() / intrinsicDeviceScaleFactor));
     int scrollbarX = m_data.m_isRTL ? 0 : scaledSize.width() - m_scrollbar->width();
     m_scrollbar->setFrameRect(IntRect(scrollbarX, 0, m_scrollbar->width(), scaledSize.height()));
 
@@ -672,9 +672,9 @@ LRESULT WebPopupMenuProxyWin::onMouseMove(HWND hWnd, UINT message, WPARAM wParam
 {
     handled = true;
 
-    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
+    float intrinsicDeviceScaleFactor = m_webView->page()->intrinsicDeviceScaleFactor();
     IntPoint mousePoint(MAKEPOINTS(lParam));
-    mousePoint.scale(1 / deviceScaleFactor);
+    mousePoint.scale(1 / intrinsicDeviceScaleFactor);
     if (m_scrollbar) {
         IntPoint scrollbarMousePoint(mousePoint);
         IntRect scrollBarRect = m_scrollbar->frameRect();
@@ -693,7 +693,7 @@ LRESULT WebPopupMenuProxyWin::onMouseMove(HWND hWnd, UINT message, WPARAM wParam
     RECT bounds;
     ::GetClientRect(m_popup, &bounds);
     FloatRect scaledBounds(bounds);
-    scaledBounds.scale(1 / deviceScaleFactor);
+    scaledBounds.scale(1 / intrinsicDeviceScaleFactor);
     bounds = enclosingIntRect(scaledBounds);
     if (!::PtInRect(&bounds, mousePoint) && !(wParam & MK_LBUTTON)) {
         // When the mouse is not inside the popup menu and the left button isn't down, just
@@ -718,9 +718,9 @@ LRESULT WebPopupMenuProxyWin::onLButtonDown(HWND hWnd, UINT message, WPARAM wPar
 {
     handled = true;
 
-    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
+    float intrinsicDeviceScaleFactor = m_webView->page()->intrinsicDeviceScaleFactor();
     IntPoint mousePoint(MAKEPOINTS(lParam));
-    mousePoint.scale((1/ deviceScaleFactor));
+    mousePoint.scale((1/ intrinsicDeviceScaleFactor));
     if (m_scrollbar) {
         IntRect scrollBarRect = m_scrollbar->frameRect();
         if (scrollBarRect.contains(mousePoint)) {
@@ -738,7 +738,7 @@ LRESULT WebPopupMenuProxyWin::onLButtonDown(HWND hWnd, UINT message, WPARAM wPar
     RECT bounds;
     ::GetClientRect(m_popup, &bounds);
     FloatRect scaledBounds(bounds);
-    scaledBounds.scale(1 / deviceScaleFactor);
+    scaledBounds.scale(1 / intrinsicDeviceScaleFactor);
     bounds = enclosingIntRect(scaledBounds);
     if (::PtInRect(&bounds, mousePoint)) {
         setFocusedIndex(listIndexAtPoint(mousePoint), true);
@@ -754,9 +754,9 @@ LRESULT WebPopupMenuProxyWin::onLButtonUp(HWND hWnd, UINT message, WPARAM wParam
 {
     handled = true;
 
-    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
+    float intrinsicDeviceScaleFactor = m_webView->page()->intrinsicDeviceScaleFactor();
     IntPoint mousePoint(MAKEPOINTS(lParam));
-    mousePoint.scale(1 / deviceScaleFactor);
+    mousePoint.scale(1 / intrinsicDeviceScaleFactor);
     if (m_scrollbar) {
         IntRect scrollBarRect = m_scrollbar->frameRect();
         if (scrollbarCapturingMouse() || scrollBarRect.contains(mousePoint)) {
@@ -766,7 +766,7 @@ LRESULT WebPopupMenuProxyWin::onLButtonUp(HWND hWnd, UINT message, WPARAM wParam
             PlatformMouseEvent event(hWnd, message, wParam, makeScaledPoint(mousePoint, m_scaleFactor));
             m_scrollbar->mouseUp(event);
             // FIXME: This is a hack to work around Scrollbar not invalidating correctly when it doesn't have a parent widget
-            scrollBarRect.scale(deviceScaleFactor);
+            scrollBarRect.scale(intrinsicDeviceScaleFactor);
             RECT r = scrollBarRect;
             ::InvalidateRect(m_popup, &r, TRUE);
             return 0;
@@ -776,7 +776,7 @@ LRESULT WebPopupMenuProxyWin::onLButtonUp(HWND hWnd, UINT message, WPARAM wParam
     RECT bounds;
     ::GetClientRect(m_popup, &bounds);
     FloatRect scaledBounds(bounds);
-    scaledBounds.scale(1 / deviceScaleFactor);
+    scaledBounds.scale(1 / intrinsicDeviceScaleFactor);
     bounds = enclosingIntRect(scaledBounds);
     if (::PtInRect(&bounds, mousePoint)) {
         hide();
@@ -914,31 +914,38 @@ void WebPopupMenuProxyWin::paint(const IntRect& damageRect, HDC hdc)
         return;
     WebCore::GraphicsContextSkia context(*canvas, WebCore::RenderingMode::Unaccelerated, WebCore::RenderingPurpose::ShareableLocalSnapshot);
 #endif
+    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
+    float intrinsicDeviceScaleFactor = m_webView->page()->intrinsicDeviceScaleFactor();
+
+    context.save();
+    context.applyDeviceScaleFactor(intrinsicDeviceScaleFactor / deviceScaleFactor);
 
     int moveX = 0;
     int selectedBackingStoreWidth = m_data.m_selectedBackingStore->size().width();
     if (m_data.m_isRTL)
-        moveX = selectedBackingStoreWidth - clientRect().width();
+        moveX = selectedBackingStoreWidth - clientRect().width() * deviceScaleFactor / intrinsicDeviceScaleFactor;
 
-    float deviceScaleFactor = m_webView->page()->deviceScaleFactor();
-    float itemHeightInDevicePixel = m_itemHeight * deviceScaleFactor;
+    float itemHeightInBackingStore = m_itemHeight * deviceScaleFactor;
 
-    IntRect translatedDamageRect = damageRect;
-    translatedDamageRect.move(IntSize(moveX, m_scrollOffset * itemHeightInDevicePixel));
-    m_data.m_notSelectedBackingStore->paint(context, damageRect.location(), translatedDamageRect);
+    IntRect damageRectInBackingStore = damageRect;
+    damageRectInBackingStore.scale(deviceScaleFactor / intrinsicDeviceScaleFactor);
+    IntPoint damagePositionInBackingStore { damageRectInBackingStore.location() };
+    damageRectInBackingStore.move(IntSize(moveX, m_scrollOffset * itemHeightInBackingStore));
+    m_data.m_notSelectedBackingStore->paint(context, damagePositionInBackingStore, damageRectInBackingStore);
 
-    IntRect selectedIndexRectInBackingStore(moveX, focusedIndex() * itemHeightInDevicePixel, selectedBackingStoreWidth - moveX, itemHeightInDevicePixel);
+    IntRect selectedIndexRectInBackingStore(moveX, focusedIndex() * itemHeightInBackingStore, selectedBackingStoreWidth - moveX, itemHeightInBackingStore);
     IntPoint selectedIndexDstPoint = selectedIndexRectInBackingStore.location();
-    selectedIndexDstPoint.move(-moveX, -m_scrollOffset * itemHeightInDevicePixel);
+    selectedIndexDstPoint.move(-moveX, -m_scrollOffset * itemHeightInBackingStore);
 
     m_data.m_selectedBackingStore->paint(context, selectedIndexDstPoint, selectedIndexRectInBackingStore);
+    context.restore();
 
     if (m_scrollbar) {
         context.save();
-        context.applyDeviceScaleFactor(deviceScaleFactor);
+        context.applyDeviceScaleFactor(intrinsicDeviceScaleFactor);
 
         IntRect scaledDamageRect = damageRect;
-        scaledDamageRect.scale(1 / deviceScaleFactor);
+        scaledDamageRect.scale(1 / intrinsicDeviceScaleFactor);
         m_scrollbar->paint(context, scaledDamageRect);
 
         context.restore();
@@ -985,7 +992,7 @@ IGNORE_CLANG_WARNINGS_END
 
 int WebPopupMenuProxyWin::visibleItems() const
 {
-    return clientRect().height() / (m_itemHeight * m_webView->page()->deviceScaleFactor());
+    return clientRect().height() / (m_itemHeight * m_webView->page()->intrinsicDeviceScaleFactor());
 }
 
 int WebPopupMenuProxyWin::listIndexAtPoint(const IntPoint& point) const

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
@@ -64,7 +64,7 @@ bool LayerTreeHost::prepareForRendering()
 
 void LayerTreeHost::compositeLayersToContext()
 {
-    IntSize windowSize = flooredIntSize(m_rootLayer->size() * deviceScaleFactor());
+    IntSize windowSize = flooredIntSize(m_rootLayer->size() * m_webPage.intrinsicDeviceScaleFactor());
     glViewport(0, 0, windowSize.width(), windowSize.height());
 
     m_textureMapper->beginPainting();
@@ -292,13 +292,14 @@ float LayerTreeHost::deviceScaleFactor() const
 
 void LayerTreeHost::applyDeviceScaleFactor()
 {
+    float intrinsicDeviceScaleFactor = m_webPage.intrinsicDeviceScaleFactor();
     const FloatSize& size = m_rootLayer->size();
 
     TransformationMatrix m;
-    m.scale(deviceScaleFactor());
+    m.scale(intrinsicDeviceScaleFactor);
     // Center view
-    double tx = (size.width() - size.width() / deviceScaleFactor()) / 2.0;
-    double ty = (size.height() - size.height() / deviceScaleFactor()) / 2.0;
+    double tx = (size.width() - size.width() / intrinsicDeviceScaleFactor) / 2.0;
+    double ty = (size.height() - size.height() / intrinsicDeviceScaleFactor) / 2.0;
     m.translate(tx, ty);
     m_rootLayer->setTransform(m);
 }

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -156,8 +156,11 @@ public:
     virtual void updateGeometry(const WebCore::IntSize& viewSize, bool flushSynchronously, const WTF::MachSendRight& fencePort, CompletionHandler<void()>&&) = 0;
 #endif
 
+#if USE(GRAPHICS_LAYER_WC) || USE(GRAPHICS_LAYER_TEXTURE_MAPPER)
+    virtual void setIntrinsicDeviceScaleFactor(float) { }
+#endif
 #if USE(GRAPHICS_LAYER_WC)
-    virtual void updateGeometryWC(uint64_t, WebCore::IntSize, float deviceScaleFactor) { };
+    virtual void updateGeometryWC(uint64_t, WebCore::IntSize, float deviceScaleFactor, float intrinsicDeviceScaleFactor) { };
 #endif
 
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
@@ -48,7 +48,7 @@ messages -> DrawingArea {
 #endif
 
 #if USE(GRAPHICS_LAYER_WC)
-    UpdateGeometryWC(uint64_t backingStoreStateID, WebCore::IntSize viewSize, float deviceScaleFactor)
+    UpdateGeometryWC(uint64_t backingStoreStateID, WebCore::IntSize viewSize, float deviceScaleFactor, float intrinsicDeviceScaleFactor)
 #endif
 
 #if PLATFORM(COCOA) || PLATFORM(GTK)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -892,6 +892,10 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     // to ensure it's created with the right size.
     m_page->setDeviceScaleFactor(parameters.deviceScaleFactor);
 
+#if USE(GRAPHICS_LAYER_WC) || USE(GRAPHICS_LAYER_TEXTURE_MAPPER)
+    setIntrinsicDeviceScaleFactor(parameters.intrinsicDeviceScaleFactor);
+#endif
+
 #if USE(SKIA)
     FontRenderOptions::singleton().setUseSubpixelPositioning(parameters.deviceScaleFactor >= 2.);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1344,6 +1344,11 @@ public:
     void setDeviceScaleFactor(float);
     float deviceScaleFactor() const;
 
+#if USE(GRAPHICS_LAYER_TEXTURE_MAPPER) || USE(GRAPHICS_LAYER_WC)
+    void setIntrinsicDeviceScaleFactor(float f) { m_intrinsicDeviceScaleFactor = f; }
+    float intrinsicDeviceScaleFactor() const { return m_intrinsicDeviceScaleFactor; }
+#endif
+
     void updateRenderingWithForcedRepaintWithoutCallback();
 
     void unmarkAllMisspellings();
@@ -2587,6 +2592,7 @@ private:
 #endif
 
 #if USE(GRAPHICS_LAYER_TEXTURE_MAPPER) || USE(GRAPHICS_LAYER_WC)
+    float m_intrinsicDeviceScaleFactor { 1 };
     uint64_t m_nativeWindowHandle { 0 };
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
@@ -140,10 +140,11 @@ void DrawingAreaWC::setLayerTreeStateIsFrozen(bool isFrozen)
     }
 }
 
-void DrawingAreaWC::updateGeometryWC(uint64_t backingStoreStateID, IntSize viewSize, float deviceScaleFactor)
+void DrawingAreaWC::updateGeometryWC(uint64_t backingStoreStateID, IntSize viewSize, float deviceScaleFactor, float intrinsicDeviceScaleFactor)
 {
     m_backingStoreStateID = backingStoreStateID;
     m_webPage->setDeviceScaleFactor(deviceScaleFactor);
+    m_webPage->setIntrinsicDeviceScaleFactor(intrinsicDeviceScaleFactor);
     m_webPage->setSize(viewSize);
 }
 
@@ -272,7 +273,7 @@ void DrawingAreaWC::sendUpdateAC()
         else
             size = frame->size();
         FloatSize viewport { size };
-        viewport.scale(m_webPage->deviceScaleFactor());
+        viewport.scale(m_webPage->intrinsicDeviceScaleFactor());
         m_updateInfo.viewport = WebCore::expandedIntSize(viewport);
         updateRootLayerDeviceScaleFactor(rootLayer.layer);
         rootLayer.layer->flushCompositingStateForThisLayerOnly();
@@ -307,9 +308,8 @@ void DrawingAreaWC::sendUpdateAC()
 
 void DrawingAreaWC::updateRootLayerDeviceScaleFactor(WebCore::GraphicsLayer& layer)
 {
-    float deviceScaleFactor = m_webPage->deviceScaleFactor();
     TransformationMatrix m;
-    m.scale(deviceScaleFactor);
+    m.scale(m_webPage->intrinsicDeviceScaleFactor());
     layer.setTransform(m);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
@@ -63,7 +63,7 @@ private:
 #if USE(GRAPHICS_LAYER_TEXTURE_MAPPER)    
     void updateGeometry(const WebCore::IntSize&, CompletionHandler<void()>&&) override { }
 #endif
-    void updateGeometryWC(uint64_t, WebCore::IntSize, float deviceScaleFactor) override;
+    void updateGeometryWC(uint64_t, WebCore::IntSize, float deviceScaleFactor, float intrinsicDeviceScaleFactor) override;
     void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
     void addRootFrame(WebCore::FrameIdentifier) override;
     void attachViewOverlayGraphicsLayer(WebCore::FrameIdentifier, WebCore::GraphicsLayer*) override;

--- a/Tools/MiniBrowser/win/WebKitBrowserWindow.cpp
+++ b/Tools/MiniBrowser/win/WebKitBrowserWindow.cpp
@@ -224,18 +224,11 @@ void WebKitBrowserWindow::updateProxySettings()
 }
 
 // FIXME: The current design of WebKit produces too many noises on fractional device scale factor.
-// This rounds device scale factor and tweaks zoom factor for tantative workarond.
+// This rounds device scale factor for tantative workarond.
 void WebKitBrowserWindow::adjustScaleFactors()
 {
     WKPageRef page = WKViewGetPage(m_view.get());
-
-    float customZoomRatio = WKPageGetPageZoomFactor(page) / m_defaultResetPageZoomFactor;
-    float deviceScaleFactor = WebCore::deviceScaleFactorForWindow(hwnd());
-    int roundedDeviceScaleFactor = std::round(deviceScaleFactor);
-    m_defaultResetPageZoomFactor = deviceScaleFactor / roundedDeviceScaleFactor;
-
-    WKPageSetCustomBackingScaleFactor(page, roundedDeviceScaleFactor);
-    WKPageSetPageZoomFactor(page, m_defaultResetPageZoomFactor * customZoomRatio);
+    WKPageSetCustomBackingScaleFactor(page, std::round(WebCore::deviceScaleFactorForWindow(hwnd())));
 }
 
 HRESULT WebKitBrowserWindow::init()
@@ -412,7 +405,7 @@ void WebKitBrowserWindow::updateStatistics(HWND)
 void WebKitBrowserWindow::resetZoom()
 {
     auto page = WKViewGetPage(m_view.get());
-    WKPageSetPageZoomFactor(page, m_defaultResetPageZoomFactor);
+    WKPageSetPageZoomFactor(page, 1);
 }
 
 void WebKitBrowserWindow::zoomIn()

--- a/Tools/MiniBrowser/win/WebKitBrowserWindow.h
+++ b/Tools/MiniBrowser/win/WebKitBrowserWindow.h
@@ -100,6 +100,4 @@ private:
     std::unordered_map<std::wstring, std::wstring> m_acceptedServerTrustCerts;
     std::vector<WKRetainPtr<WKStringRef>> m_experimentalFeatureKeys;
     std::vector<WKRetainPtr<WKStringRef>> m_internalDebugFeatureKeys;
-
-    float m_defaultResetPageZoomFactor = 1;
 };


### PR DESCRIPTION
#### b6d7f33139c733c82f439375d4fe2fb39736f2f3
<pre>
[Win] The view size shouldn&apos;t be affected by the custom device scale factor
<a href="https://bugs.webkit.org/show_bug.cgi?id=285007">https://bugs.webkit.org/show_bug.cgi?id=285007</a>

Reviewed by Don Olmstead.

&lt;<a href="https://commits.webkit.org/279794@main">https://commits.webkit.org/279794@main</a>&gt; added the device scale factor
support for Windows port.

Unlike other modern platforms, in the legacy win32 platfrom, a native
window size is scaled in high DPI. For example, 100x100 window (in
normal DPI) becomes 150x150 in a 150% DPI display. Thus, all
dimensions and positions have to be converted between the inside
WebKit and a native win32 window. The win32 coordinate system can be
converted to the WebKit coordinate system by division by the scale
factor. The WebKit coordinate system can be converted to the win32
coordinate system by multiplication by the scale factor.

However, a custom device scale factor is specified, the custom device
scale factor shouldn&apos;t be used for the conversion. The conversion
should be done by the intrinsic device scale factor.

* Source/WebCore/PlatformWin.cmake:
* Source/WebCore/platform/graphics/FloatPoint.h:
* Source/WebCore/platform/graphics/IntRect.h:
* Source/WebCore/platform/graphics/win/FloatPointWin.cpp: Added.
(WebCore::FloatPoint::FloatPoint):
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/Shared/win/WebEventFactory.cpp:
(WebKit::WebEventFactory::createWebMouseEvent):
(WebKit::WebEventFactory::createWebWheelEvent):
* Source/WebKit/UIProcess/BackingStore.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/skia/BackingStoreSkia.cpp:
(WebKit::BackingStore::paint):
* Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp:
(WebKit::DrawingAreaProxyWC::sizeDidChange):
* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp:
(WebKit::WebPopupMenuProxyWin::calculatePositionAndSize):
(WebKit::WebPopupMenuProxyWin::invalidateItem):
(WebKit::WebPopupMenuProxyWin::contentsSize const):
(WebKit::WebPopupMenuProxyWin::scrollTo):
(WebKit::WebPopupMenuProxyWin::invalidateScrollbarRect):
(WebKit::WebPopupMenuProxyWin::onSize):
(WebKit::WebPopupMenuProxyWin::onMouseMove):
(WebKit::WebPopupMenuProxyWin::onLButtonDown):
(WebKit::WebPopupMenuProxyWin::onLButtonUp):
(WebKit::WebPopupMenuProxyWin::paint):
(WebKit::WebPopupMenuProxyWin::visibleItems const):
* Source/WebKit/UIProcess/win/WebView.cpp:
(WebKit::WebView::onMouseEvent):
(WebKit::WebView::onWheelEvent):
(WebKit::drawPageBackground):
(WebKit::WebView::paint):
(WebKit::WebView::onPaintEvent):
(WebKit::WebView::onSizeEvent):
(WebKit::WebView::setScrollOffsetOnNextResize):
(WebKit::WebView::setViewNeedsDisplay):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp:
(WebKit::LayerTreeHost::compositeLayersToContext):
(WebKit::LayerTreeHost::applyDeviceScaleFactor):
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::setIntrinsicDeviceScaleFactor):
(WebKit::DrawingArea::updateGeometryWC):
* Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_textAnimationController):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp:
(WebKit::DrawingAreaWC::updateGeometryWC):
(WebKit::DrawingAreaWC::sendUpdateAC):
(WebKit::DrawingAreaWC::updateRootLayerDeviceScaleFactor):
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h:
* Tools/MiniBrowser/win/WebKitBrowserWindow.cpp:
(WebKitBrowserWindow::create):
(WebKitBrowserWindow::adjustScaleFactors):
(WebKitBrowserWindow::resetZoom):
* Tools/MiniBrowser/win/WebKitBrowserWindow.h:

Canonical link: <a href="https://commits.webkit.org/289251@main">https://commits.webkit.org/289251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/126f0533cdb10f16ad13a6e9ca9918411098bcb1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90568 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36481 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66424 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24234 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46706 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3957 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31860 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35551 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92134 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12789 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75075 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13015 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74198 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18503 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16933 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4867 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13393 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12777 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18200 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12594 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16052 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14360 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->