### PR TITLE
Expose `-[WKWebView _setUseSystemAppearance:]` on iOS-family platforms

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -5386,6 +5386,16 @@ struct WKWebViewData {
     self._protectedPage->setPresentingApplicationAuditToken(presentingApplicationAuditToken);
 }
 
+- (BOOL)_useSystemAppearance
+{
+    return [[_configuration preferences] _useSystemAppearance];
+}
+
+- (void)_setUseSystemAppearance:(BOOL)useSystemAppearance
+{
+    [[_configuration preferences] _setUseSystemAppearance:useSystemAppearance];
+}
+
 @end
 
 @implementation WKWebView (WKDeprecated)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -285,6 +285,8 @@ for this property.
 
 @property (nonatomic, setter=_setBackgroundExtendsBeyondPage:) BOOL _backgroundExtendsBeyondPage WK_API_AVAILABLE(macos(10.13.4), ios(8.0));
 
+@property (nonatomic, readwrite, setter=_setUseSystemAppearance:) BOOL _useSystemAppearance WK_API_AVAILABLE(macos(10.14), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 - (_WKAttachment *)_insertAttachmentWithFilename:(NSString *)filename contentType:(NSString *)contentType data:(NSData *)data options:(_WKAttachmentDisplayOptions *)options completion:(void(^)(BOOL success))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("-_insertAttachmentWithFileWrapper:contentType:options:completion:", macos(10.13.4, 10.14.4), ios(11.3, 12.2));
 - (_WKAttachment *)_insertAttachmentWithFileWrapper:(NSFileWrapper *)fileWrapper contentType:(NSString *)contentType options:(_WKAttachmentDisplayOptions *)options completion:(void(^)(BOOL success))completionHandler WK_API_DEPRECATED_WITH_REPLACEMENT("-_insertAttachmentWithFileWrapper:contentType:completion:", macos(10.14.4, 10.14.4), ios(12.2, 12.2));
 - (_WKAttachment *)_insertAttachmentWithFileWrapper:(NSFileWrapper *)fileWrapper contentType:(NSString *)contentType completion:(void(^)(BOOL success))completionHandler WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
@@ -814,7 +816,6 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 @property (nonatomic, setter=_setAlwaysShowsHorizontalScroller:) BOOL _alwaysShowsHorizontalScroller WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setAlwaysShowsVerticalScroller:) BOOL _alwaysShowsVerticalScroller WK_API_AVAILABLE(macos(10.13.4));
 
-@property (nonatomic, readwrite, setter=_setUseSystemAppearance:) BOOL _useSystemAppearance WK_API_AVAILABLE(macos(10.14));
 @property (nonatomic, setter=_setOverlayScrollbarStyle:) _WKOverlayScrollbarStyle _overlayScrollbarStyle WK_API_AVAILABLE(macos(10.13.4));
 @property (strong, nonatomic, setter=_setInspectorAttachmentView:) NSView *_inspectorAttachmentView WK_API_AVAILABLE(macos(10.13.4));
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1583,16 +1583,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _page->setAlwaysShowsVerticalScroller(alwaysShowsVerticalScroller);
 }
 
-- (BOOL)_useSystemAppearance
-{
-    return [[_configuration preferences] _useSystemAppearance];
-}
-
-- (void)_setUseSystemAppearance:(BOOL)useSystemAppearance
-{
-    [[_configuration preferences] _setUseSystemAppearance:useSystemAppearance];
-}
-
 - (void)_setOverlayScrollbarStyle:(_WKOverlayScrollbarStyle)scrollbarStyle
 {
     _impl->setOverlayScrollbarStyle(toCoreScrollbarStyle(scrollbarStyle));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UseSystemAppearance.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UseSystemAppearance.mm
@@ -25,7 +25,7 @@
 
 #include "config.h"
 
-#if PLATFORM(MAC)
+#if PLATFORM(COCOA)
 
 #import "PlatformUtilities.h"
 #import "Test.h"
@@ -35,6 +35,8 @@
 #import <WebKit/WebViewPrivate.h>
 #import <WebKit/_WKUserStyleSheet.h>
 #import <wtf/RetainPtr.h>
+
+#if PLATFORM(MAC)
 
 @interface UserStyleSheetParsingWebKitLegacyTest : NSObject <WebFrameLoadDelegate> {
 }
@@ -55,27 +57,6 @@
 }
 
 @end
-
-TEST(UseSystemAppearance, UserStyleSheetParsing)
-{
-    RetainPtr styleSheet1 = adoptNS([[_WKUserStyleSheet alloc] initWithSource:@"@media (prefers-dark-interface) { #test { color: green } }" forMainFrameOnly:NO]);
-    RetainPtr styleSheet2 = adoptNS([[_WKUserStyleSheet alloc] initWithSource:@"@media not screen and (prefers-dark-interface) { #test { color: green } }" forMainFrameOnly:NO]);
-
-    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    [[configuration userContentController] _addUserStyleSheet:styleSheet1.get()];
-    [[configuration userContentController] _addUserStyleSheet:styleSheet2.get()];
-
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 300) configuration:configuration.get()]);
-    [webView synchronouslyLoadHTMLString:@"<div id=test></div>"];
-
-    EXPECT_WK_STREQ("rgb(0, 0, 0)", [webView stringByEvaluatingJavaScript:@"getComputedStyle(test).color"]);
-
-    [webView _setUseSystemAppearance:YES];
-    EXPECT_WK_STREQ("rgb(0, 128, 0)", [webView stringByEvaluatingJavaScript:@"getComputedStyle(test).color"]);
-
-    [webView _setUseSystemAppearance:NO];
-    EXPECT_WK_STREQ("rgb(0, 0, 0)", [webView stringByEvaluatingJavaScript:@"getComputedStyle(test).color"]);
-}
 
 TEST(UseSystemAppearance, UserStyleSheetParsingWebKitLegacy)
 {
@@ -102,3 +83,26 @@ TEST(UseSystemAppearance, UserStyleSheetParsingWebKitLegacy)
 }
 
 #endif // PLATFORM(MAC)
+
+TEST(UseSystemAppearance, UserStyleSheetParsing)
+{
+    RetainPtr styleSheet1 = adoptNS([[_WKUserStyleSheet alloc] initWithSource:@"@media (prefers-dark-interface) { #test { color: green } }" forMainFrameOnly:NO]);
+    RetainPtr styleSheet2 = adoptNS([[_WKUserStyleSheet alloc] initWithSource:@"@media not screen and (prefers-dark-interface) { #test { color: green } }" forMainFrameOnly:NO]);
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration userContentController] _addUserStyleSheet:styleSheet1.get()];
+    [[configuration userContentController] _addUserStyleSheet:styleSheet2.get()];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 300) configuration:configuration.get()]);
+    [webView synchronouslyLoadHTMLString:@"<div id=test></div>"];
+
+    EXPECT_WK_STREQ("rgb(0, 0, 0)", [webView stringByEvaluatingJavaScript:@"getComputedStyle(test).color"]);
+
+    [webView _setUseSystemAppearance:YES];
+    EXPECT_WK_STREQ("rgb(0, 128, 0)", [webView stringByEvaluatingJavaScript:@"getComputedStyle(test).color"]);
+
+    [webView _setUseSystemAppearance:NO];
+    EXPECT_WK_STREQ("rgb(0, 0, 0)", [webView stringByEvaluatingJavaScript:@"getComputedStyle(test).color"]);
+}
+
+#endif // PLATFORM(COCOA)


### PR DESCRIPTION
#### 35047c52312bf74d1e69aa26fb3405195825635a
<pre>
Expose `-[WKWebView _setUseSystemAppearance:]` on iOS-family platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=285131">https://bugs.webkit.org/show_bug.cgi?id=285131</a>
<a href="https://rdar.apple.com/141996137">rdar://141996137</a>

Reviewed by Wenson Hsieh.

Allow iOS-family clients to use platform-specific CSS properties, values, and
rendering behaviors.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _useSystemAppearance]):
(-[WKWebView _setUseSystemAppearance:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _useSystemAppearance]): Deleted.
(-[WKWebView _setUseSystemAppearance:]): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UseSystemAppearance.mm:
(TEST(UseSystemAppearance, UserStyleSheetParsing)):

Canonical link: <a href="https://commits.webkit.org/288279@main">https://commits.webkit.org/288279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3056d08f83840af1d0cfba8493a41e79336b5bb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87469 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33398 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84442 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2072 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/9897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64171 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21922 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74921 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44449 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1359 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29102 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32439 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88825 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9643 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6902 "Exiting early after 60 failures. 52761 tests run.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72572 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71789 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15925 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14933 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/998 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12782 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9596 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15117 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9470 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12936 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11240 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->