### PR TITLE
Adopt more spans in VectorMath.h

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioParam.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParam.cpp
@@ -335,7 +335,7 @@ void AudioParam::calculateFinalValues(std::span<float> values, bool sampleAccura
     replaceNaNValues(values, m_defaultValue);
 
     // Clamp values based on range allowed by AudioParam's min and max values.
-    VectorMath::clamp(values.data(), minValue(), maxValue(), values.data(), values.size());
+    VectorMath::clamp(values, minValue(), maxValue(), values);
 }
 
 void AudioParam::calculateTimelineValues(std::span<float> values)

--- a/Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp
@@ -208,7 +208,7 @@ void DelayDSPKernel::processKRate(std::span<const float> source, std::span<float
 
     // Interpolate samples.
     // destination[k] = sample1[k] + interpolationFactor * (sample2[k] - sample1[k]);
-    VectorMath::interpolate(sample1.data(), sample2.data(), interpolationFactor, destination.data(), source.size());
+    VectorMath::interpolate(sample1.first(source.size()), sample2.first(source.size()), interpolationFactor, destination);
 }
 
 void DelayDSPKernel::processOnlyAudioParams(size_t framesToProcess)

--- a/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
+++ b/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
@@ -192,7 +192,7 @@ void RealtimeAnalyser::getFloatFrequencyData(Float32Array& destinationArray)
     
     // Convert from linear magnitude to floating-point decibels.
     size_t length = std::min<size_t>(magnitudeBuffer().size(), destinationArray.length());
-    VectorMath::linearToDecibels(magnitudeBuffer().data(), destinationArray.data(), length);
+    VectorMath::linearToDecibels(magnitudeBuffer().span().first(length), destinationArray.typedMutableSpan());
 }
 
 void RealtimeAnalyser::getByteFrequencyData(Uint8Array& destinationArray)

--- a/Source/WebCore/platform/audio/AudioBus.cpp
+++ b/Source/WebCore/platform/audio/AudioBus.cpp
@@ -309,97 +309,97 @@ void AudioBus::speakersSumFromByDownMixing(const AudioBus& sourceBus)
         // Handle stereo -> mono case. output += 0.5 * (input.L + input.R).
         AudioBus& sourceBusSafe = const_cast<AudioBus&>(sourceBus);
 
-        const float* sourceL = sourceBusSafe.channelByType(ChannelLeft)->data();
-        const float* sourceR = sourceBusSafe.channelByType(ChannelRight)->data();
+        auto sourceL = sourceBusSafe.channelByType(ChannelLeft)->span().first(length());
+        auto sourceR = sourceBusSafe.channelByType(ChannelRight)->span().first(length());
 
-        float* destination = channelByType(ChannelLeft)->mutableData();
-        VectorMath::multiplyByScalarThenAddToOutput(sourceL, 0.5, destination, length());
-        VectorMath::multiplyByScalarThenAddToOutput(sourceR, 0.5, destination, length());
+        auto destination = channelByType(ChannelLeft)->mutableSpan();
+        VectorMath::multiplyByScalarThenAddToOutput(sourceL, 0.5, destination);
+        VectorMath::multiplyByScalarThenAddToOutput(sourceR, 0.5, destination);
     } else if (numberOfSourceChannels == 4 && numberOfDestinationChannels == 1) {
         // Down-mixing: 4 -> 1
         // output = 0.25 * (input.L + input.R + input.SL + input.SR)
-        auto* sourceL = sourceBus.channelByType(ChannelLeft)->data();
-        auto* sourceR = sourceBus.channelByType(ChannelRight)->data();
-        auto* sourceSL = sourceBus.channelByType(ChannelSurroundLeft)->data();
-        auto* sourceSR = sourceBus.channelByType(ChannelSurroundRight)->data();
+        auto sourceL = sourceBus.channelByType(ChannelLeft)->span().first(length());
+        auto sourceR = sourceBus.channelByType(ChannelRight)->span().first(length());
+        auto sourceSL = sourceBus.channelByType(ChannelSurroundLeft)->span().first(length());
+        auto sourceSR = sourceBus.channelByType(ChannelSurroundRight)->span().first(length());
 
-        auto* destination = channelByType(ChannelLeft)->mutableData();
+        auto destination = channelByType(ChannelLeft)->mutableSpan();
 
-        VectorMath::multiplyByScalarThenAddToOutput(sourceL, 0.25, destination, length());
-        VectorMath::multiplyByScalarThenAddToOutput(sourceR, 0.25, destination, length());
-        VectorMath::multiplyByScalarThenAddToOutput(sourceSL, 0.25, destination, length());
-        VectorMath::multiplyByScalarThenAddToOutput(sourceSR, 0.25, destination, length());
+        VectorMath::multiplyByScalarThenAddToOutput(sourceL, 0.25, destination);
+        VectorMath::multiplyByScalarThenAddToOutput(sourceR, 0.25, destination);
+        VectorMath::multiplyByScalarThenAddToOutput(sourceSL, 0.25, destination);
+        VectorMath::multiplyByScalarThenAddToOutput(sourceSR, 0.25, destination);
     } else if (numberOfSourceChannels == 6 && numberOfDestinationChannels == 1) {
         // Down-mixing: 5.1 -> 1
         // output = sqrt(1/2) * (input.L + input.R) + input.C + 0.5 * (input.SL + input.SR)
-        auto* sourceL = sourceBus.channelByType(ChannelLeft)->data();
-        auto* sourceR = sourceBus.channelByType(ChannelRight)->data();
-        auto* sourceC = sourceBus.channelByType(ChannelCenter)->data();
-        auto* sourceSL = sourceBus.channelByType(ChannelSurroundLeft)->data();
-        auto* sourceSR = sourceBus.channelByType(ChannelSurroundRight)->data();
+        auto sourceL = sourceBus.channelByType(ChannelLeft)->span().first(length());
+        auto sourceR = sourceBus.channelByType(ChannelRight)->span().first(length());
+        auto sourceC = sourceBus.channelByType(ChannelCenter)->span().first(length());
+        auto sourceSL = sourceBus.channelByType(ChannelSurroundLeft)->span().first(length());
+        auto sourceSR = sourceBus.channelByType(ChannelSurroundRight)->span().first(length());
 
-        auto* destination = channelByType(ChannelLeft)->mutableData();
+        auto destination = channelByType(ChannelLeft)->mutableSpan().first(length());
         float scaleSqrtHalf = sqrtf(0.5);
 
-        VectorMath::multiplyByScalarThenAddToOutput(sourceL, scaleSqrtHalf, destination, length());
-        VectorMath::multiplyByScalarThenAddToOutput(sourceR, scaleSqrtHalf, destination, length());
-        VectorMath::add(sourceC, destination, destination, length());
-        VectorMath::multiplyByScalarThenAddToOutput(sourceSL, 0.5, destination, length());
-        VectorMath::multiplyByScalarThenAddToOutput(sourceSR, 0.5, destination, length());
+        VectorMath::multiplyByScalarThenAddToOutput(sourceL, scaleSqrtHalf, destination);
+        VectorMath::multiplyByScalarThenAddToOutput(sourceR, scaleSqrtHalf, destination);
+        VectorMath::add(sourceC, destination, destination);
+        VectorMath::multiplyByScalarThenAddToOutput(sourceSL, 0.5, destination);
+        VectorMath::multiplyByScalarThenAddToOutput(sourceSR, 0.5, destination);
     } else if (numberOfSourceChannels == 4 && numberOfDestinationChannels == 2) {
         // Down-mixing: 4 -> 2
         // output.L = 0.5 * (input.L + input.SL)
         // output.R = 0.5 * (input.R + input.SR)
-        auto* sourceL = sourceBus.channelByType(ChannelLeft)->data();
-        auto* sourceR = sourceBus.channelByType(ChannelRight)->data();
-        auto* sourceSL = sourceBus.channelByType(ChannelSurroundLeft)->data();
-        auto* sourceSR = sourceBus.channelByType(ChannelSurroundRight)->data();
+        auto sourceL = sourceBus.channelByType(ChannelLeft)->span().first(length());
+        auto sourceR = sourceBus.channelByType(ChannelRight)->span().first(length());
+        auto sourceSL = sourceBus.channelByType(ChannelSurroundLeft)->span().first(length());
+        auto sourceSR = sourceBus.channelByType(ChannelSurroundRight)->span().first(length());
 
-        auto* destinationL = channelByType(ChannelLeft)->mutableData();
-        auto* destinationR = channelByType(ChannelRight)->mutableData();
+        auto destinationL = channelByType(ChannelLeft)->mutableSpan();
+        auto destinationR = channelByType(ChannelRight)->mutableSpan();
 
-        VectorMath::multiplyByScalarThenAddToOutput(sourceL, 0.5, destinationL, length());
-        VectorMath::multiplyByScalarThenAddToOutput(sourceSL, 0.5, destinationL, length());
-        VectorMath::multiplyByScalarThenAddToOutput(sourceR, 0.5, destinationR, length());
-        VectorMath::multiplyByScalarThenAddToOutput(sourceSR, 0.5, destinationR, length());
+        VectorMath::multiplyByScalarThenAddToOutput(sourceL, 0.5, destinationL);
+        VectorMath::multiplyByScalarThenAddToOutput(sourceSL, 0.5, destinationL);
+        VectorMath::multiplyByScalarThenAddToOutput(sourceR, 0.5, destinationR);
+        VectorMath::multiplyByScalarThenAddToOutput(sourceSR, 0.5, destinationR);
     } else if (numberOfSourceChannels == 6 && numberOfDestinationChannels == 2) {
         // Down-mixing: 5.1 -> 2
         // output.L = input.L + sqrt(1/2) * (input.C + input.SL)
         // output.R = input.R + sqrt(1/2) * (input.C + input.SR)
-        auto* sourceL = sourceBus.channelByType(ChannelLeft)->data();
-        auto* sourceR = sourceBus.channelByType(ChannelRight)->data();
-        auto* sourceC = sourceBus.channelByType(ChannelCenter)->data();
-        auto* sourceSL = sourceBus.channelByType(ChannelSurroundLeft)->data();
-        auto* sourceSR = sourceBus.channelByType(ChannelSurroundRight)->data();
+        auto sourceL = sourceBus.channelByType(ChannelLeft)->span().first(length());
+        auto sourceR = sourceBus.channelByType(ChannelRight)->span().first(length());
+        auto sourceC = sourceBus.channelByType(ChannelCenter)->span().first(length());
+        auto sourceSL = sourceBus.channelByType(ChannelSurroundLeft)->span().first(length());
+        auto sourceSR = sourceBus.channelByType(ChannelSurroundRight)->span().first(length());
 
-        float* destinationL = channelByType(ChannelLeft)->mutableData();
-        float* destinationR = channelByType(ChannelRight)->mutableData();
+        auto destinationL = channelByType(ChannelLeft)->mutableSpan().first(length());
+        auto destinationR = channelByType(ChannelRight)->mutableSpan().first(length());
         float scaleSqrtHalf = sqrtf(0.5);
 
-        VectorMath::add(sourceL, destinationL, destinationL, length());
-        VectorMath::multiplyByScalarThenAddToOutput(sourceC, scaleSqrtHalf, destinationL, length());
-        VectorMath::multiplyByScalarThenAddToOutput(sourceSL, scaleSqrtHalf, destinationL, length());
-        VectorMath::add(sourceR, destinationR, destinationR, length());
-        VectorMath::multiplyByScalarThenAddToOutput(sourceC, scaleSqrtHalf, destinationR, length());
-        VectorMath::multiplyByScalarThenAddToOutput(sourceSR, scaleSqrtHalf, destinationR, length());
+        VectorMath::add(sourceL, destinationL, destinationL);
+        VectorMath::multiplyByScalarThenAddToOutput(sourceC, scaleSqrtHalf, destinationL);
+        VectorMath::multiplyByScalarThenAddToOutput(sourceSL, scaleSqrtHalf, destinationL);
+        VectorMath::add(sourceR, destinationR, destinationR);
+        VectorMath::multiplyByScalarThenAddToOutput(sourceC, scaleSqrtHalf, destinationR);
+        VectorMath::multiplyByScalarThenAddToOutput(sourceSR, scaleSqrtHalf, destinationR);
     } else if (numberOfSourceChannels == 6 && numberOfDestinationChannels == 4) {
         // Down-mixing: 5.1 -> 4
         // output.L = input.L + sqrt(1/2) * input.C
         // output.R = input.R + sqrt(1/2) * input.C
         // output.SL = input.SL
         // output.SR = input.SR
-        auto* sourceL = sourceBus.channelByType(ChannelLeft)->data();
-        auto* sourceR = sourceBus.channelByType(ChannelRight)->data();
-        auto* sourceC = sourceBus.channelByType(ChannelCenter)->data();
+        auto sourceL = sourceBus.channelByType(ChannelLeft)->span().first(length());
+        auto sourceR = sourceBus.channelByType(ChannelRight)->span().first(length());
+        auto sourceC = sourceBus.channelByType(ChannelCenter)->span().first(length());
 
-        auto* destinationL = channelByType(ChannelLeft)->mutableData();
-        auto* destinationR = channelByType(ChannelRight)->mutableData();
+        auto destinationL = channelByType(ChannelLeft)->mutableSpan().first(length());
+        auto destinationR = channelByType(ChannelRight)->mutableSpan().first(length());
         auto scaleSqrtHalf = sqrtf(0.5);
 
-        VectorMath::add(sourceL, destinationL, destinationL, length());
-        VectorMath::multiplyByScalarThenAddToOutput(sourceC, scaleSqrtHalf, destinationL, length());
-        VectorMath::add(sourceR, destinationR, destinationR, length());
-        VectorMath::multiplyByScalarThenAddToOutput(sourceC, scaleSqrtHalf, destinationR, length());
+        VectorMath::add(sourceL, destinationL, destinationL);
+        VectorMath::multiplyByScalarThenAddToOutput(sourceC, scaleSqrtHalf, destinationL);
+        VectorMath::add(sourceR, destinationR, destinationR);
+        VectorMath::multiplyByScalarThenAddToOutput(sourceC, scaleSqrtHalf, destinationR);
         channel(2)->sumFrom(sourceBus.channel(4));
         channel(3)->sumFrom(sourceBus.channel(5));
     } else {
@@ -466,7 +466,7 @@ void AudioBus::copyWithGainFrom(const AudioBus& sourceBus, float gain)
             zeroSpan(destinations[channelIndex].first(framesToProcess));
     } else {
         for (unsigned channelIndex = 0; channelIndex < numberOfChannels; ++channelIndex)
-            VectorMath::multiplyByScalar(sources[channelIndex].data(), gain, destinations[channelIndex].data(), framesToProcess);
+            VectorMath::multiplyByScalar(sources[channelIndex].first(framesToProcess), gain, destinations[channelIndex]);
     }
 }
 
@@ -490,12 +490,12 @@ void AudioBus::copyWithSampleAccurateGainValuesFrom(const AudioBus& sourceBus, s
     }
 
     // We handle both the 1 -> N and N -> N case here.
-    const float* source = sourceBus.channel(0)->data();
+    auto source = sourceBus.channel(0)->span().first(gainValues.size());
     for (unsigned channelIndex = 0; channelIndex < numberOfChannels(); ++channelIndex) {
         if (sourceBus.numberOfChannels() == numberOfChannels())
-            source = sourceBus.channel(channelIndex)->data();
-        float* destination = channel(channelIndex)->mutableData();
-        VectorMath::multiply(source, gainValues.data(), destination, gainValues.size());
+            source = sourceBus.channel(channelIndex)->span().first(gainValues.size());
+        auto destination = channel(channelIndex)->mutableSpan();
+        VectorMath::multiply(source, gainValues, destination);
     }
 }
 
@@ -574,12 +574,12 @@ RefPtr<AudioBus> AudioBus::createByMixingToMono(const AudioBus* sourceBus)
             unsigned n = sourceBus->length();
             RefPtr<AudioBus> destinationBus = create(1, n);
 
-            const float* sourceL = sourceBus->channel(0)->data();
-            const float* sourceR = sourceBus->channel(1)->data();
-            float* destination = destinationBus->channel(0)->mutableData();
+            auto sourceL = sourceBus->channel(0)->span();
+            auto sourceR = sourceBus->channel(1)->span();
+            auto destination = destinationBus->channel(0)->mutableSpan();
         
             // Do the mono mixdown.
-            VectorMath::addVectorsThenMultiplyByScalar(sourceL, sourceR, 0.5, destination, n);
+            VectorMath::addVectorsThenMultiplyByScalar(sourceL, sourceR, 0.5, destination);
 
             destinationBus->clearSilentFlag();
             destinationBus->setSampleRate(sourceBus->sampleRate());    

--- a/Source/WebCore/platform/audio/AudioChannel.cpp
+++ b/Source/WebCore/platform/audio/AudioChannel.cpp
@@ -47,7 +47,7 @@ void AudioChannel::scale(float scale)
     if (isSilent())
         return;
 
-    VectorMath::multiplyByScalar(data(), scale, mutableData(), length());
+    VectorMath::multiplyByScalar(span(), scale, mutableSpan());
 }
 
 void AudioChannel::copyFrom(const AudioChannel* sourceChannel)
@@ -105,7 +105,7 @@ void AudioChannel::sumFrom(const AudioChannel* sourceChannel)
     if (isSilent())
         copyFrom(sourceChannel);
     else
-        VectorMath::add(data(), sourceChannel->data(), mutableData(), length());
+        VectorMath::add(span(), sourceChannel->span().first(length()), mutableSpan());
 }
 
 float AudioChannel::maxAbsValue() const
@@ -113,7 +113,7 @@ float AudioChannel::maxAbsValue() const
     if (isSilent())
         return 0;
 
-    return VectorMath::maximumMagnitude(data(), length());
+    return VectorMath::maximumMagnitude(span());
 }
 
 } // WebCore

--- a/Source/WebCore/platform/audio/FFTConvolver.cpp
+++ b/Source/WebCore/platform/audio/FFTConvolver.cpp
@@ -96,7 +96,7 @@ void FFTConvolver::process(FFTFrame* fftKernel, std::span<const float> source, s
             m_frame.doInverseFFT(m_outputBuffer.span());
 
             // Overlap-add 1st half from previous time
-            VectorMath::add(m_outputBuffer.data(), m_lastOverlapBuffer.data(), m_outputBuffer.data(), halfSize);
+            VectorMath::add(m_outputBuffer.span().first(halfSize), m_lastOverlapBuffer.span().first(halfSize), m_outputBuffer.span());
 
             // Finally, save 2nd half of result
             bool isCopyGood3 = m_outputBuffer.size() == 2 * halfSize && m_lastOverlapBuffer.size() == halfSize;

--- a/Source/WebCore/platform/audio/FFTFrame.cpp
+++ b/Source/WebCore/platform/audio/FFTFrame.cpp
@@ -178,8 +178,8 @@ void FFTFrame::interpolateFrequencyComponents(const FFTFrame& frame1, const FFTF
 
 void FFTFrame::scaleFFT(float factor)
 {
-    VectorMath::multiplyByScalar(realData().data(), factor, realData().data(), realData().size());
-    VectorMath::multiplyByScalar(imagData().data(), factor, imagData().data(), realData().size());
+    VectorMath::multiplyByScalar(realData().span(), factor, realData().span());
+    VectorMath::multiplyByScalar(imagData().span(), factor, imagData().span());
 }
 
 void FFTFrame::multiply(const FFTFrame& frame)
@@ -194,16 +194,11 @@ void FFTFrame::multiply(const FFTFrame& frame)
 
     unsigned halfSize = m_FFTSize / 2;
 
-    RELEASE_ASSERT(realP1.size() >= halfSize);
-    RELEASE_ASSERT(imagP1.size() >= halfSize);
-    RELEASE_ASSERT(realP2.size() >= halfSize);
-    RELEASE_ASSERT(imagP2.size() >= halfSize);
-
     float real0 = realP1[0];
     float imag0 = imagP1[0];
 
     // Complex multiply
-    VectorMath::multiplyComplex(realP1.data(), imagP1.data(), realP2.data(), imagP2.data(), realP1.data(), imagP1.data(), halfSize);
+    VectorMath::multiplyComplex(realP1.span().first(halfSize), imagP1.span().first(halfSize), realP2.span().first(halfSize), imagP2.span().first(halfSize), realP1.span(), imagP1.span());
 
     // Multiply the packed DC/nyquist component
     realP1[0] = real0 * realP2[0];

--- a/Source/WebCore/platform/audio/IIRFilter.cpp
+++ b/Source/WebCore/platform/audio/IIRFilter.cpp
@@ -201,16 +201,18 @@ double IIRFilter::tailTime(double sampleRate, bool isFilterStable)
     input[0] = 1;
 
     // Process the first block and get the max magnitude of the output.
-    process(input.span().first(AudioUtilities::renderQuantumSize), output.span());
-    magnitudes[0] = VectorMath::maximumMagnitude(output.data(), AudioUtilities::renderQuantumSize);
+    auto inputSpan = input.span().first(AudioUtilities::renderQuantumSize);
+    auto outputSpan = output.span().first(AudioUtilities::renderQuantumSize);
+    process(inputSpan, outputSpan);
+    magnitudes[0] = VectorMath::maximumMagnitude(outputSpan);
 
     // Process the rest of the signal, getting the max magnitude of the
     // output for each block.
     input[0] = 0;
 
     for (int k = 1; k < numberOfBlocks; ++k) {
-        process(input.span().first(AudioUtilities::renderQuantumSize), output.span());
-        magnitudes[k] = VectorMath::maximumMagnitude(output.data(), AudioUtilities::renderQuantumSize);
+        process(inputSpan, output.span());
+        magnitudes[k] = VectorMath::maximumMagnitude(outputSpan);
     }
 
     // Done computing the impulse response; reset the state so the actual node

--- a/Source/WebCore/platform/audio/Reverb.cpp
+++ b/Source/WebCore/platform/audio/Reverb.cpp
@@ -60,7 +60,7 @@ static float calculateNormalizationScale(AudioBus* response)
     float power = 0;
 
     for (size_t i = 0; i < numberOfChannels; ++i)
-        power += VectorMath::sumOfSquares(response->channel(i)->data(), length);
+        power += VectorMath::sumOfSquares(response->channel(i)->span());
 
     power = sqrt(power / (numberOfChannels * length));
 

--- a/Source/WebCore/platform/audio/ReverbAccumulationBuffer.cpp
+++ b/Source/WebCore/platform/audio/ReverbAccumulationBuffer.cpp
@@ -100,11 +100,11 @@ int ReverbAccumulationBuffer::accumulate(std::span<float> source, size_t numberO
     if (!isSafe)
         return 0;
 
-    VectorMath::add(source.data(), destination.subspan(writeIndex).data(), destination.subspan(writeIndex).data(), numberOfFrames1);
+    VectorMath::add(source.first(numberOfFrames1), destination.subspan(writeIndex).first(numberOfFrames1), destination.subspan(writeIndex));
 
     // Handle wrap-around if necessary
     if (numberOfFrames2 > 0)       
-        VectorMath::add(source.subspan(numberOfFrames1).data(), destination.data(), destination.data(), numberOfFrames2);
+        VectorMath::add(source.subspan(numberOfFrames1).first(numberOfFrames2), destination.first(numberOfFrames2), destination);
 
     return writeIndex;
 }

--- a/Source/WebCore/platform/audio/ReverbConvolverStage.cpp
+++ b/Source/WebCore/platform/audio/ReverbConvolverStage.cpp
@@ -73,7 +73,7 @@ ReverbConvolverStage::ReverbConvolverStage(std::span<const float> impulseRespons
         m_directKernel->copyToRange(impulseResponse, 0, stageLength);
         // Account for the normalization (if any) of the convolver node.
         if (scale != 1)
-            VectorMath::multiplyByScalar(m_directKernel->data(), scale, m_directKernel->data(), stageLength);
+            VectorMath::multiplyByScalar(m_directKernel->span().first(stageLength), scale, m_directKernel->span());
         m_directConvolver = makeUnique<DirectConvolver>(renderSliceSize);
     }
 

--- a/Source/WebCore/platform/audio/VectorMath.cpp
+++ b/Source/WebCore/platform/audio/VectorMath.cpp
@@ -44,6 +44,7 @@
 
 #include <algorithm>
 #include <math.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
@@ -52,88 +53,104 @@ namespace VectorMath {
 #if USE(ACCELERATE)
 // On the Mac we use the highly optimized versions in Accelerate.framework
 
-void multiplyByScalar(const float* inputVector, float scalar, float* outputVector, size_t numberOfElementsToProcess)
+void multiplyByScalar(std::span<const float> inputVector, float scalar, std::span<float> outputVector)
 {
-    vDSP_vsmul(inputVector, 1, &scalar, outputVector, 1, numberOfElementsToProcess);
+    RELEASE_ASSERT(outputVector.size() >= inputVector.size());
+    vDSP_vsmul(inputVector.data(), 1, &scalar, outputVector.data(), 1, inputVector.size());
 }
 
-void add(const float* inputVector1, const float* inputVector2, float* outputVector, size_t numberOfElementsToProcess)
+void substract(std::span<const float> inputVector1, std::span<const float> inputVector2, std::span<float> outputVector)
 {
-    vDSP_vadd(inputVector1, 1, inputVector2, 1, outputVector, 1, numberOfElementsToProcess);
+    RELEASE_ASSERT(inputVector1.size() == inputVector2.size());
+    RELEASE_ASSERT(outputVector.size() >= inputVector1.size());
+    vDSP_vsub(inputVector1.data(), 1, inputVector2.data(), 1, outputVector.data(), 1, inputVector1.size());
 }
 
-void substract(const float* inputVector1, const float* inputVector2, float* outputVector, size_t numberOfElementsToProcess)
+void addScalar(std::span<const float> inputVector, float scalar, std::span<float> outputVector)
 {
-    vDSP_vsub(inputVector1, 1, inputVector2, 1, outputVector, 1, numberOfElementsToProcess);
+    RELEASE_ASSERT(outputVector.size() >= inputVector.size());
+    vDSP_vsadd(inputVector.data(), 1, &scalar, outputVector.data(), 1, inputVector.size());
 }
 
-void addScalar(const float* inputVector, float scalar, float* outputVector, size_t numberOfElementsToProcess)
+void multiply(std::span<const float> inputVector1, std::span<const float> inputVector2, std::span<float> outputVector)
 {
-    vDSP_vsadd(inputVector, 1, &scalar, outputVector, 1, numberOfElementsToProcess);
+    RELEASE_ASSERT(inputVector1.size() == inputVector2.size());
+    RELEASE_ASSERT(outputVector.size() >= inputVector1.size());
+    vDSP_vmul(inputVector1.data(), 1, inputVector2.data(), 1, outputVector.data(), 1, inputVector1.size());
 }
 
-void multiply(const float* inputVector1, const float* inputVector2, float* outputVector, size_t numberOfElementsToProcess)
+void interpolate(std::span<const float> inputVector1, std::span<float> inputVector2, float interpolationFactor, std::span<float> outputVector)
 {
-    vDSP_vmul(inputVector1, 1, inputVector2, 1, outputVector, 1, numberOfElementsToProcess);
+    RELEASE_ASSERT(inputVector1.size() == inputVector2.size());
+    RELEASE_ASSERT(outputVector.size() >= inputVector1.size());
+    vDSP_vintb(inputVector1.data(), 1, inputVector2.data(), 1, &interpolationFactor, outputVector.data(), 1, inputVector1.size());
 }
 
-void interpolate(const float* inputVector1, float* inputVector2, float interpolationFactor, float* outputVector, size_t numberOfElementsToProcess)
+void multiplyComplex(std::span<const float> realVector1, std::span<const float> imagVector1, std::span<const float> realVector2, std::span<const float> imagVector2, std::span<float> realOutputVector, std::span<float> imagOutputVector)
 {
-    vDSP_vintb(inputVector1, 1, inputVector2, 1, &interpolationFactor, outputVector, 1, numberOfElementsToProcess);
-}
+    RELEASE_ASSERT(realVector1.size() == imagVector1.size());
+    RELEASE_ASSERT(realVector1.size() == realVector2.size());
+    RELEASE_ASSERT(imagVector1.size() == imagVector1.size());
+    RELEASE_ASSERT(realOutputVector.size() >= realVector1.size());
+    RELEASE_ASSERT(imagOutputVector.size() >= imagVector1.size());
 
-void multiplyComplex(const float* realVector1, const float* imagVector1, const float* realVector2, const float* imag2P, float* realOutputVector, float* imagDestP, size_t numberOfElementsToProcess)
-{
     DSPSplitComplex sc1;
     DSPSplitComplex sc2;
     DSPSplitComplex dest;
-    sc1.realp = const_cast<float*>(realVector1);
-    sc1.imagp = const_cast<float*>(imagVector1);
-    sc2.realp = const_cast<float*>(realVector2);
-    sc2.imagp = const_cast<float*>(imag2P);
-    dest.realp = realOutputVector;
-    dest.imagp = imagDestP;
-    vDSP_zvmul(&sc1, 1, &sc2, 1, &dest, 1, numberOfElementsToProcess, 1);
+    sc1.realp = const_cast<float*>(realVector1.data());
+    sc1.imagp = const_cast<float*>(imagVector1.data());
+    sc2.realp = const_cast<float*>(realVector2.data());
+    sc2.imagp = const_cast<float*>(imagVector2.data());
+    dest.realp = realOutputVector.data();
+    dest.imagp = imagOutputVector.data();
+    vDSP_zvmul(&sc1, 1, &sc2, 1, &dest, 1, realVector1.size(), 1);
 }
 
-void multiplyByScalarThenAddToOutput(const float* inputVector, float scalar, float* outputVector, size_t numberOfElementsToProcess)
+void multiplyByScalarThenAddToOutput(std::span<const float> inputVector, float scalar, std::span<float> outputVector)
 {
-    vDSP_vsma(inputVector, 1, &scalar, outputVector, 1, outputVector, 1, numberOfElementsToProcess);
+    RELEASE_ASSERT(outputVector.size() >= inputVector.size());
+    vDSP_vsma(inputVector.data(), 1, &scalar, outputVector.data(), 1, outputVector.data(), 1, inputVector.size());
 }
 
-void multiplyByScalarThenAddToVector(const float* inputVector1, float scalar, const float* inputVector2, float* outputVector, size_t numberOfElementsToProcess)
+void multiplyByScalarThenAddToVector(std::span<const float> inputVector1, float scalar, std::span<const float> inputVector2, std::span<float> outputVector)
 {
-    vDSP_vsma(inputVector1, 1, &scalar, inputVector2, 1, outputVector, 1, numberOfElementsToProcess);
+    RELEASE_ASSERT(inputVector1.size() == inputVector2.size());
+    RELEASE_ASSERT(outputVector.size() >= inputVector1.size());
+    vDSP_vsma(inputVector1.data(), 1, &scalar, inputVector2.data(), 1, outputVector.data(), 1, inputVector1.size());
 }
 
-void addVectorsThenMultiplyByScalar(const float* inputVector1, const float* inputVector2, float scalar, float* outputVector, size_t numberOfElementsToProcess)
+void addVectorsThenMultiplyByScalar(std::span<const float> inputVector1, std::span<const float> inputVector2, float scalar, std::span<float> outputVector)
 {
-    vDSP_vasm(inputVector1, 1, inputVector2, 1, &scalar, outputVector, 1, numberOfElementsToProcess);
+    RELEASE_ASSERT(inputVector1.size() == inputVector2.size());
+    RELEASE_ASSERT(outputVector.size() >= inputVector1.size());
+    vDSP_vasm(inputVector1.data(), 1, inputVector2.data(), 1, &scalar, outputVector.data(), 1, inputVector1.size());
 }
 
-float maximumMagnitude(const float* inputVector, size_t numberOfElementsToProcess)
+float maximumMagnitude(std::span<const float> inputVector)
 {
     float maximumValue = 0;
-    vDSP_maxmgv(inputVector, 1, &maximumValue, numberOfElementsToProcess);
+    vDSP_maxmgv(inputVector.data(), 1, &maximumValue, inputVector.size());
     return maximumValue;
 }
 
-float sumOfSquares(const float* inputVector, size_t numberOfElementsToProcess)
+float sumOfSquares(std::span<const float> inputVector)
 {
     float sum = 0;
-    vDSP_svesq(const_cast<float*>(inputVector), 1, &sum, numberOfElementsToProcess);
+    vDSP_svesq(const_cast<float*>(inputVector.data()), 1, &sum, inputVector.size());
     return sum;
 }
 
-void clamp(const float* inputVector, float minimum, float maximum, float* outputVector, size_t numberOfElementsToProcess)
+void clamp(std::span<const float> inputVector, float minimum, float maximum, std::span<float> outputVector)
 {
-    vDSP_vclip(const_cast<float*>(inputVector), 1, &minimum, &maximum, outputVector, 1, numberOfElementsToProcess);
+    RELEASE_ASSERT(outputVector.size() >= inputVector.size());
+    vDSP_vclip(const_cast<float*>(inputVector.data()), 1, &minimum, &maximum, outputVector.data(), 1, inputVector.size());
 }
 
-void linearToDecibels(const float* inputVector, float* outputVector, size_t numberOfElementsToProcess)
+void linearToDecibels(std::span<const float> inputVector, std::span<float> outputVector)
 {
+    RELEASE_ASSERT(outputVector.size() >= inputVector.size());
     float reference = 1;
-    vDSP_vdbcon(inputVector, 1, &reference, outputVector, 1, numberOfElementsToProcess, 1);
+    vDSP_vdbcon(inputVector.data(), 1, &reference, outputVector.data(), 1, inputVector.size(), 1);
 }
 
 void add(std::span<const int> inputVector1, std::span<const int> inputVector2, std::span<int> outputVector)
@@ -166,15 +183,18 @@ static inline bool is16ByteAligned(const float* vector)
     return !(reinterpret_cast<uintptr_t>(vector) & 0x0F);
 }
 
-void multiplyByScalarThenAddToVector(const float* inputVector1, float scalar, const float* inputVector2, float* outputVector, size_t numberOfElementsToProcess)
+void multiplyByScalarThenAddToVector(std::span<const float> inputVector1, float scalar, std::span<const float> inputVector2, std::span<float> outputVector)
 {
-    multiplyByScalar(inputVector1, scalar, outputVector, numberOfElementsToProcess);
-    add(outputVector, inputVector2, outputVector, numberOfElementsToProcess);
+    multiplyByScalar(inputVector1, scalar, outputVector);
+    add(outputVector, inputVector2, outputVector);
 }
 
-void multiplyByScalarThenAddToOutput(const float* inputVector, float scalar, float* outputVector, size_t numberOfElementsToProcess)
+void multiplyByScalarThenAddToOutput(std::span<const float> inputSpan, float scalar, std::span<float> outputSpan)
 {
-    size_t n = numberOfElementsToProcess;
+    RELEASE_ASSERT(outputSpan.size() >= inputSpan.size());
+    auto* inputVector = inputSpan.data();
+    auto* outputVector = outputSpan.data();
+    size_t n = inputSpan.size();
 
 #if CPU(X86_SSE2)
     // If the inputVector address is not 16-byte aligned, the first several frames (at most three) should be processed separately.
@@ -238,9 +258,12 @@ void multiplyByScalarThenAddToOutput(const float* inputVector, float scalar, flo
     }
 }
 
-void multiplyByScalar(const float* inputVector, float scalar, float* outputVector, size_t numberOfElementsToProcess)
+void multiplyByScalar(std::span<const float> inputSpan, float scalar, std::span<float> outputSpan)
 {
-    size_t n = numberOfElementsToProcess;
+    RELEASE_ASSERT(outputSpan.size() >= inputSpan.size());
+    auto* inputVector = inputSpan.data();
+    auto* outputVector = outputSpan.data();
+    size_t n = inputSpan.size();
 
 #if CPU(X86_SSE2)
     // If the inputVector address is not 16-byte aligned, the first several frames (at most three) should be processed separately.
@@ -301,9 +324,12 @@ void multiplyByScalar(const float* inputVector, float scalar, float* outputVecto
     }
 }
 
-void addScalar(const float* inputVector, float scalar, float* outputVector, size_t numberOfElementsToProcess)
+void addScalar(std::span<const float> inputSpan, float scalar, std::span<float> outputSpan)
 {
-    size_t n = numberOfElementsToProcess;
+    RELEASE_ASSERT(outputSpan.size() >= inputSpan.size());
+    auto* inputVector = inputSpan.data();
+    auto* outputVector = outputSpan.data();
+    size_t n = inputSpan.size();
 
 #if CPU(X86_SSE2)
     // If the inputVector address is not 16-byte aligned, the first several frames (at most three) should be processed separately.
@@ -365,9 +391,14 @@ void addScalar(const float* inputVector, float scalar, float* outputVector, size
     }
 }
 
-void add(const float* inputVector1, const float* inputVector2, float* outputVector, size_t numberOfElementsToProcess)
+void add(std::span<const float> inputSpan1, std::span<const float> inputSpan2, std::span<float> outputSpan)
 {
-    size_t n = numberOfElementsToProcess;
+    RELEASE_ASSERT(inputSpan1.size() == inputSpan2.size());
+    RELEASE_ASSERT(outputSpan.size() >= inputSpan1.size());
+    auto* inputVector1 = inputSpan1.data();
+    auto* inputVector2 = inputSpan2.data();
+    auto* outputVector = outputSpan.data();
+    size_t n = inputSpan1.size();
 
 #if CPU(X86_SSE2)
     // If the inputVector address is not 16-byte aligned, the first several frames (at most three) should be processed separately.
@@ -463,9 +494,14 @@ void add(const float* inputVector1, const float* inputVector2, float* outputVect
     }
 }
 
-void substract(const float* inputVector1, const float* inputVector2, float* outputVector, size_t numberOfElementsToProcess)
+void substract(std::span<const float> inputSpan1, std::span<const float> inputSpan2, std::span<float> outputSpan)
 {
-    size_t n = numberOfElementsToProcess;
+    RELEASE_ASSERT(inputSpan1.size() == inputSpan2.size());
+    RELEASE_ASSERT(outputSpan.size() >= inputSpan1.size());
+    auto* inputVector1 = inputSpan1.data();
+    auto* inputVector2 = inputSpan2.data();
+    auto* outputVector = outputSpan.data();
+    size_t n = inputSpan1.size();
 
 #if CPU(X86_SSE2)
     // If the inputVector address is not 16-byte aligned, the first several frames (at most three) should be processed separately.
@@ -559,22 +595,27 @@ void substract(const float* inputVector1, const float* inputVector2, float* outp
     }
 }
 
-void interpolate(const float* inputVector1, float* inputVector2, float interpolationFactor, float* outputVector, size_t numberOfElementsToProcess)
+void interpolate(std::span<const float> inputVector1, std::span<float> inputVector2, float interpolationFactor, std::span<float> outputVector)
 {
-    if (inputVector1 != outputVector)
-        memcpy(outputVector, inputVector1, numberOfElementsToProcess * sizeof(float));
+    if (inputVector1.data() != outputVector.data())
+        memcpySpan(outputVector, inputVector1);
 
     // inputVector2[k] = inputVector2[k] - inputVector1[k]
-    substract(inputVector2, inputVector1, inputVector2, numberOfElementsToProcess);
+    substract(inputVector2, inputVector1, inputVector2);
 
     // outputVector[k] = outputVector[k] + interpolationFactor * inputVector2[k]
     //                 = inputVector1[k] + interpolationFactor * (inputVector2[k] - inputVector1[k]);
-    multiplyByScalarThenAddToOutput(inputVector2, interpolationFactor, outputVector, numberOfElementsToProcess);
+    multiplyByScalarThenAddToOutput(inputVector2, interpolationFactor, outputVector);
 }
 
-void multiply(const float* inputVector1, const float* inputVector2, float* outputVector, size_t numberOfElementsToProcess)
+void multiply(std::span<const float> inputSpan1, std::span<const float> inputSpan2, std::span<float> outputSpan)
 {
-    size_t n = numberOfElementsToProcess;
+    RELEASE_ASSERT(inputSpan1.size() == inputSpan2.size());
+    RELEASE_ASSERT(outputSpan.size() >= inputSpan1.size());
+    auto* inputVector1 = inputSpan1.data();
+    auto* inputVector2 = inputSpan2.data();
+    auto* outputVector = outputSpan.data();
+    size_t n = inputSpan1.size();
 
 #if CPU(X86_SSE2)
     // If the inputVector1 address is not 16-byte aligned, the first several frames (at most three) should be processed separately.
@@ -641,25 +682,39 @@ void multiply(const float* inputVector1, const float* inputVector2, float* outpu
     }
 }
 
-void multiplyComplex(const float* realVector1, const float* imagVector1, const float* realVector2, const float* imag2P, float* realOutputVector, float* imagDestP, size_t numberOfElementsToProcess)
+void multiplyComplex(std::span<const float> realSpan1, std::span<const float> imagSpan1, std::span<const float> realSpan2, std::span<const float> imagSpan2, std::span<float> realOutputSpan, std::span<float> imagOutputSpan)
 {
+    RELEASE_ASSERT(realSpan1.size() == imagSpan1.size());
+    RELEASE_ASSERT(realSpan1.size() == realSpan2.size());
+    RELEASE_ASSERT(imagSpan1.size() == imagSpan1.size());
+    RELEASE_ASSERT(realOutputSpan.size() >= realSpan1.size());
+    RELEASE_ASSERT(imagOutputSpan.size() >= imagSpan1.size());
+
+    auto* realVector1 = realSpan1.data();
+    auto* imagVector1 = imagSpan1.data();
+    auto* realVector2 = realSpan2.data();
+    auto* imagVector2 = imagSpan2.data();
+    auto* realOutputVector = realOutputSpan.data();
+    auto* imagOutputVector = imagOutputSpan.data();
+    auto numberOfElementsToProcess = realSpan1.size();
+
     unsigned i = 0;
 #if CPU(X86_SSE2)
     // Only use the SSE optimization in the very common case that all addresses are 16-byte aligned. 
     // Otherwise, fall through to the scalar code below.
-    if (is16ByteAligned(realVector1) && is16ByteAligned(imagVector1) && is16ByteAligned(realVector2) && is16ByteAligned(imag2P) && is16ByteAligned(realOutputVector) && is16ByteAligned(imagDestP)) {
+    if (is16ByteAligned(realVector1) && is16ByteAligned(imagVector1) && is16ByteAligned(realVector2) && is16ByteAligned(imagVector2) && is16ByteAligned(realOutputVector) && is16ByteAligned(imagOutputVector)) {
         unsigned endSize = numberOfElementsToProcess - numberOfElementsToProcess % 4;
         while (i < endSize) {
             __m128 real1 = _mm_load_ps(realVector1 + i);
             __m128 real2 = _mm_load_ps(realVector2 + i);
             __m128 imag1 = _mm_load_ps(imagVector1 + i);
-            __m128 imag2 = _mm_load_ps(imag2P + i);
+            __m128 imag2 = _mm_load_ps(imagVector2 + i);
             __m128 real = _mm_mul_ps(real1, real2);
             real = _mm_sub_ps(real, _mm_mul_ps(imag1, imag2));
             __m128 imag = _mm_mul_ps(real1, imag2);
             imag = _mm_add_ps(imag, _mm_mul_ps(imag1, real2));
             _mm_store_ps(realOutputVector + i, real);
-            _mm_store_ps(imagDestP + i, imag);
+            _mm_store_ps(imagOutputVector + i, imag);
             i += 4;
         }
     }
@@ -669,13 +724,13 @@ void multiplyComplex(const float* realVector1, const float* imagVector1, const f
             float32x4_t real1 = vld1q_f32(realVector1 + i);
             float32x4_t real2 = vld1q_f32(realVector2 + i);
             float32x4_t imag1 = vld1q_f32(imagVector1 + i);
-            float32x4_t imag2 = vld1q_f32(imag2P + i);
+            float32x4_t imag2 = vld1q_f32(imagVector2 + i);
 
             float32x4_t realResult = vmlsq_f32(vmulq_f32(real1, real2), imag1, imag2);
             float32x4_t imagResult = vmlaq_f32(vmulq_f32(real1, imag2), imag1, real2);
 
             vst1q_f32(realOutputVector + i, realResult);
-            vst1q_f32(imagDestP + i, imagResult);
+            vst1q_f32(imagOutputVector + i, imagResult);
 
             i += 4;
         }
@@ -683,14 +738,15 @@ void multiplyComplex(const float* realVector1, const float* imagVector1, const f
     for (; i < numberOfElementsToProcess; ++i) {
         // Read and compute result before storing them, in case the
         // destination is the same as one of the sources.
-        realOutputVector[i] = realVector1[i] * realVector2[i] - imagVector1[i] * imag2P[i];
-        imagDestP[i] = realVector1[i] * imag2P[i] + imagVector1[i] * realVector2[i];
+        realOutputVector[i] = realVector1[i] * realVector2[i] - imagVector1[i] * imagVector2[i];
+        imagOutputVector[i] = realVector1[i] * imagVector2[i] + imagVector1[i] * realVector2[i];
     }
 }
 
-float sumOfSquares(const float* inputVector, size_t numberOfElementsToProcess)
+float sumOfSquares(std::span<const float> inputSpan)
 {
-    size_t n = numberOfElementsToProcess;
+    auto* inputVector = inputSpan.data();
+    size_t n = inputSpan.size();
     float sum = 0;
 
 #if CPU(X86_SSE2)
@@ -748,9 +804,10 @@ float sumOfSquares(const float* inputVector, size_t numberOfElementsToProcess)
     return sum;
 }
 
-float maximumMagnitude(const float* inputVector, size_t numberOfElementsToProcess)
+float maximumMagnitude(std::span<const float> inputSpan)
 {
-    size_t n = numberOfElementsToProcess;
+    auto* inputVector = inputSpan.data();
+    size_t n = inputSpan.size();
     float max = 0;
 
 #if CPU(X86_SSE2)
@@ -812,9 +869,12 @@ float maximumMagnitude(const float* inputVector, size_t numberOfElementsToProces
     return max;
 }
 
-void clamp(const float* inputVector, float minimum, float maximum, float* outputVector, size_t numberOfElementsToProcess)
+void clamp(std::span<const float> inputSpan, float minimum, float maximum, std::span<float> outputSpan)
 {
-    size_t n = numberOfElementsToProcess;
+    RELEASE_ASSERT(outputSpan.size() >= inputSpan.size());
+    auto* inputVector = inputSpan.data();
+    auto* outputVector = outputSpan.data();
+    size_t n = inputSpan.size();
 
     // FIXME: Optimize for SSE2.
 #if HAVE(ARM_NEON_INTRINSICS)
@@ -838,16 +898,17 @@ void clamp(const float* inputVector, float minimum, float maximum, float* output
     }
 }
 
-void linearToDecibels(const float* inputVector, float* outputVector, size_t numberOfElementsToProcess)
+void linearToDecibels(std::span<const float> inputVector, std::span<float> outputVector)
 {
-    for (size_t i = 0; i < numberOfElementsToProcess; ++i)
-        outputVector[i] = AudioUtilities::linearToDecibels(inputVector[i]);
+    RELEASE_ASSERT(outputVector.size() >= inputVector.size());
+    for (auto [i, inputValue] : indexedRange(inputVector))
+        outputVector[i] = AudioUtilities::linearToDecibels(inputValue);
 }
 
-void addVectorsThenMultiplyByScalar(const float* inputVector1, const float* inputVector2, float scalar, float* outputVector, size_t numberOfElementsToProcess)
+void addVectorsThenMultiplyByScalar(std::span<const float> inputVector1, std::span<const float> inputVector2, float scalar, std::span<float> outputVector)
 {
-    add(inputVector1, inputVector2, outputVector, numberOfElementsToProcess);
-    multiplyByScalar(outputVector, scalar, outputVector, numberOfElementsToProcess);
+    add(inputVector1, inputVector2, outputVector);
+    multiplyByScalar(outputVector.first(inputVector1.size()), scalar, outputVector);
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
@@ -858,13 +919,6 @@ void add(std::span<const int> inputVector1, std::span<const int> inputVector2, s
     RELEASE_ASSERT(outputVector.size() >= inputVector1.size());
     for (size_t i = 0; i < inputVector1.size(); ++i)
         outputVector[i] = inputVector1[i] + inputVector2[i];
-}
-
-void add(std::span<const float> inputVector1, std::span<const float> inputVector2, std::span<float> outputVector)
-{
-    RELEASE_ASSERT(inputVector1.size() == inputVector2.size());
-    RELEASE_ASSERT(outputVector.size() >= inputVector1.size());
-    add(inputVector1.data(), inputVector2.data(), outputVector.data(), inputVector1.size());
 }
 
 void add(std::span<const double> inputVector1, std::span<const double> inputVector2, std::span<double> outputVector)

--- a/Source/WebCore/platform/audio/VectorMath.h
+++ b/Source/WebCore/platform/audio/VectorMath.h
@@ -34,47 +34,46 @@ namespace VectorMath {
 // Multiples inputVector by scalar then adds the result to outputVector (simplified vsma).
 // for (n = 0; n < numberOfElementsToProcess; ++n)
 //     outputVector[n] += inputVector[n] * scalar;
-void multiplyByScalarThenAddToOutput(const float* inputVector, float scalar, float* outputVector, size_t numberOfElementsToProcess);
+void multiplyByScalarThenAddToOutput(std::span<const float> inputVector, float scalar, std::span<float> outputVector);
 
 // Adds a vector inputVector2 to the product of a scalar value and a single-precision vector inputVector1 (vsma).
 // for (n = 0; n < numberOfElementsToProcess; ++n)
 //     outputVector[n] = inputVector1[n] * scalar + inputVector2[n];
-void multiplyByScalarThenAddToVector(const float* inputVector1, float scalar, const float* inputVector2, float* outputVector, size_t numberOfElementsToProcess);
+void multiplyByScalarThenAddToVector(std::span<const float> inputVector1, float scalar, std::span<const float> inputVector2, std::span<float> outputVector);
 
 // Multiplies the sum of two vectors by a scalar value (vasm).
-void addVectorsThenMultiplyByScalar(const float* inputVector1, const float* inputVector2, float scalar, float* outputVector, size_t numberOfElementsToProcess);
+void addVectorsThenMultiplyByScalar(std::span<const float> inputVector1, std::span<const float> inputVector2, float scalar, std::span<float> outputVector);
 
-void multiplyByScalar(const float* inputVector, float scalar, float* outputVector, size_t numberOfElementsToProcess);
-void addScalar(const float* inputVector, float scalar, float* outputVector, size_t numberOfElementsToProcess);
-void add(const float* inputVector1, const float* inputVector2, float* outputVector, size_t numberOfElementsToProcess);
-void substract(const float* inputVector1, const float* inputVector2, float* outputVector, size_t numberOfElementsToProcess);
+void multiplyByScalar(std::span<const float> inputVector, float scalar, std::span<float> outputVector);
+void addScalar(std::span<const float> inputVector, float scalar, std::span<float> outputVector);
+void substract(std::span<const float> inputVector1, std::span<const float> inputVector2, std::span<float> outputVector);
 
 void add(std::span<const int> inputVector1, std::span<const int> inputVector2, std::span<int> outputVector);
 void add(std::span<const float> inputVector1, std::span<const float> inputVector2, std::span<float> outputVector);
 void add(std::span<const double> inputVector1, std::span<const double> inputVector2, std::span<double> outputVector);
 
 // Finds the maximum magnitude of a float vector.
-float maximumMagnitude(const float* inputVector, size_t numberOfElementsToProcess);
+float maximumMagnitude(std::span<const float> inputVector);
 
 // Sums the squares of a float vector's elements (svesq).
-float sumOfSquares(const float* inputVector, size_t numberOfElementsToProcess);
+float sumOfSquares(std::span<const float> inputVector);
 
 // For an element-by-element multiply of two float vectors.
-void multiply(const float* inputVector1, const float* inputVector2, float* outputVector, size_t numberOfElementsToProcess);
+void multiply(std::span<const float> inputVector1, std::span<const float> inputVector2, std::span<float> outputVector);
 
 // Multiplies two complex vectors (zvmul).
-void multiplyComplex(const float* realVector1, const float* imagVector1, const float* realVector2, const float* imagVector2, float* realOutputVector, float* imagOutputVector, size_t numberOfElementsToProcess);
+void multiplyComplex(std::span<const float> realVector1, std::span<const float> imagVector1, std::span<const float> realVector2, std::span<const float> imagVector2, std::span<float> realOutputVector, std::span<float> imagOutputVector);
 
 // Copies elements while clipping values to the threshold inputs.
-void clamp(const float* inputVector, float mininum, float maximum, float* outputVector, size_t numberOfElementsToProcess);
+void clamp(std::span<const float> inputVector, float mininum, float maximum, std::span<float> outputVector);
 
-void linearToDecibels(const float* inputVector, float* outputVector, size_t numberOfElementsToProcess);
+void linearToDecibels(std::span<const float> inputVector, std::span<float> outputVector);
 
 // Calculates the linear interpolation between the supplied single-precision vectors
 // for (n = 0; n < numberOfElementsToProcess; ++n)
 //     outputVector[n] = inputVector1[n] + interpolationFactor * (inputVector2[n] - inputVector1[n]);
 // NOTE: Internal implementation may modify inputVector2.
-void interpolate(const float* inputVector1, float* inputVector2, float interpolationFactor, float* outputVector, size_t numberOfElementsToProcess);
+void interpolate(std::span<const float> inputVector1, std::span<float> inputVector2, float interpolationFactor, std::span<float> outputVector);
 
 } // namespace VectorMath
 

--- a/Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp
@@ -117,7 +117,7 @@ void FFTFrame::doInverseFFT(std::span<float> data)
     gst_fft_f32_inverse_fft(m_inverseFft.get(), m_complexData.get(), data.data());
 
     // Scale so that a forward then inverse FFT yields exactly the original data.
-    VectorMath::multiplyByScalar(data.data(), 1.0 / m_FFTSize, data.data(), m_FFTSize);
+    VectorMath::multiplyByScalar(data.first(m_FFTSize), 1.0 / m_FFTSize, data);
 }
 
 int FFTFrame::minFFTSize()

--- a/Source/WebCore/platform/audio/mac/FFTFrameMac.cpp
+++ b/Source/WebCore/platform/audio/mac/FFTFrameMac.cpp
@@ -118,8 +118,8 @@ void FFTFrame::doFFT(std::span<const float> data)
     // (See https://developer.apple.com/library/archive/documentation/Performance/Conceptual/vDSP_Programming_Guide/UsingFourierTransforms/UsingFourierTransforms.html#//apple_ref/doc/uid/TP40005147-CH3-SW5)
     // In the case of a Real forward Transform like above: RFimp = RFmath * 2 so we need to divide the output
     // by 2 to get the correct value.
-    VectorMath::multiplyByScalar(realData().data(), 0.5, realData().data(), halfSize);
-    VectorMath::multiplyByScalar(imagData().data(), 0.5, imagData().data(), halfSize);
+    VectorMath::multiplyByScalar(realData().span().first(halfSize), 0.5, realData().span());
+    VectorMath::multiplyByScalar(imagData().span().first(halfSize), 0.5, imagData().span());
 }
 
 void FFTFrame::doInverseFFT(std::span<float> data)
@@ -128,7 +128,7 @@ void FFTFrame::doInverseFFT(std::span<float> data)
     vDSP_ztoc(&m_frame, 1, &reinterpretCastSpanStartTo<DSPComplex>(data), 2, m_FFTSize / 2);
 
     // Do final scaling so that x == IFFT(FFT(x))
-    VectorMath::multiplyByScalar(data.data(), 1.0f / m_FFTSize, data.data(), m_FFTSize);
+    VectorMath::multiplyByScalar(data.first(m_FFTSize), 1.0f / m_FFTSize, data);
 }
 
 FFTSetup FFTFrame::fftSetupForSize(unsigned fftSize)


### PR DESCRIPTION
#### 55186327a6c41b86f59028fcffcd41f49dd4e56c
<pre>
Adopt more spans in VectorMath.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=285228">https://bugs.webkit.org/show_bug.cgi?id=285228</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/webaudio/AudioParam.cpp:
(WebCore::AudioParam::calculateFinalValues):
* Source/WebCore/Modules/webaudio/AudioParamTimeline.cpp:
(WebCore::AudioParamTimeline::valuesForFrameRange):
(WebCore::AudioParamTimeline::processLinearRamp):
(WebCore::AudioParamTimeline::processSetTarget):
* Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp:
(WebCore::DelayDSPKernel::processKRate):
* Source/WebCore/Modules/webaudio/OscillatorNode.cpp:
(WebCore::OscillatorNode::calculateSampleAccuratePhaseIncrements):
* Source/WebCore/Modules/webaudio/PeriodicWave.cpp:
(WebCore::PeriodicWave::createBandLimitedTables):
* Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp:
(WebCore::RealtimeAnalyser::getFloatFrequencyData):
* Source/WebCore/platform/audio/AudioBus.cpp:
(WebCore::AudioBus::speakersSumFromByDownMixing):
(WebCore::AudioBus::copyWithGainFrom):
(WebCore::AudioBus::copyWithSampleAccurateGainValuesFrom):
(WebCore::AudioBus::createByMixingToMono):
* Source/WebCore/platform/audio/AudioChannel.cpp:
(WebCore::AudioChannel::scale):
(WebCore::AudioChannel::sumFrom):
(WebCore::AudioChannel::maxAbsValue const):
* Source/WebCore/platform/audio/EqualPowerPanner.cpp:
(WebCore::EqualPowerPanner::pan):
* Source/WebCore/platform/audio/FFTConvolver.cpp:
(WebCore::FFTConvolver::process):
* Source/WebCore/platform/audio/FFTFrame.cpp:
(WebCore::FFTFrame::scaleFFT):
(WebCore::FFTFrame::multiply):
* Source/WebCore/platform/audio/IIRFilter.cpp:
(WebCore::IIRFilter::tailTime):
* Source/WebCore/platform/audio/Reverb.cpp:
(WebCore::calculateNormalizationScale):
* Source/WebCore/platform/audio/ReverbAccumulationBuffer.cpp:
(WebCore::ReverbAccumulationBuffer::accumulate):
* Source/WebCore/platform/audio/ReverbConvolverStage.cpp:
(WebCore::ReverbConvolverStage::ReverbConvolverStage):
* Source/WebCore/platform/audio/StereoPanner.cpp:
(WebCore::StereoPanner::panToTargetValue):
* Source/WebCore/platform/audio/VectorMath.cpp:
(WebCore::VectorMath::multiplyByScalar):
(WebCore::VectorMath::substract):
(WebCore::VectorMath::addScalar):
(WebCore::VectorMath::multiply):
(WebCore::VectorMath::interpolate):
(WebCore::VectorMath::multiplyComplex):
(WebCore::VectorMath::multiplyByScalarThenAddToOutput):
(WebCore::VectorMath::multiplyByScalarThenAddToVector):
(WebCore::VectorMath::addVectorsThenMultiplyByScalar):
(WebCore::VectorMath::maximumMagnitude):
(WebCore::VectorMath::sumOfSquares):
(WebCore::VectorMath::clamp):
(WebCore::VectorMath::linearToDecibels):
(WebCore::VectorMath::add):
* Source/WebCore/platform/audio/VectorMath.h:
* Source/WebCore/platform/audio/mac/FFTFrameMac.cpp:
(WebCore::FFTFrame::doFFT):
(WebCore::FFTFrame::doInverseFFT):

Canonical link: <a href="https://commits.webkit.org/288334@main">https://commits.webkit.org/288334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89f25733b5f2482262c90498fe6088b53ab5ea13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87711 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33647 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64365 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22123 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75132 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44640 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1569 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29318 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32681 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89075 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72773 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10112 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71987 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16129 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1273 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12809 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9837 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15358 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9711 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13176 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11480 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->