### PR TITLE
box sizing cleanup

### DIFF
--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1447,6 +1447,7 @@ bool RenderBox::hasTrimmedMargin(std::optional<MarginTrimType> marginTrimType) c
 
 LayoutUnit RenderBox::adjustBorderBoxLogicalWidthForBoxSizing(const Length& logicalWidth) const
 {
+    ASSERT(logicalWidth.isFixed());
     auto width = LayoutUnit { logicalWidth.value() };
     LayoutUnit bordersPlusPadding = borderAndPaddingLogicalWidth();
     if (style().boxSizing() == BoxSizing::ContentBox || logicalWidth.isIntrinsicOrAuto())
@@ -1456,7 +1457,7 @@ LayoutUnit RenderBox::adjustBorderBoxLogicalWidthForBoxSizing(const Length& logi
 
 LayoutUnit RenderBox::adjustBorderBoxLogicalWidthForBoxSizing(LayoutUnit computedLogicalWidth, LengthType originalType) const
 {
-    if (originalType == LengthType::Calculated)
+    if (originalType == LengthType::Calculated || originalType == LengthType::Percent)
         return adjustBorderBoxLogicalWidthForBoxSizing({ computedLogicalWidth, LengthType::Fixed, false });
     return adjustBorderBoxLogicalWidthForBoxSizing({ computedLogicalWidth, originalType, false });
 }
@@ -1471,6 +1472,7 @@ LayoutUnit RenderBox::adjustBorderBoxLogicalHeightForBoxSizing(LayoutUnit height
 
 LayoutUnit RenderBox::adjustContentBoxLogicalWidthForBoxSizing(const Length& logicalWidth) const
 {
+    ASSERT(logicalWidth.isFixed());
     auto width = LayoutUnit { logicalWidth.value() };
     if (style().boxSizing() == BoxSizing::ContentBox || logicalWidth.isIntrinsicOrAuto())
         return std::max(0_lu, width);
@@ -2809,7 +2811,7 @@ LayoutUnit RenderBox::computeLogicalWidthInFragmentUsing(SizeType widthType, Len
 {
     ASSERT(widthType == SizeType::MinSize || widthType == SizeType::MainOrPreferredSize || !logicalWidth.isAuto());
     if (widthType == SizeType::MinSize && logicalWidth.isAuto())
-        return adjustBorderBoxLogicalWidthForBoxSizing(0, logicalWidth.type());
+        return borderAndPaddingLogicalWidth();
 
     if (!logicalWidth.isIntrinsicOrAuto()) {
         // FIXME: If the containing block flow is perpendicular to our direction we need to use the available logical height instead.
@@ -3497,7 +3499,7 @@ LayoutUnit RenderBox::computeReplacedLogicalWidthUsing(SizeType widthType, Lengt
 {
     ASSERT(widthType == SizeType::MinSize || widthType == SizeType::MainOrPreferredSize || !logicalWidth.isAuto());
     if (widthType == SizeType::MinSize && logicalWidth.isAuto())
-        return adjustContentBoxLogicalWidthForBoxSizing(0, logicalWidth.type());
+        return { };
 
     switch (logicalWidth.type()) {
     case LengthType::Fixed:


### PR DESCRIPTION
#### 84f0e6ad0f9faf3864eb5eb3fdfa2f0f3862a3c5
<pre>
box sizing cleanup

work in progress
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84f0e6ad0f9faf3864eb5eb3fdfa2f0f3862a3c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82607 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87728 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33665 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10167 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64379 "Failure limit exceed. At least found 492 new test failures: accessibility/add-children-pseudo-element.html accessibility/aria-hidden-hides-all-elements.html accessibility/dialog-showModal.html accessibility/dialog-slotted-content.html accessibility/fieldset-element.html accessibility/iframe-within-cell.html accessibility/insert-children-assert.html accessibility/media-controls.html accessibility/transformed-bounds.html animations/3d/change-transform-in-end-event.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22138 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1689 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75151 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44654 "Found 10 new API test failures: /WPE/TestOptionMenu:/webkit/WebKitWebView/option-menu-activate, /WPE/TestOptionMenu:/webkit/WebKitWebView/option-menu-simple, /WPE/TestOptionMenu:/webkit/WebKitWebView/option-menu-groups, /WPE/TestWebKitWebView:/webkit/WebKitWebView/fullscreen, /WPE/TestUIClient:/webkit/WebKitWebView/display-usermedia-permission-request, /TestWebKit:WebKit.EnumerateDevicesCrash, /TestWebKit:WebKit.OnDeviceChangeCrash, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /TestWebKit:WebKit.UserMediaBasic, /WPE/TestOptionMenu:/webkit/WebKitWebView/option-menu-select (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29337 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32698 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72872 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89093 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9901 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7163 "Found 60 new test failures: accessibility/animated-dropdown.html accessibility/aria-hidden-hides-all-elements.html accessibility/dialog-properties.html accessibility/mac/children-in-navigation-order-returns-children.html accessibility/mac/doctype-node-in-text-marker-crash.html accessibility/mac/dynamic-transform-relative-frame.html accessibility/text-marker/media-emits-object-replacement.html accessibility/text-marker/text-marker-previous-next.html animations/3d/change-transform-in-end-event.html animations/3d/matrix-transform-type-animation.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72789 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72003 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16144 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15107 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1290 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9854 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15375 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9728 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13193 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11497 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->