### PR TITLE
[JSC] `Intl.DurationFormat` should not print separator for hour unit when it isn't printed

### DIFF
--- a/JSTests/stress/intl-durationformat-hourdisplay-auto.js
+++ b/JSTests/stress/intl-durationformat-hourdisplay-auto.js
@@ -1,0 +1,21 @@
+function shouldBe(a, b) {
+    if (a !== b) {
+        throw new Error(`Expected ${b} but got ${a}`);
+    }
+}
+
+const df = new Intl.DurationFormat('en-US', {
+  style: "digital",
+  hoursDisplay: "auto",
+})
+
+
+shouldBe(df.format({hours: 0, minutes: 1, seconds: 2}), "01:02");
+shouldBe(df.format({hours: 0, minutes: 0, seconds: 2}), "00:02");
+shouldBe(df.format({hours: 0, minutes: 0, seconds: 0}), "00:00");
+shouldBe(df.format({hours: 1, minutes: 0, seconds: 0}), "1:00:00");
+shouldBe(df.format({ days: 1, hours: 0, minutes: 1, seconds: 2 }), "1 day, 01:02");
+shouldBe(df.format({years: 1, days: 3, hours: 1, minutes: 2, seconds: 3}), "1 yr, 3 days, 1:02:03");
+shouldBe(df.format({years: 1, days: 3, hours: 0, minutes: 2, seconds: 3}), "1 yr, 3 days, 02:03");
+shouldBe(df.format({years: 0, days: 3, hours: 1, minutes: 2, seconds: 3}), "3 days, 1:02:03");
+shouldBe(df.format({years: 0, days: 0, hours: 0, minutes: 2, seconds: 3}), "02:03");

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -575,7 +575,7 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
                 bool needsFormatMinutes = (needsFormatHours && needsFormatSeconds) || duration[TemporalUnit::Minute] || durationFormat->units()[static_cast<unsigned>(TemporalUnit::Minute)].display() != IntlDurationFormat::Display::Auto;
 
                 bool needsFormat = (unit == TemporalUnit::Hour && needsFormatHours) || (unit == TemporalUnit::Minute && needsFormatMinutes) || (unit == TemporalUnit::Second && needsFormatSeconds);
-                bool needsSeparator = (unit == TemporalUnit::Hour && needsFormatMinutes) || (unit == TemporalUnit::Minute && needsFormatSeconds);
+                bool needsSeparator = (unit == TemporalUnit::Hour && needsFormatHours && needsFormatMinutes) || (unit == TemporalUnit::Minute && needsFormatSeconds);
 
                 if (needsFormat) {
                     auto formattedNumber = totalNanosecondsValue ? formatIntl128AsDecimal(skeletonBuilder.toString()) : formatDouble(skeletonBuilder.toString());


### PR DESCRIPTION
#### 5e50f4025022485232f83d9a40d824641aaa4bfa
<pre>
[JSC] `Intl.DurationFormat` should not print separator for hour unit when it isn&apos;t printed
<a href="https://bugs.webkit.org/show_bug.cgi?id=285078">https://bugs.webkit.org/show_bug.cgi?id=285078</a>

Reviewed by Yusuke Suzuki.

When the `hourDisplay` option is `auto` and `hours` is 0,
the hours value is not printed. Therefore, the separator
that follows the hours should also not be printed.

However, in our current implementation, only the separator
is printed in that situation:

```js
// current behavior
const df = new Intl.DurationFormat(&apos;en-US&apos;, {
  style: &quot;digital&quot;,
  hoursDisplay: &quot;auto&quot;,
});
df.format({hours: 0, minutes: 1, seconds: 2}); // &quot;:, 01:02&quot;
```

This patch fixes that issue.

* JSTests/stress/intl-durationformat-hourdisplay-auto.js: Added.
(shouldBe):
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::collectElements):

Canonical link: <a href="https://commits.webkit.org/288277@main">https://commits.webkit.org/288277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/816669ff4a924e3f481a62429c48f1b3f47950ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87461 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33390 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64164 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21916 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74913 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44442 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1351 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29094 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32431 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75317 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72642 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88817 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81383 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9635 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72565 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9861 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71783 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15918 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14925 "Found 1 new test failure: fast/mediastream/getDisplayMedia-max-constraints5.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/990 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12779 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9588 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15109 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103796 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9462 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25188 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12928 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->