### PR TITLE
[ Debug Sequoia ] TestWebKitAPI.WKWebViewCandidateTests.SoftSpaceReplacementAfterCandidateInsertionWithoutReplacement is a constant failure

### DIFF
--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -669,7 +669,6 @@ public:
 #if PLATFORM(MAC)
     virtual void didPerformImmediateActionHitTest(const WebHitTestResultData&, bool contentPreventsDefault, API::Object*) = 0;
     virtual NSObject *immediateActionAnimationControllerForHitTestResult(RefPtr<API::HitTestResult>, uint64_t, RefPtr<API::Object>) = 0;
-    virtual void didHandleAcceptedCandidate() = 0;
 #endif
 
     virtual void microphoneCaptureWillChange() { }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13451,12 +13451,6 @@ void WebPageProxy::handleAcceptedCandidate(WebCore::TextCheckingResult acceptedC
     send(Messages::WebPage::HandleAcceptedCandidate(acceptedCandidate));
 }
 
-void WebPageProxy::didHandleAcceptedCandidate()
-{
-    if (RefPtr pageClient = this->pageClient())
-        pageClient->didHandleAcceptedCandidate();
-}
-
 void WebPageProxy::setHeaderBannerHeight(int height)
 {
     send(Messages::WebPage::SetHeaderBannerHeight(height));

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1910,7 +1910,6 @@ public:
     NSObject *immediateActionAnimationControllerForHitTestResult(RefPtr<API::HitTestResult>, uint64_t, RefPtr<API::Object>);
 
     void handleAcceptedCandidate(WebCore::TextCheckingResult);
-    void didHandleAcceptedCandidate();
 
     void setHeaderBannerHeight(int);
     void setFooterBannerHeight(int);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -512,10 +512,6 @@ messages -> WebPageProxy {
 
     GetLoadDecisionForIcon(struct WebCore::LinkIcon icon, WebKit::CallbackID callbackID)
 
-#if PLATFORM(MAC)
-    DidHandleAcceptedCandidate()
-#endif
-
     StartURLSchemeTask(struct WebKit::URLSchemeTaskParameters parameters)
     StopURLSchemeTask(WebKit::WebURLSchemeHandlerIdentifier handlerIdentifier, WebCore::ResourceLoaderIdentifier taskIdentifier)
     LoadSynchronousURLSchemeTask(struct WebKit::URLSchemeTaskParameters parameters) -> (WebCore::ResourceResponse response, WebCore::ResourceError error, Vector<uint8_t> data) Synchronous

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -258,8 +258,6 @@ private:
     void didPerformImmediateActionHitTest(const WebHitTestResultData&, bool contentPreventsDefault, API::Object*) override;
     NSObject *immediateActionAnimationControllerForHitTestResult(RefPtr<API::HitTestResult>, uint64_t, RefPtr<API::Object>) override;
 
-    void didHandleAcceptedCandidate() override;
-
     void videoControlsManagerDidChange() override;
 
     void showPlatformContextMenu(NSMenu *, WebCore::IntPoint) override;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -941,11 +941,6 @@ NSObject *PageClientImpl::immediateActionAnimationControllerForHitTestResult(Ref
     return m_impl->immediateActionAnimationControllerForHitTestResult(hitTestResult.get(), type, userData.get());
 }
 
-void PageClientImpl::didHandleAcceptedCandidate()
-{
-    m_impl->didHandleAcceptedCandidate();
-}
-
 void PageClientImpl::videoControlsManagerDidChange()
 {
     PageClientImplCocoa::videoControlsManagerDidChange();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -465,7 +465,6 @@ public:
     void cancelImmediateActionAnimation();
     void completeImmediateActionAnimation();
     void didChangeContentSize(CGSize);
-    void didHandleAcceptedCandidate();
     void videoControlsManagerDidChange();
 
     void setIgnoresNonWheelEvents(bool);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -3345,6 +3345,13 @@ void WebViewImpl::handleAcceptedCandidate(NSTextCheckingResult *acceptedCandidat
     }
 
     m_page->handleAcceptedCandidate(textCheckingResultFromNSTextCheckingResult(acceptedCandidate));
+    m_page->callAfterNextPresentationUpdate([viewImpl = WeakPtr { *this }] {
+        if (!viewImpl)
+            return;
+
+        viewImpl->m_isHandlingAcceptedCandidate = false;
+        [viewImpl->m_view _didHandleAcceptedCandidate];
+    });
 }
 
 void WebViewImpl::preferencesDidChange()
@@ -3537,13 +3544,6 @@ void WebViewImpl::completeImmediateActionAnimation()
 void WebViewImpl::didChangeContentSize(CGSize newSize)
 {
     [m_view _web_didChangeContentSize:NSSizeFromCGSize(newSize)];
-}
-
-void WebViewImpl::didHandleAcceptedCandidate()
-{
-    m_isHandlingAcceptedCandidate = false;
-
-    [m_view _didHandleAcceptedCandidate];
 }
 
 void WebViewImpl::videoControlsManagerDidChange()

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -216,7 +216,6 @@ void WebPage::handleAcceptedCandidate(WebCore::TextCheckingResult acceptedCandid
         return;
 
     frame->editor().handleAcceptedCandidate(acceptedCandidate);
-    send(Messages::WebPageProxy::DidHandleAcceptedCandidate());
 }
 
 NSObject *WebPage::accessibilityObjectForMainFramePlugin()

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCandidateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCandidateTests.mm
@@ -139,12 +139,7 @@ static NSString *GetDocumentScrollTopJSExpression = @"document.body.scrollTop";
 
 @end
 
-// rdar://136705852
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 150000
-TEST(WKWebViewCandidateTests, DISABLED_SoftSpaceReplacementAfterCandidateInsertionWithoutReplacement)
-#else
 TEST(WKWebViewCandidateTests, SoftSpaceReplacementAfterCandidateInsertionWithoutReplacement)
-#endif
 {
     auto wkWebView = [CandidateTestWebView setUpWithFrame:NSMakeRect(0, 0, 800, 600) testPage:@"input-field-in-scrollable-document"];
 


### PR DESCRIPTION
#### 68279ff1ef9c8632e1a07031f592c81900d0a81f
<pre>
[ Debug Sequoia ] TestWebKitAPI.WKWebViewCandidateTests.SoftSpaceReplacementAfterCandidateInsertionWithoutReplacement is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=280352">https://bugs.webkit.org/show_bug.cgi?id=280352</a>
<a href="https://rdar.apple.com/136705852">rdar://136705852</a>

Reviewed by Abrar Rahman Protyasha.

This API test, which simulates accepting a text candidate that ends with a space and then inserts
another space, is flaky in debug. When this test fails, we get the following sequence of events:

1.  (UI) `WebViewImpl::handleAcceptedCandidate` is invoked, which sets `m_softSpaceRange`.
    `m_isHandlingAcceptedCandidate` is set here.

2.  (WEB) `WebPage::handleAcceptedCandidate` is called, scheduling an editor state update in the
    next layer tree commit in the process due to the selection change.

3.  (UI) `WebPageProxy::didHandleAcceptedCandidate` is called, which unsets
    `m_isHandlingAcceptedCandidate`.

4.  (UI) The next remote layer tree commit (with an editor state) scheduled in step (2) arrives,
    calling `WebViewImpl::selectionDidChange`. Because `m_isHandlingAcceptedCandidate` is `false`,
    `m_softSpaceRange` is set to `(NSNotFound, 0)`.

5.  (UI) The API test calls `WebViewImpl::insertText` with a single space. Since `m_softSpaceRange`
    is already reset, we don&apos;t end up replacing the first space with a period.

When this test passes, step (4) happens after step (5), so we replace the soft space. In other
words, this test failure boils down to a race between when the next layer tree commit arrives in
the UI process, and when the `m_isHandlingAcceptedCandidate` flag is unset.

To fix this, we refactor this logic so that `m_isHandlingAcceptedCandidate` is unset after the next
presentation update, to ensure that it remains set until after the next call to `selectionDidChange`
triggered by accepting the text candidate.

* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didHandleAcceptedCandidate): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::didHandleAcceptedCandidate): Deleted.

Remove this IPC message and plumbing, since it&apos;s now unnecessary — this was only used to
(prematurely) reset the value of `m_isHandlingAcceptedCandidate` in the UI process, and also to
facilitate the testing `WKWebView` subclassing hook `-_didHandleAcceptedCandidate`.

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::handleAcceptedCandidate):

Use `callAfterNextPresentationUpdate` to unset the flag.

(WebKit::WebViewImpl::didHandleAcceptedCandidate): Deleted.
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::handleAcceptedCandidate):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCandidateTests.mm:
(TEST(WKWebViewCandidateTests, SoftSpaceReplacementAfterCandidateInsertionWithoutReplacement)):

Reenable the test.

Canonical link: <a href="https://commits.webkit.org/288366@main">https://commits.webkit.org/288366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15e940d8775bfd4ac617319c73038ce92f4ae89e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87576 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64260 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22012 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75010 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44537 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29196 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32546 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72743 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29831 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88933 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72661 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71878 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17921 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16016 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15022 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1126 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9703 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15224 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9577 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13043 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11347 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->