### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in PAL

### DIFF
--- a/Source/WebCore/PAL/pal/Gunzip.h
+++ b/Source/WebCore/PAL/pal/Gunzip.h
@@ -32,7 +32,7 @@ namespace PAL {
 
 // This function is only suitable for zip files which are guaranteed to not have any flags set in their headers.
 // See https://tools.ietf.org/html/rfc1952 for more information.
-PAL_EXPORT Vector<LChar> gunzip(const unsigned char* data, size_t length);
+PAL_EXPORT Vector<LChar> gunzip(std::span<const uint8_t> data);
 
 }
 

--- a/Source/WebCore/PAL/pal/avfoundation/OutputContext.mm
+++ b/Source/WebCore/PAL/pal/avfoundation/OutputContext.mm
@@ -32,11 +32,10 @@
 #include <mutex>
 #include <pal/spi/cocoa/AVFoundationSPI.h>
 #include <wtf/NeverDestroyed.h>
-#include <wtf/text/StringBuilder.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringConcatenate.h>
 
 #include <pal/cocoa/AVFoundationSoftLink.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace PAL {
 
@@ -76,18 +75,9 @@ String OutputContext::deviceName()
     if (!supportsMultipleOutputDevices())
         return [m_context deviceName];
 
-    StringBuilder builder;
-    auto devices = outputDevices();
-    auto iterator = devices.begin();
-
-    while (iterator != devices.end()) {
-        builder.append(iterator->name());
-
-        if (++iterator != devices.end())
-            builder.append(" + "_s);
-    }
-
-    return builder.toString();
+    return makeString(interleave(outputDevices(), [](auto& device) {
+        return device.name();
+    }, " + "_s));
 }
 
 Vector<OutputDevice> OutputContext::outputDevices() const
@@ -106,7 +96,5 @@ Vector<OutputDevice> OutputContext::outputDevices() const
 
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
+++ b/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
@@ -33,8 +33,6 @@
 #include <optional>
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace PAL {
 
 struct CryptoDigestContext {
@@ -220,5 +218,3 @@ Vector<uint8_t> CryptoDigest::computeHash()
 }
 
 } // namespace PAL
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/EncodingTables.cpp
+++ b/Source/WebCore/PAL/pal/text/EncodingTables.cpp
@@ -28,11 +28,19 @@
 
 #include "TextCodecICU.h"
 #include <mutex>
+#include <wtf/StdLibExtras.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace PAL {
+
+static void ucnv_toUnicode_span(UConverter* converter, std::span<UChar> target, std::span<const uint8_t> source, int32_t* offsets, UBool flush, UErrorCode& error)
+{
+    auto* targetStart = target.data();
+    auto* targetEnd = std::to_address(target.end());
+    auto* sourceStart = byteCast<char>(source.data());
+    auto* sourceEnd = byteCast<char>(std::to_address(source.end()));
+    ucnv_toUnicode(converter, &targetStart, targetEnd, &sourceStart, sourceEnd, offsets, flush, &error);
+}
 
 #if ASSERT_ENABLED
 // From https://encoding.spec.whatwg.org/index-jis0208.txt
@@ -1073,16 +1081,13 @@ const std::array<std::pair<uint16_t, UChar>, 7724>& jis0208()
         ASSERT(!error);
 
         constexpr size_t range = 94;
-        uint8_t icuInput[2];
+        std::array<uint8_t, 2> icuInput;
         UChar icuOutput;
         for (size_t i = 0; i < range; i++) {
             for (size_t j = 0; j < range; j++) {
                 icuInput[0] = 0xA1 + i;
                 icuInput[1] = 0xA1 + j;
-
-                UChar* output = &icuOutput;
-                const char* input = byteCast<char>(&icuInput[0]);
-                ucnv_toUnicode(icuConverter.get(), &output, output + 1, &input, input + sizeof(icuInput), nullptr, true, &error);
+                ucnv_toUnicode_span(icuConverter.get(), singleElementSpan(icuOutput), std::span { icuInput }, nullptr, true, error);
                 ASSERT(!error);
                 if (icuOutput != 0xFFFD) {
                     uint16_t pointer = i * range + j;
@@ -1878,17 +1883,14 @@ const std::array<std::pair<uint16_t, UChar>, 6067>& jis0212()
         ASSERT(!error);
 
         constexpr size_t range = 94;
-        uint8_t icuInput[3];
+        std::array<uint8_t, 3> icuInput;
         UChar icuOutput;
         for (size_t i = 0; i < range; i++) {
             for (size_t j = 0; j < range; j++) {
                 icuInput[0] = 0x8F;
                 icuInput[1] = 0xA1 + i;
                 icuInput[2] = 0xA1 + j;
-
-                UChar* output = &icuOutput;
-                const char* input = byteCast<char>(&icuInput[0]);
-                ucnv_toUnicode(icuConverter.get(), &output, output + 1, &input, input + sizeof(icuInput), nullptr, true, &error);
+                ucnv_toUnicode_span(icuConverter.get(), singleElementSpan(icuOutput), std::span { icuInput }, nullptr, true, error);
                 ASSERT(!error);
                 if (icuOutput != 0xFFFD) {
                     uint16_t pointer = i * range + j;
@@ -4888,7 +4890,7 @@ const std::array<std::pair<uint16_t, char32_t>, 18590>& big5()
         auto icuConverter = ICUConverterPtr { ucnv_open("Big-5", &error) };
         ASSERT(!error);
 
-        uint8_t icuInput[2];
+        std::array<uint8_t, 2> icuInput;
         UChar icuOutput;
 
         // These are the ranges from https://encoding.spec.whatwg.org/index-big5.txt that have valid pointers.
@@ -4910,9 +4912,7 @@ const std::array<std::pair<uint16_t, char32_t>, 18590>& big5()
                 uint8_t offset = trail < 0x3F ? 0x40 : 0x62;
                 icuInput[0] = lead;
                 icuInput[1] = trail + offset;
-                UChar* output = &icuOutput;
-                const char* input = byteCast<char>(&icuInput[0]);
-                ucnv_toUnicode(icuConverter.get(), &output, output + 1, &input, input + sizeof(icuInput), nullptr, true, &error);
+                ucnv_toUnicode_span(icuConverter.get(), singleElementSpan(icuOutput), std::span { icuInput }, nullptr, true, error);
                 ASSERT(!error);
                 (*array)[arrayIndex++] = { pointer, icuOutput };
             }
@@ -4920,7 +4920,7 @@ const std::array<std::pair<uint16_t, char32_t>, 18590>& big5()
         
         for (auto& pair : big5Extras) {
             auto range = std::equal_range(array->begin(), array->end(), pair, CompareFirst { });
-            ASSERT(range.first + 1 == range.second);
+            ASSERT(range.second - range.first == 1);
             range.first->second = pair.second;
         }
         
@@ -7079,11 +7079,9 @@ const std::array<std::pair<uint16_t, UChar>, 17048>& eucKR()
         ASSERT(U_SUCCESS(error));
         auto getPair = [icuConverter = WTFMove(icuConverter)] (uint16_t pointer) -> std::optional<std::pair<uint16_t, UChar>> {
             std::array<uint8_t, 2> icuInput { static_cast<uint8_t>(pointer / 190u + 0x81), static_cast<uint8_t>(pointer % 190u + 0x41) };
-            const char* input = byteCast<char>(icuInput.data());
-            UChar icuOutput[2];
-            UChar* output = icuOutput;
+            std::array<UChar, 2> icuOutput;
             UErrorCode error = U_ZERO_ERROR;
-            ucnv_toUnicode(icuConverter.get(), &output, output + 2, &input, input + sizeof(icuInput), nullptr, true, &error);
+            ucnv_toUnicode_span(icuConverter.get(), std::span { icuOutput }, std::span { icuInput }, nullptr, true, error);
             if (icuOutput[0] == 0xFFFD)
                 return std::nullopt;
             return { { pointer, icuOutput[0] } };
@@ -8615,15 +8613,14 @@ const std::array<UChar, 23940>& gb18030()
         array = new std::array<UChar, 23940>;
         UErrorCode error = U_ZERO_ERROR;
         auto icuConverter = ICUConverterPtr { ucnv_open("gb18030", &error) };
-        for (size_t pointer = 0; pointer < 23940; pointer++) {
-            uint8_t icuInput[2];
-            icuInput[0] = pointer / 190 + 0x81;
-            icuInput[1] = pointer % 190;
+        for (size_t pointer = 0; pointer < 23940; ++pointer) {
+            std::array icuInput {
+                static_cast<uint8_t>(pointer / 190 + 0x81),
+                static_cast<uint8_t>(pointer % 190)
+            };
             icuInput[1] += (icuInput[1] < 0x3F) ? 0x40 : 0x41;
             UChar icuOutput { 0 };
-            UChar* output = &icuOutput;
-            const char* input = byteCast<char>(&icuInput[0]);
-            ucnv_toUnicode(icuConverter.get(), &output, output + 1, &input, input + sizeof(icuInput), nullptr, true, &error);
+            ucnv_toUnicode_span(icuConverter.get(), singleElementSpan(icuOutput), std::span { icuInput }, nullptr, true, error);
             ASSERT(!error);
             ASSERT(icuOutput != 0xFFFD);
             (*array)[pointer] = icuOutput;
@@ -8688,5 +8685,3 @@ void checkEncodingTableInvariants()
 #endif
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextCodecASCIIFastPath.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecASCIIFastPath.h
@@ -29,8 +29,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/ASCIIFastPath.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace PAL {
 
 template<size_t size> struct UCharByteFiller;
@@ -78,5 +76,3 @@ inline void copyASCIIMachineWord(std::span<UChar> destination, std::span<const u
 }
 
 } // namespace PAL
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -34,8 +34,6 @@
 #include <wtf/text/StringBuilder.h>
 #include <wtf/unicode/CharacterNames.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace PAL {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextCodecCJK);
@@ -677,7 +675,9 @@ static Vector<uint8_t> shiftJISEncode(StringView string, Function<void(char32_t,
             continue;
         }
 
-        ASSERT(range.first + 3 >= range.second);
+        ASSERT(range.second >= range.first);
+        ASSERT(range.second - range.first <= 3);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         for (auto pair = range.first; pair < range.second; pair++) {
             uint16_t pointer = pair->second;
             if (pointer >= 8272 && pointer <= 8835)
@@ -690,6 +690,7 @@ static Vector<uint8_t> shiftJISEncode(StringView string, Function<void(char32_t,
             result.append(trail + offset);
             break;
         }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
     return result;
 }
@@ -782,6 +783,8 @@ static const Big5EncodeIndex& big5EncodeIndex()
     return *table;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 // https://encoding.spec.whatwg.org/#big5-encoder
 static Vector<uint8_t> big5Encode(StringView string, Function<void(char32_t, Vector<uint8_t>&)>&& unencodableHandler)
 {
@@ -822,6 +825,8 @@ static Vector<uint8_t> big5Encode(StringView string, Function<void(char32_t, Vec
     return result;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
 // https://encoding.spec.whatwg.org/index-gb18030-ranges.txt
 static const std::array<std::pair<uint32_t, char32_t>, 207>& gb18030Ranges()
 {
@@ -856,6 +861,8 @@ static const std::array<std::pair<uint32_t, char32_t>, 207>& gb18030Ranges()
     return ranges;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 // https://encoding.spec.whatwg.org/#index-gb18030-ranges-code-point
 static std::optional<char32_t> gb18030RangesCodePoint(uint32_t pointer)
 {
@@ -881,6 +888,8 @@ static uint32_t gb18030RangesPointer(char32_t codePoint)
     char32_t offset = (upperBound - 1)->second;
     return pointerOffset + codePoint - offset;
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 using GB18030EncodeIndex = std::array<std::pair<UChar, uint16_t>, 23940>;
 static const GB18030EncodeIndex& gb18030EncodeIndex()
@@ -1208,5 +1217,3 @@ Vector<uint8_t> TextCodecCJK::encode(StringView string, UnencodableHandling hand
 }
 
 } // namespace PAL
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -39,8 +39,6 @@
 #include <wtf/unicode/CharacterNames.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace PAL {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextCodecICU);
@@ -73,15 +71,14 @@ DECLARE_ALIASES(x_mac_centraleurroman, "windows-10029"_s, "x-mac-ce"_s, "macce"_
 DECLARE_ALIASES(x_mac_turkish, "windows-10081"_s, "mactr"_s, "x-MacTurkish"_s);
 
 #define DECLARE_ENCODING_NAME(encoding, alias_array) \
-    { encoding, std::size(alias_array##_aliases), alias_array##_aliases }
+    { encoding, std::span { alias_array##_aliases } }
 
 #define DECLARE_ENCODING_NAME_NO_ALIASES(encoding) \
-    { encoding, 0, nullptr }
+    { encoding, { } }
 
 static const struct EncodingName {
     ASCIILiteral name;
-    unsigned aliasCount;
-    const ASCIILiteral* aliases;
+    std::span<const ASCIILiteral> aliases;
 } encodingNames[] = {
     DECLARE_ENCODING_NAME("ISO-8859-2"_s, ISO_8859_2),
     DECLARE_ENCODING_NAME("ISO-8859-4"_s, ISO_8859_4),
@@ -110,8 +107,8 @@ void TextCodecICU::registerEncodingNames(EncodingNameRegistrar registrar)
 {
     for (auto& encodingName : encodingNames) {
         registrar(encodingName.name, encodingName.name);
-        for (size_t i = 0; i < encodingName.aliasCount; ++i)
-            registrar(encodingName.aliases[i], encodingName.name);
+        for (auto& alias : encodingName.aliases)
+            registrar(alias, encodingName.name);
     }
 }
 
@@ -176,11 +173,16 @@ void TextCodecICU::createICUConverter() const
         ucnv_setFallback(m_converter.get(), true);
 }
 
-int TextCodecICU::decodeToBuffer(UChar* target, UChar* targetLimit, const char*& source, const char* sourceLimit, int32_t* offsets, bool flush, UErrorCode& error)
+int TextCodecICU::decodeToBuffer(std::span<UChar> targetSpan, std::span<const uint8_t>& sourceSpan, int32_t* offsets, bool flush, UErrorCode& error)
 {
-    UChar* targetStart = target;
+    UChar* targetStart = targetSpan.data();
     error = U_ZERO_ERROR;
+    auto* source = byteCast<char>(sourceSpan.data());
+    auto* sourceLimit = byteCast<char>(std::to_address(sourceSpan.end()));
+    auto* target = targetSpan.data();
+    auto* targetLimit = std::to_address(targetSpan.end());
     ucnv_toUnicode(m_converter.get(), &target, targetLimit, &source, sourceLimit, offsets, flush, &error);
+    sourceSpan = sourceSpan.subspan(byteCast<uint8_t>(source) - sourceSpan.data());
     return target - targetStart;
 }
 
@@ -216,7 +218,7 @@ private:
     UConverterToUCallback m_savedAction { nullptr };
 };
 
-String TextCodecICU::decode(std::span<const uint8_t> bytes, bool flush, bool stopOnError, bool& sawError)
+String TextCodecICU::decode(std::span<const uint8_t> source, bool flush, bool stopOnError, bool& sawError)
 {
     // Get a converter for the passed-in encoding.
     if (!m_converter) {
@@ -232,23 +234,21 @@ String TextCodecICU::decode(std::span<const uint8_t> bytes, bool flush, bool sto
 
     StringBuilder result;
 
-    UChar buffer[ConversionBufferSize];
-    UChar* bufferLimit = buffer + ConversionBufferSize;
-    const char* source = byteCast<char>(bytes.data());
-    const char* sourceLimit = source + bytes.size();
+    std::array<UChar, ConversionBufferSize> buffer;
+    auto target = std::span { buffer };
     int32_t* offsets = nullptr;
     UErrorCode err = U_ZERO_ERROR;
 
     do {
-        size_t ucharsDecoded = decodeToBuffer(buffer, bufferLimit, source, sourceLimit, offsets, flush, err);
-        result.append(std::span { buffer, ucharsDecoded });
+        size_t ucharsDecoded = decodeToBuffer(target, source, offsets, flush, err);
+        result.append(target.first(ucharsDecoded));
     } while (needsToGrowToProduceBuffer(err));
 
     if (U_FAILURE(err)) {
         // flush the converter so it can be reused, and not be bothered by this error.
         do {
-            decodeToBuffer(buffer, bufferLimit, source, sourceLimit, offsets, true, err);
-        } while (source < sourceLimit);
+            decodeToBuffer(target, source, offsets, true, err);
+        } while (!source.empty());
         sawError = true;
     }
 
@@ -308,21 +308,19 @@ Vector<uint8_t> TextCodecICU::encode(StringView string, UnencodableHandling hand
     }
 
     auto upconvertedCharacters = string.upconvertedCharacters();
-    auto* source = upconvertedCharacters.get();
-    auto* sourceLimit = source + string.length();
+    auto source = upconvertedCharacters.span().data();
+    auto* sourceLimit = std::to_address(upconvertedCharacters.span().end());
 
     Vector<uint8_t> result;
     do {
-        char buffer[ConversionBufferSize];
-        char* target = buffer;
-        char* targetLimit = target + ConversionBufferSize;
+        std::array<char, ConversionBufferSize> buffer;
+        char* target = buffer.data();
+        char* targetLimit = std::to_address(std::span { buffer }.end());
         error = U_ZERO_ERROR;
         ucnv_fromUnicode(m_converter.get(), &target, targetLimit, &source, sourceLimit, 0, true, &error);
-        result.append(std::span(byteCast<uint8_t>(&buffer[0]), target - buffer));
+        result.append(byteCast<uint8_t>(std::span(buffer)).first(target - buffer.data()));
     } while (needsToGrowToProduceBuffer(error));
     return result;
 }
 
 } // namespace PAL
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.h
@@ -52,7 +52,7 @@ private:
     void createICUConverter() const;
     void releaseICUConverter() const;
 
-    int decodeToBuffer(UChar* buffer, UChar* bufferLimit, const char*& source, const char* sourceLimit, int32_t* offsets, bool flush, UErrorCode&);
+    int decodeToBuffer(std::span<UChar> buffer, std::span<const uint8_t>& source, int32_t* offsets, bool flush, UErrorCode&);
 
     ASCIILiteral m_encodingName;
     ASCIILiteral const m_canonicalConverterName;

--- a/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
@@ -235,18 +235,16 @@ static Vector<uint8_t> encodeComplexWindowsLatin1(StringView string, Unencodable
     return result;
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 Vector<uint8_t> TextCodecLatin1::encode(StringView string, UnencodableHandling handling) const
 {
     {
         Vector<uint8_t> result(string.length());
-        auto* bytes = result.data();
+        size_t index = 0;
 
         // Convert and simultaneously do a check to see if it's all ASCII.
         UChar ored = 0;
         for (auto character : string.codeUnits()) {
-            *bytes++ = character;
+            result[index++] = character;
             ored |= character;
         }
 
@@ -257,7 +255,5 @@ Vector<uint8_t> TextCodecLatin1::encode(StringView string, UnencodableHandling h
     // If it wasn't all ASCII, call the function that handles more-complex cases.
     return encodeComplexWindowsLatin1(string, handling);
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace PAL

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF16.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF16.cpp
@@ -32,8 +32,6 @@
 #include <wtf/text/WTFString.h>
 #include <wtf/unicode/CharacterNames.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace PAL {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextCodecUTF16);
@@ -67,6 +65,8 @@ void TextCodecUTF16::registerCodecs(TextCodecRegistrar registrar)
         return makeUnique<TextCodecUTF16>(false);
     });
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 // https://encoding.spec.whatwg.org/#shared-utf-16-decoder
 String TextCodecUTF16::decode(std::span<const uint8_t> bytes, bool flush, bool, bool& sawError)
@@ -149,20 +149,22 @@ String TextCodecUTF16::decode(std::span<const uint8_t> bytes, bool flush, bool, 
     return result.toString();
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
 Vector<uint8_t> TextCodecUTF16::encode(StringView string, UnencodableHandling) const
 {
     Vector<uint8_t> result(WTF::checkedProduct<size_t>(string.length(), 2));
-    auto* bytes = result.data();
+    size_t index = 0;
 
     if (m_littleEndian) {
         for (auto character : string.codeUnits()) {
-            *bytes++ = character;
-            *bytes++ = character >> 8;
+            result[index++] = character;
+            result[index++] = character >> 8;
         }
     } else {
         for (auto character : string.codeUnits()) {
-            *bytes++ = character >> 8;
-            *bytes++ = character;
+            result[index++] = character >> 8;
+            result[index++] = character;
         }
     }
 
@@ -170,5 +172,3 @@ Vector<uint8_t> TextCodecUTF16::encode(StringView string, UnencodableHandling) c
 }
 
 } // namespace PAL
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp
@@ -75,18 +75,16 @@ static Vector<uint8_t> encodeComplexUserDefined(StringView string, UnencodableHa
     return result;
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 Vector<uint8_t> TextCodecUserDefined::encode(StringView string, UnencodableHandling handling) const
 {
     {
         Vector<uint8_t> result(string.length());
-        auto* bytes = result.data();
+        size_t index = 0;
 
         // Convert and simultaneously do a check to see if it's all ASCII.
         UChar ored = 0;
         for (auto character : string.codeUnits()) {
-            *bytes++ = character;
+            result[index++] = character;
             ored |= character;
         }
 
@@ -97,7 +95,5 @@ Vector<uint8_t> TextCodecUserDefined::encode(StringView string, UnencodableHandl
     // If it wasn't all ASCII, call the function that handles more-complex cases.
     return encodeComplexUserDefined(string, handling);
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace PAL


### PR DESCRIPTION
#### 76e39111b6161c3afc4f0cbbd1d722e11bb1b919
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in PAL
<a href="https://bugs.webkit.org/show_bug.cgi?id=285236">https://bugs.webkit.org/show_bug.cgi?id=285236</a>

Reviewed by Darin Adler.

* Source/WebCore/PAL/pal/Gunzip.h:
* Source/WebCore/PAL/pal/avfoundation/OutputContext.mm:
(PAL::OutputContext::deviceName):
* Source/WebCore/PAL/pal/cocoa/Gunzip.cpp:
(PAL::gunzip):
* Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp:
* Source/WebCore/PAL/pal/text/EncodingTables.cpp:
(PAL::jis0208):
(PAL::jis0212):
(PAL::big5):
(PAL::eucKR):
(PAL::gb18030):
* Source/WebCore/PAL/pal/text/TextCodecASCIIFastPath.h:
* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
(PAL::shiftJISEncode):
* Source/WebCore/PAL/pal/text/TextCodecICU.cpp:
(PAL::TextCodecICU::registerEncodingNames):
(PAL::TextCodecICU::decode):
(PAL::TextCodecICU::encode const):
* Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp:
(PAL::tableForEncoding):
* Source/WebCore/PAL/pal/text/TextCodecUTF16.cpp:
(PAL::TextCodecUTF16::decode):
(PAL::TextCodecUTF16::encode const):
* Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp:
(PAL::nonASCIISequenceLength):
(PAL::TextCodecUTF8::decode):
(PAL::TextCodecUTF8::encodeUTF8):
* Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp:
(PAL::TextCodecUserDefined::encode const):

Canonical link: <a href="https://commits.webkit.org/288345@main">https://commits.webkit.org/288345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f6bd2e128c0c31e28ce13af3bcf303c1b869a61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82673 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87793 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33731 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84767 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64420 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22191 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85730 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1747 "Found 1 new test failure: fast/loader/redirect-to-invalid-url-using-meta-refresh-calls-policy-delegate.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75203 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44695 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1642 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29389 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32765 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72918 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89159 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9966 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7218 "Found 2 new test failures: http/tests/websocket/tests/hybi/websocket-constructor-protocols.html imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-peerconnection.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72835 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10194 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71012 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72049 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16200 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1355 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12812 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9919 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15440 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9793 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13258 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->