### PR TITLE
Fix table baseline in case of 'empty rowspanned cells should not set baseline'

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/baseline-table-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/baseline-table-expected.txt
@@ -72,7 +72,7 @@ FAIL .container 13 assert_equals:
     </tr>
   </tbody></table><div style="display:inline-block" data-offset-y="15">pX</div>
 </div>
-offsetTop expected 15 but got 78
+offsetTop expected 15 but got 19
 PASS .container 14
 PASS .container 15
 

--- a/LayoutTests/platform/gtk-wk2/imported/w3c/web-platform-tests/css/css-tables/tentative/baseline-table-expected.txt
+++ b/LayoutTests/platform/gtk-wk2/imported/w3c/web-platform-tests/css/css-tables/tentative/baseline-table-expected.txt
@@ -132,7 +132,7 @@ FAIL .container 13 assert_equals:
     </tr>
   </tbody></table><div style="display:inline-block" data-offset-y="15">pX</div>
 </div>
-offsetTop expected 15 but got 76
+offsetTop expected 15 but got 19
 PASS .container 14
 PASS .container 15
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-tables/tentative/baseline-table-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-tables/tentative/baseline-table-expected.txt
@@ -72,7 +72,7 @@ FAIL .container 13 assert_equals:
     </tr>
   </tbody></table><div style="display:inline-block" data-offset-y="15">pX</div>
 </div>
-offsetTop expected 15 but got 78
+offsetTop expected 15 but got 19
 PASS .container 14
 PASS .container 15
 

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -4,7 +4,8 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  *
  * This library is free software; you can redistribute it and/or
@@ -903,7 +904,7 @@ std::optional<LayoutUnit> RenderTableSection::baselineFromCellContentEdges(ItemP
         const CellStruct& cs = row.at(i);
         const RenderTableCell* cell = cs.primaryCell();
         // Only cells with content have a baseline
-        if (cell && cell->contentLogicalHeight()) {
+        if (cell) {
             LayoutUnit candidate = cell->logicalTop() + cell->borderAndPaddingBefore() + cell->contentLogicalHeight();
             result = std::max(result.value_or(candidate), candidate);
         }


### PR DESCRIPTION
#### 48531284f250ed8f8aa3c0799896193e6271daf8
<pre>
Fix table baseline in case of &apos;empty rowspanned cells should not set baseline&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=285231">https://bugs.webkit.org/show_bug.cgi?id=285231</a>
<a href="https://rdar.apple.com/142152802">rdar://142152802</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Blink / Chromium.

Partial Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/9fa80d5986647e8be2f1b19fc5e722cb51da4e27">https://chromium.googlesource.com/chromium/src.git/+/9fa80d5986647e8be2f1b19fc5e722cb51da4e27</a>

This patch fixes case of where empty rowspanned cells should not set baseline in Table Layout.

NOTE: It does not progress tests fully, which seems more likely subpixel or width distribution issue but
as can be seen from pixel difference, the difference is now just 4px (better to see from current) from
expected layout.

* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::baselineFromCellContentEdges const):
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/baseline-table-expected.txt:
* LayoutTests/platform/gtk-wk2/imported/w3c/web-platform-tests/css/css-tables/tentative/baseline-table-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-tables/tentative/baseline-table-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48531284f250ed8f8aa3c0799896193e6271daf8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87645 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33581 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10076 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64310 "Found 8 new test failures: css2.1/20110323/margin-applies-to-014.htm css2.1/20110323/outline-color-applies-to-014.htm css2.1/20110323/table-caption-optional-002.htm fast/css/empty-cell-baseline.html fast/dynamic/insert-before-table-part-in-continuation.html ietestcenter/css3/bordersbackgrounds/border-radius-applies-to-011.htm imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-table-001.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-001.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22076 "Found 1 new test failure: fast/css/empty-cell-baseline.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85581 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1612 "Found 5 new test failures: css2.1/20110323/margin-applies-to-014.htm css2.1/20110323/outline-color-applies-to-014.htm css2.1/20110323/table-caption-optional-002.htm fast/dynamic/insert-before-table-part-in-continuation.html ietestcenter/css3/bordersbackgrounds/border-radius-applies-to-011.htm (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44587 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1508 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-table-001.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-001.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29260 "Found 9 new test failures: css2.1/20110323/margin-applies-to-014.htm css2.1/20110323/outline-color-applies-to-014.htm css2.1/20110323/table-caption-optional-002.htm fast/css/empty-cell-baseline.html fast/dynamic/insert-before-table-part-in-continuation.html ietestcenter/css3/bordersbackgrounds/border-radius-applies-to-011.htm imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-table-001.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-001.html imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32614 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72800 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29906 "Found 8 new test failures: css2.1/20110323/margin-applies-to-014.htm css2.1/20110323/outline-color-applies-to-014.htm css2.1/20110323/table-caption-optional-002.htm fast/css/empty-cell-baseline.html fast/dynamic/insert-before-table-part-in-continuation.html ietestcenter/css3/bordersbackgrounds/border-radius-applies-to-011.htm imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-table-001.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-001.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89008 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9818 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7082 "Found 60 new test failures: css2.1/20110323/margin-applies-to-014.htm css2.1/20110323/outline-color-applies-to-014.htm css2.1/20110323/table-caption-optional-002.htm fast/css/empty-cell-baseline.html fast/dynamic/insert-before-table-part-in-continuation.html fast/text/emoji-gender-7.html fast/writing-mode/english-rl-text-with-spelling-marker.html http/wpt/html/dom/elements/images/bypass-cache-redirection-revalidation.html http/wpt/opener/parent-access-child-via-windowproxy.html ietestcenter/css3/bordersbackgrounds/border-radius-applies-to-011.htm ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72717 "Found 8 new test failures: css2.1/20110323/margin-applies-to-014.htm css2.1/20110323/outline-color-applies-to-014.htm css2.1/20110323/table-caption-optional-002.htm fast/css/empty-cell-baseline.html fast/dynamic/insert-before-table-part-in-continuation.html ietestcenter/css3/bordersbackgrounds/border-radius-applies-to-011.htm imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-table-001.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-001.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10045 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71933 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16072 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15087 "Found 9 new test failures: css2.1/20110323/margin-applies-to-014.htm css2.1/20110323/outline-color-applies-to-014.htm css2.1/20110323/table-caption-optional-002.htm fast/css/empty-cell-baseline.html fast/dynamic/insert-before-table-part-in-continuation.html fast/mediastream/getDisplayMedia-max-constraints5.html ietestcenter/css3/bordersbackgrounds/border-radius-applies-to-011.htm imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-table-001.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-001.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1203 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9771 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15292 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9645 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13111 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11415 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->