### PR TITLE
Adopt CompactVariant in Style::LengthPercentage/Style::AnglePercentage

### DIFF
--- a/Source/WTF/wtf/VariantExtras.h
+++ b/Source/WTF/wtf/VariantExtras.h
@@ -90,9 +90,7 @@ template<typename Arg, typename... Ts> struct VariantBestMatch<std::variant<Ts..
 //       }
 //   );
 
-template<typename V, typename IndexType = size_t, typename... F> constexpr auto typeForIndex(IndexType index, F&&... f) -> decltype(visitTypeForIndex<V>(index, makeVisitor(std::forward<F>(f)...)));
-
-template<typename V, size_t I = 0, typename IndexType = size_t, typename F> constexpr ALWAYS_INLINE decltype(auto) visitTypeForIndex(IndexType index, F&& f)
+template<typename V, size_t I = 0, typename F> constexpr ALWAYS_INLINE decltype(auto) visitTypeForIndex(size_t index, F&& f)
 {
     constexpr auto size = std::variant_size_v<V>;
 
@@ -157,7 +155,7 @@ template<typename V, size_t I = 0, typename IndexType = size_t, typename F> cons
 #undef WTF_VARIANT_EXTRAS_VISIT_CASE
 }
 
-template<typename V, typename IndexType, typename... F> constexpr auto typeForIndex(IndexType index, F&&... f) -> decltype(visitTypeForIndex<V>(index, makeVisitor(std::forward<F>(f)...)))
+template<typename V, typename... F> constexpr auto typeForIndex(size_t index, F&&... f) -> decltype(visitTypeForIndex<V>(index, makeVisitor(std::forward<F>(f)...)))
 {
     return visitTypeForIndex<V>(index, makeVisitor(std::forward<F>(f)...));
 }

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2663,6 +2663,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/primitives/StyleNone.h
     style/values/primitives/StylePosition.h
     style/values/primitives/StylePrimitiveNumericTypes.h
+    style/values/primitives/StyleUnevaluatedCalculation.h
 
     style/values/shapes/StyleBasicShape.h
     style/values/shapes/StyleCircleFunction.h

--- a/Source/WebCore/css/values/color/CSSColorConversion+ToTypedColor.h
+++ b/Source/WebCore/css/values/color/CSSColorConversion+ToTypedColor.h
@@ -27,6 +27,7 @@
 
 #include "CSSColorConversion+Normalize.h"
 #include "CSSColorDescriptors.h"
+#include "StyleNone.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
@@ -194,3 +194,7 @@ template<typename T> struct CSSValueChildrenVisitor<UnevaluatedCalc<T>> {
 
 } // namespace CSS
 } // namespace WebCore
+
+template<typename T> struct WTF::IsSmartPtr<WebCore::CSS::UnevaluatedCalc<T>> {
+    static constexpr bool value = true;
+};

--- a/Source/WebCore/style/values/images/StyleGradient.cpp
+++ b/Source/WebCore/style/values/images/StyleGradient.cpp
@@ -128,19 +128,19 @@ static std::optional<float> resolveColorStopPosition(const GradientLinearColorSt
     if (!position)
         return std::nullopt;
 
-    return position->value.switchOn(
-        [&](Length<> length) -> std::optional<float> {
+    return WTF::switchOn(*position,
+        [&](const Length<>& length) -> std::optional<float> {
             if (gradientLength <= 0)
                 return 0;
             return length.value / gradientLength;
         },
-        [&](Percentage<> percentage) -> std::optional<float> {
+        [&](const Percentage<>& percentage) -> std::optional<float> {
             return percentage.value / 100.0;
         },
-        [&](const CalculationValue& calc) -> std::optional<float> {
+        [&](const typename LengthPercentage<>::Calc& calc) -> std::optional<float> {
             if (gradientLength <= 0)
                 return 0;
-            return calc.evaluate(gradientLength) / gradientLength;
+            return calc.protectedCalculation()->evaluate(gradientLength) / gradientLength;
         }
     );
 }
@@ -150,15 +150,15 @@ static std::optional<float> resolveColorStopPosition(const GradientAngularColorS
     if (!position)
         return std::nullopt;
 
-    return position->value.switchOn(
-        [](Angle<> angle) -> std::optional<float> {
+    return WTF::switchOn(*position,
+        [](const Angle<>& angle) -> std::optional<float> {
             return angle.value / 360.0;
         },
-        [](Percentage<> percentage) -> std::optional<float> {
+        [](const Percentage<>& percentage) -> std::optional<float> {
             return percentage.value / 100.0;
         },
-        [](const CalculationValue& calc) -> std::optional<float> {
-            return calc.evaluate(100) / 100.0;
+        [&](const typename AnglePercentage<>::Calc& calc) -> std::optional<float> {
+            return calc.protectedCalculation()->evaluate(100) / 100.0;
         }
     );
 }

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h
@@ -38,6 +38,11 @@ inline Calculation::Child copyCalculation(Ref<CalculationValue> value)
     return value->copyRoot();
 }
 
+template<auto R, auto C> Calculation::Child copyCalculation(const UnevaluatedCalculation<R, C>& value)
+{
+    return value.protectedCalculation()->copyRoot();
+}
+
 template<auto R> Calculation::Child copyCalculation(const Number<R>& value)
 {
     return Calculation::number(value.value);

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp
@@ -31,9 +31,9 @@
 namespace WebCore {
 namespace Style {
 
-Ref<CSSCalcValue> makeCalc(const CalculationValue& calculation, const RenderStyle& style)
+Ref<CSSCalcValue> makeCalc(Ref<CalculationValue> calculation, const RenderStyle& style)
 {
-    return CSSCalcValue::create(calculation, style);
+    return CSSCalcValue::create(WTFMove(calculation), style);
 }
 
 float adjustForZoom(float value, const RenderStyle& style)

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -188,7 +188,7 @@ template<auto R, typename... Rest> LengthPercentage<R> canonicalize(const CSS::L
 // MARK: - Conversion from "Style to "CSS"
 
 // Out of line to avoid inclusion of CSSCalcValue.h
-Ref<CSSCalcValue> makeCalc(const CalculationValue&, const RenderStyle&);
+Ref<CSSCalcValue> makeCalc(Ref<CalculationValue>, const RenderStyle&);
 // Out of line to avoid inclusion of RenderStyleInlines.h
 float adjustForZoom(float, const RenderStyle&);
 
@@ -205,14 +205,14 @@ template<auto R> struct ToCSS<AnglePercentage<R>> {
     auto operator()(const AnglePercentage<R>& value, const RenderStyle& style) -> CSS::AnglePercentage<R>
     {
         return WTF::switchOn(value,
-            [&](Angle<R> angle) -> CSS::AnglePercentage<R> {
+            [&](const Angle<R>& angle) -> CSS::AnglePercentage<R> {
                 return CSS::AnglePercentageRaw<R> { angle.unit, angle.value };
             },
-            [&](Percentage<R> percentage) -> CSS::AnglePercentage<R> {
+            [&](const Percentage<R>& percentage) -> CSS::AnglePercentage<R> {
                 return CSS::AnglePercentageRaw<R> { percentage.unit, percentage.value };
             },
-            [&](const CalculationValue& calculation) -> CSS::AnglePercentage<R> {
-                return CSS::UnevaluatedCalc<CSS::AnglePercentageRaw<R>> { makeCalc(calculation, style) };
+            [&](const typename AnglePercentage<R>::Calc& calculation) -> CSS::AnglePercentage<R> {
+                return CSS::UnevaluatedCalc<CSS::AnglePercentageRaw<R>> { makeCalc(calculation.protectedCalculation(), style) };
             }
         );
     }
@@ -222,14 +222,14 @@ template<auto R> struct ToCSS<LengthPercentage<R>> {
     auto operator()(const LengthPercentage<R>& value, const RenderStyle& style) -> CSS::LengthPercentage<R>
     {
         return WTF::switchOn(value,
-            [&](Length<R> length) -> CSS::LengthPercentage<R> {
+            [&](const Length<R>& length) -> CSS::LengthPercentage<R> {
                 return CSS::LengthPercentageRaw<R> { length.unit, adjustForZoom(length.value, style) };
             },
-            [&](Percentage<R> percentage) -> CSS::LengthPercentage<R> {
+            [&](const Percentage<R>& percentage) -> CSS::LengthPercentage<R> {
                 return CSS::LengthPercentageRaw<R> { percentage.unit, percentage.value };
             },
-            [&](const CalculationValue& calculation) -> CSS::LengthPercentage<R> {
-                return CSS::UnevaluatedCalc<CSS::LengthPercentageRaw<R>> { makeCalc(calculation, style) };
+            [&](const typename LengthPercentage<R>::Calc& calculation) -> CSS::LengthPercentage<R> {
+                return CSS::UnevaluatedCalc<CSS::LengthPercentageRaw<R>> { makeCalc(calculation.protectedCalculation(), style) };
             }
         );
     }

--- a/Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.h
+++ b/Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSPrimitiveNumericRange.h"
+#include "CalculationValue.h"
+
+namespace WebCore {
+namespace Style {
+
+// Wrapper for `Ref<CalculationValue>` that includes range and category as part of the type.
+template<CSS::Range R, Calculation::Category C> struct UnevaluatedCalculation {
+    static constexpr auto range = R;
+    static constexpr auto category = C;
+
+    Ref<CalculationValue> value;
+
+    Ref<CalculationValue> protectedCalculation() const
+    {
+        return value;
+    }
+
+    explicit UnevaluatedCalculation(Ref<CalculationValue> root)
+        : value { WTFMove(root) }
+    {
+    }
+
+    explicit UnevaluatedCalculation(Calculation::Child root)
+        : UnevaluatedCalculation {
+            CalculationValue::create(
+                Calculation::Tree {
+                    .root = WTFMove(root),
+                    .category = category,
+                    .range = { range.min, range.max },
+                }
+            )
+        }
+    {
+    }
+
+    bool operator==(const UnevaluatedCalculation&) const = default;
+};
+
+} // namespace Style
+} // namespace WebCore
+
+template<auto R, auto C> struct WTF::IsSmartPtr<WebCore::Style::UnevaluatedCalculation<R, C>> {
+    static constexpr bool value = true;
+};

--- a/Tools/TestWebKitAPI/Tests/WTF/CompactVariant.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompactVariant.cpp
@@ -30,8 +30,6 @@
 #include <wtf/CompactVariant.h>
 #include <wtf/GetPtr.h>
 
-namespace TestWebKitAPI {
-
 struct EmptyStruct {
     constexpr bool operator==(const EmptyStruct&) const = default;
 };
@@ -50,16 +48,12 @@ struct TooBigStruct {
     constexpr bool operator==(double other) const { return value == other; };
 };
 
-} // namespace TestWebKitAPI
-
-namespace WTF {
-
 // Treat LifecycleLogger as smart pointer to allow its use in CompactVariant.
-template<> struct IsSmartPtr<TestWebKitAPI::LifecycleLogger> {
+template<> struct WTF::IsSmartPtr<TestWebKitAPI::LifecycleLogger> {
     static constexpr bool value = true;
 };
 
-template<> struct CompactVariantTraits<TestWebKitAPI::TooBigStruct> {
+template<> struct WTF::CompactVariantTraits<TooBigStruct> {
    static constexpr bool hasAlternativeRepresentation = true;
 
    static constexpr uint64_t encodeFromArguments(double value)
@@ -67,18 +61,21 @@ template<> struct CompactVariantTraits<TestWebKitAPI::TooBigStruct> {
        return static_cast<uint64_t>(std::bit_cast<uint32_t>(static_cast<float>(value)));
    }
 
-   static constexpr uint64_t encode(TestWebKitAPI::TooBigStruct&& value)
+   static constexpr uint64_t encode(const TooBigStruct& value)
    {
        return static_cast<uint64_t>(std::bit_cast<uint32_t>(static_cast<float>(value.value)));
    }
 
-   static constexpr TestWebKitAPI::TooBigStruct decode(uint64_t value)
+   static constexpr uint64_t encode(TooBigStruct&& value)
+   {
+       return static_cast<uint64_t>(std::bit_cast<uint32_t>(static_cast<float>(value.value)));
+   }
+
+   static constexpr TooBigStruct decode(uint64_t value)
    {
        return { std::bit_cast<float>(static_cast<uint32_t>(value)) };
    }
 };
-
-} // namespace WTF
 
 namespace TestWebKitAPI {
 
@@ -87,9 +84,9 @@ TEST(WTF_CompactVariant, Pointers)
     int testInt = 1;
     float testFloat = 2.0f;
 
-    WTF::CompactVariant<std::variant<int*, float*>> variant = &testInt;
-    EXPECT_TRUE(variant.holds_alternative<int*>());
-    EXPECT_FALSE(variant.holds_alternative<float*>());
+    CompactVariant<int*, float*> variant = &testInt;
+    EXPECT_TRUE(WTF::holdsAlternative<int*>(variant));
+    EXPECT_FALSE(WTF::holdsAlternative<float*>(variant));
 
     WTF::switchOn(variant,
         [&](int* const& value)   { EXPECT_EQ(*value, 1); },
@@ -97,8 +94,8 @@ TEST(WTF_CompactVariant, Pointers)
     );
 
     variant = &testFloat;
-    EXPECT_FALSE(variant.holds_alternative<int*>());
-    EXPECT_TRUE(variant.holds_alternative<float*>());
+    EXPECT_FALSE(WTF::holdsAlternative<int*>(variant));
+    EXPECT_TRUE(WTF::holdsAlternative<float*>(variant));
 
     WTF::switchOn(variant,
         [&](int* const& value)   { FAIL(); },
@@ -112,10 +109,10 @@ TEST(WTF_CompactVariant, SmartPointers)
         RefLogger testRefLogger("testRefLogger");
         Ref<RefLogger> ref(testRefLogger);
 
-        WTF::CompactVariant<std::variant<Ref<RefLogger>, std::unique_ptr<double>>> variant { std::in_place_type<Ref<RefLogger>>, WTFMove(ref) };
+        CompactVariant<Ref<RefLogger>, std::unique_ptr<double>> variant { std::in_place_type<Ref<RefLogger>>, WTFMove(ref) };
 
-        EXPECT_TRUE(variant.holds_alternative<Ref<RefLogger>>());
-        EXPECT_FALSE(variant.holds_alternative<std::unique_ptr<double>>());
+        EXPECT_TRUE(WTF::holdsAlternative<Ref<RefLogger>>(variant));
+        EXPECT_FALSE(WTF::holdsAlternative<std::unique_ptr<double>>(variant));
 
         WTF::switchOn(variant,
             [&](const Ref<RefLogger>&)          { SUCCEED(); },
@@ -123,8 +120,8 @@ TEST(WTF_CompactVariant, SmartPointers)
         );
 
         variant = std::make_unique<double>(2.0);
-        EXPECT_FALSE(variant.holds_alternative<Ref<RefLogger>>());
-        EXPECT_TRUE(variant.holds_alternative<std::unique_ptr<double>>());
+        EXPECT_FALSE(WTF::holdsAlternative<Ref<RefLogger>>(variant));
+        EXPECT_TRUE(WTF::holdsAlternative<std::unique_ptr<double>>(variant));
 
         WTF::switchOn(variant,
             [&](const Ref<RefLogger>&)                { FAIL(); },
@@ -138,10 +135,10 @@ TEST(WTF_CompactVariant, SmallScalars)
 {
     float testFloat = 2.0f;
 
-    WTF::CompactVariant<std::variant<int*, float*, float>> variant = 3.0f;
-    EXPECT_FALSE(variant.holds_alternative<int*>());
-    EXPECT_FALSE(variant.holds_alternative<float*>());
-    EXPECT_TRUE(variant.holds_alternative<float>());
+    CompactVariant<int*, float*, float> variant = 3.0f;
+    EXPECT_FALSE(WTF::holdsAlternative<int*>(variant));
+    EXPECT_FALSE(WTF::holdsAlternative<float*>(variant));
+    EXPECT_TRUE(WTF::holdsAlternative<float>(variant));
 
     WTF::switchOn(variant,
         [&](int* const& value)   { FAIL(); },
@@ -150,9 +147,9 @@ TEST(WTF_CompactVariant, SmallScalars)
     );
 
     variant = &testFloat;
-    EXPECT_FALSE(variant.holds_alternative<int*>());
-    EXPECT_TRUE(variant.holds_alternative<float*>());
-    EXPECT_FALSE(variant.holds_alternative<float>());
+    EXPECT_FALSE(WTF::holdsAlternative<int*>(variant));
+    EXPECT_TRUE(WTF::holdsAlternative<float*>(variant));
+    EXPECT_FALSE(WTF::holdsAlternative<float>(variant));
 
     WTF::switchOn(variant,
         [&](int* const& value)   { FAIL(); },
@@ -165,10 +162,10 @@ TEST(WTF_CompactVariant, EmptyStruct)
 {
     float testFloat = 2.0f;
 
-    WTF::CompactVariant<std::variant<int*, float*, EmptyStruct>> variant = EmptyStruct { };
-    EXPECT_FALSE(variant.holds_alternative<int*>());
-    EXPECT_FALSE(variant.holds_alternative<float*>());
-    EXPECT_TRUE(variant.holds_alternative<EmptyStruct>());
+    CompactVariant<int*, float*, EmptyStruct> variant = EmptyStruct { };
+    EXPECT_FALSE(WTF::holdsAlternative<int*>(variant));
+    EXPECT_FALSE(WTF::holdsAlternative<float*>(variant));
+    EXPECT_TRUE(WTF::holdsAlternative<EmptyStruct>(variant));
 
     WTF::switchOn(variant,
         [&](int* const& value)   { FAIL(); },
@@ -177,9 +174,9 @@ TEST(WTF_CompactVariant, EmptyStruct)
     );
 
     variant = &testFloat;
-    EXPECT_FALSE(variant.holds_alternative<int*>());
-    EXPECT_TRUE(variant.holds_alternative<float*>());
-    EXPECT_FALSE(variant.holds_alternative<EmptyStruct>());
+    EXPECT_FALSE(WTF::holdsAlternative<int*>(variant));
+    EXPECT_TRUE(WTF::holdsAlternative<float*>(variant));
+    EXPECT_FALSE(WTF::holdsAlternative<EmptyStruct>(variant));
 
     WTF::switchOn(variant,
         [&](int* const& value)   { FAIL(); },
@@ -192,10 +189,10 @@ TEST(WTF_CompactVariant, SmallEnoughStruct)
 {
     float testFloat = 2.0f;
 
-    WTF::CompactVariant<std::variant<int*, float*, SmallEnoughStruct>> variant = SmallEnoughStruct { 3.0f };
-    EXPECT_FALSE(variant.holds_alternative<int*>());
-    EXPECT_FALSE(variant.holds_alternative<float*>());
-    EXPECT_TRUE(variant.holds_alternative<SmallEnoughStruct>());
+    CompactVariant<int*, float*, SmallEnoughStruct> variant = SmallEnoughStruct { 3.0f };
+    EXPECT_FALSE(WTF::holdsAlternative<int*>(variant));
+    EXPECT_FALSE(WTF::holdsAlternative<float*>(variant));
+    EXPECT_TRUE(WTF::holdsAlternative<SmallEnoughStruct>(variant));
 
     WTF::switchOn(variant,
         [&](int* const& value)              { FAIL(); },
@@ -204,9 +201,9 @@ TEST(WTF_CompactVariant, SmallEnoughStruct)
     );
 
     variant = &testFloat;
-    EXPECT_FALSE(variant.holds_alternative<int*>());
-    EXPECT_TRUE(variant.holds_alternative<float*>());
-    EXPECT_FALSE(variant.holds_alternative<SmallEnoughStruct>());
+    EXPECT_FALSE(WTF::holdsAlternative<int*>(variant));
+    EXPECT_TRUE(WTF::holdsAlternative<float*>(variant));
+    EXPECT_FALSE(WTF::holdsAlternative<SmallEnoughStruct>(variant));
 
     WTF::switchOn(variant,
         [&](int* const& value)        { FAIL(); },
@@ -219,10 +216,10 @@ TEST(WTF_CompactVariant, TooBigStruct)
 {
     float testFloat = 2.0f;
 
-    WTF::CompactVariant<std::variant<int*, float*, TooBigStruct>> variant = TooBigStruct { 4.0 };
-    EXPECT_FALSE(variant.holds_alternative<int*>());
-    EXPECT_FALSE(variant.holds_alternative<float*>());
-    EXPECT_TRUE(variant.holds_alternative<TooBigStruct>());
+    CompactVariant<int*, float*, TooBigStruct> variant = TooBigStruct { 4.0 };
+    EXPECT_FALSE(WTF::holdsAlternative<int*>(variant));
+    EXPECT_FALSE(WTF::holdsAlternative<float*>(variant));
+    EXPECT_TRUE(WTF::holdsAlternative<TooBigStruct>(variant));
 
     WTF::switchOn(variant,
         [&](int* const& value)        { FAIL(); },
@@ -231,14 +228,49 @@ TEST(WTF_CompactVariant, TooBigStruct)
     );
 
     variant = &testFloat;
-    EXPECT_FALSE(variant.holds_alternative<int*>());
-    EXPECT_TRUE(variant.holds_alternative<float*>());
-    EXPECT_FALSE(variant.holds_alternative<TooBigStruct>());
+    EXPECT_FALSE(WTF::holdsAlternative<int*>(variant));
+    EXPECT_TRUE(WTF::holdsAlternative<float*>(variant));
+    EXPECT_FALSE(WTF::holdsAlternative<TooBigStruct>(variant));
 
     WTF::switchOn(variant,
         [&](int* const& value)   { FAIL(); },
         [&](float* const& value) { EXPECT_EQ(*value, 2.0f); },
         [&](const TooBigStruct)  { FAIL(); }
+    );
+
+    variant = TooBigStruct { 5.0 };
+    CompactVariant<int*, float*, TooBigStruct> movedToVariant = WTFMove(variant);
+
+    EXPECT_TRUE(variant.valueless_by_move());
+
+    EXPECT_FALSE(WTF::holdsAlternative<int*>(movedToVariant));
+    EXPECT_FALSE(WTF::holdsAlternative<float*>(movedToVariant));
+    EXPECT_TRUE(WTF::holdsAlternative<TooBigStruct>(movedToVariant));
+
+    WTF::switchOn(movedToVariant,
+        [&](int* const& value)        { FAIL(); },
+        [&](float* const& value)      { FAIL(); },
+        [&](const TooBigStruct value) { EXPECT_EQ(value.value, 5.0); }
+    );
+
+    variant = movedToVariant;
+
+    EXPECT_FALSE(WTF::holdsAlternative<int*>(movedToVariant));
+    EXPECT_FALSE(WTF::holdsAlternative<float*>(movedToVariant));
+    EXPECT_TRUE(WTF::holdsAlternative<TooBigStruct>(movedToVariant));
+    EXPECT_FALSE(WTF::holdsAlternative<int*>(variant));
+    EXPECT_FALSE(WTF::holdsAlternative<float*>(variant));
+    EXPECT_TRUE(WTF::holdsAlternative<TooBigStruct>(variant));
+
+    WTF::switchOn(movedToVariant,
+        [&](int* const& value)        { FAIL(); },
+        [&](float* const& value)      { FAIL(); },
+        [&](const TooBigStruct value) { EXPECT_EQ(value.value, 5.0); }
+    );
+    WTF::switchOn(variant,
+        [&](int* const& value)        { FAIL(); },
+        [&](float* const& value)      { FAIL(); },
+        [&](const TooBigStruct value) { EXPECT_EQ(value.value, 5.0); }
     );
 }
 
@@ -246,10 +278,10 @@ TEST(WTF_CompactVariant, MoveOnlyStruct)
 {
     float testFloat = 2.0f;
 
-    WTF::CompactVariant<std::variant<int*, float*, MoveOnly>> variant = MoveOnly { 5u };
-    EXPECT_FALSE(variant.holds_alternative<int*>());
-    EXPECT_FALSE(variant.holds_alternative<float*>());
-    EXPECT_TRUE(variant.holds_alternative<MoveOnly>());
+    CompactVariant<int*, float*, MoveOnly> variant = MoveOnly { 5u };
+    EXPECT_FALSE(WTF::holdsAlternative<int*>(variant));
+    EXPECT_FALSE(WTF::holdsAlternative<float*>(variant));
+    EXPECT_TRUE(WTF::holdsAlternative<MoveOnly>(variant));
 
     WTF::switchOn(variant,
         [&](int* const& value)      { FAIL(); },
@@ -258,9 +290,9 @@ TEST(WTF_CompactVariant, MoveOnlyStruct)
     );
 
     variant = &testFloat;
-    EXPECT_FALSE(variant.holds_alternative<int*>());
-    EXPECT_TRUE(variant.holds_alternative<float*>());
-    EXPECT_FALSE(variant.holds_alternative<MoveOnly>());
+    EXPECT_FALSE(WTF::holdsAlternative<int*>(variant));
+    EXPECT_TRUE(WTF::holdsAlternative<float*>(variant));
+    EXPECT_FALSE(WTF::holdsAlternative<MoveOnly>(variant));
 
     WTF::switchOn(variant,
         [&](int* const& value)   { FAIL(); },
@@ -269,9 +301,9 @@ TEST(WTF_CompactVariant, MoveOnlyStruct)
     );
 
     variant = MoveOnly { 6u };
-    EXPECT_FALSE(variant.holds_alternative<int*>());
-    EXPECT_FALSE(variant.holds_alternative<float*>());
-    EXPECT_TRUE(variant.holds_alternative<MoveOnly>());
+    EXPECT_FALSE(WTF::holdsAlternative<int*>(variant));
+    EXPECT_FALSE(WTF::holdsAlternative<float*>(variant));
+    EXPECT_TRUE(WTF::holdsAlternative<MoveOnly>(variant));
 
     WTF::switchOn(variant,
         [&](int* const& value)     { FAIL(); },
@@ -283,20 +315,20 @@ TEST(WTF_CompactVariant, MoveOnlyStruct)
 TEST(WTF_CompactVariant, ValuelessByMove)
 {
     int testInt = 1;
-    WTF::CompactVariant<std::variant<int*, float*>> variant = &testInt;
+    CompactVariant<int*, float*> variant = &testInt;
     EXPECT_FALSE(variant.valueless_by_move());
 
-    WTF::CompactVariant<std::variant<int*, float*>> other = WTFMove(variant);
+    CompactVariant<int*, float*> other = WTFMove(variant);
     EXPECT_FALSE(other.valueless_by_move());
     EXPECT_TRUE(variant.valueless_by_move());
 
     // Test copying the "valueless_by_move" variant.
-    WTF::CompactVariant<std::variant<int*, float*>> copy = variant;
+    CompactVariant<int*, float*> copy = variant;
     EXPECT_TRUE(variant.valueless_by_move());
     EXPECT_TRUE(copy.valueless_by_move());
 
     // Test re-moving the "valueless_by_move" variant.
-    WTF::CompactVariant<std::variant<int*, float*>> moved = WTFMove(variant);
+    CompactVariant<int*, float*> moved = WTFMove(variant);
     EXPECT_TRUE(variant.valueless_by_move());
     EXPECT_TRUE(moved.valueless_by_move());
 }
@@ -304,7 +336,7 @@ TEST(WTF_CompactVariant, ValuelessByMove)
 TEST(WTF_CompactVariant, ArgumentAssignment)
 {
     {
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant = LifecycleLogger("compact");
+        CompactVariant<float, LifecycleLogger> variant = LifecycleLogger("compact");
 
         ASSERT_STREQ("construct(compact) move-construct(compact) destruct(<default>) ", takeLogStr().c_str());
     }
@@ -315,7 +347,7 @@ TEST(WTF_CompactVariant, ArgumentAssignment)
 TEST(WTF_CompactVariant, ArgumentConstruct)
 {
     {
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { LifecycleLogger("compact") };
+        CompactVariant<float, LifecycleLogger> variant { LifecycleLogger("compact") };
 
         ASSERT_STREQ("construct(compact) move-construct(compact) destruct(<default>) ", takeLogStr().c_str());
     }
@@ -325,7 +357,7 @@ TEST(WTF_CompactVariant, ArgumentConstruct)
 TEST(WTF_CompactVariant, ArgumentConstructInPlaceType)
 {
     {
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { std::in_place_type<LifecycleLogger>, "compact" };
+        CompactVariant<float, LifecycleLogger> variant { std::in_place_type<LifecycleLogger>, "compact" };
 
         ASSERT_STREQ("construct(compact) ", takeLogStr().c_str());
     }
@@ -335,7 +367,7 @@ TEST(WTF_CompactVariant, ArgumentConstructInPlaceType)
 TEST(WTF_CompactVariant, ArgumentConstructInPlaceIndex)
 {
     {
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { std::in_place_index<1>, "compact" };
+        CompactVariant<float, LifecycleLogger> variant { std::in_place_index<1>, "compact" };
 
         ASSERT_STREQ("construct(compact) ", takeLogStr().c_str());
     }
@@ -346,7 +378,7 @@ TEST(WTF_CompactVariant, ArgumentMoveConstruct)
 {
     {
         LifecycleLogger lifecycleLogger("compact");
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { WTFMove(lifecycleLogger) };
+        CompactVariant<float, LifecycleLogger> variant { WTFMove(lifecycleLogger) };
 
         ASSERT_STREQ("construct(compact) move-construct(compact) ", takeLogStr().c_str());
     }
@@ -357,7 +389,7 @@ TEST(WTF_CompactVariant, ArgumentCopyConstruct)
 {
     {
         LifecycleLogger lifecycleLogger("compact");
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { lifecycleLogger };
+        CompactVariant<float, LifecycleLogger> variant { lifecycleLogger };
 
         ASSERT_STREQ("construct(compact) copy-construct(compact) ", takeLogStr().c_str());
     }
@@ -368,7 +400,7 @@ TEST(WTF_CompactVariant, ArgumentMoveAssignment)
 {
     {
         LifecycleLogger lifecycleLogger("compact");
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant = WTFMove(lifecycleLogger);
+        CompactVariant<float, LifecycleLogger> variant = WTFMove(lifecycleLogger);
 
         ASSERT_STREQ("construct(compact) move-construct(compact) ", takeLogStr().c_str());
     }
@@ -379,7 +411,7 @@ TEST(WTF_CompactVariant, ArgumentCopyAssignment)
 {
     {
         LifecycleLogger lifecycleLogger("compact");
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant = lifecycleLogger;
+        CompactVariant<float, LifecycleLogger> variant = lifecycleLogger;
 
         ASSERT_STREQ("construct(compact) copy-construct(compact) ", takeLogStr().c_str());
     }
@@ -389,9 +421,9 @@ TEST(WTF_CompactVariant, ArgumentCopyAssignment)
 TEST(WTF_CompactVariant, CopyConstruct)
 {
     {
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { std::in_place_type<LifecycleLogger>, "compact" };
+        CompactVariant<float, LifecycleLogger> variant { std::in_place_type<LifecycleLogger>, "compact" };
 
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> other { variant };
+        CompactVariant<float, LifecycleLogger> other { variant };
 
         ASSERT_STREQ("construct(compact) copy-construct(compact) ", takeLogStr().c_str());
     }
@@ -401,9 +433,9 @@ TEST(WTF_CompactVariant, CopyConstruct)
 TEST(WTF_CompactVariant, CopyAssignment)
 {
     {
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { std::in_place_type<LifecycleLogger>, "compact" };
+        CompactVariant<float, LifecycleLogger> variant { std::in_place_type<LifecycleLogger>, "compact" };
 
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> other = variant;
+        CompactVariant<float, LifecycleLogger> other = variant;
 
         ASSERT_STREQ("construct(compact) copy-construct(compact) ", takeLogStr().c_str());
     }
@@ -413,9 +445,9 @@ TEST(WTF_CompactVariant, CopyAssignment)
 TEST(WTF_CompactVariant, MoveConstruct)
 {
     {
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { std::in_place_type<LifecycleLogger>, "compact" };
+        CompactVariant<float, LifecycleLogger> variant { std::in_place_type<LifecycleLogger>, "compact" };
 
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> other { WTFMove(variant) };
+        CompactVariant<float, LifecycleLogger> other { WTFMove(variant) };
 
         ASSERT_STREQ("construct(compact) move-construct(compact) ", takeLogStr().c_str());
     }
@@ -425,9 +457,9 @@ TEST(WTF_CompactVariant, MoveConstruct)
 TEST(WTF_CompactVariant, MoveAssignment)
 {
     {
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { std::in_place_type<LifecycleLogger>, "compact" };
+        CompactVariant<float, LifecycleLogger> variant { std::in_place_type<LifecycleLogger>, "compact" };
 
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> other = WTFMove(variant);
+        CompactVariant<float, LifecycleLogger> other = WTFMove(variant);
 
         ASSERT_STREQ("construct(compact) move-construct(compact) ", takeLogStr().c_str());
     }
@@ -437,7 +469,7 @@ TEST(WTF_CompactVariant, MoveAssignment)
 TEST(WTF_CompactVariant, ConstructThenReassign)
 {
     {
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { std::in_place_type<LifecycleLogger>, "compact" };
+        CompactVariant<float, LifecycleLogger> variant { std::in_place_type<LifecycleLogger>, "compact" };
 
         variant = 1.0f;
 
@@ -449,7 +481,7 @@ TEST(WTF_CompactVariant, ConstructThenReassign)
 TEST(WTF_CompactVariant, ArgumentReassignment)
 {
     {
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { 1.0f };
+        CompactVariant<float, LifecycleLogger> variant { 1.0f };
 
         variant = LifecycleLogger { "compact" };
 
@@ -461,7 +493,7 @@ TEST(WTF_CompactVariant, ArgumentReassignment)
 TEST(WTF_CompactVariant, ArgumentCopyReassignment)
 {
     {
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { 1.0f };
+        CompactVariant<float, LifecycleLogger> variant { 1.0f };
 
         LifecycleLogger lifecycleLogger { "compact" };
         variant = lifecycleLogger;
@@ -474,7 +506,7 @@ TEST(WTF_CompactVariant, ArgumentCopyReassignment)
 TEST(WTF_CompactVariant, ArgumentMoveReassignment)
 {
     {
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { 1.0f };
+        CompactVariant<float, LifecycleLogger> variant { 1.0f };
 
         LifecycleLogger lifecycleLogger { "compact" };
         variant = WTFMove(lifecycleLogger);
@@ -487,7 +519,7 @@ TEST(WTF_CompactVariant, ArgumentMoveReassignment)
 TEST(WTF_CompactVariant, EmplaceType)
 {
     {
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { 1.0f };
+        CompactVariant<float, LifecycleLogger> variant { 1.0f };
 
         variant.emplace<LifecycleLogger>("compact");
 
@@ -499,7 +531,7 @@ TEST(WTF_CompactVariant, EmplaceType)
 TEST(WTF_CompactVariant, EmplaceIndex)
 {
     {
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { 1.0f };
+        CompactVariant<float, LifecycleLogger> variant { 1.0f };
 
         variant.emplace<1>("compact");
 
@@ -512,7 +544,7 @@ TEST(WTF_CompactVariant, SwitchOn)
 {
     // `switchOn` should not cause any lifecycle events.
     {
-        WTF::CompactVariant<std::variant<float, LifecycleLogger>> variant { std::in_place_type<LifecycleLogger>, "compact" };
+        CompactVariant<float, LifecycleLogger> variant { std::in_place_type<LifecycleLogger>, "compact" };
 
         WTF::switchOn(variant,
             [&](const float&) { },


### PR DESCRIPTION
#### c5606cb19ea924582d75939ec6343cec295f1d7e
<pre>
Adopt CompactVariant in Style::LengthPercentage/Style::AnglePercentage
<a href="https://bugs.webkit.org/show_bug.cgi?id=285250">https://bugs.webkit.org/show_bug.cgi?id=285250</a>

Reviewed by Darin Adler.

Replaces hand rolled compact variant, `PrimitiveDimensionPercentage`,
used by `Style::LengthPercentage` and `Style::AnglePercentage` with
the new `WTF::CompactVariant` type.

To aid this, the direct use of `Ref&lt;CalculationValue&gt;` was replaced
with a new generic `Style::UnevaluatedCalculation&lt;&gt;` which serves as
the Style layer analog to the CSS layers `CSS::UnevaluatedCalc&lt;&gt;`.
Mark both types as being smart pointers by specializing `IsSmartPtr`
so that they both can be used in `CompactVariants`.

`Style::LengthPercentage` and `Style::AnglePercentage` were almost
identical, so rather than updating both of them to use the new type,
the generic `DimensionPercentage&lt;&gt;` was added, allowing subclassing
to define `Style::LengthPercentage` and `Style::AnglePercentage`.

A few issues arose with `WTF::CompactVariant` that ended up being
due to the implementations of move and copy not encoding types with
alternative representations correctly. This has been corrected and
tests have been added.

Additionally, it was useful to be able to swap in `std::variant&lt;&gt;`
in place of `WTF::CompactVariant` to debug issues. To make this
feasible without changing code, a new WTF::holdsAlternative&lt;&gt; was
added that works with any &quot;variant-like&quot;.

* Source/WTF/wtf/CompactVariant.h:
* Source/WTF/wtf/CompactVariantOperations.h:
* Source/WTF/wtf/StdLibExtras.h:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/values/color/CSSColorConversion+ToTypedColor.h:
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h:
* Source/WebCore/style/values/images/StyleGradient.cpp:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Blending.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Calculation.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.cpp:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes.h:
* Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.h: Added.
* Tools/TestWebKitAPI/Tests/WTF/CompactVariant.cpp:

Canonical link: <a href="https://commits.webkit.org/288346@main">https://commits.webkit.org/288346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e462512c20619484c48c588cdbd3c7c708fa36b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82669 "29 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87789 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33727 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84763 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10230 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64414 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22182 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44689 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1636 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29386 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32761 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75654 "Found 1 new JSC stress test failure: stress/json-raw-json.js.ftl-eager-no-cjit (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30045 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89155 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81717 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7215 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72829 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72043 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17912 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16194 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1351 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9915 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15436 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/104123 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9789 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25244 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13254 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11558 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->