### PR TITLE
Remove 'unrestricted' for 'fastSeek' and 'currentTime' in HTMLMediaElement.idl

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.idl
+++ b/Source/WebCore/html/HTMLMediaElement.idl
@@ -79,10 +79,8 @@ typedef (
     readonly attribute boolean seeking;
 
     // playback state
-    // FIXME: Remove 'unrestricted' from 'currentTime' below to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260738
-    [ImplementedAs=currentTimeForBindings] attribute unrestricted double currentTime;
-    // FIXME: Remove 'unrestricted' from 'fastSeek' below to align with the specification. See: https://bugs.webkit.org/show_bug.cgi?id=260738
-    undefined fastSeek(unrestricted double time);
+    [ImplementedAs=currentTimeForBindings] attribute double currentTime;
+    undefined fastSeek(double time);
     readonly attribute unrestricted double duration;
     Date getStartDate();
     readonly attribute boolean paused;


### PR DESCRIPTION
#### 0344ef65b825dcb920a28f04905e19d9edd4367d
<pre>
Remove &apos;unrestricted&apos; for &apos;fastSeek&apos; and &apos;currentTime&apos; in HTMLMediaElement.idl
<a href="https://bugs.webkit.org/show_bug.cgi?id=260738">https://bugs.webkit.org/show_bug.cgi?id=260738</a>

Reviewed by NOBODY (OOPS!).

Synchronize `HTMLMediaElement.idl` with the current specification at
<a href="https://html.spec.whatwg.org/multipage/media.html#media-elements">https://html.spec.whatwg.org/multipage/media.html#media-elements</a>

* Source/WebCore/html/HTMLMediaElement.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0344ef65b825dcb920a28f04905e19d9edd4367d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87456 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33385 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84429 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9871 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64157 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/audio_loop_seek_to_eos.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21909 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44435 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1347 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29106 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32426 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72638 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88812 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6888 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72557 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/audio_loop_seek_to_eos.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9856 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71775 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15911 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14921 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/985 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9583 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15104 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9457 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12923 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->