### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/graphics/filters/software

### DIFF
--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
@@ -76,7 +76,7 @@ bool FEColorMatrix::setValues(const Vector<float> &values)
     return true;
 }
 
-void FEColorMatrix::calculateSaturateComponents(float* components, float value)
+void FEColorMatrix::calculateSaturateComponents(std::span<float> components, float value)
 {
     auto saturationMatrix = saturationColorMatrix(value);
 
@@ -93,7 +93,7 @@ void FEColorMatrix::calculateSaturateComponents(float* components, float value)
     components[8] = saturationMatrix.at(2, 2);
 }
 
-void FEColorMatrix::calculateHueRotateComponents(float* components, float angleInDegrees)
+void FEColorMatrix::calculateHueRotateComponents(std::span<float> components, float angleInDegrees)
 {
     auto hueRotateMatrix = hueRotateColorMatrix(angleInDegrees);
 

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
@@ -47,8 +47,8 @@ public:
     const Vector<float>& values() const { return m_values; }
     bool setValues(const Vector<float>&);
 
-    static void calculateSaturateComponents(float* components, float value);
-    static void calculateHueRotateComponents(float* components, float value);
+    static void calculateSaturateComponents(std::span<float> components, float value);
+    static void calculateHueRotateComponents(std::span<float> components, float value);
     static Vector<float> normalizedFloats(const Vector<float>& values);
 
 private:

--- a/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
@@ -35,8 +35,6 @@
 #include <Accelerate/Accelerate.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FEColorMatrixSoftwareApplier);
@@ -285,5 +283,3 @@ bool FEColorMatrixSoftwareApplier::apply(const Filter&, const FilterImageVector&
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.h
@@ -51,7 +51,7 @@ private:
 
     void applyPlatform(PixelBuffer&) const;
 
-    float m_components[9];
+    std::array<float, 9> m_components;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
@@ -33,15 +33,13 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FEComponentTransferSoftwareApplier);
 
 void FEComponentTransferSoftwareApplier::applyPlatform(PixelBuffer& pixelBuffer) const
 {
-    auto* data = pixelBuffer.bytes().data();
+    auto data = pixelBuffer.bytes();
     auto pixelByteLength = pixelBuffer.bytes().size();
 
     auto redTable   = FEComponentTransfer::computeLookupTable(m_effect.redFunction());
@@ -73,5 +71,3 @@ bool FEComponentTransferSoftwareApplier::apply(const Filter&, const FilterImageV
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.h
@@ -42,12 +42,12 @@ private:
     static uint8_t clampByte(int);
 
     template <int b1, int b4>
-    static inline void computePixels(unsigned char* source, unsigned char* destination, int pixelArrayLength, float k1, float k2, float k3, float k4);
+    static inline void computePixels(std::span<unsigned char> source, std::span<unsigned char> destination, int pixelArrayLength, float k1, float k2, float k3, float k4);
 
     template <int b1, int b4>
-    static inline void computePixelsUnclamped(unsigned char* source, unsigned char* destination, int pixelArrayLength, float k1, float k2, float k3, float k4);
+    static inline void computePixelsUnclamped(std::span<unsigned char> source, std::span<unsigned char> destination, int pixelArrayLength, float k1, float k2, float k3, float k4);
 
-    static inline void applyPlatform(unsigned char* source, unsigned char* destination, int pixelArrayLength, float k1, float k2, float k3, float k4);
+    static inline void applyPlatform(std::span<unsigned char> source, std::span<unsigned char> destination, int pixelArrayLength, float k1, float k2, float k3, float k4);
 
     bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;
 };

--- a/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
@@ -62,7 +62,7 @@ private:
     };
 
     static inline uint8_t clampRGBAValue(float channel, uint8_t max = 255);
-    static inline void setDestinationPixels(const PixelBuffer& sourcePixelBuffer, PixelBuffer& destinationPixelBuffer, int& pixel, float* totals, float divisor, float bias, bool preserveAlphaValues);
+    static inline void setDestinationPixels(const PixelBuffer& sourcePixelBuffer, PixelBuffer& destinationPixelBuffer, int& pixel, std::span<float> totals, float divisor, float bias, bool preserveAlphaValues);
 
     static inline int getPixelValue(const PaintingData&, int x, int y);
 

--- a/Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.cpp
@@ -29,9 +29,8 @@
 #include "Filter.h"
 #include "GraphicsContext.h"
 #include "PixelBuffer.h"
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -98,13 +97,13 @@ bool FEDisplacementMapSoftwareApplier::apply(const Filter& filter, const FilterI
             int srcX = x + static_cast<int>(scaleForColorX * displacementPixelBuffer->item(destinationIndex + displacementChannelX) + scaledOffsetX);
             int srcY = y + static_cast<int>(scaleForColorY * displacementPixelBuffer->item(destinationIndex + displacementChannelY) + scaledOffsetY);
 
-            unsigned* destinationPixelPtr = reinterpret_cast<unsigned*>(destinationPixelBuffer->bytes().data() + destinationIndex);
+            unsigned& destinationPixel = reinterpretCastSpanStartTo<unsigned>(destinationPixelBuffer->bytes().subspan(destinationIndex));
             if (srcX < 0 || srcX >= paintSize.width() || srcY < 0 || srcY >= paintSize.height()) {
-                *destinationPixelPtr = 0;
+                destinationPixel = 0;
                 continue;
             }
 
-            *destinationPixelPtr = *reinterpret_cast<unsigned*>(inputPixelBuffer->bytes().data() + byteOffsetOfPixel(srcX, srcY, rowBytes));
+            destinationPixel = reinterpretCastSpanStartTo<unsigned>(inputPixelBuffer->bytes().subspan(byteOffsetOfPixel(srcX, srcY, rowBytes)));
         }
     }
 
@@ -112,5 +111,3 @@ bool FEDisplacementMapSoftwareApplier::apply(const Filter& filter, const FilterI
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.h
@@ -34,8 +34,6 @@
 #include "LightSource.h"
 #include <wtf/TZoneMalloc.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 class FELighting;
@@ -59,7 +57,7 @@ protected:
     static constexpr float cFactor2div3 = -2 / 3.f;
 
     struct AlphaWindow {
-        uint8_t alpha[3][3] { };
+        std::array<std::array<uint8_t, 3>, 3> alpha = { };
     
         // The implementations are lined up to make comparing indices easier.
         uint8_t topLeft() const             { return alpha[0][0]; }
@@ -78,7 +76,7 @@ protected:
         void setRight(uint8_t value)        { alpha[1][2] = value; }
         void setBottomRight(uint8_t value)  { alpha[2][2] = value; }
 
-        static void shiftRow(uint8_t alpha[3])
+        static void shiftRow(std::array<uint8_t, 3>& alpha)
         {
             alpha[0] = alpha[1];
             alpha[1] = alpha[2];
@@ -130,5 +128,3 @@ protected:
 };
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplierInlines.h
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplierInlines.h
@@ -29,8 +29,6 @@
 
 #include "FELightingSoftwareApplier.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 inline IntSize FELightingSoftwareApplier::LightingData::topLeftNormal(int offset) const
@@ -178,5 +176,3 @@ inline IntSize FELightingSoftwareApplier::LightingData::bottomRightNormal(int of
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
@@ -29,9 +29,8 @@
 #include "Filter.h"
 #include "PixelBuffer.h"
 #include <wtf/ParallelJobs.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -47,10 +46,10 @@ inline ColorComponents<uint8_t, 4> FEMorphologySoftwareApplier::minOrMax(const C
 
 inline ColorComponents<uint8_t, 4> FEMorphologySoftwareApplier::columnExtremum(const PixelBuffer& srcPixelBuffer, int x, int yStart, int yEnd, int width, MorphologyOperatorType type)
 {
-    auto extremum = makeColorComponentsfromPixelValue(PackedColor::RGBA { *reinterpret_cast<const unsigned*>(srcPixelBuffer.bytes().data() + pixelArrayIndex(x, yStart, width)) });
+    auto extremum = makeColorComponentsfromPixelValue(PackedColor::RGBA { reinterpretCastSpanStartTo<const unsigned>(srcPixelBuffer.bytes().subspan(pixelArrayIndex(x, yStart, width))) });
 
     for (int y = yStart + 1; y < yEnd; ++y) {
-        auto pixel = makeColorComponentsfromPixelValue(PackedColor::RGBA { *reinterpret_cast<const unsigned*>(srcPixelBuffer.bytes().data() + pixelArrayIndex(x, y, width)) });
+        auto pixel = makeColorComponentsfromPixelValue(PackedColor::RGBA { reinterpretCastSpanStartTo<const unsigned>(srcPixelBuffer.bytes().subspan(pixelArrayIndex(x, y, width))) });
         extremum = minOrMax(extremum, pixel, type);
     }
     return extremum;
@@ -101,8 +100,8 @@ void FEMorphologySoftwareApplier::applyPlatformGeneric(const PaintingData& paint
             if (x > radiusX)
                 extrema.remove(0);
 
-            unsigned* destPixel = reinterpret_cast<unsigned*>(dstPixelBuffer.bytes().data() + pixelArrayIndex(x, y, width));
-            *destPixel = makePixelValueFromColorComponents(kernelExtremum(extrema, paintingData.type)).value;
+            unsigned& destPixel = reinterpretCastSpanStartTo<unsigned>(dstPixelBuffer.bytes().subspan(pixelArrayIndex(x, y, width)));
+            destPixel = makePixelValueFromColorComponents(kernelExtremum(extrema, paintingData.type)).value;
         }
     }
 }
@@ -194,5 +193,3 @@ bool FEMorphologySoftwareApplier::apply(const Filter& filter, const FilterImageV
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
@@ -33,8 +33,6 @@
 #include <wtf/ParallelJobs.h>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FETurbulenceSoftwareApplier);
@@ -52,7 +50,7 @@ FETurbulenceSoftwareApplier::PaintingData FETurbulenceSoftwareApplier::initPaint
     if (paintingData.seed > s_randMaximum - 1)
         paintingData.seed = s_randMaximum - 1;
 
-    float* gradient;
+    std::span<float> gradient;
     for (int channel = 0; channel < 4; ++channel) {
         for (int i = 0; i < s_blockSize; ++i) {
             paintingData.latticeSelector[i] = i;
@@ -191,7 +189,7 @@ ColorComponents<float, 4> FETurbulenceSoftwareApplier::noise2D(const PaintingDat
         // b00 = uLatticeSelector[i + by0]
         int b00 = paintingData.latticeSelector[latticeIndex + noiseY.index];
         // q = fGradient[nColorChannel][b00]; u = rx0 * q[0] + ry0 * q[1];
-        const float* q = paintingData.gradient[channel][b00];
+        std::span<const float> q = paintingData.gradient[channel][b00];
         float u = noiseX.fraction * q[0] + noiseY.fraction * q[1];
 
         // b10 = uLatticeSelector[j + by0];
@@ -290,7 +288,7 @@ void FETurbulenceSoftwareApplier::applyPlatformGeneric(const IntRect& filterRegi
             point.setX(point.x() + 1);
             FloatPoint localPoint = point.scaled(inverseScale.width(), inverseScale.height());
             auto values = calculateTurbulenceValueForPoint(paintingData, stitchData, localPoint);
-            pixelBuffer.setRange({ values.components.data(), 4 }, indexOfPixelChannel);
+            pixelBuffer.setRange(std::span { values.components }, indexOfPixelChannel);
             indexOfPixelChannel += 4;
         }
     }
@@ -370,7 +368,5 @@ bool FETurbulenceSoftwareApplier::apply(const Filter& filter, const FilterImageV
     applyPlatform(result.absoluteImageRect(), filter.filterScale(), *destinationPixelBuffer, paintingData, stitchData);
     return true;
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.h
@@ -81,8 +81,8 @@ private:
         bool stitchTiles;
         IntSize paintingSize;
 
-        int latticeSelector[2 * s_blockSize + 2];
-        float gradient[4][2 * s_blockSize + 2][2];
+        std::array<int, 2 * s_blockSize + 2> latticeSelector;
+        std::array<std::array<std::array<float, 2>, 2 * s_blockSize + 2>, 4> gradient;
     };
 
     struct StitchData {


### PR DESCRIPTION
#### 22dfcde373d09fb812ff6ccb6edaa532f6a9530f
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/graphics/filters/software
<a href="https://bugs.webkit.org/show_bug.cgi?id=285185">https://bugs.webkit.org/show_bug.cgi?id=285185</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp:
(WebCore::FEColorMatrix::calculateSaturateComponents):
(WebCore::FEColorMatrix::calculateHueRotateComponents):
* Source/WebCore/platform/graphics/filters/FEColorMatrix.h:
* Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp:
* Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.h:
* Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp:
(WebCore::FEComponentTransferSoftwareApplier::applyPlatform const):
* Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.cpp:
(WebCore::FECompositeSoftwareArithmeticApplier::clampByte):
(WebCore::FECompositeSoftwareArithmeticApplier::computePixels):
(WebCore::FECompositeSoftwareArithmeticApplier::computePixelsUnclamped):
(WebCore::FECompositeSoftwareArithmeticApplier::applyPlatform):
(WebCore::FECompositeSoftwareArithmeticApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.h:
* Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp:
(WebCore::FEConvolveMatrixSoftwareApplier::setDestinationPixels):
* Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h:
* Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.cpp:
(WebCore::FEDisplacementMapSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp:
(WebCore::FEGaussianBlurSoftwareApplier::boxBlurAlphaOnly):
(WebCore::FEGaussianBlurSoftwareApplier::boxBlur):
* Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.h:
(WebCore::FELightingSoftwareApplier::AlphaWindow::shiftRow):
(): Deleted.
* Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplierInlines.h:
* Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp:
(WebCore::FEMorphologySoftwareApplier::columnExtremum):
(WebCore::FEMorphologySoftwareApplier::applyPlatformGeneric):
* Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp:
(WebCore::FETurbulenceSoftwareApplier::initPaintingData):
(WebCore::FETurbulenceSoftwareApplier::noise2D):
(WebCore::FETurbulenceSoftwareApplier::applyPlatformGeneric):
* Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.h:

Canonical link: <a href="https://commits.webkit.org/288312@main">https://commits.webkit.org/288312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4543b2473f8fcc4b21787c5e78dceedea70dc7ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33493 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64250 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22003 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85501 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1543 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75001 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44527 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1441 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29187 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32534 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72733 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88921 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9738 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7001 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72651 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71868 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17902 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16007 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15013 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1114 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9691 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15212 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9565 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11335 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->