### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/audio

### DIFF
--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -278,7 +278,7 @@ struct FastMalloc {
             return realResult;
         return nullptr;
     }
-    
+
     static void* realloc(void* p, size_t size) { return fastRealloc(p, size); }
 
     static void* tryRealloc(void* p, size_t size)
@@ -296,6 +296,12 @@ struct FastMalloc {
     {
         return capacity + capacity / 4 + 1;
     }
+};
+
+struct FastAlignedMalloc {
+    static void* alignedMalloc(size_t alignment, size_t size) { return fastAlignedMalloc(alignment, size); }
+    static void* tryAlignedMalloc(size_t alignment, size_t size) { return tryFastAlignedMalloc(alignment, size); }
+    static void free(void* p) { fastAlignedFree(p); }
 };
 
 struct FastCompactMalloc {
@@ -404,6 +410,7 @@ inline constexpr std::enable_if_t<!WTF::IsTypeComplete<std::remove_pointer_t<T>>
 }
 
 using WTF::DisableMallocRestrictionsForCurrentThreadScope;
+using WTF::FastAlignedMalloc;
 using WTF::FastAllocator;
 using WTF::FastMalloc;
 using WTF::FastCompactMalloc;

--- a/Source/WTF/wtf/MallocSpan.h
+++ b/Source/WTF/wtf/MallocSpan.h
@@ -100,6 +100,11 @@ public:
         return MallocSpan { static_cast<T*>(Malloc::zeroedMalloc(sizeInBytes)), sizeInBytes };
     }
 
+    static MallocSpan alignedMalloc(size_t alignment, size_t sizeInBytes)
+    {
+        return MallocSpan { static_cast<T*>(Malloc::alignedMalloc(alignment, sizeInBytes)), sizeInBytes };
+    }
+
 #if HAVE(MMAP)
     static MallocSpan mmap(size_t sizeInBytes, int pageProtection, int options, int fileDescriptor)
     {

--- a/Source/WebCore/Modules/webaudio/PannerNode.cpp
+++ b/Source/WebCore/Modules/webaudio/PannerNode.cpp
@@ -235,7 +235,7 @@ void PannerNode::processSampleAccurateValues(AudioBus* destination, const AudioB
         totalGain[k] = calculateDistanceConeGain(pannerPosition, orientation, listenerPosition, m_distanceEffect, m_coneEffect);
     }
 
-    m_panner->panWithSampleAccurateValues(azimuth.data(), elevation.data(), source, destination, framesToProcess);
+    m_panner->panWithSampleAccurateValues(std::span { azimuth }, std::span { elevation }, source, destination, framesToProcess);
     destination->copyWithSampleAccurateGainValuesFrom(*destination, std::span { totalGain }.first(framesToProcess));
 }
 

--- a/Source/WebCore/platform/audio/AudioBus.cpp
+++ b/Source/WebCore/platform/audio/AudioBus.cpp
@@ -39,8 +39,6 @@
 #include <assert.h>
 #include <math.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 constexpr unsigned MaxBusChannels = 32;
@@ -609,7 +607,5 @@ void AudioBus::clearSilentFlag()
 }
 
 } // WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/AudioChannel.cpp
+++ b/Source/WebCore/platform/audio/AudioChannel.cpp
@@ -38,8 +38,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioChannel);
@@ -119,7 +117,5 @@ float AudioChannel::maxAbsValue() const
 }
 
 } // WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/AudioChannel.h
+++ b/Source/WebCore/platform/audio/AudioChannel.h
@@ -36,8 +36,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 // An AudioChannel represents a buffer of non-interleaved floating-point audio samples.
@@ -139,7 +137,5 @@ private:
 };
 
 } // WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // AudioChannel_h

--- a/Source/WebCore/platform/audio/AudioResampler.cpp
+++ b/Source/WebCore/platform/audio/AudioResampler.cpp
@@ -101,7 +101,7 @@ void AudioResampler::process(AudioSourceProvider* provider, AudioBus* destinatio
     // Now that we have the source data, resample each channel into the destination bus.
     // FIXME: optimize for the common stereo case where it's faster to process both left/right channels in the same inner loop.
     for (unsigned i = 0; i < numberOfChannels; ++i) {
-        float* destination = destinationBus->channel(i)->mutableData();
+        auto destination = destinationBus->channel(i)->mutableSpan();
         m_kernels[i]->process(destination, framesToProcess);
     }
 }

--- a/Source/WebCore/platform/audio/AudioResamplerKernel.cpp
+++ b/Source/WebCore/platform/audio/AudioResamplerKernel.cpp
@@ -33,8 +33,6 @@
 #include <algorithm>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioResamplerKernel);
@@ -73,11 +71,11 @@ std::span<float> AudioResamplerKernel::getSourceSpan(size_t framesToProcess, siz
     return m_sourceBuffer.span().subspan(m_fillIndex);
 }
 
-void AudioResamplerKernel::process(float* destination, size_t framesToProcess)
+void AudioResamplerKernel::process(std::span<float> destination, size_t framesToProcess)
 {
     ASSERT(framesToProcess <= AudioUtilities::renderQuantumSize);
 
-    float* source = m_sourceBuffer.data();
+    auto source = m_sourceBuffer.span();
     
     double rate = this->rate();
     rate = std::max(0.0, rate);
@@ -98,6 +96,7 @@ void AudioResamplerKernel::process(float* destination, size_t framesToProcess)
 
     // Do the linear interpolation.
     int n = framesToProcess;
+    size_t destinationIndex = 0;
     while (n--) {
         unsigned readIndex = static_cast<unsigned>(virtualReadIndex);
         double interpolationFactor = virtualReadIndex - readIndex;
@@ -107,10 +106,10 @@ void AudioResamplerKernel::process(float* destination, size_t framesToProcess)
 
         double sample = (1.0 - interpolationFactor) * sample1 + interpolationFactor * sample2;
 
-        *destination++ = static_cast<float>(sample);
+        destination[destinationIndex++] = static_cast<float>(sample);
 
         virtualReadIndex += rate;
-    }                        
+    }
 
     // Save the last two sample-frames which will later be used at the beginning of the source buffer the next time around.
     int readIndex = static_cast<int>(virtualReadIndex);
@@ -139,7 +138,5 @@ double AudioResamplerKernel::rate() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/AudioResamplerKernel.h
+++ b/Source/WebCore/platform/audio/AudioResamplerKernel.h
@@ -52,7 +52,7 @@ public:
     // process() resamples framesToProcess frames from the source into destination.
     // Each call to process() must be preceded by a call to getSourceSpan() so that source input may be supplied.
     // framesToProcess must be less than or equal to AudioUtilities::renderQuantumSize.
-    void process(float* destination, size_t framesToProcess);
+    void process(std::span<float> destination, size_t framesToProcess);
 
     // Resets the processing state.
     void reset();
@@ -70,7 +70,7 @@ private:
     // m_lastValues stores the last two sample values from the last call to process().
     // m_fillIndex represents how many buffered samples we have which can be as many as 2.
     // For the first call to process() (or after reset()) there will be no buffered samples.
-    float m_lastValues[2];
+    std::array<float, 2> m_lastValues;
     unsigned m_fillIndex { 0 };
 };
 

--- a/Source/WebCore/platform/audio/AudioSession.cpp
+++ b/Source/WebCore/platform/audio/AudioSession.cpp
@@ -42,8 +42,6 @@
 #include "AudioSessionIOS.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AudioSession);
@@ -316,7 +314,7 @@ WTFLogChannel& AudioSession::logChannel() const
 
 String convertEnumerationToString(RouteSharingPolicy enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 4> values {
         MAKE_STATIC_STRING_IMPL("Default"),
         MAKE_STATIC_STRING_IMPL("LongFormAudio"),
         MAKE_STATIC_STRING_IMPL("Independent"),
@@ -332,7 +330,7 @@ String convertEnumerationToString(RouteSharingPolicy enumerationValue)
 
 String convertEnumerationToString(AudioSession::CategoryType enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 7> values {
         MAKE_STATIC_STRING_IMPL("None"),
         MAKE_STATIC_STRING_IMPL("AmbientSound"),
         MAKE_STATIC_STRING_IMPL("SoloAmbientSound"),
@@ -354,7 +352,7 @@ String convertEnumerationToString(AudioSession::CategoryType enumerationValue)
 
 String convertEnumerationToString(AudioSession::Mode enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 3> values {
         MAKE_STATIC_STRING_IMPL("Default"),
         MAKE_STATIC_STRING_IMPL("VideoChat"),
         MAKE_STATIC_STRING_IMPL("MoviePlayback"),
@@ -368,7 +366,7 @@ String convertEnumerationToString(AudioSession::Mode enumerationValue)
 
 String convertEnumerationToString(AudioSessionRoutingArbitrationClient::RoutingArbitrationError enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 3> values {
         MAKE_STATIC_STRING_IMPL("None"),
         MAKE_STATIC_STRING_IMPL("Failed"),
         MAKE_STATIC_STRING_IMPL("Cancelled"),
@@ -382,7 +380,7 @@ String convertEnumerationToString(AudioSessionRoutingArbitrationClient::RoutingA
 
 String convertEnumerationToString(AudioSessionRoutingArbitrationClient::DefaultRouteChanged enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 2> values {
         MAKE_STATIC_STRING_IMPL("No"),
         MAKE_STATIC_STRING_IMPL("Yes"),
     };
@@ -394,7 +392,7 @@ String convertEnumerationToString(AudioSessionRoutingArbitrationClient::DefaultR
 
 String convertEnumerationToString(AudioSession::SoundStageSize size)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 4> values {
         MAKE_STATIC_STRING_IMPL("Automatic"),
         MAKE_STATIC_STRING_IMPL("Small"),
         MAKE_STATIC_STRING_IMPL("Medium"),
@@ -409,7 +407,5 @@ String convertEnumerationToString(AudioSession::SoundStageSize size)
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(AUDIO_SESSION)

--- a/Source/WebCore/platform/audio/AudioUtilities.cpp
+++ b/Source/WebCore/platform/audio/AudioUtilities.cpp
@@ -32,8 +32,6 @@
 #include <wtf/MathExtras.h>
 #include <wtf/WeakRandomNumber.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 namespace AudioUtilities {
@@ -107,7 +105,5 @@ void applyNoise(std::span<float> values, float standardDeviation)
 } // AudioUtilites
 
 } // WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/Biquad.cpp
+++ b/Source/WebCore/platform/audio/Biquad.cpp
@@ -45,8 +45,6 @@
 #include <Accelerate/Accelerate.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Biquad);
@@ -87,11 +85,11 @@ void Biquad::process(std::span<const float> source, std::span<float> destination
         double y1 = m_y1;
         double y2 = m_y2;
 
-        auto* b0 = m_b0.data();
-        auto* b1 = m_b1.data();
-        auto* b2 = m_b2.data();
-        auto* a1 = m_a1.data();
-        auto* a2 = m_a2.data();
+        auto b0 = m_b0.span();
+        auto b1 = m_b1.span();
+        auto b2 = m_b2.span();
+        auto a1 = m_a1.span();
+        auto a2 = m_a2.span();
 
         size_t sourceIndex = 0;
         size_t destinationIndex = 0;
@@ -258,11 +256,11 @@ void Biquad::reset()
 {
 #if USE(ACCELERATE)
     // Two extra samples for filter history
-    double* inputP = m_inputBuffer.data();
+    auto inputP = m_inputBuffer.span();
     inputP[0] = 0;
     inputP[1] = 0;
 
-    double* outputP = m_outputBuffer.data();
+    auto outputP = m_outputBuffer.span();
     outputP[0] = 0;
     outputP[1] = 0;
 #endif
@@ -903,7 +901,5 @@ double Biquad::tailFrame(size_t coefIndex, double maxFrame)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/DirectConvolver.cpp
+++ b/Source/WebCore/platform/audio/DirectConvolver.cpp
@@ -40,8 +40,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
     
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DirectConvolver);
@@ -78,7 +76,9 @@ void DirectConvolver::process(AudioFloatArray* convolutionKernel, std::span<cons
     memcpySpan(inputP, source);
 
 #if USE(ACCELERATE)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     vDSP_conv(inputP.data() - kernelSize + 1, 1, kernelP.subspan(kernelSize - 1).data(), -1, destination.data(), 1, source.size(), kernelSize);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #else
     // FIXME: The macro can be further optimized to avoid pipeline stalls. One possibility is to maintain 4 separate sums and change the macro to CONVOLVE_FOUR_SAMPLES.
 #define CONVOLVE_ONE_SAMPLE             \
@@ -361,7 +361,5 @@ void DirectConvolver::reset()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/DownSampler.cpp
+++ b/Source/WebCore/platform/audio/DownSampler.cpp
@@ -36,8 +36,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DownSampler);
@@ -118,8 +116,10 @@ void DownSampler::process(std::span<const float> source, std::span<float> destin
     // Copy the odd sample-frames from source, delayed by one sample-frame (destination sample-rate)
     // to match shifting forward in time in m_reducedKernel.
     auto oddSamplesP = m_tempBuffer.span().first(destFramesToProcess);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     for (size_t i = 0; i < oddSamplesP.size(); ++i)
         oddSamplesP[i] = *((inputP.data() - 1) + i * 2);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     // Actually process oddSamplesP with m_reducedKernel for efficiency.
     // The theoretical kernel is double this size with 0 values for even terms (except center).
@@ -129,9 +129,11 @@ void DownSampler::process(std::span<const float> source, std::span<float> destin
     // This amounts to a delay-line of length halfSize (at the source sample-rate),
     // scaled by 0.5.
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // Sum into the destination.
     for (size_t i = 0; i < destFramesToProcess; ++i)
         destination[i] += 0.5 * *((inputP.data() - halfSize) + i * 2);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     // Copy 2nd half of input buffer to 1st half.
     memcpySpan(m_inputBuffer.span(), inputP);
@@ -150,7 +152,5 @@ size_t DownSampler::latencyFrames() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/DynamicsCompressor.h
+++ b/Source/WebCore/platform/audio/DynamicsCompressor.h
@@ -89,13 +89,16 @@ protected:
     unsigned m_numberOfChannels;
 
     // m_parameters holds the tweakable compressor parameters.
-    float m_parameters[ParamLast];
+    std::array<float, ParamLast> m_parameters;
     void initializeParameters();
+
+    std::span<std::span<const float>> sourceChannels() const { return unsafeMakeSpan(m_sourceChannels.get(), m_numberOfChannels); }
+    std::span<std::span<float>> destinationChannels() const { return unsafeMakeSpan(m_destinationChannels.get(), m_numberOfChannels); }
 
     float m_sampleRate;
 
-    UniqueArray<const float*> m_sourceChannels;
-    UniqueArray<float*> m_destinationChannels;
+    UniqueArray<std::span<const float>> m_sourceChannels;
+    UniqueArray<std::span<float>> m_destinationChannels;
 
     // The core compressor.
     DynamicsCompressorKernel m_compressor;

--- a/Source/WebCore/platform/audio/DynamicsCompressorKernel.h
+++ b/Source/WebCore/platform/audio/DynamicsCompressorKernel.h
@@ -44,11 +44,9 @@ public:
     void setNumberOfChannels(unsigned);
 
     // Performs stereo-linked compression.
-    void process(const float* sourceChannels[],
-                 float* destinationChannels[],
-                 unsigned numberOfChannels,
+    void process(std::span<std::span<const float>> sourceChannels,
+                 std::span<std::span<float>> destinationChannels,
                  unsigned framesToProcess,
-
                  float dbThreshold,
                  float dbKnee,
                  float ratio,

--- a/Source/WebCore/platform/audio/EqualPowerPanner.h
+++ b/Source/WebCore/platform/audio/EqualPowerPanner.h
@@ -36,7 +36,7 @@ public:
     EqualPowerPanner();
 
     void pan(double azimuth, double elevation, const AudioBus* inputBus, AudioBus* outputBuf, size_t framesToProcess) final;
-    void panWithSampleAccurateValues(double* azimuth, double* elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess) final;
+    void panWithSampleAccurateValues(std::span<double> azimuth, std::span<double> elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess) final;
 
     void reset() override { }
 

--- a/Source/WebCore/platform/audio/FFTConvolver.cpp
+++ b/Source/WebCore/platform/audio/FFTConvolver.cpp
@@ -36,8 +36,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
     
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FFTConvolver);
@@ -121,7 +119,5 @@ void FFTConvolver::reset()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/HRTFElevation.cpp
+++ b/Source/WebCore/platform/audio/HRTFElevation.cpp
@@ -44,8 +44,6 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HRTFElevation);
@@ -190,7 +188,7 @@ bool HRTFElevation::calculateKernelsForAzimuthElevation(int azimuth, int elevati
 // The range of elevations for the IRCAM impulse responses varies depending on azimuth, but the minimum elevation appears to always be -45.
 //
 // Here's how it goes:
-static const int maxElevations[] = {
+static const std::array<int, 24> maxElevations {
         //  Azimuth
         //
     90, // 0  
@@ -321,7 +319,5 @@ void HRTFElevation::getKernelsFromAzimuth(double azimuthBlend, unsigned azimuthI
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/HRTFKernel.cpp
+++ b/Source/WebCore/platform/audio/HRTFKernel.cpp
@@ -38,8 +38,6 @@
 #include "FloatConversion.h"
 #include <wtf/MathExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 // Takes the input AudioChannel as an input impulse response and calculates the average group delay.
@@ -137,7 +135,5 @@ RefPtr<HRTFKernel> HRTFKernel::createInterpolatedKernel(HRTFKernel* kernel1, HRT
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/HRTFPanner.cpp
+++ b/Source/WebCore/platform/audio/HRTFPanner.cpp
@@ -36,8 +36,6 @@
 #include <algorithm>
 #include <wtf/MathExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 // The value of 2 milliseconds is larger than the largest delay which exists in any HRTFKernel from the default HRTFDatabase (0.0136 seconds).
@@ -306,7 +304,7 @@ void HRTFPanner::pan(double desiredAzimuth, double elevation, const AudioBus* in
     }
 }
 
-void HRTFPanner::panWithSampleAccurateValues(double* azimuth, double* elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess)
+void HRTFPanner::panWithSampleAccurateValues(std::span<double> azimuth, std::span<double> elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess)
 {
     // Sample-accurate (a-rate) HRTF panner is not implemented, just k-rate. Just
     // grab the current azimuth/elevation and use that.
@@ -342,7 +340,5 @@ bool HRTFPanner::requiresTailProcessing() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/HRTFPanner.h
+++ b/Source/WebCore/platform/audio/HRTFPanner.h
@@ -40,7 +40,7 @@ public:
 
     // Panner
     void pan(double azimuth, double elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess) final;
-    void panWithSampleAccurateValues(double* azimuth, double* elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess) final;
+    void panWithSampleAccurateValues(std::span<double> azimuth, std::span<double> elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess) final;
     void reset() override;
 
     size_t fftSize() const { return fftSizeForSampleRate(m_sampleRate); }

--- a/Source/WebCore/platform/audio/Panner.h
+++ b/Source/WebCore/platform/audio/Panner.h
@@ -54,7 +54,7 @@ public:
     PanningModelType panningModel() const { return m_panningModel; }
 
     virtual void pan(double azimuth, double elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess) = 0;
-    virtual void panWithSampleAccurateValues(double* azimuth, double* elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess) = 0;
+    virtual void panWithSampleAccurateValues(std::span<double> azimuth, std::span<double> elevation, const AudioBus* inputBus, AudioBus* outputBus, size_t framesToProcess) = 0;
     virtual void reset() = 0;
 
     virtual double tailTime() const = 0;

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -39,15 +39,13 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PlatformMediaSession);
 
 String convertEnumerationToString(PlatformMediaSession::State state)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 5> values {
         MAKE_STATIC_STRING_IMPL("Idle"),
         MAKE_STATIC_STRING_IMPL("Autoplaying"),
         MAKE_STATIC_STRING_IMPL("Playing"),
@@ -65,7 +63,7 @@ String convertEnumerationToString(PlatformMediaSession::State state)
 
 String convertEnumerationToString(PlatformMediaSession::InterruptionType type)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 8> values {
         MAKE_STATIC_STRING_IMPL("NoInterruption"),
         MAKE_STATIC_STRING_IMPL("SystemSleep"),
         MAKE_STATIC_STRING_IMPL("EnteringBackground"),
@@ -89,7 +87,7 @@ String convertEnumerationToString(PlatformMediaSession::InterruptionType type)
 
 String convertEnumerationToString(PlatformMediaSession::MediaType mediaType)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 5> values {
         MAKE_STATIC_STRING_IMPL("None"),
         MAKE_STATIC_STRING_IMPL("Video"),
         MAKE_STATIC_STRING_IMPL("VideoAudio"),
@@ -108,7 +106,7 @@ String convertEnumerationToString(PlatformMediaSession::MediaType mediaType)
 
 String convertEnumerationToString(PlatformMediaSession::RemoteControlCommandType command)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 16> values {
         MAKE_STATIC_STRING_IMPL("NoCommand"),
         MAKE_STATIC_STRING_IMPL("PlayCommand"),
         MAKE_STATIC_STRING_IMPL("PauseCommand"),
@@ -534,7 +532,5 @@ std::optional<NowPlayingInfo> PlatformMediaSessionClient::nowPlayingInfo() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(VIDEO) || ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -37,8 +37,6 @@
 #include "VP9UtilitiesCocoa.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #define PLATFORMMEDIASESSIONMANAGER_RELEASE_LOG(fmt, ...) RELEASE_LOG_FORWARDABLE(Media, fmt, ##__VA_ARGS__)
 
 namespace WebCore {
@@ -923,5 +921,3 @@ void PlatformMediaSessionManager::dumpSessionStates()
 #endif
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -248,7 +248,7 @@ private:
     void dumpSessionStates();
 #endif
 
-    SessionRestrictions m_restrictions[static_cast<unsigned>(PlatformMediaSession::MediaType::WebAudio) + 1];
+    std::array<SessionRestrictions, static_cast<unsigned>(PlatformMediaSession::MediaType::WebAudio) + 1> m_restrictions;
     mutable Vector<WeakPtr<PlatformMediaSession>> m_sessions;
 
     std::optional<PlatformMediaSession::InterruptionType> m_currentInterruption;

--- a/Source/WebCore/platform/audio/PushPullFIFO.cpp
+++ b/Source/WebCore/platform/audio/PushPullFIFO.cpp
@@ -30,8 +30,6 @@
 #include "AudioBus.h"
 #include <wtf/StdLibExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 PushPullFIFO::PushPullFIFO(unsigned numberOfChannels, size_t fifoLength)
@@ -135,7 +133,5 @@ unsigned PushPullFIFO::numberOfChannels() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/ReverbAccumulationBuffer.h
+++ b/Source/WebCore/platform/audio/ReverbAccumulationBuffer.h
@@ -49,7 +49,7 @@ public:
     // We need to pass in and update readIndex here, since each ReverbConvolverStage may be running in
     // a different thread than the realtime thread calling ReadAndClear() and maintaining m_readIndex
     // Returns the writeIndex where the accumulation took place
-    int accumulate(float* source, size_t numberOfFrames, int* readIndex, size_t delayFrames);
+    int accumulate(std::span<float> source, size_t numberOfFrames, int* readIndex, size_t delayFrames);
 
     size_t readIndex() const { return m_readIndex; }
     void updateReadIndex(int* readIndex, size_t numberOfFrames) const;

--- a/Source/WebCore/platform/audio/ReverbConvolverStage.cpp
+++ b/Source/WebCore/platform/audio/ReverbConvolverStage.cpp
@@ -42,8 +42,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ReverbConvolverStage);
@@ -166,7 +164,7 @@ void ReverbConvolverStage::process(std::span<const float> source)
             m_directConvolver->process(m_directKernel.get(), preDelayedSource, temporaryBuffer);
 
         // Now accumulate into reverb's accumulation buffer.
-        m_accumulationBuffer->accumulate(temporaryBuffer.data(), source.size(), &m_accumulationReadIndex, m_postDelayLength);
+        m_accumulationBuffer->accumulate(temporaryBuffer, source.size(), &m_accumulationReadIndex, m_postDelayLength);
     }
 
     // Finally copy input to pre-delay.
@@ -195,7 +193,5 @@ void ReverbConvolverStage::reset()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/ReverbInputBuffer.cpp
+++ b/Source/WebCore/platform/audio/ReverbInputBuffer.cpp
@@ -34,8 +34,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ReverbInputBuffer);
@@ -90,7 +88,5 @@ void ReverbInputBuffer::reset()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/StereoPanner.cpp
+++ b/Source/WebCore/platform/audio/StereoPanner.cpp
@@ -31,9 +31,8 @@
 
 #include "SharedBuffer.h"
 #include "VectorMath.h"
+#include <wtf/IndexedRange.h>
 #include <wtf/MathExtras.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -53,13 +52,10 @@ void panWithSampleAccurateValues(const AudioBus* inputBus, AudioBus* outputBus, 
     if (!isOutputSafe)
         return;
     
-    const float* sourceL = inputBus->channel(0)->data();
-    const float* sourceR = numberOfInputChannels > 1 ? inputBus->channel(1)->data() : sourceL;
-    float* destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableData();
-    float* destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableData();
-    
-    if (!sourceL || !sourceR || !destinationL || !destinationR)
-        return;
+    auto sourceL = inputBus->channel(0)->span();
+    auto sourceR = numberOfInputChannels > 1 ? inputBus->channel(1)->span() : sourceL;
+    auto destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableSpan();
+    auto destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableSpan();
     
     double gainL;
     double gainR;
@@ -67,31 +63,31 @@ void panWithSampleAccurateValues(const AudioBus* inputBus, AudioBus* outputBus, 
     
     // Handles mono source case first, then stereo source case.
     if (numberOfInputChannels == 1) {
-        for (auto panValue : panValues) {
-            float inputL = *sourceL++;
+        for (auto [i, panValue] : indexedRange(panValues)) {
+            float inputL = sourceL[i];
             double pan = clampTo(panValue, -1.0, 1.0);
             // Pan from left to right [-1; 1] will be normalized as [0; 1].
             panRadian = (pan * 0.5 + 0.5) * piOverTwoDouble;
             gainL = cos(panRadian);
             gainR = sin(panRadian);
-            *destinationL++ = static_cast<float>(inputL * gainL);
-            *destinationR++ = static_cast<float>(inputL * gainR);
+            destinationL[i] = static_cast<float>(inputL * gainL);
+            destinationR[i] = static_cast<float>(inputL * gainR);
         }
     } else {
-        for (auto panValue : panValues) {
-            float inputL = *sourceL++;
-            float inputR = *sourceR++;
+        for (auto [i, panValue] : indexedRange(panValues)) {
+            float inputL = sourceL[i];
+            float inputR = sourceR[i];
             double pan = clampTo(panValue, -1.0, 1.0);
             // Normalize [-1; 0] to [0; 1]. Do nothing when [0; 1].
             panRadian = (pan <= 0 ? pan + 1 : pan) * piOverTwoDouble;
             gainL = cos(panRadian);
             gainR = sin(panRadian);
             if (pan <= 0) {
-                *destinationL++ = static_cast<float>(inputL + inputR * gainL);
-                *destinationR++ = static_cast<float>(inputR * gainR);
+                destinationL[i] = static_cast<float>(inputL + inputR * gainL);
+                destinationR[i] = static_cast<float>(inputR * gainR);
             } else {
-                *destinationL++ = static_cast<float>(inputL * gainL);
-                *destinationR++ = static_cast<float>(inputR + inputL * gainR);
+                destinationL[i] = static_cast<float>(inputL * gainL);
+                destinationR[i] = static_cast<float>(inputR + inputL * gainR);
             }
         }
     }
@@ -148,7 +144,5 @@ void panToTargetValue(const AudioBus* inputBus, AudioBus* outputBus, float panVa
 } // namespace StereoPanner
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/UpSampler.cpp
+++ b/Source/WebCore/platform/audio/UpSampler.cpp
@@ -36,8 +36,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(UpSampler);
@@ -106,9 +104,11 @@ void UpSampler::process(std::span<const float> source, std::span<float> destinat
     auto inputP = m_inputBuffer.span().subspan(source.size());
     memcpySpan(inputP, source);
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // Copy even sample-frames 0,2,4,6... (delayed by the linear phase delay) directly into destination.
     for (size_t i = 0; i < source.size(); ++i)
         destination[i * 2] = *((inputP.data() - halfSize) + i);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     // Compute odd sample-frames 1,3,5,7...
     auto oddSamplesP = m_tempBuffer.span();
@@ -134,7 +134,5 @@ size_t UpSampler::latencyFrames() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/ZeroPole.cpp
+++ b/Source/WebCore/platform/audio/ZeroPole.cpp
@@ -35,13 +35,11 @@
 #include "DenormalDisabler.h"
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ZeroPole);
 
-void ZeroPole::process(const float *source, float *destination, unsigned framesToProcess)
+void ZeroPole::process(std::span<const float> source, std::span<float> destination, unsigned framesToProcess)
 {
     float zero = m_zero;
     float pole = m_pole;
@@ -54,8 +52,8 @@ void ZeroPole::process(const float *source, float *destination, unsigned framesT
     float lastX = m_lastX;
     float lastY = m_lastY;
 
-    while (framesToProcess--) {
-        float input = *source++;
+    for (unsigned i = 0; i < framesToProcess; ++i) {
+        float input = source[i];
 
         // Zero
         float output1 = k1 * (input - zero * lastX);
@@ -65,7 +63,7 @@ void ZeroPole::process(const float *source, float *destination, unsigned framesT
         float output2 = k2 * output1 + pole * lastY;
         lastY = output2;
 
-        *destination++ = output2;
+        destination[i] = output2;
     }
     
     // Locals to member variables. Flush denormals here so we don't
@@ -75,7 +73,5 @@ void ZeroPole::process(const float *source, float *destination, unsigned framesT
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/ZeroPole.h
+++ b/Source/WebCore/platform/audio/ZeroPole.h
@@ -46,7 +46,7 @@ public:
     {
     }
 
-    void process(const float *source, float *destination, unsigned framesToProcess);
+    void process(std::span<const float> source, std::span<float> destination, unsigned framesToProcess);
 
     // Reset filter state.
     void reset() { m_lastX = 0; m_lastY = 0; }


### PR DESCRIPTION
#### 563f1bbd4b2ca0508561c9a562663a4fe0b12866
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/audio
<a href="https://bugs.webkit.org/show_bug.cgi?id=285173">https://bugs.webkit.org/show_bug.cgi?id=285173</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/Modules/webaudio/PannerNode.cpp:
(WebCore::PannerNode::processSampleAccurateValues):
* Source/WebCore/platform/audio/AudioArray.h:
(WebCore::AudioArray::~AudioArray):
(WebCore::AudioArray::resize):
(WebCore::AudioArray::span):
(WebCore::AudioArray::span const):
(WebCore::AudioArray::data):
(WebCore::AudioArray::data const):
(WebCore::AudioArray::size const):
(WebCore::AudioArray::isEmpty const):
(WebCore::AudioArray::at):
(WebCore::AudioArray::at const):
(WebCore::AudioArray::containsConstantValue const):
(): Deleted.
* Source/WebCore/platform/audio/AudioBus.cpp:
* Source/WebCore/platform/audio/AudioChannel.cpp:
* Source/WebCore/platform/audio/AudioChannel.h:
* Source/WebCore/platform/audio/AudioResampler.cpp:
(WebCore::AudioResampler::process):
* Source/WebCore/platform/audio/AudioResamplerKernel.cpp:
(WebCore::AudioResamplerKernel::process):
* Source/WebCore/platform/audio/AudioResamplerKernel.h:
* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/audio/AudioUtilities.cpp:
* Source/WebCore/platform/audio/Biquad.cpp:
(WebCore::Biquad::process):
(WebCore::Biquad::reset):
* Source/WebCore/platform/audio/DirectConvolver.cpp:
(WebCore::DirectConvolver::process):
* Source/WebCore/platform/audio/DownSampler.cpp:
(WebCore::DownSampler::process):
* Source/WebCore/platform/audio/DynamicsCompressor.cpp:
(WebCore::DynamicsCompressor::process):
(WebCore::DynamicsCompressor::setNumberOfChannels):
* Source/WebCore/platform/audio/DynamicsCompressor.h:
* Source/WebCore/platform/audio/DynamicsCompressorKernel.cpp:
(WebCore::DynamicsCompressorKernel::process):
* Source/WebCore/platform/audio/DynamicsCompressorKernel.h:
* Source/WebCore/platform/audio/EqualPowerPanner.cpp:
(WebCore::EqualPowerPanner::panWithSampleAccurateValues):
* Source/WebCore/platform/audio/EqualPowerPanner.h:
* Source/WebCore/platform/audio/FFTConvolver.cpp:
* Source/WebCore/platform/audio/HRTFElevation.cpp:
* Source/WebCore/platform/audio/HRTFKernel.cpp:
* Source/WebCore/platform/audio/HRTFPanner.cpp:
(WebCore::HRTFPanner::panWithSampleAccurateValues):
* Source/WebCore/platform/audio/HRTFPanner.h:
* Source/WebCore/platform/audio/IIRFilter.cpp:
(WebCore::evaluatePolynomial):
(WebCore::IIRFilter::process):
(WebCore::IIRFilter::getFrequencyResponse):
* Source/WebCore/platform/audio/Panner.h:
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
* Source/WebCore/platform/audio/PushPullFIFO.cpp:
* Source/WebCore/platform/audio/ReverbAccumulationBuffer.cpp:
(WebCore::ReverbAccumulationBuffer::accumulate):
* Source/WebCore/platform/audio/ReverbAccumulationBuffer.h:
* Source/WebCore/platform/audio/ReverbConvolverStage.cpp:
(WebCore::ReverbConvolverStage::process):
* Source/WebCore/platform/audio/ReverbInputBuffer.cpp:
* Source/WebCore/platform/audio/StereoPanner.cpp:
(WebCore::StereoPanner::panWithSampleAccurateValues):
* Source/WebCore/platform/audio/UpSampler.cpp:
(WebCore::UpSampler::process):
* Source/WebCore/platform/audio/ZeroPole.cpp:
(WebCore::ZeroPole::process):
* Source/WebCore/platform/audio/ZeroPole.h:

Canonical link: <a href="https://commits.webkit.org/288315@main">https://commits.webkit.org/288315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b8564e84493239b133a31e4802885c6d75830d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82435 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33496 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84540 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9987 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64255 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22006 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1546 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75004 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44532 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1444 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29190 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32537 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75423 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88924 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81489 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9741 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7004 "Found 2 new test failures: http/wpt/mediarecorder/record-96KHz-sources.html swipe/navigate-event-back-swipe-verify-ua-transition.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72654 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70818 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71871 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16010 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15016 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1117 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12799 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9694 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15215 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103902 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9568 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25202 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13034 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11338 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->