### PR TITLE
AX: ENABLE(AX_THREAD_TEXT_APIS) should utilize ignored objects provided by ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -836,6 +836,7 @@ public:
     // reader announces "link", it doesn't need to announce "clickable" or "pressable" — that
     // is implicit in the concept of a link.
     bool isImplicitlyInteractive() const;
+    bool isReplacedElement() const;
 
     // Table support.
     virtual bool isTable() const = 0;
@@ -1271,10 +1272,13 @@ public:
     virtual void updateChildrenIfNecessary() = 0;
     AXCoreObject* nextInPreOrder(bool updateChildrenIfNeeded, AXCoreObject& stayWithin);
     AXCoreObject* nextSiblingIncludingIgnored(bool updateChildrenIfNeeded) const;
-    // In some contexts, we may have already computed the unignored parent for `this`, so take that as an optional
-    // parameter. If nullptr, we will compute it inside the function.
     AXCoreObject* nextUnignoredSibling(bool updateChildrenIfNeeded, AXCoreObject* unignoredParent = nullptr) const;
-    AXCoreObject* nextUnignoredSiblingOrParent() const;
+    AXCoreObject* nextSiblingIncludingIgnoredOrParent() const;
+
+    AXCoreObject* previousInPreOrder(bool updateChildrenIfNeeded, AXCoreObject& stayWithin);
+    AXCoreObject* previousSiblingIncludingIgnored(bool updateChildrenIfNeeded);
+    AXCoreObject* deepestLastChildIncludingIgnored(bool updateChildrenIfNeeded);
+
     virtual void detachFromParent() = 0;
     virtual bool isDetachedFromParent() = 0;
 
@@ -1451,6 +1455,7 @@ public:
 
     virtual AccessibilityChildrenVector documentLinks() = 0;
 
+    virtual bool hasAttachmentTag() const = 0;
     virtual bool hasBodyTag() const = 0;
     virtual bool hasMarkTag() const = 0;
     virtual String innerHTML() const = 0;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -765,9 +765,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::HasApplePDFAnnotationAttribute:
         stream << "HasApplePDFAnnotationAttribute";
         break;
-    case AXProperty::HasBodyTag:
-        stream << "HasBodyTag";
-        break;
     case AXProperty::HasBoldFont:
         stream << "HasBoldFont";
         break;
@@ -782,9 +779,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
         break;
     case AXProperty::HasLinethrough:
         stream << "HasLinethrough";
-        break;
-    case AXProperty::HasMarkTag:
-        stream << "HasMarkTag";
         break;
     case AXProperty::HasPlainText:
         stream << "HasPlainText";
@@ -1166,6 +1160,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
         break;
     case AXProperty::SupportsSetSize:
         stream << "SupportsSetSize";
+        break;
+    case AXProperty::TagName:
+        stream << "TagName";
         break;
 #if !ENABLE(AX_THREAD_TEXT_APIS)
     case AXProperty::TextContent:

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -3213,7 +3213,7 @@ bool AccessibilityObject::supportsRangeValue() const
         || isScrollbar()
         || isSpinButton()
         || (isSplitter() && canSetFocusAttribute())
-        || isAttachmentElement();
+        || hasAttachmentTag();
 }
     
 bool AccessibilityObject::supportsHasPopup() const

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -568,6 +568,7 @@ public:
     String nameAttribute() const final;
     int getIntegralAttribute(const QualifiedName&) const;
     bool hasTagName(const QualifiedName&) const;
+    bool hasAttachmentTag() const final { return hasTagName(HTMLNames::attachmentTag); }
     bool hasBodyTag() const final { return hasTagName(HTMLNames::bodyTag); }
     bool hasMarkTag() const final { return hasTagName(HTMLNames::markTag); }
     AtomString tagName() const;

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -862,7 +862,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
         break;
     }
 
-    if (self.axBackingObject->isAttachmentElement())
+    if (self.axBackingObject->hasAttachmentTag())
         traits |= [self _axUpdatesFrequentlyTrait];
     
     if (self.axBackingObject->isSelected())

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -109,10 +109,15 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
         setProperty(AXProperty::HasClickHandler, object.hasClickHandler());
         auto tag = object.tagName();
         if (tag == bodyTag)
-            setProperty(AXProperty::HasBodyTag, true);
+            setProperty(AXProperty::TagName, TagName::body);
 #if ENABLE(AX_THREAD_TEXT_APIS)
         else if (tag == markTag)
-            setProperty(AXProperty::HasMarkTag, true);
+            setProperty(AXProperty::TagName, TagName::mark);
+        else if (tag == attachmentTag)
+            setProperty(AXProperty::TagName, TagName::attachment);
+
+        setProperty(AXProperty::TextRuns, object.textRuns());
+        setProperty(AXProperty::EmitTextAfterBehavior, object.emitTextAfterBehavior());
 #endif // ENABLE(AX_THREAD_TEXT_APIS)
     };
 
@@ -436,11 +441,6 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
 
         setProperty(AXProperty::CanBeMultilineTextField, canBeMultilineTextField(object));
     }
-
-#if ENABLE(AX_THREAD_TEXT_APIS)
-    setProperty(AXProperty::TextRuns, object.textRuns());
-    setProperty(AXProperty::EmitTextAfterBehavior, object.emitTextAfterBehavior());
-#endif
 
     // These properties are only needed on the AXCoreObject interface due to their use in ATSPI,
     // so only cache them for ATSPI.

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -64,8 +64,9 @@ public:
     bool isExposable() const final { return boolAttributeValue(AXProperty::IsExposable); }
     bool hasClickHandler() const final { return boolAttributeValue(AXProperty::HasClickHandler); }
 
-    bool hasBodyTag() const final { return boolAttributeValue(AXProperty::HasBodyTag); }
-    bool hasMarkTag() const final { return boolAttributeValue(AXProperty::HasMarkTag); }
+    bool hasAttachmentTag() const final { return propertyValue<TagName>(AXProperty::TagName) == TagName::attachment; }
+    bool hasBodyTag() const final { return propertyValue<TagName>(AXProperty::TagName) == TagName::body; }
+    bool hasMarkTag() const final { return propertyValue<TagName>(AXProperty::TagName) == TagName::mark; }
 
     const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) final;
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -34,6 +34,7 @@
 #include "ColorHash.h"
 #include "PageIdentifier.h"
 #include "RenderStyleConstants.h"
+#include "TagName.h"
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/RefPtr.h>
@@ -135,12 +136,10 @@ enum class AXProperty : uint16_t {
     TextColor,
     HasApplePDFAnnotationAttribute,
     HasBoldFont,
-    HasBodyTag,
     HasClickHandler,
     HasHighlighting,
     HasItalicFont,
     HasLinethrough,
-    HasMarkTag,
     HasPlainText,
     HasRemoteFrameChild,
     IsSubscript,
@@ -268,6 +267,7 @@ enum class AXProperty : uint16_t {
     SupportsPosInSet,
     SupportsRangeValue,
     SupportsSetSize,
+    TagName,
 #if !ENABLE(AX_THREAD_TEXT_APIS)
     // Rather than caching text content as property when ENABLE(AX_THREAD_TEXT_APIS), we should
     // synthesize it on-the-fly using AXProperty::TextRuns.
@@ -293,7 +293,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, AXProperty);
 using AXPropertySet = HashSet<AXProperty, IntHash<AXProperty>, WTF::StrongEnumHashTraits<AXProperty>>;
 
 // If this type is modified, the switchOn statment in AXIsolatedObject::setProperty must be updated as well.
-using AXPropertyValueVariant = std::variant<std::nullptr_t, Markable<AXID>, String, bool, int, unsigned, double, float, uint64_t, WallTime, DateComponentsType, AccessibilityButtonState, Color, std::shared_ptr<URL>, LayoutRect, FloatPoint, FloatRect, IntPoint, IntRect, std::pair<unsigned, unsigned>, Vector<AccessibilityText>, Vector<AXID>, Vector<std::pair<Markable<AXID>, Markable<AXID>>>, Vector<String>, std::shared_ptr<Path>, OptionSet<AXAncestorFlag>, InsideLink, Vector<Vector<Markable<AXID>>>, CharacterRange, std::pair<Markable<AXID>, CharacterRange>
+using AXPropertyValueVariant = std::variant<std::nullptr_t, Markable<AXID>, String, bool, int, unsigned, double, float, uint64_t, WallTime, DateComponentsType, AccessibilityButtonState, Color, std::shared_ptr<URL>, LayoutRect, FloatPoint, FloatRect, IntPoint, IntRect, std::pair<unsigned, unsigned>, Vector<AccessibilityText>, Vector<AXID>, Vector<std::pair<Markable<AXID>, Markable<AXID>>>, Vector<String>, std::shared_ptr<Path>, OptionSet<AXAncestorFlag>, InsideLink, Vector<Vector<Markable<AXID>>>, CharacterRange, std::pair<Markable<AXID>, CharacterRange>, TagName
 #if PLATFORM(COCOA)
     , RetainPtr<NSAttributedString>
     , RetainPtr<id>

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -210,7 +210,7 @@ AXTextMarkerRange AXIsolatedObject::textMarkerRange() const
         // {ID 5, Role Group}
         //
         // We would expect the returned range to be: {ID 2, offset 0} to {ID 4, offset 3}
-        auto* stopObject = nextUnignoredSiblingOrParent();
+        auto* stopObject = nextSiblingIncludingIgnoredOrParent();
 
         auto thisMarker = AXTextMarker { *this, 0 };
         AXTextMarkerRange range { thisMarker, thisMarker };


### PR DESCRIPTION
#### faa4b20a62f299f89f135366fcaafc1e181e0122
<pre>
AX: ENABLE(AX_THREAD_TEXT_APIS) should utilize ignored objects provided by ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
<a href="https://bugs.webkit.org/show_bug.cgi?id=285219">https://bugs.webkit.org/show_bug.cgi?id=285219</a>
<a href="https://rdar.apple.com/142126734">rdar://142126734</a>

Reviewed by Chris Fleizach.

ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE) gives us access to ignored objects in ENABLE(AX_THREAD_TEXT_APIS), and with this
commit we make use of them. This lets us remove several hacks, like considering white-space only RenderText or br-element
renderers unignored only in ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE). This also fixes a couple layout tests with ENABLE(AX_THREAD_TEXT_APIS),
and gives the necessary foundation to fix even more.

This patch also refactors AXProperty::{HasBodyTag, HasMarkTag} into a new AXProperty::TagName. This lets us more easily
add new interesting tag names we need off the main-thread (which we will have a need for in future patches).

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::previousInPreOrder):
(WebCore::AXCoreObject::deepestLastChildIncludingIgnored):
(WebCore::AXCoreObject::previousSiblingIncludingIgnored):
(WebCore::AXCoreObject::nextSiblingIncludingIgnoredOrParent const):
(WebCore::AXCoreObject::isReplacedElement const):
(WebCore::AXCoreObject::nextUnignoredSiblingOrParent const): Deleted.
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::characterRangeForLine const):
(WebCore::AXTextMarker::lineNumberForIndex const):
(WebCore::Accessibility::findObjectWithRuns):
(WebCore::appendChildren): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::supportsRangeValue const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::computeIsIgnored const):
(WebCore::AccessibilityRenderObject::textRuns):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityTraits]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::textMarkerRange const):

Canonical link: <a href="https://commits.webkit.org/288479@main">https://commits.webkit.org/288479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/002b06e8fe8223b44cf25425c3cab9ebea5f6a69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87601 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33531 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84573 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64275 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22030 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44552 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1470 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29213 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32570 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72762 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/88959 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7037 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72678 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10003 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71895 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17971 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16037 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15039 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1156 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9727 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15248 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9601 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13067 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11371 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->