### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/graphics

### DIFF
--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -530,10 +530,10 @@ FloatSize BifurcatedGraphicsContext::drawText(const FontCascade& cascade, const 
     return size;
 }
 
-void BifurcatedGraphicsContext::drawGlyphs(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned numGlyphs, const FloatPoint& point, FontSmoothingMode fontSmoothingMode)
+void BifurcatedGraphicsContext::drawGlyphs(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& point, FontSmoothingMode fontSmoothingMode)
 {
-    m_primaryContext.drawGlyphs(font, glyphs, advances, numGlyphs, point, fontSmoothingMode);
-    m_secondaryContext.drawGlyphs(font, glyphs, advances, numGlyphs, point, fontSmoothingMode);
+    m_primaryContext.drawGlyphs(font, glyphs, advances, point, fontSmoothingMode);
+    m_secondaryContext.drawGlyphs(font, glyphs, advances, point, fontSmoothingMode);
 
     VERIFY_STATE_SYNCHRONIZATION();
 }

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -132,7 +132,7 @@ public:
     void drawFocusRing(const Vector<FloatRect>&, float outlineOffset, float outlineWidth, const Color&) final;
 
     FloatSize drawText(const FontCascade&, const TextRun&, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt) final;
-    void drawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned numGlyphs, const FloatPoint&, FontSmoothingMode) final;
+    void drawGlyphs(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint&, FontSmoothingMode) final;
     void drawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) final;
     void drawEmphasisMarks(const FontCascade&, const TextRun&, const AtomString& mark, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt) final;
     void drawBidiText(const FontCascade&, const TextRun&, const FloatPoint&, FontCascade::CustomFontNotReadyAction = FontCascade::CustomFontNotReadyAction::DoNotPaintIfFontNotReady) final;

--- a/Source/WebCore/platform/graphics/ColorConversion.cpp
+++ b/Source/WebCore/platform/graphics/ColorConversion.cpp
@@ -32,8 +32,6 @@
 #include "DestinationColorSpace.h"
 #include <wtf/MathExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 // MARK: Lab-Like to LCH-Like conversion utilities.
@@ -386,5 +384,3 @@ ColorComponents<float, 4> convertAndResolveColorComponents(ColorSpace inputColor
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/ColorConversion.h
+++ b/Source/WebCore/platform/graphics/ColorConversion.h
@@ -28,8 +28,6 @@
 #include "ColorTypes.h"
 #include <wtf/MathExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 class DestinationColorSpace;
@@ -134,8 +132,8 @@ template<typename Output, typename Input> Output convertColorCarryingForwardMiss
 
 // MARK: White Point.
 
-constexpr float D50WhitePoint[] = { 0.3457 / 0.3585, 1.0, (1.0 - 0.3457 - 0.3585) / 0.3585 };
-constexpr float D65WhitePoint[] = { 0.3127 / 0.3290, 1.0, (1.0 - 0.3127 - 0.3290) / 0.3290 };
+constexpr std::array<float, 3> D50WhitePoint { 0.3457 / 0.3585, 1.0, (1.0 - 0.3457 - 0.3585) / 0.3585 };
+constexpr std::array<float, 3> D65WhitePoint { 0.3127 / 0.3290, 1.0, (1.0 - 0.3127 - 0.3290) / 0.3290 };
 
 // MARK: Chromatic Adaptation conversions.
 
@@ -554,5 +552,3 @@ private:
 };
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/ComplexTextController.h
+++ b/Source/WebCore/platform/graphics/ComplexTextController.h
@@ -42,8 +42,6 @@ typedef const struct __CTLine * CTLineRef;
 
 typedef struct hb_buffer_t hb_buffer_t;
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 class CachedTextBreakIterator;
 }
@@ -83,32 +81,31 @@ public:
 
     class ComplexTextRun : public RefCounted<ComplexTextRun> {
     public:
-        static Ref<ComplexTextRun> create(CTRunRef ctRun, const Font& font, const UChar* characters, unsigned stringLocation, unsigned stringLength, unsigned indexBegin, unsigned indexEnd)
+        static Ref<ComplexTextRun> create(CTRunRef ctRun, const Font& font, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd)
         {
-            return adoptRef(*new ComplexTextRun(ctRun, font, characters, stringLocation, stringLength, indexBegin, indexEnd));
+            return adoptRef(*new ComplexTextRun(ctRun, font, characters, stringLocation, indexBegin, indexEnd));
         }
 
-        static Ref<ComplexTextRun> create(hb_buffer_t* buffer, const Font& font, const UChar* characters, unsigned stringLocation, unsigned stringLength, unsigned indexBegin, unsigned indexEnd)
+        static Ref<ComplexTextRun> create(hb_buffer_t* buffer, const Font& font, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd)
         {
-            return adoptRef(*new ComplexTextRun(buffer, font, characters, stringLocation, stringLength, indexBegin, indexEnd));
+            return adoptRef(*new ComplexTextRun(buffer, font, characters, stringLocation, indexBegin, indexEnd));
         }
 
-        static Ref<ComplexTextRun> create(const Font& font, const UChar* characters, unsigned stringLocation, unsigned stringLength, unsigned indexBegin, unsigned indexEnd, bool ltr)
+        static Ref<ComplexTextRun> create(const Font& font, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd, bool ltr)
         {
-            return adoptRef(*new ComplexTextRun(font, characters, stringLocation, stringLength, indexBegin, indexEnd, ltr));
+            return adoptRef(*new ComplexTextRun(font, characters, stringLocation, indexBegin, indexEnd, ltr));
         }
 
-        static Ref<ComplexTextRun> create(const Vector<FloatSize>& advances, const Vector<FloatPoint>& origins, const Vector<Glyph>& glyphs, const Vector<unsigned>& stringIndices, FloatSize initialAdvance, const Font& font, const UChar* characters, unsigned stringLocation, unsigned stringLength, unsigned indexBegin, unsigned indexEnd, bool ltr)
+        static Ref<ComplexTextRun> create(const Vector<FloatSize>& advances, const Vector<FloatPoint>& origins, const Vector<Glyph>& glyphs, const Vector<unsigned>& stringIndices, FloatSize initialAdvance, const Font& font, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd, bool ltr)
         {
-            return adoptRef(*new ComplexTextRun(advances, origins, glyphs, stringIndices, initialAdvance, font, characters, stringLocation, stringLength, indexBegin, indexEnd, ltr));
+            return adoptRef(*new ComplexTextRun(advances, origins, glyphs, stringIndices, initialAdvance, font, characters, stringLocation, indexBegin, indexEnd, ltr));
         }
 
         unsigned glyphCount() const { return m_glyphCount; }
         const Font& font() const { return m_font; }
-        const UChar* characters() const { return m_characters; }
-        std::span<const UChar> span() const { return { m_characters, stringLength() }; }
+        std::span<const UChar> characters() const { return m_characters; }
         unsigned stringLocation() const { return m_stringLocation; }
-        unsigned stringLength() const { return m_stringLength; }
+        size_t stringLength() const { return m_characters.size(); }
         ALWAYS_INLINE unsigned indexAt(unsigned) const;
         unsigned indexBegin() const { return m_indexBegin; }
         unsigned indexEnd() const { return m_indexEnd; }
@@ -125,10 +122,10 @@ public:
         float textAutospaceSize() const { return m_textAutospaceSize; }
 
     private:
-        ComplexTextRun(CTRunRef, const Font&, const UChar* characters, unsigned stringLocation, unsigned stringLength, unsigned indexBegin, unsigned indexEnd);
-        ComplexTextRun(hb_buffer_t*, const Font&, const UChar* characters, unsigned stringLocation, unsigned stringLength, unsigned indexBegin, unsigned indexEnd);
-        ComplexTextRun(const Font&, const UChar* characters, unsigned stringLocation, unsigned stringLength, unsigned indexBegin, unsigned indexEnd, bool ltr);
-        WEBCORE_EXPORT ComplexTextRun(const Vector<FloatSize>& advances, const Vector<FloatPoint>& origins, const Vector<Glyph>& glyphs, const Vector<unsigned>& stringIndices, FloatSize initialAdvance, const Font&, const UChar* characters, unsigned stringLocation, unsigned stringLength, unsigned indexBegin, unsigned indexEnd, bool ltr);
+        ComplexTextRun(CTRunRef, const Font&, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd);
+        ComplexTextRun(hb_buffer_t*, const Font&, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd);
+        ComplexTextRun(const Font&, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd, bool ltr);
+        WEBCORE_EXPORT ComplexTextRun(const Vector<FloatSize>& advances, const Vector<FloatPoint>& origins, const Vector<Glyph>& glyphs, const Vector<unsigned>& stringIndices, FloatSize initialAdvance, const Font&, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd, bool ltr);
 
         using BaseAdvancesVector = Vector<FloatSize, 64>;
         using GlyphVector = Vector<CGGlyph, 64>;
@@ -141,8 +138,7 @@ public:
         CoreTextIndicesVector m_coreTextIndices;
         FloatSize m_initialAdvance;
         const Font& m_font;
-        const UChar* m_characters;
-        unsigned m_stringLength;
+        std::span<const UChar> m_characters;
         unsigned m_indexBegin;
         unsigned m_indexEnd;
         unsigned m_glyphCount;
@@ -228,5 +224,3 @@ private:
 };
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/DecomposedGlyphs.cpp
+++ b/Source/WebCore/platform/graphics/DecomposedGlyphs.cpp
@@ -28,15 +28,13 @@
 
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DecomposedGlyphs);
 
-Ref<DecomposedGlyphs> DecomposedGlyphs::create(const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode mode, RenderingResourceIdentifier renderingResourceIdentifier)
+Ref<DecomposedGlyphs> DecomposedGlyphs::create(std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& localAnchor, FontSmoothingMode mode, RenderingResourceIdentifier renderingResourceIdentifier)
 {
-    return adoptRef(*new DecomposedGlyphs({ Vector(std::span { glyphs, count }), Vector(std::span { advances, count }), localAnchor, mode }, renderingResourceIdentifier));
+    return adoptRef(*new DecomposedGlyphs({ Vector(glyphs), Vector(advances), localAnchor, mode }, renderingResourceIdentifier));
 }
 
 Ref<DecomposedGlyphs> DecomposedGlyphs::create(PositionedGlyphs&& positionedGlyphs, RenderingResourceIdentifier renderingResourceIdentifier)
@@ -52,5 +50,3 @@ DecomposedGlyphs::DecomposedGlyphs(PositionedGlyphs&& positionedGlyphs, Renderin
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/DecomposedGlyphs.h
+++ b/Source/WebCore/platform/graphics/DecomposedGlyphs.h
@@ -34,7 +34,7 @@ namespace WebCore {
 class DecomposedGlyphs final : public RenderingResource {
     WTF_MAKE_TZONE_ALLOCATED(DecomposedGlyphs);
 public:
-    static WEBCORE_EXPORT Ref<DecomposedGlyphs> create(const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
+    static WEBCORE_EXPORT Ref<DecomposedGlyphs> create(std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& localAnchor, FontSmoothingMode, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
     static WEBCORE_EXPORT Ref<DecomposedGlyphs> create(PositionedGlyphs&&, RenderingResourceIdentifier);
 
     const PositionedGlyphs& positionedGlyphs() const { return m_positionedGlyphs; }

--- a/Source/WebCore/platform/graphics/DrawGlyphsRecorder.h
+++ b/Source/WebCore/platform/graphics/DrawGlyphsRecorder.h
@@ -55,14 +55,14 @@ public:
     enum class DeriveFontFromContext : bool { No, Yes };
     explicit DrawGlyphsRecorder(GraphicsContext&, float scaleFactor = 1, DeriveFontFromContext = DeriveFontFromContext::No);
 
-    void drawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned numGlyphs, const FloatPoint& anchorPoint, FontSmoothingMode);
+    void drawGlyphs(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& anchorPoint, FontSmoothingMode);
 
 #if USE(CORE_TEXT)
     void drawNativeText(CTFontRef, CGFloat fontSize, CTLineRef, CGRect lineRect);
 
     void recordBeginLayer(CGRenderingStateRef, CGGStateRef, CGRect);
     void recordEndLayer(CGRenderingStateRef, CGGStateRef);
-    void recordDrawGlyphs(CGRenderingStateRef, CGGStateRef, const CGAffineTransform*, const CGGlyph[], const CGPoint positions[], size_t count);
+    void recordDrawGlyphs(CGRenderingStateRef, CGGStateRef, const CGAffineTransform*, std::span<const CGGlyph>, std::span<const CGPoint> positions);
     void recordDrawImage(CGRenderingStateRef, CGGStateRef, CGRect, CGImageRef);
     void recordDrawPath(CGRenderingStateRef, CGGStateRef, CGPathDrawingMode, CGPathRef);
 #endif
@@ -72,9 +72,9 @@ private:
     UniqueRef<GraphicsContext> createInternalContext();
 #endif
 
-    void drawBySplittingIntoOTSVGAndNonOTSVGRuns(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned numGlyphs, const FloatPoint& anchorPoint, FontSmoothingMode);
-    void drawOTSVGRun(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned numGlyphs, const FloatPoint& anchorPoint, FontSmoothingMode);
-    void drawNonOTSVGRun(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned numGlyphs, const FloatPoint& anchorPoint, FontSmoothingMode);
+    void drawBySplittingIntoOTSVGAndNonOTSVGRuns(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& anchorPoint, FontSmoothingMode);
+    void drawOTSVGRun(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& anchorPoint, FontSmoothingMode);
+    void drawNonOTSVGRun(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& anchorPoint, FontSmoothingMode);
 
     void populateInternalState(const GraphicsContextState&);
     void populateInternalContext(const GraphicsContextState&);

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -50,8 +50,6 @@
 #include "OpenTypeVerticalData.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 unsigned GlyphPage::s_count = 0;
@@ -289,7 +287,7 @@ static std::optional<size_t> codePointSupportIndex(char32_t codePoint)
     }
 
 #ifndef NDEBUG
-    char32_t codePointOrder[] = {
+    auto codePointOrder = std::to_array<char32_t>({
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
         0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
         0x7F,
@@ -315,7 +313,7 @@ static std::optional<size_t> codePointSupportIndex(char32_t codePoint)
         firstStrongIsolate,
         objectReplacementCharacter,
         zeroWidthNoBreakSpace
-    };
+    });
     bool found = false;
     for (size_t i = 0; i < std::size(codePointOrder); ++i) {
         if (codePointOrder[i] == codePoint) {
@@ -688,5 +686,3 @@ TextStream& operator<<(TextStream& ts, const Font& font)
 #endif
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -232,9 +232,9 @@ public:
     GlyphBufferAdvance applyTransforms(GlyphBuffer&, unsigned beginningGlyphIndex, unsigned beginningStringIndex, bool enableKerning, bool requiresShaping, const AtomString& locale, StringView text, TextDirection) const;
 
     // Returns nullopt if none of the glyphs are OT-SVG glyphs.
-    std::optional<BitVector> findOTSVGGlyphs(const GlyphBufferGlyph*, unsigned count) const;
+    std::optional<BitVector> findOTSVGGlyphs(std::span<const GlyphBufferGlyph>) const;
 
-    bool hasAnyComplexColorFormatGlyphs(const GlyphBufferGlyph*, unsigned count) const;
+    bool hasAnyComplexColorFormatGlyphs(std::span<const GlyphBufferGlyph>) const;
 
 #if PLATFORM(WIN)
     SCRIPT_CACHE* scriptCache() const { return &m_scriptCache; }

--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -56,8 +56,6 @@
 #include <dwrite.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FontCache);
@@ -468,7 +466,7 @@ bool FontCache::useBackslashAsYenSignForFamily(const AtomString& family)
     if (m_familiesUsingBackslashAsYenSign.isEmpty()) {
         auto add = [&] (ASCIILiteral name, std::initializer_list<UChar> unicodeName) {
             m_familiesUsingBackslashAsYenSign.add(AtomString { name });
-            m_familiesUsingBackslashAsYenSign.add(AtomString({ unicodeName.begin(), unicodeName.size() }));
+            m_familiesUsingBackslashAsYenSign.add(AtomString(std::span { unicodeName }));
         };
         add("MS PGothic"_s, { 0xFF2D, 0xFF33, 0x0020, 0xFF30, 0x30B4, 0x30B7, 0x30C3, 0x30AF });
         add("MS PMincho"_s, { 0xFF2D, 0xFF33, 0x0020, 0xFF30, 0x660E, 0x671D });
@@ -506,5 +504,3 @@ void FontCache::platformReleaseNoncriticalMemory()
 #endif
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -141,7 +141,7 @@ public:
 
     enum class CustomFontNotReadyAction : bool { DoNotPaintIfFontNotReady, UseFallbackIfFontNotReady };
     WEBCORE_EXPORT FloatSize drawText(GraphicsContext&, const TextRun&, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt, CustomFontNotReadyAction = CustomFontNotReadyAction::DoNotPaintIfFontNotReady) const;
-    static void drawGlyphs(GraphicsContext&, const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned numGlyphs, const FloatPoint&, FontSmoothingMode);
+    static void drawGlyphs(GraphicsContext&, const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint&, FontSmoothingMode);
     void drawEmphasisMarks(GraphicsContext&, const TextRun&, const AtomString& mark, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt) const;
 
     DashArray dashesForIntersectionsWithRect(const TextRun&, const FloatPoint& textOrigin, const FloatRect& lineExtents) const;

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -35,8 +35,6 @@
 #include "GlyphPage.h"
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 class MixedFontGlyphPage {
@@ -53,7 +51,6 @@ public:
     GlyphData glyphDataForCharacter(char32_t c) const
     {
         unsigned index = GlyphPage::indexForCodePoint(c);
-        ASSERT_WITH_SECURITY_IMPLICATION(index < GlyphPage::size);
         return { m_glyphs[index], m_fonts[index].get() };
     }
 
@@ -65,13 +62,12 @@ public:
 private:
     void setGlyphDataForIndex(unsigned index, const GlyphData& glyphData)
     {
-        ASSERT_WITH_SECURITY_IMPLICATION(index < GlyphPage::size);
         m_glyphs[index] = glyphData.glyph;
         m_fonts[index] = glyphData.font.get();
     }
 
-    Glyph m_glyphs[GlyphPage::size] { };
-    SingleThreadWeakPtr<const Font> m_fonts[GlyphPage::size] { };
+    std::array<Glyph, GlyphPage::size> m_glyphs = { };
+    std::array<SingleThreadWeakPtr<const Font>, GlyphPage::size> m_fonts = { };
 };
 
 inline FontCascadeFonts::GlyphPageCacheEntry::GlyphPageCacheEntry(RefPtr<GlyphPage>&& singleFont)
@@ -579,5 +575,3 @@ TextStream& operator<<(TextStream& ts, const FontCascadeFonts& fontCascadeFonts)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -60,27 +60,28 @@ public:
         m_offsetsInString.clear();
     }
 
-    const Font** fonts(unsigned from) { return m_fonts.data() + from; }
-    GlyphBufferGlyph* glyphs(unsigned from) { return m_glyphs.data() + from; }
-    GlyphBufferAdvance* advances(unsigned from) { return m_advances.data() + from; }
-    GlyphBufferOrigin* origins(unsigned from) { return m_origins.data() + from; }
-    GlyphBufferStringOffset* offsetsInString(unsigned from) { return m_offsetsInString.data() + from; }
-    const Font* const * fonts(unsigned from) const { return m_fonts.data() + from; }
-    const GlyphBufferGlyph* glyphs(unsigned from) const { return m_glyphs.data() + from; }
-    const GlyphBufferAdvance* advances(unsigned from) const { return m_advances.data() + from; }
-    const GlyphBufferOrigin* origins(unsigned from) const { return m_origins.data() + from; }
-    const GlyphBufferStringOffset* offsetsInString(unsigned from) const { return m_offsetsInString.data() + from; }
+    std::span<const Font*> fonts(size_t from = 0, size_t count = std::dynamic_extent) { return m_fonts.mutableSpan().subspan(from, count); }
+    std::span<GlyphBufferGlyph> glyphs(size_t from = 0, size_t count = std::dynamic_extent) { return m_glyphs.mutableSpan().subspan(from, count); }
+    std::span<GlyphBufferAdvance> advances(size_t from = 0, size_t count = std::dynamic_extent) { return m_advances.mutableSpan().subspan(from, count); }
+    std::span<GlyphBufferOrigin> origins(size_t from = 0, size_t count = std::dynamic_extent) { return m_origins.mutableSpan().subspan(from, count); }
+    std::span<GlyphBufferStringOffset> offsetsInString(size_t from = 0, size_t count = std::dynamic_extent) { return m_offsetsInString.mutableSpan().subspan(from, count); }
+    std::span<const Font* const> fonts(size_t from = 0, size_t count = std::dynamic_extent) const { return m_fonts.subspan(from, count); }
+    std::span<const GlyphBufferGlyph> glyphs(size_t from = 0, size_t count = std::dynamic_extent) const { return m_glyphs.subspan(from, count); }
+    std::span<const GlyphBufferAdvance> advances(size_t from = 0, size_t count = std::dynamic_extent) const { return m_advances.subspan(from, count); }
+    std::span<const GlyphBufferOrigin> origins(size_t from = 0, size_t count = std::dynamic_extent) const { return m_origins.subspan(from, count); }
+    std::span<const GlyphBufferStringOffset> offsetsInString(size_t from = 0, size_t count = std::dynamic_extent) const { return m_offsetsInString.subspan(from, count); }
 
-    const Font& fontAt(unsigned index) const
+    const Font& fontAt(size_t index) const
     {
         ASSERT(m_fonts[index]);
         return *m_fonts[index];
     }
-    GlyphBufferGlyph glyphAt(unsigned index) const { return m_glyphs[index]; }
-    GlyphBufferAdvance advanceAt(unsigned index) const { return m_advances[index]; }
-    GlyphBufferOrigin originAt(unsigned index) const { return m_origins[index]; }
-    GlyphBufferStringOffset uncheckedStringOffsetAt(unsigned index) const { return m_offsetsInString[index]; }
-    std::optional<GlyphBufferStringOffset> checkedStringOffsetAt(unsigned index, unsigned stringLength) const
+    GlyphBufferGlyph glyphAt(size_t index) const { return m_glyphs[index]; }
+    GlyphBufferAdvance& advanceAt(size_t index) { return m_advances[index]; }
+    GlyphBufferAdvance advanceAt(size_t index) const { return m_advances[index]; }
+    GlyphBufferOrigin originAt(size_t index) const { return m_origins[index]; }
+    GlyphBufferStringOffset uncheckedStringOffsetAt(size_t index) const { return m_offsetsInString[index]; }
+    std::optional<GlyphBufferStringOffset> checkedStringOffsetAt(size_t index, unsigned stringLength) const
     {
         auto result = uncheckedStringOffsetAt(index);
         if (static_cast<std::make_unsigned_t<GlyphBufferStringOffset>>(result) >= stringLength)

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -168,15 +168,15 @@ FloatSize GraphicsContext::drawText(const FontCascade& font, const TextRun& run,
     return font.drawText(*this, run, point, from, to);
 }
 
-void GraphicsContext::drawGlyphs(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned numGlyphs, const FloatPoint& point, FontSmoothingMode fontSmoothingMode)
+void GraphicsContext::drawGlyphs(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& point, FontSmoothingMode fontSmoothingMode)
 {
-    FontCascade::drawGlyphs(*this, font, glyphs, advances, numGlyphs, point, fontSmoothingMode);
+    FontCascade::drawGlyphs(*this, font, glyphs, advances, point, fontSmoothingMode);
 }
 
 void GraphicsContext::drawDecomposedGlyphs(const Font& font, const DecomposedGlyphs& decomposedGlyphs)
 {
     auto positionedGlyphs = decomposedGlyphs.positionedGlyphs();
-    FontCascade::drawGlyphs(*this, font, positionedGlyphs.glyphs.data(), positionedGlyphs.advances.data(), positionedGlyphs.glyphs.size(), positionedGlyphs.localAnchor, positionedGlyphs.smoothingMode);
+    FontCascade::drawGlyphs(*this, font, positionedGlyphs.glyphs.span(), positionedGlyphs.advances.span(), positionedGlyphs.localAnchor, positionedGlyphs.smoothingMode);
 }
 
 void GraphicsContext::drawEmphasisMarks(const FontCascade& font, const TextRun& run, const AtomString& mark, const FloatPoint& point, unsigned from, std::optional<unsigned> to)

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -304,12 +304,12 @@ public:
     WEBCORE_EXPORT virtual void drawEmphasisMarks(const FontCascade&, const TextRun&, const AtomString& mark, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt);
     WEBCORE_EXPORT virtual void drawBidiText(const FontCascade&, const TextRun&, const FloatPoint&, FontCascade::CustomFontNotReadyAction = FontCascade::CustomFontNotReadyAction::DoNotPaintIfFontNotReady);
 
-    virtual void drawGlyphsAndCacheResources(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned numGlyphs, const FloatPoint& point, FontSmoothingMode fontSmoothingMode)
+    virtual void drawGlyphsAndCacheResources(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& point, FontSmoothingMode fontSmoothingMode)
     {
-        drawGlyphs(font, glyphs, advances, numGlyphs, point, fontSmoothingMode);
+        drawGlyphs(font, glyphs, advances, point, fontSmoothingMode);
     }
 
-    WEBCORE_EXPORT virtual void drawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned numGlyphs, const FloatPoint&, FontSmoothingMode);
+    WEBCORE_EXPORT virtual void drawGlyphs(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint&, FontSmoothingMode);
     WEBCORE_EXPORT virtual void drawDecomposedGlyphs(const Font&, const DecomposedGlyphs&);
 
     WEBCORE_EXPORT FloatRect computeUnderlineBoundsForText(const FloatRect&, bool printing);

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -110,7 +110,7 @@ private:
 
     FloatSize drawText(const FontCascade&, const TextRun&, const FloatPoint&, unsigned = 0, std::optional<unsigned> = std::nullopt) final { return { }; }
 
-    void drawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned, const FloatPoint&, FontSmoothingMode) final { }
+    void drawGlyphs(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint&, FontSmoothingMode) final { }
     void drawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) final { }
 
     void drawEmphasisMarks(const FontCascade&, const TextRun&, const AtomString&, const FloatPoint&, unsigned = 0, std::optional<unsigned> = std::nullopt) final { }

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -88,7 +88,7 @@ inline auto WidthIterator::applyFontTransforms(GlyphBuffer& glyphBuffer, unsigne
     if (lastGlyphCount >= glyphBufferSize)
         return { 0, makeGlyphBufferAdvance() };
 
-    GlyphBufferAdvance* advances = glyphBuffer.advances(0);
+    auto advances = glyphBuffer.advances();
     float beforeWidth = 0;
     for (unsigned i = lastGlyphCount; i < glyphBufferSize; ++i)
         beforeWidth += width(advances[i]);
@@ -96,9 +96,9 @@ inline auto WidthIterator::applyFontTransforms(GlyphBuffer& glyphBuffer, unsigne
     auto initialAdvance = font.applyTransforms(glyphBuffer, lastGlyphCount, m_currentCharacterIndex, m_enableKerning, m_requiresShaping, m_font->fontDescription().computedLocale(), m_run->text(), direction());
 
     glyphBufferSize = glyphBuffer.size();
-    advances = glyphBuffer.advances(0);
+    advances = glyphBuffer.advances();
 
-    GlyphBufferOrigin* origins = glyphBuffer.origins(0);
+    auto origins = glyphBuffer.origins();
     for (unsigned i = lastGlyphCount; i < glyphBufferSize; ++i) {
         setHeight(advances[i], -height(advances[i]));
         setY(origins[i], -y(origins[i]));
@@ -112,7 +112,7 @@ inline auto WidthIterator::applyFontTransforms(GlyphBuffer& glyphBuffer, unsigne
         if (iterator == charactersTreatedAsSpace.end() || iterator->stringOffset != characterIndex)
             continue;
         const auto& originalAdvances = *iterator;
-        setWidth(*glyphBuffer.advances(i), originalAdvances.advance);
+        setWidth(glyphBuffer.advanceAt(i), originalAdvances.advance);
     }
     charactersTreatedAsSpace.clear();
 
@@ -168,7 +168,7 @@ void WidthIterator::applyInitialAdvance(GlyphBuffer& glyphBuffer, GlyphBufferAdv
     ASSERT(lastGlyphCount || (!width(m_leftoverInitialAdvance) && !height(m_leftoverInitialAdvance)));
 
     if (rtl() && lastGlyphCount) {
-        auto& visuallyLastAdvance = *glyphBuffer.advances(lastGlyphCount);
+        auto& visuallyLastAdvance = glyphBuffer.advanceAt(lastGlyphCount);
         expandWithInitialAdvance(visuallyLastAdvance, m_leftoverInitialAdvance);
         m_runWidthSoFar += width(m_leftoverInitialAdvance);
         m_leftoverInitialAdvance = makeGlyphBufferAdvance();
@@ -178,7 +178,7 @@ void WidthIterator::applyInitialAdvance(GlyphBuffer& glyphBuffer, GlyphBufferAdv
         m_leftoverInitialAdvance = initialAdvance;
     else {
         if (lastGlyphCount) {
-            auto& visuallyPreviousAdvance = *glyphBuffer.advances(lastGlyphCount - 1);
+            auto& visuallyPreviousAdvance = glyphBuffer.advanceAt(lastGlyphCount - 1);
             expandWithInitialAdvance(visuallyPreviousAdvance, initialAdvance);
             m_runWidthSoFar += width(initialAdvance);
         } else

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
@@ -66,7 +66,7 @@ private:
     void strokeEllipse(const WebCore::FloatRect&) override;
     void clearRect(const WebCore::FloatRect&) override;
 
-    void drawGlyphs(const WebCore::Font&, const WebCore::GlyphBufferGlyph*, const WebCore::GlyphBufferAdvance*, unsigned numGlyphs, const WebCore::FloatPoint&, WebCore::FontSmoothingMode) override;
+    void drawGlyphs(const WebCore::Font&, std::span<const WebCore::GlyphBufferGlyph>, std::span<const WebCore::GlyphBufferAdvance>, const WebCore::FloatPoint&, WebCore::FontSmoothingMode) override;
     void drawDecomposedGlyphs(const WebCore::Font&, const WebCore::DecomposedGlyphs&) override;
 
     void drawImageBuffer(WebCore::ImageBuffer&, const WebCore::FloatRect& destination, const WebCore::FloatRect& source, WebCore::ImagePaintingOptions) override;

--- a/Source/WebCore/platform/graphics/cairo/FontCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/FontCairo.cpp
@@ -49,8 +49,8 @@
 
 namespace WebCore {
 
-void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, const GlyphBufferGlyph* glyphs,
-    const GlyphBufferAdvance* advances, unsigned numGlyphs, const FloatPoint& point,
+void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, std::span<const GlyphBufferGlyph> glyphs,
+    std::span<const GlyphBufferAdvance> advances, const FloatPoint& point,
     FontSmoothingMode fontSmoothingMode)
 {
     if (!font.platformData().size())
@@ -58,10 +58,10 @@ void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, const G
 
     auto xOffset = point.x();
     Vector<cairo_glyph_t> cairoGlyphs;
-    cairoGlyphs.reserveInitialCapacity(numGlyphs);
+    cairoGlyphs.reserveInitialCapacity(glyphs.size());
     {
         auto yOffset = point.y();
-        for (size_t i = 0; i < numGlyphs; ++i) {
+        for (size_t i = 0; i < glyphs.size(); ++i) {
             bool append = true;
 #if PLATFORM(WIN)
             // GlyphBuffer::makeGlyphInvisible expects 0xFFFF glyph is invisible. However, DirectWrite shows a blank square for it.

--- a/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
+++ b/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
@@ -37,11 +37,10 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
-ComplexTextController::ComplexTextRun::ComplexTextRun(CTRunRef ctRun, const Font& font, const UChar* characters, unsigned stringLocation, unsigned stringLength, unsigned indexBegin, unsigned indexEnd)
+ComplexTextController::ComplexTextRun::ComplexTextRun(CTRunRef ctRun, const Font& font, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd)
     : m_initialAdvance(CTRunGetInitialAdvance(ctRun))
     , m_font(font)
     , m_characters(characters)
-    , m_stringLength(stringLength)
     , m_indexBegin(indexBegin)
     , m_indexEnd(indexEnd)
     , m_glyphCount(CTRunGetGlyphCount(ctRun))
@@ -162,7 +161,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.
-        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), cp.data(), stringLocation, cp.size(), 0, cp.size(), m_run.ltr()));
+        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), cp, stringLocation, 0, cp.size(), m_run.ltr()));
         return;
     }
 
@@ -255,7 +254,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
                 if (!runFont) {
                     RetainPtr<CFStringRef> fontName = adoptCF(CTFontCopyPostScriptName(runCTFont));
                     if (CFEqual(fontName.get(), CFSTR("LastResort"))) {
-                        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), cp.data(), stringLocation, cp.size(), runRange.location, runRange.location + runRange.length, m_run.ltr()));
+                        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), cp, stringLocation, runRange.location, runRange.location + runRange.length, m_run.ltr()));
                         continue;
                     }
                     FontPlatformData runFontPlatformData(runCTFont, CTFontGetSize(runCTFont));
@@ -270,7 +269,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
 
         LOG_WITH_STREAM(TextShaping, stream << "Run " << r << ":");
 
-        m_complexTextRuns.append(ComplexTextRun::create(ctRun, *runFont, cp.data(), stringLocation, cp.size(), runRange.location, runRange.location + runRange.length));
+        m_complexTextRuns.append(ComplexTextRun::create(ctRun, *runFont, cp, stringLocation, runRange.location, runRange.location + runRange.length));
     }
 }
 

--- a/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
@@ -62,7 +62,7 @@ static CGError drawGlyphs(CGContextDelegateRef delegate, CGRenderingStateRef rst
 {
     if (CGGStateGetAlpha(gstate) > 0) {
         DrawGlyphsRecorder& recorder = *static_cast<DrawGlyphsRecorder*>(CGContextDelegateGetInfo(delegate));
-        recorder.recordDrawGlyphs(rstate, gstate, tm, glyphs, positions, count);
+        recorder.recordDrawGlyphs(rstate, gstate, tm, unsafeMakeSpan(glyphs, count), unsafeMakeSpan(positions, count));
     }
     return kCGErrorSuccess;
 }
@@ -258,16 +258,14 @@ struct AdvancesAndInitialPosition {
     CGPoint initialPosition;
 };
 
-static AdvancesAndInitialPosition computeHorizontalAdvancesFromPositions(const CGPoint positions[], size_t count, const CGAffineTransform& textMatrix)
+static AdvancesAndInitialPosition computeHorizontalAdvancesFromPositions(std::span<const CGPoint> positions, const CGAffineTransform& textMatrix)
 {
     // This function needs to be the inverse of fillVectorWithHorizontalGlyphPositions().
 
-    ASSERT(count); // Because we say "positions[0]" below.
-
     AdvancesAndInitialPosition result;
-    result.advances.reserveInitialCapacity(count);
+    result.advances.reserveInitialCapacity(positions.size());
     result.initialPosition = CGPointApplyAffineTransform(positions[0], textMatrix);
-    for (size_t i = 0; i < count - 1; ++i) {
+    for (size_t i = 0; i < positions.size() - 1; ++i) {
         auto nextPosition = positions[i + 1];
         auto currentPosition = positions[i];
         auto advance = CGSizeMake(nextPosition.x - currentPosition.x, nextPosition.y - currentPosition.y);
@@ -277,11 +275,9 @@ static AdvancesAndInitialPosition computeHorizontalAdvancesFromPositions(const C
     return result;
 }
 
-static AdvancesAndInitialPosition computeVerticalAdvancesFromPositions(const CGSize translations[], const CGPoint positions[], unsigned count, float ascentDelta, AffineTransform textMatrix)
+static AdvancesAndInitialPosition computeVerticalAdvancesFromPositions(std::span<const CGSize> translations, std::span<const CGPoint> positions, float ascentDelta, AffineTransform textMatrix)
 {
     // This function needs to be the inverse of fillVectorWithVerticalGlyphPositions().
-
-    ASSERT(count); // Because we say "positions[0]" below.
 
     auto constantSyntheticTextMatrixOmittingOblique = computeBaseVerticalTextMatrix(computeBaseOverallTextMatrix(std::nullopt)); // See fillVectorWithVerticalGlyphPositions(), which describes what this is.
 
@@ -292,12 +288,12 @@ static AdvancesAndInitialPosition computeVerticalAdvancesFromPositions(const CGS
     };
 
     AdvancesAndInitialPosition result;
-    result.advances.reserveInitialCapacity(count);
+    result.advances.reserveInitialCapacity(positions.size());
     result.initialPosition = transformPoint(positions[0], translations[0]);
     CGPoint previousPosition = result.initialPosition;
     result.initialPosition.y -= ascentDelta;
 
-    for (size_t i = 1; i < count; ++i) {
+    for (size_t i = 1; i < positions.size(); ++i) {
         auto currentPosition = transformPoint(positions[i], translations[i]);
         result.advances.constructAndAppend(CGSizeMake(currentPosition.x - previousPosition.x, currentPosition.y - previousPosition.y));
         previousPosition = currentPosition;
@@ -306,11 +302,11 @@ static AdvancesAndInitialPosition computeVerticalAdvancesFromPositions(const CGS
     return result;
 }
 
-void DrawGlyphsRecorder::recordDrawGlyphs(CGRenderingStateRef, CGGStateRef gstate, const CGAffineTransform*, const CGGlyph glyphs[], const CGPoint positions[], size_t count)
+void DrawGlyphsRecorder::recordDrawGlyphs(CGRenderingStateRef, CGGStateRef gstate, const CGAffineTransform*, std::span<const CGGlyph> glyphs, std::span<const CGPoint> positions)
 {
     ASSERT_IMPLIES(m_deriveFontFromContext == DeriveFontFromContext::No, m_originalFont);
 
-    if (!count)
+    if (glyphs.empty())
         return;
 
     CGFontRef usedFont = CGGStateGetFont(gstate);
@@ -357,14 +353,14 @@ void DrawGlyphsRecorder::recordDrawGlyphs(CGRenderingStateRef, CGGStateRef gstat
 
     AdvancesAndInitialPosition advances;
     if (font->platformData().orientation() == FontOrientation::Vertical) {
-        Vector<CGSize, 256> translations(count);
-        CTFontGetVerticalTranslationsForGlyphs(font->platformData().ctFont(), glyphs, translations.data(), count);
+        Vector<CGSize, 256> translations(glyphs.size());
+        CTFontGetVerticalTranslationsForGlyphs(font->platformData().ctFont(), glyphs.data(), translations.data(), glyphs.size());
         auto ascentDelta = font->fontMetrics().ascent(IdeographicBaseline) - font->fontMetrics().ascent();
-        advances = computeVerticalAdvancesFromPositions(translations.data(), positions, count, ascentDelta, textMatrix);
+        advances = computeVerticalAdvancesFromPositions(translations.span(), positions, ascentDelta, textMatrix);
     } else
-        advances = computeHorizontalAdvancesFromPositions(positions, count, textMatrix);
+        advances = computeHorizontalAdvancesFromPositions(positions, textMatrix);
 
-    m_owner.drawGlyphsAndCacheResources(font, glyphs, advances.advances.data(), count, advances.initialPosition, m_smoothingMode);
+    m_owner.drawGlyphsAndCacheResources(font, glyphs, advances.advances.span(), advances.initialPosition, m_smoothingMode);
 
     m_owner.concatCTM(inverseCTMFixup);
 }
@@ -432,16 +428,16 @@ void DrawGlyphsRecorder::recordDrawPath(CGRenderingStateRef, CGGStateRef gstate,
     }
 }
 
-void DrawGlyphsRecorder::drawOTSVGRun(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned numGlyphs, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
+void DrawGlyphsRecorder::drawOTSVGRun(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
 {
     FloatPoint penPosition = startPoint;
 
-    for (unsigned i = 0; i < numGlyphs; ++i) {
+    for (size_t i = 0; i < glyphs.size(); ++i) {
         auto bounds = font.boundsForGlyph(glyphs[i]);
 
         // Create a local ImageBuffer because decoding the SVG fonts has to happen in WebProcess.
         if (auto imageBuffer = m_owner.createAlignedImageBuffer(bounds, DestinationColorSpace::SRGB(), RenderingMethod::Local)) {
-            FontCascade::drawGlyphs(imageBuffer->context(), font, glyphs + i, advances + i, 1, FloatPoint(), smoothingMode);
+            FontCascade::drawGlyphs(imageBuffer->context(), font, glyphs.subspan(i, 1), advances.subspan(i, 1), FloatPoint(), smoothingMode);
 
             FloatRect destinationRect = enclosingIntRect(bounds);
             destinationRect.moveBy(penPosition);
@@ -452,22 +448,22 @@ void DrawGlyphsRecorder::drawOTSVGRun(const Font& font, const GlyphBufferGlyph* 
     }
 }
 
-void DrawGlyphsRecorder::drawNonOTSVGRun(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned numGlyphs, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
+void DrawGlyphsRecorder::drawNonOTSVGRun(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
 {
     prepareInternalContext(font, smoothingMode);
-    FontCascade::drawGlyphs(m_internalContext, font, glyphs, advances, numGlyphs, startPoint, smoothingMode);
+    FontCascade::drawGlyphs(m_internalContext, font, glyphs, advances, startPoint, smoothingMode);
     concludeInternalContext();
 }
 
-void DrawGlyphsRecorder::drawBySplittingIntoOTSVGAndNonOTSVGRuns(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned numGlyphs, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
+void DrawGlyphsRecorder::drawBySplittingIntoOTSVGAndNonOTSVGRuns(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
 {
-    auto otsvgGlyphs = font.findOTSVGGlyphs(glyphs, numGlyphs);
+    auto otsvgGlyphs = font.findOTSVGGlyphs(glyphs);
     if (!otsvgGlyphs) {
-        drawNonOTSVGRun(font, glyphs, advances, numGlyphs, startPoint, smoothingMode);
+        drawNonOTSVGRun(font, glyphs, advances, startPoint, smoothingMode);
         return;
     }
 
-    ASSERT(otsvgGlyphs->size() >= numGlyphs);
+    ASSERT(otsvgGlyphs->size() >= glyphs.size());
 
     // We can't just partition the glyphs into OT-SVG glyphs and non-OT-SVG glyphs because glyphs are allowed to draw outside of their layout boxes.
     // This means that glyphs can overlap, which means we have to get the z-order correct. We can't have an earlier run be drawn on top of a later run.
@@ -475,16 +471,16 @@ void DrawGlyphsRecorder::drawBySplittingIntoOTSVGAndNonOTSVGRuns(const Font& fon
     FloatPoint penPosition = startPoint;
     size_t glyphCountInRun = 0;
     bool isOTSVGRun = false;
-    unsigned i;
+    size_t i;
     auto draw = [&] () {
         if (!glyphCountInRun)
             return;
         if (isOTSVGRun)
-            drawOTSVGRun(font, glyphs + i - glyphCountInRun, advances + i - glyphCountInRun, glyphCountInRun, runOrigin, smoothingMode);
+            drawOTSVGRun(font, glyphs.subspan(i - glyphCountInRun, glyphCountInRun), advances.subspan(i - glyphCountInRun, glyphCountInRun), runOrigin, smoothingMode);
         else
-            drawNonOTSVGRun(font, glyphs + i - glyphCountInRun, advances + i - glyphCountInRun, glyphCountInRun, runOrigin, smoothingMode);
+            drawNonOTSVGRun(font, glyphs.subspan(i - glyphCountInRun, glyphCountInRun), advances.subspan(i - glyphCountInRun, glyphCountInRun), runOrigin, smoothingMode);
     };
-    for (i = 0; i < numGlyphs; ++i) {
+    for (i = 0; i < glyphs.size(); ++i) {
         bool isOTSVGGlyph = otsvgGlyphs->quickGet(i);
         if (isOTSVGGlyph != isOTSVGRun) {
             draw();
@@ -498,9 +494,9 @@ void DrawGlyphsRecorder::drawBySplittingIntoOTSVGAndNonOTSVGRuns(const Font& fon
     draw();
 }
 
-void DrawGlyphsRecorder::drawGlyphs(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned numGlyphs, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
+void DrawGlyphsRecorder::drawGlyphs(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
 {
-    drawBySplittingIntoOTSVGAndNonOTSVGRuns(font, glyphs, advances, numGlyphs, startPoint, smoothingMode);
+    drawBySplittingIntoOTSVGAndNonOTSVGRuns(font, glyphs, advances, startPoint, smoothingMode);
 }
 
 void DrawGlyphsRecorder::drawNativeText(CTFontRef font, CGFloat fontSize, CTLineRef line, CGRect lineRect)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -294,15 +294,15 @@ DrawGlyphs::DrawGlyphs(RenderingResourceIdentifier fontIdentifier, PositionedGly
 {
 }
 
-DrawGlyphs::DrawGlyphs(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode smoothingMode)
+DrawGlyphs::DrawGlyphs(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& localAnchor, FontSmoothingMode smoothingMode)
     : m_fontIdentifier(font.renderingResourceIdentifier())
-    , m_positionedGlyphs { Vector(std::span { glyphs, count }), Vector(std::span { advances, count }), localAnchor, smoothingMode }
+    , m_positionedGlyphs { Vector(glyphs), Vector(advances), localAnchor, smoothingMode }
 {
 }
 
 void DrawGlyphs::apply(GraphicsContext& context, const Font& font) const
 {
-    return context.drawGlyphs(font, m_positionedGlyphs.glyphs.data(), m_positionedGlyphs.advances.data(), m_positionedGlyphs.glyphs.size(), anchorPoint(), m_positionedGlyphs.smoothingMode);
+    return context.drawGlyphs(font, m_positionedGlyphs.glyphs.span(), m_positionedGlyphs.advances.span(), anchorPoint(), m_positionedGlyphs.smoothingMode);
 }
 
 void DrawGlyphs::dump(TextStream& ts, OptionSet<AsTextFlag>) const

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -506,7 +506,7 @@ public:
     FontSmoothingMode fontSmoothingMode() const { return m_positionedGlyphs.smoothingMode; }
     const Vector<GlyphBufferGlyph>& glyphs() const { return m_positionedGlyphs.glyphs; }
 
-    WEBCORE_EXPORT DrawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode);
+    WEBCORE_EXPORT DrawGlyphs(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& localAnchor, FontSmoothingMode);
     WEBCORE_EXPORT DrawGlyphs(RenderingResourceIdentifier, PositionedGlyphs&&);
 
     WEBCORE_EXPORT void apply(GraphicsContext&, const Font&) const;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -191,16 +191,16 @@ bool Recorder::shouldDeconstructDrawGlyphs() const
     return false;
 }
 
-void Recorder::drawGlyphs(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned numGlyphs, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
+void Recorder::drawGlyphs(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
 {
     if (shouldDeconstructDrawGlyphs()) {
         if (!m_drawGlyphsRecorder)
             m_drawGlyphsRecorder = makeUnique<DrawGlyphsRecorder>(*this, m_initialScale);
-        m_drawGlyphsRecorder->drawGlyphs(font, glyphs, advances, numGlyphs, startPoint, smoothingMode);
+        m_drawGlyphsRecorder->drawGlyphs(font, glyphs, advances, startPoint, smoothingMode);
         return;
     }
 
-    drawGlyphsAndCacheResources(font, glyphs, advances, numGlyphs, startPoint, smoothingMode);
+    drawGlyphsAndCacheResources(font, glyphs, advances, startPoint, smoothingMode);
 }
 
 void Recorder::drawDecomposedGlyphs(const Font& font, const DecomposedGlyphs& decomposedGlyphs)
@@ -211,19 +211,19 @@ void Recorder::drawDecomposedGlyphs(const Font& font, const DecomposedGlyphs& de
     recordDrawDecomposedGlyphs(font, decomposedGlyphs);
 }
 
-void Recorder::drawGlyphsAndCacheResources(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned numGlyphs, const FloatPoint& localAnchor, FontSmoothingMode smoothingMode)
+void Recorder::drawGlyphsAndCacheResources(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& localAnchor, FontSmoothingMode smoothingMode)
 {
     appendStateChangeItemIfNecessary();
     recordResourceUse(const_cast<Font&>(font));
 
     if (m_drawGlyphsMode == DrawGlyphsMode::DeconstructUsingDrawDecomposedGlyphsCommands) {
-        auto decomposedGlyphs = DecomposedGlyphs::create(glyphs, advances, numGlyphs, localAnchor, smoothingMode);
+        auto decomposedGlyphs = DecomposedGlyphs::create(glyphs, advances, localAnchor, smoothingMode);
         recordResourceUse(decomposedGlyphs.get());
         recordDrawDecomposedGlyphs(font, decomposedGlyphs.get());
         return;
     }
 
-    recordDrawGlyphs(font, glyphs, advances, numGlyphs, localAnchor, smoothingMode);
+    recordDrawGlyphs(font, glyphs, advances, localAnchor, smoothingMode);
 }
 
 void Recorder::drawDisplayListItems(const Vector<Item>& items, const ResourceHeap& resourceHeap, ControlFactory&, const FloatPoint& destination)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -77,7 +77,7 @@ protected:
     virtual void recordClearDropShadow() = 0;
     virtual void recordClipToImageBuffer(ImageBuffer&, const FloatRect& destinationRect) = 0;
     virtual void recordDrawFilteredImageBuffer(ImageBuffer*, const FloatRect& sourceImageRect, Filter&) = 0;
-    virtual void recordDrawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode) = 0;
+    virtual void recordDrawGlyphs(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& localAnchor, FontSmoothingMode) = 0;
     virtual void recordDrawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) = 0;
     virtual void recordDrawImageBuffer(ImageBuffer&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) = 0;
     virtual void recordDrawNativeImage(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) = 0;
@@ -180,9 +180,9 @@ private:
     WEBCORE_EXPORT void fillPath(const Path&) final;
     WEBCORE_EXPORT void strokePath(const Path&) final;
     WEBCORE_EXPORT void drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, FilterResults&) final;
-    WEBCORE_EXPORT void drawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned numGlyphs, const FloatPoint& anchorPoint, FontSmoothingMode) final;
+    WEBCORE_EXPORT void drawGlyphs(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& anchorPoint, FontSmoothingMode) final;
     WEBCORE_EXPORT void drawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) override;
-    WEBCORE_EXPORT void drawGlyphsAndCacheResources(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode) final;
+    WEBCORE_EXPORT void drawGlyphsAndCacheResources(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& localAnchor, FontSmoothingMode) final;
     WEBCORE_EXPORT void drawDisplayListItems(const Vector<Item>&, const ResourceHeap&, ControlFactory&, const FloatPoint& destination) final;
     WEBCORE_EXPORT void drawImageBuffer(ImageBuffer&, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions) final;
     WEBCORE_EXPORT void drawConsumingImageBuffer(RefPtr<ImageBuffer>, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions) final;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -200,9 +200,9 @@ void RecorderImpl::recordDrawFilteredImageBuffer(ImageBuffer* sourceImage, const
     append(DrawFilteredImageBuffer(WTFMove(identifier), sourceImageRect, filter));
 }
 
-void RecorderImpl::recordDrawGlyphs(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode mode)
+void RecorderImpl::recordDrawGlyphs(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& localAnchor, FontSmoothingMode mode)
 {
-    append(DrawGlyphs(font, glyphs, advances, count, localAnchor, mode));
+    append(DrawGlyphs(font, glyphs, advances, localAnchor, mode));
 }
 
 void RecorderImpl::recordDrawDecomposedGlyphs(const Font& font, const DecomposedGlyphs& decomposedGlyphs)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -101,7 +101,7 @@ private:
     void recordClearDropShadow() final;
     void recordClipToImageBuffer(ImageBuffer&, const FloatRect& destinationRect) final;
     void recordDrawFilteredImageBuffer(ImageBuffer*, const FloatRect& sourceImageRect, Filter&) final;
-    void recordDrawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode) final;
+    void recordDrawGlyphs(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& localAnchor, FontSmoothingMode) final;
     void recordDrawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) final;
     void recordDrawImageBuffer(ImageBuffer&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) final;
     void recordDrawNativeImage(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) final;

--- a/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
+++ b/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
@@ -132,11 +132,10 @@ static hb_font_funcs_t* harfBuzzFontFunctions()
     return fontFunctions;
 }
 
-ComplexTextController::ComplexTextRun::ComplexTextRun(hb_buffer_t* buffer, const Font& font, const UChar* characters, unsigned stringLocation, unsigned stringLength, unsigned indexBegin, unsigned indexEnd)
+ComplexTextController::ComplexTextRun::ComplexTextRun(hb_buffer_t* buffer, const Font& font, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd)
     : m_initialAdvance(0, 0)
     , m_font(font)
     , m_characters(characters)
-    , m_stringLength(stringLength)
     , m_indexBegin(indexBegin)
     , m_indexEnd(indexEnd)
     , m_glyphCount(hb_buffer_get_length(buffer))
@@ -311,7 +310,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.
-        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), characters.data(), stringLocation, characters.size(), 0, characters.size(), m_run.ltr()));
+        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), characters, stringLocation, 0, characters.size(), m_run.ltr()));
         return;
     }
 
@@ -383,7 +382,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
         hb_buffer_add_utf16(buffer.get(), reinterpret_cast<const uint16_t*>(characters.data()), characters.size(), run.startIndex, run.endIndex - run.startIndex);
 
         hb_shape(harfBuzzFont.get(), buffer.get(), features.isEmpty() ? nullptr : features.data(), features.size());
-        m_complexTextRuns.append(ComplexTextRun::create(buffer.get(), *font, characters.data(), stringLocation, characters.size(), run.startIndex, run.endIndex));
+        m_complexTextRuns.append(ComplexTextRun::create(buffer.get(), *font, characters, stringLocation, run.startIndex, run.endIndex));
         hb_buffer_reset(buffer.get());
     }
 }

--- a/Source/WebCore/platform/graphics/harfbuzz/DrawGlyphsRecorderHarfBuzz.cpp
+++ b/Source/WebCore/platform/graphics/harfbuzz/DrawGlyphsRecorderHarfBuzz.cpp
@@ -38,9 +38,9 @@ DrawGlyphsRecorder::DrawGlyphsRecorder(GraphicsContext& owner, float, DeriveFont
 {
 }
 
-void DrawGlyphsRecorder::drawGlyphs(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned numGlyphs, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
+void DrawGlyphsRecorder::drawGlyphs(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
 {
-    m_owner.drawGlyphsAndCacheResources(font, glyphs, advances, numGlyphs, startPoint, smoothingMode);
+    m_owner.drawGlyphsAndCacheResources(font, glyphs, advances, startPoint, smoothingMode);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
@@ -41,11 +41,10 @@ static inline float harfBuzzPositionToFloat(hb_position_t value)
     return static_cast<float>(value) / (1 << 16);
 }
 
-ComplexTextController::ComplexTextRun::ComplexTextRun(hb_buffer_t* buffer, const Font& font, const UChar* characters, unsigned stringLocation, unsigned stringLength, unsigned indexBegin, unsigned indexEnd)
+ComplexTextController::ComplexTextRun::ComplexTextRun(hb_buffer_t* buffer, const Font& font, std::span<const UChar> characters, unsigned stringLocation, unsigned indexBegin, unsigned indexEnd)
     : m_initialAdvance(0, 0)
     , m_font(font)
     , m_characters(characters)
-    , m_stringLength(stringLength)
     , m_indexBegin(indexBegin)
     , m_indexEnd(indexEnd)
     , m_glyphCount(hb_buffer_get_length(buffer))
@@ -155,7 +154,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.
-        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), characters.data(), stringLocation, characters.size(), 0, characters.size(), m_run.ltr()));
+        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), characters, stringLocation, 0, characters.size(), m_run.ltr()));
         return;
     }
 
@@ -205,7 +204,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
         hb_buffer_add_utf16(buffer.get(), reinterpret_cast<const uint16_t*>(characters.data()), characters.size(), run.startIndex, run.endIndex - run.startIndex);
 
         hb_shape(hbFont, buffer.get(), featuresData, featuresSize);
-        m_complexTextRuns.append(ComplexTextRun::create(buffer.get(), *font, characters.data(), stringLocation, characters.size(), run.startIndex, run.endIndex));
+        m_complexTextRuns.append(ComplexTextRun::create(buffer.get(), *font, characters, stringLocation, run.startIndex, run.endIndex));
         hb_buffer_reset(buffer.get());
     }
 }

--- a/Source/WebCore/platform/graphics/skia/DrawGlyphsRecorderSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/DrawGlyphsRecorderSkia.cpp
@@ -38,9 +38,9 @@ DrawGlyphsRecorder::DrawGlyphsRecorder(GraphicsContext& owner, float, DeriveFont
 {
 }
 
-void DrawGlyphsRecorder::drawGlyphs(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned numGlyphs, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
+void DrawGlyphsRecorder::drawGlyphs(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
 {
-    m_owner.drawGlyphsAndCacheResources(font, glyphs, advances, numGlyphs, startPoint, smoothingMode);
+    m_owner.drawGlyphsAndCacheResources(font, glyphs, advances, startPoint, smoothingMode);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib/Win port
 
-void FontCascade::drawGlyphs(GraphicsContext& graphicsContext, const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned glyphCount, const FloatPoint& position, FontSmoothingMode smoothingMode)
+void FontCascade::drawGlyphs(GraphicsContext& graphicsContext, const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& position, FontSmoothingMode smoothingMode)
 {
     if (!font.platformData().size())
         return;
@@ -68,15 +68,15 @@ void FontCascade::drawGlyphs(GraphicsContext& graphicsContext, const Font& font,
     SkTextBlobBuilder builder;
     const auto& buffer = [&]() {
         if (skFont.getEdging() == edging)
-            return isVertical ? builder.allocRunPos(skFont, glyphCount) : builder.allocRunPosH(skFont, glyphCount, 0);
+            return isVertical ? builder.allocRunPos(skFont, glyphs.size()) : builder.allocRunPosH(skFont, glyphs.size(), 0);
 
         SkFont copiedFont = skFont;
         copiedFont.setEdging(edging);
-        return isVertical ? builder.allocRunPos(copiedFont, glyphCount) : builder.allocRunPosH(copiedFont, glyphCount, 0);
+        return isVertical ? builder.allocRunPos(copiedFont, glyphs.size()) : builder.allocRunPosH(copiedFont, glyphs.size(), 0);
     }();
 
     FloatSize glyphPosition;
-    for (unsigned i = 0; i < glyphCount; ++i) {
+    for (size_t i = 0; i < glyphs.size(); ++i) {
         buffer.glyphs[i] = glyphs[i];
 
         if (isVertical) {

--- a/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
+++ b/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
@@ -173,7 +173,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.
-        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), cp.data(), stringLocation, cp.size(), 0, cp.size(), m_run.ltr()));
+        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), cp, stringLocation, 0, cp.size(), m_run.ltr()));
         return;
     }
 
@@ -248,7 +248,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
         baseAdvances.reserveCapacity(glyphs.size());
         origins.reserveCapacity(glyphs.size());
 
-        for (unsigned k = 0; k < glyphs.size(); k++) {
+        for (size_t k = 0; k < glyphs.size(); k++) {
             const float cLogicalScale = cWindowsFontScaleFactor;
             float advance = advances[k] / cLogicalScale;
             float offsetX = offsets[k].du / cLogicalScale;
@@ -260,7 +260,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
         bool ltr = !item.a.fRTL;
         auto stringIndices = stringIndicesFromClusters(clusters, std::span(str, length), item.iCharPos, glyphs.size(), ltr);
         FloatSize initialAdvance = toFloatSize(origins[0]);
-        m_complexTextRuns.append(ComplexTextRun::create(baseAdvances, origins, glyphs, stringIndices, initialAdvance, *font, cp.data(), stringLocation, cp.size(), item.iCharPos, items[i+1].iCharPos, ltr));
+        m_complexTextRuns.append(ComplexTextRun::create(baseAdvances, origins, glyphs, stringIndices, initialAdvance, *font, cp, stringLocation, item.iCharPos, items[i+1].iCharPos, ltr));
     }
 }
 

--- a/Source/WebCore/platform/graphics/win/DrawGlyphsRecorderWin.cpp
+++ b/Source/WebCore/platform/graphics/win/DrawGlyphsRecorderWin.cpp
@@ -38,9 +38,9 @@ DrawGlyphsRecorder::DrawGlyphsRecorder(GraphicsContext& owner, float, DeriveFont
 {
 }
 
-void DrawGlyphsRecorder::drawGlyphs(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned numGlyphs, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
+void DrawGlyphsRecorder::drawGlyphs(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
 {
-    m_owner.drawGlyphsAndCacheResources(font, glyphs, advances, numGlyphs, startPoint, smoothingMode);
+    m_owner.drawGlyphsAndCacheResources(font, glyphs, advances, startPoint, smoothingMode);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/mathml/MathOperator.cpp
+++ b/Source/WebCore/rendering/mathml/MathOperator.cpp
@@ -31,6 +31,7 @@
 
 #include "RenderStyleInlines.h"
 #include "StyleInheritedData.h"
+#include <wtf/StdLibExtras.h>
 
 static const unsigned kRadicalOperator = 0x221A;
 static const unsigned kMaximumExtensionCount = 128;
@@ -518,7 +519,7 @@ LayoutRect MathOperator::paintGlyph(const RenderStyle& style, PaintInfo& info, c
 
     // FIXME: If we're just drawing a single glyph, why do we need to compute an advance?
     auto advance = makeGlyphBufferAdvance(advanceWidthForGlyph(data));
-    info.context().drawGlyphs(*data.font, &data.glyph, &advance, 1, origin, style.fontCascade().fontDescription().usedFontSmoothing());
+    info.context().drawGlyphs(*data.font, singleElementSpan(data.glyph), singleElementSpan(advance), origin, style.fontCascade().fontDescription().usedFontSmoothing());
 
     return glyphPaintRect;
 }
@@ -725,7 +726,7 @@ void MathOperator::paint(const RenderStyle& style, PaintInfo& info, const Layout
     LayoutPoint operatorOrigin { operatorTopLeft.x(), LayoutUnit(operatorTopLeft.y() - glyphBounds.y()) };
     // FIXME: If we're just drawing a single glyph, why do we need to compute an advance?
     auto advance = makeGlyphBufferAdvance(advanceWidthForGlyph(glyphData));
-    paintInfo.context().drawGlyphs(*glyphData.font, &glyphData.glyph, &advance, 1, operatorOrigin, style.fontCascade().fontDescription().usedFontSmoothing());
+    paintInfo.context().drawGlyphs(*glyphData.font, singleElementSpan(glyphData.glyph), singleElementSpan(advance), operatorOrigin, style.fontCascade().fontDescription().usedFontSmoothing());
 }
 
 }

--- a/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
@@ -39,6 +39,7 @@
 #include "RenderElement.h"
 #include "RenderIterator.h"
 #include "RenderStyleInlines.h"
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -623,7 +624,7 @@ void RenderMathMLToken::paint(PaintInfo& info, const LayoutPoint& paintOffset)
     LayoutUnit glyphAscent = static_cast<int>(lroundf(-mathVariantGlyph.font->boundsForGlyph(mathVariantGlyph.glyph).y()));
     // FIXME: If we're just drawing a single glyph, why do we need to compute an advance?
     auto advance = makeGlyphBufferAdvance(mathVariantGlyph.font->widthForGlyph(mathVariantGlyph.glyph));
-    info.context().drawGlyphs(*mathVariantGlyph.font, &mathVariantGlyph.glyph, &advance, 1, paintOffset + location() + LayoutPoint(borderLeft() + paddingLeft(), glyphAscent + borderAndPaddingBefore()), style().fontCascade().fontDescription().usedFontSmoothing());
+    info.context().drawGlyphs(*mathVariantGlyph.font, singleElementSpan(mathVariantGlyph.glyph), singleElementSpan(advance), paintOffset + location() + LayoutPoint(borderLeft() + paddingLeft(), glyphAscent + borderAndPaddingBefore()), style().fontCascade().fontDescription().usedFontSmoothing());
 }
 
 void RenderMathMLToken::paintChildren(PaintInfo& paintInfo, const LayoutPoint& paintOffset, PaintInfo& paintInfoForChild, bool usePrintRect)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -259,9 +259,9 @@ void RemoteDisplayListRecorderProxy::recordDrawFilteredImageBuffer(ImageBuffer* 
     send(Messages::RemoteDisplayListRecorder::DrawFilteredImageBuffer(WTFMove(identifier), sourceImageRect, filter));
 }
 
-void RemoteDisplayListRecorderProxy::recordDrawGlyphs(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode mode)
+void RemoteDisplayListRecorderProxy::recordDrawGlyphs(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& localAnchor, FontSmoothingMode mode)
 {
-    send(Messages::RemoteDisplayListRecorder::DrawGlyphs(DisplayList::DrawGlyphs { font, glyphs, advances, count, localAnchor, mode }));
+    send(Messages::RemoteDisplayListRecorder::DrawGlyphs(DisplayList::DrawGlyphs { font, glyphs, advances, localAnchor, mode }));
 }
 
 void RemoteDisplayListRecorderProxy::recordDrawDecomposedGlyphs(const Font& font, const DecomposedGlyphs& decomposedGlyphs)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -124,7 +124,7 @@ private:
     void recordClearDropShadow() final;
     void recordClipToImageBuffer(WebCore::ImageBuffer&, const WebCore::FloatRect& destinationRect) final;
     void recordDrawFilteredImageBuffer(WebCore::ImageBuffer*, const WebCore::FloatRect& sourceImageRect, WebCore::Filter&) final;
-    void recordDrawGlyphs(const WebCore::Font&, const WebCore::GlyphBufferGlyph*, const WebCore::GlyphBufferAdvance*, unsigned count, const WebCore::FloatPoint& localAnchor, WebCore::FontSmoothingMode) final;
+    void recordDrawGlyphs(const WebCore::Font&, std::span<const WebCore::GlyphBufferGlyph>, std::span<const WebCore::GlyphBufferAdvance>, const WebCore::FloatPoint& localAnchor, WebCore::FontSmoothingMode) final;
     void recordDrawDecomposedGlyphs(const WebCore::Font&, const WebCore::DecomposedGlyphs&) final;
     void recordDrawDisplayListItems(const Vector<WebCore::DisplayList::Item>&, const WebCore::FloatPoint& destination);
     void recordDrawImageBuffer(WebCore::ImageBuffer&, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions) final;

--- a/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
@@ -58,11 +58,10 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInRTL)
 
     FloatSize initialAdvance = FloatSize(-15.15625, 18.046875);
 
-    UChar characters[] = { 0x644, 0x637, 0x641, 0x627, 0x64b, 0x20 };
-    size_t charactersLength = std::size(characters);
+    std::array<UChar, 6> characters { 0x644, 0x637, 0x641, 0x627, 0x64b, 0x20 };
     TextRun textRun { StringView(characters) };
-    auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(21.875, 0) }, { FloatPoint() }, { 5 }, { 5 }, FloatSize(), font.primaryFont(), characters, 0, charactersLength, 5, 6, false);
-    auto run2 = ComplexTextController::ComplexTextRun::create(advances, origins, { 193, 377, 447, 431, 458 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 0, 5, false);
+    auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(21.875, 0) }, { FloatPoint() }, { 5 }, { 5 }, FloatSize(), font.primaryFont(), std::span { characters }, 0, 5, 6, false);
+    auto run2 = ComplexTextController::ComplexTextRun::create(advances, origins, { 193, 377, 447, 431, 458 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 0, 5, false);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
     runs.append(WTFMove(run1));
     runs.append(WTFMove(run2));
@@ -104,10 +103,9 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInRTL)
 
     FloatSize initialAdvance = FloatSize(-15.15625, 18.046875);
 
-    UChar characters[] = { 0x644, 0x637, 0x641, 0x627, 0x64b };
-    size_t charactersLength = std::size(characters);
+    std::array<UChar, 5> characters { 0x644, 0x637, 0x641, 0x627, 0x64b };
     TextRun textRun { StringView(characters) };
-    auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 193, 377, 447, 431, 458 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 0, 5, false);
+    auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 193, 377, 447, 431, 458 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 0, 5, false);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
     runs.append(WTFMove(run));
     ComplexTextController controller(font, textRun, runs);
@@ -149,11 +147,10 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInLTR)
 
     FloatSize initialAdvance = FloatSize(28.144531, 0);
 
-    UChar characters[] = { 0x20, 0x61, 0x20e3 };
-    size_t charactersLength = std::size(characters);
+    std::array<UChar, 3> characters { 0x20, 0x61, 0x20e3 };
     TextRun textRun { StringView(characters) };
-    auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(spaceWidth, 0) }, { FloatPoint() }, { 5 }, { 0 }, FloatSize(), font.primaryFont(), characters, 0, charactersLength, 0, 1, true);
-    auto run2 = ComplexTextController::ComplexTextRun::create(advances, origins, { 68, 1471 }, { 1, 2 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 1, 3, true);
+    auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(spaceWidth, 0) }, { FloatPoint() }, { 5 }, { 0 }, FloatSize(), font.primaryFont(), std::span { characters }, 0, 0, 1, true);
+    auto run2 = ComplexTextController::ComplexTextRun::create(advances, origins, { 68, 1471 }, { 1, 2 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 1, 3, true);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
     runs.append(WTFMove(run1));
     runs.append(WTFMove(run2));
@@ -191,10 +188,9 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInLTR)
 
     FloatSize initialAdvance = FloatSize(28.144531, 0);
 
-    UChar characters[] = { 0x61, 0x20e3 };
-    size_t charactersLength = std::size(characters);
+    std::array<UChar, 2> characters { 0x61, 0x20e3 };
     TextRun textRun { StringView(characters) };
-    auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 68, 1471 }, { 0, 1 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 0, 2, true);
+    auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 68, 1471 }, { 0, 1 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 0, 2, true);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
     runs.append(WTFMove(run));
     ComplexTextController controller(font, textRun, runs);
@@ -225,12 +221,11 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInRTLNoOrigins)
 
     FloatSize initialAdvance = FloatSize(4.33996383363472, 12.368896925859);
 
-    UChar characters[] = { 0x633, 0x20, 0x627, 0x650 };
-    size_t charactersLength = std::size(characters);
+    std::array<UChar, 4> characters { 0x633, 0x20, 0x627, 0x650 };
     TextRun textRun { StringView(characters) };
-    auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(-4.33996383363472, -12.368896925859), FloatSize(14.0397830018083, 0) }, { }, { 884, 240 }, { 3, 2 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 2, 4, false);
-    auto run2 = ComplexTextController::ComplexTextRun::create({ FloatSize(12.0, 0) }, { }, { 3 }, { 1 }, FloatSize(), font.primaryFont(), characters, 0, charactersLength, 1, 2, false);
-    auto run3 = ComplexTextController::ComplexTextRun::create({ FloatSize(43.8119349005425, 0) }, { }, { 276 }, { 0 }, FloatSize(), font.primaryFont(), characters, 0, charactersLength, 0, 1, false);
+    auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(-4.33996383363472, -12.368896925859), FloatSize(14.0397830018083, 0) }, { }, { 884, 240 }, { 3, 2 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 2, 4, false);
+    auto run2 = ComplexTextController::ComplexTextRun::create({ FloatSize(12.0, 0) }, { }, { 3 }, { 1 }, FloatSize(), font.primaryFont(), std::span { characters }, 0, 1, 2, false);
+    auto run3 = ComplexTextController::ComplexTextRun::create({ FloatSize(43.8119349005425, 0) }, { }, { 276 }, { 0 }, FloatSize(), font.primaryFont(), std::span { characters }, 0, 0, 1, false);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
     runs.append(WTFMove(run1));
     runs.append(WTFMove(run2));
@@ -269,10 +264,9 @@ TEST_F(ComplexTextControllerTest, LeftExpansion)
     FontCascade font(WTFMove(description));
     font.update();
 
-    UChar characters[] = { 'a' };
-    size_t charactersLength = std::size(characters);
+    std::array<UChar, 1> characters { 'a' };
     TextRun textRun(StringView(characters), 0, 100, ExpansionBehavior::forceLeftOnly());
-    auto run = ComplexTextController::ComplexTextRun::create({ FloatSize(24, 0) }, { }, { 16 }, { 0 }, FloatSize(), font.primaryFont(), characters, 0, charactersLength, 0, 1, true);
+    auto run = ComplexTextController::ComplexTextRun::create({ FloatSize(24, 0) }, { }, { 16 }, { 0 }, FloatSize(), font.primaryFont(), std::span { characters }, 0, 0, 1, true);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
     runs.append(WTFMove(run));
     ComplexTextController controller(font, textRun, runs);
@@ -299,11 +293,10 @@ TEST_F(ComplexTextControllerTest, VerticalAdvances)
     FontCascade font(WTFMove(description));
     font.update();
 
-    UChar characters[] = { 'a', 'b', 'c', 'd' };
-    size_t charactersLength = std::size(characters);
+    std::array<UChar, 4> characters { 'a', 'b', 'c', 'd' };
     TextRun textRun { StringView(characters) };
-    auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(0, 1), FloatSize(0, 2) }, { FloatPoint(0, 4), FloatPoint(0, 8) }, { 16, 17 }, { 0, 1 }, FloatSize(0, 16), font.primaryFont(), characters, 0, charactersLength, 0, 2, true);
-    auto run2 = ComplexTextController::ComplexTextRun::create({ FloatSize(0, 32), FloatSize(0, 64) }, { FloatPoint(0, 128), FloatPoint(0, 256) }, { 18, 19 }, { 2, 3 }, FloatSize(0, 512), font.primaryFont(), characters, 0, charactersLength, 2, 4, true);
+    auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(0, 1), FloatSize(0, 2) }, { FloatPoint(0, 4), FloatPoint(0, 8) }, { 16, 17 }, { 0, 1 }, FloatSize(0, 16), font.primaryFont(), std::span { characters }, 0, 0, 2, true);
+    auto run2 = ComplexTextController::ComplexTextRun::create({ FloatSize(0, 32), FloatSize(0, 64) }, { FloatPoint(0, 128), FloatPoint(0, 256) }, { 18, 19 }, { 2, 3 }, FloatSize(0, 512), font.primaryFont(), std::span { characters }, 0, 2, 4, true);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
     runs.append(WTFMove(run1));
     runs.append(WTFMove(run2));
@@ -348,10 +341,9 @@ TEST_F(ComplexTextControllerTest, TotalWidthWithJustification)
 
     FloatSize initialAdvance = FloatSize();
 
-    UChar characters[] = { 0x644, ' ', 0x644, ' ', 0x644 };
-    size_t charactersLength = std::size(characters);
+    std::array<UChar, 5> characters { 0x644, ' ', 0x644, ' ', 0x644 };
     TextRun textRun(StringView(characters), 0, 14, ExpansionBehavior::defaultBehavior(), TextDirection::RTL);
-    auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 5, 6, 7, 8, 9 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 0, 5, false);
+    auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 5, 6, 7, 8, 9 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), std::span { characters }, 0, 0, 5, false);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
     runs.append(WTFMove(run));
     ComplexTextController controller(font, textRun, runs);


### PR DESCRIPTION
#### 36e2b75b534d1ba68cbbcab3f6c9208dce412411
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/graphics
<a href="https://bugs.webkit.org/show_bug.cgi?id=285238">https://bugs.webkit.org/show_bug.cgi?id=285238</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::drawGlyphs):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/ColorConversion.cpp:
* Source/WebCore/platform/graphics/ColorConversion.h:
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
* Source/WebCore/platform/graphics/ComplexTextController.h:
(WebCore::ComplexTextController::ComplexTextRun::span const):
* Source/WebCore/platform/graphics/DecomposedGlyphs.cpp:
(WebCore::DecomposedGlyphs::create):
* Source/WebCore/platform/graphics/DecomposedGlyphs.h:
* Source/WebCore/platform/graphics/DrawGlyphsRecorder.h:
* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::codePointSupportIndex):
* Source/WebCore/platform/graphics/Font.h:
* Source/WebCore/platform/graphics/FontCache.cpp:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::drawGlyphBuffer const):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
* Source/WebCore/platform/graphics/GlyphBuffer.h:
(WebCore::GlyphBuffer::glyphsSpan):
(WebCore::GlyphBuffer::advancesSpan):
(WebCore::GlyphBuffer::glyphsSpan const):
(WebCore::GlyphBuffer::advancesSpan const):
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawGlyphs):
(WebCore::GraphicsContext::drawDecomposedGlyphs):
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::drawGlyphsAndCacheResources):
* Source/WebCore/platform/graphics/NullGraphicsContext.h:
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp:
(WebCore::drawGlyphs):
(WebCore::computeHorizontalAdvancesFromPositions):
(WebCore::computeVerticalAdvancesFromPositions):
(WebCore::DrawGlyphsRecorder::recordDrawGlyphs):
(WebCore::DrawGlyphsRecorder::drawOTSVGRun):
(WebCore::DrawGlyphsRecorder::drawNonOTSVGRun):
(WebCore::DrawGlyphsRecorder::drawBySplittingIntoOTSVGAndNonOTSVGRuns):
(WebCore::DrawGlyphsRecorder::drawGlyphs):
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::showGlyphsWithAdvances):
(WebCore::FontCascade::drawGlyphs):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::findOTSVGGlyphs const):
(WebCore::Font::hasAnyComplexColorFormatGlyphs const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::DrawGlyphs::DrawGlyphs):
(WebCore::DisplayList::DrawGlyphs::apply const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::drawGlyphs):
(WebCore::DisplayList::Recorder::drawGlyphsAndCacheResources):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::recordDrawGlyphs):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebCore/platform/graphics/harfbuzz/DrawGlyphsRecorderHarfBuzz.cpp:
(WebCore::DrawGlyphsRecorder::drawGlyphs):
* Source/WebCore/platform/graphics/skia/DrawGlyphsRecorderSkia.cpp:
(WebCore::DrawGlyphsRecorder::drawGlyphs):
* Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp:
(WebCore::FontCascade::drawGlyphs):
* Source/WebCore/platform/graphics/win/DrawGlyphsRecorderWin.cpp:
(WebCore::DrawGlyphsRecorder::drawGlyphs):
* Source/WebCore/rendering/mathml/MathOperator.cpp:
(WebCore::MathOperator::paintGlyph):
* Source/WebCore/rendering/mathml/RenderMathMLToken.cpp:
(WebCore::RenderMathMLToken::paint):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordDrawGlyphs):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:

Canonical link: <a href="https://commits.webkit.org/288340@main">https://commits.webkit.org/288340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c084febf7e95563c8828ba27e3b1c4424c41c1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87762 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33699 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10201 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/64400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22163 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44675 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29362 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32734 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72889 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89127 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72814 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72028 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16171 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12810 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9888 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15409 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9762 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13227 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11531 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->