### PR TITLE
[TextureMapper] Use OpenGL API to determine maximum texture size

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -74,6 +74,7 @@ public:
     GLuint getStaticVBO(GLenum target, GLsizeiptr, const void* data);
     Ref<TextureMapperShaderProgram> getShaderProgram(TextureMapperShaderProgram::Options);
     Ref<TextureMapperGPUBuffer> getBufferFromPool(size_t, TextureMapperGPUBuffer::Type);
+    int32_t maxTextureSize() const;
 
     TransformationMatrix projectionMatrix;
     TextureMapper::FlipY flipY { TextureMapper::FlipY::No };
@@ -123,9 +124,13 @@ private:
             return map;
         }
 
-        SharedGLData() = default;
+        SharedGLData()
+        {
+            glGetIntegerv(GL_MAX_TEXTURE_SIZE, &m_maxTextureSize);
+        }
 
         UncheckedKeyHashMap<unsigned, RefPtr<TextureMapperShaderProgram>> m_programs;
+        int32_t m_maxTextureSize;
     };
 
     Ref<SharedGLData> m_sharedGLData;
@@ -204,6 +209,11 @@ Ref<TextureMapperGPUBuffer> TextureMapperGLData::getBufferFromPool(size_t size, 
 
     buffers.append(TextureMapperGPUBuffer::create(size, type, TextureMapperGPUBuffer::Usage::Dynamic));
     return buffers.last();
+}
+
+int32_t TextureMapperGLData::maxTextureSize() const
+{
+    return m_sharedGLData->m_maxTextureSize;
 }
 
 std::unique_ptr<TextureMapper> TextureMapper::create()
@@ -1426,6 +1436,11 @@ void TextureMapper::endClip()
 IntRect TextureMapper::clipBounds()
 {
     return clipStack().current().scissorBox;
+}
+
+IntSize TextureMapper::maxTextureSize() const
+{
+    return IntSize(data().maxTextureSize(), data().maxTextureSize());
 }
 
 void TextureMapper::setDepthRange(double zNear, double zFar)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -85,7 +85,7 @@ public:
     WEBCORE_EXPORT void endPainting();
     void endClip();
     IntRect clipBounds();
-    IntSize maxTextureSize() const { return IntSize(2000, 2000); }
+    IntSize maxTextureSize() const;
     void setDepthRange(double zNear, double zFar);
     std::pair<double, double> depthRange() const;
     void setMaskMode(bool m) { m_isMaskMode = m; }


### PR DESCRIPTION
#### 2473fd5f5e04e88c3cfc90117c7bd332a6633e87
<pre>
[TextureMapper] Use OpenGL API to determine maximum texture size
<a href="https://bugs.webkit.org/show_bug.cgi?id=285128">https://bugs.webkit.org/show_bug.cgi?id=285128</a>

Reviewed by Fujii Hironori.

Replace the hardcoded 2000x2000 maximum texture size with the value provided
by the OpenGL API (GL_MAX_TEXTURE_SIZE).

* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapperGLData::SharedGLData::SharedGLData):
(WebCore::TextureMapperGLData::maxTextureSize const):
(WebCore::TextureMapper::maxTextureSize const):
* Source/WebCore/platform/graphics/texmap/TextureMapper.h:
(WebCore::TextureMapper::maxTextureSize const): Deleted.

Canonical link: <a href="https://commits.webkit.org/288267@main">https://commits.webkit.org/288267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4d01a057aada1c242695ec04456f0247a2febf8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87454 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33383 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64156 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21908 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44434 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1344 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29088 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32424 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72635 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88810 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9628 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6886 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72556 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71774 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15909 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14919 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12776 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9581 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15102 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9455 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12921 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11225 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->