### PR TITLE
[JSC] `Array.prototype.toReversed` should fill holes with undefined

### DIFF
--- a/JSTests/stress/array-prototype-toReversed-empty.js
+++ b/JSTests/stress/array-prototype-toReversed-empty.js
@@ -1,0 +1,62 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let source = new Array(6);
+    source[0] = 42;
+    let result = source.toReversed();
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        if (i === 5)
+            shouldBe(result[i], 42);
+        else
+            shouldBe(result[i], undefined);
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = 42.195;
+    let result = source.toReversed();
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        if (i === 5)
+            shouldBe(result[i], 42.195);
+        else
+            shouldBe(result[i], undefined);
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = "string";
+    let result = source.toReversed();
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        if (i === 5)
+            shouldBe(result[i], "string");
+        else
+            shouldBe(result[i], undefined);
+    }
+}
+
+{
+    let source = new Array(6);
+    source[0] = "string";
+    $vm.ensureArrayStorage(source);
+    source[5] = "Hello";
+    let result = source.toReversed();
+    shouldBe(result.length, 6);
+    for (var i = 0; i < result.length; ++i) {
+        shouldBe(result.hasOwnProperty(i), true);
+        if (i === 0)
+            shouldBe(result[i], "Hello");
+        else if (i === 5)
+            shouldBe(result[i], "string");
+    }
+}

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -546,9 +546,9 @@ JSArray* JSArray::fastToReversed(JSGlobalObject* globalObject, uint64_t length)
         auto srcData = this->butterfly()->contiguous().data();
 
         if (hasDouble(indexingType)) {
-            if (holesMustForwardToPrototype() && containsHole(this->butterfly()->contiguousDouble().data(), static_cast<uint32_t>(length)))
+            if (containsHole(this->butterfly()->contiguousDouble().data(), static_cast<uint32_t>(length)))
                 return nullptr;
-        } else if (holesMustForwardToPrototype() && containsHole(srcData, static_cast<uint32_t>(length)))
+        } else if (containsHole(srcData, static_cast<uint32_t>(length)))
             return nullptr;
 
         auto vectorLength = Butterfly::optimalContiguousVectorLength(resultStructure, length);
@@ -579,7 +579,7 @@ JSArray* JSArray::fastToReversed(JSGlobalObject* globalObject, uint64_t length)
             return nullptr;
         if (length > storage.vectorLength())
             return nullptr;
-        if (storage.hasHoles() && holesMustForwardToPrototype())
+        if (storage.hasHoles())
             return nullptr;
 
         Structure* resultStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous);


### PR DESCRIPTION
#### 448746e32905bec49553cfca2e174d9381143386
<pre>
[JSC] `Array.prototype.toReversed` should fill holes with undefined
<a href="https://bugs.webkit.org/show_bug.cgi?id=285254">https://bugs.webkit.org/show_bug.cgi?id=285254</a>

Reviewed by Yusuke Suzuki.

<a href="https://commits.webkit.org/287431@main">https://commits.webkit.org/287431@main</a> rewrote `Array.prototype.toReversed`
in C++. According to the spec[1], `toReversed` should fill holes with `undefined`,
but this C++ implementation sometimes leaves those holes intact.

This commit fixes that issue by making the function bail out from the fast path
when the array contains any holes.

[1]: <a href="https://tc39.es/ecma262/#sec-array.prototype.toreversed">https://tc39.es/ecma262/#sec-array.prototype.toreversed</a>

* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastToReversed):

Canonical link: <a href="https://commits.webkit.org/288339@main">https://commits.webkit.org/288339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c324c6bf98b08f97acb05e46d7935736d2b364aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33694 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64398 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22159 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75171 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44673 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29357 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32729 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75621 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89122 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81685 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7183 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72812 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10158 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70981 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72026 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17911 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16167 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9883 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15404 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/104091 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9757 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25235 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13222 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11526 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->