### PR TITLE
[macOS] Double clicking over UI in store.steampowered.com, beta.maps.apple.com, and other sites triggers unexpected text selection

### DIFF
--- a/LayoutTests/editing/selection/double-click-does-not-expand-selection-over-empty-div-expected.txt
+++ b/LayoutTests/editing/selection/double-click-does-not-expand-selection-over-empty-div-expected.txt
@@ -1,0 +1,11 @@
+To manually run this test, double click inside the red box below and verify that no selection appears.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getSelection().type is not 'Range'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/editing/selection/double-click-does-not-expand-selection-over-empty-div.html
+++ b/LayoutTests/editing/selection/double-click-does-not-expand-selection-over-empty-div.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    margin: 0;
+}
+
+div.container {
+    width: 100px;
+    height: 100px;
+    border: 1px solid tomato;
+    border-radius: 6px;
+    position: relative;
+}
+
+div.hidden {
+    width: 1px;
+    visibility: hidden;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("To manually run this test, double click inside the red box below and verify that no selection appears.");
+    await UIHelper.doubleActivateAt(50, 90);
+    shouldNotBe("getSelection().type", "'Range'")
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <p id="description"></p>
+    <p id="console"></p>
+    <div class="container"></div>
+    <div class="hidden"></div>
+</body>
+</html>

--- a/LayoutTests/platform/mac/fast/events/objc-event-api-expected.txt
+++ b/LayoutTests/platform/mac/fast/events/objc-event-api-expected.txt
@@ -283,11 +283,6 @@ event type:      mousedown
   screenX:       -9600
   screenY:       -9850
   modifier keys: c:0 s:0 a:0 m:0
-event type:      selectstart
-  target:        <div>
-  eventPhase:    3
-  bubbles:       1
-  cancelable:    1
 event type:      mouseout
   target:        <div>
   eventPhase:    3
@@ -329,6 +324,11 @@ event type:      mousemove
   screenX:       -9999
   screenY:       -9999
   modifier keys: c:0 s:0 a:0 m:0
+event type:      selectstart
+  target:        <div>
+  eventPhase:    3
+  bubbles:       1
+  cancelable:    1
 event type:      mouseup
   target:        <html>
   eventPhase:    3

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -2543,9 +2543,12 @@ SimpleRange resolveCharacterRange(const SimpleRange& scope, CharacterRange range
 
 // --------
 
-bool hasAnyPlainText(const SimpleRange& range, TextIteratorBehaviors behaviors)
+bool hasAnyPlainText(const SimpleRange& range, TextIteratorBehaviors behaviors, IgnoreCollapsedRanges ignoreCollapsedRanges)
 {
     for (TextIterator iterator { range, behaviors }; !iterator.atEnd(); iterator.advance()) {
+        if (ignoreCollapsedRanges == IgnoreCollapsedRanges::Yes && iterator.range().collapsed())
+            continue;
+
         if (!iterator.text().isEmpty())
             return true;
     }

--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -47,7 +47,9 @@ WEBCORE_EXPORT SimpleRange resolveCharacterRange(const SimpleRange& scope, Chara
 
 // Text from the text iterator.
 WEBCORE_EXPORT String plainText(const SimpleRange&, TextIteratorBehaviors = { }, bool isDisplayString = false);
-WEBCORE_EXPORT bool hasAnyPlainText(const SimpleRange&, TextIteratorBehaviors = { });
+
+enum class IgnoreCollapsedRanges : bool { No, Yes };
+WEBCORE_EXPORT bool hasAnyPlainText(const SimpleRange&, TextIteratorBehaviors = { }, IgnoreCollapsedRanges = IgnoreCollapsedRanges::No);
 WEBCORE_EXPORT String plainTextReplacingNoBreakSpace(const SimpleRange&, TextIteratorBehaviors = { }, bool isDisplayString = false);
 
 // Find within the document, based on the text from the text iterator.

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -391,10 +391,10 @@ private:
 
     bool eventActivatedView(const PlatformMouseEvent&) const;
     bool updateSelectionForMouseDownDispatchingSelectStart(Node*, const VisibleSelection&, TextGranularity);
+    bool expandAndUpdateSelectionForMouseDownIfNeeded(Node& targetNode, const VisibleSelection&, TextGranularity);
     void selectClosestWordFromHitTestResult(const HitTestResult&, AppendTrailingWhitespace);
     VisibleSelection selectClosestWordFromHitTestResultBasedOnLookup(const HitTestResult&);
     void selectClosestContextualWordFromHitTestResult(const HitTestResult&, AppendTrailingWhitespace);
-    
 
     bool handleMouseDoubleClickEvent(const PlatformMouseEvent&);
 


### PR DESCRIPTION
#### 9fb8e1239267b11deab0e28e637cdbd0bad32642
<pre>
[macOS] Double clicking over UI in store.steampowered.com, beta.maps.apple.com, and other sites triggers unexpected text selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=285204">https://bugs.webkit.org/show_bug.cgi?id=285204</a>
<a href="https://rdar.apple.com/137991406">rdar://137991406</a>

Reviewed by Abrar Rahman Protyasha.

Add a heuristic to prevent double- and triple-clicks from setting the selection using word or
paragraph granularity, in the case where the resulting selection would contain no relevant text or
replaced content.

This helps mitigate scenarios where double clicking interactive UI on various websites creates an
unintended (and often confusing) text selection, and also aligns our behavior more closely with
Chrome and Firefox, when double-clicking to select text.

Also fixes: <a href="https://rdar.apple.com/138062079">rdar://138062079</a>

* LayoutTests/editing/selection/double-click-does-not-expand-selection-over-empty-div-expected.txt: Added.
* LayoutTests/editing/selection/double-click-does-not-expand-selection-over-empty-div.html: Added.

Add a new layout test to exercise this scenario, by double-clicking in an empty `div` and checking
that there&apos;s no ranged selection.

* LayoutTests/platform/mac/fast/events/objc-event-api-expected.txt:

Rebaseline an existing layout test, now that text selection only starts upon mouse drag rather than
the second mouse down in this test.

* Source/WebCore/editing/TextIterator.cpp:
(WebCore::hasAnyPlainText):
* Source/WebCore/editing/TextIterator.h:
(WebCore::hasAnyPlainText):

Add an option to ignore collapsed ranges when determining whether the given range contains any text.
This allows us to ignore leading newline characters emitted by `TextIterator` for positioning, for
the purposes of determining whether we should extend the selection on double/triple click.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::shouldAvoidExtendingSelectionOnClick):

See description above.

(WebCore::EventHandler::expandAndUpdateSelectionForMouseDownIfNeeded):

Add a helper method to (1) expand the given selection to respect select on mouse down, and (2)
update the selection, dispatching the select start event, only if it passes the check against
`shouldAvoidExtendingSelectionOnClick` above.

(WebCore::EventHandler::selectClosestWordFromHitTestResult):
(WebCore::EventHandler::handleMousePressEventTripleClick):
* Source/WebCore/page/EventHandler.h:

Canonical link: <a href="https://commits.webkit.org/288369@main">https://commits.webkit.org/288369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95050db1ea97d23dfde366ffbae01f8720207188

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37176 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/33943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10455 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/88006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/33943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1937 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75400 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1835 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29589 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32977 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89372 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7400 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10407 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72231 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17925 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16394 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10132 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/15646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10004 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13469 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11772 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->