### PR TITLE
Previously cleared text reappears when typing in Korean after tapping ⨯ in Google search field

### DIFF
--- a/LayoutTests/editing/input/ios/invalidate-text-entry-context-when-clearing-text-area-expected.txt
+++ b/LayoutTests/editing/input/ios/invalidate-text-entry-context-when-clearing-text-area-expected.txt
@@ -1,0 +1,10 @@
+This test requires WebKitTestRunner.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS updateCountBefore is not updateCountAfter
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/input/ios/invalidate-text-entry-context-when-clearing-text-area.html
+++ b/LayoutTests/editing/input/ios/invalidate-text-entry-context-when-clearing-text-area.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body {
+    margin: 0;
+    font-family: system-ui;
+    line-height: 150%;
+}
+
+textarea {
+    border: 1px solid tomato;
+    box-sizing: border-box;
+    outline: none;
+    font-size: 18px;
+    width: 300px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test requires WebKitTestRunner.");
+
+    const textarea = document.querySelector("textarea");
+    await UIHelper.activateElementAndWaitForInputSession(textarea);
+
+    for (let character of [..."hello"]) {
+        await UIHelper.callFunctionAndWaitForEvent(async () => {
+            await UIHelper.typeCharacter(character);
+            await UIHelper.ensurePresentationUpdate();
+        }, textarea, "keyup");
+    }
+
+    updateCountBefore = await UIHelper.keyboardUpdateForChangedSelectionCount();
+    textarea.value = "";
+    await UIHelper.ensurePresentationUpdate();
+    updateCountAfter = await UIHelper.keyboardUpdateForChangedSelectionCount();
+
+    shouldNotBe("updateCountBefore", "updateCountAfter");
+
+    textarea.blur();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <textarea></textarea>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2258,6 +2258,15 @@ window.UIHelper = class UIHelper {
             testRunner.runUIScript(`uiController.frontmostViewAtPoint(${x}, ${y})`, resolve);
         });
     }
+
+    static async keyboardUpdateForChangedSelectionCount() {
+        if (!this.isWebKit2())
+            return 0;
+
+        return new Promise(resolve => {
+            testRunner.runUIScript("uiController.keyboardUpdateForChangedSelectionCount", resolve);
+        });
+    }
 }
 
 UIHelper.EventStreamBuilder = class {

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1205,6 +1205,11 @@ ExceptionOr<void> HTMLInputElement::setValue(const String& value, TextFieldEvent
 
         if (m_isAutoFilledAndObscured)
             setAutofilledAndObscured(false);
+
+        if (valueChanged && value.isEmpty()) {
+            if (RefPtr page = document().page())
+                page->chrome().client().didProgrammaticallyClearTextFormControl(*this);
+        }
     }
 
     return { };

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -98,6 +98,7 @@ class HTMLImageElement;
 class HTMLInputElement;
 class HTMLMediaElement;
 class HTMLSelectElement;
+class HTMLTextFormControlElement;
 class HTMLVideoElement;
 class HitTestResult;
 class Icon;
@@ -718,6 +719,8 @@ public:
     virtual void callAfterPendingSyntheticClick(CompletionHandler<void(SyntheticClickResult)>&& completion) { completion(SyntheticClickResult::Failed); }
 
     virtual void didDispatchClickEvent(const PlatformMouseEvent&, Node&) { }
+
+    virtual void didProgrammaticallyClearTextFormControl(const HTMLTextFormControlElement&) { }
 
     WEBCORE_EXPORT virtual ~ChromeClient();
 

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -131,6 +131,7 @@ enum class ScrollIsAnimated : bool;
 struct AppHighlight;
 struct DataDetectorElementInfo;
 struct DictionaryPopupInfo;
+struct ElementContext;
 struct TextIndicatorData;
 struct ShareDataWithParsedURL;
 
@@ -551,6 +552,7 @@ public:
 
     virtual void elementDidFocus(const FocusedElementInformation&, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState> activityStateChanges, API::Object* userData) = 0;
     virtual void updateInputContextAfterBlurringAndRefocusingElement() = 0;
+    virtual void didProgrammaticallyClearFocusedElement(WebCore::ElementContext&&) = 0;
     virtual void updateFocusedElementInformation(const FocusedElementInformation&) = 0;
     virtual void elementDidBlur() = 0;
     virtual void focusedElementDidChangeInputMode(WebCore::InputMode) = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3018,6 +3018,7 @@ private:
     void elementDidFocus(const FocusedElementInformation&, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState> activityStateChanges, const UserData&);
     void elementDidBlur();
     void updateInputContextAfterBlurringAndRefocusingElement();
+    void didProgrammaticallyClearFocusedElement(WebCore::ElementContext&&);
     void updateFocusedElementInformation(const FocusedElementInformation&);
     void focusedElementDidChangeInputMode(WebCore::InputMode);
     void didReleaseAllTouchPoints();

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -402,6 +402,7 @@ messages -> WebPageProxy {
     ElementDidFocus(struct WebKit::FocusedElementInformation information, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState> activityStateChanges, WebKit::UserData userData)
     ElementDidBlur()
     UpdateInputContextAfterBlurringAndRefocusingElement()
+    DidProgrammaticallyClearFocusedElement(struct WebCore::ElementContext context)
     UpdateFocusedElementInformation(struct WebKit::FocusedElementInformation information)
     FocusedElementDidChangeInputMode(enum:uint8_t WebCore::InputMode mode)
     ScrollingNodeScrollWillStartScroll(std::optional<WebCore::ScrollingNodeID> nodeID)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -197,6 +197,7 @@ private:
 
     void elementDidFocus(const FocusedElementInformation&, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState> activityStateChanges, API::Object* userData) override;
     void updateInputContextAfterBlurringAndRefocusingElement() final;
+    void didProgrammaticallyClearFocusedElement(WebCore::ElementContext&&) final;
     void updateFocusedElementInformation(const FocusedElementInformation&) final;
     void elementDidBlur() override;
     void focusedElementDidChangeInputMode(WebCore::InputMode) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -675,6 +675,11 @@ void PageClientImpl::updateInputContextAfterBlurringAndRefocusingElement()
     [contentView() _updateInputContextAfterBlurringAndRefocusingElement];
 }
 
+void PageClientImpl::didProgrammaticallyClearFocusedElement(WebCore::ElementContext&& context)
+{
+    [contentView() _didProgrammaticallyClearFocusedElement:WTFMove(context)];
+}
+
 void PageClientImpl::updateFocusedElementInformation(const FocusedElementInformation& information)
 {
     [contentView() _updateFocusedElementInformation:information];

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -740,6 +740,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)_handleSmartMagnificationInformationForPotentialTap:(WebKit::TapIdentifier)requestID renderRect:(const WebCore::FloatRect&)renderRect fitEntireRect:(BOOL)fitEntireRect viewportMinimumScale:(double)viewportMinimumScale viewportMaximumScale:(double)viewportMaximumScale nodeIsRootLevel:(BOOL)nodeIsRootLevel;
 - (void)_elementDidFocus:(const WebKit::FocusedElementInformation&)information userIsInteracting:(BOOL)userIsInteracting blurPreviousNode:(BOOL)blurPreviousNode activityStateChanges:(OptionSet<WebCore::ActivityState>)activityStateChanges userObject:(NSObject <NSSecureCoding> *)userObject;
 - (void)_updateInputContextAfterBlurringAndRefocusingElement;
+- (void)_didProgrammaticallyClearFocusedElement:(WebCore::ElementContext&&)context;
 - (void)_updateFocusedElementInformation:(const WebKit::FocusedElementInformation&)information;
 - (void)_elementDidBlur;
 - (void)_didUpdateInputMode:(WebCore::InputMode)mode;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -8364,6 +8364,22 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
     if (!self._hasFocusedElement || !_suppressSelectionAssistantReasons)
         return;
 
+    [self _internalInvalidateTextEntryContext];
+}
+
+- (void)_didProgrammaticallyClearFocusedElement:(WebCore::ElementContext&&)context
+{
+    if (!self._hasFocusedElement)
+        return;
+
+    if (!context.isSameElement(_focusedElementInformation.elementContext))
+        return;
+
+    [self _internalInvalidateTextEntryContext];
+}
+
+- (void)_internalInvalidateTextEntryContext
+{
 #if USE(BROWSERENGINEKIT)
     if (self.shouldUseAsyncInteractions) {
         [_asyncInputDelegate invalidateTextEntryContextForTextInput:self.asBETextInput];

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -936,6 +936,12 @@ void WebPageProxy::updateInputContextAfterBlurringAndRefocusingElement()
         pageClient->updateInputContextAfterBlurringAndRefocusingElement();
 }
 
+void WebPageProxy::didProgrammaticallyClearFocusedElement(WebCore::ElementContext&& context)
+{
+    if (RefPtr client = pageClient())
+        client->didProgrammaticallyClearFocusedElement(WTFMove(context));
+}
+
 void WebPageProxy::elementDidFocus(const FocusedElementInformation& information, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState> activityStateChanges, const UserData& userData)
 {
     m_pendingInputModeChange = std::nullopt;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1994,4 +1994,9 @@ void WebChromeClient::didDispatchClickEvent(const PlatformMouseEvent& event, Nod
     protectedPage()->didDispatchClickEvent(event, node);
 }
 
+void WebChromeClient::didProgrammaticallyClearTextFormControl(const HTMLTextFormControlElement& element)
+{
+    protectedPage()->didProgrammaticallyClearTextFormControl(element);
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -555,6 +555,8 @@ private:
 
     void didDispatchClickEvent(const WebCore::PlatformMouseEvent&, WebCore::Node&) final;
 
+    void didProgrammaticallyClearTextFormControl(const WebCore::HTMLTextFormControlElement&) final;
+
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };
     mutable bool m_cachedMainFrameHasVerticalScrollbar { false };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8845,7 +8845,7 @@ RefPtr<Element> WebPage::elementForContext(const ElementContext& elementContext)
     return element;
 }
 
-std::optional<WebCore::ElementContext> WebPage::contextForElement(WebCore::Element& element) const
+std::optional<WebCore::ElementContext> WebPage::contextForElement(const WebCore::Element& element) const
 {
     Ref document = element.document();
     if (!m_page || document->page() != m_page.get())

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -184,6 +184,7 @@ class HTMLElement;
 class HTMLImageElement;
 class HTMLPlugInElement;
 class HTMLSelectElement;
+class HTMLTextFormControlElement;
 class HTMLVideoElement;
 class HandleUserInputEventResult;
 class HistoryItem;
@@ -1640,7 +1641,7 @@ public:
     void configureLoggingChannel(const String&, WTFLogChannelState, WTFLogLevel);
 
     RefPtr<WebCore::Element> elementForContext(const WebCore::ElementContext&) const;
-    std::optional<WebCore::ElementContext> contextForElement(WebCore::Element&) const;
+    std::optional<WebCore::ElementContext> contextForElement(const WebCore::Element&) const;
 
     void startTextManipulations(Vector<WebCore::TextManipulationController::ExclusionRule>&&, bool includesSubframes, CompletionHandler<void()>&&);
     void completeTextManipulation(const Vector<WebCore::TextManipulationItem>&, CompletionHandler<void(bool allFailed, const Vector<WebCore::TextManipulationController::ManipulationFailure>&)>&&);
@@ -1936,6 +1937,8 @@ public:
 #if HAVE(AUDIT_TOKEN)
     void setPresentingApplicationAuditToken(CoreIPCAuditToken&&);
 #endif
+
+    void didProgrammaticallyClearTextFormControl(const WebCore::HTMLTextFormControlElement&);
 
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
@@ -3009,6 +3012,7 @@ private:
 inline void WebPage::platformWillPerformEditingCommand() { }
 inline bool WebPage::requiresPostLayoutDataForEditorState(const WebCore::LocalFrame&) const { return false; }
 inline void WebPage::prepareToRunModalJavaScriptDialog() { }
+inline void WebPage::didProgrammaticallyClearTextFormControl(const WebCore::HTMLTextFormControlElement&) { }
 #endif
 
 #if !ENABLE(IOS_TOUCH_EVENTS)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1472,6 +1472,26 @@ void WebPage::updateInputContextAfterBlurringAndRefocusingElementIfNeeded(Elemen
     });
 }
 
+void WebPage::didProgrammaticallyClearTextFormControl(const HTMLTextFormControlElement& element)
+{
+    if (!m_isShowingInputViewForFocusedElement)
+        return;
+
+    if (m_focusedElement != &element && m_recentlyBlurredElement != &element)
+        return;
+
+    callOnMainRunLoop([protectedThis = Ref { *this }, element = Ref { element }] {
+        if (protectedThis->m_focusedElement != element.ptr())
+            return;
+
+        auto context = protectedThis->contextForElement(element);
+        if (!context)
+            return;
+
+        protectedThis->send(Messages::WebPageProxy::DidProgrammaticallyClearFocusedElement(WTFMove(*context)));
+    });
+}
+
 void WebPage::blurFocusedElement()
 {
     if (!m_focusedElement)

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -93,6 +93,7 @@ interface UIScriptController {
 
     readonly attribute unsigned long keyboardWillHideCount;
     readonly attribute boolean keyboardIsAutomaticallyShifted;
+    readonly attribute unsigned long keyboardUpdateForChangedSelectionCount;
 
     undefined rawKeyDown(DOMString key);
     undefined rawKeyUp(DOMString key);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -210,6 +210,12 @@ public:
         return false;
     }
 
+    virtual unsigned keyboardUpdateForChangedSelectionCount() const
+    {
+        notImplemented();
+        return 0;
+    }
+
     virtual bool isAnimatingDragCancel() const
     {
         notImplemented();

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -280,6 +280,7 @@ typedef NS_ENUM(NSInteger, _UIDataOwner) {
 - (BOOL)isAutoShifted;
 - (void)dismissKeyboard;
 - (void)setCorrectionLearningAllowed:(BOOL)allowed;
+- (void)updateForChangedSelection;
 @end
 
 @interface UIScreen ()

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -368,6 +368,7 @@ public:
     UIKeyboardInputMode *overriddenKeyboardInputMode() const { return m_overriddenKeyboardInputMode.get(); }
     void setIsInHardwareKeyboardMode(bool value) { m_isInHardwareKeyboardMode = value; }
     bool isInHardwareKeyboardMode() const { return m_isInHardwareKeyboardMode; }
+    unsigned keyboardUpdateForChangedSelectionCount() const;
 #endif
 
     void setAllowedMenuActions(const Vector<String>&);

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -149,6 +149,7 @@ private:
     void toggleCapsLock(JSValueRef) override;
     unsigned keyboardWillHideCount() const override;
     bool keyboardIsAutomaticallyShifted() const override;
+    unsigned keyboardUpdateForChangedSelectionCount() const final;
     bool isAnimatingDragCancel() const override;
     JSRetainPtr<JSStringRef> selectionCaretBackgroundColor() const override;
     JSObjectRef tapHighlightViewRect() const override;

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -1446,6 +1446,11 @@ bool UIScriptControllerIOS::keyboardIsAutomaticallyShifted() const
     return UIKeyboardImpl.activeInstance.isAutoShifted;
 }
 
+unsigned UIScriptControllerIOS::keyboardUpdateForChangedSelectionCount() const
+{
+    return TestController::singleton().keyboardUpdateForChangedSelectionCount();
+}
+
 unsigned UIScriptControllerIOS::keyboardWillHideCount() const
 {
     return static_cast<unsigned>(webView().keyboardWillHideCount);


### PR DESCRIPTION
#### 296ab29f51e372d0e00721ff34ad360ef75466b6
<pre>
Previously cleared text reappears when typing in Korean after tapping ⨯ in Google search field
<a href="https://bugs.webkit.org/show_bug.cgi?id=285175">https://bugs.webkit.org/show_bug.cgi?id=285175</a>
<a href="https://rdar.apple.com/131897908">rdar://131897908</a>

Reviewed by Richard Robinson.

When using Korean keyboards to search on Google (typing in a `textarea` element) on Google on iOS,
if you:

(1) Type some Korean text (stopping in the middle of a composed word).
(2) Tap the ⨯ button, which programmatically clears the text field.
(3) Continue typing on Korean.

...text that was previously typed and then cleared during (2) will reappear. This happens because
there&apos;s no mechanism to invalidate and update the keyboard&apos;s text entry context when text content
changes programmatically, so the stored input context ends up being reinserted.

To fix this, we add a heuristic to respond to programmatic changes in text content that cause the
value of focused text form controls to become empty, and `-invalidateTextEntryContextForTextInput:`
in the UI process. While we could potentially apply this treatment to *all* programmatic value
changes, this poses a more significant web compat and performance risk.

* LayoutTests/editing/input/ios/invalidate-text-entry-context-when-clearing-text-area-expected.txt: Added.
* LayoutTests/editing/input/ios/invalidate-text-entry-context-when-clearing-text-area.html: Added.

Add a layout test to exercise this change, by teaching the test runner to count the number of times
`-[_UIKeyboardStateManager updateForChangedSelection]` is invoked and verifying that clearing the
text in a `textarea` calls into this method.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async keyboardUpdateForChangedSelectionCount):
(window.UIHelper):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::setValue):

Call the new client hook below, when the value is set to the empty string from bindings.

* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::setValueCommon):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::didProgrammaticallyClearTextFormControl):

Add a client hook to notify `WebPage` when a text form control&apos;s text value is cleared.

* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::didProgrammaticallyClearFocusedElement):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _updateInputContextAfterBlurringAndRefocusingElement]):
(-[WKContentView _didProgrammaticallyClearFocusedElement:]):
(-[WKContentView _internalInvalidateTextEntryContext]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::didProgrammaticallyClearFocusedElement):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::didProgrammaticallyClearTextFormControl):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::contextForElement const):

Make this method const, so that we can pass in the form control element below.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::didProgrammaticallyClearTextFormControl):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::didProgrammaticallyClearTextFormControl):

Notify the UI process when the focused form control value is cleared. The IPC message is sent on the
next runloop, so that we&apos;ll still invalidate the text entry context in the case where a focused
element is blurred and immediately refocused.

* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::keyboardUpdateForChangedSelectionCount const):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(-[NSObject swizzled_updateForChangedSelection]):
(WTR::TestController::platformInitialize):
(WTR::TestController::keyboardUpdateForChangedSelectionCount const):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::keyboardUpdateForChangedSelectionCount const):

Add test infrastructure to keep track of the number of times `-updateForChangedSelection` is
invoked; also expose a new script controller hook to request this count from layout tests.

Canonical link: <a href="https://commits.webkit.org/288313@main">https://commits.webkit.org/288313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e03c81a3974de04eb9a4aa7f3d2c4ff940d6ac57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87548 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33477 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84521 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64238 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21992 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85485 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/1529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/74990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44515 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/1428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/29175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32518 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/29809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88904 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/6990 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72640 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9948 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/70804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71857 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17901 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15993 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1095 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9675 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15196 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9549 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13015 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11319 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->