### PR TITLE
DisplayListRecorder should clone all the mutable RefCounted resources

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1248,8 +1248,9 @@ platform/graphics/coretext/ComplexTextControllerCoreText.mm
 platform/graphics/coretext/FontCascadeCoreText.cpp
 platform/graphics/coretext/FontPlatformDataCoreText.cpp
 platform/graphics/cv/GraphicsContextGLCVCocoa.mm
-platform/graphics/displaylists/DisplayListItem.cpp
+platform/graphics/filters/FEDiffuseLighting.cpp
 platform/graphics/filters/FEDisplacementMap.cpp
+platform/graphics/filters/FESpecularLighting.cpp
 platform/graphics/filters/FilterImage.cpp
 platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
 platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -742,7 +742,6 @@ platform/graphics/coretext/GlyphPageCoreText.cpp
 platform/graphics/cv/VideoFrameCV.mm
 platform/graphics/displaylists/DisplayListItem.cpp
 platform/graphics/displaylists/DisplayListItems.cpp
-platform/graphics/displaylists/DisplayListRecorder.cpp
 platform/graphics/displaylists/DisplayListRecorderImpl.cpp
 platform/graphics/displaylists/DisplayListResourceHeap.h
 platform/graphics/filters/FilterEffect.cpp

--- a/Source/WebCore/platform/graphics/Gradient.cpp
+++ b/Source/WebCore/platform/graphics/Gradient.cpp
@@ -49,6 +49,15 @@ Gradient::Gradient(Data&& data, ColorInterpolationMethod colorInterpolationMetho
 {
 }
 
+Gradient::Gradient(const Gradient& other)
+    : RenderingResource(other.renderingResourceIdentifier())
+    , m_data(other.m_data)
+    , m_colorInterpolationMethod(other.m_colorInterpolationMethod)
+    , m_spreadMethod(other.m_spreadMethod)
+    , m_stops(other.m_stops)
+{
+}
+
 void Gradient::adjustParametersForTiledDrawing(FloatSize& size, FloatRect& srcRect, const FloatSize& spacing)
 {
     if (srcRect.isEmpty())

--- a/Source/WebCore/platform/graphics/Gradient.h
+++ b/Source/WebCore/platform/graphics/Gradient.h
@@ -86,6 +86,8 @@ public:
 
     WEBCORE_EXPORT static Ref<Gradient> create(Data&&, ColorInterpolationMethod, GradientSpreadMethod = GradientSpreadMethod::Pad, GradientColorStops&& = { }, std::optional<RenderingResourceIdentifier> = std::nullopt);
 
+    Ref<Gradient> clone() const { return adoptRef(*new Gradient(*this)); }
+
     const Data& data() const { return m_data; }
     ColorInterpolationMethod colorInterpolationMethod() const { return m_colorInterpolationMethod; }
     GradientSpreadMethod spreadMethod() const { return m_spreadMethod; }
@@ -115,6 +117,7 @@ public:
 
 private:
     Gradient(Data&&, ColorInterpolationMethod, GradientSpreadMethod, GradientColorStops&&, std::optional<RenderingResourceIdentifier>);
+    Gradient(const Gradient&);
 
     bool isGradient() const final { return true; }
 

--- a/Source/WebCore/platform/graphics/SourceBrush.cpp
+++ b/Source/WebCore/platform/graphics/SourceBrush.cpp
@@ -80,6 +80,11 @@ void SourceBrush::setGradient(Ref<Gradient>&& gradient, const AffineTransform& s
     m_patternGradient = SourceBrushLogicalGradient { WTFMove(gradient), spaceTransform };
 }
 
+void SourceBrush::setGradient(RenderingResourceIdentifier renderingResourceIdentifier, const AffineTransform& spaceTransform)
+{
+    m_patternGradient = SourceBrushLogicalGradient { renderingResourceIdentifier, spaceTransform };
+}
+
 void SourceBrush::setPattern(Ref<Pattern>&& pattern)
 {
     m_patternGradient.emplace<Ref<Pattern>>(WTFMove(pattern));

--- a/Source/WebCore/platform/graphics/SourceBrush.h
+++ b/Source/WebCore/platform/graphics/SourceBrush.h
@@ -51,7 +51,8 @@ public:
     WEBCORE_EXPORT std::optional<RenderingResourceIdentifier> gradientIdentifier() const;
 
     WEBCORE_EXPORT void setGradient(Ref<Gradient>&&, const AffineTransform& spaceTransform = { });
-    void setPattern(Ref<Pattern>&&);
+    WEBCORE_EXPORT void setGradient(RenderingResourceIdentifier, const AffineTransform& spaceTransform = { });
+    WEBCORE_EXPORT void setPattern(Ref<Pattern>&&);
 
     bool isInlineColor() const { return !hasPatternOrGradient() && m_color.tryGetAsSRGBABytes(); }
     bool isVisible() const { return hasPatternOrGradient() || m_color.isVisible(); }

--- a/Source/WebCore/platform/graphics/SourceImage.cpp
+++ b/Source/WebCore/platform/graphics/SourceImage.cpp
@@ -48,6 +48,18 @@ bool SourceImage::operator==(const SourceImage& other) const
     return imageIdentifier() == other.imageIdentifier();
 }
 
+SourceImage SourceImage::clone() const
+{
+    RefPtr imageBuffer = imageBufferIfExists();
+    if (!imageBuffer)
+        return *this;
+
+    if (RefPtr clone = imageBuffer->clone())
+        return { clone.releaseNonNull() };
+
+    return *this;
+}
+
 static inline NativeImage* nativeImageOf(const SourceImage::ImageVariant& imageVariant)
 {
     if (auto* nativeImage = std::get_if<Ref<NativeImage>>(&imageVariant))

--- a/Source/WebCore/platform/graphics/SourceImage.h
+++ b/Source/WebCore/platform/graphics/SourceImage.h
@@ -51,6 +51,8 @@ public:
 
     bool operator==(const SourceImage&) const;
 
+    SourceImage clone() const;
+
     NativeImage* nativeImageIfExists() const;
     NativeImage* nativeImage() const;
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
@@ -28,6 +28,7 @@
 
 #include "DisplayListItems.h"
 #include "DisplayListResourceHeap.h"
+#include "FEImage.h"
 #include "FilterResults.h"
 #include "GraphicsContext.h"
 #include <wtf/text/TextStream.h>
@@ -53,10 +54,21 @@ bool isValid(const Item& item)
 template<class T>
 inline static std::optional<RenderingResourceIdentifier> applyFilteredImageBufferItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const T& item, OptionSet<ReplayOption> options)
 {
-    auto resourceIdentifier = item.sourceImageIdentifier();
-    auto sourceImage = resourceIdentifier ? resourceHeap.getImageBuffer(*resourceIdentifier, options) : nullptr;
-    if (UNLIKELY(!sourceImage && resourceIdentifier))
-        return resourceIdentifier;
+    auto sourceImageIdentifier = item.sourceImageIdentifier();
+    auto sourceImage = sourceImageIdentifier ? resourceHeap.getImageBuffer(*sourceImageIdentifier, options) : nullptr;
+    if (UNLIKELY(!sourceImage && sourceImageIdentifier))
+        return sourceImageIdentifier;
+
+    for (auto& effect : item.filter()->effectsOfType(FilterEffect::Type::FEImage)) {
+        Ref feImage = downcast<FEImage>(effect.get());
+
+        auto feSourceImageIdentifier = feImage->sourceImage().imageIdentifier();
+        auto effectImage = resourceHeap.getSourceImage(feSourceImageIdentifier);
+        if (!effectImage)
+            return feSourceImageIdentifier;
+
+        feImage->setImageSource(WTFMove(*effectImage));
+    }
 
     FilterResults results;
     item.apply(context, sourceImage, results);
@@ -98,26 +110,52 @@ inline static std::optional<RenderingResourceIdentifier> applySourceImageItem(Gr
 
 inline static std::optional<RenderingResourceIdentifier> applySetStateItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const SetState& item, OptionSet<ReplayOption> options)
 {
-    auto fixPatternTileImage = [&](Pattern* pattern) -> std::optional<RenderingResourceIdentifier> {
+    auto cloneItem = item;
+
+    auto fixBrushPattern = [&](SourceBrush& brush) -> std::optional<RenderingResourceIdentifier> {
+        RefPtr pattern = brush.pattern();
         if (!pattern)
             return std::nullopt;
 
-        auto imageIdentifier = pattern->tileImage().imageIdentifier();
-        auto sourceImage = resourceHeap.getSourceImage(imageIdentifier, options);
+        auto renderingResourceIdentifier = pattern->tileImage().imageIdentifier();
+        auto sourceImage = resourceHeap.getSourceImage(renderingResourceIdentifier, options);
         if (!sourceImage)
-            return imageIdentifier;
+            return renderingResourceIdentifier;
 
         pattern->setTileImage(WTFMove(*sourceImage));
         return std::nullopt;
     };
 
-    if (auto imageIdentifier = fixPatternTileImage(item.state().strokeBrush().pattern()))
-        return *imageIdentifier;
+    auto fixBrushGradient = [&](SourceBrush& brush) -> std::optional<RenderingResourceIdentifier> {
+        auto renderingResourceIdentifier = brush.gradientIdentifier();
+        if (!renderingResourceIdentifier)
+            return std::nullopt;
 
-    if (auto imageIdentifier = fixPatternTileImage(item.state().fillBrush().pattern()))
-        return *imageIdentifier;
+        auto cachedGradient = resourceHeap.getGradient(*renderingResourceIdentifier);
+        if (!cachedGradient)
+            return renderingResourceIdentifier;
 
-    item.apply(context);
+        brush.setGradient(Ref { *cachedGradient }, brush.gradientSpaceTransform());
+        return std::nullopt;
+    };
+
+    auto fixBrush = [&](SourceBrush& brush) -> std::optional<RenderingResourceIdentifier> {
+        if (auto imageIdentifier = fixBrushPattern(brush))
+            return *imageIdentifier;
+
+        if (auto gradientIdentifier = fixBrushGradient(brush))
+            return *gradientIdentifier;
+
+        return std::nullopt;
+    };
+
+    if (auto renderingResourceIdentifier = fixBrush(cloneItem.state().strokeBrush()))
+        return *renderingResourceIdentifier;
+
+    if (auto renderingResourceIdentifier = fixBrush(cloneItem.state().fillBrush()))
+        return *renderingResourceIdentifier;
+
+    cloneItem.apply(context);
     return std::nullopt;
 }
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -74,7 +74,7 @@ void Recorder::commitRecording()
 void Recorder::appendStateChangeItem(const GraphicsContextState& state)
 {
     ASSERT(state.changes());
-    
+
     if (state.containsOnlyInlineChanges()) {
         if (state.changes().contains(GraphicsContextState::Change::FillBrush))
             recordSetInlineFillColor(*fillColor().tryGetAsPackedInline());
@@ -84,6 +84,11 @@ void Recorder::appendStateChangeItem(const GraphicsContextState& state)
         return;
     }
 
+    appendSetStateItem(state);
+}
+
+void Recorder::appendSetStateItem(const GraphicsContextState& state)
+{
     if (state.changes().contains(GraphicsContextState::Change::FillBrush)) {
         if (auto pattern = fillPattern())
             recordResourceUse(pattern->tileImage());
@@ -166,16 +171,17 @@ void Recorder::drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect
     }
 
     if (!sourceImage) {
-        recordDrawFilteredImageBuffer(nullptr, sourceImageRect, filter);
+        recordDrawFilteredImageBuffer(std::nullopt, sourceImageRect, filter);
         return;
     }
 
-    if (!recordResourceUse(*sourceImage)) {
+    auto renderingResourceIdentifier = recordResourceUse(*sourceImage);
+    if (!renderingResourceIdentifier) {
         GraphicsContext::drawFilteredImageBuffer(sourceImage, sourceImageRect, filter, results);
         return;
     }
 
-    recordDrawFilteredImageBuffer(sourceImage, sourceImageRect, filter);
+    recordDrawFilteredImageBuffer(renderingResourceIdentifier, sourceImageRect, filter);
 }
 
 bool Recorder::shouldDeconstructDrawGlyphs() const
@@ -262,12 +268,13 @@ void Recorder::drawImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRe
 {
     appendStateChangeItemIfNecessary();
 
-    if (!recordResourceUse(imageBuffer)) {
+    auto renderingResourceIdentifier = recordResourceUse(imageBuffer);
+    if (!renderingResourceIdentifier) {
         GraphicsContext::drawImageBuffer(imageBuffer, destRect, srcRect, options);
         return;
     }
 
-    recordDrawImageBuffer(imageBuffer, destRect, srcRect, options);
+    recordDrawImageBuffer(*renderingResourceIdentifier, destRect, srcRect, options);
 }
 void Recorder::drawConsumingImageBuffer(RefPtr<ImageBuffer> imageBuffer, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
@@ -312,12 +319,13 @@ void Recorder::drawPattern(ImageBuffer& imageBuffer, const FloatRect& destRect, 
 {
     appendStateChangeItemIfNecessary();
 
-    if (!recordResourceUse(imageBuffer)) {
+    auto renderingResourceIdentifier = recordResourceUse(imageBuffer);
+    if (!renderingResourceIdentifier) {
         GraphicsContext::drawPattern(imageBuffer, destRect, tileRect, patternTransform, phase, spacing, options);
         return;
     }
 
-    recordDrawPattern(imageBuffer.renderingResourceIdentifier(), destRect, tileRect, patternTransform, phase, spacing, options);
+    recordDrawPattern(*renderingResourceIdentifier, destRect, tileRect, patternTransform, phase, spacing, options);
 }
 
 void Recorder::updateStateForSave(GraphicsContextState::Purpose purpose)
@@ -526,8 +534,8 @@ void Recorder::clipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& dest
 {
     appendStateChangeItemIfNecessary(); // Conservative: we do not know if the clip application might use state such as antialiasing.
     currentState().clipBounds.intersect(currentState().ctm.mapRect(destRect));
-    recordResourceUse(imageBuffer);
-    recordClipToImageBuffer(imageBuffer, destRect);
+    if (auto renderingResourceIdentifier = recordResourceUse(imageBuffer))
+        recordClipToImageBuffer(*renderingResourceIdentifier, destRect);
 }
 
 void Recorder::updateStateForApplyDeviceScaleFactor(float deviceScaleFactor)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -75,11 +75,11 @@ protected:
     virtual void recordSetInlineStroke(SetInlineStroke&&) = 0;
     virtual void recordSetState(const GraphicsContextState&) = 0;
     virtual void recordClearDropShadow() = 0;
-    virtual void recordClipToImageBuffer(ImageBuffer&, const FloatRect& destinationRect) = 0;
-    virtual void recordDrawFilteredImageBuffer(ImageBuffer*, const FloatRect& sourceImageRect, Filter&) = 0;
+    virtual void recordClipToImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destinationRect) = 0;
+    virtual void recordDrawFilteredImageBuffer(std::optional<RenderingResourceIdentifier> sourceImageIdentifier, const FloatRect& sourceImageRect, Filter&) = 0;
     virtual void recordDrawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode) = 0;
     virtual void recordDrawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) = 0;
-    virtual void recordDrawImageBuffer(ImageBuffer&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) = 0;
+    virtual void recordDrawImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) = 0;
     virtual void recordDrawNativeImage(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) = 0;
     virtual void recordDrawSystemImage(SystemImage&, const FloatRect&) = 0;
     virtual void recordDrawPattern(RenderingResourceIdentifier, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) = 0;
@@ -104,12 +104,12 @@ protected:
     virtual void recordStrokePath(const Path&) = 0;
     virtual void recordDrawDisplayListItems(const Vector<Item>&, const FloatPoint& destination) = 0;
 
-    virtual bool recordResourceUse(NativeImage&) = 0;
-    virtual bool recordResourceUse(ImageBuffer&) = 0;
-    virtual bool recordResourceUse(const SourceImage&) = 0;
+    virtual std::optional<RenderingResourceIdentifier> recordResourceUse(NativeImage&) = 0;
+    virtual std::optional<RenderingResourceIdentifier> recordResourceUse(ImageBuffer&) = 0;
+    virtual std::optional<RenderingResourceIdentifier> recordResourceUse(const SourceImage&) = 0;
+    virtual std::optional<RenderingResourceIdentifier> recordResourceUse(Gradient&) = 0;
     virtual bool recordResourceUse(Font&) = 0;
     virtual bool recordResourceUse(DecomposedGlyphs&) = 0;
-    virtual bool recordResourceUse(Gradient&) = 0;
     virtual bool recordResourceUse(Filter&) = 0;
 
     struct ContextState {
@@ -140,6 +140,7 @@ protected:
     ContextState& currentState();
 
 protected:
+    WEBCORE_EXPORT virtual void appendSetStateItem(const GraphicsContextState&);
     WEBCORE_EXPORT void updateStateForSave(GraphicsContextState::Purpose);
     [[nodiscard]] WEBCORE_EXPORT bool updateStateForRestore(GraphicsContextState::Purpose);
     [[nodiscard]] WEBCORE_EXPORT bool updateStateForTranslate(float x, float y);
@@ -160,6 +161,7 @@ protected:
     WEBCORE_EXPORT void updateStateForApplyDeviceScaleFactor(float);
     WEBCORE_EXPORT void appendStateChangeItemIfNecessary();
     FloatRect initialClip() const { return m_initialClip; }
+    WEBCORE_EXPORT void drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, FilterResults&) override;
 
 private:
     bool hasPlatformContext() const final { return false; }
@@ -179,7 +181,6 @@ private:
     WEBCORE_EXPORT void didUpdateSingleState(GraphicsContextState&, GraphicsContextState::ChangeIndex) final;
     WEBCORE_EXPORT void fillPath(const Path&) final;
     WEBCORE_EXPORT void strokePath(const Path&) final;
-    WEBCORE_EXPORT void drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, FilterResults&) final;
     WEBCORE_EXPORT void drawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned numGlyphs, const FloatPoint& anchorPoint, FontSmoothingMode) final;
     WEBCORE_EXPORT void drawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) override;
     WEBCORE_EXPORT void drawGlyphsAndCacheResources(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode) final;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -29,6 +29,7 @@
 #include "DisplayList.h"
 #include "DisplayListDrawingContext.h"
 #include "DisplayListItems.h"
+#include "FEImage.h"
 #include "Filter.h"
 #include "GraphicsContext.h"
 #include "ImageBuffer.h"
@@ -55,6 +56,47 @@ RecorderImpl::RecorderImpl(DisplayList& displayList, const GraphicsContextState&
 RecorderImpl::~RecorderImpl()
 {
     ASSERT(stateStack().size() == 1); // If this fires, it indicates mismatched save/restore.
+}
+
+void RecorderImpl::appendSetStateItem(const GraphicsContextState& state)
+{
+#if USE(SKIA)
+    Recorder::appendSetStateItem(state);
+#else
+    auto clone = state;
+
+    auto recordPatternUse = [&](SourceBrush& brush) {
+        RefPtr pattern = brush.pattern();
+        if (!pattern)
+            return;
+        auto renderingResourceIdentifier = recordResourceUse(pattern->tileImage());
+        if (!renderingResourceIdentifier)
+            return;
+        pattern->setTileImage(SourceImage { *renderingResourceIdentifier });
+    };
+
+    auto recordGradientUse = [&](SourceBrush& brush) {
+        RefPtr gradient = brush.gradient();
+        if (!gradient || !gradient->hasValidRenderingResourceIdentifier())
+            return;
+        auto renderingResourceIdentifier = recordResourceUse(*gradient);
+        if (!renderingResourceIdentifier)
+            return;
+        brush.setGradient(*renderingResourceIdentifier, brush.gradientSpaceTransform());
+    };
+
+    if (clone.changes().contains(GraphicsContextState::Change::FillBrush)) {
+        recordPatternUse(clone.fillBrush());
+        recordGradientUse(clone.fillBrush());
+    }
+
+    if (clone.changes().contains(GraphicsContextState::Change::StrokeBrush)) {
+        recordPatternUse(clone.strokeBrush());
+        recordGradientUse(clone.strokeBrush());
+    }
+
+    recordSetState(state);
+#endif
 }
 
 void RecorderImpl::save(GraphicsContextState::Purpose purpose)
@@ -102,6 +144,42 @@ void RecorderImpl::concatCTM(const AffineTransform& transform)
     if (!updateStateForConcatCTM(transform))
         return;
     append(ConcatenateCTM(transform));
+}
+
+void RecorderImpl::drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter, FilterResults& results)
+{
+#if USE(SKIA)
+    Recorder::drawFilteredImageBuffer(sourceImage, sourceImageRect, filter, results);
+#else
+    appendStateChangeItemIfNecessary();
+
+    Ref clone = filter.clone();
+
+    for (auto& effect : clone->effectsOfType(FilterEffect::Type::FEImage)) {
+        auto& feImage = downcast<FEImage>(effect.get());
+
+        auto renderingResourceIdentifier = recordResourceUse(feImage.sourceImage());
+        if (!renderingResourceIdentifier) {
+            GraphicsContext::drawFilteredImageBuffer(sourceImage, sourceImageRect, filter, results);
+            return;
+        }
+
+        feImage.setImageSource(SourceImage { *renderingResourceIdentifier });
+    }
+
+    if (!sourceImage) {
+        recordDrawFilteredImageBuffer(std::nullopt, sourceImageRect, clone);
+        return;
+    }
+
+    auto renderingResourceIdentifier = recordResourceUse(*sourceImage);
+    if (!renderingResourceIdentifier) {
+        GraphicsContext::drawFilteredImageBuffer(sourceImage, sourceImageRect, filter, results);
+        return;
+    }
+
+    recordDrawFilteredImageBuffer(renderingResourceIdentifier, sourceImageRect, clone);
+#endif
 }
 
 void RecorderImpl::recordSetInlineFillColor(PackedColor::RGBA inlineColor)
@@ -175,9 +253,9 @@ void RecorderImpl::clipOutRoundedRect(const FloatRoundedRect& clipRect)
     append(ClipOutRoundedRect(clipRect));
 }
 
-void RecorderImpl::recordClipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destinationRect)
+void RecorderImpl::recordClipToImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destinationRect)
 {
-    append(ClipToImageBuffer(imageBuffer.renderingResourceIdentifier(), destinationRect));
+    append(ClipToImageBuffer(imageBufferIdentifier, destinationRect));
 }
 
 void RecorderImpl::clipOut(const Path& path)
@@ -192,12 +270,9 @@ void RecorderImpl::clipPath(const Path& path, WindRule rule)
     append(ClipPath(path, rule));
 }
 
-void RecorderImpl::recordDrawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter)
+void RecorderImpl::recordDrawFilteredImageBuffer(std::optional<RenderingResourceIdentifier> sourceImageIdentifier, const FloatRect& sourceImageRect, Filter& filter)
 {
-    std::optional<RenderingResourceIdentifier> identifier;
-    if (sourceImage)
-        identifier = sourceImage->renderingResourceIdentifier();
-    append(DrawFilteredImageBuffer(WTFMove(identifier), sourceImageRect, filter));
+    append(DrawFilteredImageBuffer(WTFMove(sourceImageIdentifier), sourceImageRect, filter));
 }
 
 void RecorderImpl::recordDrawGlyphs(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode mode)
@@ -215,9 +290,9 @@ void RecorderImpl::recordDrawDisplayListItems(const Vector<Item>& items, const F
     append(DrawDisplayListItems(items, destination));
 }
 
-void RecorderImpl::recordDrawImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
+void RecorderImpl::recordDrawImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
-    append(DrawImageBuffer(imageBuffer.renderingResourceIdentifier(), destRect, srcRect, options));
+    append(DrawImageBuffer(imageBufferIdentifier, destRect, srcRect, options));
 }
 
 void RecorderImpl::recordDrawNativeImage(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
@@ -499,7 +574,7 @@ void RecorderImpl::endPage()
     append(EndPage());
 }
 
-bool RecorderImpl::recordResourceUse(NativeImage& nativeImage)
+std::optional<RenderingResourceIdentifier> RecorderImpl::recordResourceUse(NativeImage& nativeImage)
 {
 #if USE(SKIA)
     if (m_displayList.replayOptions().contains(ReplayOption::FlushImagesAndWaitForCompletion))
@@ -507,29 +582,38 @@ bool RecorderImpl::recordResourceUse(NativeImage& nativeImage)
 #endif
 
     m_displayList.cacheNativeImage(nativeImage);
-    return true;
+    return nativeImage.renderingResourceIdentifier();
 }
 
-bool RecorderImpl::recordResourceUse(ImageBuffer& imageBuffer)
+std::optional<RenderingResourceIdentifier> RecorderImpl::recordResourceUse(ImageBuffer& imageBuffer)
 {
 #if USE(SKIA)
     if (m_displayList.replayOptions().contains(ReplayOption::FlushImagesAndWaitForCompletion))
         imageBuffer.finishAcceleratedRenderingAndCreateFence();
-#endif
 
     m_displayList.cacheImageBuffer(imageBuffer);
-    return true;
+    return imageBuffer.renderingResourceIdentifier();
+#else
+    RefPtr clone = imageBuffer.clone();
+    if (!clone)
+        return std::nullopt;
+
+    m_displayList.cacheImageBuffer(*clone);
+    return clone->renderingResourceIdentifier();
+#endif
 }
 
-bool RecorderImpl::recordResourceUse(const SourceImage& image)
+std::optional<RenderingResourceIdentifier> RecorderImpl::recordResourceUse(const SourceImage& image)
 {
     if (auto imageBuffer = image.imageBufferIfExists())
         return recordResourceUse(*imageBuffer);
 
-    if (auto nativeImage = image.nativeImageIfExists())
-        return recordResourceUse(*nativeImage);
+    if (auto nativeImage = image.nativeImageIfExists()) {
+        recordResourceUse(*nativeImage);
+        nativeImage->renderingResourceIdentifier();
+    }
 
-    return true;
+    return std::nullopt;
 }
 
 bool RecorderImpl::recordResourceUse(Font& font)
@@ -544,10 +628,16 @@ bool RecorderImpl::recordResourceUse(DecomposedGlyphs& decomposedGlyphs)
     return true;
 }
 
-bool RecorderImpl::recordResourceUse(Gradient& gradient)
+std::optional<RenderingResourceIdentifier> RecorderImpl::recordResourceUse(Gradient& gradient)
 {
+#if USE(SKIA)
     m_displayList.cacheGradient(gradient);
-    return true;
+    return gradient.renderingResourceIdentifier();
+#else
+    Ref clone = gradient.clone();
+    m_displayList.cacheGradient(clone);
+    return clone->renderingResourceIdentifier();
+#endif
 }
 
 bool RecorderImpl::recordResourceUse(Filter& filter)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -83,6 +83,7 @@ public:
 #endif
     void strokeRect(const FloatRect&, float) final;
     void strokeEllipse(const FloatRect&) final;
+    void drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, FilterResults&) final;
     void clearRect(const FloatRect&) final;
     void drawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) final;
 #if USE(CG)
@@ -95,15 +96,16 @@ public:
     void endPage() final;
 
 private:
+    void appendSetStateItem(const GraphicsContextState&) final;
     void recordSetInlineFillColor(PackedColor::RGBA) final;
     void recordSetInlineStroke(SetInlineStroke&&) final;
     void recordSetState(const GraphicsContextState&) final;
     void recordClearDropShadow() final;
-    void recordClipToImageBuffer(ImageBuffer&, const FloatRect& destinationRect) final;
-    void recordDrawFilteredImageBuffer(ImageBuffer*, const FloatRect& sourceImageRect, Filter&) final;
+    void recordClipToImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destinationRect) final;
+    void recordDrawFilteredImageBuffer(std::optional<RenderingResourceIdentifier> sourceImageIdentifier, const FloatRect& sourceImageRect, Filter&) final;
     void recordDrawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode) final;
     void recordDrawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) final;
-    void recordDrawImageBuffer(ImageBuffer&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) final;
+    void recordDrawImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) final;
     void recordDrawNativeImage(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) final;
     void recordDrawSystemImage(SystemImage&, const FloatRect&) final;
     void recordDrawPattern(RenderingResourceIdentifier, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) final;
@@ -128,12 +130,12 @@ private:
     void recordStrokePath(const Path&) final;
     void recordDrawDisplayListItems(const Vector<Item>&, const FloatPoint& destination) final;
 
-    bool recordResourceUse(NativeImage&) final;
-    bool recordResourceUse(ImageBuffer&) final;
-    bool recordResourceUse(const SourceImage&) final;
+    std::optional<RenderingResourceIdentifier> recordResourceUse(NativeImage&) final;
+    std::optional<RenderingResourceIdentifier> recordResourceUse(ImageBuffer&) final;
+    std::optional<RenderingResourceIdentifier> recordResourceUse(const SourceImage&) final;
+    std::optional<RenderingResourceIdentifier> recordResourceUse(Gradient&) final;
     bool recordResourceUse(Font&) final;
     bool recordResourceUse(DecomposedGlyphs&) final;
-    bool recordResourceUse(Gradient&) final;
     bool recordResourceUse(Filter&) final;
 
     void append(Item&& item)

--- a/Source/WebCore/platform/graphics/filters/DistantLightSource.cpp
+++ b/Source/WebCore/platform/graphics/filters/DistantLightSource.cpp
@@ -47,6 +47,11 @@ DistantLightSource::DistantLightSource(float azimuth, float elevation)
 {
 }
 
+DistantLightSource::DistantLightSource(const DistantLightSource& other)
+    : DistantLightSource(other.m_azimuth, other.m_elevation)
+{
+}
+
 bool DistantLightSource::operator==(const DistantLightSource& other) const
 {
     return LightSource::operator==(other)

--- a/Source/WebCore/platform/graphics/filters/DistantLightSource.h
+++ b/Source/WebCore/platform/graphics/filters/DistantLightSource.h
@@ -50,7 +50,9 @@ public:
 
 private:
     DistantLightSource(float azimuth, float elevation);
+    DistantLightSource(const DistantLightSource&);
 
+    Ref<LightSource> clone() const override { return adoptRef(*new DistantLightSource(*this)); }
     bool operator==(const LightSource& other) const override { return areEqual<DistantLightSource>(*this, other); }
 
     float m_azimuth;

--- a/Source/WebCore/platform/graphics/filters/FEBlend.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEBlend.cpp
@@ -44,6 +44,11 @@ FEBlend::FEBlend(BlendMode mode, DestinationColorSpace colorSpace)
 {
 }
 
+FEBlend::FEBlend(const FEBlend& other)
+    : FEBlend(other.m_mode, other.m_operatingColorSpace)
+{
+}
+
 bool FEBlend::operator==(const FEBlend& other) const
 {
     return FilterEffect::operator==(other) && m_mode == other.m_mode;

--- a/Source/WebCore/platform/graphics/filters/FEBlend.h
+++ b/Source/WebCore/platform/graphics/filters/FEBlend.h
@@ -39,7 +39,9 @@ public:
 
 private:
     FEBlend(BlendMode, DestinationColorSpace);
+    FEBlend(const FEBlend&);
 
+    Ref<FilterFunction> deepClone() const override { return adoptRef(*new FEBlend(*this)); }
     bool operator==(const FilterEffect& other) const override { return areEqual<FEBlend>(*this, other); }
 
     unsigned numberOfEffectInputs() const override { return 2; }

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
@@ -53,6 +53,11 @@ FEColorMatrix::FEColorMatrix(ColorMatrixType type, Vector<float>&& values, Desti
 {
 }
 
+FEColorMatrix::FEColorMatrix(const FEColorMatrix& other)
+    : FEColorMatrix(other.m_type, Vector<float> { other.m_values }, other.m_operatingColorSpace)
+{
+}
+
 bool FEColorMatrix::operator==(const FEColorMatrix& other) const
 {
     return FilterEffect::operator==(other)

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
@@ -53,7 +53,9 @@ public:
 
 private:
     FEColorMatrix(ColorMatrixType, Vector<float>&&, DestinationColorSpace);
+    FEColorMatrix(const FEColorMatrix&);
 
+    Ref<FilterFunction> deepClone() const override { return adoptRef(*new FEColorMatrix(*this)); }
     bool operator==(const FilterEffect& other) const override { return areEqual<FEColorMatrix>(*this, other); }
 
     bool resultIsAlphaImage(const FilterImageVector& inputs) const override;

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
@@ -63,6 +63,11 @@ FEComponentTransfer::FEComponentTransfer(ComponentTransferFunctions&& functions)
 {
 }
 
+FEComponentTransfer::FEComponentTransfer(const FEComponentTransfer& other)
+    : FEComponentTransfer(ComponentTransferFunctions { other.m_functions })
+{
+}
+
 bool FEComponentTransfer::operator==(const FEComponentTransfer& other) const
 {
     return FilterEffect::operator==(other) && m_functions == other.m_functions;

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
@@ -85,7 +85,9 @@ public:
 private:
     FEComponentTransfer(const ComponentTransferFunction& redFunc, const ComponentTransferFunction& greenFunc, const ComponentTransferFunction& blueFunc, const ComponentTransferFunction& alphaFunc, DestinationColorSpace);
     FEComponentTransfer(ComponentTransferFunctions&&);
+    FEComponentTransfer(const FEComponentTransfer&);
 
+    Ref<FilterFunction> deepClone() const override { return adoptRef(*new FEComponentTransfer(*this)); }
     bool operator==(const FilterEffect& other) const override { return areEqual<FEComponentTransfer>(*this, other); }
 
     OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const override;

--- a/Source/WebCore/platform/graphics/filters/FEComposite.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEComposite.cpp
@@ -48,6 +48,11 @@ FEComposite::FEComposite(const CompositeOperationType& type, float k1, float k2,
 {
 }
 
+FEComposite::FEComposite(const FEComposite& other)
+    : FEComposite(other.m_type, other.m_k1, other.m_k2, other.m_k3, other.m_k4, other.m_operatingColorSpace)
+{
+}
+
 bool FEComposite::operator==(const FEComposite& other) const
 {
     return FilterEffect::operator==(other)

--- a/Source/WebCore/platform/graphics/filters/FEComposite.h
+++ b/Source/WebCore/platform/graphics/filters/FEComposite.h
@@ -61,7 +61,9 @@ public:
 
 private:
     FEComposite(const CompositeOperationType&, float k1, float k2, float k3, float k4, DestinationColorSpace);
+    FEComposite(const FEComposite&);
 
+    Ref<FilterFunction> deepClone() const override { return adoptRef(*new FEComposite(*this)); }
     bool operator==(const FilterEffect& other) const override { return areEqual<FEComposite>(*this, other); }
 
     unsigned numberOfEffectInputs() const override { return 2; }

--- a/Source/WebCore/platform/graphics/filters/FEConvolveMatrix.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEConvolveMatrix.cpp
@@ -52,6 +52,11 @@ FEConvolveMatrix::FEConvolveMatrix(const IntSize& kernelSize, float divisor, flo
     ASSERT(IntRect(IntPoint::zero(), kernelSize).contains(targetOffset));
 }
 
+FEConvolveMatrix::FEConvolveMatrix(const FEConvolveMatrix& other)
+    : FEConvolveMatrix(other.m_kernelSize, other.m_divisor, other.m_bias, other.m_targetOffset, other.m_edgeMode, other.m_kernelUnitLength, other.m_preserveAlpha, Vector<float> { other.m_kernelMatrix }, other.m_operatingColorSpace)
+{
+}
+
 bool FEConvolveMatrix::operator==(const FEConvolveMatrix& other) const
 {
     return FilterEffect::operator==(other)

--- a/Source/WebCore/platform/graphics/filters/FEConvolveMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEConvolveMatrix.h
@@ -68,7 +68,9 @@ public:
 
 private:
     FEConvolveMatrix(const IntSize& kernelSize, float divisor, float bias, const IntPoint& targetOffset, EdgeModeType, const FloatPoint& kernelUnitLength, bool preserveAlpha, const Vector<float>& kernelMatrix, DestinationColorSpace);
+    FEConvolveMatrix(const FEConvolveMatrix&);
 
+    Ref<FilterFunction> deepClone() const override { return adoptRef(*new FEConvolveMatrix(*this)); }
     bool operator==(const FilterEffect& other) const override { return areEqual<FEConvolveMatrix>(*this, other); }
 
     FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;

--- a/Source/WebCore/platform/graphics/filters/FEDiffuseLighting.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEDiffuseLighting.cpp
@@ -40,6 +40,11 @@ FEDiffuseLighting::FEDiffuseLighting(const Color& lightingColor, float surfaceSc
 {
 }
 
+FEDiffuseLighting::FEDiffuseLighting(const FEDiffuseLighting& other)
+    : FEDiffuseLighting(other.m_lightingColor, other.m_surfaceScale, other.m_diffuseConstant, other.m_kernelUnitLengthX, other.m_kernelUnitLengthY, other.m_lightSource->clone(), other.m_operatingColorSpace)
+{
+}
+
 bool FEDiffuseLighting::setDiffuseConstant(float diffuseConstant)
 {
     diffuseConstant = std::max(diffuseConstant, 0.0f);

--- a/Source/WebCore/platform/graphics/filters/FEDiffuseLighting.h
+++ b/Source/WebCore/platform/graphics/filters/FEDiffuseLighting.h
@@ -41,7 +41,9 @@ public:
 
 private:
     FEDiffuseLighting(const Color& lightingColor, float surfaceScale, float diffuseConstant, float kernelUnitLengthX, float kernelUnitLengthY, Ref<LightSource>&&, DestinationColorSpace);
+    FEDiffuseLighting(const FEDiffuseLighting&);
 
+    Ref<FilterFunction> deepClone() const override { return adoptRef(*new FEDiffuseLighting(*this)); }
     bool operator==(const FilterEffect& other) const override { return areEqual<FEDiffuseLighting>(*this, other); }
 };
 

--- a/Source/WebCore/platform/graphics/filters/FEDisplacementMap.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEDisplacementMap.cpp
@@ -44,6 +44,11 @@ FEDisplacementMap::FEDisplacementMap(ChannelSelectorType xChannelSelector, Chann
 {
 }
 
+FEDisplacementMap::FEDisplacementMap(const FEDisplacementMap& other)
+    : FEDisplacementMap(other.m_xChannelSelector, other.m_yChannelSelector, other.m_scale, other.m_operatingColorSpace)
+{
+}
+
 bool FEDisplacementMap::operator==(const FEDisplacementMap& other) const
 {
     return FilterEffect::operator==(other)

--- a/Source/WebCore/platform/graphics/filters/FEDisplacementMap.h
+++ b/Source/WebCore/platform/graphics/filters/FEDisplacementMap.h
@@ -52,7 +52,9 @@ public:
 
 private:
     FEDisplacementMap(ChannelSelectorType xChannelSelector, ChannelSelectorType yChannelSelector, float, DestinationColorSpace);
+    FEDisplacementMap(const FEDisplacementMap&);
 
+    Ref<FilterFunction> deepClone() const override { return adoptRef(*new FEDisplacementMap(*this)); }
     bool operator==(const FilterEffect& other) const override { return areEqual<FEDisplacementMap>(*this, other); }
 
     unsigned numberOfEffectInputs() const override { return 2; }

--- a/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
@@ -50,6 +50,11 @@ FEDropShadow::FEDropShadow(float stdX, float stdY, float dx, float dy, const Col
 {
 }
 
+FEDropShadow::FEDropShadow(const FEDropShadow& other)
+    : FEDropShadow(other.m_stdX, other.m_stdY, other.m_dx, other.m_dy, other.m_shadowColor, other.m_shadowOpacity, other.m_operatingColorSpace)
+{
+}
+
 bool FEDropShadow::operator==(const FEDropShadow& other) const
 {
     return FilterEffect::operator==(other)

--- a/Source/WebCore/platform/graphics/filters/FEDropShadow.h
+++ b/Source/WebCore/platform/graphics/filters/FEDropShadow.h
@@ -44,7 +44,7 @@ public:
     bool setDy(float);
 
     const Color& shadowColor() const { return m_shadowColor; } 
-    bool setShadowColor(const Color&);
+    WEBCORE_EXPORT bool setShadowColor(const Color&);
 
     float shadowOpacity() const { return m_shadowOpacity; }
     bool setShadowOpacity(float);
@@ -57,7 +57,9 @@ public:
 
 private:
     FEDropShadow(float stdX, float stdY, float dx, float dy, const Color& shadowColor, float shadowOpacity, DestinationColorSpace);
+    FEDropShadow(const FEDropShadow&);
 
+    Ref<FilterFunction> deepClone() const override { return adoptRef(*new FEDropShadow(*this)); }
     bool operator==(const FilterEffect& other) const override { return areEqual<FEDropShadow>(*this, other); }
 
     FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;

--- a/Source/WebCore/platform/graphics/filters/FEFlood.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEFlood.cpp
@@ -48,6 +48,11 @@ FEFlood::FEFlood(const Color& floodColor, float floodOpacity, DestinationColorSp
 {
 }
 
+FEFlood::FEFlood(const FEFlood& other)
+    : FEFlood(other.m_floodColor, other.m_floodOpacity, other.m_operatingColorSpace)
+{
+}
+
 bool FEFlood::operator==(const FEFlood& other) const
 {
     return FilterEffect::operator==(other)

--- a/Source/WebCore/platform/graphics/filters/FEFlood.h
+++ b/Source/WebCore/platform/graphics/filters/FEFlood.h
@@ -47,7 +47,9 @@ public:
 
 private:
     FEFlood(const Color& floodColor, float floodOpacity, DestinationColorSpace = DestinationColorSpace::SRGB());
+    FEFlood(const FEFlood&);
 
+    Ref<FilterFunction> deepClone() const override { return adoptRef(*new FEFlood(*this)); }
     bool operator==(const FilterEffect& other) const override { return areEqual<FEFlood>(*this, other); }
 
     unsigned numberOfEffectInputs() const override { return 0; }

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
@@ -49,6 +49,11 @@ FEGaussianBlur::FEGaussianBlur(float x, float y, EdgeModeType edgeMode, Destinat
 {
 }
 
+FEGaussianBlur::FEGaussianBlur(const FEGaussianBlur& other)
+    : FEGaussianBlur(other.m_stdX, other.m_stdY, other.m_edgeMode, other.m_operatingColorSpace)
+{
+}
+
 bool FEGaussianBlur::operator==(const FEGaussianBlur& other) const
 {
     return FilterEffect::operator==(other)

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.h
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.h
@@ -50,7 +50,9 @@ public:
 
 private:
     FEGaussianBlur(float x, float y, EdgeModeType, DestinationColorSpace);
+    FEGaussianBlur(const FEGaussianBlur&);
 
+    Ref<FilterFunction> deepClone() const override { return adoptRef(*new FEGaussianBlur(*this)); }
     bool operator==(const FilterEffect& other) const override { return areEqual<FEGaussianBlur>(*this, other); }
 
     FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;

--- a/Source/WebCore/platform/graphics/filters/FEImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEImage.cpp
@@ -43,6 +43,11 @@ FEImage::FEImage(SourceImage&& sourceImage, const FloatRect& sourceImageRect, co
 {
 }
 
+FEImage::FEImage(const FEImage& other)
+    : FEImage(SourceImage { other.m_sourceImage }, other.m_sourceImageRect, other.m_preserveAspectRatio)
+{
+}
+
 bool FEImage::operator==(const FEImage& other) const
 {
     return FilterEffect::operator==(other)

--- a/Source/WebCore/platform/graphics/filters/FEImage.h
+++ b/Source/WebCore/platform/graphics/filters/FEImage.h
@@ -48,7 +48,9 @@ public:
 
 private:
     FEImage(SourceImage&&, const FloatRect& sourceImageRect, const SVGPreserveAspectRatioValue&);
+    FEImage(const FEImage&);
 
+    Ref<FilterFunction> deepClone() const override { return adoptRef(*new FEImage(*this)); }
     bool operator==(const FilterEffect& other) const override { return areEqual<FEImage>(*this, other); }
 
     unsigned numberOfEffectInputs() const override { return 0; }

--- a/Source/WebCore/platform/graphics/filters/FEMerge.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEMerge.cpp
@@ -40,6 +40,11 @@ FEMerge::FEMerge(unsigned numberOfEffectInputs, DestinationColorSpace colorSpace
 {
 }
 
+FEMerge::FEMerge(const FEMerge& other)
+    : FEMerge(other.m_numberOfEffectInputs, other.m_operatingColorSpace)
+{
+}
+
 bool FEMerge::operator==(const FEMerge& other) const
 {
     return FilterEffect::operator==(other) && m_numberOfEffectInputs == other.m_numberOfEffectInputs;

--- a/Source/WebCore/platform/graphics/filters/FEMerge.h
+++ b/Source/WebCore/platform/graphics/filters/FEMerge.h
@@ -36,7 +36,9 @@ public:
 
 private:
     FEMerge(unsigned numberOfEffectInputs, DestinationColorSpace);
+    FEMerge(const FEMerge&);
 
+    Ref<FilterFunction> deepClone() const override { return adoptRef(*new FEMerge(*this)); }
     bool operator==(const FilterEffect& other) const override { return areEqual<FEMerge>(*this, other); }
 
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;

--- a/Source/WebCore/platform/graphics/filters/FEMorphology.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEMorphology.cpp
@@ -45,6 +45,11 @@ FEMorphology::FEMorphology(MorphologyOperatorType type, float radiusX, float rad
 {
 }
 
+FEMorphology::FEMorphology(const FEMorphology& other)
+    : FEMorphology(other.m_type, other.m_radiusX, other.m_radiusY, other.m_operatingColorSpace)
+{
+}
+
 bool FEMorphology::operator==(const FEMorphology& other) const
 {
     return FilterEffect::operator==(other)

--- a/Source/WebCore/platform/graphics/filters/FEMorphology.h
+++ b/Source/WebCore/platform/graphics/filters/FEMorphology.h
@@ -49,7 +49,9 @@ public:
 
 private:
     FEMorphology(MorphologyOperatorType, float radiusX, float radiusY, DestinationColorSpace);
+    FEMorphology(const FEMorphology&);
 
+    Ref<FilterFunction> deepClone() const override { return adoptRef(*new FEMorphology(*this)); }
     bool operator==(const FilterEffect& other) const override { return areEqual<FEMorphology>(*this, other); }
 
     FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;

--- a/Source/WebCore/platform/graphics/filters/FEOffset.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEOffset.cpp
@@ -43,6 +43,11 @@ FEOffset::FEOffset(float dx, float dy, DestinationColorSpace colorSpace)
 {
 }
 
+FEOffset::FEOffset(const FEOffset& other)
+    : FEOffset(other.m_dx, other.m_dy, other.m_operatingColorSpace)
+{
+}
+
 bool FEOffset::operator==(const FEOffset& other) const
 {
     return FilterEffect::operator==(other)

--- a/Source/WebCore/platform/graphics/filters/FEOffset.h
+++ b/Source/WebCore/platform/graphics/filters/FEOffset.h
@@ -42,7 +42,9 @@ public:
 
 private:
     FEOffset(float dx, float dy, DestinationColorSpace);
+    FEOffset(const FEOffset&);
 
+    Ref<FilterFunction> deepClone() const override { return adoptRef(*new FEOffset(*this)); }
     bool operator==(const FilterEffect& other) const override { return areEqual<FEOffset>(*this, other); }
 
     FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;

--- a/Source/WebCore/platform/graphics/filters/FESpecularLighting.cpp
+++ b/Source/WebCore/platform/graphics/filters/FESpecularLighting.cpp
@@ -40,6 +40,11 @@ FESpecularLighting::FESpecularLighting(const Color& lightingColor, float surface
 {
 }
 
+FESpecularLighting::FESpecularLighting(const FESpecularLighting& other)
+    : FESpecularLighting(other.m_lightingColor, other.m_surfaceScale, other.m_specularConstant, other.m_specularExponent, other.m_kernelUnitLengthX, other.m_kernelUnitLengthY, other.m_lightSource->clone(), other.m_operatingColorSpace)
+{
+}
+
 bool FESpecularLighting::setSpecularConstant(float specularConstant)
 {
     specularConstant = std::max(specularConstant, 0.0f);

--- a/Source/WebCore/platform/graphics/filters/FESpecularLighting.h
+++ b/Source/WebCore/platform/graphics/filters/FESpecularLighting.h
@@ -42,7 +42,9 @@ public:
 
 private:
     FESpecularLighting(const Color& lightingColor, float surfaceScale, float specularConstant, float specularExponent, float kernelUnitLengthX, float kernelUnitLengthY, Ref<LightSource>&&, DestinationColorSpace);
+    FESpecularLighting(const FESpecularLighting&);
 
+    Ref<FilterFunction> deepClone() const override { return adoptRef(*new FESpecularLighting(*this)); }
     bool operator==(const FilterEffect& other) const override { return areEqual<FESpecularLighting>(*this, other); }
 };
 

--- a/Source/WebCore/platform/graphics/filters/FETile.h
+++ b/Source/WebCore/platform/graphics/filters/FETile.h
@@ -33,6 +33,8 @@ public:
 private:
     explicit FETile(DestinationColorSpace);
 
+    Ref<FilterFunction> deepClone() const override { return Ref { const_cast<FETile&>(*this) }; }
+
     FloatRect calculateImageRect(const Filter&, std::span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;
 
     bool resultIsAlphaImage(const FilterImageVector& inputs) const override;

--- a/Source/WebCore/platform/graphics/filters/FETurbulence.cpp
+++ b/Source/WebCore/platform/graphics/filters/FETurbulence.cpp
@@ -48,6 +48,11 @@ FETurbulence::FETurbulence(TurbulenceType type, float baseFrequencyX, float base
 {
 }
 
+FETurbulence::FETurbulence(const FETurbulence& other)
+    : FETurbulence(other.m_type, other.m_baseFrequencyX, other.m_baseFrequencyY, other.m_numOctaves, other.m_seed, other.m_stitchTiles, other.m_operatingColorSpace)
+{
+}
+
 bool FETurbulence::operator==(const FETurbulence& other) const
 {
     return FilterEffect::operator==(other)

--- a/Source/WebCore/platform/graphics/filters/FETurbulence.h
+++ b/Source/WebCore/platform/graphics/filters/FETurbulence.h
@@ -61,7 +61,9 @@ public:
 
 private:
     FETurbulence(TurbulenceType, float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed, bool stitchTiles, DestinationColorSpace);
+    FETurbulence(const FETurbulence&);
 
+    Ref<FilterFunction> deepClone() const override { return adoptRef(*new FETurbulence(*this)); }
     bool operator==(const FilterEffect& other) const override { return areEqual<FETurbulence>(*this, other); }
 
     unsigned numberOfEffectInputs() const override { return 0; }

--- a/Source/WebCore/platform/graphics/filters/Filter.h
+++ b/Source/WebCore/platform/graphics/filters/Filter.h
@@ -40,6 +40,8 @@ class Filter : public FilterFunction {
     using FilterFunction::createFilterStyles;
 
 public:
+    Ref<Filter> clone() const { return downcast<Filter>(deepClone()); }
+
     RenderingMode renderingMode() const;
 
     OptionSet<FilterRenderingMode> filterRenderingModes() const { return m_filterRenderingModes; }

--- a/Source/WebCore/platform/graphics/filters/FilterFunction.h
+++ b/Source/WebCore/platform/graphics/filters/FilterFunction.h
@@ -81,6 +81,8 @@ public:
     FilterFunction(Type, std::optional<RenderingResourceIdentifier> = std::nullopt);
     virtual ~FilterFunction() = default;
 
+    virtual Ref<FilterFunction> deepClone() const = 0;
+
     Type filterType() const { return m_filterType; }
 
     bool isCSSFilter() const { return m_filterType == Type::CSSFilter; }

--- a/Source/WebCore/platform/graphics/filters/LightSource.h
+++ b/Source/WebCore/platform/graphics/filters/LightSource.h
@@ -64,6 +64,8 @@ public:
 
     virtual ~LightSource() = default;
 
+    virtual Ref<LightSource> clone() const = 0;
+
     virtual bool operator==(const LightSource& other) const
     {
         return m_type == other.m_type;

--- a/Source/WebCore/platform/graphics/filters/PointLightSource.cpp
+++ b/Source/WebCore/platform/graphics/filters/PointLightSource.cpp
@@ -49,6 +49,11 @@ PointLightSource::PointLightSource(const FloatPoint3D& position)
 {
 }
 
+PointLightSource::PointLightSource(const PointLightSource& other)
+    : PointLightSource(other.m_position)
+{
+}
+
 bool PointLightSource::operator==(const PointLightSource& other) const
 {
     return LightSource::operator==(other) && m_position == other.m_position;

--- a/Source/WebCore/platform/graphics/filters/PointLightSource.h
+++ b/Source/WebCore/platform/graphics/filters/PointLightSource.h
@@ -46,7 +46,9 @@ public:
 
 private:
     PointLightSource(const FloatPoint3D& position);
+    PointLightSource(const PointLightSource&);
 
+    Ref<LightSource> clone() const override { return adoptRef(*new PointLightSource(*this)); }
     bool operator==(const LightSource& other) const override { return areEqual<PointLightSource>(*this, other); }
 
     FloatPoint3D m_position;

--- a/Source/WebCore/platform/graphics/filters/SourceAlpha.h
+++ b/Source/WebCore/platform/graphics/filters/SourceAlpha.h
@@ -33,6 +33,8 @@ public:
 private:
     explicit SourceAlpha(DestinationColorSpace);
 
+    Ref<FilterFunction> deepClone() const override { return Ref { const_cast<SourceAlpha&>(*this) }; }
+
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const override;

--- a/Source/WebCore/platform/graphics/filters/SourceGraphic.h
+++ b/Source/WebCore/platform/graphics/filters/SourceGraphic.h
@@ -34,6 +34,8 @@ public:
 private:
     explicit SourceGraphic(DestinationColorSpace);
 
+    Ref<FilterFunction> deepClone() const override { return Ref { const_cast<SourceGraphic&>(*this) }; }
+
     unsigned numberOfEffectInputs() const override { return 0; }
 
     OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const override;

--- a/Source/WebCore/platform/graphics/filters/SpotLightSource.cpp
+++ b/Source/WebCore/platform/graphics/filters/SpotLightSource.cpp
@@ -58,6 +58,11 @@ SpotLightSource::SpotLightSource(const FloatPoint3D& position, const FloatPoint3
 {
 }
 
+SpotLightSource::SpotLightSource(const SpotLightSource& other)
+    : SpotLightSource(other.m_position, other.m_pointsAt, other.m_specularExponent, other.m_limitingConeAngle)
+{
+}
+
 bool SpotLightSource::operator==(const SpotLightSource& other) const
 {
     return LightSource::operator==(other)

--- a/Source/WebCore/platform/graphics/filters/SpotLightSource.h
+++ b/Source/WebCore/platform/graphics/filters/SpotLightSource.h
@@ -56,7 +56,9 @@ public:
 
 private:
     SpotLightSource(const FloatPoint3D& position, const FloatPoint3D& direction, float specularExponent, float limitingConeAngle);
+    SpotLightSource(const SpotLightSource&);
 
+    Ref<LightSource> clone() const override { return adoptRef(*new SpotLightSource(*this)); }
     bool operator==(const LightSource& other) const override { return areEqual<SpotLightSource>(*this, other); }
 
     FloatPoint3D m_position;

--- a/Source/WebCore/rendering/CSSFilter.cpp
+++ b/Source/WebCore/rendering/CSSFilter.cpp
@@ -63,11 +63,6 @@ RefPtr<CSSFilter> CSSFilter::create(RenderElement& renderer, const FilterOperati
     return filter;
 }
 
-Ref<CSSFilter> CSSFilter::create(Vector<Ref<FilterFunction>>&& functions)
-{
-    return adoptRef(*new CSSFilter(WTFMove(functions)));
-}
-
 Ref<CSSFilter> CSSFilter::create(Vector<Ref<FilterFunction>>&& functions, OptionSet<FilterRenderingMode> filterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion)
 {
     Ref filter = adoptRef(*new CSSFilter(WTFMove(functions), filterScale, filterRegion));
@@ -84,17 +79,26 @@ CSSFilter::CSSFilter(const FloatSize& filterScale, bool hasFilterThatMovesPixels
 {
 }
 
-CSSFilter::CSSFilter(Vector<Ref<FilterFunction>>&& functions)
-    : Filter(Type::CSSFilter)
-    , m_functions(WTFMove(functions))
-{
-}
-
 CSSFilter::CSSFilter(Vector<Ref<FilterFunction>>&& functions, const FloatSize& filterScale, const FloatRect& filterRegion)
     : Filter(Type::CSSFilter, filterScale, filterRegion)
     , m_functions(WTFMove(functions))
 {
     clampFilterRegionIfNeeded();
+}
+
+Ref<FilterFunction> CSSFilter::deepClone() const
+{
+    Vector<Ref<FilterFunction>> functions;
+
+    for (auto& function : m_functions)
+        functions.append(function->deepClone());
+
+    Ref filter = CSSFilter::create(WTFMove(functions), filterRenderingModes(), filterScale(), filterRegion());
+
+    filter->m_hasFilterThatMovesPixels = m_hasFilterThatMovesPixels;
+    filter->m_hasFilterThatShouldBeRestrictedBySecurityOrigin = m_hasFilterThatShouldBeRestrictedBySecurityOrigin;
+
+    return filter;
 }
 
 static RefPtr<FilterEffect> createBlurEffect(const BlurFilterOperation& blurOperation)

--- a/Source/WebCore/rendering/CSSFilter.h
+++ b/Source/WebCore/rendering/CSSFilter.h
@@ -39,7 +39,6 @@ class CSSFilter final : public Filter {
     WTF_MAKE_TZONE_ALLOCATED(CSSFilter);
 public:
     static RefPtr<CSSFilter> create(RenderElement&, const FilterOperations&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
-    WEBCORE_EXPORT static Ref<CSSFilter> create(Vector<Ref<FilterFunction>>&&);
     WEBCORE_EXPORT static Ref<CSSFilter> create(Vector<Ref<FilterFunction>>&&, OptionSet<FilterRenderingMode>, const FloatSize& filterScale, const FloatRect& filterRegion);
 
     const Vector<Ref<FilterFunction>>& functions() const { return m_functions; }
@@ -59,8 +58,9 @@ public:
 
 private:
     CSSFilter(const FloatSize& filterScale, bool hasFilterThatMovesPixels, bool hasFilterThatShouldBeRestrictedBySecurityOrigin);
-    CSSFilter(Vector<Ref<FilterFunction>>&&);
     CSSFilter(Vector<Ref<FilterFunction>>&&, const FloatSize& filterScale, const FloatRect& filterRegion);
+
+    Ref<FilterFunction> deepClone() const final;
 
     bool buildFilterFunctions(RenderElement&, const FilterOperations&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
 

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -94,6 +94,16 @@ SVGFilter::SVGFilter(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitTy
 {
 }
 
+Ref<FilterFunction> SVGFilter::deepClone() const
+{
+    FilterEffectVector effects;
+
+    for (auto& effect : m_effects)
+        effects.append(downcast<FilterEffect>(effect->deepClone()));
+
+    return SVGFilter::create(m_targetBoundingBox, m_primitiveUnits, SVGFilterExpression { m_expression }, WTFMove(effects), std::nullopt, filterRenderingModes(), filterScale(), filterRegion());
+}
+
 static std::optional<std::tuple<SVGFilterEffectsGraph, FilterEffectGeometryMap>> buildFilterEffectsGraph(SVGFilterElement& filterElement, const SVGFilter& filter, const GraphicsContext& destinationContext)
 {
     if (filterElement.countChildNodes() > maxCountChildNodes)

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.h
@@ -68,6 +68,8 @@ private:
     SVGFilter(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, FilterEffectVector&&, std::optional<RenderingResourceIdentifier>);
     SVGFilter(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, FilterEffectVector&&, std::optional<RenderingResourceIdentifier>, const FloatSize& filterScale, const FloatRect& filterRegion);
 
+    Ref<FilterFunction> deepClone() const final;
+
     static std::optional<std::tuple<SVGFilterExpression, FilterEffectVector>> buildExpression(SVGFilterElement&, const SVGFilter&, const GraphicsContext& destinationContext);
     void setExpression(SVGFilterExpression&& expression) { m_expression = WTFMove(expression); }
     void setEffects(FilterEffectVector&& effects) { m_effects = WTFMove(effects); }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -38,6 +38,7 @@
 #include <WebCore/DisplayList.h>
 #include <WebCore/DisplayListDrawingContext.h>
 #include <WebCore/DisplayListItems.h>
+#include <WebCore/FEImage.h>
 #include <WebCore/Filter.h>
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/ImageBuffer.h>
@@ -222,9 +223,9 @@ void RemoteDisplayListRecorderProxy::clipOutRoundedRect(const FloatRoundedRect& 
     send(Messages::RemoteDisplayListRecorder::ClipOutRoundedRect(rect));
 }
 
-void RemoteDisplayListRecorderProxy::recordClipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destinationRect)
+void RemoteDisplayListRecorderProxy::recordClipToImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destinationRect)
 {
-    send(Messages::RemoteDisplayListRecorder::ClipToImageBuffer(imageBuffer.renderingResourceIdentifier(), destinationRect));
+    send(Messages::RemoteDisplayListRecorder::ClipToImageBuffer(imageBufferIdentifier, destinationRect));
 }
 
 void RemoteDisplayListRecorderProxy::clipOut(const Path& path)
@@ -246,17 +247,13 @@ void RemoteDisplayListRecorderProxy::resetClip()
     clip(initialClip());
 }
 
-void RemoteDisplayListRecorderProxy::recordDrawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter)
+void RemoteDisplayListRecorderProxy::recordDrawFilteredImageBuffer(std::optional<RenderingResourceIdentifier> sourceImageIdentifier, const FloatRect& sourceImageRect, Filter& filter)
 {
-    std::optional<RenderingResourceIdentifier> identifier;
-    if (sourceImage)
-        identifier = sourceImage->renderingResourceIdentifier();
-
     auto* svgFilter = dynamicDowncast<SVGFilter>(filter);
     if (svgFilter && svgFilter->hasValidRenderingResourceIdentifier())
         recordResourceUse(filter);
 
-    send(Messages::RemoteDisplayListRecorder::DrawFilteredImageBuffer(WTFMove(identifier), sourceImageRect, filter));
+    send(Messages::RemoteDisplayListRecorder::DrawFilteredImageBuffer(WTFMove(sourceImageIdentifier), sourceImageRect, filter));
 }
 
 void RemoteDisplayListRecorderProxy::recordDrawGlyphs(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode mode)
@@ -274,9 +271,9 @@ void RemoteDisplayListRecorderProxy::recordDrawDisplayListItems(const Vector<Dis
     send(Messages::RemoteDisplayListRecorder::DrawDisplayListItems(items, destination));
 }
 
-void RemoteDisplayListRecorderProxy::recordDrawImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
+void RemoteDisplayListRecorderProxy::recordDrawImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
-    send(Messages::RemoteDisplayListRecorder::DrawImageBuffer(imageBuffer.renderingResourceIdentifier(), destRect, srcRect, options));
+    send(Messages::RemoteDisplayListRecorder::DrawImageBuffer(imageBufferIdentifier, destRect, srcRect, options));
 }
 
 void RemoteDisplayListRecorderProxy::recordDrawNativeImage(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
@@ -570,33 +567,33 @@ void RemoteDisplayListRecorderProxy::endPage()
     send(Messages::RemoteDisplayListRecorder::EndPage());
 }
 
-bool RemoteDisplayListRecorderProxy::recordResourceUse(NativeImage& image)
+std::optional<RenderingResourceIdentifier> RemoteDisplayListRecorderProxy::recordResourceUse(NativeImage& image)
 {
     if (UNLIKELY(!m_renderingBackend)) {
         ASSERT_NOT_REACHED();
-        return false;
+        return std::nullopt;
     }
 
     m_renderingBackend->remoteResourceCacheProxy().recordNativeImageUse(image);
-    return true;
+    return image.renderingResourceIdentifier();
 }
 
-bool RemoteDisplayListRecorderProxy::recordResourceUse(ImageBuffer& imageBuffer)
+std::optional<RenderingResourceIdentifier> RemoteDisplayListRecorderProxy::recordResourceUse(ImageBuffer& imageBuffer)
 {
     RefPtr renderingBackend = m_renderingBackend.get();
     if (UNLIKELY(!renderingBackend)) {
         ASSERT_NOT_REACHED();
-        return false;
+        return std::nullopt;
     }
 
     if (!renderingBackend->isCached(imageBuffer))
-        return false;
+        return std::nullopt;
 
     renderingBackend->remoteResourceCacheProxy().recordImageBufferUse(imageBuffer);
-    return true;
+    return imageBuffer.renderingResourceIdentifier();
 }
 
-bool RemoteDisplayListRecorderProxy::recordResourceUse(const SourceImage& image)
+std::optional<RenderingResourceIdentifier> RemoteDisplayListRecorderProxy::recordResourceUse(const SourceImage& image)
 {
     if (RefPtr imageBuffer = image.imageBufferIfExists())
         return recordResourceUse(*imageBuffer);
@@ -604,7 +601,18 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(const SourceImage& image)
     if (RefPtr nativeImage = image.nativeImageIfExists())
         return recordResourceUse(*nativeImage);
 
-    return true;
+    return std::nullopt;
+}
+
+std::optional<RenderingResourceIdentifier> RemoteDisplayListRecorderProxy::recordResourceUse(Gradient& gradient)
+{
+    if (UNLIKELY(!m_renderingBackend)) {
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
+
+    m_renderingBackend->remoteResourceCacheProxy().recordGradientUse(gradient);
+    return gradient.renderingResourceIdentifier();
 }
 
 bool RemoteDisplayListRecorderProxy::recordResourceUse(Font& font)
@@ -626,17 +634,6 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(DecomposedGlyphs& decompo
     }
 
     m_renderingBackend->remoteResourceCacheProxy().recordDecomposedGlyphsUse(decomposedGlyphs);
-    return true;
-}
-
-bool RemoteDisplayListRecorderProxy::recordResourceUse(Gradient& gradient)
-{
-    if (UNLIKELY(!m_renderingBackend)) {
-        ASSERT_NOT_REACHED();
-        return false;
-    }
-
-    m_renderingBackend->remoteResourceCacheProxy().recordGradientUse(gradient);
     return true;
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -122,12 +122,12 @@ private:
     void recordSetInlineStroke(WebCore::DisplayList::SetInlineStroke&&) final;
     void recordSetState(const WebCore::GraphicsContextState&) final;
     void recordClearDropShadow() final;
-    void recordClipToImageBuffer(WebCore::ImageBuffer&, const WebCore::FloatRect& destinationRect) final;
-    void recordDrawFilteredImageBuffer(WebCore::ImageBuffer*, const WebCore::FloatRect& sourceImageRect, WebCore::Filter&) final;
+    void recordClipToImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, const WebCore::FloatRect& destinationRect) final;
+    void recordDrawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, WebCore::Filter&) final;
     void recordDrawGlyphs(const WebCore::Font&, const WebCore::GlyphBufferGlyph*, const WebCore::GlyphBufferAdvance*, unsigned count, const WebCore::FloatPoint& localAnchor, WebCore::FontSmoothingMode) final;
     void recordDrawDecomposedGlyphs(const WebCore::Font&, const WebCore::DecomposedGlyphs&) final;
     void recordDrawDisplayListItems(const Vector<WebCore::DisplayList::Item>&, const WebCore::FloatPoint& destination);
-    void recordDrawImageBuffer(WebCore::ImageBuffer&, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions) final;
+    void recordDrawImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions) final;
     void recordDrawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions) final;
     void recordDrawSystemImage(WebCore::SystemImage&, const WebCore::FloatRect&);
     void recordDrawPattern(WebCore::RenderingResourceIdentifier, const WebCore::FloatRect& destRect, const WebCore::FloatRect& tileRect, const WebCore::AffineTransform&, const WebCore::FloatPoint& phase, const WebCore::FloatSize& spacing, WebCore::ImagePaintingOptions = { }) final;
@@ -151,12 +151,12 @@ private:
     void recordStrokePathSegment(const WebCore::PathSegment&) final;
     void recordStrokePath(const WebCore::Path&) final;
 
-    bool recordResourceUse(WebCore::NativeImage&) final;
-    bool recordResourceUse(WebCore::ImageBuffer&) final;
-    bool recordResourceUse(const WebCore::SourceImage&) final;
+    std::optional<WebCore::RenderingResourceIdentifier> recordResourceUse(WebCore::NativeImage&) final;
+    std::optional<WebCore::RenderingResourceIdentifier> recordResourceUse(WebCore::ImageBuffer&) final;
+    std::optional<WebCore::RenderingResourceIdentifier> recordResourceUse(const WebCore::SourceImage&) final;
+    std::optional<WebCore::RenderingResourceIdentifier> recordResourceUse(WebCore::Gradient&) final;
     bool recordResourceUse(WebCore::Font&) final;
     bool recordResourceUse(WebCore::DecomposedGlyphs&) final;
-    bool recordResourceUse(WebCore::Gradient&) final;
     bool recordResourceUse(WebCore::Filter&) final;
 
     RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, float resolutionScale, const WebCore::DestinationColorSpace&, std::optional<WebCore::RenderingMode>, std::optional<WebCore::RenderingMethod>) const final;

--- a/Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp
@@ -27,10 +27,17 @@
 
 #include "Test.h"
 #include "WebCoreTestUtilities.h"
+#include <WebCore/CSSFilter.h>
 #include <WebCore/Color.h>
+#include <WebCore/DisplayListDrawingContext.h>
+#include <WebCore/FEDropShadow.h>
+#include <WebCore/FEImage.h>
+#include <WebCore/FilterResults.h>
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/PixelBuffer.h>
+#include <WebCore/SVGFilter.h>
+#include <WebCore/SourceGraphic.h>
 #include <cmath>
 #include <type_traits>
 #include <wtf/MemoryFootprint.h>
@@ -233,6 +240,334 @@ TEST(ImageBufferTests, DISABLED_DrawImageBufferDoesNotReferenceExtraMemory)
     unaccelerated = nullptr;
     lastFootprint = initialFootprint;
     EXPECT_TRUE(memoryFootprintChangedBy(lastFootprint, 0, footprintError));
+}
+
+// This test records setFillGradient to a DisplayList. Before replaying back the
+// DisplayList, the Gradient is altered. The expectation is the DisplayList keeps
+// references only to immutable Gradient.
+TEST(ImageBufferTests, DisplayListSetFillGradient)
+{
+    auto colorSpace = DestinationColorSpace::SRGB();
+    auto pixelFormat = ImageBufferPixelFormat::BGRA8;
+    FloatSize destinationSize { 100, 100 };
+    float scale = 1;
+
+    RefPtr destination = ImageBuffer::create(destinationSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+
+    auto destinationRect = FloatRect { { }, destinationSize };
+
+    auto gradient = Gradient::create(Gradient::LinearData { destinationRect.minXMinYCorner(), destinationRect.maxXMaxYCorner() },
+        { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied },
+        GradientSpreadMethod::Pad,
+        { },
+        RenderingResourceIdentifier::generate());
+
+    gradient->addColorStop({ 0.0f, Color::green });
+    gradient->addColorStop({ 1.0f, Color::green });
+
+    DisplayList::DrawingContext drawingContext(destinationSize);
+    drawingContext.context().setFillGradient(Ref { gradient });
+    drawingContext.context().fillRect(destinationRect);
+
+    // Mutating the pattern tileImage should not affect the DisplayList drawing.
+    gradient->addColorStop({ 0.0f, Color::red });
+    gradient->addColorStop({ 1.0f, Color::red });
+
+    // The DisplayList should have cloned the gradient when recording drawImageBuffer().
+    drawingContext.replayDisplayList(destination->context());
+
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, destinationRect.x() + 1, destinationRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, destinationRect.maxX() - 1, destinationRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, destinationRect.x() + 1, destinationRect.maxY() - 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, destinationRect.maxX() - 1, destinationRect.maxY() - 1));
+}
+
+// This test records setFillPattern to a DisplayList. Before replaying back the
+// DisplayList, the tileImage of the Pattern is altered. The expectation is the
+// DisplayList keeps references only to immutable ImageBuffers.
+TEST(ImageBufferTests, DisplayListSetFillPattern)
+{
+    auto colorSpace = DestinationColorSpace::SRGB();
+    auto pixelFormat = ImageBufferPixelFormat::BGRA8;
+    FloatSize patternSize { 100, 100 };
+    FloatSize destinationSize { 100, 100 };
+    float scale = 1;
+
+    RefPtr patternSource = ImageBuffer::create(patternSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+    RefPtr destination = ImageBuffer::create(destinationSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+
+    auto patternRect = FloatRect { { }, patternSize };
+    patternSource->context().fillRect(patternRect, Color::green);
+
+    DisplayList::DrawingContext drawingContext(destinationSize);
+    drawingContext.context().setFillPattern(Pattern::create({ Ref { *patternSource } }));
+
+    auto destinationRect = FloatRect { { }, destinationSize };
+    drawingContext.context().fillRect(destinationRect);
+
+    // Mutating the pattern tileImage should not affect the DisplayList drawing.
+    patternSource->context().fillRect(destinationRect, Color::red);
+
+    // The DisplayList should have cloned the patternSource ImageBuffer when recording drawImageBuffer().
+    drawingContext.replayDisplayList(destination->context());
+
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, destinationRect.x() + 1, destinationRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, destinationRect.maxX() - 1, destinationRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, destinationRect.x() + 1, destinationRect.maxY() - 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, destinationRect.maxX() - 1, destinationRect.maxY() - 1));
+}
+
+// This test records drawImageBuffer to a DisplayList. Before replaying back the
+// DisplayList, the ImageBuffer is altered. The expectation is the DisplayList
+// keeps references only to immutable ImageBuffers.
+TEST(ImageBufferTests, DisplayListDrawImageBuffer)
+{
+    auto colorSpace = DestinationColorSpace::SRGB();
+    auto pixelFormat = ImageBufferPixelFormat::BGRA8;
+    FloatSize logicalSize { 4096, 4096 };
+    float scale = 1;
+
+    RefPtr source1 = ImageBuffer::create(logicalSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+    RefPtr source2 = ImageBuffer::create(logicalSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+    RefPtr source3 = ImageBuffer::create(logicalSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+    RefPtr destination = ImageBuffer::create(logicalSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+
+    auto redRect = FloatRect { { }, logicalSize };
+    source1->context().fillRect(redRect, Color::red);
+
+    auto greenRatio = 0.5;
+    auto greenRect = FloatRect { FloatPoint { logicalSize.scaled((1 - greenRatio) / 2) }, logicalSize.scaled(greenRatio) };
+    source2->context().fillRect(greenRect, Color::green);
+
+    auto blueRatio = 0.25;
+    auto blueRect = FloatRect { FloatPoint { logicalSize.scaled((1 - blueRatio) / 2) }, logicalSize.scaled(blueRatio) };
+    source3->context().fillRect(blueRect, Color::blue);
+
+    DisplayList::DrawingContext drawingContext(logicalSize);
+    drawingContext.context().drawImageBuffer(*source1, FloatPoint());
+    drawingContext.context().drawImageBuffer(*source2, FloatPoint());
+    drawingContext.context().drawImageBuffer(*source3, FloatPoint());
+
+    // Mutating the ImageBuffers should not affect the DisplayList drawing.
+    source1->context().fillRect(redRect, Color::black);
+    source2->context().fillRect(redRect, Color::black);
+    source3->context().fillRect(redRect, Color::black);
+
+    // The DisplayList should have cloned the source ImageBuffers when recording drawImageBuffer().
+    drawingContext.replayDisplayList(destination->context());
+
+    EXPECT_TRUE(imageBufferPixelIs(Color::red, *destination, redRect.x() + 1, redRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::red, *destination, redRect.maxX() - 1, redRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::red, *destination, redRect.x() + 1, redRect.maxY() - 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::red, *destination, redRect.maxX() - 1, redRect.maxY() - 1));
+
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, greenRect.x() + 1, greenRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, greenRect.maxX() - 1, greenRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, greenRect.x() + 1, greenRect.maxY() - 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, greenRect.maxX() - 1, greenRect.maxY() - 1));
+
+    EXPECT_TRUE(imageBufferPixelIs(Color::blue, *destination, blueRect.x() + 1, blueRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::blue, *destination, blueRect.maxX() - 1, blueRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::blue, *destination, blueRect.x() + 1, blueRect.maxY() - 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::blue, *destination, blueRect.maxX() - 1, blueRect.maxY() - 1));
+}
+
+// This test records drawFilteredImageBuffer to a DisplayList. Before replaying back
+// the DisplayList, the sourceImage of the Filter is altered. The expectation is the
+// DisplayList keeps references only to immutable ImageBuffers.
+TEST(ImageBufferTests, DisplayListDrawFilteredImageBufferSourceImage)
+{
+    auto colorSpace = DestinationColorSpace::SRGB();
+    auto pixelFormat = ImageBufferPixelFormat::BGRA8;
+    FloatSize sourceSize { 100, 100 };
+    FloatSize destinationSize { 200, 100 };
+    float scale = 1;
+
+    RefPtr source = ImageBuffer::create(sourceSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+    RefPtr destination = ImageBuffer::create(destinationSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+
+    auto greenRect = FloatRect { { }, sourceSize };
+    source->context().fillRect(greenRect, Color::green);
+
+    Vector<Ref<FilterFunction>> functions;
+    functions.append(SourceGraphic::create());
+    functions.append(FEDropShadow::create(0, 0, 100, 0, Color::blue, 1));
+
+    auto filterRegion = FloatRect { { }, destinationSize };
+    RefPtr filter = CSSFilter::create(WTFMove(functions), FilterRenderingMode::Software, { 1, 1 }, filterRegion);
+
+    DisplayList::DrawingContext drawingContext(destinationSize);
+
+    FilterResults results;
+    drawingContext.context().drawFilteredImageBuffer(source.get(), greenRect, *filter, results);
+
+    // Mutating the ImageBuffers should not affect the DisplayList drawing.
+    auto redRect = FloatRect { { }, sourceSize };
+    source->context().fillRect(redRect, Color::red);
+
+    // The DisplayList should have cloned the source ImageBuffer when recording drawImageBuffer().
+    drawingContext.replayDisplayList(destination->context());
+
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, filterRegion.x() + 1, filterRegion.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::blue, *destination, filterRegion.maxX() - 1, filterRegion.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, filterRegion.x() + 1, filterRegion.maxY() - 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::blue, *destination, filterRegion.maxX() - 1, filterRegion.maxY() - 1));
+}
+
+// This test records drawFilteredImageBuffer to a DisplayList. Before replaying back
+// the DisplayList, the Filter is altered. The expectation is the DisplayList keeps
+// references only to immutable Filters.
+TEST(ImageBufferTests, DisplayListDrawFilteredImageBufferFilter)
+{
+    auto colorSpace = DestinationColorSpace::SRGB();
+    auto pixelFormat = ImageBufferPixelFormat::BGRA8;
+    FloatSize sourceSize { 100, 100 };
+    FloatSize destinationSize { 200, 100 };
+    float scale = 1;
+
+    RefPtr source = ImageBuffer::create(sourceSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+    RefPtr destination = ImageBuffer::create(destinationSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+
+    auto greenRect = FloatRect { { }, sourceSize };
+    source->context().fillRect(greenRect, Color::green);
+
+    Vector<Ref<FilterFunction>> functions;
+    functions.append(SourceGraphic::create());
+
+    Ref dropShadow = FEDropShadow::create(0, 0, 100, 0, Color::blue, 1);
+    functions.append(Ref { dropShadow });
+
+    auto filterRegion = FloatRect { { }, destinationSize };
+    RefPtr filter = CSSFilter::create(WTFMove(functions), FilterRenderingMode::Software, { 1, 1 }, filterRegion);
+
+    DisplayList::DrawingContext drawingContext(destinationSize);
+
+    FilterResults results;
+    drawingContext.context().drawFilteredImageBuffer(source.get(), greenRect, *filter, results);
+
+    // Mutating the filter should not affect the DisplayList drawing.
+    dropShadow->setShadowColor(Color::red);
+
+    // The DisplayList should have cloned the filter when recording drawImageBuffer().
+    drawingContext.replayDisplayList(destination->context());
+
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, filterRegion.x() + 1, filterRegion.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::blue, *destination, filterRegion.maxX() - 1, filterRegion.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, filterRegion.x() + 1, filterRegion.maxY() - 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::blue, *destination, filterRegion.maxX() - 1, filterRegion.maxY() - 1));
+}
+
+// This test records drawFilteredImageBuffer to a DisplayList. Before replaying
+// back the DisplayList, the SourceImage of an FEImage in the Filter is altered.
+// The expectation is the DisplayList keeps references only to immutable Filters.
+TEST(ImageBufferTests, DisplayListDrawFilteredImageBufferFEImage)
+{
+    auto colorSpace = DestinationColorSpace::SRGB();
+    auto pixelFormat = ImageBufferPixelFormat::BGRA8;
+    FloatSize logicalSize { 100, 100 };
+    float scale = 1;
+
+    RefPtr source = ImageBuffer::create(logicalSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+    RefPtr destination = ImageBuffer::create(logicalSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+
+    auto fillRect = FloatRect { { }, logicalSize };
+    source->context().fillRect(fillRect, Color::green);
+
+    FilterEffectVector effects;
+    effects.append(FEImage::create({ *source }, fillRect, { }));
+
+    SVGFilterExpression expression;
+    expression.append({ 0, 0, std::nullopt });
+
+    auto targetBoundingBox = fillRect;
+    auto filterRegion = fillRect;
+    RefPtr filter = SVGFilter::create(targetBoundingBox, SVGUnitTypes::SVG_UNIT_TYPE_USERSPACEONUSE, WTFMove(expression), WTFMove(effects), std::nullopt, FilterRenderingMode::Software, { 1, 1 }, filterRegion);
+
+    DisplayList::DrawingContext drawingContext(logicalSize);
+
+    FilterResults results;
+    drawingContext.context().drawFilteredImageBuffer(nullptr, fillRect, *filter, results);
+
+    // Mutating the filter should not affect the DisplayList drawing.
+    source->context().fillRect(fillRect, Color::red);
+
+    // The DisplayList should have cloned the filter feImage SourceImages when recording drawImageBuffer().
+    drawingContext.replayDisplayList(destination->context());
+
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, filterRegion.x() + 1, filterRegion.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, filterRegion.maxX() - 1, filterRegion.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, filterRegion.x() + 1, filterRegion.maxY() - 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, filterRegion.maxX() - 1, filterRegion.maxY() - 1));
+}
+
+// This test records clipToImageBuffer to a DisplayList. Before replaying back the
+// DisplayList, the ImageBuffer is altered. The expectation is the DisplayList keeps
+// references only to immutable ImageBuffers.
+TEST(ImageBufferTests, DisplayListClipToImageBuffer)
+{
+    auto colorSpace = DestinationColorSpace::SRGB();
+    auto pixelFormat = ImageBufferPixelFormat::BGRA8;
+    FloatSize logicalSize { 100, 100 };
+    float scale = 1;
+
+    RefPtr maskSource = ImageBuffer::create(logicalSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+    RefPtr destination = ImageBuffer::create(logicalSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+
+    auto ratio = 0.5;
+    auto maskRect = FloatRect { FloatPoint { logicalSize.scaled((1 - ratio) / 2) }, logicalSize.scaled(ratio) };
+    maskSource->context().fillRect(maskRect, Color::white);
+
+    DisplayList::DrawingContext drawingContext(logicalSize);
+
+    auto fillRect = FloatRect { { }, logicalSize };
+    drawingContext.context().fillRect(fillRect, Color::green);
+    drawingContext.context().clipToImageBuffer(*maskSource, fillRect);
+    drawingContext.context().fillRect(fillRect, Color::red);
+
+    // Mutating the ImageBuffers should not affect the DisplayList drawing.
+    maskSource->context().fillRect(fillRect, Color::white);
+
+    // The DisplayList should have cloned the maskSource ImageBuffer when recording drawImageBuffer().
+    drawingContext.replayDisplayList(destination->context());
+
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, fillRect.x() + 1, fillRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, fillRect.maxX() - 1, fillRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, fillRect.x() + 1, fillRect.maxY() - 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, fillRect.maxX() - 1, fillRect.maxY() - 1));
+}
+
+// This test records drawPattern to a DisplayList. Before replaying back the DisplayList,
+// the ImageBuffer is altered. The expectation is the DisplayList keeps references only
+// to immutable ImageBuffers.
+TEST(ImageBufferTests, DisplayListDrawPattern)
+{
+    auto colorSpace = DestinationColorSpace::SRGB();
+    auto pixelFormat = ImageBufferPixelFormat::BGRA8;
+    FloatSize logicalSize { 100, 100 };
+    float scale = 1;
+
+    RefPtr patternSource = ImageBuffer::create(logicalSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+    RefPtr destination = ImageBuffer::create(logicalSize, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+
+    auto fillRect = FloatRect { { }, logicalSize };
+    patternSource->context().fillRect(fillRect, Color::green);
+
+    DisplayList::DrawingContext drawingContext(logicalSize);
+
+    FloatPoint phase;
+    FloatSize spacing;
+    drawingContext.context().drawPattern(*patternSource, fillRect, fillRect, AffineTransform(), phase, spacing, ImagePaintingOptions());
+
+    // Mutating the ImageBuffers should not affect the DisplayList drawing.
+    patternSource->context().fillRect(fillRect, Color::red);
+
+    // The DisplayList should have cloned the ImageBuffer when recording drawImageBuffer().
+    drawingContext.replayDisplayList(destination->context());
+
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, fillRect.x() + 1, fillRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, fillRect.maxX() - 1, fillRect.y() + 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, fillRect.x() + 1, fillRect.maxY() - 1));
+    EXPECT_TRUE(imageBufferPixelIs(Color::green, *destination, fillRect.maxX() - 1, fillRect.maxY() - 1));
 }
 
 enum class TestPreserveResolution : bool { No, Yes };


### PR DESCRIPTION
#### 508ee95ab94863cff21cd128aaacf043ac69e50d
<pre>
DisplayListRecorder should clone all the mutable RefCounted resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=285137#">https://bugs.webkit.org/show_bug.cgi?id=285137#</a>
<a href="https://rdar.apple.com/142007598">rdar://142007598</a>

Reviewed by NOBODY (OOPS!).

Some DisplayList items reference mutable resources such as: ImageBuffer, filter
or gradient. If these resources are changed before replaying back the items, newer
versions of these resources will be used. This will result in wrong DisplayList
drawing.

To fix this issue, the DisplayListRecorder should clone these resources whenever
they are referenced. This fix will not work for SKIA because the DisplayList is
played back on a different thread. A crash will happen when the cloned resources
are destroyed on a thread different from the main thread.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/platform/graphics/Gradient.cpp:
(WebCore::Gradient::Gradient):
* Source/WebCore/platform/graphics/Gradient.h:
(WebCore::Gradient::clone const):
* Source/WebCore/platform/graphics/SourceBrush.cpp:
(WebCore::SourceBrush::setGradient):
* Source/WebCore/platform/graphics/SourceBrush.h:
(WebCore::SourceBrush::setGradient):
* Source/WebCore/platform/graphics/SourceImage.cpp:
(WebCore::SourceImage::clone const):
* Source/WebCore/platform/graphics/SourceImage.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp:
(WebCore::DisplayList::applyFilteredImageBufferItem):
(WebCore::DisplayList::applySetStateItem):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::appendStateChangeItem):
(WebCore::DisplayList::Recorder::appendSetStateItem):
(WebCore::DisplayList::Recorder::drawFilteredImageBuffer):
(WebCore::DisplayList::Recorder::drawImageBuffer):
(WebCore::DisplayList::Recorder::drawPattern):
(WebCore::DisplayList::Recorder::clipToImageBuffer):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::appendSetStateItem):
(WebCore::DisplayList::RecorderImpl::drawFilteredImageBuffer):
(WebCore::DisplayList::RecorderImpl::recordClipToImageBuffer):
(WebCore::DisplayList::RecorderImpl::recordDrawFilteredImageBuffer):
(WebCore::DisplayList::RecorderImpl::recordDrawImageBuffer):
(WebCore::DisplayList::RecorderImpl::recordResourceUse):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebCore/platform/graphics/filters/DistantLightSource.cpp:
(WebCore::DistantLightSource::DistantLightSource):
* Source/WebCore/platform/graphics/filters/DistantLightSource.h:
* Source/WebCore/platform/graphics/filters/FEBlend.cpp:
(WebCore::FEBlend::FEBlend):
* Source/WebCore/platform/graphics/filters/FEBlend.h:
* Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp:
(WebCore::FEColorMatrix::FEColorMatrix):
* Source/WebCore/platform/graphics/filters/FEColorMatrix.h:
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp:
(WebCore::FEComponentTransfer::FEComponentTransfer):
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.h:
* Source/WebCore/platform/graphics/filters/FEComposite.cpp:
(WebCore::FEComposite::FEComposite):
* Source/WebCore/platform/graphics/filters/FEComposite.h:
* Source/WebCore/platform/graphics/filters/FEConvolveMatrix.cpp:
(WebCore::FEConvolveMatrix::FEConvolveMatrix):
* Source/WebCore/platform/graphics/filters/FEConvolveMatrix.h:
* Source/WebCore/platform/graphics/filters/FEDiffuseLighting.cpp:
(WebCore::FEDiffuseLighting::FEDiffuseLighting):
* Source/WebCore/platform/graphics/filters/FEDiffuseLighting.h:
* Source/WebCore/platform/graphics/filters/FEDisplacementMap.cpp:
(WebCore::FEDisplacementMap::FEDisplacementMap):
* Source/WebCore/platform/graphics/filters/FEDisplacementMap.h:
* Source/WebCore/platform/graphics/filters/FEDropShadow.cpp:
(WebCore::FEDropShadow::FEDropShadow):
* Source/WebCore/platform/graphics/filters/FEDropShadow.h:
* Source/WebCore/platform/graphics/filters/FEFlood.cpp:
(WebCore::FEFlood::FEFlood):
* Source/WebCore/platform/graphics/filters/FEFlood.h:
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp:
(WebCore::FEGaussianBlur::FEGaussianBlur):
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.h:
* Source/WebCore/platform/graphics/filters/FEImage.cpp:
(WebCore::FEImage::FEImage):
* Source/WebCore/platform/graphics/filters/FEImage.h:
* Source/WebCore/platform/graphics/filters/FEMerge.cpp:
(WebCore::FEMerge::FEMerge):
* Source/WebCore/platform/graphics/filters/FEMerge.h:
* Source/WebCore/platform/graphics/filters/FEMorphology.cpp:
(WebCore::FEMorphology::FEMorphology):
* Source/WebCore/platform/graphics/filters/FEMorphology.h:
* Source/WebCore/platform/graphics/filters/FEOffset.cpp:
(WebCore::FEOffset::FEOffset):
* Source/WebCore/platform/graphics/filters/FEOffset.h:
* Source/WebCore/platform/graphics/filters/FESpecularLighting.cpp:
(WebCore::FESpecularLighting::FESpecularLighting):
* Source/WebCore/platform/graphics/filters/FESpecularLighting.h:
* Source/WebCore/platform/graphics/filters/FETile.h:
* Source/WebCore/platform/graphics/filters/FETurbulence.cpp:
(WebCore::FETurbulence::FETurbulence):
* Source/WebCore/platform/graphics/filters/FETurbulence.h:
* Source/WebCore/platform/graphics/filters/Filter.h:
(WebCore::Filter::clone const):
* Source/WebCore/platform/graphics/filters/FilterFunction.h:
* Source/WebCore/platform/graphics/filters/LightSource.h:
* Source/WebCore/platform/graphics/filters/PointLightSource.cpp:
(WebCore::PointLightSource::PointLightSource):
* Source/WebCore/platform/graphics/filters/PointLightSource.h:
* Source/WebCore/platform/graphics/filters/SourceAlpha.h:
* Source/WebCore/platform/graphics/filters/SourceGraphic.h:
* Source/WebCore/platform/graphics/filters/SpotLightSource.cpp:
(WebCore::SpotLightSource::SpotLightSource):
* Source/WebCore/platform/graphics/filters/SpotLightSource.h:
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::CSSFilter::deepClone const):
* Source/WebCore/rendering/CSSFilter.h:
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::SVGFilter::deepClone const):
* Source/WebCore/svg/graphics/filters/SVGFilter.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordClipToImageBuffer):
(WebKit::RemoteDisplayListRecorderProxy::recordDrawFilteredImageBuffer):
(WebKit::RemoteDisplayListRecorderProxy::recordDrawImageBuffer):
(WebKit::RemoteDisplayListRecorderProxy::recordResourceUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
* Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp:
(TestWebKitAPI::TEST(ImageBufferTests, DisplayListSetFillGradient)):
(TestWebKitAPI::TEST(ImageBufferTests, DisplayListSetFillPattern)):
(TestWebKitAPI::TEST(ImageBufferTests, DisplayListDrawImageBuffer)):
(TestWebKitAPI::TEST(ImageBufferTests, DisplayListDrawFilteredImageBufferSourceImage)):
(TestWebKitAPI::TEST(ImageBufferTests, DisplayListDrawFilteredImageBufferFilter)):
(TestWebKitAPI::TEST(ImageBufferTests, DisplayListDrawFilteredImageBufferFEImage)):
(TestWebKitAPI::TEST(ImageBufferTests, DisplayListClipToImageBuffer)):
(TestWebKitAPI::TEST(ImageBufferTests, DisplayListDrawPattern)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/508ee95ab94863cff21cd128aaacf043ac69e50d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33461 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84505 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64224 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21976 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44501 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1414 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29159 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32502 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88888 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9706 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72622 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9932 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71840 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15979 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14988 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1077 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9659 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15180 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9533 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11303 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->