### PR TITLE
[SVG2] Add support for the 'lh' length type

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-lh-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-lh-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL lh unit in SVGLength undefined is not an object (evaluating 'lh_length.unitType')
-FAIL Convert back to lh from new user unit value undefined is not an object (evaluating 'lh_length.value = ref_width * 2')
+PASS lh unit in SVGLength
+PASS Convert back to lh from new user unit value
 

--- a/Source/WebCore/svg/SVGLength.h
+++ b/Source/WebCore/svg/SVGLength.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,6 +81,9 @@ public:
 
     unsigned short unitType()  const
     {
+        // Per spec: https://svgwg.org/svg2-draft/types.html#__svg__SVGLength__SVG_LENGTHTYPE_UNKNOWN
+        if (m_value.lengthType() > SVGLengthType::Picas)
+            return 0;
         return static_cast<unsigned>(m_value.lengthType());
     }
 

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2007-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
  * Copyright (C) Research In Motion Limited 2011. All rights reserved.
  * Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
  *
@@ -136,6 +136,8 @@ ExceptionOr<float> SVGLengthContext::convertValueToUserUnits(float value, SVGLen
         return convertValueFromEMSToUserUnits(value);
     case SVGLengthType::Exs:
         return convertValueFromEXSToUserUnits(value);
+    case SVGLengthType::Lh:
+        return convertValueFromLhToUserUnits(value);
     case SVGLengthType::Centimeters:
         return value * CSS::pixelsPerCm;
     case SVGLengthType::Millimeters:
@@ -165,6 +167,8 @@ ExceptionOr<float> SVGLengthContext::convertValueFromUserUnits(float value, SVGL
         return convertValueFromUserUnitsToEMS(value);
     case SVGLengthType::Exs:
         return convertValueFromUserUnitsToEXS(value);
+    case SVGLengthType::Lh:
+        return convertValueFromUserUnitsToLh(value);
     case SVGLengthType::Pixels:
         return value;
     case SVGLengthType::Centimeters:
@@ -272,6 +276,24 @@ ExceptionOr<float> SVGLengthContext::convertValueFromEXSToUserUnits(float value)
     // Use of ceil allows a pixel match to the W3Cs expected output of coords-units-03-b.svg
     // if this causes problems in real world cases maybe it would be best to remove this
     return value * std::ceil(style->metricsOfPrimaryFont().xHeight().value_or(0));
+}
+
+ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToLh(float value) const
+{
+    auto* style = renderStyleForLengthResolving(protectedContext().get());
+    if (!style)
+        return Exception { ExceptionCode::NotSupportedError };
+
+    return value / adjustForAbsoluteZoom(style->computedLineHeight(), *style);
+}
+
+ExceptionOr<float> SVGLengthContext::convertValueFromLhToUserUnits(float value) const
+{
+    auto* style = renderStyleForLengthResolving(protectedContext().get());
+    if (!style)
+        return Exception { ExceptionCode::NotSupportedError };
+
+    return value * adjustForAbsoluteZoom(style->computedLineHeight(), *style);
 }
 
 std::optional<FloatSize> SVGLengthContext::viewportSize() const

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) Research In Motion Limited 2011. All rights reserved.
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -63,6 +63,9 @@ private:
 
     ExceptionOr<float> convertValueFromUserUnitsToEXS(float value) const;
     ExceptionOr<float> convertValueFromEXSToUserUnits(float value) const;
+
+    ExceptionOr<float> convertValueFromUserUnitsToLh(float value) const;
+    ExceptionOr<float> convertValueFromLhToUserUnits(float value) const;
 
     std::optional<FloatSize> computeViewportSize() const;
 

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2007-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -60,6 +60,8 @@ static inline ASCIILiteral lengthTypeToString(SVGLengthType lengthType)
         return "pt"_s;
     case SVGLengthType::Picas:
         return "pc"_s;
+    case SVGLengthType::Lh:
+        return "lh"_s;
     }
 
     ASSERT_NOT_REACHED();
@@ -98,6 +100,8 @@ template<typename CharacterType> static inline SVGLengthType parseLengthType(Str
         return SVGLengthType::Points;
     if (compareCharacters(firstCharacterPosition, 'p', 'c'))
         return SVGLengthType::Picas;
+    if (compareCharacters(firstCharacterPosition, 'l', 'h'))
+        return SVGLengthType::Lh;
 
     return SVGLengthType::Unknown;
 }
@@ -127,6 +131,8 @@ static inline SVGLengthType primitiveTypeToLengthType(CSSUnitType primitiveType)
         return SVGLengthType::Points;
     case CSSUnitType::CSS_PC:
         return SVGLengthType::Picas;
+    case CSSUnitType::CSS_LH:
+        return SVGLengthType::Lh;
     default:
         return SVGLengthType::Unknown;
     }
@@ -159,6 +165,8 @@ static inline CSSUnitType lengthTypeToPrimitiveType(SVGLengthType lengthType)
         return CSSUnitType::CSS_PT;
     case SVGLengthType::Picas:
         return CSSUnitType::CSS_PC;
+    case SVGLengthType::Lh:
+        return CSSUnitType::CSS_LH;
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/svg/SVGLengthValue.h
+++ b/Source/WebCore/svg/SVGLengthValue.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -43,7 +43,8 @@ enum class SVGLengthType : uint8_t {
     Millimeters,
     Inches,
     Points,
-    Picas
+    Picas,
+    Lh
 };
 
 enum class SVGLengthMode : uint8_t {


### PR DESCRIPTION
#### e552416b237a8358fc0acbeff8315263139be4a3
<pre>
[SVG2] Add support for the &apos;lh&apos; length type
<a href="https://bugs.webkit.org/show_bug.cgi?id=285168">https://bugs.webkit.org/show_bug.cgi?id=285168</a>
<a href="https://rdar.apple.com/142068343">rdar://142068343</a>

Reviewed by Darin Adler.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

It adds support for `lh` (line-height) length type for SVGLength, similar to
other length types.

* Source/WebCore/svg/SVGLength.h:
(WebCore::SVGLength::unitType const):
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::convertValueToUserUnits const):
(WebCore::SVGLengthContext::convertValueFromUserUnits const):
(WebCore::SVGLengthContext::convertValueFromUserUnitsToLh const):
(WebCore::SVGLengthContext::convertValueFromLhToUserUnits const):
* Source/WebCore/svg/SVGLengthContext.h:
* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::lengthTypeToString):
(WebCore::parseLengthType):
(WebCore::primitiveTypeToLengthType):
(WebCore::lengthTypeToPrimitiveType):
* Source/WebCore/svg/SVGLengthValue.h:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-lh-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/288448@main">https://commits.webkit.org/288448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb257b7df8b0a8972a11e57c527e54f8cf1e850e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82396 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87528 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33457 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64220 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21971 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74971 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44497 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1409 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29154 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32498 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72700 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88884 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6960 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72617 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70785 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71835 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17956 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15975 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14983 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1073 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9655 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15176 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9529 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12995 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11299 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->