### PR TITLE
Sync `html/rendering/non-replaced-elements/form-controls` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -9498,6 +9498,7 @@
         "web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/div-align-ref.html",
         "web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/figure-ref.html",
         "web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/support/dialog-framed.html",
+        "web-platform-tests/html/rendering/non-replaced-elements/form-controls/datetime-dynamic-type-change-ref.html",
         "web-platform-tests/html/rendering/non-replaced-elements/form-controls/input-line-height-ref.html",
         "web-platform-tests/html/rendering/non-replaced-elements/form-controls/input-placeholder-line-height-ref.html",
         "web-platform-tests/html/rendering/non-replaced-elements/form-controls/select-sizing-001-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/datetime-dynamic-type-change-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/datetime-dynamic-type-change-expected.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<input type="datetime-local">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/datetime-dynamic-type-change-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/datetime-dynamic-type-change-ref.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<input type="datetime-local">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/datetime-dynamic-type-change.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/datetime-dynamic-type-change.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1797139">
+<link rel="match" href="datetime-dynamic-type-change-ref.html">
+<input type="date">
+<script>
+  onload = function() {
+    document.querySelector("input").type = "datetime-local";
+  }
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt
@@ -8,6 +8,8 @@ PASS <input type="hidden"> - text-indent
 PASS <input type="hidden"> - text-shadow
 PASS <input type="hidden"> - text-align
 PASS <input type="hidden"> - display
+FAIL <input type="hidden"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="hidden"> - overflow-clip-margin
 PASS <input type="hidden"> - box-sizing
 PASS <input type="text"> - letter-spacing
 PASS <input type="text"> - word-spacing
@@ -17,6 +19,8 @@ PASS <input type="text"> - text-indent
 PASS <input type="text"> - text-shadow
 PASS <input type="text"> - text-align
 PASS <input type="text"> - display
+FAIL <input type="text"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="text"> - overflow-clip-margin
 PASS <input type="text"> - box-sizing
 PASS <input type="search"> - letter-spacing
 PASS <input type="search"> - word-spacing
@@ -26,6 +30,8 @@ PASS <input type="search"> - text-indent
 PASS <input type="search"> - text-shadow
 PASS <input type="search"> - text-align
 PASS <input type="search"> - display
+FAIL <input type="search"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="search"> - overflow-clip-margin
 PASS <input type="search"> - box-sizing
 PASS <input type="tel"> - letter-spacing
 PASS <input type="tel"> - word-spacing
@@ -35,6 +41,8 @@ PASS <input type="tel"> - text-indent
 PASS <input type="tel"> - text-shadow
 PASS <input type="tel"> - text-align
 PASS <input type="tel"> - display
+FAIL <input type="tel"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="tel"> - overflow-clip-margin
 PASS <input type="tel"> - box-sizing
 PASS <input type="url"> - letter-spacing
 PASS <input type="url"> - word-spacing
@@ -44,6 +52,8 @@ PASS <input type="url"> - text-indent
 PASS <input type="url"> - text-shadow
 PASS <input type="url"> - text-align
 PASS <input type="url"> - display
+FAIL <input type="url"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="url"> - overflow-clip-margin
 PASS <input type="url"> - box-sizing
 PASS <input type="email"> - letter-spacing
 PASS <input type="email"> - word-spacing
@@ -53,6 +63,8 @@ PASS <input type="email"> - text-indent
 PASS <input type="email"> - text-shadow
 PASS <input type="email"> - text-align
 PASS <input type="email"> - display
+FAIL <input type="email"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="email"> - overflow-clip-margin
 PASS <input type="email"> - box-sizing
 PASS <input type="password"> - letter-spacing
 PASS <input type="password"> - word-spacing
@@ -62,6 +74,8 @@ PASS <input type="password"> - text-indent
 PASS <input type="password"> - text-shadow
 PASS <input type="password"> - text-align
 PASS <input type="password"> - display
+FAIL <input type="password"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="password"> - overflow-clip-margin
 PASS <input type="password"> - box-sizing
 PASS <input type="date"> - letter-spacing
 PASS <input type="date"> - word-spacing
@@ -71,6 +85,8 @@ PASS <input type="date"> - text-indent
 PASS <input type="date"> - text-shadow
 PASS <input type="date"> - text-align
 FAIL <input type="date"> - display assert_equals: expected "inline-block" but got "inline-flex"
+FAIL <input type="date"> - overflow assert_equals: expected "clip" but got "hidden"
+PASS <input type="date"> - overflow-clip-margin
 PASS <input type="date"> - box-sizing
 PASS <input type="month"> - letter-spacing
 PASS <input type="month"> - word-spacing
@@ -80,6 +96,8 @@ PASS <input type="month"> - text-indent
 PASS <input type="month"> - text-shadow
 PASS <input type="month"> - text-align
 FAIL <input type="month"> - display assert_equals: expected "inline-block" but got "inline-flex"
+FAIL <input type="month"> - overflow assert_equals: expected "clip" but got "hidden"
+PASS <input type="month"> - overflow-clip-margin
 PASS <input type="month"> - box-sizing
 PASS <input type="week"> - letter-spacing
 PASS <input type="week"> - word-spacing
@@ -89,6 +107,8 @@ PASS <input type="week"> - text-indent
 PASS <input type="week"> - text-shadow
 PASS <input type="week"> - text-align
 FAIL <input type="week"> - display assert_equals: expected "inline-block" but got "inline-flex"
+FAIL <input type="week"> - overflow assert_equals: expected "clip" but got "hidden"
+PASS <input type="week"> - overflow-clip-margin
 PASS <input type="week"> - box-sizing
 PASS <input type="time"> - letter-spacing
 PASS <input type="time"> - word-spacing
@@ -98,6 +118,8 @@ PASS <input type="time"> - text-indent
 PASS <input type="time"> - text-shadow
 PASS <input type="time"> - text-align
 FAIL <input type="time"> - display assert_equals: expected "inline-block" but got "inline-flex"
+FAIL <input type="time"> - overflow assert_equals: expected "clip" but got "hidden"
+PASS <input type="time"> - overflow-clip-margin
 PASS <input type="time"> - box-sizing
 PASS <input type="datetime-local"> - letter-spacing
 PASS <input type="datetime-local"> - word-spacing
@@ -107,6 +129,8 @@ PASS <input type="datetime-local"> - text-indent
 PASS <input type="datetime-local"> - text-shadow
 PASS <input type="datetime-local"> - text-align
 FAIL <input type="datetime-local"> - display assert_equals: expected "inline-block" but got "inline-flex"
+FAIL <input type="datetime-local"> - overflow assert_equals: expected "clip" but got "hidden"
+PASS <input type="datetime-local"> - overflow-clip-margin
 PASS <input type="datetime-local"> - box-sizing
 PASS <input type="number"> - letter-spacing
 PASS <input type="number"> - word-spacing
@@ -116,6 +140,8 @@ PASS <input type="number"> - text-indent
 PASS <input type="number"> - text-shadow
 PASS <input type="number"> - text-align
 PASS <input type="number"> - display
+FAIL <input type="number"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="number"> - overflow-clip-margin
 PASS <input type="number"> - box-sizing
 PASS <input type="range"> - letter-spacing
 PASS <input type="range"> - word-spacing
@@ -125,6 +151,8 @@ PASS <input type="range"> - text-indent
 PASS <input type="range"> - text-shadow
 PASS <input type="range"> - text-align
 PASS <input type="range"> - display
+PASS <input type="range"> - overflow
+PASS <input type="range"> - overflow-clip-margin
 PASS <input type="range"> - box-sizing
 PASS <input type="color"> - letter-spacing
 PASS <input type="color"> - word-spacing
@@ -134,6 +162,8 @@ PASS <input type="color"> - text-indent
 PASS <input type="color"> - text-shadow
 PASS <input type="color"> - text-align
 PASS <input type="color"> - display
+FAIL <input type="color"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="color"> - overflow-clip-margin
 PASS <input type="color"> - box-sizing
 PASS <input type="checkbox"> - letter-spacing
 PASS <input type="checkbox"> - word-spacing
@@ -143,6 +173,8 @@ PASS <input type="checkbox"> - text-indent
 PASS <input type="checkbox"> - text-shadow
 PASS <input type="checkbox"> - text-align
 PASS <input type="checkbox"> - display
+PASS <input type="checkbox"> - overflow
+PASS <input type="checkbox"> - overflow-clip-margin
 PASS <input type="checkbox"> - box-sizing
 PASS <input type="radio"> - letter-spacing
 PASS <input type="radio"> - word-spacing
@@ -152,6 +184,8 @@ PASS <input type="radio"> - text-indent
 PASS <input type="radio"> - text-shadow
 PASS <input type="radio"> - text-align
 PASS <input type="radio"> - display
+PASS <input type="radio"> - overflow
+PASS <input type="radio"> - overflow-clip-margin
 PASS <input type="radio"> - box-sizing
 PASS <input type="file"> - letter-spacing
 PASS <input type="file"> - word-spacing
@@ -161,6 +195,8 @@ PASS <input type="file"> - text-indent
 PASS <input type="file"> - text-shadow
 PASS <input type="file"> - text-align
 PASS <input type="file"> - display
+FAIL <input type="file"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="file"> - overflow-clip-margin
 PASS <input type="file"> - box-sizing
 PASS <input type="submit"> - letter-spacing
 PASS <input type="submit"> - word-spacing
@@ -170,6 +206,8 @@ PASS <input type="submit"> - text-indent
 PASS <input type="submit"> - text-shadow
 PASS <input type="submit"> - text-align
 PASS <input type="submit"> - display
+FAIL <input type="submit"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="submit"> - overflow-clip-margin
 PASS <input type="submit"> - box-sizing
 PASS <input type="image"> - letter-spacing
 PASS <input type="image"> - word-spacing
@@ -179,6 +217,8 @@ PASS <input type="image"> - text-indent
 PASS <input type="image"> - text-shadow
 PASS <input type="image"> - text-align
 PASS <input type="image"> - display
+PASS <input type="image"> - overflow
+PASS <input type="image"> - overflow-clip-margin
 PASS <input type="image"> - box-sizing
 PASS <input type="reset"> - letter-spacing
 PASS <input type="reset"> - word-spacing
@@ -188,6 +228,8 @@ PASS <input type="reset"> - text-indent
 PASS <input type="reset"> - text-shadow
 PASS <input type="reset"> - text-align
 PASS <input type="reset"> - display
+FAIL <input type="reset"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="reset"> - overflow-clip-margin
 PASS <input type="reset"> - box-sizing
 PASS <input type="button"> - letter-spacing
 PASS <input type="button"> - word-spacing
@@ -197,6 +239,8 @@ PASS <input type="button"> - text-indent
 PASS <input type="button"> - text-shadow
 PASS <input type="button"> - text-align
 PASS <input type="button"> - display
+FAIL <input type="button"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="button"> - overflow-clip-margin
 PASS <input type="button"> - box-sizing
 PASS <select><optgroup><option> - letter-spacing
 PASS <select><optgroup><option> - word-spacing
@@ -206,6 +250,7 @@ PASS <select><optgroup><option> - text-indent
 PASS <select><optgroup><option> - text-shadow
 PASS <select><optgroup><option> - text-align
 PASS <select><optgroup><option> - display
+PASS <select><optgroup><option> - overflow-clip-margin
 PASS <select><optgroup><option> - box-sizing
 PASS <optgroup><option> (in <select>) - letter-spacing
 PASS <optgroup><option> (in <select>) - word-spacing
@@ -214,6 +259,8 @@ PASS <optgroup><option> (in <select>) - text-transform
 PASS <optgroup><option> (in <select>) - text-indent
 PASS <optgroup><option> (in <select>) - text-shadow
 PASS <optgroup><option> (in <select>) - text-align
+PASS <optgroup><option> (in <select>) - overflow
+PASS <optgroup><option> (in <select>) - overflow-clip-margin
 PASS <optgroup><option> (in <select>) - box-sizing
 PASS <option> (in <select><optgroup>) - letter-spacing
 PASS <option> (in <select><optgroup>) - word-spacing
@@ -222,6 +269,8 @@ PASS <option> (in <select><optgroup>) - text-transform
 PASS <option> (in <select><optgroup>) - text-indent
 PASS <option> (in <select><optgroup>) - text-shadow
 PASS <option> (in <select><optgroup>) - text-align
+PASS <option> (in <select><optgroup>) - overflow
+PASS <option> (in <select><optgroup>) - overflow-clip-margin
 PASS <option> (in <select><optgroup>) - box-sizing
 PASS <select multiple=""> - letter-spacing
 PASS <select multiple=""> - word-spacing
@@ -231,6 +280,7 @@ PASS <select multiple=""> - text-indent
 PASS <select multiple=""> - text-shadow
 PASS <select multiple=""> - text-align
 PASS <select multiple=""> - display
+PASS <select multiple=""> - overflow-clip-margin
 PASS <select multiple=""> - box-sizing
 PASS <optgroup> - letter-spacing
 PASS <optgroup> - word-spacing
@@ -239,6 +289,8 @@ PASS <optgroup> - text-transform
 PASS <optgroup> - text-indent
 PASS <optgroup> - text-shadow
 PASS <optgroup> - text-align
+PASS <optgroup> - overflow
+PASS <optgroup> - overflow-clip-margin
 PASS <optgroup> - box-sizing
 PASS <option> - letter-spacing
 PASS <option> - word-spacing
@@ -247,6 +299,8 @@ PASS <option> - text-transform
 PASS <option> - text-indent
 PASS <option> - text-shadow
 PASS <option> - text-align
+PASS <option> - overflow
+PASS <option> - overflow-clip-margin
 PASS <option> - box-sizing
 PASS <button> - letter-spacing
 PASS <button> - word-spacing
@@ -256,6 +310,8 @@ PASS <button> - text-indent
 PASS <button> - text-shadow
 PASS <button> - text-align
 PASS <button> - display
+PASS <button> - overflow
+PASS <button> - overflow-clip-margin
 PASS <button> - box-sizing
 PASS <textarea> - letter-spacing
 PASS <textarea> - word-spacing
@@ -265,6 +321,8 @@ PASS <textarea> - text-indent
 PASS <textarea> - text-shadow
 PASS <textarea> - text-align
 PASS <textarea> - display
+FAIL <textarea> - overflow assert_equals: expected "visible" but got "auto"
+PASS <textarea> - overflow-clip-margin
 PASS <textarea> - box-sizing
 PASS <table><tbody><tr><td> - letter-spacing
 PASS <table><tbody><tr><td> - word-spacing
@@ -274,6 +332,8 @@ PASS <table><tbody><tr><td> - text-indent
 PASS <table><tbody><tr><td> - text-shadow
 PASS <table><tbody><tr><td> - text-align
 PASS <table><tbody><tr><td> - display
+PASS <table><tbody><tr><td> - overflow
+PASS <table><tbody><tr><td> - overflow-clip-margin
 PASS <table><tbody><tr><td> - box-sizing
 PASS <tbody><tr><td> (in <table>) - letter-spacing
 PASS <tbody><tr><td> (in <table>) - word-spacing
@@ -283,6 +343,8 @@ PASS <tbody><tr><td> (in <table>) - text-indent
 PASS <tbody><tr><td> (in <table>) - text-shadow
 PASS <tbody><tr><td> (in <table>) - text-align
 PASS <tbody><tr><td> (in <table>) - display
+PASS <tbody><tr><td> (in <table>) - overflow
+PASS <tbody><tr><td> (in <table>) - overflow-clip-margin
 PASS <tbody><tr><td> (in <table>) - box-sizing
 PASS <tr><td> (in <table><tbody>) - letter-spacing
 PASS <tr><td> (in <table><tbody>) - word-spacing
@@ -292,6 +354,8 @@ PASS <tr><td> (in <table><tbody>) - text-indent
 PASS <tr><td> (in <table><tbody>) - text-shadow
 PASS <tr><td> (in <table><tbody>) - text-align
 PASS <tr><td> (in <table><tbody>) - display
+PASS <tr><td> (in <table><tbody>) - overflow
+PASS <tr><td> (in <table><tbody>) - overflow-clip-margin
 PASS <tr><td> (in <table><tbody>) - box-sizing
 PASS <td> (in <table><tbody><tr>) - letter-spacing
 PASS <td> (in <table><tbody><tr>) - word-spacing
@@ -301,6 +365,8 @@ PASS <td> (in <table><tbody><tr>) - text-indent
 PASS <td> (in <table><tbody><tr>) - text-shadow
 PASS <td> (in <table><tbody><tr>) - text-align
 PASS <td> (in <table><tbody><tr>) - display
+PASS <td> (in <table><tbody><tr>) - overflow
+PASS <td> (in <table><tbody><tr>) - overflow-clip-margin
 PASS <td> (in <table><tbody><tr>) - box-sizing
 PASS <marquee> - letter-spacing
 PASS <marquee> - word-spacing
@@ -309,5 +375,7 @@ PASS <marquee> - text-transform
 PASS <marquee> - text-indent
 PASS <marquee> - text-shadow
 PASS <marquee> - text-align
+PASS <marquee> - overflow
+PASS <marquee> - overflow-clip-margin
 PASS <marquee> - box-sizing
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets.html
@@ -41,11 +41,16 @@ input[type=submit i], input[type=color i], input[type=search i], select, button 
 input, button {
   display: inline-block;
 }
+input:not([type=image i], [type=range i], [type=checkbox i], [type=radio i]) {
+  overflow: clip;
+  overflow-clip-margin: 0;
+}
 /* in spec prose: */ select, textarea, meter, progress {
   display: inline-block;
 }
 input[type=hidden i] { display: none !important; }
 marquee {
+  overflow: hidden;
   text-align: initial;
 }
 table { display: table; box-sizing: border-box; }
@@ -106,6 +111,8 @@ table {
                 'text-shadow',
                 'text-align',
                 'display',
+                'overflow',
+                'overflow-clip-margin',
                 'box-sizing'];
  runUAStyleTests(props);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/w3c-import.log
@@ -14,6 +14,9 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/datetime-dynamic-type-change-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/datetime-dynamic-type-change-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/datetime-dynamic-type-change.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/input-line-height-computed.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/input-line-height-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/input-line-height-ref.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/support/test-ua-stylesheet.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/support/test-ua-stylesheet.js
@@ -26,6 +26,10 @@ function runUAStyleTests(props) {
       ) {
       continue;
      }
+     if (prop === 'overflow' && testEl.localName === 'select') {
+      // TODO: https://github.com/whatwg/html/issues/10031
+      continue;
+     }
      test(() => {
        assert_equals(testStyle.getPropertyValue(prop), refStyle.getPropertyValue(prop));
      }, `${testNameContext(testEl)} - ${prop}`);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt
@@ -38,7 +38,6 @@ FAIL <select multiple=""><option>1 - font-size assert_equals: expected "16px" bu
 FAIL <select multiple=""><option>1 - font-family assert_equals: expected "-webkit-standard" but got "system-ui"
 PASS <select multiple=""><option>1 - writing-mode
 PASS <select multiple=""><option>1 - scrollbar-width
-PASS <select multiple=""><option>1 - overflow
 PASS <select multiple=""><option>1 - vertical-align
 PASS <select multiple=""><option>1 - user-select
 PASS <select multiple=""><option>1 - page-break-inside

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt
@@ -38,7 +38,6 @@ FAIL <select multiple=""><option>1 - font-size assert_equals: expected "16px" bu
 FAIL <select multiple=""><option>1 - font-family assert_equals: expected "-webkit-standard" but got "system-ui"
 PASS <select multiple=""><option>1 - writing-mode
 PASS <select multiple=""><option>1 - scrollbar-width
-PASS <select multiple=""><option>1 - overflow
 PASS <select multiple=""><option>1 - vertical-align
 PASS <select multiple=""><option>1 - user-select
 PASS <select multiple=""><option>1 - page-break-inside

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt
@@ -8,6 +8,8 @@ PASS <input type="hidden"> - text-indent
 PASS <input type="hidden"> - text-shadow
 PASS <input type="hidden"> - text-align
 PASS <input type="hidden"> - display
+FAIL <input type="hidden"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="hidden"> - overflow-clip-margin
 PASS <input type="hidden"> - box-sizing
 PASS <input type="text"> - letter-spacing
 PASS <input type="text"> - word-spacing
@@ -17,6 +19,8 @@ PASS <input type="text"> - text-indent
 PASS <input type="text"> - text-shadow
 PASS <input type="text"> - text-align
 PASS <input type="text"> - display
+FAIL <input type="text"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="text"> - overflow-clip-margin
 PASS <input type="text"> - box-sizing
 PASS <input type="search"> - letter-spacing
 PASS <input type="search"> - word-spacing
@@ -26,6 +30,8 @@ PASS <input type="search"> - text-indent
 PASS <input type="search"> - text-shadow
 PASS <input type="search"> - text-align
 PASS <input type="search"> - display
+FAIL <input type="search"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="search"> - overflow-clip-margin
 PASS <input type="search"> - box-sizing
 PASS <input type="tel"> - letter-spacing
 PASS <input type="tel"> - word-spacing
@@ -35,6 +41,8 @@ PASS <input type="tel"> - text-indent
 PASS <input type="tel"> - text-shadow
 PASS <input type="tel"> - text-align
 PASS <input type="tel"> - display
+FAIL <input type="tel"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="tel"> - overflow-clip-margin
 PASS <input type="tel"> - box-sizing
 PASS <input type="url"> - letter-spacing
 PASS <input type="url"> - word-spacing
@@ -44,6 +52,8 @@ PASS <input type="url"> - text-indent
 PASS <input type="url"> - text-shadow
 PASS <input type="url"> - text-align
 PASS <input type="url"> - display
+FAIL <input type="url"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="url"> - overflow-clip-margin
 PASS <input type="url"> - box-sizing
 PASS <input type="email"> - letter-spacing
 PASS <input type="email"> - word-spacing
@@ -53,6 +63,8 @@ PASS <input type="email"> - text-indent
 PASS <input type="email"> - text-shadow
 PASS <input type="email"> - text-align
 PASS <input type="email"> - display
+FAIL <input type="email"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="email"> - overflow-clip-margin
 PASS <input type="email"> - box-sizing
 PASS <input type="password"> - letter-spacing
 PASS <input type="password"> - word-spacing
@@ -62,6 +74,8 @@ PASS <input type="password"> - text-indent
 PASS <input type="password"> - text-shadow
 PASS <input type="password"> - text-align
 PASS <input type="password"> - display
+FAIL <input type="password"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="password"> - overflow-clip-margin
 PASS <input type="password"> - box-sizing
 PASS <input type="date"> - letter-spacing
 PASS <input type="date"> - word-spacing
@@ -71,6 +85,8 @@ PASS <input type="date"> - text-indent
 PASS <input type="date"> - text-shadow
 PASS <input type="date"> - text-align
 FAIL <input type="date"> - display assert_equals: expected "inline-block" but got "inline-flex"
+FAIL <input type="date"> - overflow assert_equals: expected "clip" but got "hidden"
+PASS <input type="date"> - overflow-clip-margin
 PASS <input type="date"> - box-sizing
 PASS <input type="month"> - letter-spacing
 PASS <input type="month"> - word-spacing
@@ -80,6 +96,8 @@ PASS <input type="month"> - text-indent
 PASS <input type="month"> - text-shadow
 PASS <input type="month"> - text-align
 FAIL <input type="month"> - display assert_equals: expected "inline-block" but got "inline-flex"
+FAIL <input type="month"> - overflow assert_equals: expected "clip" but got "hidden"
+PASS <input type="month"> - overflow-clip-margin
 PASS <input type="month"> - box-sizing
 PASS <input type="week"> - letter-spacing
 PASS <input type="week"> - word-spacing
@@ -89,6 +107,8 @@ PASS <input type="week"> - text-indent
 PASS <input type="week"> - text-shadow
 PASS <input type="week"> - text-align
 FAIL <input type="week"> - display assert_equals: expected "inline-block" but got "inline-flex"
+FAIL <input type="week"> - overflow assert_equals: expected "clip" but got "hidden"
+PASS <input type="week"> - overflow-clip-margin
 PASS <input type="week"> - box-sizing
 PASS <input type="time"> - letter-spacing
 PASS <input type="time"> - word-spacing
@@ -98,6 +118,8 @@ PASS <input type="time"> - text-indent
 PASS <input type="time"> - text-shadow
 PASS <input type="time"> - text-align
 FAIL <input type="time"> - display assert_equals: expected "inline-block" but got "inline-flex"
+FAIL <input type="time"> - overflow assert_equals: expected "clip" but got "hidden"
+PASS <input type="time"> - overflow-clip-margin
 PASS <input type="time"> - box-sizing
 PASS <input type="datetime-local"> - letter-spacing
 PASS <input type="datetime-local"> - word-spacing
@@ -107,6 +129,8 @@ PASS <input type="datetime-local"> - text-indent
 PASS <input type="datetime-local"> - text-shadow
 PASS <input type="datetime-local"> - text-align
 FAIL <input type="datetime-local"> - display assert_equals: expected "inline-block" but got "inline-flex"
+FAIL <input type="datetime-local"> - overflow assert_equals: expected "clip" but got "hidden"
+PASS <input type="datetime-local"> - overflow-clip-margin
 PASS <input type="datetime-local"> - box-sizing
 PASS <input type="number"> - letter-spacing
 PASS <input type="number"> - word-spacing
@@ -116,6 +140,8 @@ PASS <input type="number"> - text-indent
 PASS <input type="number"> - text-shadow
 PASS <input type="number"> - text-align
 PASS <input type="number"> - display
+FAIL <input type="number"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="number"> - overflow-clip-margin
 PASS <input type="number"> - box-sizing
 PASS <input type="range"> - letter-spacing
 PASS <input type="range"> - word-spacing
@@ -125,6 +151,8 @@ PASS <input type="range"> - text-indent
 PASS <input type="range"> - text-shadow
 PASS <input type="range"> - text-align
 PASS <input type="range"> - display
+PASS <input type="range"> - overflow
+PASS <input type="range"> - overflow-clip-margin
 PASS <input type="range"> - box-sizing
 PASS <input type="color"> - letter-spacing
 PASS <input type="color"> - word-spacing
@@ -134,6 +162,8 @@ PASS <input type="color"> - text-indent
 PASS <input type="color"> - text-shadow
 PASS <input type="color"> - text-align
 PASS <input type="color"> - display
+FAIL <input type="color"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="color"> - overflow-clip-margin
 FAIL <input type="color"> - box-sizing assert_equals: expected "border-box" but got "content-box"
 PASS <input type="checkbox"> - letter-spacing
 PASS <input type="checkbox"> - word-spacing
@@ -143,6 +173,8 @@ PASS <input type="checkbox"> - text-indent
 PASS <input type="checkbox"> - text-shadow
 PASS <input type="checkbox"> - text-align
 PASS <input type="checkbox"> - display
+PASS <input type="checkbox"> - overflow
+PASS <input type="checkbox"> - overflow-clip-margin
 PASS <input type="checkbox"> - box-sizing
 PASS <input type="radio"> - letter-spacing
 PASS <input type="radio"> - word-spacing
@@ -152,6 +184,8 @@ PASS <input type="radio"> - text-indent
 PASS <input type="radio"> - text-shadow
 PASS <input type="radio"> - text-align
 PASS <input type="radio"> - display
+PASS <input type="radio"> - overflow
+PASS <input type="radio"> - overflow-clip-margin
 PASS <input type="radio"> - box-sizing
 PASS <input type="file"> - letter-spacing
 PASS <input type="file"> - word-spacing
@@ -161,6 +195,8 @@ PASS <input type="file"> - text-indent
 PASS <input type="file"> - text-shadow
 PASS <input type="file"> - text-align
 PASS <input type="file"> - display
+FAIL <input type="file"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="file"> - overflow-clip-margin
 PASS <input type="file"> - box-sizing
 PASS <input type="submit"> - letter-spacing
 PASS <input type="submit"> - word-spacing
@@ -170,6 +206,8 @@ PASS <input type="submit"> - text-indent
 PASS <input type="submit"> - text-shadow
 PASS <input type="submit"> - text-align
 PASS <input type="submit"> - display
+FAIL <input type="submit"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="submit"> - overflow-clip-margin
 PASS <input type="submit"> - box-sizing
 PASS <input type="image"> - letter-spacing
 PASS <input type="image"> - word-spacing
@@ -179,6 +217,8 @@ PASS <input type="image"> - text-indent
 PASS <input type="image"> - text-shadow
 PASS <input type="image"> - text-align
 PASS <input type="image"> - display
+PASS <input type="image"> - overflow
+PASS <input type="image"> - overflow-clip-margin
 PASS <input type="image"> - box-sizing
 PASS <input type="reset"> - letter-spacing
 PASS <input type="reset"> - word-spacing
@@ -188,6 +228,8 @@ PASS <input type="reset"> - text-indent
 PASS <input type="reset"> - text-shadow
 PASS <input type="reset"> - text-align
 PASS <input type="reset"> - display
+FAIL <input type="reset"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="reset"> - overflow-clip-margin
 PASS <input type="reset"> - box-sizing
 PASS <input type="button"> - letter-spacing
 PASS <input type="button"> - word-spacing
@@ -197,6 +239,8 @@ PASS <input type="button"> - text-indent
 PASS <input type="button"> - text-shadow
 PASS <input type="button"> - text-align
 PASS <input type="button"> - display
+FAIL <input type="button"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="button"> - overflow-clip-margin
 PASS <input type="button"> - box-sizing
 PASS <select><optgroup><option> - letter-spacing
 PASS <select><optgroup><option> - word-spacing
@@ -206,6 +250,7 @@ PASS <select><optgroup><option> - text-indent
 PASS <select><optgroup><option> - text-shadow
 PASS <select><optgroup><option> - text-align
 PASS <select><optgroup><option> - display
+PASS <select><optgroup><option> - overflow-clip-margin
 PASS <select><optgroup><option> - box-sizing
 PASS <optgroup><option> (in <select>) - letter-spacing
 PASS <optgroup><option> (in <select>) - word-spacing
@@ -214,6 +259,8 @@ PASS <optgroup><option> (in <select>) - text-transform
 PASS <optgroup><option> (in <select>) - text-indent
 PASS <optgroup><option> (in <select>) - text-shadow
 PASS <optgroup><option> (in <select>) - text-align
+PASS <optgroup><option> (in <select>) - overflow
+PASS <optgroup><option> (in <select>) - overflow-clip-margin
 PASS <optgroup><option> (in <select>) - box-sizing
 PASS <option> (in <select><optgroup>) - letter-spacing
 PASS <option> (in <select><optgroup>) - word-spacing
@@ -222,6 +269,8 @@ PASS <option> (in <select><optgroup>) - text-transform
 PASS <option> (in <select><optgroup>) - text-indent
 PASS <option> (in <select><optgroup>) - text-shadow
 PASS <option> (in <select><optgroup>) - text-align
+PASS <option> (in <select><optgroup>) - overflow
+PASS <option> (in <select><optgroup>) - overflow-clip-margin
 PASS <option> (in <select><optgroup>) - box-sizing
 PASS <select multiple=""> - letter-spacing
 PASS <select multiple=""> - word-spacing
@@ -231,6 +280,7 @@ PASS <select multiple=""> - text-indent
 PASS <select multiple=""> - text-shadow
 PASS <select multiple=""> - text-align
 PASS <select multiple=""> - display
+PASS <select multiple=""> - overflow-clip-margin
 PASS <select multiple=""> - box-sizing
 PASS <optgroup> - letter-spacing
 PASS <optgroup> - word-spacing
@@ -239,6 +289,8 @@ PASS <optgroup> - text-transform
 PASS <optgroup> - text-indent
 PASS <optgroup> - text-shadow
 PASS <optgroup> - text-align
+PASS <optgroup> - overflow
+PASS <optgroup> - overflow-clip-margin
 PASS <optgroup> - box-sizing
 PASS <option> - letter-spacing
 PASS <option> - word-spacing
@@ -247,6 +299,8 @@ PASS <option> - text-transform
 PASS <option> - text-indent
 PASS <option> - text-shadow
 PASS <option> - text-align
+PASS <option> - overflow
+PASS <option> - overflow-clip-margin
 PASS <option> - box-sizing
 PASS <button> - letter-spacing
 PASS <button> - word-spacing
@@ -256,6 +310,8 @@ PASS <button> - text-indent
 PASS <button> - text-shadow
 PASS <button> - text-align
 PASS <button> - display
+PASS <button> - overflow
+PASS <button> - overflow-clip-margin
 PASS <button> - box-sizing
 PASS <textarea> - letter-spacing
 PASS <textarea> - word-spacing
@@ -265,6 +321,8 @@ PASS <textarea> - text-indent
 PASS <textarea> - text-shadow
 PASS <textarea> - text-align
 PASS <textarea> - display
+FAIL <textarea> - overflow assert_equals: expected "visible" but got "auto"
+PASS <textarea> - overflow-clip-margin
 PASS <textarea> - box-sizing
 PASS <table><tbody><tr><td> - letter-spacing
 PASS <table><tbody><tr><td> - word-spacing
@@ -274,6 +332,8 @@ PASS <table><tbody><tr><td> - text-indent
 PASS <table><tbody><tr><td> - text-shadow
 PASS <table><tbody><tr><td> - text-align
 PASS <table><tbody><tr><td> - display
+PASS <table><tbody><tr><td> - overflow
+PASS <table><tbody><tr><td> - overflow-clip-margin
 PASS <table><tbody><tr><td> - box-sizing
 PASS <tbody><tr><td> (in <table>) - letter-spacing
 PASS <tbody><tr><td> (in <table>) - word-spacing
@@ -283,6 +343,8 @@ PASS <tbody><tr><td> (in <table>) - text-indent
 PASS <tbody><tr><td> (in <table>) - text-shadow
 PASS <tbody><tr><td> (in <table>) - text-align
 PASS <tbody><tr><td> (in <table>) - display
+PASS <tbody><tr><td> (in <table>) - overflow
+PASS <tbody><tr><td> (in <table>) - overflow-clip-margin
 PASS <tbody><tr><td> (in <table>) - box-sizing
 PASS <tr><td> (in <table><tbody>) - letter-spacing
 PASS <tr><td> (in <table><tbody>) - word-spacing
@@ -292,6 +354,8 @@ PASS <tr><td> (in <table><tbody>) - text-indent
 PASS <tr><td> (in <table><tbody>) - text-shadow
 PASS <tr><td> (in <table><tbody>) - text-align
 PASS <tr><td> (in <table><tbody>) - display
+PASS <tr><td> (in <table><tbody>) - overflow
+PASS <tr><td> (in <table><tbody>) - overflow-clip-margin
 PASS <tr><td> (in <table><tbody>) - box-sizing
 PASS <td> (in <table><tbody><tr>) - letter-spacing
 PASS <td> (in <table><tbody><tr>) - word-spacing
@@ -301,6 +365,8 @@ PASS <td> (in <table><tbody><tr>) - text-indent
 PASS <td> (in <table><tbody><tr>) - text-shadow
 PASS <td> (in <table><tbody><tr>) - text-align
 PASS <td> (in <table><tbody><tr>) - display
+PASS <td> (in <table><tbody><tr>) - overflow
+PASS <td> (in <table><tbody><tr>) - overflow-clip-margin
 PASS <td> (in <table><tbody><tr>) - box-sizing
 PASS <marquee> - letter-spacing
 PASS <marquee> - word-spacing
@@ -309,5 +375,7 @@ PASS <marquee> - text-transform
 PASS <marquee> - text-indent
 PASS <marquee> - text-shadow
 PASS <marquee> - text-align
+PASS <marquee> - overflow
+PASS <marquee> - overflow-clip-margin
 PASS <marquee> - box-sizing
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt
@@ -8,6 +8,8 @@ PASS <input type="hidden"> - text-indent
 PASS <input type="hidden"> - text-shadow
 PASS <input type="hidden"> - text-align
 PASS <input type="hidden"> - display
+FAIL <input type="hidden"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="hidden"> - overflow-clip-margin
 PASS <input type="hidden"> - box-sizing
 PASS <input type="text"> - letter-spacing
 PASS <input type="text"> - word-spacing
@@ -17,6 +19,8 @@ PASS <input type="text"> - text-indent
 PASS <input type="text"> - text-shadow
 PASS <input type="text"> - text-align
 PASS <input type="text"> - display
+FAIL <input type="text"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="text"> - overflow-clip-margin
 PASS <input type="text"> - box-sizing
 PASS <input type="search"> - letter-spacing
 PASS <input type="search"> - word-spacing
@@ -26,6 +30,8 @@ PASS <input type="search"> - text-indent
 PASS <input type="search"> - text-shadow
 PASS <input type="search"> - text-align
 PASS <input type="search"> - display
+FAIL <input type="search"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="search"> - overflow-clip-margin
 PASS <input type="search"> - box-sizing
 PASS <input type="tel"> - letter-spacing
 PASS <input type="tel"> - word-spacing
@@ -35,6 +41,8 @@ PASS <input type="tel"> - text-indent
 PASS <input type="tel"> - text-shadow
 PASS <input type="tel"> - text-align
 PASS <input type="tel"> - display
+FAIL <input type="tel"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="tel"> - overflow-clip-margin
 PASS <input type="tel"> - box-sizing
 PASS <input type="url"> - letter-spacing
 PASS <input type="url"> - word-spacing
@@ -44,6 +52,8 @@ PASS <input type="url"> - text-indent
 PASS <input type="url"> - text-shadow
 PASS <input type="url"> - text-align
 PASS <input type="url"> - display
+FAIL <input type="url"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="url"> - overflow-clip-margin
 PASS <input type="url"> - box-sizing
 PASS <input type="email"> - letter-spacing
 PASS <input type="email"> - word-spacing
@@ -53,6 +63,8 @@ PASS <input type="email"> - text-indent
 PASS <input type="email"> - text-shadow
 PASS <input type="email"> - text-align
 PASS <input type="email"> - display
+FAIL <input type="email"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="email"> - overflow-clip-margin
 PASS <input type="email"> - box-sizing
 PASS <input type="password"> - letter-spacing
 PASS <input type="password"> - word-spacing
@@ -62,6 +74,8 @@ PASS <input type="password"> - text-indent
 PASS <input type="password"> - text-shadow
 PASS <input type="password"> - text-align
 PASS <input type="password"> - display
+FAIL <input type="password"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="password"> - overflow-clip-margin
 PASS <input type="password"> - box-sizing
 PASS <input type="date"> - letter-spacing
 PASS <input type="date"> - word-spacing
@@ -71,6 +85,8 @@ PASS <input type="date"> - text-indent
 PASS <input type="date"> - text-shadow
 PASS <input type="date"> - text-align
 PASS <input type="date"> - display
+FAIL <input type="date"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="date"> - overflow-clip-margin
 PASS <input type="date"> - box-sizing
 PASS <input type="month"> - letter-spacing
 PASS <input type="month"> - word-spacing
@@ -80,6 +96,8 @@ PASS <input type="month"> - text-indent
 PASS <input type="month"> - text-shadow
 PASS <input type="month"> - text-align
 PASS <input type="month"> - display
+FAIL <input type="month"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="month"> - overflow-clip-margin
 PASS <input type="month"> - box-sizing
 PASS <input type="week"> - letter-spacing
 PASS <input type="week"> - word-spacing
@@ -89,6 +107,8 @@ PASS <input type="week"> - text-indent
 PASS <input type="week"> - text-shadow
 PASS <input type="week"> - text-align
 PASS <input type="week"> - display
+FAIL <input type="week"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="week"> - overflow-clip-margin
 PASS <input type="week"> - box-sizing
 PASS <input type="time"> - letter-spacing
 PASS <input type="time"> - word-spacing
@@ -98,6 +118,8 @@ PASS <input type="time"> - text-indent
 PASS <input type="time"> - text-shadow
 PASS <input type="time"> - text-align
 PASS <input type="time"> - display
+FAIL <input type="time"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="time"> - overflow-clip-margin
 PASS <input type="time"> - box-sizing
 PASS <input type="datetime-local"> - letter-spacing
 PASS <input type="datetime-local"> - word-spacing
@@ -107,6 +129,8 @@ PASS <input type="datetime-local"> - text-indent
 PASS <input type="datetime-local"> - text-shadow
 PASS <input type="datetime-local"> - text-align
 PASS <input type="datetime-local"> - display
+FAIL <input type="datetime-local"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="datetime-local"> - overflow-clip-margin
 PASS <input type="datetime-local"> - box-sizing
 PASS <input type="number"> - letter-spacing
 PASS <input type="number"> - word-spacing
@@ -116,6 +140,8 @@ PASS <input type="number"> - text-indent
 PASS <input type="number"> - text-shadow
 PASS <input type="number"> - text-align
 PASS <input type="number"> - display
+FAIL <input type="number"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="number"> - overflow-clip-margin
 PASS <input type="number"> - box-sizing
 PASS <input type="range"> - letter-spacing
 PASS <input type="range"> - word-spacing
@@ -125,6 +151,8 @@ PASS <input type="range"> - text-indent
 PASS <input type="range"> - text-shadow
 PASS <input type="range"> - text-align
 PASS <input type="range"> - display
+PASS <input type="range"> - overflow
+PASS <input type="range"> - overflow-clip-margin
 PASS <input type="range"> - box-sizing
 PASS <input type="color"> - letter-spacing
 PASS <input type="color"> - word-spacing
@@ -134,6 +162,8 @@ PASS <input type="color"> - text-indent
 PASS <input type="color"> - text-shadow
 PASS <input type="color"> - text-align
 PASS <input type="color"> - display
+FAIL <input type="color"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="color"> - overflow-clip-margin
 FAIL <input type="color"> - box-sizing assert_equals: expected "border-box" but got "content-box"
 PASS <input type="checkbox"> - letter-spacing
 PASS <input type="checkbox"> - word-spacing
@@ -143,6 +173,8 @@ PASS <input type="checkbox"> - text-indent
 PASS <input type="checkbox"> - text-shadow
 PASS <input type="checkbox"> - text-align
 PASS <input type="checkbox"> - display
+PASS <input type="checkbox"> - overflow
+PASS <input type="checkbox"> - overflow-clip-margin
 PASS <input type="checkbox"> - box-sizing
 PASS <input type="radio"> - letter-spacing
 PASS <input type="radio"> - word-spacing
@@ -152,6 +184,8 @@ PASS <input type="radio"> - text-indent
 PASS <input type="radio"> - text-shadow
 PASS <input type="radio"> - text-align
 PASS <input type="radio"> - display
+PASS <input type="radio"> - overflow
+PASS <input type="radio"> - overflow-clip-margin
 PASS <input type="radio"> - box-sizing
 PASS <input type="file"> - letter-spacing
 PASS <input type="file"> - word-spacing
@@ -161,6 +195,8 @@ PASS <input type="file"> - text-indent
 PASS <input type="file"> - text-shadow
 PASS <input type="file"> - text-align
 PASS <input type="file"> - display
+FAIL <input type="file"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="file"> - overflow-clip-margin
 PASS <input type="file"> - box-sizing
 PASS <input type="submit"> - letter-spacing
 PASS <input type="submit"> - word-spacing
@@ -170,6 +206,8 @@ PASS <input type="submit"> - text-indent
 PASS <input type="submit"> - text-shadow
 PASS <input type="submit"> - text-align
 PASS <input type="submit"> - display
+FAIL <input type="submit"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="submit"> - overflow-clip-margin
 PASS <input type="submit"> - box-sizing
 PASS <input type="image"> - letter-spacing
 PASS <input type="image"> - word-spacing
@@ -179,6 +217,8 @@ PASS <input type="image"> - text-indent
 PASS <input type="image"> - text-shadow
 PASS <input type="image"> - text-align
 PASS <input type="image"> - display
+PASS <input type="image"> - overflow
+PASS <input type="image"> - overflow-clip-margin
 PASS <input type="image"> - box-sizing
 PASS <input type="reset"> - letter-spacing
 PASS <input type="reset"> - word-spacing
@@ -188,6 +228,8 @@ PASS <input type="reset"> - text-indent
 PASS <input type="reset"> - text-shadow
 PASS <input type="reset"> - text-align
 PASS <input type="reset"> - display
+FAIL <input type="reset"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="reset"> - overflow-clip-margin
 PASS <input type="reset"> - box-sizing
 PASS <input type="button"> - letter-spacing
 PASS <input type="button"> - word-spacing
@@ -197,6 +239,8 @@ PASS <input type="button"> - text-indent
 PASS <input type="button"> - text-shadow
 PASS <input type="button"> - text-align
 PASS <input type="button"> - display
+FAIL <input type="button"> - overflow assert_equals: expected "clip" but got "visible"
+PASS <input type="button"> - overflow-clip-margin
 PASS <input type="button"> - box-sizing
 PASS <select><optgroup><option> - letter-spacing
 PASS <select><optgroup><option> - word-spacing
@@ -206,6 +250,7 @@ PASS <select><optgroup><option> - text-indent
 PASS <select><optgroup><option> - text-shadow
 PASS <select><optgroup><option> - text-align
 PASS <select><optgroup><option> - display
+PASS <select><optgroup><option> - overflow-clip-margin
 PASS <select><optgroup><option> - box-sizing
 PASS <optgroup><option> (in <select>) - letter-spacing
 PASS <optgroup><option> (in <select>) - word-spacing
@@ -214,6 +259,8 @@ PASS <optgroup><option> (in <select>) - text-transform
 PASS <optgroup><option> (in <select>) - text-indent
 PASS <optgroup><option> (in <select>) - text-shadow
 PASS <optgroup><option> (in <select>) - text-align
+PASS <optgroup><option> (in <select>) - overflow
+PASS <optgroup><option> (in <select>) - overflow-clip-margin
 PASS <optgroup><option> (in <select>) - box-sizing
 PASS <option> (in <select><optgroup>) - letter-spacing
 PASS <option> (in <select><optgroup>) - word-spacing
@@ -222,6 +269,8 @@ PASS <option> (in <select><optgroup>) - text-transform
 PASS <option> (in <select><optgroup>) - text-indent
 PASS <option> (in <select><optgroup>) - text-shadow
 PASS <option> (in <select><optgroup>) - text-align
+PASS <option> (in <select><optgroup>) - overflow
+PASS <option> (in <select><optgroup>) - overflow-clip-margin
 PASS <option> (in <select><optgroup>) - box-sizing
 PASS <select multiple=""> - letter-spacing
 PASS <select multiple=""> - word-spacing
@@ -231,6 +280,7 @@ PASS <select multiple=""> - text-indent
 PASS <select multiple=""> - text-shadow
 PASS <select multiple=""> - text-align
 PASS <select multiple=""> - display
+PASS <select multiple=""> - overflow-clip-margin
 PASS <select multiple=""> - box-sizing
 PASS <optgroup> - letter-spacing
 PASS <optgroup> - word-spacing
@@ -239,6 +289,8 @@ PASS <optgroup> - text-transform
 PASS <optgroup> - text-indent
 PASS <optgroup> - text-shadow
 PASS <optgroup> - text-align
+PASS <optgroup> - overflow
+PASS <optgroup> - overflow-clip-margin
 PASS <optgroup> - box-sizing
 PASS <option> - letter-spacing
 PASS <option> - word-spacing
@@ -247,6 +299,8 @@ PASS <option> - text-transform
 PASS <option> - text-indent
 PASS <option> - text-shadow
 PASS <option> - text-align
+PASS <option> - overflow
+PASS <option> - overflow-clip-margin
 PASS <option> - box-sizing
 PASS <button> - letter-spacing
 PASS <button> - word-spacing
@@ -256,6 +310,8 @@ PASS <button> - text-indent
 PASS <button> - text-shadow
 PASS <button> - text-align
 PASS <button> - display
+PASS <button> - overflow
+PASS <button> - overflow-clip-margin
 PASS <button> - box-sizing
 PASS <textarea> - letter-spacing
 PASS <textarea> - word-spacing
@@ -265,6 +321,8 @@ PASS <textarea> - text-indent
 PASS <textarea> - text-shadow
 PASS <textarea> - text-align
 PASS <textarea> - display
+FAIL <textarea> - overflow assert_equals: expected "visible" but got "auto"
+PASS <textarea> - overflow-clip-margin
 PASS <textarea> - box-sizing
 PASS <table><tbody><tr><td> - letter-spacing
 PASS <table><tbody><tr><td> - word-spacing
@@ -274,6 +332,8 @@ PASS <table><tbody><tr><td> - text-indent
 PASS <table><tbody><tr><td> - text-shadow
 PASS <table><tbody><tr><td> - text-align
 PASS <table><tbody><tr><td> - display
+PASS <table><tbody><tr><td> - overflow
+PASS <table><tbody><tr><td> - overflow-clip-margin
 PASS <table><tbody><tr><td> - box-sizing
 PASS <tbody><tr><td> (in <table>) - letter-spacing
 PASS <tbody><tr><td> (in <table>) - word-spacing
@@ -283,6 +343,8 @@ PASS <tbody><tr><td> (in <table>) - text-indent
 PASS <tbody><tr><td> (in <table>) - text-shadow
 PASS <tbody><tr><td> (in <table>) - text-align
 PASS <tbody><tr><td> (in <table>) - display
+PASS <tbody><tr><td> (in <table>) - overflow
+PASS <tbody><tr><td> (in <table>) - overflow-clip-margin
 PASS <tbody><tr><td> (in <table>) - box-sizing
 PASS <tr><td> (in <table><tbody>) - letter-spacing
 PASS <tr><td> (in <table><tbody>) - word-spacing
@@ -292,6 +354,8 @@ PASS <tr><td> (in <table><tbody>) - text-indent
 PASS <tr><td> (in <table><tbody>) - text-shadow
 PASS <tr><td> (in <table><tbody>) - text-align
 PASS <tr><td> (in <table><tbody>) - display
+PASS <tr><td> (in <table><tbody>) - overflow
+PASS <tr><td> (in <table><tbody>) - overflow-clip-margin
 PASS <tr><td> (in <table><tbody>) - box-sizing
 PASS <td> (in <table><tbody><tr>) - letter-spacing
 PASS <td> (in <table><tbody><tr>) - word-spacing
@@ -301,6 +365,8 @@ PASS <td> (in <table><tbody><tr>) - text-indent
 PASS <td> (in <table><tbody><tr>) - text-shadow
 PASS <td> (in <table><tbody><tr>) - text-align
 PASS <td> (in <table><tbody><tr>) - display
+PASS <td> (in <table><tbody><tr>) - overflow
+PASS <td> (in <table><tbody><tr>) - overflow-clip-margin
 PASS <td> (in <table><tbody><tr>) - box-sizing
 PASS <marquee> - letter-spacing
 PASS <marquee> - word-spacing
@@ -309,5 +375,7 @@ PASS <marquee> - text-transform
 PASS <marquee> - text-indent
 PASS <marquee> - text-shadow
 PASS <marquee> - text-align
+PASS <marquee> - overflow
+PASS <marquee> - overflow-clip-margin
 PASS <marquee> - box-sizing
 


### PR DESCRIPTION
#### d7ba780797fcdce60dc5c981fb9f233b93e360b1
<pre>
Sync `html/rendering/non-replaced-elements/form-controls` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=285146">https://bugs.webkit.org/show_bug.cgi?id=285146</a>
<a href="https://rdar.apple.com/142024374">rdar://142024374</a>

Reviewed by Fujii Hironori.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/e8ba63bc89b804dda46d77a70bd81ec349248138">https://github.com/web-platform-tests/wpt/commit/e8ba63bc89b804dda46d77a70bd81ec349248138</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/support/test-ua-stylesheet.js:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/datetime-dynamic-type-change.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/datetime-dynamic-type-change-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/datetime-dynamic-type-change-expected.html:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt:

Canonical link: <a href="https://commits.webkit.org/288309@main">https://commits.webkit.org/288309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22f2a39de8b907656185e9d498ce8644a795a1d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33449 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64213 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21964 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44490 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1401 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29146 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32490 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72692 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88876 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6985 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72611 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70777 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71829 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17900 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15969 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14975 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1064 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9647 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9521 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12987 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11291 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->