### PR TITLE
Further reduce use of memcpy in WebCore/

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/HIServicesSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/HIServicesSPI.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include <pal/spi/cg/CoreGraphicsSPI.h>
+#include <span>
+#include <wtf/StdLibExtras.h>
 
 #if USE(APPLE_INTERNAL_SDK)
 
@@ -157,6 +159,11 @@ extern CFStringRef kAXInterfaceDifferentiateWithoutColorKey;
 WTF_EXTERN_C_END
 
 #endif // USE(APPLE_INTERNAL_SDK)
+
+inline std::span<const uint8_t> AXTextMarkerGetByteSpan(AXTextMarkerRef marker)
+{
+    return unsafeMakeSpan(AXTextMarkerGetBytePtr(marker), AXTextMarkerGetLength(marker));
+}
 
 WTF_EXTERN_C_BEGIN
 

--- a/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
@@ -26,6 +26,8 @@
 #import "AXTextMarker.h"
 
 #import <Foundation/NSRange.h>
+#import <wtf/StdLibExtras.h>
+
 #if PLATFORM(MAC)
 #import "AXIsolatedObject.h"
 #import "WebAccessibilityObjectWrapperMac.h"
@@ -54,7 +56,7 @@ AXTextMarker::AXTextMarker(PlatformTextMarkerData platformData)
         return;
     }
 
-    memcpy(&m_data, AXTextMarkerGetBytePtr(platformData), sizeof(m_data));
+    memcpySpan(asMutableByteSpan(m_data), AXTextMarkerGetByteSpan(platformData));
 #else // PLATFORM(IOS_FAMILY)
     [platformData getBytes:&m_data length:sizeof(m_data)];
 #endif

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -37,6 +37,7 @@
 #import "WebAccessibilityObjectWrapperMac.h"
 #import <pal/spi/cocoa/NSAccessibilitySPI.h>
 #import <pal/spi/mac/HIServicesSPI.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -863,7 +864,7 @@ static TextMarkerData getBytesFromAXTextMarker(AXTextMarkerRef textMarker)
     if (AXTextMarkerGetLength(textMarker) != sizeof(textMarkerData))
         return { };
 
-    memcpy(&textMarkerData, AXTextMarkerGetBytePtr(textMarker), sizeof(textMarkerData));
+    memcpySpan(asMutableByteSpan(textMarkerData), AXTextMarkerGetByteSpan(textMarker));
     return textMarkerData;
 }
 

--- a/Source/WebCore/contentextensions/DFABytecodeCompiler.cpp
+++ b/Source/WebCore/contentextensions/DFABytecodeCompiler.cpp
@@ -39,7 +39,7 @@ template <typename IntType>
 void append(Vector<DFABytecode>& bytecode, IntType value)
 {
     bytecode.grow(bytecode.size() + sizeof(IntType));
-    memcpy(&bytecode[bytecode.size() - sizeof(IntType)], &value, sizeof(IntType));
+    memcpySpan(bytecode.mutableSpan().last(sizeof(IntType)), asByteSpan(value));
 }
 
 static void append24BitUnsignedInteger(Vector<DFABytecode>& bytecode, uint32_t value)

--- a/Source/WebCore/platform/audio/PushPullFIFO.cpp
+++ b/Source/WebCore/platform/audio/PushPullFIFO.cpp
@@ -55,15 +55,15 @@ void PushPullFIFO::push(const AudioBus* inputBus)
     const size_t remainder = m_fifoLength - m_indexWrite;
 
     for (unsigned i = 0; i < m_fifoBus->numberOfChannels(); ++i) {
-        float* fifoBusChannel = m_fifoBus->channel(i)->mutableData();
-        const float* inputBusChannel = inputBus->channel(i)->data();
+        auto fifoBusChannel = m_fifoBus->channel(i)->mutableSpan();
+        auto inputBusChannel = inputBus->channel(i)->span();
         if (remainder >= inputBusLength) {
             // The remainder is big enough for the input data.
-            memcpy(fifoBusChannel + m_indexWrite, inputBusChannel, inputBusLength * sizeof(*fifoBusChannel));
+            memcpySpan(fifoBusChannel.subspan(m_indexWrite), inputBusChannel);
         } else {
             // The input data overflows the remainder size. Wrap around the index.
-            memcpy(fifoBusChannel + m_indexWrite, inputBusChannel, remainder * sizeof(*fifoBusChannel));
-            memcpy(fifoBusChannel, inputBusChannel + remainder, (inputBusLength - remainder) * sizeof(*fifoBusChannel));
+            memcpySpan(fifoBusChannel.subspan(m_indexWrite), inputBusChannel.first(remainder));
+            memcpySpan(fifoBusChannel, inputBusChannel.subspan(remainder));
         }
     }
 


### PR DESCRIPTION
#### b9354c0e931733e938062f896ba604c1b2cefa19
<pre>
Further reduce use of memcpy in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=285163">https://bugs.webkit.org/show_bug.cgi?id=285163</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm:
(WebCore::AXTextMarker::AXTextMarker):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::getBytesFromAXTextMarker):
* Source/WebCore/contentextensions/DFABytecodeCompiler.cpp:
(WebCore::ContentExtensions::append):
* Source/WebCore/platform/audio/PushPullFIFO.cpp:
(WebCore::PushPullFIFO::push):

Canonical link: <a href="https://commits.webkit.org/288301@main">https://commits.webkit.org/288301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc371d452dbec995823623a614febf5c5d977902

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87538 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33467 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64228 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21981 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44505 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1419 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29163 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32508 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72710 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29798 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88894 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9712 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6969 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/72628 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71846 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15985 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14992 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1083 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12790 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9665 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15186 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9539 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13005 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11309 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->