### PR TITLE
Fix few baseline calculation cases for tables with empty rows

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/baseline-table-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/baseline-table-expected.txt
@@ -50,47 +50,16 @@ Xp   > 
 
 PASS .container 1
 PASS .container 2
-FAIL .container 3 assert_equals:
-<div class="container">
-  Xp<table data-offset-y="25">
-    <tbody>
-      <tr></tr>
-    </tbody>
-  </table>
-</div>
-offsetTop expected 25 but got 10
-FAIL .container 4 assert_equals:
-<div class="container">
-  Xp<table style="font: 12px fixed" data-offset-y="25">
-    <tbody>
-      <tr></tr>
-      <tr><td>1,0</td></tr>
-    </tbody>
-  </table>
-</div>
-offsetTop expected 25 but got 0
+PASS .container 3
+PASS .container 4
 PASS .container 5
 PASS .container 6
 PASS .container 7
 PASS .container 8
 PASS .container 9
 PASS .container 10
-FAIL .container 11 assert_equals:
-<div class="container">
-  Xp<table data-offset-y="25" data-expected-height="50">
-    <tbody><tr style="height:20px"></tr>
-    <tr></tr>
-  </tbody></table>
-</div>
-offsetTop expected 25 but got 0
-FAIL .container 12 assert_equals:
-<div class="container">
-  Xp<table data-offset-y="25" data-expected-height="68">
-    <tbody><tr style="height:20px"></tr>
-    <tr><td style="font-size:10px">X</td></tr>
-  </tbody></table>
-</div>
-offsetTop expected 25 but got 0
+PASS .container 11
+PASS .container 12
 FAIL .container 13 assert_equals:
 <div class="container">
   Xp<table>

--- a/LayoutTests/platform/glib/fast/dynamic/insert-before-table-part-in-continuation-expected.txt
+++ b/LayoutTests/platform/glib/fast/dynamic/insert-before-table-part-in-continuation-expected.txt
@@ -44,18 +44,18 @@ layer at (0,0) size 800x600
                 RenderTableCell {DIV} at (0,0) size 103x18 [r=0 c=1 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 103x17
                     text run at (0,0) width 103: "...continues here"
-      RenderBlock {DIV} at (0,158) size 784x22
-        RenderInline {SPAN} at (0,4) size 143x17
-          RenderText {#text} at (0,4) size 40x17
-            text run at (0,4) width 40: "Text..."
-          RenderTable at (39,0) size 104x18
+      RenderBlock {DIV} at (0,158) size 784x32
+        RenderInline {SPAN} at (0,0) size 143x17
+          RenderText {#text} at (0,0) size 40x17
+            text run at (0,0) width 40: "Text..."
+          RenderTable at (39,14) size 104x18
             RenderTableSection (anonymous) at (0,0) size 103x18
               RenderTableRow {TR} at (0,0) size 103x0
               RenderTableRow (anonymous) at (0,0) size 103x18
                 RenderTableCell {DIV} at (0,0) size 103x18 [r=1 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 103x17
                     text run at (0,0) width 103: "...continues here"
-      RenderBlock {DIV} at (0,180) size 784x18
+      RenderBlock {DIV} at (0,190) size 784x18
         RenderInline {SPAN} at (0,0) size 143x17
           RenderText {#text} at (0,0) size 40x17
             text run at (0,0) width 40: "Text..."
@@ -66,7 +66,7 @@ layer at (0,0) size 800x600
                 RenderTableCell {DIV} at (0,0) size 103x18 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 103x17
                     text run at (0,0) width 103: "...continues here"
-      RenderBlock {DIV} at (0,198) size 784x36
+      RenderBlock {DIV} at (0,208) size 784x36
         RenderBlock (anonymous) at (0,0) size 784x18
           RenderInline {SPAN} at (0,0) size 40x17
             RenderText {#text} at (0,0) size 40x17
@@ -81,7 +81,7 @@ layer at (0,0) size 800x600
                   RenderTableCell {DIV} at (0,0) size 103x18 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (0,0) size 103x17
                       text run at (0,0) width 103: "...continues here"
-      RenderBlock {DIV} at (0,234) size 784x18
+      RenderBlock {DIV} at (0,244) size 784x18
         RenderInline {SPAN} at (0,0) size 230x17
           RenderText {#text} at (0,0) size 40x17
             text run at (0,0) width 40: "Text..."
@@ -93,7 +93,7 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 103x18 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 103x17
                     text run at (0,0) width 103: "...continues here"
-      RenderBlock {DIV} at (0,252) size 784x22
+      RenderBlock {DIV} at (0,262) size 784x22
         RenderInline {SPAN} at (0,4) size 143x17
           RenderText {#text} at (0,4) size 40x17
             text run at (0,4) width 40: "Text..."
@@ -105,18 +105,18 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 103x18 [r=1 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 103x17
                     text run at (0,0) width 103: "...continues here"
-      RenderBlock {DIV} at (0,274) size 784x22
-        RenderInline {SPAN} at (0,4) size 143x17
-          RenderText {#text} at (0,4) size 40x17
-            text run at (0,4) width 40: "Text..."
-          RenderTable at (39,0) size 104x18
+      RenderBlock {DIV} at (0,284) size 784x32
+        RenderInline {SPAN} at (0,0) size 143x17
+          RenderText {#text} at (0,0) size 40x17
+            text run at (0,0) width 40: "Text..."
+          RenderTable at (39,14) size 104x18
             RenderTableSection (anonymous) at (0,0) size 103x18
               RenderTableRow {TR} at (0,0) size 103x0
               RenderTableRow {DIV} at (0,0) size 103x18
                 RenderTableCell (anonymous) at (0,0) size 103x18 [r=1 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 103x17
                     text run at (0,0) width 103: "...continues here"
-      RenderBlock {DIV} at (0,296) size 784x18
+      RenderBlock {DIV} at (0,316) size 784x18
         RenderInline {SPAN} at (0,0) size 143x17
           RenderText {#text} at (0,0) size 40x17
             text run at (0,0) width 40: "Text..."
@@ -127,7 +127,7 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 103x18 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 103x17
                     text run at (0,0) width 103: "...continues here"
-      RenderBlock {DIV} at (0,314) size 784x36
+      RenderBlock {DIV} at (0,334) size 784x36
         RenderBlock (anonymous) at (0,0) size 784x18
           RenderInline {SPAN} at (0,0) size 40x17
             RenderText {#text} at (0,0) size 40x17
@@ -142,7 +142,7 @@ layer at (0,0) size 800x600
                   RenderTableCell (anonymous) at (0,0) size 103x18 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (0,0) size 103x17
                       text run at (0,0) width 103: "...continues here"
-      RenderBlock {DIV} at (0,350) size 784x18
+      RenderBlock {DIV} at (0,370) size 784x18
         RenderInline {SPAN} at (0,0) size 230x17
           RenderText {#text} at (0,0) size 40x17
             text run at (0,0) width 40: "Text..."
@@ -154,7 +154,7 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 103x18 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 103x17
                     text run at (0,0) width 103: "...continues here"
-      RenderBlock {DIV} at (0,368) size 784x22
+      RenderBlock {DIV} at (0,388) size 784x22
         RenderInline {SPAN} at (0,4) size 143x17
           RenderText {#text} at (0,4) size 40x17
             text run at (0,4) width 40: "Text..."
@@ -167,11 +167,11 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 103x18 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 103x17
                     text run at (0,0) width 103: "...continues here"
-      RenderBlock {DIV} at (0,390) size 784x22
-        RenderInline {SPAN} at (0,4) size 143x17
-          RenderText {#text} at (0,4) size 40x17
-            text run at (0,4) width 40: "Text..."
-          RenderTable at (39,0) size 104x18
+      RenderBlock {DIV} at (0,410) size 784x32
+        RenderInline {SPAN} at (0,0) size 143x17
+          RenderText {#text} at (0,0) size 40x17
+            text run at (0,0) width 40: "Text..."
+          RenderTable at (39,14) size 104x18
             RenderTableSection (anonymous) at (0,0) size 103x0
               RenderTableRow {TR} at (0,0) size 103x0
             RenderTableSection {DIV} at (0,0) size 103x18
@@ -179,7 +179,7 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 103x18 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 103x17
                     text run at (0,0) width 103: "...continues here"
-      RenderBlock {DIV} at (0,412) size 784x18
+      RenderBlock {DIV} at (0,442) size 784x18
         RenderInline {SPAN} at (0,0) size 143x17
           RenderText {#text} at (0,0) size 40x17
             text run at (0,0) width 40: "Text..."
@@ -190,7 +190,7 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 103x18 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 103x17
                     text run at (0,0) width 103: "...continues here"
-      RenderBlock {DIV} at (0,430) size 784x36
+      RenderBlock {DIV} at (0,460) size 784x36
         RenderBlock (anonymous) at (0,0) size 784x18
           RenderInline {SPAN} at (0,0) size 40x17
             RenderText {#text} at (0,0) size 40x17

--- a/LayoutTests/platform/ios/fast/dynamic/insert-before-table-part-in-continuation-expected.txt
+++ b/LayoutTests/platform/ios/fast/dynamic/insert-before-table-part-in-continuation-expected.txt
@@ -44,18 +44,18 @@ layer at (0,0) size 800x600
                 RenderTableCell {DIV} at (0,0) size 105x20 [r=0 c=1 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x19
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,172) size 784x25
-        RenderInline {SPAN} at (0,5) size 146x19
-          RenderText {#text} at (0,5) size 41x19
-            text run at (0,5) width 41: "Text..."
-          RenderTable at (40,0) size 106x20
+      RenderBlock {DIV} at (0,172) size 784x35
+        RenderInline {SPAN} at (0,0) size 146x19
+          RenderText {#text} at (0,0) size 41x19
+            text run at (0,0) width 41: "Text..."
+          RenderTable at (40,15) size 106x20
             RenderTableSection (anonymous) at (0,0) size 105x20
               RenderTableRow {TR} at (0,0) size 105x0
               RenderTableRow (anonymous) at (0,0) size 105x20
                 RenderTableCell {DIV} at (0,0) size 105x20 [r=1 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x19
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,197) size 784x20
+      RenderBlock {DIV} at (0,207) size 784x20
         RenderInline {SPAN} at (0,0) size 146x19
           RenderText {#text} at (0,0) size 41x19
             text run at (0,0) width 41: "Text..."
@@ -66,7 +66,7 @@ layer at (0,0) size 800x600
                 RenderTableCell {DIV} at (0,0) size 105x20 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x19
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,217) size 784x40
+      RenderBlock {DIV} at (0,227) size 784x40
         RenderBlock (anonymous) at (0,0) size 784x20
           RenderInline {SPAN} at (0,0) size 41x19
             RenderText {#text} at (0,0) size 41x19
@@ -81,7 +81,7 @@ layer at (0,0) size 800x600
                   RenderTableCell {DIV} at (0,0) size 105x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (0,0) size 105x19
                       text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,257) size 784x20
+      RenderBlock {DIV} at (0,267) size 784x20
         RenderInline {SPAN} at (0,0) size 234x19
           RenderText {#text} at (0,0) size 41x19
             text run at (0,0) width 41: "Text..."
@@ -93,7 +93,7 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 105x20 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x19
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,277) size 784x25
+      RenderBlock {DIV} at (0,287) size 784x25
         RenderInline {SPAN} at (0,5) size 146x19
           RenderText {#text} at (0,5) size 41x19
             text run at (0,5) width 41: "Text..."
@@ -105,18 +105,18 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 105x20 [r=1 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x19
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,302) size 784x25
-        RenderInline {SPAN} at (0,5) size 146x19
-          RenderText {#text} at (0,5) size 41x19
-            text run at (0,5) width 41: "Text..."
-          RenderTable at (40,0) size 106x20
+      RenderBlock {DIV} at (0,312) size 784x35
+        RenderInline {SPAN} at (0,0) size 146x19
+          RenderText {#text} at (0,0) size 41x19
+            text run at (0,0) width 41: "Text..."
+          RenderTable at (40,15) size 106x20
             RenderTableSection (anonymous) at (0,0) size 105x20
               RenderTableRow {TR} at (0,0) size 105x0
               RenderTableRow {DIV} at (0,0) size 105x20
                 RenderTableCell (anonymous) at (0,0) size 105x20 [r=1 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x19
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,327) size 784x20
+      RenderBlock {DIV} at (0,347) size 784x20
         RenderInline {SPAN} at (0,0) size 146x19
           RenderText {#text} at (0,0) size 41x19
             text run at (0,0) width 41: "Text..."
@@ -127,7 +127,7 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 105x20 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x19
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,347) size 784x40
+      RenderBlock {DIV} at (0,367) size 784x40
         RenderBlock (anonymous) at (0,0) size 784x20
           RenderInline {SPAN} at (0,0) size 41x19
             RenderText {#text} at (0,0) size 41x19
@@ -142,7 +142,7 @@ layer at (0,0) size 800x600
                   RenderTableCell (anonymous) at (0,0) size 105x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (0,0) size 105x19
                       text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,387) size 784x20
+      RenderBlock {DIV} at (0,407) size 784x20
         RenderInline {SPAN} at (0,0) size 234x19
           RenderText {#text} at (0,0) size 41x19
             text run at (0,0) width 41: "Text..."
@@ -154,7 +154,7 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 105x20 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x19
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,407) size 784x25
+      RenderBlock {DIV} at (0,427) size 784x25
         RenderInline {SPAN} at (0,5) size 146x19
           RenderText {#text} at (0,5) size 41x19
             text run at (0,5) width 41: "Text..."
@@ -167,11 +167,11 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 105x20 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x19
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,432) size 784x25
-        RenderInline {SPAN} at (0,5) size 146x19
-          RenderText {#text} at (0,5) size 41x19
-            text run at (0,5) width 41: "Text..."
-          RenderTable at (40,0) size 106x20
+      RenderBlock {DIV} at (0,452) size 784x35
+        RenderInline {SPAN} at (0,0) size 146x19
+          RenderText {#text} at (0,0) size 41x19
+            text run at (0,0) width 41: "Text..."
+          RenderTable at (40,15) size 106x20
             RenderTableSection (anonymous) at (0,0) size 105x0
               RenderTableRow {TR} at (0,0) size 105x0
             RenderTableSection {DIV} at (0,0) size 105x20
@@ -179,7 +179,7 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 105x20 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x19
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,457) size 784x20
+      RenderBlock {DIV} at (0,487) size 784x20
         RenderInline {SPAN} at (0,0) size 146x19
           RenderText {#text} at (0,0) size 41x19
             text run at (0,0) width 41: "Text..."
@@ -190,7 +190,7 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 105x20 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x19
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,477) size 784x40
+      RenderBlock {DIV} at (0,507) size 784x40
         RenderBlock (anonymous) at (0,0) size 784x20
           RenderInline {SPAN} at (0,0) size 41x19
             RenderText {#text} at (0,0) size 41x19

--- a/LayoutTests/platform/mac/fast/dynamic/insert-before-table-part-in-continuation-expected.txt
+++ b/LayoutTests/platform/mac/fast/dynamic/insert-before-table-part-in-continuation-expected.txt
@@ -44,18 +44,18 @@ layer at (0,0) size 800x600
                 RenderTableCell {DIV} at (0,0) size 105x18 [r=0 c=1 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x18
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,158) size 784x22
-        RenderInline {SPAN} at (0,4) size 146x18
-          RenderText {#text} at (0,4) size 41x18
-            text run at (0,4) width 41: "Text..."
-          RenderTable at (40,0) size 106x18
+      RenderBlock {DIV} at (0,158) size 784x32
+        RenderInline {SPAN} at (0,0) size 146x18
+          RenderText {#text} at (0,0) size 41x18
+            text run at (0,0) width 41: "Text..."
+          RenderTable at (40,14) size 106x18
             RenderTableSection (anonymous) at (0,0) size 105x18
               RenderTableRow {TR} at (0,0) size 105x0
               RenderTableRow (anonymous) at (0,0) size 105x18
                 RenderTableCell {DIV} at (0,0) size 105x18 [r=1 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x18
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,180) size 784x18
+      RenderBlock {DIV} at (0,190) size 784x18
         RenderInline {SPAN} at (0,0) size 146x18
           RenderText {#text} at (0,0) size 41x18
             text run at (0,0) width 41: "Text..."
@@ -66,7 +66,7 @@ layer at (0,0) size 800x600
                 RenderTableCell {DIV} at (0,0) size 105x18 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x18
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,198) size 784x36
+      RenderBlock {DIV} at (0,208) size 784x36
         RenderBlock (anonymous) at (0,0) size 784x18
           RenderInline {SPAN} at (0,0) size 41x18
             RenderText {#text} at (0,0) size 41x18
@@ -81,7 +81,7 @@ layer at (0,0) size 800x600
                   RenderTableCell {DIV} at (0,0) size 105x18 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (0,0) size 105x18
                       text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,234) size 784x18
+      RenderBlock {DIV} at (0,244) size 784x18
         RenderInline {SPAN} at (0,0) size 234x18
           RenderText {#text} at (0,0) size 41x18
             text run at (0,0) width 41: "Text..."
@@ -93,7 +93,7 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 105x18 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x18
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,252) size 784x22
+      RenderBlock {DIV} at (0,262) size 784x22
         RenderInline {SPAN} at (0,4) size 146x18
           RenderText {#text} at (0,4) size 41x18
             text run at (0,4) width 41: "Text..."
@@ -105,18 +105,18 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 105x18 [r=1 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x18
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,274) size 784x22
-        RenderInline {SPAN} at (0,4) size 146x18
-          RenderText {#text} at (0,4) size 41x18
-            text run at (0,4) width 41: "Text..."
-          RenderTable at (40,0) size 106x18
+      RenderBlock {DIV} at (0,284) size 784x32
+        RenderInline {SPAN} at (0,0) size 146x18
+          RenderText {#text} at (0,0) size 41x18
+            text run at (0,0) width 41: "Text..."
+          RenderTable at (40,14) size 106x18
             RenderTableSection (anonymous) at (0,0) size 105x18
               RenderTableRow {TR} at (0,0) size 105x0
               RenderTableRow {DIV} at (0,0) size 105x18
                 RenderTableCell (anonymous) at (0,0) size 105x18 [r=1 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x18
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,296) size 784x18
+      RenderBlock {DIV} at (0,316) size 784x18
         RenderInline {SPAN} at (0,0) size 146x18
           RenderText {#text} at (0,0) size 41x18
             text run at (0,0) width 41: "Text..."
@@ -127,7 +127,7 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 105x18 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x18
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,314) size 784x36
+      RenderBlock {DIV} at (0,334) size 784x36
         RenderBlock (anonymous) at (0,0) size 784x18
           RenderInline {SPAN} at (0,0) size 41x18
             RenderText {#text} at (0,0) size 41x18
@@ -142,7 +142,7 @@ layer at (0,0) size 800x600
                   RenderTableCell (anonymous) at (0,0) size 105x18 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (0,0) size 105x18
                       text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,350) size 784x18
+      RenderBlock {DIV} at (0,370) size 784x18
         RenderInline {SPAN} at (0,0) size 234x18
           RenderText {#text} at (0,0) size 41x18
             text run at (0,0) width 41: "Text..."
@@ -154,7 +154,7 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 105x18 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x18
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,368) size 784x22
+      RenderBlock {DIV} at (0,388) size 784x22
         RenderInline {SPAN} at (0,4) size 146x18
           RenderText {#text} at (0,4) size 41x18
             text run at (0,4) width 41: "Text..."
@@ -167,11 +167,11 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 105x18 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x18
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,390) size 784x22
-        RenderInline {SPAN} at (0,4) size 146x18
-          RenderText {#text} at (0,4) size 41x18
-            text run at (0,4) width 41: "Text..."
-          RenderTable at (40,0) size 106x18
+      RenderBlock {DIV} at (0,410) size 784x32
+        RenderInline {SPAN} at (0,0) size 146x18
+          RenderText {#text} at (0,0) size 41x18
+            text run at (0,0) width 41: "Text..."
+          RenderTable at (40,14) size 106x18
             RenderTableSection (anonymous) at (0,0) size 105x0
               RenderTableRow {TR} at (0,0) size 105x0
             RenderTableSection {DIV} at (0,0) size 105x18
@@ -179,7 +179,7 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 105x18 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x18
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,412) size 784x18
+      RenderBlock {DIV} at (0,442) size 784x18
         RenderInline {SPAN} at (0,0) size 146x18
           RenderText {#text} at (0,0) size 41x18
             text run at (0,0) width 41: "Text..."
@@ -190,7 +190,7 @@ layer at (0,0) size 800x600
                 RenderTableCell (anonymous) at (0,0) size 105x18 [r=0 c=0 rs=1 cs=1]
                   RenderText {#text} at (0,0) size 105x18
                     text run at (0,0) width 105: "...continues here"
-      RenderBlock {DIV} at (0,430) size 784x36
+      RenderBlock {DIV} at (0,460) size 784x36
         RenderBlock (anonymous) at (0,0) size 784x18
           RenderInline {SPAN} at (0,0) size 41x18
             RenderText {#text} at (0,0) size 41x18

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-tables/tentative/baseline-table-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-tables/tentative/baseline-table-expected.txt
@@ -50,47 +50,16 @@ Xp   > 
 
 PASS .container 1
 PASS .container 2
-FAIL .container 3 assert_equals:
-<div class="container">
-  Xp<table data-offset-y="25">
-    <tbody>
-      <tr></tr>
-    </tbody>
-  </table>
-</div>
-offsetTop expected 25 but got 10
-FAIL .container 4 assert_equals:
-<div class="container">
-  Xp<table style="font: 12px fixed" data-offset-y="25">
-    <tbody>
-      <tr></tr>
-      <tr><td>1,0</td></tr>
-    </tbody>
-  </table>
-</div>
-offsetTop expected 25 but got 0
+PASS .container 3
+PASS .container 4
 PASS .container 5
 PASS .container 6
 PASS .container 7
 PASS .container 8
 PASS .container 9
 PASS .container 10
-FAIL .container 11 assert_equals:
-<div class="container">
-  Xp<table data-offset-y="25" data-expected-height="50">
-    <tbody><tr style="height:20px"></tr>
-    <tr></tr>
-  </tbody></table>
-</div>
-offsetTop expected 25 but got 0
-FAIL .container 12 assert_equals:
-<div class="container">
-  Xp<table data-offset-y="25" data-expected-height="68">
-    <tbody><tr style="height:20px"></tr>
-    <tr><td style="font-size:10px">X</td></tr>
-  </tbody></table>
-</div>
-offsetTop expected 25 but got 0
+PASS .container 11
+PASS .container 12
 FAIL .container 13 assert_equals:
 <div class="container">
   Xp<table>

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -4,7 +4,7 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2014-2019 Google Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  *
@@ -1593,7 +1593,11 @@ std::optional<LayoutUnit> RenderTable::firstLineBaseline() const
     if (auto baseline = topNonEmptySection->firstLineBaseline())
         return std::optional<LayoutUnit>(topNonEmptySection->logicalTop() + baseline.value());
 
-    // FIXME: A table row always has a baseline per CSS 2.1. Will this return the right value?
+    // Other browsers use the top of the section as the baseline if its first row is empty of cells or content.
+    // The baseline of an empty row isn't specified by CSS 2.1.
+    if (topNonEmptySection->firstRow() && !topNonEmptySection->firstRow()->firstCell())
+        return topNonEmptySection->logicalTop();
+
     return std::optional<LayoutUnit>();
 }
 


### PR DESCRIPTION
#### 28d5064d279331b68e2fe8487cb317c271fc1299
<pre>
Fix few baseline calculation cases for tables with empty rows

<a href="https://bugs.webkit.org/show_bug.cgi?id=285159">https://bugs.webkit.org/show_bug.cgi?id=285159</a>
<a href="https://rdar.apple.com/142046863">rdar://142046863</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Partial Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/9fa80d5986647e8be2f1b19fc5e722cb51da4e27">https://chromium.googlesource.com/chromium/src.git/+/9fa80d5986647e8be2f1b19fc5e722cb51da4e27</a>

CSS says: &quot;If a row has no cell box aligned to its baseline, the baseline of that
row is the bottom content edge of the lowest cell in the row.&quot;

This partial merge progresses following cases of baseline in WPT test case:

&gt; Empty row&apos;s baseline is center of the row.
&gt; First row defines baseline even if empty.
&gt; Two rows empty, 1st row has css height.
&gt; First row empty with css height, 2 row has content

* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::firstLineBaseline const):
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/baseline-table-expected.txt: Rebaselined
* LayoutTests/platform/glib/fast/dynamic/insert-before-table-part-in-continuation-expected.txt:
* LayoutTests/platform/ios/fast/dynamic/insert-before-table-part-in-continuation-expected.txt:
* LayoutTests/platform/mac/fast/dynamic/insert-before-table-part-in-continuation-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-tables/tentative/baseline-table-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/288314@main">https://commits.webkit.org/288314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f7406180029361ad47469dfcb201bcab12511e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87572 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9992 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/64256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/22009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85509 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/1549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/75007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/44533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/1447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/29193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32542 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/29828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88929 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9746 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7007 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/72657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9972 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/70821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/71874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/16014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1122 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12798 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9699 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15220 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9573 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13039 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11343 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->