### PR TITLE
Sync `html/rendering/non-replaced-elements/flow-content-0` from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: search
+  files:
+  - search-*

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/search-styles-iso-8859-8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/search-styles-iso-8859-8-expected.txt
@@ -9,5 +9,5 @@ PASS <search> - padding-top
 PASS <search> - padding-right
 PASS <search> - padding-bottom
 PASS <search> - padding-left
-FAIL <search> - unicode-bidi assert_equals: expected "bidi-override" but got "isolate"
+PASS <search> - unicode-bidi
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/search-styles-iso-8859-8.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/search-styles-iso-8859-8.html
@@ -19,7 +19,7 @@ legend, listing, main, p, plaintext, pre, summary, xmp, article, aside, h1, h2,
 h3, h4, h5, h6, hgroup, nav, section, search, table, caption, colgroup, col,
 thead, tbody, tfoot, tr, td, th, dir, dd, dl, dt, menu, ol, ul, li, bdi, output,
 [dir=ltr i], [dir=rtl i], [dir=auto i], * /* only apply to the bogus namespace */ {
-  unicode-bidi: bidi-override;
+  unicode-bidi: isolate;
 }
 
 </style>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-focusable.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-focusable.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+PASS slot element with display: block should be focusable
+FAIL slot element with default style should be focusable assert_equals: slot is now focused expected Element node <slot tabindex="1" style=""></slot> but got null
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-focusable.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-focusable.tentative.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<title>CSS Test (Display): <slot> elements should be focusable</title>
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Google" href="http://www.google.com/">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#flow-content-3">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/2632">
+<link rel="help" href="https://github.com/whatwg/html/issues/1837">
+<link rel="help" href="https://github.com/whatwg/html/pull/9425">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1366037">
+<!--
+
+  This requirement is not particularly clear from current specs,
+  so this test is tentative.  See issues above.
+
+-->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<script>
+
+  function do_test(slot_style, description) {
+    test(
+      function() {
+        let host = document.createElement("div");
+        document.body.appendChild(host);
+        var root = host.attachShadow({mode:"open"});
+        root.innerHTML = `
+          <style>
+            slot       { --test-value: slot-not-focused; }
+            slot:focus { --test-value: slot-is-focused; }
+          </style>
+          <slot tabindex="1" style="${slot_style}"></slot>
+        `;
+        let slot = root.querySelector("slot");
+        let cs = getComputedStyle(slot);
+        assert_not_equals(root.activeElement, slot, "precondition");
+        assert_equals(cs.getPropertyValue("--test-value"), "slot-not-focused", "precondition (style)");
+        slot.focus();
+        assert_equals(root.activeElement, slot, "slot is now focused");
+        assert_equals(cs.getPropertyValue("--test-value"), "slot-is-focused", "slot is now focused (style)");
+        document.body.removeChild(host);
+      }, `slot element with ${description} should be focusable`);
+  }
+
+  do_test("display: block", "display: block");
+  do_test("", "default style");
+
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-tabbable.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-tabbable.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+PASS slot element with display: block should be focusable
+FAIL slot element with default style should be focusable assert_equals: slot is now focused expected Element node <slot tabindex="1" style=""></slot> but got null
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-tabbable.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-tabbable.tentative.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<title>CSS Test (Display): <slot> elements should be tabbable</title>
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Google" href="http://www.google.com/">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#flow-content-3">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/2632">
+<link rel="help" href="https://github.com/whatwg/html/issues/1837">
+<link rel="help" href="https://github.com/whatwg/html/pull/9425">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1366037">
+<!--
+
+  This requirement is not particularly clear from current specs,
+  so this test is tentative.  See issues above.
+
+-->
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<body>
+
+<div id="before" tabindex="1" style="height: 10px"></div>
+
+<script>
+
+  function do_test(slot_style, description) {
+    promise_test(
+      async () => {
+        let before = document.getElementById("before");
+        before.focus();
+        let host = document.createElement("div");
+        document.body.appendChild(host);
+        var root = host.attachShadow({mode:"open"});
+        root.innerHTML = `
+          <style>
+            slot       { --test-value: slot-not-focused; }
+            slot:focus { --test-value: slot-is-focused; }
+          </style>
+          <slot tabindex="1" style="${slot_style}"></slot>
+        `;
+        let slot = root.querySelector("slot");
+        let cs = getComputedStyle(slot);
+        assert_equals(document.activeElement, before, "precondition");
+        assert_not_equals(root.activeElement, slot, "precondition");
+        assert_equals(cs.getPropertyValue("--test-value"), "slot-not-focused", "precondition (style)");
+        await test_driver.send_keys(before, "\uE004");
+        assert_equals(root.activeElement, slot, "slot is now focused");
+        assert_equals(cs.getPropertyValue("--test-value"), "slot-is-focused", "slot is now focused (style)");
+        document.body.removeChild(host);
+      }, `slot element with ${description} should be focusable`);
+  }
+
+  do_test("display: block", "display: block");
+  do_test("", "default style");
+
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/dialog-display.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/dialog.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/div-align-expected.html
@@ -25,3 +26,5 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/form-margin-quirk.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/search-styles-iso-8859-8.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/search-styles.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-focusable.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-tabbable.tentative.html

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-tabbable.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-tabbable.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL slot element with display: block should be focusable assert_equals: slot is now focused expected Element node <slot tabindex="1" style="display: block"></slot> but got null
+FAIL slot element with default style should be focusable assert_equals: slot is now focused expected Element node <slot tabindex="1" style=""></slot> but got null
+


### PR DESCRIPTION
#### e58d3aa6a41a6a2a17b4f38b7973e4802e6ee07a
<pre>
Sync `html/rendering/non-replaced-elements/flow-content-0` from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=285165">https://bugs.webkit.org/show_bug.cgi?id=285165</a>
<a href="https://rdar.apple.com/142062695">rdar://142062695</a>

Reviewed by Fujii Hironori.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/7f001e1c77df092dcd77f3a06b0f27335e8b859c">https://github.com/web-platform-tests/wpt/commit/7f001e1c77df092dcd77f3a06b0f27335e8b859c</a>

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/search-styles-iso-8859-8-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/search-styles-iso-8859-8.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-focusable.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-focusable.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-tabbable.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-tabbable.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/WEB_FEATURES.yml:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/flow-content-0/slot-element-tabbable.tentative-expected.txt: Add Platform Specific Result

Canonical link: <a href="https://commits.webkit.org/288308@main">https://commits.webkit.org/288308@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fddde83d19acf8336f54fb58a255900c624ea03a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87530 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33459 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9947 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64221 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21972 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1511 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74973 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44498 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29156 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32500 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72702 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88886 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6963 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72619 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9930 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71837 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17898 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15977 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14985 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1075 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9657 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9531 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11301 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->