### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/mac

### DIFF
--- a/Source/WebCore/platform/mac/KeyEventMac.mm
+++ b/Source/WebCore/platform/mac/KeyEventMac.mm
@@ -34,13 +34,11 @@
 #import <Carbon/Carbon.h>
 #import <wtf/MainThread.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 int windowsKeyCodeForKeyCode(uint16_t keyCode)
 {
-    static const int windowsKeyCode[] = {
+    static constexpr auto windowsKeyCode = std::to_array<int>({
         /* 0 */ VK_A,
         /* 1 */ VK_S,
         /* 2 */ VK_D,
@@ -168,7 +166,7 @@ int windowsKeyCodeForKeyCode(uint16_t keyCode)
         /* 0x7C */ VK_RIGHT, // Right Arrow
         /* 0x7D */ VK_DOWN, // Down Arrow
         /* 0x7E */ VK_UP, // Up Arrow
-    };
+    });
     if (keyCode < std::size(windowsKeyCode))
         return windowsKeyCode[keyCode];
     return 0;
@@ -285,7 +283,5 @@ OptionSet<PlatformEvent::Modifier> PlatformKeyboardEvent::currentStateOfModifier
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -52,8 +52,6 @@
 
 // FIXME: There are repainting problems due to Aqua scroll bar buttons' visual overflow.
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 using ScrollbarSet = HashSet<SingleThreadWeakRef<Scrollbar>>;
@@ -128,13 +126,13 @@ ScrollbarTheme& ScrollbarTheme::nativeTheme()
 }
 
 // FIXME: Get these numbers from CoreUI.
-static const int cRealButtonLength[] = { 28, 21 };
-static const int cButtonHitInset[] = { 3, 2 };
+static constexpr std::array cRealButtonLength { 28, 21 };
+static constexpr std::array cButtonHitInset { 3, 2 };
 // cRealButtonLength - cButtonInset
-static const int cButtonLength[] = { 14, 10 };
+static constexpr std::array cButtonLength { 14, 10 };
 
-static const int cOuterButtonLength[] = { 16, 14 }; // The outer button in a double button pair is a bit bigger.
-static const int cOuterButtonOverlap = 2;
+static constexpr std::array cOuterButtonLength { 16, 14 }; // The outer button in a double button pair is a bit bigger.
+static constexpr int cOuterButtonOverlap = 2;
 
 static bool gJumpOnTrackClick = false;
 static bool gUsesOverlayScrollbars = false;
@@ -600,7 +598,5 @@ void ScrollbarThemeMac::removeOverhangAreaShadow(CALayer *layer)
 #endif
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/mac/ThemeMac.mm
+++ b/Source/WebCore/platform/mac/ThemeMac.mm
@@ -37,8 +37,6 @@
 #import <wtf/NeverDestroyed.h>
 #import <wtf/StdLibExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 // FIXME: Default buttons really should be more like push buttons and not like buttons.
 
 namespace WebCore {
@@ -103,7 +101,7 @@ static NSControlSize controlSizeFromPixelSize(const std::array<IntSize, 4>& size
     return NSControlSizeMini;
 }
 
-static FloatRect inflateRect(const FloatRect& zoomedRect, const IntSize& zoomedSize, const int* margins, float zoomFactor)
+static FloatRect inflateRect(const FloatRect& zoomedRect, const IntSize& zoomedSize, std::span<const int> margins, float zoomFactor)
 {
     // Only do the inflation if the available width/height are too small.
     // Otherwise try to fit the glow/check space into the available box's width/height.
@@ -129,15 +127,14 @@ static const std::array<IntSize, 4>& checkboxSizes()
     return sizes;
 }
 
-static const int* checkboxMargins(NSControlSize controlSize)
+static std::span<const int> checkboxMargins(NSControlSize controlSize)
 {
-    static const int margins[4][4] =
-    {
+    static constexpr std::array margins {
         // top right bottom left
-        { 2, 2, 2, 2 },
-        { 2, 1, 2, 1 },
-        { 0, 0, 1, 0 },
-        { 2, 2, 2, 2 },
+        std::array { 2, 2, 2, 2 },
+        std::array { 2, 1, 2, 1 },
+        std::array { 0, 0, 1, 0 },
+        std::array { 2, 2, 2, 2 },
     };
     return margins[controlSize];
 }
@@ -167,15 +164,14 @@ static const std::array<IntSize, 4>& radioSizes()
     return sizes;
 }
 
-static const int* radioMargins(NSControlSize controlSize)
+static std::span<const int> radioMargins(NSControlSize controlSize)
 {
-    static const int margins[4][4] =
-    {
+    static constexpr std::array margins {
         // top right bottom left
-        { 1, 0, 1, 2 },
-        { 1, 1, 2, 1 },
-        { 0, 0, 1, 1 },
-        { 1, 0, 1, 2 },
+        std::array { 1, 0, 1, 2 },
+        std::array { 1, 1, 2, 1 },
+        std::array { 0, 0, 1, 1 },
+        std::array { 1, 0, 1, 2 },
     };
     return margins[controlSize];
 }
@@ -198,40 +194,38 @@ static const std::array<IntSize, 4>& buttonSizes()
     return sizes;
 }
 
-static const int* buttonMargins(NSControlSize controlSize)
+static std::span<const int> buttonMargins(NSControlSize controlSize)
 {
     // FIXME: These values may need to be reevaluated. They appear to have been originally chosen
     // to reflect the size of shadows around native form controls on macOS, but as of macOS 10.15,
     // these margins extend well past the boundaries of a native button cell's shadows.
-    static const int margins[4][4] =
-    {
-        { 5, 7, 7, 7 },
-        { 4, 6, 7, 6 },
-        { 1, 2, 2, 2 },
-        { 6, 6, 6, 6 },
+    static constexpr std::array margins {
+        std::array { 5, 7, 7, 7 },
+        std::array { 4, 6, 7, 6 },
+        std::array { 1, 2, 2, 2 },
+        std::array { 6, 6, 6, 6 },
     };
     return margins[controlSize];
 }
 
 // Stepper
 
-static const int* stepperMargins(NSControlSize controlSize)
+static std::span<const int> stepperMargins(NSControlSize controlSize)
 {
 #if HAVE(NSSTEPPERCELL_INCREMENTING)
     if ([NSStepperCell instancesRespondToSelector:@selector(setIncrementing:)]) {
-        static const int margins[4][4] =
-        {
-            { 4, 3, 4, 3 },
-            { 2, 2, 4, 2 },
-            { 2, 2, 3, 2 },
-            { 4, 3, 4, 3 },
+        static constexpr std::array margins {
+            std::array { 4, 3, 4, 3 },
+            std::array { 2, 2, 4, 2 },
+            std::array { 2, 2, 3, 2 },
+            std::array { 4, 3, 4, 3 },
         };
         return margins[controlSize];
     }
 #else
     UNUSED_PARAM(controlSize);
 #endif
-    static const int stepperMargin[4] = { 0, 0, 0, 0 };
+    static constexpr std::array stepperMargin { 0, 0, 0, 0 };
     return stepperMargin;
 }
 
@@ -280,24 +274,23 @@ static const std::array<IntSize, 4>& switchSizes()
     return sizes;
 }
 
-static const int* switchMargins(NSControlSize controlSize)
+static std::span<const int> switchMargins(NSControlSize controlSize)
 {
-    static const int margins[4][4] =
-    {
+    static constexpr std::array margins {
         // top right bottom left
-        { 2, 2, 1, 2 },
-        { 2, 2, 1, 2 },
-        { 1, 1, 0, 1 },
-        { 2, 2, 1, 2 },
+        std::array { 2, 2, 1, 2 },
+        std::array { 2, 2, 1, 2 },
+        std::array { 1, 1, 0, 1 },
+        std::array { 2, 2, 1, 2 },
     };
     return margins[controlSize];
 }
 
-static const int* visualSwitchMargins(NSControlSize controlSize, bool isVertical)
+static std::span<const int> visualSwitchMargins(NSControlSize controlSize, bool isVertical)
 {
     auto margins = switchMargins(controlSize);
     if (isVertical) {
-        static const int verticalMargins[4] = { margins[3], margins[0], margins[1], margins[2] };
+        static const std::array verticalMargins { margins[3], margins[0], margins[1], margins[2] };
         return verticalMargins;
     }
     return margins;
@@ -485,7 +478,5 @@ bool ThemeMac::supportsLargeFormControls()
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/mac/ThreadCheck.mm
+++ b/Source/WebCore/platform/mac/ThreadCheck.mm
@@ -33,13 +33,11 @@
 #import <wtf/StdLibExtras.h>
 #import <wtf/text/StringHash.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static bool didReadThreadViolationBehaviorFromUserDefaults = false;
 static bool threadViolationBehaviorIsDefault = true;
-static ThreadViolationBehavior threadViolationBehavior[MaximumThreadViolationRound] = { RaiseExceptionOnThreadViolation, RaiseExceptionOnThreadViolation, RaiseExceptionOnThreadViolation };
+static std::array<ThreadViolationBehavior, MaximumThreadViolationRound> threadViolationBehavior { RaiseExceptionOnThreadViolation, RaiseExceptionOnThreadViolation, RaiseExceptionOnThreadViolation };
 
 static void readThreadViolationBehaviorFromUserDefaults()
 {
@@ -121,7 +119,5 @@ void WebCoreReportThreadViolation(const char* function, WebCore::ThreadViolation
             break;
     }
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### ebf2e8e93d7d88cb6cfc802a3e075d07601b1a3c
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/mac
<a href="https://bugs.webkit.org/show_bug.cgi?id=285197">https://bugs.webkit.org/show_bug.cgi?id=285197</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/platform/mac/KeyEventMac.mm:
(WebCore::windowsKeyCodeForKeyCode):
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::flipImageSpec):
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
* Source/WebCore/platform/mac/ThemeMac.mm:
(WebCore::inflateRect):
(WebCore::checkboxMargins):
(WebCore::radioMargins):
(WebCore::buttonMargins):
(WebCore::stepperMargins):
(WebCore::switchMargins):
(WebCore::visualSwitchMargins):
* Source/WebCore/platform/mac/ThreadCheck.mm:

Canonical link: <a href="https://commits.webkit.org/288319@main">https://commits.webkit.org/288319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0905228e8a4df336eb39cd683d7f34b4f7034c1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87569 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33498 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9989 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64253 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22007 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1547 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75005 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44530 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1445 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29191 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32539 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72737 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88926 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7005 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72655 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9969 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70819 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71872 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16011 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15017 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1119 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12801 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9696 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15217 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9570 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11340 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->