### PR TITLE
rowspan="0" results in different table layout than Firefox/Chrome

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6638,8 +6638,6 @@ imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-border-spacin
 imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-colspan-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowspan-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/whitespace-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-tables/zero-rowspan-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-tables/zero-rowspan-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/html5-table-formatting-fixed-layout-1.html [ Pass Failure ]
 
 # New failures after re-importing css-overflow

--- a/LayoutTests/platform/glib/tables/mozilla/bugs/bug30332-1-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla/bugs/bug30332-1-expected.txt
@@ -8,25 +8,25 @@ layer at (0,0) size 800x600
           text run at (0,0) width 39: "BAD:"
         RenderBR {BR} at (39,0) size 0x17
         RenderBR {BR} at (0,18) size 0x17
-      RenderBlock {CENTER} at (0,36) size 784x60
-        RenderTable {TABLE} at (0,0) size 784x60 [border: (5px outset #000000)]
-          RenderTableSection {TBODY} at (5,5) size 774x50
-            RenderTableRow {TR} at (0,2) size 774x22
-              RenderTableCell {TD} at (2,2) size 770x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+      RenderBlock {CENTER} at (0,36) size 784x38
+        RenderTable {TABLE} at (0,0) size 784x38 [border: (5px outset #000000)]
+          RenderTableSection {TBODY} at (5,5) size 774x28
+            RenderTableRow {TR} at (0,2) size 774x0
+              RenderTableCell {TD} at (2,3) size 373x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+                RenderText {#text} at (2,3) size 27x17
                   text run at (2,2) width 27: "One"
-            RenderTableRow {TR} at (0,26) size 774x22
-              RenderTableCell {TD} at (2,26) size 770x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,4) size 774x22
+              RenderTableCell {TD} at (376,4) size 397x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 29x17
                   text run at (2,2) width 29: "Two"
-      RenderBlock (anonymous) at (0,96) size 784x72
+      RenderBlock (anonymous) at (0,74) size 784x72
         RenderBR {BR} at (0,0) size 0x17
         RenderBR {BR} at (0,18) size 0x17
         RenderText {#text} at (0,36) size 52x17
           text run at (0,36) width 52: "GOOD:"
         RenderBR {BR} at (52,36) size 0x17
         RenderBR {BR} at (0,54) size 0x17
-      RenderBlock {CENTER} at (0,168) size 784x60
+      RenderBlock {CENTER} at (0,146) size 784x60
         RenderTable {TABLE} at (0,0) size 784x60 [border: (5px outset #000000)]
           RenderTableSection {TBODY} at (5,5) size 774x50
             RenderTableRow {TR} at (0,2) size 774x22

--- a/LayoutTests/platform/glib/tables/mozilla/bugs/bug30332-2-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla/bugs/bug30332-2-expected.txt
@@ -1,32 +1,32 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x244
-  RenderBlock {HTML} at (0,0) size 800x244
-    RenderBody {BODY} at (8,8) size 784x228
+layer at (0,0) size 800x222
+  RenderBlock {HTML} at (0,0) size 800x222
+    RenderBody {BODY} at (8,8) size 784x206
       RenderBlock (anonymous) at (0,0) size 784x36
         RenderText {#text} at (0,0) size 39x17
           text run at (0,0) width 39: "BAD:"
         RenderBR {BR} at (39,0) size 0x17
         RenderBR {BR} at (0,18) size 0x17
-      RenderBlock {CENTER} at (0,36) size 784x60
-        RenderTable {TABLE} at (0,0) size 784x60 [border: (5px outset #000000)]
-          RenderTableSection {TBODY} at (5,5) size 774x50
-            RenderTableRow {TR} at (0,2) size 774x22
-              RenderTableCell {TD} at (2,2) size 770x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+      RenderBlock {CENTER} at (0,36) size 784x38
+        RenderTable {TABLE} at (0,0) size 784x38 [border: (5px outset #000000)]
+          RenderTableSection {TBODY} at (5,5) size 774x28
+            RenderTableRow {TR} at (0,2) size 774x0
+              RenderTableCell {TD} at (2,3) size 373x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+                RenderText {#text} at (2,3) size 27x17
                   text run at (2,2) width 27: "One"
-            RenderTableRow {TR} at (0,26) size 774x22
-              RenderTableCell {TD} at (2,26) size 770x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,4) size 774x22
+              RenderTableCell {TD} at (376,4) size 397x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 29x17
                   text run at (2,2) width 29: "Two"
-      RenderBlock (anonymous) at (0,96) size 784x72
+      RenderBlock (anonymous) at (0,74) size 784x72
         RenderBR {BR} at (0,0) size 0x17
         RenderBR {BR} at (0,18) size 0x17
         RenderText {#text} at (0,36) size 52x17
           text run at (0,36) width 52: "GOOD:"
         RenderBR {BR} at (52,36) size 0x17
         RenderBR {BR} at (0,54) size 0x17
-      RenderBlock {CENTER} at (0,168) size 784x60
+      RenderBlock {CENTER} at (0,146) size 784x60
         RenderTable {TABLE} at (0,0) size 784x60 [border: (5px outset #000000)]
           RenderTableSection {TBODY} at (5,5) size 774x50
             RenderTableRow {TR} at (0,2) size 774x22

--- a/LayoutTests/platform/glib/tables/mozilla/bugs/bug9879-1-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla/bugs/bug9879-1-expected.txt
@@ -3,20 +3,20 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x348
   RenderBlock {HTML} at (0,0) size 800x348
     RenderBody {BODY} at (8,8) size 784x332
-      RenderTable {TABLE} at (0,0) size 142x52 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 140x50
-          RenderTableRow {TR} at (0,2) size 140x22
-            RenderTableCell {TD} at (2,2) size 70x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 66x17
+      RenderTable {TABLE} at (0,0) size 156x52 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 154x50
+          RenderTableRow {TR} at (0,2) size 154x22
+            RenderTableCell {TD} at (2,14) size 70x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+              RenderText {#text} at (2,14) size 66x17
                 text run at (2,2) width 66: "rowspan 0"
             RenderTableCell {TD} at (74,2) size 64x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 60x17
                 text run at (2,2) width 60: "colspan 0"
-          RenderTableRow {TR} at (0,26) size 140x22
-            RenderTableCell {TD} at (2,26) size 70x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,26) size 154x22
+            RenderTableCell {TD} at (74,26) size 64x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 8x17
                 text run at (2,2) width 8: "5"
-            RenderTableCell {TD} at (74,26) size 64x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (140,26) size 12x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 8x17
                 text run at (2,2) width 8: "6"
       RenderBlock (anonymous) at (0,52) size 784x18
@@ -75,25 +75,25 @@ layer at (0,0) size 800x348
                 text run at (2,2) width 8: "3"
       RenderBlock (anonymous) at (0,262) size 784x18
         RenderBR {BR} at (0,0) size 0x17
-      RenderTable {TABLE} at (0,280) size 142x52 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 140x50
-          RenderTableRow {TR} at (0,2) size 140x22
+      RenderTable {TABLE} at (0,280) size 175x52 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 173x50
+          RenderTableRow {TR} at (0,2) size 173x22
             RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x17
                 text run at (2,2) width 27: "auto"
-            RenderTableCell {TD} at (35,2) size 70x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 66x17
+            RenderTableCell {TD} at (35,14) size 70x22 [border: (1px inset #000000)] [r=0 c=1 rs=65534 cs=1]
+              RenderText {#text} at (2,14) size 66x17
                 text run at (2,2) width 66: "rowspan 0"
             RenderTableCell {TD} at (107,2) size 31x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x17
                 text run at (2,2) width 27: "auto"
-          RenderTableRow {TR} at (0,26) size 140x22
+          RenderTableRow {TR} at (0,26) size 173x22
             RenderTableCell {TD} at (2,26) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x17
                 text run at (2,2) width 27: "auto"
-            RenderTableCell {TD} at (35,26) size 70x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (107,26) size 31x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x17
                 text run at (2,2) width 27: "auto"
-            RenderTableCell {TD} at (107,26) size 31x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (140,26) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x17
                 text run at (2,2) width 27: "auto"

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt
@@ -3,20 +3,20 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x348
   RenderBlock {HTML} at (0,0) size 800x348
     RenderBody {BODY} at (8,8) size 784x332
-      RenderTable {TABLE} at (0,0) size 142x52 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 140x50
-          RenderTableRow {TR} at (0,2) size 140x22
-            RenderTableCell {TD} at (2,2) size 70x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 66x17
+      RenderTable {TABLE} at (0,0) size 156x52 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 154x50
+          RenderTableRow {TR} at (0,2) size 154x22
+            RenderTableCell {TD} at (2,14) size 70x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+              RenderText {#text} at (2,14) size 66x17
                 text run at (2,2) width 66: "rowspan 0"
             RenderTableCell {TD} at (74,2) size 64x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 60x17
                 text run at (2,2) width 60: "colspan 0"
-          RenderTableRow {TR} at (0,26) size 140x22
-            RenderTableCell {TD} at (2,26) size 70x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,26) size 154x22
+            RenderTableCell {TD} at (74,26) size 64x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 8x17
                 text run at (2,2) width 8: "5"
-            RenderTableCell {TD} at (74,26) size 64x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (140,26) size 12x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 8x17
                 text run at (2,2) width 8: "6"
       RenderBlock (anonymous) at (0,52) size 784x18
@@ -75,25 +75,25 @@ layer at (0,0) size 800x348
                 text run at (2,2) width 8: "3"
       RenderBlock (anonymous) at (0,262) size 784x18
         RenderBR {BR} at (0,0) size 0x17
-      RenderTable {TABLE} at (0,280) size 142x52 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 140x50
-          RenderTableRow {TR} at (0,2) size 140x22
+      RenderTable {TABLE} at (0,280) size 175x52 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 173x50
+          RenderTableRow {TR} at (0,2) size 173x22
             RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x17
                 text run at (2,2) width 27: "auto"
-            RenderTableCell {TD} at (35,2) size 70x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 66x17
+            RenderTableCell {TD} at (35,14) size 70x22 [border: (1px inset #000000)] [r=0 c=1 rs=65534 cs=1]
+              RenderText {#text} at (2,14) size 66x17
                 text run at (2,2) width 66: "rowspan 0"
             RenderTableCell {TD} at (107,2) size 31x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x17
                 text run at (2,2) width 27: "auto"
-          RenderTableRow {TR} at (0,26) size 140x22
+          RenderTableRow {TR} at (0,26) size 173x22
             RenderTableCell {TD} at (2,26) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x17
                 text run at (2,2) width 27: "auto"
-            RenderTableCell {TD} at (35,26) size 70x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (107,26) size 31x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x17
                 text run at (2,2) width 27: "auto"
-            RenderTableCell {TD} at (107,26) size 31x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (140,26) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x17
                 text run at (2,2) width 27: "auto"

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug30332-1-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug30332-1-expected.txt
@@ -8,25 +8,25 @@ layer at (0,0) size 800x600
           text run at (0,0) width 39: "BAD:"
         RenderBR {BR} at (38,0) size 1x19
         RenderBR {BR} at (0,20) size 0x19
-      RenderBlock {CENTER} at (0,40) size 784x64
-        RenderTable {TABLE} at (0,0) size 784x64 [border: (5px outset #000000)]
-          RenderTableSection {TBODY} at (5,5) size 774x54
-            RenderTableRow {TR} at (0,2) size 774x24
-              RenderTableCell {TD} at (2,2) size 770x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+      RenderBlock {CENTER} at (0,40) size 784x40
+        RenderTable {TABLE} at (0,0) size 784x40 [border: (5px outset #000000)]
+          RenderTableSection {TBODY} at (5,5) size 774x30
+            RenderTableRow {TR} at (0,2) size 774x0
+              RenderTableCell {TD} at (2,3) size 375x24 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+                RenderText {#text} at (2,3) size 27x19
                   text run at (2,2) width 27: "One"
-            RenderTableRow {TR} at (0,28) size 774x24
-              RenderTableCell {TD} at (2,28) size 770x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,4) size 774x24
+              RenderTableCell {TD} at (378,4) size 395x24 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 29x19
                   text run at (2,2) width 29: "Two"
-      RenderBlock (anonymous) at (0,104) size 784x80
+      RenderBlock (anonymous) at (0,80) size 784x80
         RenderBR {BR} at (0,0) size 0x19
         RenderBR {BR} at (0,20) size 0x19
         RenderText {#text} at (0,40) size 51x19
           text run at (0,40) width 51: "GOOD:"
         RenderBR {BR} at (50,40) size 1x19
         RenderBR {BR} at (0,60) size 0x19
-      RenderBlock {CENTER} at (0,184) size 784x64
+      RenderBlock {CENTER} at (0,160) size 784x64
         RenderTable {TABLE} at (0,0) size 784x64 [border: (5px outset #000000)]
           RenderTableSection {TBODY} at (5,5) size 774x54
             RenderTableRow {TR} at (0,2) size 774x24

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug30332-2-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug30332-2-expected.txt
@@ -1,32 +1,32 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x264
-  RenderBlock {HTML} at (0,0) size 800x264
-    RenderBody {BODY} at (8,8) size 784x248
+layer at (0,0) size 800x240
+  RenderBlock {HTML} at (0,0) size 800x240
+    RenderBody {BODY} at (8,8) size 784x224
       RenderBlock (anonymous) at (0,0) size 784x40
         RenderText {#text} at (0,0) size 39x19
           text run at (0,0) width 39: "BAD:"
         RenderBR {BR} at (38,0) size 1x19
         RenderBR {BR} at (0,20) size 0x19
-      RenderBlock {CENTER} at (0,40) size 784x64
-        RenderTable {TABLE} at (0,0) size 784x64 [border: (5px outset #000000)]
-          RenderTableSection {TBODY} at (5,5) size 774x54
-            RenderTableRow {TR} at (0,2) size 774x24
-              RenderTableCell {TD} at (2,2) size 770x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+      RenderBlock {CENTER} at (0,40) size 784x40
+        RenderTable {TABLE} at (0,0) size 784x40 [border: (5px outset #000000)]
+          RenderTableSection {TBODY} at (5,5) size 774x30
+            RenderTableRow {TR} at (0,2) size 774x0
+              RenderTableCell {TD} at (2,3) size 375x24 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+                RenderText {#text} at (2,3) size 27x19
                   text run at (2,2) width 27: "One"
-            RenderTableRow {TR} at (0,28) size 774x24
-              RenderTableCell {TD} at (2,28) size 770x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,4) size 774x24
+              RenderTableCell {TD} at (378,4) size 395x24 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 29x19
                   text run at (2,2) width 29: "Two"
-      RenderBlock (anonymous) at (0,104) size 784x80
+      RenderBlock (anonymous) at (0,80) size 784x80
         RenderBR {BR} at (0,0) size 0x19
         RenderBR {BR} at (0,20) size 0x19
         RenderText {#text} at (0,40) size 51x19
           text run at (0,40) width 51: "GOOD:"
         RenderBR {BR} at (50,40) size 1x19
         RenderBR {BR} at (0,60) size 0x19
-      RenderBlock {CENTER} at (0,184) size 784x64
+      RenderBlock {CENTER} at (0,160) size 784x64
         RenderTable {TABLE} at (0,0) size 784x64 [border: (5px outset #000000)]
           RenderTableSection {TBODY} at (5,5) size 774x54
             RenderTableRow {TR} at (0,2) size 774x24

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug9879-1-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug9879-1-expected.txt
@@ -3,20 +3,20 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x376
   RenderBlock {HTML} at (0,0) size 800x376
     RenderBody {BODY} at (8,8) size 784x360
-      RenderTable {TABLE} at (0,0) size 144x56 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 142x54
-          RenderTableRow {TR} at (0,2) size 142x24
-            RenderTableCell {TD} at (2,2) size 71x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 67x19
+      RenderTable {TABLE} at (0,0) size 158x56 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 156x54
+          RenderTableRow {TR} at (0,2) size 156x24
+            RenderTableCell {TD} at (2,15) size 71x24 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+              RenderText {#text} at (2,15) size 67x19
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (74,2) size 66x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 61x19
                 text run at (2,2) width 61: "colspan 0"
-          RenderTableRow {TR} at (0,28) size 142x24
-            RenderTableCell {TD} at (2,28) size 71x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,28) size 156x24
+            RenderTableCell {TD} at (74,28) size 66x24 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 8x19
                 text run at (2,2) width 8: "5"
-            RenderTableCell {TD} at (74,28) size 66x24 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (141,28) size 13x24 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 8x19
                 text run at (2,2) width 8: "6"
       RenderBlock (anonymous) at (0,56) size 784x20
@@ -75,25 +75,25 @@ layer at (0,0) size 800x376
                 text run at (2,2) width 8: "3"
       RenderBlock (anonymous) at (0,284) size 784x20
         RenderBR {BR} at (0,0) size 0x19
-      RenderTable {TABLE} at (0,304) size 144x56 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 142x54
-          RenderTableRow {TR} at (0,2) size 142x24
+      RenderTable {TABLE} at (0,304) size 177x56 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 175x54
+          RenderTableRow {TR} at (0,2) size 175x24
             RenderTableCell {TD} at (2,2) size 32x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (35,2) size 71x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 67x19
+            RenderTableCell {TD} at (35,15) size 71x24 [border: (1px inset #000000)] [r=0 c=1 rs=65534 cs=1]
+              RenderText {#text} at (2,15) size 67x19
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (107,2) size 33x24 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "auto"
-          RenderTableRow {TR} at (0,28) size 142x24
+          RenderTableRow {TR} at (0,28) size 175x24
             RenderTableCell {TD} at (2,28) size 32x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (35,28) size 71x24 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (107,28) size 33x24 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (107,28) size 33x24 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (141,28) size 32x24 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "auto"

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt
@@ -3,20 +3,20 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x376
   RenderBlock {HTML} at (0,0) size 800x376
     RenderBody {BODY} at (8,8) size 784x360
-      RenderTable {TABLE} at (0,0) size 144x56 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 142x54
-          RenderTableRow {TR} at (0,2) size 142x24
-            RenderTableCell {TD} at (2,2) size 71x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 67x19
+      RenderTable {TABLE} at (0,0) size 158x56 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 156x54
+          RenderTableRow {TR} at (0,2) size 156x24
+            RenderTableCell {TD} at (2,15) size 71x24 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+              RenderText {#text} at (2,15) size 67x19
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (74,2) size 66x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 61x19
                 text run at (2,2) width 61: "colspan 0"
-          RenderTableRow {TR} at (0,28) size 142x24
-            RenderTableCell {TD} at (2,28) size 71x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,28) size 156x24
+            RenderTableCell {TD} at (74,28) size 66x24 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 8x19
                 text run at (2,2) width 8: "5"
-            RenderTableCell {TD} at (74,28) size 66x24 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (141,28) size 13x24 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 8x19
                 text run at (2,2) width 8: "6"
       RenderBlock (anonymous) at (0,56) size 784x20
@@ -75,25 +75,25 @@ layer at (0,0) size 800x376
                 text run at (2,2) width 8: "3"
       RenderBlock (anonymous) at (0,284) size 784x20
         RenderBR {BR} at (0,0) size 0x19
-      RenderTable {TABLE} at (0,304) size 144x56 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 142x54
-          RenderTableRow {TR} at (0,2) size 142x24
+      RenderTable {TABLE} at (0,304) size 177x56 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 175x54
+          RenderTableRow {TR} at (0,2) size 175x24
             RenderTableCell {TD} at (2,2) size 32x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (35,2) size 71x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 67x19
+            RenderTableCell {TD} at (35,15) size 71x24 [border: (1px inset #000000)] [r=0 c=1 rs=65534 cs=1]
+              RenderText {#text} at (2,15) size 67x19
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (107,2) size 33x24 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "auto"
-          RenderTableRow {TR} at (0,28) size 142x24
+          RenderTableRow {TR} at (0,28) size 175x24
             RenderTableCell {TD} at (2,28) size 32x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (35,28) size 71x24 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (107,28) size 33x24 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (107,28) size 33x24 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (141,28) size 32x24 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x19
                 text run at (2,2) width 28: "auto"

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-1-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-1-expected.txt
@@ -8,25 +8,25 @@ layer at (0,0) size 800x600
           text run at (0,0) width 39: "BAD:"
         RenderBR {BR} at (38,0) size 1x18
         RenderBR {BR} at (0,18) size 0x18
-      RenderBlock {CENTER} at (0,36) size 784x60
-        RenderTable {TABLE} at (0,0) size 784x60 [border: (5px outset #000000)]
-          RenderTableSection {TBODY} at (5,5) size 774x50
-            RenderTableRow {TR} at (0,2) size 774x22
-              RenderTableCell {TD} at (2,2) size 770x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+      RenderBlock {CENTER} at (0,36) size 784x38
+        RenderTable {TABLE} at (0,0) size 784x38 [border: (5px outset #000000)]
+          RenderTableSection {TBODY} at (5,5) size 774x28
+            RenderTableRow {TR} at (0,2) size 774x0
+              RenderTableCell {TD} at (2,3) size 375x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+                RenderText {#text} at (2,3) size 27x18
                   text run at (2,2) width 27: "One"
-            RenderTableRow {TR} at (0,26) size 774x22
-              RenderTableCell {TD} at (2,26) size 770x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,4) size 774x22
+              RenderTableCell {TD} at (378,4) size 395x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 29x18
                   text run at (2,2) width 29: "Two"
-      RenderBlock (anonymous) at (0,96) size 784x72
+      RenderBlock (anonymous) at (0,74) size 784x72
         RenderBR {BR} at (0,0) size 0x18
         RenderBR {BR} at (0,18) size 0x18
         RenderText {#text} at (0,36) size 51x18
           text run at (0,36) width 51: "GOOD:"
         RenderBR {BR} at (50,36) size 1x18
         RenderBR {BR} at (0,54) size 0x18
-      RenderBlock {CENTER} at (0,168) size 784x60
+      RenderBlock {CENTER} at (0,146) size 784x60
         RenderTable {TABLE} at (0,0) size 784x60 [border: (5px outset #000000)]
           RenderTableSection {TBODY} at (5,5) size 774x50
             RenderTableRow {TR} at (0,2) size 774x22

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-2-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-2-expected.txt
@@ -1,32 +1,32 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x244
-  RenderBlock {HTML} at (0,0) size 800x244
-    RenderBody {BODY} at (8,8) size 784x228
+layer at (0,0) size 800x222
+  RenderBlock {HTML} at (0,0) size 800x222
+    RenderBody {BODY} at (8,8) size 784x206
       RenderBlock (anonymous) at (0,0) size 784x36
         RenderText {#text} at (0,0) size 39x18
           text run at (0,0) width 39: "BAD:"
         RenderBR {BR} at (38,0) size 1x18
         RenderBR {BR} at (0,18) size 0x18
-      RenderBlock {CENTER} at (0,36) size 784x60
-        RenderTable {TABLE} at (0,0) size 784x60 [border: (5px outset #000000)]
-          RenderTableSection {TBODY} at (5,5) size 774x50
-            RenderTableRow {TR} at (0,2) size 774x22
-              RenderTableCell {TD} at (2,2) size 770x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+      RenderBlock {CENTER} at (0,36) size 784x38
+        RenderTable {TABLE} at (0,0) size 784x38 [border: (5px outset #000000)]
+          RenderTableSection {TBODY} at (5,5) size 774x28
+            RenderTableRow {TR} at (0,2) size 774x0
+              RenderTableCell {TD} at (2,3) size 375x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+                RenderText {#text} at (2,3) size 27x18
                   text run at (2,2) width 27: "One"
-            RenderTableRow {TR} at (0,26) size 774x22
-              RenderTableCell {TD} at (2,26) size 770x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,4) size 774x22
+              RenderTableCell {TD} at (378,4) size 395x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 29x18
                   text run at (2,2) width 29: "Two"
-      RenderBlock (anonymous) at (0,96) size 784x72
+      RenderBlock (anonymous) at (0,74) size 784x72
         RenderBR {BR} at (0,0) size 0x18
         RenderBR {BR} at (0,18) size 0x18
         RenderText {#text} at (0,36) size 51x18
           text run at (0,36) width 51: "GOOD:"
         RenderBR {BR} at (50,36) size 1x18
         RenderBR {BR} at (0,54) size 0x18
-      RenderBlock {CENTER} at (0,168) size 784x60
+      RenderBlock {CENTER} at (0,146) size 784x60
         RenderTable {TABLE} at (0,0) size 784x60 [border: (5px outset #000000)]
           RenderTableSection {TBODY} at (5,5) size 774x50
             RenderTableRow {TR} at (0,2) size 774x22

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug9879-1-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug9879-1-expected.txt
@@ -3,20 +3,20 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x348
   RenderBlock {HTML} at (0,0) size 800x348
     RenderBody {BODY} at (8,8) size 784x332
-      RenderTable {TABLE} at (0,0) size 144x52 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 142x50
-          RenderTableRow {TR} at (0,2) size 142x22
-            RenderTableCell {TD} at (2,2) size 71x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 67x18
+      RenderTable {TABLE} at (0,0) size 158x52 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 156x50
+          RenderTableRow {TR} at (0,2) size 156x22
+            RenderTableCell {TD} at (2,14) size 71x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+              RenderText {#text} at (2,14) size 67x18
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (74,2) size 66x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 61x18
                 text run at (2,2) width 61: "colspan 0"
-          RenderTableRow {TR} at (0,26) size 142x22
-            RenderTableCell {TD} at (2,26) size 71x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,26) size 156x22
+            RenderTableCell {TD} at (74,26) size 66x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 8x18
                 text run at (2,2) width 8: "5"
-            RenderTableCell {TD} at (74,26) size 66x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (141,26) size 13x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 8x18
                 text run at (2,2) width 8: "6"
       RenderBlock (anonymous) at (0,52) size 784x18
@@ -75,25 +75,25 @@ layer at (0,0) size 800x348
                 text run at (2,2) width 8: "3"
       RenderBlock (anonymous) at (0,262) size 784x18
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,280) size 144x52 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 142x50
-          RenderTableRow {TR} at (0,2) size 142x22
+      RenderTable {TABLE} at (0,280) size 177x52 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 175x50
+          RenderTableRow {TR} at (0,2) size 175x22
             RenderTableCell {TD} at (2,2) size 32x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x18
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (35,2) size 71x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 67x18
+            RenderTableCell {TD} at (35,14) size 71x22 [border: (1px inset #000000)] [r=0 c=1 rs=65534 cs=1]
+              RenderText {#text} at (2,14) size 67x18
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (107,2) size 33x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x18
                 text run at (2,2) width 28: "auto"
-          RenderTableRow {TR} at (0,26) size 142x22
+          RenderTableRow {TR} at (0,26) size 175x22
             RenderTableCell {TD} at (2,26) size 32x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x18
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (35,26) size 71x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (107,26) size 33x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x18
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (107,26) size 33x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (141,26) size 32x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x18
                 text run at (2,2) width 28: "auto"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt
@@ -3,20 +3,20 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x348
   RenderBlock {HTML} at (0,0) size 800x348
     RenderBody {BODY} at (8,8) size 784x332
-      RenderTable {TABLE} at (0,0) size 144x52 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 142x50
-          RenderTableRow {TR} at (0,2) size 142x22
-            RenderTableCell {TD} at (2,2) size 71x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 67x18
+      RenderTable {TABLE} at (0,0) size 158x52 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 156x50
+          RenderTableRow {TR} at (0,2) size 156x22
+            RenderTableCell {TD} at (2,14) size 71x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+              RenderText {#text} at (2,14) size 67x18
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (74,2) size 66x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 61x18
                 text run at (2,2) width 61: "colspan 0"
-          RenderTableRow {TR} at (0,26) size 142x22
-            RenderTableCell {TD} at (2,26) size 71x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,26) size 156x22
+            RenderTableCell {TD} at (74,26) size 66x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
               RenderText {#text} at (2,2) size 8x18
                 text run at (2,2) width 8: "5"
-            RenderTableCell {TD} at (74,26) size 66x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (141,26) size 13x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 8x18
                 text run at (2,2) width 8: "6"
       RenderBlock (anonymous) at (0,52) size 784x18
@@ -75,25 +75,25 @@ layer at (0,0) size 800x348
                 text run at (2,2) width 8: "3"
       RenderBlock (anonymous) at (0,262) size 784x18
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,280) size 144x52 [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 142x50
-          RenderTableRow {TR} at (0,2) size 142x22
+      RenderTable {TABLE} at (0,280) size 177x52 [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 175x50
+          RenderTableRow {TR} at (0,2) size 175x22
             RenderTableCell {TD} at (2,2) size 32x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x18
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (35,2) size 71x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (2,2) size 67x18
+            RenderTableCell {TD} at (35,14) size 71x22 [border: (1px inset #000000)] [r=0 c=1 rs=65534 cs=1]
+              RenderText {#text} at (2,14) size 67x18
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (107,2) size 33x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x18
                 text run at (2,2) width 28: "auto"
-          RenderTableRow {TR} at (0,26) size 142x22
+          RenderTableRow {TR} at (0,26) size 175x22
             RenderTableCell {TD} at (2,26) size 32x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x18
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (35,26) size 71x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (107,26) size 33x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x18
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (107,26) size 33x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (141,26) size 32x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x18
                 text run at (2,2) width 28: "auto"

--- a/Source/WebCore/html/HTMLTableCellElement.cpp
+++ b/Source/WebCore/html/HTMLTableCellElement.cpp
@@ -59,8 +59,14 @@ unsigned HTMLTableCellElement::colSpan() const
 
 unsigned HTMLTableCellElement::rowSpan() const
 {
-    // FIXME: a rowSpan equal to 0 should be allowed, and mean that the cell is to span all the remaining rows in the row group.
-    return std::max(1u, rowSpanForBindings());
+    unsigned rowSpanValue = rowSpanForBindings();
+    // when rowspan=0, the HTML spec says it should apply to the full remaining rows.
+    // In https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-rowspan
+    // > For this attribute, the value zero means that the cell is
+    // > to span all the remaining rows in the row group.
+    if (!rowSpanValue)
+        return maxRowspan;
+    return std::max(1u, rowSpanValue);
 }
 
 unsigned HTMLTableCellElement::rowSpanForBindings() const


### PR DESCRIPTION
#### 75a5507d4d8f004d43076ca036c32d4c798daccd
<pre>
rowspan=&quot;0&quot; results in different table layout than Firefox/Chrome
<a href="https://bugs.webkit.org/show_bug.cgi?id=185341">https://bugs.webkit.org/show_bug.cgi?id=185341</a>
<a href="https://rdar.apple.com/133910430">rdar://133910430</a>

Reviewed by Alan Baradlay.

<a href="https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-rowspan">https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-rowspan</a>
&gt; The td and th elements may also have a rowspan content attribute specified,
&gt; whose value must be
&gt; a valid non-negative integer less than or equal to 65534.
&gt; For this attribute, the value zero means that the cell is
&gt; to span all the remaining rows in the row group.

Basically is the equivalent of an imaginary all keyword.

&gt; The rowSpan IDL attribute must reflect the rowspan content attribute.
&gt; It is clamped to the range [0, 65534],
&gt; and its default value is 1.

We can put the value to the maximum number of rowspan, because
it will be clamped later on for the layout to the actual number of rows.

Setting rowspan=&quot;0&quot; is like setting a 3 or more on a table of 3 rows.

* LayoutTests/TestExpectations:
* LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt:
* LayoutTests/platform/glib/tables/mozilla/bugs/bug30332-1-expected.txt:
* LayoutTests/platform/glib/tables/mozilla/bugs/bug30332-2-expected.txt:
* LayoutTests/platform/glib/tables/mozilla/bugs/bug9879-1-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug30332-1-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug30332-2-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug9879-1-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-1-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-2-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug9879-1-expected.txt:
* Source/WebCore/html/HTMLTableCellElement.cpp:
(WebCore::HTMLTableCellElement::rowSpan const):

Canonical link: <a href="https://commits.webkit.org/288746@main">https://commits.webkit.org/288746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44c06fce861cb45a54f086565bc8febfafe2b7da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38610 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/35314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11903 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/89383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/35314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87351 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/76599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/2962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/30829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/34363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/31597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/90764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11572 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/90764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11799 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/72424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/90764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/17542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13045 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11524 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11373 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14849 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/13146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->