### PR TITLE
[Materials] Gate support for blur/vibrancy effects with the UseSystemAppearance preference

### DIFF
--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AppleSystemVisualEffectsEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
 <html>
 <head>
 <title>This tests that the chrome material works properly.</title>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AppleSystemVisualEffectsEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
 <html>
 <head>
 <title>This tests that the thick material works properly.</title>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AppleSystemVisualEffectsEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
 <html>
 <head>
 <title>This tests that the thin material works properly.</title>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AppleSystemVisualEffectsEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
 <html>
 <head>
 <title>This tests that the ultra thin material works properly.</title>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AppleSystemVisualEffectsEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
 <html>
 <head>
 <title>This tests that the default material works properly.</title>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-parsing.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-parsing.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AppleSystemVisualEffectsEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
 <html>
 <head>
 <script src="../resources/testharness.js"></script>

--- a/LayoutTests/apple-visual-effects/backdrop-filter-with-apple-visual-effect-expected.html
+++ b/LayoutTests/apple-visual-effects/backdrop-filter-with-apple-visual-effect-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AppleSystemVisualEffectsEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
 <html>
 <head>
 <title>This tests that `backdrop-filter` is not applied on an element with `-apple-visual-effect`.</title>

--- a/LayoutTests/apple-visual-effects/backdrop-filter-with-apple-visual-effect.html
+++ b/LayoutTests/apple-visual-effects/backdrop-filter-with-apple-visual-effect.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AppleSystemVisualEffectsEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
 <html>
 <head>
 <title>This tests that `backdrop-filter` is not applied on an element with `-apple-visual-effect`.</title>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -627,18 +627,6 @@ ApplePayEnabled:
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
-AppleSystemVisualEffectsEnabled:
-  type: bool
-  status: embedder
-  condition: HAVE(CORE_MATERIAL)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
-
 # FIXME: This is on by default in WebKit2 PLATFORM(COCOA). Perhaps we should consider turning it on for WebKitLegacy as well.
 AsyncClipboardAPIEnabled:
   type: bool

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9637,7 +9637,7 @@
             ],
             "codegen-properties": {
                 "enable-if": "HAVE_CORE_MATERIAL",
-                "settings-flag": "appleSystemVisualEffectsEnabled",
+                "settings-flag": "useSystemAppearance",
                 "parser-grammar": "<<values>>"
             },
             "status": "non-standard"


### PR DESCRIPTION
#### 4d6fa2fb29eea109f1fccdbf95e35e7fcec6003f
<pre>
[Materials] Gate support for blur/vibrancy effects with the UseSystemAppearance preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=285218">https://bugs.webkit.org/show_bug.cgi?id=285218</a>
<a href="https://rdar.apple.com/142124660">rdar://142124660</a>

Reviewed by Richard Robinson.

Enable support for `-apple-visual-effect` via `-[WKWebView _setUseSystemAppearance:]`.

This approach is preferred over a separate setting for system visual effects, so that
clients that use `WKWebView`s to mimic system UI do not need to set multiple preferences.

* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome.html:
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick.html:
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin.html:
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin.html:
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material.html:
* LayoutTests/apple-visual-effects/apple-visual-effect-parsing.html:
* LayoutTests/apple-visual-effects/backdrop-filter-with-apple-visual-effect-expected.html:
* LayoutTests/apple-visual-effects/backdrop-filter-with-apple-visual-effect.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSProperties.json:

Canonical link: <a href="https://commits.webkit.org/288320@main">https://commits.webkit.org/288320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2a4127ba43bc62ac9ffd1fbde3c229c16ef4f30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87594 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33523 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64270 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22024 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1564 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75022 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44547 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1462 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29209 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32563 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75450 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72754 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88951 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81516 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9767 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7027 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/connect-src-star-websocket-allowed.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72673 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70836 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71890 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16028 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1149 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12802 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9720 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15241 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103928 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9594 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25210 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13060 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11364 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->