### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/css

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -43,8 +43,6 @@
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/TextStream.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSSelector);
@@ -360,6 +358,7 @@ std::optional<CSSSelector::PseudoElement> CSSSelector::parsePseudoElementName(St
     return *type;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 const CSSSelector* CSSSelector::firstInCompound() const
 {
     auto* selector = this;
@@ -371,6 +370,7 @@ const CSSSelector* CSSSelector::firstInCompound() const
     }
     return selector;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static void appendPseudoClassFunctionTail(StringBuilder& builder, const CSSSelector* selector)
 {
@@ -910,5 +910,3 @@ bool CSSSelector::isHostPseudoClass() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -28,8 +28,6 @@
 #include <wtf/FixedVector.h>
 #include <wtf/TZoneMalloc.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 class CSSSelectorList;
@@ -133,7 +131,10 @@ public:
 
     // Selectors are kept in an array by CSSSelectorList.
     // The next component of the selector is the next item in the array.
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     const CSSSelector* tagHistory() const { return m_isLastInTagHistory ? nullptr : this + 1; }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
     const CSSSelector* firstInCompound() const;
 
     const QualifiedName& tagQName() const;
@@ -205,7 +206,10 @@ private:
     void setImplicit() { m_isImplicit = true; }
 
     unsigned simpleSelectorSpecificityForPage() const;
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     CSSSelector* tagHistory() { return m_isLastInTagHistory ? nullptr : this + 1; }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     unsigned m_relation : 4 { enumToUnderlyingType(Relation::DescendantSpace) };
     mutable unsigned m_match : 5 { enumToUnderlyingType(Match::Unknown) };
@@ -452,5 +456,3 @@ inline void CSSSelector::setMatch(Match match)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -32,8 +32,6 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSSelectorList);
@@ -87,6 +85,7 @@ CSSSelectorList::CSSSelectorList(MutableCSSSelectorList&& selectorVector)
     m_selectorArray[arrayIndex - 1].setLastInSelectorList();
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 unsigned CSSSelectorList::componentCount() const
 {
     if (!m_selectorArray)
@@ -110,6 +109,7 @@ unsigned CSSSelectorList::listSize() const
     }
     return size;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 String CSSSelectorList::selectorsText() const
 {
@@ -180,5 +180,3 @@ bool CSSSelectorList::hasOnlyNestingSelector() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -31,8 +31,6 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueArray.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 class MutableCSSSelector;
@@ -102,6 +100,7 @@ private:
     UniqueArray<CSSSelector> m_selectorArray;
 };
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 inline const CSSSelector* CSSSelectorList::next(const CSSSelector* current)
 {
     // Skip subparts of compound selectors.
@@ -109,7 +108,6 @@ inline const CSSSelector* CSSSelectorList::next(const CSSSelector* current)
         current++;
     return current->isLastInSelectorList() ? 0 : current + 1;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/CSSValueList.cpp
+++ b/Source/WebCore/css/CSSValueList.cpp
@@ -25,8 +25,6 @@
 #include <wtf/Hasher.h>
 #include <wtf/text/StringBuilder.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 CSSValueContainingVector::CSSValueContainingVector(ClassType type, ValueSeparator separator)
@@ -50,8 +48,10 @@ CSSValueContainingVector::CSSValueContainingVector(ClassType type, ValueSeparato
         for (unsigned i = 0; i < maxInlineSize; ++i)
             m_inlineStorage[i] = &values[i].leakRef();
         m_additionalStorage = static_cast<const CSSValue**>(fastMalloc(sizeof(const CSSValue*) * (m_size - maxInlineSize)));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         for (unsigned i = maxInlineSize; i < m_size; ++i)
             m_additionalStorage[i - maxInlineSize] = &values[i].leakRef();
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 }
 
@@ -299,5 +299,3 @@ IterationStatus CSSValueContainingVector::customVisitChildren(const Function<Ite
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -24,8 +24,6 @@
 #include <array>
 #include <unicode/umachine.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static constexpr size_t CSSValueListBuilderInlineCapacity = 4;
@@ -148,7 +146,9 @@ inline const CSSValue& CSSValueContainingVector::operator[](unsigned index) cons
         return *m_inlineStorage[index];
     }
     RELEASE_ASSERT(index < m_size);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return *m_additionalStorage[index - maxInlineSize];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 void add(Hasher&, const CSSValueContainingVector&);
@@ -157,5 +157,3 @@ void add(Hasher&, const CSSValueContainingVector&);
 
 SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSValueContainingVector, containsVector())
 SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSValueList, isValueList())
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/CSSValuePool.cpp
+++ b/Source/WebCore/css/CSSValuePool.cpp
@@ -31,8 +31,6 @@
 #include "CSSValueKeywords.h"
 #include "CSSValueList.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSValuePool);
 
@@ -131,5 +129,3 @@ void CSSValuePool::drain()
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/CSSValuePool.h
+++ b/Source/WebCore/css/CSSValuePool.h
@@ -32,8 +32,6 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/AtomStringHash.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 class CSSValueList;
@@ -58,10 +56,10 @@ private:
 
     static constexpr int maximumCacheableIntegerValue = 255;
 
-    LazyNeverDestroyed<CSSPrimitiveValue> m_pixelValues[maximumCacheableIntegerValue + 1];
-    LazyNeverDestroyed<CSSPrimitiveValue> m_percentageValues[maximumCacheableIntegerValue + 1];
-    LazyNeverDestroyed<CSSPrimitiveValue> m_numberValues[maximumCacheableIntegerValue + 1];
-    LazyNeverDestroyed<CSSPrimitiveValue> m_identifierValues[numCSSValueKeywords];
+    std::array<LazyNeverDestroyed<CSSPrimitiveValue>, maximumCacheableIntegerValue + 1> m_pixelValues;
+    std::array<LazyNeverDestroyed<CSSPrimitiveValue>, maximumCacheableIntegerValue + 1> m_percentageValues;
+    std::array<LazyNeverDestroyed<CSSPrimitiveValue>, maximumCacheableIntegerValue + 1> m_numberValues;
+    std::array<LazyNeverDestroyed<CSSPrimitiveValue>, numCSSValueKeywords> m_identifierValues;
 };
 
 WEBCORE_EXPORT extern LazyNeverDestroyed<StaticCSSValuePool> staticCSSValuePool;
@@ -97,5 +95,3 @@ inline Ref<CSSPrimitiveValue> CSSPrimitiveValue::create(CSSValueID identifier)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -105,8 +105,6 @@
 #include "ViewTimeline.h"
 #include "WebAnimationUtilities.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ComputedStyleExtractor);
 
@@ -5047,9 +5045,11 @@ Ref<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesForShorthandProper
 
 RefPtr<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesFor2SidesShorthand(const StylePropertyShorthand& shorthand) const
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // Assume the properties are in the usual order start, end.
     auto startValue = propertyValue(shorthand.properties()[0], UpdateLayout::No);
     auto endValue = propertyValue(shorthand.properties()[1], UpdateLayout::No);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     // All 2 properties must be specified.
     if (!startValue || !endValue)
@@ -5062,11 +5062,13 @@ RefPtr<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesFor2SidesShorth
 
 RefPtr<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesFor4SidesShorthand(const StylePropertyShorthand& shorthand) const
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // Assume the properties are in the usual order top, right, bottom, left.
     auto topValue = propertyValue(shorthand.properties()[0], UpdateLayout::No);
     auto rightValue = propertyValue(shorthand.properties()[1], UpdateLayout::No);
     auto bottomValue = propertyValue(shorthand.properties()[2], UpdateLayout::No);
     auto leftValue = propertyValue(shorthand.properties()[3], UpdateLayout::No);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     // All 4 properties must be specified.
     if (!topValue || !rightValue || !bottomValue || !leftValue)
@@ -5193,5 +5195,3 @@ Ref<CSSValue> ComputedStyleExtractor::getMaskShorthandValue() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/ImmutableStyleProperties.cpp
+++ b/Source/WebCore/css/ImmutableStyleProperties.cpp
@@ -31,12 +31,11 @@
 #include <wtf/Hasher.h>
 #include <wtf/NeverDestroyed.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ImmutableStyleProperties);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 ImmutableStyleProperties::ImmutableStyleProperties(const CSSProperty* properties, unsigned length, CSSParserMode mode)
     : StyleProperties(mode, length)
 {
@@ -49,12 +48,15 @@ ImmutableStyleProperties::ImmutableStyleProperties(const CSSProperty* properties
         value->ref();
     }
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 ImmutableStyleProperties::~ImmutableStyleProperties()
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     auto* valueArray = std::bit_cast<PackedPtr<CSSValue>*>(this->valueArray());
     for (unsigned i = 0; i < m_arraySize; ++i)
         valueArray[i]->deref();
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 Ref<ImmutableStyleProperties> ImmutableStyleProperties::create(const CSSProperty* properties, unsigned count, CSSParserMode mode)
@@ -69,6 +71,7 @@ static auto& deduplicationMap()
     return map.get();
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 Ref<ImmutableStyleProperties> ImmutableStyleProperties::createDeduplicating(const CSSProperty* properties, unsigned count, CSSParserMode mode)
 {
     static constexpr auto maximumDeduplicationMapSize = 1024u;
@@ -111,6 +114,7 @@ Ref<ImmutableStyleProperties> ImmutableStyleProperties::createDeduplicating(cons
 
     return result.iterator->value;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void ImmutableStyleProperties::clearDeduplicationMap()
 {
@@ -123,8 +127,10 @@ int ImmutableStyleProperties::findPropertyIndex(CSSPropertyID propertyID) const
     // the compiler converting it to an int multiple times in the loop.
     uint16_t id = enumToUnderlyingType(propertyID);
     for (int n = m_arraySize - 1 ; n >= 0; --n) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (metadataArray()[n].m_propertyID == id)
             return n;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
     return -1;
 }
@@ -132,6 +138,7 @@ int ImmutableStyleProperties::findPropertyIndex(CSSPropertyID propertyID) const
 int ImmutableStyleProperties::findCustomPropertyIndex(StringView propertyName) const
 {
     for (int n = m_arraySize - 1 ; n >= 0; --n) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (metadataArray()[n].m_propertyID == CSSPropertyCustom) {
             // We found a custom property. See if the name matches.
             auto* value = valueArray()[n].get();
@@ -140,10 +147,9 @@ int ImmutableStyleProperties::findCustomPropertyIndex(StringView propertyName) c
             if (downcast<CSSCustomPropertyValue>(*value).name() == propertyName)
                 return n;
         }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
     return -1;
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/ImmutableStyleProperties.h
+++ b/Source/WebCore/css/ImmutableStyleProperties.h
@@ -26,8 +26,6 @@
 
 #include "StyleProperties.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ImmutableStyleProperties);
@@ -69,16 +67,19 @@ inline void ImmutableStyleProperties::deref() const
         delete this;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 inline PackedPtr<const CSSValue>* ImmutableStyleProperties::valueArray() const
 {
     return std::bit_cast<PackedPtr<const CSSValue>*>(std::bit_cast<const uint8_t*>(metadataArray()) + (m_arraySize * sizeof(StylePropertyMetadata)));
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 inline const StylePropertyMetadata* ImmutableStyleProperties::metadataArray() const
 {
     return reinterpret_cast<const StylePropertyMetadata*>(const_cast<const void**>((&(this->m_storage))));
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 inline ImmutableStyleProperties::PropertyReference ImmutableStyleProperties::propertyAt(unsigned index) const
 {
     return PropertyReference(metadataArray()[index], valueArray()[index].get());
@@ -88,11 +89,10 @@ constexpr size_t ImmutableStyleProperties::objectSize(unsigned count)
 {
     return sizeof(ImmutableStyleProperties) - sizeof(void*) + sizeof(StylePropertyMetadata) * count + sizeof(PackedPtr<const CSSValue>) * count;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 }
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ImmutableStyleProperties)
     static bool isType(const WebCore::StyleProperties& properties) { return !properties.isMutable(); }
 SPECIALIZE_TYPE_TRAITS_END()
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -54,8 +54,6 @@
 #include "ViewTransition.h"
 #include "ViewTransitionTypeSet.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 using namespace HTMLNames;
@@ -1304,7 +1302,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
             if (list.size() == 1)
                 return true;
 
-            return std::ranges::all_of(list.begin() + 1, list.end(),
+            return std::ranges::all_of(list.span().subspan(1),
                 [&](const AtomString& classSelector) {
                     return checkingContext.classList.contains(classSelector);
                 }
@@ -1656,5 +1654,3 @@ unsigned SelectorChecker::determineLinkMatchType(const CSSSelector* selector)
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/StylePropertyShorthand.h
+++ b/Source/WebCore/css/StylePropertyShorthand.h
@@ -25,8 +25,6 @@
 #include "CSSValueKeywords.h"
 #include <wtf/Vector.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 class StylePropertyShorthand {
@@ -41,11 +39,15 @@ public:
     }
 
     const CSSPropertyID* begin() const { return properties(); }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     const CSSPropertyID* end() const { return properties() + length(); }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     const CSSPropertyID* properties() const { return m_properties; }
     unsigned length() const { return m_length; }
     CSSPropertyID id() const { return m_shorthandID; }
+
+    std::span<const CSSPropertyID> propertiesSpan() const { return unsafeMakeSpan(m_properties, m_length); }
 
 private:
     const CSSPropertyID* m_properties { nullptr };
@@ -72,5 +74,3 @@ unsigned indexOfShorthandForLonghand(CSSPropertyID, const StylePropertyShorthand
 namespace WTF {
 template<> inline size_t containerSize(const WebCore::StylePropertyShorthand& container) { return container.length(); }
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -47,8 +47,6 @@
 #include "MediaQueryParser.h"
 #include <wtf/SortedArrayMap.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 namespace CSSCalc {
 
@@ -1301,8 +1299,10 @@ std::optional<TypedChild> parseCalcSum(CSSParserTokenRange& tokens, int depth, P
         if (operatorCharacter != static_cast<char>(Calculation::Operator::Sum) && operatorCharacter != static_cast<char>(Calculation::Operator::Negate))
             break;
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (!CSSTokenizer::isWhitespace((&tokens.peek() - 1)->type()))
             return std::nullopt; // calc(1px+ 2px) is invalid
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         tokens.consume();
         if (!CSSTokenizer::isWhitespace(tokens.peek().type()))
@@ -1535,5 +1535,3 @@ std::optional<TypedChild> parseCalcDimension(const CSSParserToken& token, Parser
 
 } // namespace CSSCalc
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -78,8 +78,6 @@
 #include <memory>
 #include <optional>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 CSSParserImpl::~CSSParserImpl() = default;
@@ -165,7 +163,7 @@ static Ref<ImmutableStyleProperties> createStyleProperties(ParsedPropertyVector&
     filterProperties(IsImportant::Yes, parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
     filterProperties(IsImportant::No, parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
 
-    Ref result = ImmutableStyleProperties::createDeduplicating(results.data() + unusedEntries, results.size() - unusedEntries, mode);
+    Ref result = ImmutableStyleProperties::createDeduplicating(results.subspan(unusedEntries).data(), results.size() - unusedEntries, mode);
     parsedProperties.clear();
     return result;
 }
@@ -1651,5 +1649,3 @@ Vector<double> CSSParserImpl::consumeKeyframeKeyList(CSSParserTokenRange range)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/parser/CSSParserObserverWrapper.cpp
+++ b/Source/WebCore/css/parser/CSSParserObserverWrapper.cpp
@@ -32,8 +32,6 @@
 
 #include "CSSParserTokenRange.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 unsigned CSSParserObserverWrapper::startOffset(const CSSParserTokenRange& range)
@@ -53,6 +51,7 @@ unsigned CSSParserObserverWrapper::endOffset(const CSSParserTokenRange& range)
     return m_tokenOffsets[range.end() - m_firstParserToken];
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 void CSSParserObserverWrapper::skipCommentsBefore(const CSSParserTokenRange& range, bool leaveDirectlyBefore)
 {
     unsigned startIndex = range.begin() - m_firstParserToken;
@@ -70,7 +69,6 @@ void CSSParserObserverWrapper::yieldCommentsBefore(const CSSParserTokenRange& ra
         ++m_commentIterator;
     }
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -35,8 +35,6 @@
 #include <wtf/HexNumber.h>
 #include <wtf/text/StringBuilder.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSParserToken);
 
@@ -401,6 +399,7 @@ CSSParserToken::CSSParserToken(HashTokenType type, StringView value)
     initValueFromStringView(value);
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 static StringView mergeIfAdjacent(StringView a, StringView b)
 {
     if (a.is8Bit() && b.is8Bit()) {
@@ -414,6 +413,7 @@ static StringView mergeIfAdjacent(StringView a, StringView b)
     }
     return { };
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void CSSParserToken::convertToDimensionWithUnit(StringView unit)
 {
@@ -797,5 +797,3 @@ void CSSParserToken::serialize(StringBuilder& builder, const CSSParserToken* nex
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/parser/CSSParserTokenRange.cpp
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.cpp
@@ -34,8 +34,6 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringBuilder.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 CSSParserToken& CSSParserTokenRange::eofToken()
@@ -54,6 +52,7 @@ CSSParserTokenRange CSSParserTokenRange::makeSubRange(const CSSParserToken* firs
     return CSSParserTokenRange(first, last);
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 CSSParserTokenRange CSSParserTokenRange::consumeBlock()
 {
     ASSERT(peek().getBlockType() == CSSParserToken::BlockStart);
@@ -129,7 +128,6 @@ String CSSParserTokenRange::serialize(CSSParserToken::SerializationMode mode) co
         it->serialize(builder, it + 1 == m_last ? nullptr : it + 1, mode);
     return builder.toString();
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -33,8 +33,6 @@
 #include "CSSTokenizer.h"
 #include <wtf/Forward.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 class StyleSheetContents;
@@ -61,6 +59,7 @@ public:
 
     size_t size() const { return end() - begin(); }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     const CSSParserToken& peek(unsigned offset = 0) const
     {
         if (m_first + offset >= m_last)
@@ -74,6 +73,7 @@ public:
             return eofToken();
         return *m_first++;
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     const CSSParserToken& consumeIncludingWhitespace()
     {
@@ -88,11 +88,13 @@ public:
 
     void consumeComponentValue();
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     void consumeWhitespace()
     {
         while (CSSTokenizer::isWhitespace(peek().type()))
             ++m_first;
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     void trimTrailingWhitespace();
     const CSSParserToken& consumeLast();
@@ -102,7 +104,7 @@ public:
     String serialize(CSSParserToken::SerializationMode = CSSParserToken::SerializationMode::Normal) const;
 
     const CSSParserToken* begin() const { return m_first; }
-    std::span<const CSSParserToken> span() const { return std::span { begin(), size() }; }
+    std::span<const CSSParserToken> span() const { return unsafeMakeSpan(begin(), size()); }
 
     static CSSParserToken& eofToken();
 
@@ -117,5 +119,3 @@ private:
 };
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -95,8 +95,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/StringBuilder.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 bool isCustomPropertyName(StringView propertyName)
@@ -106,14 +104,14 @@ bool isCustomPropertyName(StringView propertyName)
 
 template<typename CharacterType> static CSSPropertyID cssPropertyID(std::span<const CharacterType> characters)
 {
-    char buffer[maxCSSPropertyNameLength];
+    std::array<char, maxCSSPropertyNameLength> buffer;
     for (size_t i = 0; i != characters.size(); ++i) {
         auto character = characters[i];
         if (!character || !isASCII(character))
             return CSSPropertyInvalid;
         buffer[i] = toASCIILower(character);
     }
-    return findCSSProperty(buffer, characters.size());
+    return findCSSProperty(buffer.data(), characters.size());
 }
 
 // FIXME: Remove this mechanism entirely once we can do it without breaking the web.
@@ -724,7 +722,7 @@ bool CSSPropertyParser::consumeFont(bool important)
 
     auto range = m_range;
 
-    RefPtr<CSSValue> values[7];
+    std::array<RefPtr<CSSValue>, 7> values;
     auto& fontStyle = values[0];
     auto& fontVariantCaps = values[1];
     auto& fontWeight = values[2];
@@ -771,8 +769,11 @@ bool CSSPropertyParser::consumeFont(bool important)
 
     m_range = range;
     auto shorthand = fontShorthand();
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     for (unsigned i = 0; i < shorthand.length(); ++i)
         addProperty(shorthand.properties()[i], CSSPropertyFont, i < std::size(values) ? WTFMove(values[i]) : nullptr, important, true);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
     return true;
 }
 
@@ -1523,13 +1524,14 @@ CSSValueID initialValueIDForLonghand(CSSPropertyID longhand)
 bool CSSPropertyParser::consumeShorthandGreedily(const StylePropertyShorthand& shorthand, bool important)
 {
     ASSERT(shorthand.length() <= 6); // Existing shorthands have at most 6 longhands.
-    RefPtr<CSSValue> longhands[6];
-    const CSSPropertyID* shorthandProperties = shorthand.properties();
+    std::array<RefPtr<CSSValue>, 6> longhands;
+    auto shorthandProperties = shorthand.propertiesSpan();
     do {
         bool foundLonghand = false;
         for (size_t i = 0; !foundLonghand && i < shorthand.length(); ++i) {
             if (longhands[i])
                 continue;
+
             longhands[i] = parseSingleValue(shorthandProperties[i], shorthand.id());
             if (longhands[i])
                 foundLonghand = true;
@@ -1665,7 +1667,7 @@ bool CSSPropertyParser::consumeBorderShorthand(CSSPropertyID widthProperty, CSSP
 bool CSSPropertyParser::consume2ValueShorthand(const StylePropertyShorthand& shorthand, bool important)
 {
     ASSERT(shorthand.length() == 2);
-    const CSSPropertyID* longhands = shorthand.properties();
+    auto longhands = shorthand.propertiesSpan();
     RefPtr start = parseSingleValue(longhands[0], shorthand.id());
     if (!start)
         return false;
@@ -1683,7 +1685,7 @@ bool CSSPropertyParser::consume2ValueShorthand(const StylePropertyShorthand& sho
 bool CSSPropertyParser::consume4ValueShorthand(const StylePropertyShorthand& shorthand, bool important)
 {
     ASSERT(shorthand.length() == 4);
-    const CSSPropertyID* longhands = shorthand.properties();
+    auto longhands = shorthand.propertiesSpan();
     RefPtr top = parseSingleValue(longhands[0], shorthand.id());
     if (!top)
         return false;
@@ -1895,19 +1897,20 @@ static RefPtr<CSSValue> consumeAnimationValueForShorthand(CSSPropertyID property
 
 bool CSSPropertyParser::consumeAnimationShorthand(const StylePropertyShorthand& shorthand, bool important)
 {
+    auto shorthandProperties = shorthand.propertiesSpan();
     const unsigned longhandCount = shorthand.length();
-    CSSValueListBuilder longhands[8];
+    std::array<CSSValueListBuilder, 8> longhands;
     ASSERT(longhandCount <= 8);
 
     do {
-        bool parsedLonghand[8] = { false };
+        std::array<bool, 8> parsedLonghand = { };
         do {
             bool foundProperty = false;
             for (size_t i = 0; i < longhandCount; ++i) {
                 if (parsedLonghand[i])
                     continue;
 
-                if (auto value = consumeAnimationValueForShorthand(shorthand.properties()[i], m_range, m_context)) {
+                if (auto value = consumeAnimationValueForShorthand(shorthandProperties[i], m_range, m_context)) {
                     parsedLonghand[i] = true;
                     foundProperty = true;
                     longhands[i].append(*value);
@@ -1926,12 +1929,12 @@ bool CSSPropertyParser::consumeAnimationShorthand(const StylePropertyShorthand& 
     } while (consumeCommaIncludingWhitespace(m_range));
 
     for (size_t i = 0; i < longhandCount; ++i) {
-        if (!isValidAnimationPropertyList(shorthand.properties()[i], longhands[i]))
+        if (!isValidAnimationPropertyList(shorthandProperties[i], longhands[i]))
             return false;
     }
 
     for (size_t i = 0; i < longhandCount; ++i)
-        addProperty(shorthand.properties()[i], shorthand.id(), CSSValueList::createCommaSeparated(WTFMove(longhands[i])), important);
+        addProperty(shorthandProperties[i], shorthand.id(), CSSValueList::createCommaSeparated(WTFMove(longhands[i])), important);
 
     return m_range.atEnd();
 }
@@ -2027,17 +2030,18 @@ static RefPtr<CSSValue> consumeBackgroundComponent(CSSPropertyID property, CSSPa
 // the x properties in the shorthand array.
 bool CSSPropertyParser::consumeBackgroundShorthand(const StylePropertyShorthand& shorthand, bool important)
 {
+    auto shorthandProperties = shorthand.propertiesSpan();
     unsigned longhandCount = shorthand.length();
 
     // mask resets mask-border properties outside of this method.
     if (shorthand.id() == CSSPropertyMask)
         longhandCount -= maskBorderShorthand().length();
 
-    CSSValueListBuilder longhands[10];
+    std::array<CSSValueListBuilder, 10> longhands;
     ASSERT(longhandCount <= 10);
 
     do {
-        bool parsedLonghand[10] = { false };
+        std::array<bool, 10> parsedLonghand = { };
         bool lastParsedWasPosition = false;
         bool clipIsBorderArea = false;
         RefPtr<CSSValue> originValue;
@@ -2049,7 +2053,7 @@ bool CSSPropertyParser::consumeBackgroundShorthand(const StylePropertyShorthand&
 
                 RefPtr<CSSValue> value;
                 RefPtr<CSSValue> valueY;
-                CSSPropertyID property = shorthand.properties()[i];
+                CSSPropertyID property = shorthandProperties[i];
                 if (property == CSSPropertyBackgroundPositionX || property == CSSPropertyWebkitMaskPositionX) {
                     CSSParserTokenRange rangeCopy = m_range;
                     auto position = consumePositionCoordinates(rangeCopy, m_context, UnitlessQuirk::Forbid, PositionSyntax::BackgroundPosition);
@@ -2099,7 +2103,7 @@ bool CSSPropertyParser::consumeBackgroundShorthand(const StylePropertyShorthand&
         } while (!m_range.atEnd() && m_range.peek().type() != CommaToken);
 
         for (size_t i = 0; i < longhandCount; ++i) {
-            CSSPropertyID property = shorthand.properties()[i];
+            CSSPropertyID property = shorthandProperties[i];
             if (property == CSSPropertyBackgroundColor && !m_range.atEnd()) {
                 if (parsedLonghand[i])
                     return false; // Colors are only allowed in the last layer.
@@ -2121,7 +2125,7 @@ bool CSSPropertyParser::consumeBackgroundShorthand(const StylePropertyShorthand&
         return false;
 
     for (size_t i = 0; i < longhandCount; ++i) {
-        CSSPropertyID property = shorthand.properties()[i];
+        CSSPropertyID property = shorthandProperties[i];
         if (longhands[i].size() == 1)
             addProperty(property, shorthand.id(), WTFMove(longhands[i][0]), important);
         else
@@ -2183,8 +2187,9 @@ bool CSSPropertyParser::consumeGridItemPositionShorthand(CSSPropertyID shorthand
     }
     if (!m_range.atEnd())
         return false;
-    addProperty(shorthand.properties()[0], shorthandId, startValue.releaseNonNull(), important);
-    addProperty(shorthand.properties()[1], shorthandId, endValue.releaseNonNull(), important);
+    auto longhands = shorthand.propertiesSpan();
+    addProperty(longhands[0], shorthandId, startValue.releaseNonNull(), important);
+    addProperty(longhands[1], shorthandId, endValue.releaseNonNull(), important);
     return true;
 }
 
@@ -2427,7 +2432,7 @@ bool CSSPropertyParser::consumeAlignShorthand(const StylePropertyShorthand& shor
     //   <'gap'>           https://drafts.csswg.org/css-align/#propdef-gap
 
     ASSERT(shorthand.length() == 2);
-    const auto* longhands = shorthand.properties();
+    auto longhands = shorthand.propertiesSpan();
 
     auto rangeCopy = m_range;
 
@@ -3221,5 +3226,3 @@ bool CSSPropertyParser::parseShorthand(CSSPropertyID property, bool important)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -38,8 +38,6 @@
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/unicode/CharacterNames.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSTokenizer);
 
@@ -388,7 +386,7 @@ CSSParserToken CSSTokenizer::endOfFile(UChar)
     return CSSParserToken(EOFToken);
 }
 
-const CSSTokenizer::CodePoint CSSTokenizer::codePoints[128] = {
+const std::array<CSSTokenizer::CodePoint, 128> CSSTokenizer::codePoints {
     &CSSTokenizer::endOfFile,
     0,
     0,
@@ -882,5 +880,3 @@ StringView CSSTokenizer::registerString(const String& string)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/css/parser/CSSTokenizer.h
+++ b/Source/WebCore/css/parser/CSSTokenizer.h
@@ -126,7 +126,7 @@ private:
     StringView registerString(const String&);
 
     using CodePoint = CSSParserToken (CSSTokenizer::*)(UChar);
-    static const CodePoint codePoints[];
+    static const std::array<CodePoint, 128> codePoints;
 
     Vector<CSSParserTokenType, 8> m_blockStack;
     Vector<CSSParserToken, 32> m_tokens;


### PR DESCRIPTION
#### 59753bb799563449ba706cd1c8cb5e37ba9978ba
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/css
<a href="https://bugs.webkit.org/show_bug.cgi?id=285155">https://bugs.webkit.org/show_bug.cgi?id=285155</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/css/CSSCounterStyle.cpp:
(WebCore::counterForSystemCJK):
(WebCore::CSSCounterStyle::counterForSystemEthiopicNumeric):
* Source/WebCore/css/CSSSelector.cpp:
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/CSSSelectorList.cpp:
* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/css/CSSStyleDeclaration.cpp:
(WebCore::lookupCSSPropertyFromIDLAttribute):
* Source/WebCore/css/CSSValueList.cpp:
(WebCore::CSSValueContainingVector::CSSValueContainingVector):
* Source/WebCore/css/CSSValueList.h:
(WebCore::CSSValueContainingVector::operator[] const):
* Source/WebCore/css/CSSValuePool.cpp:
* Source/WebCore/css/CSSValuePool.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesFor2SidesShorthand const):
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesFor4SidesShorthand const):
* Source/WebCore/css/ImmutableStyleProperties.cpp:
(WebCore::ImmutableStyleProperties::ImmutableStyleProperties):
(WebCore::ImmutableStyleProperties::~ImmutableStyleProperties):
(WebCore::ImmutableStyleProperties::createDeduplicating):
(WebCore::ImmutableStyleProperties::findPropertyIndex const):
(WebCore::ImmutableStyleProperties::findCustomPropertyIndex const):
* Source/WebCore/css/ImmutableStyleProperties.h:
* Source/WebCore/css/MutableStyleProperties.cpp:
(WebCore::MutableStyleProperties::removeShorthandProperty):
(WebCore::MutableStyleProperties::setProperty):
(WebCore::MutableStyleProperties::canUpdateInPlace const):
(WebCore::MutableStyleProperties::findPropertyIndex const):
(WebCore::MutableStyleProperties::findCustomPropertyIndex const):
(WebCore::span): Deleted.
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::longhandProperty const):
(WebCore::LayerValues::set):
(WebCore::ShorthandSerializer::serializeBorderRadius const):
* Source/WebCore/css/StylePropertyShorthand.h:
(WebCore::StylePropertyShorthand::propertiesSpan const):
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::parseCalcSum):
* Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp:
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
* Source/WebCore/css/parser/CSSParserObserverWrapper.cpp:
* Source/WebCore/css/parser/CSSParserToken.cpp:
* Source/WebCore/css/parser/CSSParserTokenRange.cpp:
* Source/WebCore/css/parser/CSSParserTokenRange.h:
(WebCore::CSSParserTokenRange::span const):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
* Source/WebCore/css/parser/CSSTokenizer.cpp:

Canonical link: <a href="https://commits.webkit.org/288299@main">https://commits.webkit.org/288299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c25a1bc08dce0d8ee4a321b03c95d29e57ec11a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87516 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33445 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9933 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64210 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21959 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1497 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44487 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1397 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29143 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32486 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72688 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88872 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6949 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72608 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9916 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71825 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15963 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14972 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1059 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12789 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9643 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15164 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9517 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12983 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11287 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->