### PR TITLE
Fix to return `initial value` for SVG Length in case of parser error and being invalid

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedLength-initial-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedLength-initial-values-expected.txt
@@ -13,22 +13,22 @@ PASS SVGAnimatedLength, initial values, SVGEllipseElement.prototype.rx (remove)
 PASS SVGAnimatedLength, initial values, SVGEllipseElement.prototype.rx (invalid value)
 PASS SVGAnimatedLength, initial values, SVGEllipseElement.prototype.ry (remove)
 PASS SVGAnimatedLength, initial values, SVGEllipseElement.prototype.ry (invalid value)
-FAIL SVGAnimatedLength, initial values, SVGFilterElement.prototype.x (remove) assert_equals: initial after expected "-10%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGFilterElement.prototype.x (invalid value) assert_equals: initial after expected "-10%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGFilterElement.prototype.y (remove) assert_equals: initial after expected "-10%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGFilterElement.prototype.y (invalid value) assert_equals: initial after expected "-10%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGFilterElement.prototype.width (remove) assert_equals: initial after expected "120%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGFilterElement.prototype.width (invalid value) assert_equals: initial after expected "120%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGFilterElement.prototype.height (remove) assert_equals: initial after expected "120%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGFilterElement.prototype.height (invalid value) assert_equals: initial after expected "120%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.x (remove) assert_equals: initial after expected "0%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.x (invalid value) assert_equals: initial after expected "0%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.y (remove) assert_equals: initial after expected "0%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.y (invalid value) assert_equals: initial after expected "0%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.width (remove) assert_equals: initial after expected "100%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.width (invalid value) assert_equals: initial after expected "100%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.height (remove) assert_equals: initial after expected "100%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.height (invalid value) assert_equals: initial after expected "100%" but got "0"
+PASS SVGAnimatedLength, initial values, SVGFilterElement.prototype.x (remove)
+PASS SVGAnimatedLength, initial values, SVGFilterElement.prototype.x (invalid value)
+PASS SVGAnimatedLength, initial values, SVGFilterElement.prototype.y (remove)
+PASS SVGAnimatedLength, initial values, SVGFilterElement.prototype.y (invalid value)
+PASS SVGAnimatedLength, initial values, SVGFilterElement.prototype.width (remove)
+PASS SVGAnimatedLength, initial values, SVGFilterElement.prototype.width (invalid value)
+PASS SVGAnimatedLength, initial values, SVGFilterElement.prototype.height (remove)
+PASS SVGAnimatedLength, initial values, SVGFilterElement.prototype.height (invalid value)
+PASS SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.x (remove)
+PASS SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.x (invalid value)
+PASS SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.y (remove)
+PASS SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.y (invalid value)
+PASS SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.width (remove)
+PASS SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.width (invalid value)
+PASS SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.height (remove)
+PASS SVGAnimatedLength, initial values, SVGFilterPrimitiveStandardAttributes.prototype.height (invalid value)
 PASS SVGAnimatedLength, initial values, SVGForeignObjectElement.prototype.x (remove)
 PASS SVGAnimatedLength, initial values, SVGForeignObjectElement.prototype.x (invalid value)
 PASS SVGAnimatedLength, initial values, SVGForeignObjectElement.prototype.y (remove)
@@ -53,30 +53,30 @@ PASS SVGAnimatedLength, initial values, SVGLineElement.prototype.x2 (remove)
 PASS SVGAnimatedLength, initial values, SVGLineElement.prototype.x2 (invalid value)
 PASS SVGAnimatedLength, initial values, SVGLineElement.prototype.y2 (remove)
 PASS SVGAnimatedLength, initial values, SVGLineElement.prototype.y2 (invalid value)
-FAIL SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.x1 (remove) assert_equals: initial after expected "0%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.x1 (invalid value) assert_equals: initial after expected "0%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.y1 (remove) assert_equals: initial after expected "0%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.y1 (invalid value) assert_equals: initial after expected "0%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.x2 (remove) assert_equals: initial after expected "100%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.x2 (invalid value) assert_equals: initial after expected "100%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.y2 (remove) assert_equals: initial after expected "0%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.y2 (invalid value) assert_equals: initial after expected "0%" but got "0"
+PASS SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.x1 (remove)
+PASS SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.x1 (invalid value)
+PASS SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.y1 (remove)
+PASS SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.y1 (invalid value)
+PASS SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.x2 (remove)
+PASS SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.x2 (invalid value)
+PASS SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.y2 (remove)
+PASS SVGAnimatedLength, initial values, SVGLinearGradientElement.prototype.y2 (invalid value)
 PASS SVGAnimatedLength, initial values, SVGMarkerElement.prototype.refX (remove)
 PASS SVGAnimatedLength, initial values, SVGMarkerElement.prototype.refX (invalid value)
 PASS SVGAnimatedLength, initial values, SVGMarkerElement.prototype.refY (remove)
 PASS SVGAnimatedLength, initial values, SVGMarkerElement.prototype.refY (invalid value)
-FAIL SVGAnimatedLength, initial values, SVGMarkerElement.prototype.markerWidth (remove) assert_equals: initial after expected "3" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGMarkerElement.prototype.markerWidth (invalid value) assert_equals: initial after expected "3" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGMarkerElement.prototype.markerHeight (remove) assert_equals: initial after expected "3" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGMarkerElement.prototype.markerHeight (invalid value) assert_equals: initial after expected "3" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGMaskElement.prototype.x (remove) assert_equals: initial after expected "-10%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGMaskElement.prototype.x (invalid value) assert_equals: initial after expected "-10%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGMaskElement.prototype.y (remove) assert_equals: initial after expected "-10%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGMaskElement.prototype.y (invalid value) assert_equals: initial after expected "-10%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGMaskElement.prototype.width (remove) assert_equals: initial after expected "120%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGMaskElement.prototype.width (invalid value) assert_equals: initial after expected "120%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGMaskElement.prototype.height (remove) assert_equals: initial after expected "120%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGMaskElement.prototype.height (invalid value) assert_equals: initial after expected "120%" but got "0"
+PASS SVGAnimatedLength, initial values, SVGMarkerElement.prototype.markerWidth (remove)
+PASS SVGAnimatedLength, initial values, SVGMarkerElement.prototype.markerWidth (invalid value)
+PASS SVGAnimatedLength, initial values, SVGMarkerElement.prototype.markerHeight (remove)
+PASS SVGAnimatedLength, initial values, SVGMarkerElement.prototype.markerHeight (invalid value)
+PASS SVGAnimatedLength, initial values, SVGMaskElement.prototype.x (remove)
+PASS SVGAnimatedLength, initial values, SVGMaskElement.prototype.x (invalid value)
+PASS SVGAnimatedLength, initial values, SVGMaskElement.prototype.y (remove)
+PASS SVGAnimatedLength, initial values, SVGMaskElement.prototype.y (invalid value)
+PASS SVGAnimatedLength, initial values, SVGMaskElement.prototype.width (remove)
+PASS SVGAnimatedLength, initial values, SVGMaskElement.prototype.width (invalid value)
+PASS SVGAnimatedLength, initial values, SVGMaskElement.prototype.height (remove)
+PASS SVGAnimatedLength, initial values, SVGMaskElement.prototype.height (invalid value)
 PASS SVGAnimatedLength, initial values, SVGPatternElement.prototype.x (remove)
 PASS SVGAnimatedLength, initial values, SVGPatternElement.prototype.x (invalid value)
 PASS SVGAnimatedLength, initial values, SVGPatternElement.prototype.y (remove)
@@ -85,18 +85,18 @@ PASS SVGAnimatedLength, initial values, SVGPatternElement.prototype.width (remov
 PASS SVGAnimatedLength, initial values, SVGPatternElement.prototype.width (invalid value)
 PASS SVGAnimatedLength, initial values, SVGPatternElement.prototype.height (remove)
 PASS SVGAnimatedLength, initial values, SVGPatternElement.prototype.height (invalid value)
-FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.cx (remove) assert_equals: initial after expected "50%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.cx (invalid value) assert_equals: initial after expected "50%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.cy (remove) assert_equals: initial after expected "50%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.cy (invalid value) assert_equals: initial after expected "50%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.r (remove) assert_equals: initial after expected "50%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.r (invalid value) assert_equals: initial after expected "50%" but got "0"
+PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.cx (remove)
+PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.cx (invalid value)
+PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.cy (remove)
+PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.cy (invalid value)
+PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.r (remove)
+PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.r (invalid value)
 FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fx (remove) assert_equals: initial before expected "50%" but got "0"
 FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fx (invalid value) assert_equals: initial before expected "50%" but got "0"
 FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fy (remove) assert_equals: initial before expected "50%" but got "0"
 FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fy (invalid value) assert_equals: initial before expected "50%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fr (remove) assert_equals: initial after expected "0%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fr (invalid value) assert_equals: initial after expected "0%" but got "0"
+PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fr (remove)
+PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fr (invalid value)
 PASS SVGAnimatedLength, initial values, SVGRectElement.prototype.x (remove)
 PASS SVGAnimatedLength, initial values, SVGRectElement.prototype.x (invalid value)
 PASS SVGAnimatedLength, initial values, SVGRectElement.prototype.y (remove)

--- a/Source/WebCore/svg/SVGFilterElement.cpp
+++ b/Source/WebCore/svg/SVGFilterElement.cpp
@@ -5,7 +5,7 @@
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  * Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -86,16 +86,16 @@ void SVGFilterElement::attributeChanged(const QualifiedName& name, const AtomStr
         break;
     }
     case AttributeNames::xAttr:
-        Ref { m_x }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "-10%"_s));
         break;
     case AttributeNames::yAttr:
-        Ref { m_y }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "-10%"_s));
         break;
     case AttributeNames::widthAttr:
-        Ref { m_width }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_width }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "120%"_s));
         break;
     case AttributeNames::heightAttr:
-        Ref { m_height }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_height }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "120%"_s));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2004, 2005, 2006, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
- * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -59,16 +59,16 @@ void SVGFilterPrimitiveStandardAttributes::attributeChanged(const QualifiedName&
 
     switch (name.nodeName()) {
     case AttributeNames::xAttr:
-        Ref { m_x }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "0%"_s));
         break;
     case AttributeNames::yAttr:
-        Ref { m_y }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "0%"_s));
         break;
     case AttributeNames::widthAttr:
-        Ref { m_width }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_width }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "100%"_s));
         break;
     case AttributeNames::heightAttr:
-        Ref { m_height }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_height }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "100%"_s));
         break;
     case AttributeNames::resultAttr:
         Ref { m_result }->setBaseValInternal(newValue);

--- a/Source/WebCore/svg/SVGLengthList.cpp
+++ b/Source/WebCore/svg/SVGLengthList.cpp
@@ -47,11 +47,12 @@ bool SVGLengthList::parse(StringView value)
             if (buffer.position() == start)
                 break;
 
-            auto value = SVGLengthValue::construct(m_lengthMode, std::span(start, buffer.position() - start));
-            if (!value)
+            SVGParsingError parseError;
+            auto length = SVGLengthValue::construct(m_lengthMode, std::span(start, buffer.position() - start), parseError);
+            if (parseError != SVGParsingError::None)
                 break;
 
-            append(SVGLength::create(WTFMove(*value)));
+            append(SVGLength::create(WTFMove(length)));
             skipOptionalSVGSpacesOrDelimiter(buffer);
         }
 

--- a/Source/WebCore/svg/SVGLengthValue.h
+++ b/Source/WebCore/svg/SVGLengthValue.h
@@ -67,8 +67,7 @@ public:
     SVGLengthValue(float valueInSpecifiedUnits, SVGLengthType, SVGLengthMode = SVGLengthMode::Other);
     SVGLengthValue(const SVGLengthContext&, float, SVGLengthType = SVGLengthType::Number, SVGLengthMode = SVGLengthMode::Other);
 
-    static std::optional<SVGLengthValue> construct(SVGLengthMode, StringView);
-    static SVGLengthValue construct(SVGLengthMode, StringView, SVGParsingError&, SVGLengthNegativeValuesMode = SVGLengthNegativeValuesMode::Allow);
+    static SVGLengthValue construct(SVGLengthMode, StringView, SVGParsingError&, SVGLengthNegativeValuesMode = SVGLengthNegativeValuesMode::Allow, ASCIILiteral = { });
 
     SVGLengthType lengthType() const;
     SVGLengthMode lengthMode() const { return m_lengthMode; }

--- a/Source/WebCore/svg/SVGLinearGradientElement.cpp
+++ b/Source/WebCore/svg/SVGLinearGradientElement.cpp
@@ -4,7 +4,7 @@
  * Copyright (C) 2008 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2008 Dirk Schulze <krit@webkit.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -72,16 +72,16 @@ void SVGLinearGradientElement::attributeChanged(const QualifiedName& name, const
 
     switch (name.nodeName()) {
     case AttributeNames::x1Attr:
-        Ref { m_x1 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x1 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "0%"_s));
         break;
     case AttributeNames::y1Attr:
-        Ref { m_y1 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y1 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "0%"_s));
         break;
     case AttributeNames::x2Attr:
-        Ref { m_x2 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x2 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "100%"_s));
         break;
     case AttributeNames::y2Attr:
-        Ref { m_y2 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y2 }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "0%"_s));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGMarkerElement.cpp
+++ b/Source/WebCore/svg/SVGMarkerElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2004, 2005, 2006, 2007, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
  * Copyright (C) Research In Motion Limited 2009-2010. All rights reserved.
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2024 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
@@ -90,10 +90,10 @@ void SVGMarkerElement::attributeChanged(const QualifiedName& name, const AtomStr
         Ref { m_refY }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
     case AttributeNames::markerWidthAttr:
-        Ref { m_markerWidth }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_markerWidth }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "3"_s));
         break;
     case AttributeNames::markerHeightAttr:
-        Ref { m_markerHeight }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_markerHeight }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "3"_s));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGMaskElement.cpp
+++ b/Source/WebCore/svg/SVGMaskElement.cpp
@@ -5,7 +5,7 @@
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
  * Copyright (C) Research In Motion Limited 2009-2010. All rights reserved.
  * Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -90,16 +90,16 @@ void SVGMaskElement::attributeChanged(const QualifiedName& name, const AtomStrin
         break;
     }
     case AttributeNames::xAttr:
-        Ref { m_x }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_x }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "-10%"_s));
         break;
     case AttributeNames::yAttr:
-        Ref { m_y }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_y }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "-10%"_s));
         break;
     case AttributeNames::widthAttr:
-        Ref { m_width }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_width }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "120%"_s));
         break;
     case AttributeNames::heightAttr:
-        Ref { m_height }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_height }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "120%"_s));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -4,7 +4,7 @@
  * Copyright (C) 2008 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2008 Dirk Schulze <krit@webkit.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -74,22 +74,22 @@ void SVGRadialGradientElement::attributeChanged(const QualifiedName& name, const
 
     switch (name.nodeName()) {
     case AttributeNames::cxAttr:
-        Ref { m_cx }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_cx }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "50%"_s));
         break;
     case AttributeNames::cyAttr:
-        Ref { m_cy }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_cy }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "50%"_s));
         break;
     case AttributeNames::rAttr:
-        Ref { m_r }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        Ref { m_r }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "50%"_s));
         break;
     case AttributeNames::fxAttr:
-        Ref { m_fx }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
+        Ref { m_fx }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "50%"_s));
         break;
     case AttributeNames::fyAttr:
-        Ref { m_fy }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
+        Ref { m_fy }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Allow, "50%"_s));
         break;
     case AttributeNames::frAttr:
-        Ref { m_fr }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
+        Ref { m_fr }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError, SVGLengthNegativeValuesMode::Forbid, "0%"_s));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -210,26 +210,12 @@ void SVGSVGElement::attributeChanged(const QualifiedName& name, const AtomString
     case AttributeNames::yAttr:
         Ref { m_y }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
         break;
-    case AttributeNames::widthAttr: {
-        auto length = SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid);
-        if (parseError != SVGParsingError::None || newValue.isEmpty()) {
-            // FIXME: This is definitely the correct behavior for a missing/removed attribute.
-            // Not sure it's correct for the empty string or for something that can't be parsed.
-            length = SVGLengthValue(SVGLengthMode::Width, "100%"_s);
-        }
-        Ref { m_width }->setBaseValInternal(length);
+    case AttributeNames::widthAttr:
+        Ref { m_width }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid, "100%"_s));
         break;
-    }
-    case AttributeNames::heightAttr: {
-        auto length = SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid);
-        if (parseError != SVGParsingError::None || newValue.isEmpty()) {
-            // FIXME: This is definitely the correct behavior for a removed attribute.
-            // Not sure it's correct for the empty string or for something that can't be parsed.
-            length = SVGLengthValue(SVGLengthMode::Height, "100%"_s);
-        }
-        Ref { m_height }->setBaseValInternal(length);
+    case AttributeNames::heightAttr:
+        Ref { m_height }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid, "100%"_s));
         break;
-    }
     default:
         break;
     }


### PR DESCRIPTION
#### 38b65cc65f133e6e5ac0afbf9a24149897e556b1
<pre>
Fix to return `initial value` for SVG Length in case of parser error and being invalid
<a href="https://bugs.webkit.org/show_bug.cgi?id=279379">https://bugs.webkit.org/show_bug.cgi?id=279379</a>
<a href="https://rdar.apple.com/136102554">rdar://136102554</a>

Reviewed by Darin Adler.

Our current implementation for initial values was not taking account when
there was any parser error or when the value was empty string or null, this
patch fixes the bug by ensuring that we return the initial value as per
web-standard in those cases.

NOTE: We still fail test about `fx` and `fy`, where the initial value fallback
is unclear in specification, so this patch does not fix those cases.

* Source/WebCore/svg/SVGFilterElement.cpp:
(WebCore::SVGFilterElement::attributeChanged):
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp:
(WebCore::SVGFilterPrimitiveStandardAttributes::attributeChanged):
* Source/WebCore/svg/SVGLengthList.cpp:
(WebCore::SVGLengthList::parse):
* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::SVGLengthValue::construct):
* Source/WebCore/svg/SVGLengthValue.h:
(WebCore::SVGLengthValue::construct):
* Source/WebCore/svg/SVGLinearGradientElement.cpp:
(WebCore::SVGLinearGradientElement::attributeChanged):
* Source/WebCore/svg/SVGMarkerElement.cpp:
(WebCore::SVGMarkerElement::attributeChanged):
* Source/WebCore/svg/SVGMaskElement.cpp:
(WebCore::SVGMaskElement::attributeChanged):
* Source/WebCore/svg/SVGRadialGradientElement.cpp:
(WebCore::SVGRadialGradientElement::attributeChanged):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::attributeChanged):

* imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedLength-initial-values-expected.txt: Progressions

Canonical link: <a href="https://commits.webkit.org/303577@main">https://commits.webkit.org/303577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/187e6588070eb4207fd4d58556489cd72cae126f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140353 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84849 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/d9caa900-5723-4c0e-a941-faf417969012) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134691 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101556 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68857 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/c10158c1-ea86-4825-a545-9f4c4575f7a1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/3969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118996 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82349 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/cb9ee19b-2e14-44c5-8b7e-5f5cd469bbbe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/3856 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1542 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83586 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/112844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143008 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4991 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37699 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109930 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110108 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27924 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3816 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115262 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58506 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5045 "Build is in progress. Recent messages:OS: Tahoe (26.0), Xcode: 26.0.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33615 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4883 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68497 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5135 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5003 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->