### PR TITLE
Correctly orient shadow offsets in sideways-lr modes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-shadow-sideways-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-shadow-sideways-001-expected.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<title>Reference for Sideways Inline Layout: Text Decoration</title>
+<meta charset=utf-8>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body > div {
+  /* styling */
+  border: solid gray;
+  font: 30px/1 Ahem;
+  color: silver;
+  float: left;
+  margin: 8px;
+
+  /* test */
+  text-decoration: underline;
+  text-decoration-color: orange;
+  text-decoration-thickness: 14px;
+
+  /* reference hacking */
+  width: 1em;
+  height: 5em;
+  white-space: nowrap;
+}
+div > div {
+  /* compensate for WebKit propagation bug */
+  text-decoration-thickness: 4px;
+}
+.lr > div {
+  text-shadow: -4px 2px aqua;
+  transform: rotate(-90deg) translateX(-4em);
+}
+.rl > div {
+  text-shadow: 4px -2px aqua;
+  transform: rotate(90deg);
+}
+</style>
+
+<div class=lr><div>Ap Éx</div></div>
+
+<div class=rl><div>Ap Éx</div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-shadow-sideways-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-shadow-sideways-001-ref.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<title>Reference for Sideways Inline Layout: Text Decoration</title>
+<meta charset=utf-8>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body > div {
+  /* styling */
+  border: solid gray;
+  font: 30px/1 Ahem;
+  color: silver;
+  float: left;
+  margin: 8px;
+
+  /* test */
+  text-decoration: underline;
+  text-decoration-color: orange;
+  text-decoration-thickness: 14px;
+
+  /* reference hacking */
+  width: 1em;
+  height: 5em;
+  white-space: nowrap;
+}
+div > div {
+  /* compensate for WebKit propagation bug */
+  text-decoration-thickness: 4px;
+}
+.lr > div {
+  text-shadow: -4px 2px aqua;
+  transform: rotate(-90deg) translateX(-4em);
+}
+.rl > div {
+  text-shadow: 4px -2px aqua;
+  transform: rotate(90deg);
+}
+</style>
+
+<div class=lr><div>Ap Éx</div></div>
+
+<div class=rl><div>Ap Éx</div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-shadow-sideways-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-shadow-sideways-001.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<title>Sideways Inline Layout: Text Decoration</title>
+<meta charset=utf-8>
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#block-flow">
+<link rel="help" href="https://www.w3.org/TR/CSS2/text.html#lining-striking-props">
+<link rel="help" href="https://www.w3.org/TR/css-text-decor-3/#text-shadow-property">
+
+<link rel="match" href="text-shadow-sideways-001-ref.html">
+
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body > div {
+  /* styling */
+  border: solid gray;
+  font: 30px/1 Ahem;
+  color: silver;
+  float: left;
+  margin: 8px;
+
+  /* test */
+  text-decoration: underline;
+  text-decoration-color: orange;
+  text-decoration-thickness: 4px;
+  text-shadow: 2px 4px aqua;
+}
+.lr {
+  writing-mode: sideways-lr;
+}
+.rl {
+  writing-mode: sideways-rl;
+}
+</style>
+
+<div class=lr>Ap Éx</div>
+
+<div class=rl>Ap Éx</div>

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -501,7 +501,6 @@ void TextBoxPainter::paintForeground(const StyledMarkedText& markedText)
 
     TextPainter textPainter { context, font, m_style };
     textPainter.setStyle(markedText.style.textStyles);
-    textPainter.setIsHorizontal(textBox().isHorizontal());
     if (markedText.style.textShadow) {
         textPainter.setShadow(&markedText.style.textShadow.value());
         if (m_style.hasAppleColorFilter())

--- a/Source/WebCore/rendering/TextBoxPainter.h
+++ b/Source/WebCore/rendering/TextBoxPainter.h
@@ -53,6 +53,8 @@ public:
 
     void paint();
 
+    static inline FloatSize rotateShadowOffset(const SpaceSeparatedPoint<Style::Length<>>& offset, WritingMode);
+
 protected:
     auto& textBox() const { return m_textBox; }
     InlineIterator::TextBoxIterator makeIterator() const;
@@ -113,4 +115,12 @@ protected:
     std::optional<bool> m_emphasisMarkExistsAndIsAbove { };
 };
 
+inline FloatSize TextBoxPainter::rotateShadowOffset(const SpaceSeparatedPoint<Style::Length<>>& offset, WritingMode writingMode)
+{
+    if (writingMode.isHorizontal())
+        return { offset.x().value, offset.y().value };
+    if (writingMode.isLineOverLeft()) // sideways-lr
+        return { -offset.y().value, offset.x().value };
+    return { offset.y().value, -offset.x().value };
+}
 }

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -33,6 +33,7 @@
 #include "RenderStyleInlines.h"
 #include "RenderText.h"
 #include "ShadowData.h"
+#include "TextBoxPainter.h"
 #include "TextRun.h"
 
 namespace WebCore {
@@ -202,6 +203,15 @@ TextDecorationPainter::TextDecorationPainter(GraphicsContext& context, const Fon
 {
 }
 
+static inline FloatSize convertShadowOffset(const LengthPoint& offset, WritingMode writingMode)
+{
+    if (writingMode.isHorizontal())
+        return { offset.x.value(), offset.y.value() };
+    if (writingMode.isLineOverLeft()) // sideways-lr
+        return { -offset.y.value(), offset.x.value() };
+    return { offset.y.value(), -offset.x.value() };
+}
+
 // Paint text-shadow, underline, overline
 void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style, const TextRun& textRun, const BackgroundDecorationGeometry& decorationGeometry, OptionSet<TextDecorationLine> decorationType, const Styles& decorationStyle)
 {
@@ -249,11 +259,10 @@ void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style,
             auto shadowExtent = shadow->paintingExtent();
             auto shadowRect = clipRect;
             shadowRect.inflate(shadowExtent);
-            auto shadowX = m_writingMode.isHorizontal() ? shadow->x().value : shadow->y().value;
-            auto shadowY = m_writingMode.isHorizontal() ? shadow->y().value : -shadow->x().value;
-            shadowRect.move(shadowX, shadowY);
+            auto shadowOffset = TextBoxPainter::rotateShadowOffset(shadow->location(), m_writingMode);
+            shadowRect.move(shadowOffset);
             clipRect.unite(shadowRect);
-            extraOffset = std::max(extraOffset, std::max(0.f, shadowY) + shadowExtent);
+            extraOffset = std::max(extraOffset, std::max(0.f, shadowOffset.height()) + shadowExtent);
         }
         m_context.save();
         m_context.clip(clipRect);
@@ -283,9 +292,9 @@ void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style,
             if (m_shadowColorFilter)
                 m_shadowColorFilter->transformColor(shadowColor);
 
-            auto shadowX = m_writingMode.isHorizontal() ? shadow->x().value : shadow->y().value;
-            auto shadowY = m_writingMode.isHorizontal() ? shadow->y().value : -shadow->x().value;
-            m_context.setDropShadow({ { shadowX, shadowY - extraOffset }, shadow->radius().value, shadowColor, ShadowRadiusMode::Default });
+            auto shadowOffset = TextBoxPainter::rotateShadowOffset(shadow->location(), m_writingMode);
+            shadowOffset.expand(0, -extraOffset);
+            m_context.setDropShadow({ shadowOffset, shadow->radius().value, shadowColor, ShadowRadiusMode::Default });
             shadow = shadow->next();
         };
         applyShadowIfNeeded();

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -36,11 +36,12 @@
 #include "RenderLayer.h"
 #include "RenderStyle.h"
 #include "ShadowData.h"
+#include "TextBoxPainter.h"
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 
-ShadowApplier::ShadowApplier(const RenderStyle& style, GraphicsContext& context, const ShadowData* shadow, const FilterOperations* colorFilter, const FloatRect& textRect, bool lastShadowIterationShouldDrawText, bool opaque, FontOrientation orientation)
+ShadowApplier::ShadowApplier(const RenderStyle& style, GraphicsContext& context, const ShadowData* shadow, const FilterOperations* colorFilter, const FloatRect& textRect, bool lastShadowIterationShouldDrawText, bool opaque, bool ignoreWritingMode)
     : m_context { context }
     , m_shadow { shadow }
     , m_onlyDrawsShadow { !isLastShadowIteration() || !lastShadowIterationShouldDrawText }
@@ -53,9 +54,7 @@ ShadowApplier::ShadowApplier(const RenderStyle& style, GraphicsContext& context,
         return;
     }
 
-    auto shadowX = orientation == FontOrientation::Horizontal ? shadow->x().value : shadow->y().value;
-    auto shadowY = orientation == FontOrientation::Horizontal ? shadow->y().value : -shadow->x().value;
-    auto shadowOffset = FloatSize(shadowX, shadowY);
+    auto shadowOffset = TextBoxPainter::rotateShadowOffset(shadow->location(), ignoreWritingMode ? WritingMode() : style.writingMode());
     auto shadowRadius = shadow->radius().value;
     auto shadowColor = style.colorResolvingCurrentColor(shadow->color());
     if (colorFilter)
@@ -104,6 +103,7 @@ TextPainter::TextPainter(GraphicsContext& context, const FontCascade& font, cons
     : m_context(context)
     , m_font(font)
     , m_renderStyle(renderStyle)
+    , m_writingMode(renderStyle.writingMode())
 {
 }
 
@@ -142,7 +142,7 @@ void TextPainter::paintTextWithShadows(const ShadowData* shadow, const FilterOpe
     if (!opaque)
         m_context.setFillColor(Color::black);
     while (shadow) {
-        ShadowApplier shadowApplier(m_renderStyle, m_context, shadow, colorFilter, boxRect, lastShadowIterationShouldDrawText, opaque, (m_textBoxIsHorizontal || m_combinedText) ? FontOrientation::Horizontal : FontOrientation::Vertical);
+        ShadowApplier shadowApplier(m_renderStyle, m_context, shadow, colorFilter, boxRect, lastShadowIterationShouldDrawText, opaque, m_combinedText);
         if (!shadowApplier.nothingToDraw())
             paintTextOrEmphasisMarks(font, textRun, emphasisMark, emphasisMarkOffset, textOrigin + shadowApplier.extraOffset(), startOffset, endOffset);
         shadow = shadow->next();

--- a/Source/WebCore/rendering/TextPainter.h
+++ b/Source/WebCore/rendering/TextPainter.h
@@ -55,7 +55,6 @@ public:
     void setStyle(const TextPaintStyle& textPaintStyle) { m_style = textPaintStyle; }
     void setShadow(const ShadowData* shadow) { m_shadow = shadow; }
     void setShadowColorFilter(const FilterOperations* colorFilter) { m_shadowColorFilter = colorFilter; }
-    void setIsHorizontal(bool isHorizontal) { m_textBoxIsHorizontal = isHorizontal; }
     void setEmphasisMark(const AtomString& mark, float offset, const RenderCombineText*);
 
     void paintRange(const TextRun&, const FloatRect& boxRect, const FloatPoint& textOrigin, unsigned start, unsigned end);
@@ -98,7 +97,7 @@ private:
     const RenderCombineText* m_combinedText { nullptr };
     DisplayList::DisplayList* m_glyphDisplayList { nullptr };
     float m_emphasisMarkOffset { 0 };
-    bool m_textBoxIsHorizontal { true };
+    WritingMode m_writingMode;
 };
 
 inline void TextPainter::setEmphasisMark(const AtomString& mark, float offset, const RenderCombineText* combinedText)
@@ -110,7 +109,7 @@ inline void TextPainter::setEmphasisMark(const AtomString& mark, float offset, c
 
 class ShadowApplier {
 public:
-    ShadowApplier(const RenderStyle&, GraphicsContext&, const ShadowData*, const FilterOperations* colorFilter, const FloatRect& textRect, bool lastShadowIterationShouldDrawText = true, bool opaque = false, FontOrientation = FontOrientation::Horizontal);
+    ShadowApplier(const RenderStyle&, GraphicsContext&, const ShadowData*, const FilterOperations* colorFilter, const FloatRect& textRect, bool lastShadowIterationShouldDrawText = true, bool opaque = false, bool ignoreWritingMode = false);
     FloatSize extraOffset() const { return m_extraOffset; }
     bool nothingToDraw() const { return m_nothingToDraw; }
     bool didSaveContext() const { return m_didSaveContext; }


### PR DESCRIPTION
#### 319ce4ee332042cc4b4a7ca5677fc7d338f87d41
<pre>
Correctly orient shadow offsets in sideways-lr modes
<a href="https://bugs.webkit.org/show_bug.cgi?id=285221">https://bugs.webkit.org/show_bug.cgi?id=285221</a>
<a href="https://rdar.apple.com/problem/142128648">rdar://problem/142128648</a>

Reviewed by Alan Baradlay.

Teaches the text and text decoration shadow offset adjustment code
to handle counter-clockwise rotation for sideways-lr.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-shadow-sideways-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-shadow-sideways-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-shadow-sideways-001.html: Added.
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter::paintForeground):
* Source/WebCore/rendering/TextBoxPainter.h:
(WebCore::TextBoxPainter::rotateShadowOffset):
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::convertShadowOffset):
(WebCore::TextDecorationPainter::paintBackgroundDecorations):
* Source/WebCore/rendering/TextPainter.cpp:
(WebCore::ShadowApplier::ShadowApplier):
(WebCore::TextPainter::TextPainter):
(WebCore::TextPainter::paintTextWithShadows):
* Source/WebCore/rendering/TextPainter.h:
(WebCore::TextPainter::setShadowColorFilter):
(WebCore::TextPainter::setIsHorizontal): Deleted.

Canonical link: <a href="https://commits.webkit.org/288377@main">https://commits.webkit.org/288377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d1c9916edf2370d20170d010ada64eceaef8dbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82941 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/2587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/37235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/33992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2661 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/10504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/88055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/33992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85997 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/1957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/75436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/1864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/29629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/33026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/30313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/89421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/10228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/89421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/10456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/71244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/89421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12826 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/10181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/15693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/10053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/13518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/11821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->