### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in Source/WebCore/platform/audio

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -861,28 +861,16 @@ std::span<uint8_t> asMutableByteSpan(std::span<T, Extent> input)
     return unsafeMakeSpan(reinterpret_cast<uint8_t*>(input.data()), input.size_bytes());
 }
 
-template<typename T, std::size_t Extent>
-const T& reinterpretCastSpanStartTo(std::span<const uint8_t, Extent> span)
+template<typename T, typename U, std::size_t Extent>
+const T& reinterpretCastSpanStartTo(std::span<const U, Extent> span)
 {
-    return spanReinterpretCast<const T>(span.first(sizeof(T)))[0];
+    return spanReinterpretCast<const T>(asByteSpan(span).first(sizeof(T)))[0];
 }
 
-template<typename T, std::size_t Extent>
-T& reinterpretCastSpanStartTo(std::span<uint8_t, Extent> span)
+template<typename T, typename U, std::size_t Extent>
+T& reinterpretCastSpanStartTo(std::span<U, Extent> span)
 {
-    return spanReinterpretCast<T>(span.first(sizeof(T)))[0];
-}
-
-template<typename T, std::size_t Extent>
-const T& reinterpretCastSpanStartTo(std::span<const std::byte, Extent> span)
-{
-    return spanReinterpretCast<const T>(span.first(sizeof(T)))[0];
-}
-
-template<typename T, std::size_t Extent>
-T& reinterpretCastSpanStartTo(std::span<std::byte, Extent> span)
-{
-    return spanReinterpretCast<T>(span.first(sizeof(T)))[0];
+    return spanReinterpretCast<T>(asMutableByteSpan(span).first(sizeof(T)))[0];
 }
 
 enum class IgnoreTypeChecks : bool { No, Yes };

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
@@ -59,10 +59,10 @@ static inline void copyChannelData(AudioChannel& channel, AudioBuffer& buffer, s
     buffer.mDataByteSize = numberOfFrames * sizeof(float);
     buffer.mNumberChannels = 1;
     if (isMuted) {
-        zeroSpan(dataMutableByteSpan(buffer));
+        zeroSpan(mutableSpan<uint8_t>(buffer));
         return;
     }
-    memcpySpan(dataMutableByteSpan(buffer), asByteSpan(channel.span()).first(buffer.mDataByteSize));
+    memcpySpan(mutableSpan<uint8_t>(buffer), asByteSpan(channel.span()).first(buffer.mDataByteSize));
 }
 
 void MediaStreamAudioSource::consumeAudio(AudioBus& bus, size_t numberOfFrames)

--- a/Source/WebCore/platform/audio/VectorMath.cpp
+++ b/Source/WebCore/platform/audio/VectorMath.cpp
@@ -136,6 +136,27 @@ void linearToDecibels(const float* inputVector, float* outputVector, size_t numb
     vDSP_vdbcon(inputVector, 1, &reference, outputVector, 1, numberOfElementsToProcess, 1);
 }
 
+void add(std::span<const int> inputVector1, std::span<const int> inputVector2, std::span<int> outputVector)
+{
+    RELEASE_ASSERT(inputVector1.size() == inputVector2.size());
+    RELEASE_ASSERT(outputVector.size() >= inputVector1.size());
+    vDSP_vaddi(inputVector1.data(), 1, inputVector2.data(), 1, outputVector.data(), 1, inputVector1.size());
+}
+
+void add(std::span<const float> inputVector1, std::span<const float> inputVector2, std::span<float> outputVector)
+{
+    RELEASE_ASSERT(inputVector1.size() == inputVector2.size());
+    RELEASE_ASSERT(outputVector.size() >= inputVector1.size());
+    vDSP_vadd(inputVector1.data(), 1, inputVector2.data(), 1, outputVector.data(), 1, inputVector1.size());
+}
+
+void add(std::span<const double> inputVector1, std::span<const double> inputVector2, std::span<double> outputVector)
+{
+    RELEASE_ASSERT(inputVector1.size() == inputVector2.size());
+    RELEASE_ASSERT(outputVector.size() >= inputVector1.size());
+    vDSP_vaddD(inputVector1.data(), 1, inputVector2.data(), 1, outputVector.data(), 1, inputVector1.size());
+}
+
 #else
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib/Win port
@@ -830,6 +851,29 @@ void addVectorsThenMultiplyByScalar(const float* inputVector1, const float* inpu
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+void add(std::span<const int> inputVector1, std::span<const int> inputVector2, std::span<int> outputVector)
+{
+    RELEASE_ASSERT(inputVector1.size() == inputVector2.size());
+    RELEASE_ASSERT(outputVector.size() >= inputVector1.size());
+    for (size_t i = 0; i < inputVector1.size(); ++i)
+        outputVector[i] = inputVector1[i] + inputVector2[i];
+}
+
+void add(std::span<const float> inputVector1, std::span<const float> inputVector2, std::span<float> outputVector)
+{
+    RELEASE_ASSERT(inputVector1.size() == inputVector2.size());
+    RELEASE_ASSERT(outputVector.size() >= inputVector1.size());
+    add(inputVector1.data(), inputVector2.data(), outputVector.data(), inputVector1.size());
+}
+
+void add(std::span<const double> inputVector1, std::span<const double> inputVector2, std::span<double> outputVector)
+{
+    RELEASE_ASSERT(inputVector1.size() == inputVector2.size());
+    RELEASE_ASSERT(outputVector.size() >= inputVector1.size());
+    for (size_t i = 0; i < inputVector1.size(); ++i)
+        outputVector[i] = inputVector1[i] + inputVector2[i];
+}
 
 #endif // USE(ACCELERATE)
 

--- a/Source/WebCore/platform/audio/VectorMath.h
+++ b/Source/WebCore/platform/audio/VectorMath.h
@@ -49,6 +49,10 @@ void addScalar(const float* inputVector, float scalar, float* outputVector, size
 void add(const float* inputVector1, const float* inputVector2, float* outputVector, size_t numberOfElementsToProcess);
 void substract(const float* inputVector1, const float* inputVector2, float* outputVector, size_t numberOfElementsToProcess);
 
+void add(std::span<const int> inputVector1, std::span<const int> inputVector2, std::span<int> outputVector);
+void add(std::span<const float> inputVector1, std::span<const float> inputVector2, std::span<float> outputVector);
+void add(std::span<const double> inputVector1, std::span<const double> inputVector2, std::span<double> outputVector);
+
 // Finds the maximum magnitude of a float vector.
 float maximumMagnitude(const float* inputVector, size_t numberOfElementsToProcess);
 

--- a/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp
@@ -38,8 +38,6 @@
 #include "SpanCoreAudio.h"
 #include <algorithm>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 constexpr size_t fifoSize = 96 * AudioUtilities::renderQuantumSize;
@@ -113,12 +111,12 @@ OSStatus AudioDestinationCocoa::render(double sampleTime, uint64_t hostTime, UIn
 {
     ASSERT(!isMainThread());
 
-    auto* buffers = ioData->mBuffers;
     auto numberOfBuffers = std::min<UInt32>(ioData->mNumberBuffers, m_outputBus->numberOfChannels());
+    auto buffers = span(*ioData);
 
     // Associate the destination data array with the output bus then fill the FIFO.
     for (UInt32 i = 0; i < numberOfBuffers; ++i) {
-        auto memory = dataMutableFloatSpan(buffers[i]);
+        auto memory = mutableSpan<float>(buffers[i]);
         if (numberOfFrames < memory.size())
             memory = memory.first(numberOfFrames);
         m_outputBus->setChannelMemory(i, memory);
@@ -129,7 +127,5 @@ OSStatus AudioDestinationCocoa::render(double sampleTime, uint64_t hostTime, UIn
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
@@ -31,13 +31,13 @@
 #include "CAAudioStreamDescription.h"
 #include "Logging.h"
 #include "SpanCoreAudio.h"
+#include "VectorMath.h"
 #include <Accelerate/Accelerate.h>
 #include <CoreAudio/CoreAudioTypes.h>
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#include <wtf/ZippedRange.h>
 
 namespace WebCore {
 
@@ -45,7 +45,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(CARingBuffer);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(InProcessCARingBuffer);
 
 CARingBuffer::CARingBuffer(size_t bytesPerFrame, size_t frameCount, uint32_t numChannelStreams)
-    : m_pointers(numChannelStreams)
+    : m_channels(numChannelStreams)
     , m_channelCount(numChannelStreams)
     , m_bytesPerFrame(bytesPerFrame)
     , m_frameCount(frameCount)
@@ -68,69 +68,79 @@ CheckedSize CARingBuffer::computeSizeForBuffers(size_t bytesPerFrame, size_t fra
 
 void CARingBuffer::initialize()
 {
-    Byte* channelData = static_cast<Byte*>(data());
-    for (auto& pointer : m_pointers) {
-        pointer = channelData;
-        channelData += m_capacityBytes;
+    auto channelData = span();
+    for (auto& channel : m_channels) {
+        channel = channelData.first(m_capacityBytes);
+        channelData = channelData.subspan(m_capacityBytes);
     }
 }
 
-static void ZeroRange(Vector<Byte*>& pointers, size_t offset, size_t nbytes)
+static void ZeroRange(Vector<std::span<Byte>>& channels, size_t offset, size_t nbytes)
 {
-    for (auto& pointer : pointers)
-        memset(pointer + offset, 0, nbytes);
+    for (auto& channel : channels)
+        zeroSpan(channel.subspan(offset, nbytes));
 }
 
-static void StoreABL(Vector<Byte*>& pointers, size_t destOffset, const AudioBufferList* list, size_t srcOffset, size_t nbytes)
+static void StoreABL(Vector<std::span<Byte>>& channels, size_t destOffset, const AudioBufferList* list, size_t srcOffset, size_t nbytes)
 {
-    ASSERT(list->mNumberBuffers == pointers.size());
+    ASSERT(list->mNumberBuffers == channels.size());
+    auto buffers = span(*list);
     const AudioBuffer* src = list->mBuffers;
-    for (auto& pointer : pointers) {
-        if (srcOffset > src->mDataByteSize)
+    for (auto& channel : channels) {
+        if (srcOffset > buffers[0].mDataByteSize)
             continue;
-        memcpy(pointer + destOffset, static_cast<Byte*>(src->mData) + srcOffset, std::min<size_t>(nbytes, src->mDataByteSize - srcOffset));
-        ++src;
+        auto srcData = span<Byte>(buffers[0]);
+        memcpySpan(channel.subspan(destOffset), srcData.subspan(srcOffset, std::min<size_t>(nbytes, src->mDataByteSize - srcOffset)));
+        buffers = buffers.subspan(1);
     }
 }
 
-static void FetchABL(AudioBufferList* list, size_t destOffset, Vector<Byte*>& pointers, size_t srcOffset, size_t nbytesTarget, CARingBuffer::FetchMode mode, bool shouldUpdateListDataByteSize)
+static void FetchABL(AudioBufferList* list, size_t destOffset, Vector<std::span<Byte>>& channels, size_t srcOffset, size_t nbytesTarget, CARingBuffer::FetchMode mode, bool shouldUpdateListDataByteSize)
 {
-    ASSERT(list->mNumberBuffers == pointers.size());
-    auto bufferCount = std::min<size_t>(list->mNumberBuffers, pointers.size());
+    ASSERT(list->mNumberBuffers == channels.size());
+    auto buffers = span(*list);
+    auto bufferCount = std::min<size_t>(list->mNumberBuffers, channels.size());
     for (size_t bufferIndex = 0; bufferIndex < bufferCount; ++bufferIndex) {
-        auto& pointer = pointers[bufferIndex];
-        auto& dest = list->mBuffers[bufferIndex];
+        auto& channel = channels[bufferIndex];
+        auto& dest = buffers[bufferIndex];
 
         if (destOffset > dest.mDataByteSize)
             continue;
 
-        auto destinationData = dataMutableByteSpan(dest).subspan(destOffset);
-        auto* sourceData = pointer + srcOffset;
+        auto destinationData = mutableSpan<uint8_t>(dest).subspan(destOffset);
+        auto sourceData = channel.subspan(srcOffset);
         auto nbytes = std::min<size_t>(nbytesTarget, dest.mDataByteSize - destOffset);
         switch (mode) {
         case CARingBuffer::Copy:
-            memcpySpan(destinationData, unsafeMakeSpan(sourceData, nbytes));
+            memcpySpan(destinationData, sourceData.first(nbytes));
             break;
         case CARingBuffer::MixInt16: {
-            auto destination = spanReinterpretCast<int16_t>(destinationData);
-            auto* source = reinterpret_cast<int16_t*>(sourceData);
-            for (size_t i = 0; i < nbytes / sizeof(int16_t); i++)
-                destination[i] += source[i];
+            size_t frameCount = nbytes / sizeof(int16_t);
+            auto source = spanReinterpretCast<const int16_t>(sourceData).first(frameCount);
+            auto destination = spanReinterpretCast<int16_t>(destinationData).first(frameCount);
+            for (auto [s, d] : zippedRange(source, destination))
+                d += s;
             break;
         }
         case CARingBuffer::MixInt32: {
-            auto destination = spanReinterpretCast<int32_t>(destinationData);
-            vDSP_vaddi(destination.data(), 1, reinterpret_cast<int32_t*>(sourceData), 1, destination.data(), 1, nbytes / sizeof(int32_t));
+            size_t frameCount = nbytes / sizeof(int32_t);
+            auto source = spanReinterpretCast<const int32_t>(sourceData).first(frameCount);
+            auto destination = spanReinterpretCast<int32_t>(destinationData).first(frameCount);
+            VectorMath::add(destination, source, destination);
             break;
         }
         case CARingBuffer::MixFloat32: {
-            auto destination = spanReinterpretCast<float>(destinationData);
-            vDSP_vadd(destination.data(), 1, reinterpret_cast<float*>(sourceData), 1, destination.data(), 1, nbytes / sizeof(float));
+            size_t frameCount = nbytes / sizeof(float);
+            auto source = spanReinterpretCast<const float>(sourceData).first(frameCount);
+            auto destination = spanReinterpretCast<float>(destinationData).first(frameCount);
+            VectorMath::add(destination, source, destination);
             break;
         }
         case CARingBuffer::MixFloat64: {
-            auto destination = spanReinterpretCast<double>(destinationData);
-            vDSP_vaddD(destination.data(), 1, reinterpret_cast<double*>(sourceData), 1, destination.data(), 1, nbytes / sizeof(double));
+            size_t frameCount = nbytes / sizeof(double);
+            auto source = spanReinterpretCast<const double>(sourceData).first(frameCount);
+            auto destination = spanReinterpretCast<double>(destinationData).first(frameCount);
+            VectorMath::add(destination, source, destination);
             break;
         }
         }
@@ -143,15 +153,15 @@ static void FetchABL(AudioBufferList* list, size_t destOffset, Vector<Byte*>& po
 inline void ZeroABL(AudioBufferList* list, size_t destOffset, size_t nbytes)
 {
     int nBuffers = list->mNumberBuffers;
-    AudioBuffer* dest = list->mBuffers;
+    auto destinations = span(*list);
     while (--nBuffers >= 0) {
-        if (destOffset > dest->mDataByteSize)
+        if (destOffset > destinations[0].mDataByteSize)
             continue;
-        auto dataSpan = dataMutableByteSpan(*dest).subspan(destOffset);
+        auto dataSpan = mutableSpan<uint8_t>(destinations[0]).subspan(destOffset);
         if (nbytes < dataSpan.size())
             dataSpan = dataSpan.first(nbytes);
         zeroSpan(dataSpan);
-        ++dest;
+        destinations = destinations.subspan(1);
     }
 }
 
@@ -200,10 +210,10 @@ CARingBuffer::Error CARingBuffer::store(const AudioBufferList* list, size_t fram
         offset0 = frameOffset(m_storeBounds.endFrame);
         offset1 = frameOffset(startFrame);
         if (offset0 < offset1)
-            ZeroRange(m_pointers, offset0, offset1 - offset0);
+            ZeroRange(m_channels, offset0, offset1 - offset0);
         else {
-            ZeroRange(m_pointers, offset0, m_capacityBytes - offset0);
-            ZeroRange(m_pointers, 0, offset1);
+            ZeroRange(m_channels, offset0, m_capacityBytes - offset0);
+            ZeroRange(m_channels, 0, offset1);
         }
         offset0 = offset1;
     } else
@@ -211,11 +221,11 @@ CARingBuffer::Error CARingBuffer::store(const AudioBufferList* list, size_t fram
 
     offset1 = frameOffset(endFrame);
     if (offset0 < offset1)
-        StoreABL(m_pointers, offset0, list, 0, offset1 - offset0);
+        StoreABL(m_channels, offset0, list, 0, offset1 - offset0);
     else {
         size_t nbytes = m_capacityBytes - offset0;
-        StoreABL(m_pointers, offset0, list, 0, nbytes);
-        StoreABL(m_pointers, 0, list, nbytes, offset1);
+        StoreABL(m_channels, offset0, list, 0, nbytes);
+        StoreABL(m_channels, 0, list, nbytes, offset1);
     }
 
     // Now update the end time.
@@ -291,12 +301,12 @@ void CARingBuffer::fetchInternal(AudioBufferList* list, size_t nFrames, uint64_t
     
     if (offset0 < offset1) {
         nbytes = offset1 - offset0;
-        FetchABL(list, destStartByteOffset, m_pointers, offset0, nbytes, mode, true);
+        FetchABL(list, destStartByteOffset, m_channels, offset0, nbytes, mode, true);
     } else {
         nbytes = m_capacityBytes - offset0;
-        FetchABL(list, destStartByteOffset, m_pointers, offset0, nbytes, mode, !offset1);
+        FetchABL(list, destStartByteOffset, m_channels, offset0, nbytes, mode, !offset1);
         if (offset1)
-            FetchABL(list, destStartByteOffset + nbytes, m_pointers, 0, offset1, mode, true);
+            FetchABL(list, destStartByteOffset + nbytes, m_channels, 0, offset1, mode, true);
     }
 }
 
@@ -332,7 +342,5 @@ InProcessCARingBuffer::InProcessCARingBuffer(size_t bytesPerFrame, size_t frameC
 InProcessCARingBuffer::~InProcessCARingBuffer() = default;
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEB_AUDIO) && USE(MEDIATOOLBOX)

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.h
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.h
@@ -79,6 +79,7 @@ protected:
     WEBCORE_EXPORT static CheckedSize computeSizeForBuffers(size_t bytesPerFrame, size_t frameCount, uint32_t numChannelStreams);
 
     virtual void* data() = 0;
+    std::span<uint8_t> span() { return unsafeMakeSpan(static_cast<uint8_t*>(data()), m_channelCount * m_capacityBytes); }
     using TimeBoundsBuffer = SequenceLocked<TimeBounds>;
     virtual TimeBoundsBuffer& timeBoundsBuffer() = 0;
 
@@ -87,7 +88,7 @@ private:
     void setTimeBounds(TimeBounds bufferBounds);
     void fetchInternal(AudioBufferList*, size_t frameCount, uint64_t startFrame, FetchMode, TimeBounds bufferBounds);
 
-    Vector<Byte*> m_pointers;
+    Vector<std::span<Byte>> m_channels;
     const uint32_t m_channelCount;
     const size_t m_bytesPerFrame;
     const uint32_t m_frameCount;

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -50,8 +50,6 @@
 #import "MediaRemoteSoftLink.h"
 #include <pal/cocoa/AVFoundationSoftLink.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 static const size_t kLowPowerVideoBufferSize = 4096;
 
 #if USE(NOW_PLAYING_ACTIVITY_SUPPRESSION)
@@ -591,8 +589,7 @@ std::optional<bool> MediaSessionManagerCocoa::supportsSpatialAudioPlaybackForCon
         if (channelCount <= 0)
             return true;
 
-        for (uint32_t i = 0; i < spatialAudioPreferences.spatialAudioSourceCount; ++i) {
-            auto& source = spatialAudioPreferences.spatialAudioSources[i];
+        for (auto& source : std::span { spatialAudioPreferences.spatialAudioSources }.first(spatialAudioPreferences.spatialAudioSourceCount)) {
             if (source == kSpatialAudioSource_Multichannel && channelCount > 2)
                 return true;
             if (source == kSpatialAudioSource_MonoOrStereo && channelCount >= 1)
@@ -633,7 +630,5 @@ void MediaSessionManagerCocoa::updateNowPlayingSuppression(const NowPlayingInfo*
 #endif // USE(NOW_PLAYING_ACTIVITY_SUPPRESSION)
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(AUDIO_SESSION) && PLATFORM(COCOA)

--- a/Source/WebCore/platform/audio/cocoa/SpanCoreAudio.h
+++ b/Source/WebCore/platform/audio/cocoa/SpanCoreAudio.h
@@ -31,24 +31,26 @@
 
 namespace WebCore {
 
-inline std::span<uint8_t> dataMutableByteSpan(AudioBuffer& buffer)
+template<typename T>
+inline std::span<const T> span(const AudioBuffer& buffer)
 {
-    return unsafeMakeSpan(static_cast<uint8_t*>(buffer.mData), buffer.mDataByteSize);
+    return unsafeMakeSpan(static_cast<const T*>(buffer.mData), buffer.mDataByteSize / sizeof(T));
 }
 
-inline std::span<float> dataMutableFloatSpan(AudioBuffer& buffer)
+template<typename T>
+inline std::span<T> mutableSpan(AudioBuffer& buffer)
 {
-    return unsafeMakeSpan(static_cast<float*>(buffer.mData), buffer.mDataByteSize / sizeof(float));
+    return unsafeMakeSpan(static_cast<T*>(buffer.mData), buffer.mDataByteSize / sizeof(T));
 }
 
-inline std::span<const uint8_t> dataByteSpan(const AudioBuffer& buffer)
+inline std::span<AudioBuffer> span(AudioBufferList& list)
 {
-    return unsafeMakeSpan(static_cast<const uint8_t*>(buffer.mData), buffer.mDataByteSize);
+    return unsafeMakeSpan(list.mBuffers, list.mNumberBuffers);
 }
 
-inline std::span<const float> dataFloatSpan(AudioBuffer& buffer)
+inline std::span<const AudioBuffer> span(const AudioBufferList& list)
 {
-    return unsafeMakeSpan(static_cast<const float*>(buffer.mData), buffer.mDataByteSize / sizeof(float));
+    return unsafeMakeSpan(list.mBuffers, list.mNumberBuffers);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp
+++ b/Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp
@@ -31,8 +31,6 @@
 #include <algorithm>
 #include <wtf/StdLibExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 enum {
     kAudioHardwarePropertyProcessIsRunning = 'prun'
 };
@@ -127,7 +125,7 @@ AudioHardwareListenerMac::AudioHardwareListenerMac(Client& client)
     WeakPtr weakThis { *this };
     m_block = Block_copy(^(UInt32 count, const AudioObjectPropertyAddress properties[]) {
         if (weakThis)
-            weakThis->propertyChanged(count, properties);
+            weakThis->propertyChanged(unsafeMakeSpan(properties, count));
     });
 
     AudioObjectAddPropertyListenerBlock(kAudioObjectSystemObject, &processIsRunningPropertyDescriptor(), dispatch_get_main_queue(), m_block);
@@ -141,17 +139,16 @@ AudioHardwareListenerMac::~AudioHardwareListenerMac()
     Block_release(m_block);
 }
 
-void AudioHardwareListenerMac::propertyChanged(UInt32 propertyCount, const AudioObjectPropertyAddress properties[])
+void AudioHardwareListenerMac::propertyChanged(std::span<const AudioObjectPropertyAddress> properties)
 {
     auto deviceRunning = asByteSpan(processIsRunningPropertyDescriptor());
     auto outputDevice = asByteSpan(outputDevicePropertyDescriptor());
 
-    for (UInt32 i = 0; i < propertyCount; ++i) {
-        auto property = asByteSpan(properties[i]);
-
-        if (equalSpans(property, deviceRunning))
+    for (auto& property : properties) {
+        auto propertyBytes = asByteSpan(property);
+        if (equalSpans(propertyBytes, deviceRunning))
             processIsRunningChanged();
-        else if (equalSpans(property, outputDevice))
+        else if (equalSpans(propertyBytes, outputDevice))
             outputDeviceChanged();
     }
 }
@@ -176,7 +173,5 @@ void AudioHardwareListenerMac::outputDeviceChanged()
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.h
+++ b/Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.h
@@ -48,7 +48,7 @@ private:
     void processIsRunningChanged();
     void outputDeviceChanged();
 
-    void propertyChanged(UInt32, const AudioObjectPropertyAddress[]);
+    void propertyChanged(std::span<const AudioObjectPropertyAddress>);
 
     AudioObjectPropertyListenerBlock m_block;
 };

--- a/Source/WebCore/platform/audio/mac/AudioSessionMac.mm
+++ b/Source/WebCore/platform/audio/mac/AudioSessionMac.mm
@@ -31,6 +31,7 @@
 #import "FloatConversion.h"
 #import "Logging.h"
 #import "NotImplemented.h"
+#import "SpanCoreAudio.h"
 #import <CoreAudio/AudioHardware.h>
 #import <wtf/LoggerHelper.h>
 #import <wtf/MainThread.h>
@@ -39,8 +40,6 @@
 #import <wtf/text/WTFString.h>
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -408,8 +407,8 @@ size_t AudioSessionMac::maximumNumberOfOutputChannels() const
         return 0;
 
     size_t channels = 0;
-    for (UInt32 i = 0; i < audioBufferList->mNumberBuffers; ++i)
-        channels += audioBufferList->mBuffers[i].mNumberChannels;
+    for (auto& buffer : span(*audioBufferList))
+        channels += buffer.mNumberChannels;
     return channels;
 }
 
@@ -567,7 +566,5 @@ uint64_t AudioSessionMac::logIdentifier() const
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(AUDIO_SESSION) && PLATFORM(MAC)

--- a/Source/WebCore/platform/audio/mac/FFTFrameMac.cpp
+++ b/Source/WebCore/platform/audio/mac/FFTFrameMac.cpp
@@ -107,9 +107,7 @@ FFTFrame::~FFTFrame() = default;
 void FFTFrame::doFFT(std::span<const float> data)
 {
     unsigned halfSize = m_FFTSize / 2;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    vDSP_ctoz(reinterpret_cast<const DSPComplex*>(data.data()), 2, &m_frame, 1, halfSize);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    vDSP_ctoz(&reinterpretCastSpanStartTo<const DSPComplex>(data), 2, &m_frame, 1, halfSize);
     vDSP_fft_zrip(m_FFTSetup, &m_frame, 1, m_log2FFTSize, FFT_FORWARD);
 
     RELEASE_ASSERT(realData().size() >= halfSize);
@@ -127,9 +125,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 void FFTFrame::doInverseFFT(std::span<float> data)
 {
     vDSP_fft_zrip(m_FFTSetup, &m_frame, 1, m_log2FFTSize, FFT_INVERSE);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    vDSP_ztoc(&m_frame, 1, reinterpret_cast<DSPComplex*>(data.data()), 2, m_FFTSize / 2);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    vDSP_ztoc(&m_frame, 1, &reinterpretCastSpanStartTo<DSPComplex>(data), 2, m_FFTSize / 2);
 
     // Do final scaling so that x == IFFT(FFT(x))
     VectorMath::multiplyByScalar(data.data(), 1.0f / m_FFTSize, data.data(), m_FFTSize);

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
@@ -409,7 +409,7 @@ void AudioSourceProviderAVFObjC::process(MTAudioProcessingTapRef tap, CMItemCoun
     // Mute the default audio playback by zeroing the tap-owned buffers.
     for (uint32_t i = 0; i < bufferListInOut->mNumberBuffers; ++i) {
         AudioBuffer& buffer = bufferListInOut->mBuffers[i];
-        zeroSpan(dataMutableByteSpan(buffer));
+        zeroSpan(mutableSpan<uint8_t>(buffer));
     }
     *numberFramesOut = 0;
 

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -370,7 +370,7 @@ void MockAudioSharedInternalUnit::generateSampleBuffers(MonotonicTime renderTime
         uint32_t bipBopCount = std::min(frameCount, bipBopRemain);
         for (auto& audioBuffer : m_audioBufferList->buffers()) {
             audioBuffer.mDataByteSize = frameCount * m_streamFormat.mBytesPerFrame;
-            memcpySpan(dataMutableFloatSpan(audioBuffer), m_bipBopBuffer.subspan(bipBopStart, bipBopCount));
+            memcpySpan(mutableSpan<float>(audioBuffer), m_bipBopBuffer.subspan(bipBopStart, bipBopCount));
             addHum(HumVolume, HumFrequency, sampleRate(), m_samplesRendered, static_cast<float*>(audioBuffer.mData), bipBopCount);
         }
         emitSampleBuffers(bipBopCount);
@@ -400,8 +400,8 @@ OSStatus MockAudioSharedInternalUnit::render(AudioUnitRenderActionFlags*, const 
         if (copySize > buffer->mBuffers[i].mDataByteSize)
             return kAudio_ParamError;
 
-        auto source = dataByteSpan(sourceBuffer->mBuffers[i]);
-        auto destination = dataMutableByteSpan(buffer->mBuffers[i]);
+        auto source = span<uint8_t>(sourceBuffer->mBuffers[i]);
+        auto destination = mutableSpan<uint8_t>(buffer->mBuffers[i]);
         memcpySpan(destination, source.first(copySize));
     }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -247,7 +247,7 @@ void RemoteAudioDestinationProxy::renderAudio(unsigned frameCount)
 
         // Associate the destination data array with the output bus then fill the FIFO.
         for (UInt32 i = 0; i < numberOfBuffers; ++i) {
-            auto memory = dataMutableFloatSpan(buffers[i]);
+            auto memory = mutableSpan<float>(buffers[i]);
             if (numberOfFrames < memory.size())
                 memory = memory.first(numberOfFrames);
             m_outputBus->setChannelMemory(i, memory);


### PR DESCRIPTION
#### 3d996666c89c13d17718f5ee0ff71f9d97f36c9b
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in Source/WebCore/platform/audio
<a href="https://bugs.webkit.org/show_bug.cgi?id=285203">https://bugs.webkit.org/show_bug.cgi?id=285203</a>

Reviewed by Geoffrey Garen and Darin Adler.

* Source/WTF/wtf/StdLibExtras.h:
(WTF::reinterpretCastSpanStartTo):
* Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp:
(WebCore::AudioDestinationCocoa::render):
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::validateAudioBufferList):
(WebCore::passthroughInputDataCallback):
(WebCore::AudioFileReader::decodeWebMData const):
(WebCore::AudioFileReader::createBus):
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.cpp:
(WebCore::AudioSampleBufferList::applyGain):
(WebCore::mixBuffers):
(WebCore::AudioSampleBufferList::copyTo):
(WebCore::AudioSampleBufferList::zeroABL):
(WebCore::audioConverterFromABLCallback):
* Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp:
(WebCore::CARingBuffer::CARingBuffer):
(WebCore::CARingBuffer::initialize):
(WebCore::ZeroRange):
(WebCore::StoreABL):
(WebCore::FetchABL):
(WebCore::ZeroABL):
(WebCore::CARingBuffer::store):
(WebCore::CARingBuffer::fetchInternal):
* Source/WebCore/platform/audio/cocoa/CARingBuffer.h:
(WebCore::CARingBuffer::span):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::supportsSpatialAudioPlaybackForConfiguration):
* Source/WebCore/platform/audio/cocoa/SpanCoreAudio.h:
(WebCore::dataSpan):
(WebCore::dataMutableSpan):
(WebCore::span):
* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp:
(WebCore::WebAudioBufferList::WebAudioBufferList):
(WebCore::WebAudioBufferList::setSampleCount):
(WebCore::WebAudioBufferList::setSampleCountWithBlockBuffer):
(WebCore::WebAudioBufferList::initializeList):
(WebCore:: const):
(WebCore::WebAudioBufferList::buffer const):
* Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp:
(WebCore::AudioHardwareListenerMac::AudioHardwareListenerMac):
(WebCore::AudioHardwareListenerMac::propertyChanged):
* Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.h:
* Source/WebCore/platform/audio/mac/AudioSessionMac.mm:
(WebCore::AudioSessionMac::maximumNumberOfOutputChannels const):
* Source/WebCore/platform/audio/mac/FFTFrameMac.cpp:
(WebCore::FFTFrame::doFFT):
(WebCore::FFTFrame::doInverseFFT):

Canonical link: <a href="https://commits.webkit.org/288322@main">https://commits.webkit.org/288322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e7316962f1398aa5dfa2de620f60fa25cd9b6b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87608 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33539 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64282 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22038 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1578 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75036 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44559 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1476 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29223 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32577 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75466 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72768 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88967 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81532 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7043 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72685 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10008 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70850 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71902 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16042 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15049 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12804 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9734 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15255 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103942 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9608 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25217 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13074 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11378 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->