### PR TITLE
[ Sequoia ] TestWebKitAPI.FontManagerTests.ChangeTypingAttributesWithInspectorBar is a constant failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm
@@ -391,12 +391,7 @@ TEST(FontManagerTests, ChangeFontColorWithColorPanel)
         [webView stringByEvaluatingJavaScript:@"document.body.innerHTML"]);
 }
 
-// rdar://136532193
-#if (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 150000)
-TEST(FontManagerTests, DISABLED_ChangeTypingAttributesWithInspectorBar)
-#else
 TEST(FontManagerTests, ChangeTypingAttributesWithInspectorBar)
-#endif
 {
     auto webView = webViewForFontManagerTesting(NSFontManager.sharedFontManager);
     auto inspectorBar = adoptNS([[TestInspectorBar alloc] initWithWebView:webView.get()]);
@@ -441,14 +436,16 @@ TEST(FontManagerTests, ChangeTypingAttributesWithInspectorBar)
     {
         // Add foreground and background colors.
         [webView selectNextWord];
-        NSColor *foregroundColor = [NSColor colorWithRed:1 green:1 blue:1 alpha:0.2];
-        NSColor *backgroundColor = [NSColor colorWithRed:0.8 green:0.2 blue:0.6 alpha:1];
-        [inspectorBar chooseForegroundColor:foregroundColor];
-        [inspectorBar chooseBackgroundColor:backgroundColor];
+        RetainPtr backgroundColor = [NSColor colorWithRed:0.8 green:0.2 blue:0.6 alpha:1];
+        RetainPtr foregroundColor = [NSColor colorWithRed:1 green:0 blue:0 alpha:1];
+
+        [inspectorBar chooseBackgroundColor:backgroundColor.get()];
         [webView waitForNextPresentationUpdate];
-        NSDictionary *attributes = [webView typingAttributes];
-        EXPECT_TRUE([attributes[NSForegroundColorAttributeName] isEqual:foregroundColor]);
-        EXPECT_TRUE([attributes[NSBackgroundColorAttributeName] isEqual:backgroundColor]);
+        EXPECT_TRUE([[webView typingAttributes][NSBackgroundColorAttributeName] isEqual:backgroundColor.get()]);
+
+        [inspectorBar chooseForegroundColor:foregroundColor.get()];
+        [webView waitForNextPresentationUpdate];
+        EXPECT_TRUE([[webView typingAttributes][NSForegroundColorAttributeName] isEqual:foregroundColor.get()]);
     }
 }
 


### PR DESCRIPTION
#### 36d40c7dfd972e688c9c0febea6821825a85d6ac
<pre>
[ Sequoia ] TestWebKitAPI.FontManagerTests.ChangeTypingAttributesWithInspectorBar is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=280215">https://bugs.webkit.org/show_bug.cgi?id=280215</a>
<a href="https://rdar.apple.com/136532193">rdar://136532193</a>

Reviewed by Aditya Keerthi.

On macOS Sequoia and later, the inspector bar&apos;s color well no longer supports alpha by default. In
the inspector bar&apos;s UI, there&apos;s no way to actually pick a foreground color with an alpha component
that&apos;s not fully opaque, so this isn&apos;t an issue; however, this failing API test currently sets a
transparent foreground color.

Fix this test by changing it to reflect a legitimate user-facing workflow, by specifying an opaque
color.

* Tools/TestWebKitAPI/Tests/mac/FontManagerTests.mm:
(TestWebKitAPI::repr):
(TestWebKitAPI::TEST(FontManagerTests, ChangeTypingAttributesWithInspectorBar)):

Canonical link: <a href="https://commits.webkit.org/288283@main">https://commits.webkit.org/288283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04f1c2c57bf00fbbcb628a26f076ee1937a3b69a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82345 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87477 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33406 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64176 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21927 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85414 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/1463 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44454 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1364 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29110 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32447 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29738 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88833 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6909 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72577 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9877 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71794 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17890 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15930 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14939 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1007 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9604 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9478 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12944 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11248 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->