### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
@@ -151,7 +151,7 @@ void IDBKeyData::encode(KeyedEncoder& encoder) const
         return;
     case IndexedDB::KeyType::Array: {
         auto& array = std::get<Vector<IDBKeyData>>(m_value);
-        encoder.encodeObjects("array"_s, array.begin(), array.end(), [](KeyedEncoder& encoder, const IDBKeyData& key) {
+        encoder.encodeObjects("array"_s, array, [](KeyedEncoder& encoder, const IDBKeyData& key) {
             key.encode(encoder);
         });
         return;

--- a/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
@@ -50,7 +50,7 @@ RefPtr<SharedBuffer> serializeIDBKeyPath(const std::optional<IDBKeyPath>& keyPat
             encoder->encodeString("string"_s, string);
         }, [&](const Vector<String>& vector) {
             encoder->encodeEnum("type"_s, KeyPathType::Array);
-            encoder->encodeObjects("array"_s, vector.begin(), vector.end(), [](WebCore::KeyedEncoder& encoder, const String& string) {
+            encoder->encodeObjects("array"_s, vector, [](WebCore::KeyedEncoder& encoder, const String& string) {
                 encoder.encodeString("string"_s, string);
             });
         });

--- a/Source/WebCore/fileapi/AsyncFileStream.cpp
+++ b/Source/WebCore/fileapi/AsyncFileStream.cpp
@@ -162,10 +162,10 @@ void AsyncFileStream::close()
     });
 }
 
-void AsyncFileStream::read(void* buffer, int length)
+void AsyncFileStream::read(std::span<uint8_t> buffer)
 {
-    perform([buffer, length](FileStream& stream) -> Function<void(FileStreamClient&)> {
-        int bytesRead = stream.read(buffer, length);
+    perform([buffer](FileStream& stream) -> Function<void(FileStreamClient&)> {
+        int bytesRead = stream.read(buffer);
         return [bytesRead](FileStreamClient& client) {
             client.didRead(bytesRead);
         };

--- a/Source/WebCore/fileapi/AsyncFileStream.h
+++ b/Source/WebCore/fileapi/AsyncFileStream.h
@@ -50,7 +50,7 @@ public:
     void getSize(const String& path, std::optional<WallTime> expectedModificationTime);
     void openForRead(const String& path, long long offset, long long length);
     void close();
-    void read(void* buffer, int length);
+    void read(std::span<uint8_t> buffer);
 
 private:
     void start();

--- a/Source/WebCore/loader/ResourceLoadStatistics.cpp
+++ b/Source/WebCore/loader/ResourceLoadStatistics.cpp
@@ -44,7 +44,7 @@ static void encodeHashSet(KeyedEncoder& encoder, const String& label,  const Str
     if (hashSet.isEmpty())
         return;
 
-    encoder.encodeObjects(label, hashSet.begin(), hashSet.end(), [&key](KeyedEncoder& encoderInner, const RegistrableDomain& domain) {
+    encoder.encodeObjects(label, hashSet, [&key](KeyedEncoder& encoderInner, const RegistrableDomain& domain) {
         encoderInner.encodeString(key, domain.string());
     });
 }
@@ -65,7 +65,7 @@ static void encodeHashSet(KeyedEncoder& encoder, const String& label,  const Str
     if (hashSet.isEmpty())
         return;
 
-    encoder.encodeObjects(label, hashSet.begin(), hashSet.end(), [&key](KeyedEncoder& encoderInner, const String& origin) {
+    encoder.encodeObjects(label, hashSet, [&key](KeyedEncoder& encoderInner, const String& origin) {
         encoderInner.encodeString(key, origin);
     });
 }
@@ -79,7 +79,7 @@ static void encodeCanvasActivityRecord(KeyedEncoder& encoder, const String& labe
 {
     encoder.encodeObject(label, canvasActivityRecord, [] (KeyedEncoder& encoderInner, const CanvasActivityRecord& canvasActivityRecord) {
         encoderInner.encodeBool("wasDataRead"_s, canvasActivityRecord.wasDataRead);
-        encoderInner.encodeObjects("textWritten"_s, canvasActivityRecord.textWritten.begin(), canvasActivityRecord.textWritten.end(), [] (KeyedEncoder& encoderInner2, const String& text) {
+        encoderInner.encodeObjects("textWritten"_s, canvasActivityRecord.textWritten, [] (KeyedEncoder& encoderInner2, const String& text) {
             encoderInner2.encodeString("text"_s, text);
         });
     });

--- a/Source/WebCore/platform/DateComponents.cpp
+++ b/Source/WebCore/platform/DateComponents.cpp
@@ -39,8 +39,6 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringParsingBuffer.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 // HTML defines minimum week of year is one.
@@ -53,7 +51,7 @@ static constexpr int maximumMonthInMaximumYear = 8; // This is September, since 
 static constexpr int maximumDayInMaximumMonth = 13;
 static constexpr int maximumWeekInMaximumYear = 37; // The week of 275760-09-13
 
-static constexpr int daysInMonth[12] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+static constexpr std::array<int, 12> daysInMonth { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 
 // 'month' is 0-based.
 static int maxDayOfMonth(int year, int month)
@@ -788,5 +786,3 @@ String DateComponents::toString(SecondFormat format) const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/FileHandle.cpp
+++ b/Source/WebCore/platform/FileHandle.cpp
@@ -29,8 +29,6 @@
 #include "config.h"
 #include "FileHandle.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 FileHandle::FileHandle(const String& path, FileSystem::FileOpenMode mode)
@@ -134,7 +132,7 @@ bool FileHandle::printf(const char* format, ...)
 
     va_end(args);
 
-    return write({ byteCast<uint8_t>(buffer.data()), stringLength }) >= 0;
+    return write(byteCast<uint8_t>(buffer.mutableSpan()).first(stringLength)) >= 0;
 }
 
 void FileHandle::close()
@@ -159,5 +157,3 @@ String FileHandle::path() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/FileStream.cpp
+++ b/Source/WebCore/platform/FileStream.cpp
@@ -34,8 +34,6 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FileStream);
@@ -101,16 +99,16 @@ void FileStream::close()
     }
 }
 
-int FileStream::read(void* buffer, int bufferSize)
+int FileStream::read(std::span<uint8_t> buffer)
 {
     if (!FileSystem::isHandleValid(m_handle))
         return -1;
 
     long long remaining = m_totalBytesToRead - m_bytesProcessed;
-    int bytesToRead = (remaining < bufferSize) ? static_cast<int>(remaining) : bufferSize;
+    int bytesToRead = remaining < static_cast<int>(buffer.size()) ? static_cast<int>(remaining) : static_cast<int>(buffer.size());
     int bytesRead = 0;
     if (bytesToRead > 0)
-        bytesRead = FileSystem::readFromFile(m_handle, { static_cast<uint8_t*>(buffer), static_cast<size_t>(bytesToRead) });
+        bytesRead = FileSystem::readFromFile(m_handle, buffer.first(bytesToRead));
     if (bytesRead < 0)
         return -1;
     if (bytesRead > 0)
@@ -120,5 +118,3 @@ int FileStream::read(void* buffer, int bufferSize)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/FileStream.h
+++ b/Source/WebCore/platform/FileStream.h
@@ -56,7 +56,7 @@ public:
     // Reads a file into the provided data buffer.
     // Returns number of bytes being read on success. -1 otherwise.
     // If 0 is returned, it means that the reading is completed.
-    int read(void* buffer, int length);
+    int read(std::span<uint8_t> buffer);
 
 private:
     FileSystem::PlatformFileHandle m_handle;

--- a/Source/WebCore/platform/KeyedCoding.h
+++ b/Source/WebCore/platform/KeyedCoding.h
@@ -30,8 +30,6 @@
 #include <wtf/Forward.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 class SharedBuffer;
@@ -188,13 +186,13 @@ public:
         encodeObject(key, *object, std::forward<F>(function));
     }
 
-    template<typename T, typename F>
-    void encodeObjects(const String& key, T begin, T end, F&& function)
+    template<typename CollectionType, typename F>
+    void encodeObjects(const String& key, const CollectionType& collection, F&& function)
     {
         beginArray(key);
-        for (T it = begin; it != end; ++it) {
+        for (auto& item : collection) {
             beginArrayElement();
-            function(*this, *it);
+            function(*this, item);
             endArrayElement();
         }
         endArray();
@@ -216,5 +214,3 @@ private:
 };
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/PlatformMediaError.cpp
+++ b/Source/WebCore/platform/PlatformMediaError.cpp
@@ -28,13 +28,11 @@
 
 #include <wtf/NeverDestroyed.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 String convertEnumerationToString(PlatformMediaError enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static std::array<const NeverDestroyed<String>, 13> values {
         MAKE_STATIC_STRING_IMPL("AppendError"),
         MAKE_STATIC_STRING_IMPL("ClientDisconnected"),
         MAKE_STATIC_STRING_IMPL("BufferRemoved"),
@@ -65,7 +63,5 @@ String convertEnumerationToString(PlatformMediaError enumerationValue)
     ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ProcessQualified.h
+++ b/Source/WebCore/platform/ProcessQualified.h
@@ -31,8 +31,6 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/TextStream.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 template <typename T>
@@ -190,5 +188,3 @@ public:
 };
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/ScrollingMomentumCalculator.cpp
+++ b/Source/WebCore/platform/ScrollingMomentumCalculator.cpp
@@ -30,8 +30,6 @@
 #include "FloatSize.h"
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingMomentumCalculator);
@@ -241,5 +239,3 @@ float BasicScrollingMomentumCalculator::animationProgressAfterElapsedTime(Second
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/ScrollingMomentumCalculator.h
+++ b/Source/WebCore/platform/ScrollingMomentumCalculator.h
@@ -85,7 +85,7 @@ private:
 
     float m_snapAnimationCurveMagnitude { 0 };
     float m_snapAnimationDecayFactor { 0 };
-    FloatSize m_snapAnimationCurveCoefficients[4] { };
+    std::array<FloatSize, 4> m_snapAnimationCurveCoefficients = { };
     bool m_forceLinearAnimationCurve { false };
     bool m_momentumCalculatorRequiresInitialization { true };
 };

--- a/Source/WebCore/platform/SharedBufferChunkReader.cpp
+++ b/Source/WebCore/platform/SharedBufferChunkReader.cpp
@@ -38,8 +38,6 @@ namespace WebCore {
 
 #if ENABLE(MHTML)
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 SharedBufferChunkReader::SharedBufferChunkReader(FragmentedSharedBuffer* buffer, const Vector<char>& separator)
     : m_iteratorCurrent(buffer->begin())
     , m_iteratorEnd(buffer->end())
@@ -141,8 +139,6 @@ size_t SharedBufferChunkReader::peek(Vector<uint8_t>& data, size_t requestedSize
     }
     return readBytesCount;
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif
 

--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -42,8 +42,6 @@
 #include <wtf/MachSendRight.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #if PLATFORM(COCOA)
 OBJC_CLASS NSData;
 #endif
@@ -121,8 +119,8 @@ public:
 
     size_t size() const { return m_size; }
 
-    std::span<const uint8_t> span() const { return { static_cast<const uint8_t*>(m_data), m_size }; }
-    std::span<uint8_t> mutableSpan() const { return { static_cast<uint8_t*>(m_data), m_size }; }
+    std::span<const uint8_t> span() const { return unsafeMakeSpan(static_cast<const uint8_t*>(m_data), m_size); }
+    std::span<uint8_t> mutableSpan() const { return unsafeMakeSpan(static_cast<uint8_t*>(m_data), m_size); }
 
 #if OS(WINDOWS)
     HANDLE handle() const { return m_handle.get(); }
@@ -157,5 +155,3 @@ private:
 };
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/Timer.cpp
+++ b/Source/WebCore/platform/Timer.cpp
@@ -45,8 +45,6 @@
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TimerBase);
@@ -151,7 +149,7 @@ inline void TimerHeapReference::swap(TimerHeapReference& other)
 inline void TimerHeapReference::updateHeapIndex()
 {
     auto& heap = m_reference->timerHeap();
-    if (&m_reference >= heap.data() && &m_reference < heap.data() + heap.size())
+    if (&m_reference >= heap.data() && &m_reference < heap.end())
         m_reference->setHeapIndex(&m_reference - heap.data());
 }
 
@@ -174,6 +172,7 @@ public:
 
     explicit TimerHeapIterator(RefPtr<ThreadTimerHeapItem>* pointer) : m_pointer(pointer) { checkConsistency(); }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     TimerHeapIterator& operator++() { checkConsistency(); ++m_pointer; checkConsistency(); return *this; }
     TimerHeapIterator operator++(int) { checkConsistency(1); return TimerHeapIterator(m_pointer++); }
 
@@ -183,11 +182,14 @@ public:
     TimerHeapIterator& operator+=(ptrdiff_t i) { checkConsistency(); m_pointer += i; checkConsistency(); return *this; }
     TimerHeapIterator& operator-=(ptrdiff_t i) { checkConsistency(); m_pointer -= i; checkConsistency(); return *this; }
 
-    TimerHeapReference operator*() const { return TimerHeapReference(*m_pointer); }
     TimerHeapReference operator[](ptrdiff_t i) const { return TimerHeapReference(m_pointer[i]); }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+    TimerHeapReference operator*() const { return TimerHeapReference(*m_pointer); }
     RefPtr<ThreadTimerHeapItem>& operator->() const { return *m_pointer; }
 
 private:
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     void checkConsistency(ptrdiff_t offset = 0) const
     {
         ASSERT(m_pointer >= threadGlobalTimerHeap().data());
@@ -195,6 +197,7 @@ private:
         ASSERT_UNUSED(offset, m_pointer + offset >= threadGlobalTimerHeap().data());
         ASSERT_UNUSED(offset, m_pointer + offset <= threadGlobalTimerHeap().data() + threadGlobalTimerHeap().size());
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     friend bool operator==(TimerHeapIterator, TimerHeapIterator) = default;
     friend bool operator<(TimerHeapIterator, TimerHeapIterator);
@@ -216,11 +219,13 @@ inline bool operator>(TimerHeapIterator a, TimerHeapIterator b) { return a.m_poi
 inline bool operator<=(TimerHeapIterator a, TimerHeapIterator b) { return a.m_pointer <= b.m_pointer; }
 inline bool operator>=(TimerHeapIterator a, TimerHeapIterator b) { return a.m_pointer >= b.m_pointer; }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 inline TimerHeapIterator operator+(TimerHeapIterator a, size_t b) { return TimerHeapIterator(a.m_pointer + b); }
 inline TimerHeapIterator operator+(size_t a, TimerHeapIterator b) { return TimerHeapIterator(a + b.m_pointer); }
 
 inline TimerHeapIterator operator-(TimerHeapIterator a, size_t b) { return TimerHeapIterator(a.m_pointer - b); }
 inline ptrdiff_t operator-(TimerHeapIterator a, TimerHeapIterator b) { return a.m_pointer - b.m_pointer; }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 // ----------------
 
@@ -361,6 +366,7 @@ inline void TimerBase::checkConsistency() const
         checkHeapIndex();
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 void TimerBase::heapDecreaseKey()
 {
     ASSERT(static_cast<bool>(nextFireTime()));
@@ -371,6 +377,7 @@ void TimerBase::heapDecreaseKey()
     std::push_heap(TimerHeapIterator(heapData), TimerHeapIterator(heapData + item->heapIndex() + 1), TimerHeapLessThanFunction());
     checkHeapIndex();
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 inline void TimerBase::heapDelete()
 {
@@ -422,6 +429,7 @@ inline void TimerBase::heapPop()
     item->time = fireTime;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 void TimerBase::heapPopMin()
 {
     RefPtr item = m_heapItemWithBitfields.pointer();
@@ -443,6 +451,7 @@ void TimerBase::heapDeleteNullMin(ThreadTimerHeap& heap)
     std::pop_heap(TimerHeapIterator(heapData), TimerHeapIterator(heapData + heap.size()), TimerHeapLessThanFunction());
     heap.removeLast();
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static inline bool parentHeapPropertyHolds(const TimerBase* current, const ThreadTimerHeap& heap, unsigned currentIndex)
 {
@@ -577,5 +586,3 @@ Seconds TimerBase::nextUnalignedFireInterval() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -410,7 +410,7 @@ int BlobResourceHandle::readFileSync(const BlobDataItem& item, std::span<uint8_t
         m_fileOpened = true;
     }
 
-    int bytesRead = m_stream->read(buffer.data(), buffer.size());
+    int bytesRead = m_stream->read(buffer);
     if (bytesRead < 0) {
         m_errorCode = Error::NotReadableError;
         return 0;
@@ -471,7 +471,7 @@ void BlobResourceHandle::readFileAsync(const BlobDataItem& item)
     ASSERT(isMainThread());
 
     if (m_fileOpened) {
-        m_asyncStream->read(m_buffer.data(), m_buffer.size());
+        m_asyncStream->read(m_buffer.mutableSpan());
         return;
     }
 

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -342,7 +342,7 @@ void NetworkDataTaskBlob::readFile(const BlobDataItem& item)
     ASSERT(m_stream);
 
     if (m_fileOpened) {
-        m_stream->read(m_buffer.data(), m_buffer.size());
+        m_stream->read(m_buffer.mutableSpan());
         return;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/KeyedCoding.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/KeyedCoding.cpp
@@ -262,7 +262,7 @@ TEST(KeyedCoding, SetAndGetObjects)
         users.append(KeyedCodingTestObject("username"_s, i));
 
     auto encoder = WebCore::KeyedEncoder::encoder();
-    encoder->encodeObjects("users"_s, users.begin(), users.end(), KeyedCodingTestObject::encode);
+    encoder->encodeObjects("users"_s, users, KeyedCodingTestObject::encode);
     auto encodedBuffer = encoder->finishEncoding();
 
     auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->span());


### PR DESCRIPTION
#### cd924977264c4e9e6e4eda4483c3c63ee2a7daf9
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=285171">https://bugs.webkit.org/show_bug.cgi?id=285171</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/Modules/indexeddb/IDBKeyData.cpp:
(WebCore::IDBKeyData::encode const):
* Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp:
(WebCore::serializeIDBKeyPath):
* Source/WebCore/fileapi/AsyncFileStream.cpp:
(WebCore::AsyncFileStream::read):
* Source/WebCore/fileapi/AsyncFileStream.h:
* Source/WebCore/loader/ResourceLoadStatistics.cpp:
(WebCore::encodeHashSet):
(WebCore::encodeCanvasActivityRecord):
* Source/WebCore/platform/DateComponents.cpp:
* Source/WebCore/platform/FileHandle.cpp:
(WebCore::FileHandle::printf):
* Source/WebCore/platform/FileStream.cpp:
(WebCore::FileStream::read):
* Source/WebCore/platform/FileStream.h:
* Source/WebCore/platform/KeyedCoding.h:
(WebCore::KeyedEncoder::encodeObjects):
* Source/WebCore/platform/PlatformMediaError.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/ProcessQualified.h:
* Source/WebCore/platform/ScrollingMomentumCalculator.cpp:
* Source/WebCore/platform/ScrollingMomentumCalculator.h:
* Source/WebCore/platform/SharedBufferChunkReader.cpp:
* Source/WebCore/platform/SharedMemory.h:
(WebCore::SharedMemory::span const):
(WebCore::SharedMemory::mutableSpan const):
* Source/WebCore/platform/Timer.cpp:
(WebCore::TimerHeapReference::updateHeapIndex):
(WebCore::TimerHeapIterator::operator* const):
* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::readFileSync):
(WebCore::BlobResourceHandle::readFileAsync):
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::readFile):
* Tools/TestWebKitAPI/Tests/WebCore/KeyedCoding.cpp:
(TestWebKitAPI::TEST(KeyedCoding, SetAndGetObjects)):

Canonical link: <a href="https://commits.webkit.org/288303@main">https://commits.webkit.org/288303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a548268f1db0dc575fe7bfe7abbc2f6f415fb80d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33465 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84509 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64227 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21979 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44504 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29162 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32506 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72709 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88892 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9710 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6968 "Found 1 new test failure: http/wpt/mediarecorder/record-96KHz-sources.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72626 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9936 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71844 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15983 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14991 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1081 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12792 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9663 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15184 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9537 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13003 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->