### PR TITLE
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/Modules

### DIFF
--- a/Source/WebCore/Modules/applepay/PaymentRequestValidator.mm
+++ b/Source/WebCore/Modules/applepay/PaymentRequestValidator.mm
@@ -113,20 +113,20 @@ ExceptionOr<void> PaymentRequestValidator::validateTotal(const ApplePayLineItem&
     return { };
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 static ExceptionOr<void> validateCountryCode(const String& countryCode)
 {
     if (!countryCode)
         return Exception { ExceptionCode::TypeError, "Missing country code."_s };
 
-    for (auto *countryCodePtr = uloc_getISOCountries(); *countryCodePtr; ++countryCodePtr) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    for (auto* countryCodePtr = uloc_getISOCountries(); *countryCodePtr; ++countryCodePtr) {
         if (countryCode == StringView::fromLatin1(*countryCodePtr))
             return { };
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return Exception { ExceptionCode::TypeError, makeString("\""_s, countryCode, "\" is not a valid country code."_s) };
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static ExceptionOr<void> validateCurrencyCode(const String& currencyCode)
 {

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -73,15 +73,13 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(MediaSource);
 
 String convertEnumerationToString(MediaSourcePrivate::AddStatus enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 3> values {
         MAKE_STATIC_STRING_IMPL("Ok"),
         MAKE_STATIC_STRING_IMPL("NotSupported"),
         MAKE_STATIC_STRING_IMPL("ReachedIdLimit"),
@@ -95,7 +93,7 @@ String convertEnumerationToString(MediaSourcePrivate::AddStatus enumerationValue
 
 String convertEnumerationToString(MediaSourcePrivate::EndOfStreamStatus enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 3> values {
         MAKE_STATIC_STRING_IMPL("NoError"),
         MAKE_STATIC_STRING_IMPL("NetworkError"),
         MAKE_STATIC_STRING_IMPL("DecodeError"),
@@ -1757,7 +1755,5 @@ bool MediaSource::canConstructInDedicatedWorker(ScriptExecutionContext& context)
 #endif
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -49,8 +49,6 @@
 #include <wtf/EnumTraits.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(RTCRtpSFrameTransform);
@@ -211,7 +209,7 @@ void transformFrame(Frame& frame, JSDOMGlobalObject& globalObject, RTCRtpSFrameT
     auto result = processFrame(chunk, transformer, identifier, weakTransform);
     std::span<const uint8_t> transformedChunk;
     if (result)
-        transformedChunk = { result->data(), result->size() };
+        transformedChunk = result->span();
     rtcFrame->setData(transformedChunk);
     source.enqueue(toJS(&globalObject, &globalObject, frame));
 }
@@ -290,7 +288,5 @@ bool RTCRtpSFrameTransform::virtualHasPendingActivity() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp
@@ -32,8 +32,6 @@
 #include <wtf/Algorithms.h>
 #include <wtf/StdLibExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 #if ASSERT_ENABLED
@@ -392,7 +390,5 @@ void RTCRtpSFrameTransformer::updateAuthenticationSize()
 #endif // !PLATFORM(COCOA) && !USE(GSTREAMER_WEBRTC)
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/SFrameUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/SFrameUtils.cpp
@@ -31,8 +31,6 @@
 #include <wtf/Function.h>
 #include <wtf/StdLibExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static inline bool isSliceNALU(uint8_t data)
@@ -150,7 +148,7 @@ IGNORE_GCC_WARNINGS_END
 static inline void findEscapeRbspPatterns(const Vector<uint8_t>& frame, size_t offset, const Function<void(size_t, bool)>& callback)
 {
     size_t numConsecutiveZeros = 0;
-    auto* data = frame.data();
+    auto data = frame.span();
     for (size_t i = offset; i < frame.size(); ++i) {
         bool shouldEscape = data[i] <= 3 && numConsecutiveZeros >= 2;
         if (shouldEscape)
@@ -179,7 +177,7 @@ void toRbsp(Vector<uint8_t>& frame, size_t offset)
     newFrame.reserveInitialCapacity(frame.size() + count);
     newFrame.append(frame.subspan(0, offset));
 
-    findEscapeRbspPatterns(frame, offset, [data = frame.data(), &newFrame](size_t position, bool shouldBeEscaped) {
+    findEscapeRbspPatterns(frame, offset, [data = frame.span(), &newFrame](size_t position, bool shouldBeEscaped) {
         if (shouldBeEscaped)
             newFrame.append(3);
         newFrame.append(data[position]);
@@ -206,7 +204,5 @@ SFrameCompatibilityPrefixBuffer computeVP8PrefixBuffer(std::span<const uint8_t> 
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/SFrameUtils.h
+++ b/Source/WebCore/Modules/mediastream/SFrameUtils.h
@@ -29,8 +29,6 @@
 
 #include <wtf/Vector.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 using SFrameCompatibilityPrefixBuffer = std::variant<std::span<const uint8_t>, Vector<uint8_t>>;
@@ -49,14 +47,12 @@ static inline Vector<uint8_t, 8> encodeBigEndian(uint64_t value)
 {
     Vector<uint8_t, 8> result(8);
     for (int i = 7; i >= 0; --i) {
-        result.data()[i] = value & 0xff;
+        result[i] = value & 0xff;
         value = value >> 8;
     }
     return result;
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_RTC)

--- a/Source/WebCore/Modules/mediastream/STUNMessageParsing.cpp
+++ b/Source/WebCore/Modules/mediastream/STUNMessageParsing.cpp
@@ -35,8 +35,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <webrtc/rtc_base/byte_order.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 namespace WebRTC {
 
@@ -52,8 +50,8 @@ std::optional<STUNMessageLengths> getSTUNOrTURNMessageLengths(std::span<const ui
     if (data.size() < 4)
         return { };
 
-    auto messageType = be16toh(*reinterpret_cast<const uint16_t*>(data.data()));
-    auto messageLength = be16toh(*reinterpret_cast<const uint16_t*>(data.data() + 2));
+    auto messageType = be16toh(reinterpretCastSpanStartTo<const uint16_t>(data));
+    auto messageLength = be16toh(reinterpretCastSpanStartTo<const uint16_t>(data.subspan(2)));
 
     // STUN data message header is 20 bytes.
     if (isStunMessage(messageType)) {
@@ -122,7 +120,5 @@ Vector<uint8_t> extractMessages(Vector<uint8_t>&& buffer, MessageType type, cons
 
 } // namespace WebRTC
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/push-api/PushDatabase.cpp
+++ b/Source/WebCore/Modules/push-api/PushDatabase.cpp
@@ -41,8 +41,6 @@
 #include <wtf/UniqueRef.h>
 #include <wtf/text/MakeString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #define PUSHDB_RELEASE_LOG(fmt, ...) RELEASE_LOG(Push, "%p - PushDatabase::" fmt, this, ##__VA_ARGS__)
 #define PUSHDB_RELEASE_LOG_ERROR(fmt, ...) RELEASE_LOG_ERROR(Push, "%p - PushDatabase::" fmt, this, ##__VA_ARGS__)
 
@@ -62,11 +60,11 @@ namespace WebCore {
 // In the database, the state column in the SubscriptionSets table uses 0 for enabled and 1 for ignored.
 enum class SubscriptionSetsStateColumn { Enabled, Ignored };
 
-static constexpr ASCIILiteral pushDatabaseSchemaV1Statements[] = {
+static constexpr std::array<ASCIILiteral, 1> pushDatabaseSchemaV1Statements {
     "PRAGMA auto_vacuum=INCREMENTAL"_s,
 };
 
-static constexpr ASCIILiteral pushDatabaseSchemaV2Statements[] = {
+static constexpr std::array<ASCIILiteral, 3> pushDatabaseSchemaV2Statements {
     "CREATE TABLE SubscriptionSets("
     "  rowID INTEGER PRIMARY KEY AUTOINCREMENT,"
     "  creationTime INT NOT NULL,"
@@ -90,15 +88,15 @@ static constexpr ASCIILiteral pushDatabaseSchemaV2Statements[] = {
     "CREATE INDEX Subscriptions_SubscriptionSetID_Index ON Subscriptions(subscriptionSetID)"_s,
 };
 
-static constexpr ASCIILiteral pushDatabaseSchemaV3Statements[] = {
+static constexpr std::array<ASCIILiteral, 1> pushDatabaseSchemaV3Statements {
     "CREATE TABLE Metadata(key TEXT, value, UNIQUE(key))"_s,
 };
 
-static constexpr ASCIILiteral pushDatabaseSchemaV4Statements[] = {
+static constexpr std::array<ASCIILiteral, 1> pushDatabaseSchemaV4Statements {
     "ALTER TABLE SubscriptionSets ADD COLUMN state INT NOT NULL DEFAULT 0"_s,
 };
 
-static constexpr ASCIILiteral pushDatabaseSchemaV5Statements[] = {
+static constexpr std::array<ASCIILiteral, 4> pushDatabaseSchemaV5Statements {
     "ALTER TABLE SubscriptionSets RENAME TO SubscriptionSetsOld"_s,
     "CREATE TABLE SubscriptionSets("
     "  rowID INTEGER PRIMARY KEY AUTOINCREMENT,"
@@ -114,12 +112,12 @@ static constexpr ASCIILiteral pushDatabaseSchemaV5Statements[] = {
     "DROP TABLE SubscriptionSetsOld"_s,
 };
 
-static constexpr std::span<const ASCIILiteral> pushDatabaseSchemaStatements[] = {
-    { pushDatabaseSchemaV1Statements },
-    { pushDatabaseSchemaV2Statements },
-    { pushDatabaseSchemaV3Statements },
-    { pushDatabaseSchemaV4Statements },
-    { pushDatabaseSchemaV5Statements },
+static constexpr std::array<std::span<const ASCIILiteral>, 5> pushDatabaseSchemaStatements {
+    std::span { pushDatabaseSchemaV1Statements },
+    std::span { pushDatabaseSchemaV2Statements },
+    std::span { pushDatabaseSchemaV3Statements },
+    std::span { pushDatabaseSchemaV4Statements },
+    std::span { pushDatabaseSchemaV5Statements },
 };
 
 static constexpr int currentPushDatabaseVersion = std::size(pushDatabaseSchemaStatements);
@@ -991,5 +989,3 @@ void PushDatabase::setPushesEnabledForOrigin(const PushSubscriptionSetIdentifier
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/Modules/push-api/cocoa/PushCryptoCocoa.cpp
+++ b/Source/WebCore/Modules/push-api/cocoa/PushCryptoCocoa.cpp
@@ -31,8 +31,6 @@
 #include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore::PushCrypto {
 
 P256DHKeyPair P256DHKeyPair::generate(void)
@@ -122,7 +120,7 @@ std::optional<Vector<uint8_t>> decryptAES128GCM(std::span<const uint8_t> key, st
 
     Vector<uint8_t> plainText(cipherTextWithTag.size() - aes128GCMTagLength);
     auto nonTagCipherTextLength = cipherTextWithTag.size() - aes128GCMTagLength;
-    auto result = CCCryptorGCMOneshotDecrypt(kCCAlgorithmAES, key.data(), key.size(), iv.data(), iv.size(), nullptr /* additionalData */, 0 /* additionalDataLength */, cipherTextWithTag.data(), nonTagCipherTextLength, plainText.data(), cipherTextWithTag.data() + nonTagCipherTextLength, aes128GCMTagLength);
+    auto result = CCCryptorGCMOneshotDecrypt(kCCAlgorithmAES, key.data(), key.size(), iv.data(), iv.size(), nullptr /* additionalData */, 0 /* additionalDataLength */, cipherTextWithTag.data(), nonTagCipherTextLength, plainText.data(), cipherTextWithTag.subspan(nonTagCipherTextLength).data(), aes128GCMTagLength);
     if (result != kCCSuccess)
         return std::nullopt;
 
@@ -130,5 +128,3 @@ std::optional<Vector<uint8_t>> decryptAES128GCM(std::span<const uint8_t> key, st
 }
 
 } // namespace WebCore::PushCrypto
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/Modules/speech/SpeechRecognitionUpdate.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionUpdate.cpp
@@ -28,13 +28,11 @@
 
 #include <wtf/NeverDestroyed.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 String convertEnumerationToString(SpeechRecognitionUpdateType enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 11> values {
         MAKE_STATIC_STRING_IMPL("UpdateTypeStart"),
         MAKE_STATIC_STRING_IMPL("UpdateTypeAudioStart"),
         MAKE_STATIC_STRING_IMPL("UpdateTypeSoundStart"),
@@ -101,5 +99,3 @@ Vector<SpeechRecognitionResultData> SpeechRecognitionUpdate::result() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/Modules/streams/ReadableStreamSink.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamSink.cpp
@@ -33,8 +33,6 @@
 #include "SharedBuffer.h"
 #include <JavaScriptCore/Uint8Array.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 ReadableStreamToSharedBufferSink::ReadableStreamToSharedBufferSink(Callback&& callback)
@@ -53,7 +51,7 @@ void ReadableStreamToSharedBufferSink::enqueue(const Ref<JSC::Uint8Array>& buffe
         return;
 
     if (m_callback) {
-        std::span<const uint8_t> chunk { buffer->data(), buffer->byteLength() };
+        auto chunk = buffer->span();
         m_callback(&chunk);
     }
 }
@@ -77,5 +75,3 @@ void ReadableStreamToSharedBufferSink::error(String&& message)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -50,8 +50,6 @@
 #include <wtf/ASCIICType.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebCodecsVideoDecoder);
@@ -112,14 +110,11 @@ static VideoDecoder::Config createVideoDecoderConfig(const WebCodecsVideoDecoder
 {
     std::span<const uint8_t> description;
     if (config.description) {
-        auto* data = std::visit([](auto& buffer) -> const uint8_t* {
-            return buffer ? static_cast<const uint8_t*>(buffer->data()) : nullptr;
+        auto data = std::visit([](auto& buffer) {
+            return buffer ? buffer->span() : std::span<const uint8_t> { };
         }, *config.description);
-        auto length = std::visit([](auto& buffer) -> size_t {
-            return buffer ? buffer->byteLength() : 0;
-        }, *config.description);
-        if (length)
-            description = { data, length };
+        if (!data.empty())
+            description = data;
     }
 
     return {
@@ -321,7 +316,5 @@ void WebCodecsVideoDecoder::stop()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_CODECS)


### PR DESCRIPTION
#### 4f6c347b9d21d2f6c42e2e5b9c5c7e9017283f95
<pre>
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/Modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=285138">https://bugs.webkit.org/show_bug.cgi?id=285138</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/Modules/applepay/PaymentRequestValidator.mm:
(WebCore::validateCountryCode):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
(WebCore::transformFrame):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp:
* Source/WebCore/Modules/mediastream/SFrameUtils.cpp:
(WebCore::findEscapeRbspPatterns):
(WebCore::toRbsp):
* Source/WebCore/Modules/mediastream/SFrameUtils.h:
(WebCore::encodeBigEndian):
* Source/WebCore/Modules/mediastream/STUNMessageParsing.cpp:
(WebCore::WebRTC::getSTUNOrTURNMessageLengths):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp:
(WebCore::LibWebRTCDataChannelHandler::OnMessage):
* Source/WebCore/Modules/push-api/PushDatabase.cpp:
* Source/WebCore/Modules/push-api/PushMessageCrypto.cpp:
(WebCore::PushCrypto::computeAES128GCMPaddingLength):
(WebCore::PushCrypto::decryptAES128GCMPayload):
(WebCore::PushCrypto::decryptAESGCMPayload):
* Source/WebCore/Modules/push-api/cocoa/PushCryptoCocoa.cpp:
(WebCore::PushCrypto::decryptAES128GCM):
* Source/WebCore/Modules/speech/SpeechRecognitionUpdate.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/Modules/streams/ReadableStreamSink.cpp:
(WebCore::ReadableStreamToSharedBufferSink::enqueue):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::createAudioDecoderConfig):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::createVideoDecoderConfig):

Canonical link: <a href="https://commits.webkit.org/288292@main">https://commits.webkit.org/288292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5503d3a50d62243612ea26ca22c0f302c10b35e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87504 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33433 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84477 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9920 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64198 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21951 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85441 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/1488 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74950 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44476 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29133 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32474 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72679 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29761 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88860 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72598 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9904 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71815 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15954 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14962 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1045 "Failed to checkout and rebase branch from PR 38368") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12787 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9631 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15152 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9505 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12971 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11275 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->