### PR TITLE
Sync `input` specific unicode-bidi rendering from Web Specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules-expected.txt
@@ -108,10 +108,10 @@ PASS UA stylesheet rule for unicode-bidi, for <wbr>
 PASS UA stylesheet rule for unicode-bidi, for <bdo>
 PASS UA stylesheet rule for unicode-bidi, for <input type=hidden>
 PASS UA stylesheet rule for unicode-bidi, for <input type=text>
-FAIL UA stylesheet rule for unicode-bidi, for <input type=search> assert_equals: with dir=auto expected "plaintext" but got "isolate"
-FAIL UA stylesheet rule for unicode-bidi, for <input type=tel> assert_equals: with dir=auto expected "plaintext" but got "isolate"
-FAIL UA stylesheet rule for unicode-bidi, for <input type=url> assert_equals: with dir=auto expected "plaintext" but got "isolate"
-FAIL UA stylesheet rule for unicode-bidi, for <input type=email> assert_equals: with dir=auto expected "plaintext" but got "isolate"
+PASS UA stylesheet rule for unicode-bidi, for <input type=search>
+PASS UA stylesheet rule for unicode-bidi, for <input type=tel>
+PASS UA stylesheet rule for unicode-bidi, for <input type=url>
+PASS UA stylesheet rule for unicode-bidi, for <input type=email>
 PASS UA stylesheet rule for unicode-bidi, for <input type=password>
 PASS UA stylesheet rule for unicode-bidi, for <input type=date>
 PASS UA stylesheet rule for unicode-bidi, for <input type=time>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1412,6 +1412,10 @@ thead, tbody, tfoot, tr, td, th, dir, dd, dl, dt, menu, ol, ul, li, bdi, output,
     unicode-bidi: isolate; 
 }
 
+textarea[dir=auto i], pre[dir=auto i] {
+    unicode-bidi: plaintext;
+}
+
 input[type=tel i]:dir(ltr) { direction: ltr; }
 
 bdo, bdo[dir] {

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -130,7 +130,9 @@ String HTMLElement::nodeName() const
 static inline CSSValueID unicodeBidiAttributeForDirAuto(HTMLElement& element)
 {
     ASSERT(!element.hasTagName(bdoTag));
-    if (element.hasTagName(preTag) || element.hasTagName(textareaTag))
+    ASSERT(!element.hasTagName(preTag));
+    ASSERT(!element.hasTagName(textareaTag));
+    if (RefPtr input = dynamicDowncast<HTMLInputElement>(element); input && (input->isTelephoneField() || input->isEmailField() || input->isSearchField() || input->isURLField()))
         return CSSValuePlaintext;
     return CSSValueIsolate;
 }
@@ -246,7 +248,7 @@ void HTMLElement::collectPresentationalHintsForAttribute(const QualifiedName& na
         break;
     case AttributeNames::dirAttr:
         if (equalLettersIgnoringASCIICase(value, "auto"_s)) {
-            if (!hasTagName(bdoTag))
+            if (!hasTagName(bdoTag) && !hasTagName(preTag) && !hasTagName(textareaTag))
                 addPropertyToPresentationalHintStyle(style, CSSPropertyUnicodeBidi, unicodeBidiAttributeForDirAuto(*this));
         } else if (equalLettersIgnoringASCIICase(value, "rtl"_s) || equalLettersIgnoringASCIICase(value, "ltr"_s))
             addPropertyToPresentationalHintStyle(style, CSSPropertyDirection, value);


### PR DESCRIPTION
#### f9c75ce4940750e1d205141765f84f50241e97aa
<pre>
Sync `input` specific unicode-bidi rendering from Web Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=285252">https://bugs.webkit.org/show_bug.cgi?id=285252</a>
<a href="https://rdar.apple.com/142191490">rdar://142191490</a>

Reviewed by Aditya Keerthi.

This patch aligns WebKit with Web Specification [1]:

[1] <a href="https://html.spec.whatwg.org/multipage/rendering.html#bidi-rendering">https://html.spec.whatwg.org/multipage/rendering.html#bidi-rendering</a>

This patch implements `input` specific rules for directionality being `auto`
and move `textarea` and `pre` rules in UA stylesheet. The rationale is that `is:`
can be lead to performance concern, so did the change in C++, it also
matches Blink / Chromium.

Despite aligning with specification, there is still ambiguity on how to deal with
`password` and `text` input types for which following issue is raised [2].

[2] <a href="https://github.com/whatwg/html/issues/10896">https://github.com/whatwg/html/issues/10896</a>

* Source/WebCore/css/html.css:
(textarea[dir=auto i], pre[dir=auto i]):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::unicodeBidiAttributeForDirAuto):
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules-expected.txt: Rebaselined
(WebCore::HTMLElement::collectPresentationalHintsForAttribute):

Canonical link: <a href="https://commits.webkit.org/288511@main">https://commits.webkit.org/288511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1e6a104a7ab1054d3b25433e38072dab39201af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88740 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11244 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65082 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22898 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76022 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45370 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30232 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33726 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90119 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10934 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73516 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11158 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72741 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17983 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17001 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15701 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10886 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/16358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10734 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14209 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12506 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->