### PR TITLE
Introduce ImmutableImageBuffer

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2118,6 +2118,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ImagePaintingOptions.h
     platform/graphics/ImageSource.h
     platform/graphics/ImageTypes.h
+    platform/graphics/ImmutableImageBuffer.h
     platform/graphics/InbandGenericCue.h
     platform/graphics/InbandGenericCueIdentifier.h
     platform/graphics/InbandTextTrackPrivate.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2508,6 +2508,7 @@ platform/graphics/ImageFrameAnimator.cpp
 platform/graphics/ImageFrameWorkQueue.cpp
 platform/graphics/ImagePaintingOptions.cpp
 platform/graphics/ImageSource.cpp
+platform/graphics/ImmutableImageBuffer.cpp
 platform/graphics/InbandGenericCue.cpp
 platform/graphics/ImageResolution.cpp
 platform/graphics/IntPoint.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -2857,6 +2857,7 @@
 		72A64523294908A200C14BA3 /* MeterPart.h in Headers */ = {isa = PBXBuildFile; fileRef = 722623C429486B6A006DCCF1 /* MeterPart.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72A645262949158000C14BA3 /* ControlFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 722623C029486B28006DCCF1 /* ControlFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72A73BEF245A3F90001C9D03 /* AnimationFrameRate.h in Headers */ = {isa = PBXBuildFile; fileRef = 722A815C238FD50500C00583 /* AnimationFrameRate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		72A8BBB62D1BBF88002261BA /* ImmutableImageBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 72A8BBB32D1B975F002261BA /* ImmutableImageBuffer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72ACC9C627629A7700D523F7 /* SVGPreserveAspectRatioValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C8F22461DD3D1C500E92DA3 /* SVGPreserveAspectRatioValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72B2213129502059002B5609 /* TextFieldPart.h in Headers */ = {isa = PBXBuildFile; fileRef = 72B2212E295015BB002B5609 /* TextFieldPart.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72B8B0352753438600F752AA /* FilterFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = 7262D756272A174100C56A09 /* FilterFunction.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -13405,6 +13406,8 @@
 		72A13AD7274DE57800E2A88E /* SourceGraphicSoftwareApplier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SourceGraphicSoftwareApplier.h; sourceTree = "<group>"; };
 		72A6451F2948F25900C14BA3 /* WebControlView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebControlView.h; sourceTree = "<group>"; };
 		72A645A4294FCDC600C14BA3 /* ControlStyle.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ControlStyle.cpp; sourceTree = "<group>"; };
+		72A8BBB32D1B975F002261BA /* ImmutableImageBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImmutableImageBuffer.h; sourceTree = "<group>"; };
+		72A8BBB42D1B975F002261BA /* ImmutableImageBuffer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImmutableImageBuffer.cpp; sourceTree = "<group>"; };
 		72B2212E295015BB002B5609 /* TextFieldPart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextFieldPart.h; sourceTree = "<group>"; };
 		72B2212F295015D5002B5609 /* TextFieldMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextFieldMac.mm; sourceTree = "<group>"; };
 		72B22130295015D5002B5609 /* TextFieldMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextFieldMac.h; sourceTree = "<group>"; };
@@ -33857,6 +33860,8 @@
 				554675781FD1FC1A003B10B0 /* ImageSource.h */,
 				5550CB411E955E3C00111AA0 /* ImageTypes.h */,
 				55BBD42824DB53A200BB6E0C /* ImageUtilities.h */,
+				72A8BBB42D1B975F002261BA /* ImmutableImageBuffer.cpp */,
+				72A8BBB32D1B975F002261BA /* ImmutableImageBuffer.h */,
 				078633F8240715D20087AE21 /* InbandGenericCue.cpp */,
 				078633DE23FEDF220087AE21 /* InbandGenericCue.h */,
 				0706A0D7240830A600E93818 /* InbandGenericCueIdentifier.h */,
@@ -41382,6 +41387,7 @@
 				5550CB421E955E3C00111AA0 /* ImageTypes.h in Headers */,
 				55BBD42924DB560400BB6E0C /* ImageUtilities.h in Headers */,
 				33E5A6AA2C6E023400F2CD04 /* ImmediateActionStage.h in Headers */,
+				72A8BBB62D1BBF88002261BA /* ImmutableImageBuffer.h in Headers */,
 				26F756B31B3B66F70005DD79 /* ImmutableNFA.h in Headers */,
 				26F756B51B3B68F20005DD79 /* ImmutableNFANodeBuilder.h in Headers */,
 				930A76C9297FA1CE0055B743 /* ImmutableStyleProperties.h in Headers */,

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2270,7 +2270,7 @@ ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(H
 
     videoElement.paintCurrentFrameInContext(imageBuffer->context(), FloatRect(FloatPoint(), size(videoElement)));
     
-    return RefPtr<CanvasPattern> { CanvasPattern::create({ imageBuffer.releaseNonNull() }, repeatX, repeatY, originClean) };
+    return RefPtr<CanvasPattern> { CanvasPattern::create({ static_reference_cast<ImmutableImageBuffer>(imageBuffer.releaseNonNull()) }, repeatX, repeatY, originClean) };
 }
 
 #endif
@@ -2292,7 +2292,7 @@ ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(I
     if (!buffer)
         return Exception { ExceptionCode::InvalidStateError };
 
-    return RefPtr<CanvasPattern> { CanvasPattern::create({ buffer.releaseNonNull() }, repeatX, repeatY, imageBitmap.originClean()) };
+    return RefPtr<CanvasPattern> { CanvasPattern::create({ static_reference_cast<ImmutableImageBuffer>(buffer.releaseNonNull()) }, repeatX, repeatY, imageBitmap.originClean()) };
 }
 
 ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(CSSStyleImageValue&, bool, bool)

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -334,7 +334,7 @@ void BifurcatedGraphicsContext::clipPath(const Path& path, WindRule windRule)
     VERIFY_STATE_SYNCHRONIZATION();
 }
 
-void BifurcatedGraphicsContext::clipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect)
+void BifurcatedGraphicsContext::clipToImageBuffer(ImmutableImageBuffer& imageBuffer, const FloatRect& destRect)
 {
     m_primaryContext.clipToImageBuffer(imageBuffer, destRect);
     m_secondaryContext.clipToImageBuffer(imageBuffer, destRect);

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -97,7 +97,7 @@ public:
     void clipOutRoundedRect(const FloatRoundedRect&) final;
     void clipOut(const Path&) final;
 
-    void clipToImageBuffer(ImageBuffer&, const FloatRect&) final;
+    void clipToImageBuffer(ImmutableImageBuffer&, const FloatRect&) final;
 
     IntRect clipBounds() const final;
 

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -351,11 +351,23 @@ ImageDrawResult GraphicsContext::drawTiledImage(Image& image, const FloatRect& d
     return image.drawTiled(*this, destination, source, tileScaleFactor, hRule, vRule, { options.compositeOperator() });
 }
 
-RefPtr<NativeImage> GraphicsContext::nativeImageForDrawing(ImageBuffer& imageBuffer)
+void GraphicsContext::drawImageBuffer(ImmutableImageBuffer& image, const FloatPoint& destination, ImagePaintingOptions imagePaintingOptions)
 {
-    if (m_isDeferred == IsDeferred::Yes || &imageBuffer.context() == this)
-        return imageBuffer.copyNativeImage();
-    return imageBuffer.createNativeImageReference();
+    drawImageBuffer(image, FloatRect(destination, image.logicalSize()), FloatRect({ }, image.logicalSize()), imagePaintingOptions);
+}
+
+void GraphicsContext::drawImageBuffer(ImmutableImageBuffer& image, const FloatRect& destination, ImagePaintingOptions imagePaintingOptions)
+{
+    drawImageBuffer(image, destination, FloatRect({ }, image.logicalSize()), imagePaintingOptions);
+}
+
+void GraphicsContext::drawImageBuffer(ImmutableImageBuffer& image, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions options)
+{
+    InterpolationQualityMaintainer interpolationQualityForThisScope(*this, options.interpolationQuality());
+    FloatRect sourceScaled = source;
+    sourceScaled.scale(image.resolutionScale());
+    if (auto nativeImage = image.nativeImageForDrawing(*this))
+        drawNativeImageInternal(*nativeImage, destination, sourceScaled, options);
 }
 
 void GraphicsContext::drawImageBuffer(ImageBuffer& image, const FloatPoint& destination, ImagePaintingOptions imagePaintingOptions)
@@ -370,14 +382,10 @@ void GraphicsContext::drawImageBuffer(ImageBuffer& image, const FloatRect& desti
 
 void GraphicsContext::drawImageBuffer(ImageBuffer& image, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions options)
 {
-    InterpolationQualityMaintainer interpolationQualityForThisScope(*this, options.interpolationQuality());
-    FloatRect sourceScaled = source;
-    sourceScaled.scale(image.resolutionScale());
-    if (auto nativeImage = nativeImageForDrawing(image))
-        drawNativeImageInternal(*nativeImage, destination, sourceScaled, options);
+    drawImageBuffer(static_cast<ImmutableImageBuffer&>(image), destination, source, options);
 }
 
-void GraphicsContext::drawConsumingImageBuffer(RefPtr<ImageBuffer> image, const FloatPoint& destination, ImagePaintingOptions imagePaintingOptions)
+void GraphicsContext::drawConsumingImageBuffer(RefPtr<ImmutableImageBuffer> image, const FloatPoint& destination, ImagePaintingOptions imagePaintingOptions)
 {
     if (!image)
         return;
@@ -385,7 +393,7 @@ void GraphicsContext::drawConsumingImageBuffer(RefPtr<ImageBuffer> image, const 
     drawConsumingImageBuffer(WTFMove(image), FloatRect(destination, imageLogicalSize), FloatRect({ }, imageLogicalSize), imagePaintingOptions);
 }
 
-void GraphicsContext::drawConsumingImageBuffer(RefPtr<ImageBuffer> image, const FloatRect& destination, ImagePaintingOptions imagePaintingOptions)
+void GraphicsContext::drawConsumingImageBuffer(RefPtr<ImmutableImageBuffer> image, const FloatRect& destination, ImagePaintingOptions imagePaintingOptions)
 {
     if (!image)
         return;
@@ -393,11 +401,10 @@ void GraphicsContext::drawConsumingImageBuffer(RefPtr<ImageBuffer> image, const 
     drawConsumingImageBuffer(WTFMove(image), destination, FloatRect({ }, imageLogicalSize), imagePaintingOptions);
 }
 
-void GraphicsContext::drawConsumingImageBuffer(RefPtr<ImageBuffer> image, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions options)
+void GraphicsContext::drawConsumingImageBuffer(RefPtr<ImmutableImageBuffer> image, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions options)
 {
     if (!image)
         return;
-    ASSERT(this != &image->context());
     InterpolationQualityMaintainer interpolationQualityForThisScope(*this, options.interpolationQuality());
     FloatRect scaledSource = source;
     scaledSource.scale(image->resolutionScale());
@@ -405,13 +412,13 @@ void GraphicsContext::drawConsumingImageBuffer(RefPtr<ImageBuffer> image, const 
         drawNativeImageInternal(*nativeImage, destination, scaledSource, options);
 }
 
-void GraphicsContext::drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter, FilterResults& results)
+void GraphicsContext::drawFilteredImageBuffer(ImmutableImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter, FilterResults& results)
 {
     auto result = filter.apply(sourceImage, sourceImageRect, results);
     if (!result)
         return;
     
-    RefPtr imageBuffer = result->imageBuffer();
+    RefPtr imageBuffer = result->immutableImageBuffer();
     if (!imageBuffer)
         return;
 
@@ -420,12 +427,22 @@ void GraphicsContext::drawFilteredImageBuffer(ImageBuffer* sourceImage, const Fl
     scale(filter.filterScale());
 }
 
-void GraphicsContext::drawPattern(ImageBuffer& image, const FloatRect& destRect, const FloatRect& source, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
+void GraphicsContext::drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter, FilterResults& results)
+{
+    drawFilteredImageBuffer(static_cast<ImmutableImageBuffer*>(sourceImage), sourceImageRect, filter, results);
+}
+
+void GraphicsContext::drawPattern(ImmutableImageBuffer& image, const FloatRect& destRect, const FloatRect& source, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
 {
     FloatRect scaledSource = source;
     scaledSource.scale(image.resolutionScale());
-    if (auto nativeImage = nativeImageForDrawing(image))
+    if (auto nativeImage = image.nativeImageForDrawing(*this))
         drawPattern(*nativeImage, destRect, source, patternTransform, phase, spacing, options);
+}
+
+void GraphicsContext::drawPattern(ImageBuffer& image, const FloatRect& destRect, const FloatRect& source, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
+{
+    drawPattern(static_cast<ImmutableImageBuffer&>(image), destRect, source, patternTransform, phase, spacing, options);
 }
 
 void GraphicsContext::drawControlPart(ControlPart& part, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
@@ -463,6 +480,11 @@ IntRect GraphicsContext::clipBounds() const
 {
     ASSERT_NOT_REACHED();
     return IntRect();
+}
+
+void GraphicsContext::clipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect)
+{
+    clipToImageBuffer(static_cast<ImmutableImageBuffer&>(imageBuffer), destRect);
 }
 
 void GraphicsContext::fillRect(const FloatRect& rect, Gradient& gradient)

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -30,6 +30,7 @@
 #include "DashArray.h"
 #include "DestinationColorSpace.h"
 #include "DisplayListItem.h"
+#include "DisplayListResourceHeap.h"
 #include "FloatRect.h"
 #include "FontCascade.h"
 #include "GraphicsContextState.h"
@@ -54,6 +55,7 @@ class FilterResults;
 class FloatRoundedRect;
 class Gradient;
 class ImageBuffer;
+class ImmutableImageBuffer;
 class Path;
 class SystemImage;
 class TextRun;
@@ -81,6 +83,8 @@ public:
     WEBCORE_EXPORT GraphicsContext(IsDeferred = IsDeferred::No, const GraphicsContextState::ChangeFlags& = { }, InterpolationQuality = InterpolationQuality::Default);
     WEBCORE_EXPORT GraphicsContext(IsDeferred, const GraphicsContextState&);
     WEBCORE_EXPORT virtual ~GraphicsContext();
+
+    IsDeferred isDeferred() const { return m_isDeferred; }
 
     virtual bool hasPlatformContext() const { return false; }
     virtual PlatformGraphicsContext* platformContext() const { return nullptr; }
@@ -262,14 +266,19 @@ public:
     WEBCORE_EXPORT virtual ImageDrawResult drawTiledImage(Image&, const FloatRect& destination, const FloatPoint& source, const FloatSize& tileSize, const FloatSize& spacing, ImagePaintingOptions = { });
     WEBCORE_EXPORT virtual ImageDrawResult drawTiledImage(Image&, const FloatRect& destination, const FloatRect& source, const FloatSize& tileScaleFactor, Image::TileRule, Image::TileRule, ImagePaintingOptions = { });
 
+    WEBCORE_EXPORT void drawImageBuffer(ImmutableImageBuffer&, const FloatPoint& destination, ImagePaintingOptions = { });
+    WEBCORE_EXPORT void drawImageBuffer(ImmutableImageBuffer&, const FloatRect& destination, ImagePaintingOptions = { });
+    WEBCORE_EXPORT virtual void drawImageBuffer(ImmutableImageBuffer&, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions = { });
+
     WEBCORE_EXPORT void drawImageBuffer(ImageBuffer&, const FloatPoint& destination, ImagePaintingOptions = { });
     WEBCORE_EXPORT void drawImageBuffer(ImageBuffer&, const FloatRect& destination, ImagePaintingOptions = { });
     WEBCORE_EXPORT virtual void drawImageBuffer(ImageBuffer&, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions = { });
 
-    WEBCORE_EXPORT void drawConsumingImageBuffer(RefPtr<ImageBuffer>, const FloatPoint& destination, ImagePaintingOptions = { });
-    WEBCORE_EXPORT void drawConsumingImageBuffer(RefPtr<ImageBuffer>, const FloatRect& destination, ImagePaintingOptions = { });
-    WEBCORE_EXPORT virtual void drawConsumingImageBuffer(RefPtr<ImageBuffer>, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions = { });
+    WEBCORE_EXPORT void drawConsumingImageBuffer(RefPtr<ImmutableImageBuffer>, const FloatPoint& destination, ImagePaintingOptions = { });
+    WEBCORE_EXPORT void drawConsumingImageBuffer(RefPtr<ImmutableImageBuffer>, const FloatRect& destination, ImagePaintingOptions = { });
+    WEBCORE_EXPORT virtual void drawConsumingImageBuffer(RefPtr<ImmutableImageBuffer>, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions = { });
 
+    WEBCORE_EXPORT virtual void drawFilteredImageBuffer(ImmutableImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, FilterResults&);
     WEBCORE_EXPORT virtual void drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, FilterResults&);
 
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
@@ -277,6 +286,7 @@ public:
 #endif
 
     virtual void drawPattern(NativeImage&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) = 0;
+    WEBCORE_EXPORT virtual void drawPattern(ImmutableImageBuffer&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { });
     WEBCORE_EXPORT virtual void drawPattern(ImageBuffer&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { });
 
     WEBCORE_EXPORT virtual void drawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&);
@@ -295,7 +305,8 @@ public:
     virtual void clipOut(const Path&) = 0;
     WEBCORE_EXPORT virtual void clipOutRoundedRect(const FloatRoundedRect&);
     virtual void clipPath(const Path&, WindRule = WindRule::EvenOdd) = 0;
-    WEBCORE_EXPORT virtual void clipToImageBuffer(ImageBuffer&, const FloatRect&) = 0;
+    WEBCORE_EXPORT virtual void clipToImageBuffer(ImmutableImageBuffer&, const FloatRect&) = 0;
+    WEBCORE_EXPORT virtual void clipToImageBuffer(ImageBuffer&, const FloatRect&);
     WEBCORE_EXPORT virtual IntRect clipBounds() const;
 
     // Text
@@ -381,7 +392,6 @@ private:
     virtual void drawNativeImageInternal(NativeImage&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions = { }) = 0;
 
 protected:
-    WEBCORE_EXPORT RefPtr<NativeImage> nativeImageForDrawing(ImageBuffer&);
     WEBCORE_EXPORT void fillEllipseAsPath(const FloatRect&);
     WEBCORE_EXPORT void strokeEllipseAsPath(const FloatRect&);
 

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -32,15 +32,12 @@
 #include "Filter.h"
 #include "FilterImage.h"
 #include "FilterResults.h"
+#include "GraphicsClient.h"
 #include "GraphicsContext.h"
-#include "HostWindow.h"
 #include "ImageBufferPlatformBackend.h"
-#include "MIMETypeRegistry.h"
 #include "ProcessCapabilities.h"
 #include "TransparencyLayerContextSwitcher.h"
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/text/Base64.h>
-#include <wtf/text/MakeString.h>
 
 #if USE(CG)
 #include "ImageBufferCGPDFDocumentBackend.h"
@@ -50,6 +47,7 @@
 #if USE(CAIRO)
 #include "ImageBufferUtilitiesCairo.h"
 #endif
+
 #if USE(SKIA)
 #include "ImageBufferSkiaAcceleratedBackend.h"
 #include "ImageBufferUtilitiesSkia.h"
@@ -67,9 +65,6 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageBuffer);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SerializedImageBuffer);
-
-static const float MaxClampedLength = 4096;
-static const float MaxClampedArea = MaxClampedLength * MaxClampedLength;
 
 RefPtr<ImageBuffer> ImageBuffer::create(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, ImageBufferPixelFormat pixelFormat, GraphicsClient* graphicsClient)
 {
@@ -114,42 +109,69 @@ RefPtr<ImageBuffer> ImageBuffer::create(const FloatSize& size, RenderingMode ren
     return nullptr;
 }
 
-ImageBuffer::ImageBuffer(Parameters parameters, const ImageBufferBackend::Info& backendInfo, const WebCore::ImageBufferCreationContext&, std::unique_ptr<ImageBufferBackend>&& backend, RenderingResourceIdentifier renderingResourceIdentifier)
-    : m_parameters(parameters)
-    , m_backendInfo(backendInfo)
-    , m_backend(WTFMove(backend))
-    , m_renderingResourceIdentifier(renderingResourceIdentifier)
+ImageBuffer::ImageBuffer(Parameters parameters, const ImageBufferBackend::Info& backendInfo, const WebCore::ImageBufferCreationContext& context, std::unique_ptr<ImageBufferBackend>&& backend, RenderingResourceIdentifier renderingResourceIdentifier)
+    : ImmutableImageBuffer(parameters, backendInfo, context, WTFMove(backend), renderingResourceIdentifier)
 {
 }
 
 ImageBuffer::~ImageBuffer() = default;
 
-IntSize ImageBuffer::calculateBackendSize(FloatSize logicalSize, float resolutionScale)
+void ImageBuffer::flushDrawingContext()
 {
-    FloatSize scaledSize = { ceilf(resolutionScale * logicalSize.width()), ceilf(resolutionScale * logicalSize.height()) };
-    if (scaledSize.isEmpty() || !scaledSize.isExpressibleAsIntSize())
-        return { };
-    return IntSize { scaledSize };
+    // FIXME: this will be removed and flushDrawingContext will be renamed as flushContext().
+    // The direct backend context flush is not part of ImageBuffer abstraction semantics,
+    // rather implementation detail of the ImageBufferBackends that need separate management
+    // of their context lifetime for purposes of drawing from the image buffer.
+    if (auto* backend = ensureBackend())
+        backend->flushContext();
 }
 
-ImageBufferBackendParameters ImageBuffer::backendParameters(const ImageBufferParameters& parameters)
+bool ImageBuffer::flushDrawingContextAsync()
 {
-    return { calculateBackendSize(parameters.logicalSize, parameters.resolutionScale), parameters.resolutionScale, parameters.colorSpace, parameters.pixelFormat, parameters.purpose };
+    // This function is only really useful for the Remote subclass.
+    flushDrawingContext();
+    return true;
 }
 
-bool ImageBuffer::sizeNeedsClamping(const FloatSize& size)
+void ImageBuffer::convertToLuminanceMask()
 {
-    if (size.isEmpty())
-        return false;
-
-    return floorf(size.height()) * floorf(size.width()) > MaxClampedArea;
+    if (auto* backend = ensureBackend())
+        backend->convertToLuminanceMask();
 }
 
-RefPtr<ImageBuffer> SerializedImageBuffer::sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer> buffer, GraphicsClient* graphicsClient)
+void ImageBuffer::transformToColorSpace(const DestinationColorSpace& newColorSpace)
 {
-    if (graphicsClient)
-        return graphicsClient->sinkIntoImageBuffer(WTFMove(buffer));
-    return buffer->sinkIntoImageBuffer();
+    if (auto* backend = ensureBackend()) {
+        backend->transformToColorSpace(newColorSpace);
+        m_parameters.colorSpace = newColorSpace;
+    }
+}
+
+void ImageBuffer::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& sourceRect, const IntPoint& destinationPoint, AlphaPremultiplication destinationFormat)
+{
+    ASSERT(resolutionScale() == 1);
+    auto* backend = ensureBackend();
+    if (!backend)
+        return;
+    auto sourceRectScaled = sourceRect;
+    sourceRectScaled.scale(resolutionScale());
+    auto destinationPointScaled = destinationPoint;
+    destinationPointScaled.scale(resolutionScale());
+    backend->putPixelBuffer(pixelBuffer, sourceRectScaled, destinationPointScaled, destinationFormat);
+}
+
+RefPtr<ImageBuffer> ImageBuffer::sinkIntoBufferForDifferentThread(RefPtr<ImageBuffer> buffer)
+{
+    if (!buffer)
+        return nullptr;
+    ASSERT(buffer->hasOneRef());
+    return buffer->sinkIntoBufferForDifferentThread();
+}
+
+RefPtr<ImageBuffer> ImageBuffer::sinkIntoBufferForDifferentThread()
+{
+    ASSERT(hasOneRef());
+    return this;
 }
 
 // The default serialization of an ImageBuffer just assumes that we can
@@ -189,480 +211,11 @@ std::unique_ptr<SerializedImageBuffer> ImageBuffer::sinkIntoSerializedImageBuffe
     return move->sinkIntoSerializedImageBuffer();
 }
 
-bool ImageBuffer::sizeNeedsClamping(const FloatSize& size, FloatSize& scale)
+RefPtr<ImageBuffer> SerializedImageBuffer::sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer> buffer, GraphicsClient* graphicsClient)
 {
-    FloatSize scaledSize(size);
-    scaledSize.scale(scale.width(), scale.height());
-
-    if (!sizeNeedsClamping(scaledSize))
-        return false;
-
-    // The area of scaled size is bigger than the upper limit, adjust the scale to fit.
-    scale.scale(sqrtf(MaxClampedArea / (scaledSize.width() * scaledSize.height())));
-    ASSERT(!sizeNeedsClamping(size, scale));
-    return true;
-}
-
-FloatSize ImageBuffer::clampedSize(const FloatSize& size)
-{
-    return size.shrunkTo(FloatSize(MaxClampedLength, MaxClampedLength));
-}
-
-FloatSize ImageBuffer::clampedSize(const FloatSize& size, FloatSize& scale)
-{
-    if (size.isEmpty())
-        return size;
-
-    FloatSize clampedSize = ImageBuffer::clampedSize(size);
-    scale = clampedSize / size;
-    ASSERT(!sizeNeedsClamping(clampedSize));
-    ASSERT(!sizeNeedsClamping(size, scale));
-    return clampedSize;
-}
-
-FloatRect ImageBuffer::clampedRect(const FloatRect& rect)
-{
-    return FloatRect(rect.location(), clampedSize(rect.size()));
-}
-
-static RefPtr<ImageBuffer> copyImageBuffer(Ref<ImageBuffer> source, PreserveResolution preserveResolution, std::optional<RenderingMode> renderingMode = std::nullopt)
-{
-    if (source->resolutionScale() == 1 || preserveResolution == PreserveResolution::Yes) {
-        if (source->hasOneRef()
-#if USE(SKIA)
-            && (!renderingMode || *renderingMode == source->renderingMode())
-#endif
-        )
-            return source;
-    }
-    auto copySize = source->logicalSize();
-    auto copyScale = preserveResolution == PreserveResolution::Yes ? source->resolutionScale() : 1.f;
-    auto copyBuffer = source->context().createImageBuffer(copySize, copyScale, source->colorSpace(), renderingMode);
-    if (!copyBuffer)
-        return nullptr;
-    if (source->hasOneRef())
-        copyBuffer->context().drawConsumingImageBuffer(WTFMove(source), FloatRect { { }, copySize }, FloatRect { 0, 0, -1, -1 }, { CompositeOperator::Copy });
-    else
-        copyBuffer->context().drawImageBuffer(source, FloatPoint { }, { CompositeOperator::Copy });
-    return copyBuffer;
-}
-
-static RefPtr<NativeImage> copyImageBufferToNativeImage(Ref<ImageBuffer> source, BackingStoreCopy copyBehavior, PreserveResolution preserveResolution)
-{
-    if (source->resolutionScale() == 1 || preserveResolution == PreserveResolution::Yes) {
-        if (source->hasOneRef())
-            return ImageBuffer::sinkIntoNativeImage(WTFMove(source));
-        if (copyBehavior == CopyBackingStore)
-            return source->copyNativeImage();
-        return source->createNativeImageReference();
-    }
-    auto copyBuffer = copyImageBuffer(WTFMove(source), preserveResolution);
-    if (!copyBuffer)
-        return nullptr;
-    return ImageBuffer::sinkIntoNativeImage(WTFMove(copyBuffer));
-}
-
-static RefPtr<NativeImage> copyImageBufferToOpaqueNativeImage(Ref<ImageBuffer> source, PreserveResolution preserveResolution)
-{
-    // Composite this ImageBuffer on top of opaque black, because JPEG does not have an alpha channel.
-    auto copyBuffer = copyImageBuffer(WTFMove(source), preserveResolution);
-    if (!copyBuffer)
-        return { };
-    // We composite the copy on top of black by drawing black under the copy.
-    copyBuffer->context().fillRect({ { }, copyBuffer->logicalSize() }, Color::black, CompositeOperator::DestinationOver);
-    return ImageBuffer::sinkIntoNativeImage(WTFMove(copyBuffer));
-}
-
-RefPtr<ImageBuffer> ImageBuffer::clone() const
-{
-    return copyImageBuffer(const_cast<ImageBuffer&>(*this), PreserveResolution::Yes);
-}
-
-GraphicsContext& ImageBuffer::context() const
-{
-    ASSERT(m_backend);
-    ASSERT(volatilityState() == VolatilityState::NonVolatile);
-    return m_backend->context();
-}
-
-void ImageBuffer::flushDrawingContext()
-{
-    // FIXME: this will be removed and flushDrawingContext will be renamed as flushContext().
-    // The direct backend context flush is not part of ImageBuffer abstraction semantics,
-    // rather implementation detail of the ImageBufferBackends that need separate management
-    // of their context lifetime for purposes of drawing from the image buffer.
-    if (auto* backend = ensureBackend())
-        backend->flushContext();
-}
-
-bool ImageBuffer::flushDrawingContextAsync()
-{
-    // This function is only really useful for the Remote subclass.
-    flushDrawingContext();
-    return true;
-}
-
-void ImageBuffer::setBackend(std::unique_ptr<ImageBufferBackend>&& backend)
-{
-    if (m_backend.get() == backend.get())
-        return;
-
-    m_backend = WTFMove(backend);
-    ++m_backendGeneration;
-}
-
-IntSize ImageBuffer::backendSize() const
-{
-    return calculateBackendSize(m_parameters.logicalSize, m_parameters.resolutionScale);
-}
-
-RefPtr<NativeImage> ImageBuffer::copyNativeImage() const
-{
-    if (auto* backend = ensureBackend())
-        return backend->copyNativeImage();
-    return nullptr;
-}
-
-RefPtr<NativeImage> ImageBuffer::createNativeImageReference() const
-{
-    if (auto* backend = ensureBackend())
-        return backend->createNativeImageReference();
-    return nullptr;
-}
-
-RefPtr<NativeImage> ImageBuffer::sinkIntoNativeImage()
-{
-    if (auto* backend = ensureBackend())
-        return backend->sinkIntoNativeImage();
-    return nullptr;
-}
-
-RefPtr<ImageBuffer> ImageBuffer::sinkIntoBufferForDifferentThread(RefPtr<ImageBuffer> buffer)
-{
-    if (!buffer)
-        return nullptr;
-    ASSERT(buffer->hasOneRef());
-    return buffer->sinkIntoBufferForDifferentThread();
-}
-
-#if USE(SKIA)
-RefPtr<ImageBuffer> ImageBuffer::sinkIntoImageBufferForCrossThreadTransfer(RefPtr<ImageBuffer> buffer)
-{
-    if (!buffer || buffer->renderingMode() != RenderingMode::Accelerated)
-        return buffer;
-    if (buffer->hasOneRef()) {
-        buffer->finishAcceleratedRenderingAndCreateFence();
-        return buffer;
-    }
-    auto bufferCopy = copyImageBuffer(const_cast<ImageBuffer&>(*buffer), PreserveResolution::Yes, RenderingMode::Accelerated);
-    bufferCopy->finishAcceleratedRenderingAndCreateFence();
-    return bufferCopy;
-}
-
-RefPtr<ImageBuffer> ImageBuffer::sinkIntoImageBufferAfterCrossThreadTransfer(RefPtr<ImageBuffer> buffer)
-{
-    if (!buffer || buffer->renderingMode() != RenderingMode::Accelerated)
-        return buffer;
-    buffer->waitForAcceleratedRenderingFenceCompletion();
-    return buffer->copyAcceleratedImageBufferBorrowingBackendRenderTarget();
-}
-#endif
-
-RefPtr<ImageBuffer> ImageBuffer::sinkIntoBufferForDifferentThread()
-{
-    ASSERT(hasOneRef());
-    return this;
-}
-
-RefPtr<NativeImage> ImageBuffer::filteredNativeImage(Filter& filter)
-{
-    ASSERT(!filter.filterRenderingModes().contains(FilterRenderingMode::GraphicsContext));
-
-    auto* backend = ensureBackend();
-    if (!backend)
-        return nullptr;
-
-    FilterResults results;
-    auto result = filter.apply(this, { { }, logicalSize() }, results);
-    if (!result)
-        return nullptr;
-
-    RefPtr imageBuffer = result->imageBuffer();
-    if (!imageBuffer)
-        return nullptr;
-
-    return copyImageBufferToNativeImage(*imageBuffer, CopyBackingStore, PreserveResolution::No);
-}
-
-RefPtr<NativeImage> ImageBuffer::filteredNativeImage(Filter& filter, Function<void(GraphicsContext&)> drawCallback)
-{
-    std::unique_ptr<GraphicsContextSwitcher> targetSwitcher;
-
-    if (filter.filterRenderingModes().contains(FilterRenderingMode::GraphicsContext)) {
-        targetSwitcher = makeUnique<TransparencyLayerContextSwitcher>(context(), FloatRect { { }, logicalSize() }, &filter);
-        if (!targetSwitcher)
-            return nullptr;
-        targetSwitcher->beginDrawSourceImage(context());
-    }
-
-    drawCallback(context());
-
-    if (filter.filterRenderingModes().contains(FilterRenderingMode::GraphicsContext)) {
-        ASSERT(targetSwitcher);
-        targetSwitcher->endDrawSourceImage(context(), colorSpace());
-        return copyImageBufferToNativeImage(*this, CopyBackingStore, PreserveResolution::No);
-    }
-
-    return filteredNativeImage(filter);
-}
-
-#if HAVE(IOSURFACE)
-IOSurface* ImageBuffer::surface()
-{
-    return m_backend ? m_backend->surface() : nullptr;
-}
-#endif
-
-#if USE(CAIRO)
-RefPtr<cairo_surface_t> ImageBuffer::createCairoSurface()
-{
-    auto* backend = ensureBackend();
-    if (!backend)
-        return nullptr;
-
-    auto surface = backend->createCairoSurface();
-
-    ref(); // Balanced by deref below.
-
-    static cairo_user_data_key_t dataKey;
-    cairo_surface_set_user_data(surface.get(), &dataKey, this, [](void *buffer) {
-        static_cast<ImageBuffer*>(buffer)->deref();
-    });
-
-    return surface;
-}
-#endif
-
-#if USE(SKIA)
-void ImageBuffer::finishAcceleratedRenderingAndCreateFence()
-{
-    if (auto* backend = ensureBackend())
-        backend->finishAcceleratedRenderingAndCreateFence();
-}
-
-void ImageBuffer::waitForAcceleratedRenderingFenceCompletion()
-{
-    if (auto* backend = ensureBackend())
-        backend->waitForAcceleratedRenderingFenceCompletion();
-}
-
-const GrDirectContext* ImageBuffer::skiaGrContext() const
-{
-    auto* backend = ensureBackend();
-    if (!backend)
-        return nullptr;
-    return backend->skiaGrContext();
-}
-
-RefPtr<ImageBuffer> ImageBuffer::copyAcceleratedImageBufferBorrowingBackendRenderTarget() const
-{
-    ASSERT(renderingMode() == RenderingMode::Accelerated);
-
-    auto* backend = ensureBackend();
-    if (!backend)
-        return nullptr;
-    return backend->copyAcceleratedImageBufferBorrowingBackendRenderTarget(*this);
-}
-#endif
-
-RefPtr<GraphicsLayerContentsDisplayDelegate> ImageBuffer::layerContentsDisplayDelegate()
-{
-    if (auto* backend = ensureBackend())
-        return backend->layerContentsDisplayDelegate();
-    return nullptr;
-}
-
-RefPtr<NativeImage> ImageBuffer::sinkIntoNativeImage(RefPtr<ImageBuffer> source)
-{
-    if (!source)
-        return nullptr;
-    return source->sinkIntoNativeImage();
-}
-
-void ImageBuffer::convertToLuminanceMask()
-{
-    if (auto* backend = ensureBackend())
-        backend->convertToLuminanceMask();
-}
-
-void ImageBuffer::transformToColorSpace(const DestinationColorSpace& newColorSpace)
-{
-    if (auto* backend = ensureBackend()) {
-        backend->transformToColorSpace(newColorSpace);
-        m_parameters.colorSpace = newColorSpace;
-    }
-}
-
-String ImageBuffer::toDataURL(const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution) const
-{
-    return toDataURL(Ref { const_cast<ImageBuffer&>(*this) }, mimeType, quality, preserveResolution);
-}
-
-Vector<uint8_t> ImageBuffer::toData(const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution) const
-{
-    return toData(Ref { const_cast<ImageBuffer&>(*this) }, mimeType, quality, preserveResolution);
-}
-
-String ImageBuffer::toDataURL(Ref<ImageBuffer> source, const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution)
-{
-    auto encodedData = toData(WTFMove(source), mimeType, quality, preserveResolution);
-    if (encodedData.isEmpty())
-        return "data:,"_s;
-    return makeString("data:"_s, mimeType, ";base64,"_s, base64Encoded(encodedData));
-}
-
-Vector<uint8_t> ImageBuffer::toData(Ref<ImageBuffer> source, const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution)
-{
-    RefPtr<NativeImage> image = MIMETypeRegistry::isJPEGMIMEType(mimeType) ? copyImageBufferToOpaqueNativeImage(WTFMove(source), preserveResolution) : copyImageBufferToNativeImage(WTFMove(source), DontCopyBackingStore, preserveResolution);
-    if (!image)
-        return { };
-    return encodeData(image->platformImage().get(), mimeType, quality);
-}
-
-RefPtr<PixelBuffer> ImageBuffer::getPixelBuffer(const PixelBufferFormat& destinationFormat, const IntRect& sourceRect, const ImageBufferAllocator& allocator) const
-{
-    ASSERT(PixelBuffer::supportedPixelFormat(destinationFormat.pixelFormat));
-    auto sourceRectScaled = sourceRect;
-    sourceRectScaled.scale(resolutionScale());
-    auto destination = allocator.createPixelBuffer(destinationFormat, sourceRectScaled.size());
-    if (!destination)
-        return nullptr;
-    if (auto* backend = ensureBackend())
-        backend->getPixelBuffer(sourceRectScaled, *destination);
-    else
-        destination->zeroFill();
-    return destination;
-}
-
-void ImageBuffer::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& sourceRect, const IntPoint& destinationPoint, AlphaPremultiplication destinationFormat)
-{
-    ASSERT(resolutionScale() == 1);
-    auto* backend = ensureBackend();
-    if (!backend)
-        return;
-    auto sourceRectScaled = sourceRect;
-    sourceRectScaled.scale(resolutionScale());
-    auto destinationPointScaled = destinationPoint;
-    destinationPointScaled.scale(resolutionScale());
-    backend->putPixelBuffer(pixelBuffer, sourceRectScaled, destinationPointScaled, destinationFormat);
-}
-
-RefPtr<SharedBuffer> ImageBuffer::sinkIntoPDFDocument()
-{
-    if (auto* backend = ensureBackend())
-        return backend->sinkIntoPDFDocument();
-    return nullptr;
-}
-
-bool ImageBuffer::isInUse() const
-{
-    if (auto* backend = ensureBackend())
-        return backend->isInUse();
-    return false;
-}
-
-void ImageBuffer::releaseGraphicsContext()
-{
-    if (auto* backend = ensureBackend())
-        return backend->releaseGraphicsContext();
-}
-
-bool ImageBuffer::setVolatile()
-{
-    if (auto* backend = ensureBackend())
-        return backend->setVolatile();
-
-    return true; // Just claim we succeedded.
-}
-
-SetNonVolatileResult ImageBuffer::setNonVolatile()
-{
-    auto result = SetNonVolatileResult::Valid;
-    if (auto* backend = ensureBackend())
-        result = backend->setNonVolatile();
-
-    if (m_hasForcedPurgeForTesting) {
-        result = SetNonVolatileResult::Empty;
-        m_hasForcedPurgeForTesting = false;
-    }
-
-    return result;
-}
-
-VolatilityState ImageBuffer::volatilityState() const
-{
-    if (auto* backend = ensureBackend())
-        return backend->volatilityState();
-    return VolatilityState::NonVolatile;
-}
-
-void ImageBuffer::setVolatilityState(VolatilityState volatilityState)
-{
-    if (auto* backend = ensureBackend())
-        backend->setVolatilityState(volatilityState);
-}
-
-void ImageBuffer::setVolatileAndPurgeForTesting()
-{
-    releaseGraphicsContext();
-    context().clearRect(FloatRect(FloatPoint::zero(), logicalSize()));
-    releaseGraphicsContext();
-    setVolatile();
-    m_hasForcedPurgeForTesting = true;
-}
-
-std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBuffer::createFlusher()
-{
-    if (auto* backend = ensureBackend())
-        return backend->createFlusher();
-    return nullptr;
-}
-
-unsigned ImageBuffer::backendGeneration() const
-{
-    return m_backendGeneration;
-}
-
-ImageBufferBackendSharing* ImageBuffer::toBackendSharing()
-{
-    if (auto* backend = ensureBackend())
-        return backend->toBackendSharing();
-    return nullptr;
-}
-
-#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-std::optional<DynamicContentScalingDisplayList> ImageBuffer::dynamicContentScalingDisplayList()
-{
-    return std::nullopt;
-}
-#endif
-
-void ImageBuffer::transferToNewContext(const ImageBufferCreationContext& context)
-{
-    backend()->transferToNewContext(context);
-}
-
-String ImageBuffer::debugDescription() const
-{
-    TextStream stream;
-    stream << "ImageBuffer " << this << " " << renderingResourceIdentifier() << " " << logicalSize() << " " << resolutionScale() << "x " << renderingMode() << " backend " << ValueOrNull(m_backend.get());
-    return stream.release();
-}
-
-TextStream& operator<<(TextStream& ts, const ImageBuffer& imageBuffer)
-{
-    ts << imageBuffer.debugDescription();
-    return ts;
+    if (graphicsClient)
+        return graphicsClient->sinkIntoImageBuffer(WTFMove(buffer));
+    return buffer->sinkIntoImageBuffer();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -27,45 +27,20 @@
 
 #pragma once
 
-#include "ImageBufferAllocator.h"
-#include "ImageBufferBackend.h"
-#include "ImageBufferPixelFormat.h"
-#include "PlatformScreen.h"
+#include "ImmutableImageBuffer.h"
 #include "ProcessIdentity.h"
-#include "RenderingMode.h"
-#include "RenderingResourceIdentifier.h"
-#include <wtf/Function.h>
-#include <wtf/OptionSet.h>
-#include <wtf/RefCounted.h>
-#include <wtf/TZoneMalloc.h>
-#include <wtf/ThreadSafeWeakPtr.h>
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
 #include "DynamicContentScalingResourceCache.h"
 #endif
 
-#if HAVE(IOSURFACE)
-#include "IOSurface.h"
-#endif
-
-#if USE(SKIA)
-class GrDirectContext;
-#endif
-
-namespace WTF {
-class TextStream;
-}
-
 namespace WebCore {
 
-class BifurcatedGraphicsContext;
 class DynamicContentScalingDisplayList;
-class Filter;
 class GraphicsClient;
 #if HAVE(IOSURFACE)
 class IOSurfacePool;
 #endif
-class ScriptExecutionContext;
 
 class SerializedImageBuffer;
 
@@ -82,18 +57,9 @@ struct ImageBufferCreationContext {
     ImageBufferCreationContext() = default;
 };
 
-struct ImageBufferParameters {
-    FloatSize logicalSize;
-    float resolutionScale;
-    DestinationColorSpace colorSpace;
-    ImageBufferPixelFormat pixelFormat;
-    RenderingPurpose purpose;
-};
-
-class ImageBuffer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ImageBuffer> {
+class ImageBuffer : public ImmutableImageBuffer {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ImageBuffer, WEBCORE_EXPORT);
 public:
-    using Parameters = ImageBufferParameters;
     WEBCORE_EXPORT static RefPtr<ImageBuffer> create(const FloatSize&, RenderingMode, RenderingPurpose, float resolutionScale, const DestinationColorSpace&, ImageBufferPixelFormat, GraphicsClient* = nullptr);
 
     template<typename BackendType, typename ImageBufferType = ImageBuffer, typename... Arguments>
@@ -126,148 +92,25 @@ public:
 
     WEBCORE_EXPORT virtual ~ImageBuffer();
 
-    WEBCORE_EXPORT static IntSize calculateBackendSize(FloatSize logicalSize, float resolutionScale);
-    WEBCORE_EXPORT static ImageBufferBackendParameters backendParameters(const Parameters&);
-
-    // These functions are used when clamping the ImageBuffer which is created for filter, masker or clipper.
-    static bool sizeNeedsClamping(const FloatSize&);
-    static bool sizeNeedsClamping(const FloatSize&, FloatSize& scale);
-    static FloatSize clampedSize(const FloatSize&);
-    static FloatSize clampedSize(const FloatSize&, FloatSize& scale);
-    static FloatRect clampedRect(const FloatRect&);
-
-    WEBCORE_EXPORT RefPtr<ImageBuffer> clone() const;
-
-    WEBCORE_EXPORT virtual GraphicsContext& context() const;
+    using ImmutableImageBuffer::context;
 
     WEBCORE_EXPORT virtual void flushDrawingContext();
     WEBCORE_EXPORT virtual bool flushDrawingContextAsync();
 
-    WEBCORE_EXPORT IntSize backendSize() const;
-
-    virtual void ensureBackendCreated() const { ensureBackend(); }
-    bool hasBackend() { return !!backend(); }
-
-    WEBCORE_EXPORT void transferToNewContext(const ImageBufferCreationContext&);
-
-    RenderingResourceIdentifier renderingResourceIdentifier() const { return m_renderingResourceIdentifier; }
-
-    FloatSize logicalSize() const { return m_parameters.logicalSize; }
-    IntSize truncatedLogicalSize() const { return IntSize(m_parameters.logicalSize); } // You probably should be calling logicalSize() instead.
-    float resolutionScale() const { return m_parameters.resolutionScale; }
-    DestinationColorSpace colorSpace() const { return m_parameters.colorSpace; }
-    
-    RenderingPurpose renderingPurpose() const { return m_parameters.purpose; }
-    ImageBufferPixelFormat pixelFormat() const { return m_parameters.pixelFormat; }
-    const Parameters& parameters() const { return m_parameters; }
-
-    RenderingMode renderingMode() const { return m_backendInfo.renderingMode; }
-    AffineTransform baseTransform() const { return m_backendInfo.baseTransform; }
-    size_t memoryCost() const { return m_backendInfo.memoryCost; }
-    const ImageBufferBackend::Info& backendInfo() const { return m_backendInfo; }
-
-    // Returns NativeImage of the current drawing results. Results in an immutable copy of the current back buffer.
-    WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImage() const;
-
-    // Returns NativeImage referencing the back buffer. Changes to ImageBuffer might be reflected to the NativeImage.
-    // Useful when caller can guarantee the use of the NativeImage ends "immediately", before the next draw to this ImageBuffer.
-    WEBCORE_EXPORT virtual RefPtr<NativeImage> createNativeImageReference() const;
-
-    WEBCORE_EXPORT virtual RefPtr<NativeImage> filteredNativeImage(Filter&);
-    RefPtr<NativeImage> filteredNativeImage(Filter&, Function<void(GraphicsContext&)> drawCallback);
-
-#if HAVE(IOSURFACE)
-    IOSurface* surface();
-#endif
-
-#if USE(CAIRO)
-    WEBCORE_EXPORT RefPtr<cairo_surface_t> createCairoSurface();
-#endif
-
-#if USE(SKIA)
-    // During DisplayList recording a fence is created, so that we can wait until the SkSurface finished rendering
-    // before we attempt to access the GPU resource from a secondary thread during replay (in threaded GPU painting mode).
-    void finishAcceleratedRenderingAndCreateFence();
-    void waitForAcceleratedRenderingFenceCompletion();
-
-    const GrDirectContext* skiaGrContext() const;
-
-    // Use to copy an accelerated ImageBuffer, cloning the ImageBufferSkiaAcceleratedBackend, creating
-    // a new SkSurface tied to the current thread (and thus the thread-local GrDirectContext), but re-using
-    // the existing backend render target, of this ImageBuffer. This avoids any GPU->GPU copies and has the
-    // sole purpose to abe able to access an accelerated ImageBuffer from another thread, that is not
-    // the creation thread.
-    RefPtr<ImageBuffer> copyAcceleratedImageBufferBorrowingBackendRenderTarget() const;
-#endif
-
-#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-    WEBCORE_EXPORT virtual std::optional<DynamicContentScalingDisplayList> dynamicContentScalingDisplayList();
-#endif
-
-    RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate();
-
-    // Returns NativeImage of the current drawing results. Results in an immutable copy of the current back buffer.
-    // Caller is responsible for ensuring that the passed reference is the only reference to the ImageBuffer.
-    // Has better performance than:
-    //     RefPtr<ImageBuffer> buffer = ..;
-    //     ASSERT(buffer.hasOneRef());
-    //     auto nativeImage = buffer.copyNativeImage();
-    //     buffer = nullptr;
-    WEBCORE_EXPORT static RefPtr<NativeImage> sinkIntoNativeImage(RefPtr<ImageBuffer>);
-    WEBCORE_EXPORT static RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread(RefPtr<ImageBuffer>);
-#if USE(SKIA)
-    static RefPtr<ImageBuffer> sinkIntoImageBufferForCrossThreadTransfer(RefPtr<ImageBuffer>);
-    static RefPtr<ImageBuffer> sinkIntoImageBufferAfterCrossThreadTransfer(RefPtr<ImageBuffer>);
-#endif
-    static std::unique_ptr<SerializedImageBuffer> sinkIntoSerializedImageBuffer(RefPtr<ImageBuffer>&&);
-
     WEBCORE_EXPORT virtual void convertToLuminanceMask();
     WEBCORE_EXPORT virtual void transformToColorSpace(const DestinationColorSpace& newColorSpace);
 
-    WEBCORE_EXPORT String toDataURL(const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No) const;
-    WEBCORE_EXPORT Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No) const;
-
-    WEBCORE_EXPORT static String toDataURL(Ref<ImageBuffer> source, const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No);
-    WEBCORE_EXPORT static Vector<uint8_t> toData(Ref<ImageBuffer> source, const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No);
-
-    WEBCORE_EXPORT virtual RefPtr<PixelBuffer> getPixelBuffer(const PixelBufferFormat& outputFormat, const IntRect& srcRect, const ImageBufferAllocator& = ImageBufferAllocator()) const;
     WEBCORE_EXPORT virtual void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint = { }, AlphaPremultiplication destFormat = AlphaPremultiplication::Premultiplied);
 
-    WEBCORE_EXPORT virtual RefPtr<SharedBuffer> sinkIntoPDFDocument();
+    WEBCORE_EXPORT static RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread(RefPtr<ImageBuffer>);
 
-    WEBCORE_EXPORT bool isInUse() const;
-    WEBCORE_EXPORT virtual void releaseGraphicsContext();
-    WEBCORE_EXPORT bool setVolatile();
-    WEBCORE_EXPORT SetNonVolatileResult setNonVolatile();
-    WEBCORE_EXPORT VolatilityState volatilityState() const;
-    WEBCORE_EXPORT void setVolatilityState(VolatilityState);
-    WEBCORE_EXPORT void setVolatileAndPurgeForTesting();
-    WEBCORE_EXPORT virtual std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher();
-
-    // This value increments when the ImageBuffer gets a new backend, which can happen if, for example, the GPU Process exits.
-    WEBCORE_EXPORT unsigned backendGeneration() const;
-
-    WEBCORE_EXPORT virtual String debugDescription() const;
-
-    WEBCORE_EXPORT virtual ImageBufferBackendSharing* toBackendSharing();
+    static std::unique_ptr<SerializedImageBuffer> sinkIntoSerializedImageBuffer(RefPtr<ImageBuffer>&&);
 
 protected:
     WEBCORE_EXPORT ImageBuffer(ImageBufferParameters, const ImageBufferBackend::Info&, const WebCore::ImageBufferCreationContext&, std::unique_ptr<ImageBufferBackend>&& = nullptr, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
 
-    WEBCORE_EXPORT virtual RefPtr<NativeImage> sinkIntoNativeImage();
     WEBCORE_EXPORT virtual RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread();
     WEBCORE_EXPORT virtual std::unique_ptr<SerializedImageBuffer> sinkIntoSerializedImageBuffer();
-
-    WEBCORE_EXPORT void setBackend(std::unique_ptr<ImageBufferBackend>&&);
-    ImageBufferBackend* backend() const { return m_backend.get(); }
-    virtual ImageBufferBackend* ensureBackend() const { return m_backend.get(); }
-
-    Parameters m_parameters;
-    ImageBufferBackend::Info m_backendInfo;
-    std::unique_ptr<ImageBufferBackend> m_backend;
-    RenderingResourceIdentifier m_renderingResourceIdentifier;
-    unsigned m_backendGeneration { 0 };
-    bool m_hasForcedPurgeForTesting { false };
 };
 
 class SerializedImageBuffer {
@@ -287,7 +130,5 @@ public:
 protected:
     virtual RefPtr<ImageBuffer> sinkIntoImageBuffer() = 0;
 };
-
-WEBCORE_EXPORT TextStream& operator<<(TextStream&, const ImageBuffer&);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -180,7 +180,7 @@ AffineTransform ImageBufferBackend::calculateBaseTransform(const Parameters& par
 }
 
 #if USE(SKIA)
-RefPtr<ImageBuffer> ImageBufferBackend::copyAcceleratedImageBufferBorrowingBackendRenderTarget(const ImageBuffer&) const
+RefPtr<ImageBuffer> ImageBufferBackend::copyAcceleratedImageBufferBorrowingBackendRenderTarget(const ImmutableImageBuffer&) const
 {
     return nullptr;
 }

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -63,6 +63,8 @@ namespace WebCore {
 struct ImageBufferCreationContext;
 class GraphicsContext;
 class GraphicsContextGL;
+class ImageBuffer;
+class ImmutableImageBuffer;
 #if HAVE(IOSURFACE)
 class IOSurfacePool;
 #endif
@@ -146,7 +148,7 @@ public:
     virtual void waitForAcceleratedRenderingFenceCompletion() { }
 
     virtual const GrDirectContext* skiaGrContext() const { return nullptr; }
-    WEBCORE_EXPORT virtual RefPtr<ImageBuffer> copyAcceleratedImageBufferBorrowingBackendRenderTarget(const ImageBuffer&) const;
+    WEBCORE_EXPORT virtual RefPtr<ImageBuffer> copyAcceleratedImageBufferBorrowingBackendRenderTarget(const ImmutableImageBuffer&) const;
 #endif
 
     virtual bool isInUse() const { return false; }

--- a/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp
@@ -82,9 +82,11 @@ void ImageBufferContextSwitcher::endClipAndDrawSourceImage(GraphicsContext& dest
 
 void ImageBufferContextSwitcher::endDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace& colorSpace)
 {
+    RefPtr sourceImage = static_pointer_cast<ImmutableImageBuffer>(m_sourceImage);
+
     if (!m_filter) {
-        if (m_sourceImage)
-            destinationContext.drawImageBuffer(*m_sourceImage, m_sourceImageRect, { destinationContext.compositeOperation(), destinationContext.blendMode() });
+        if (sourceImage)
+            destinationContext.drawImageBuffer(*sourceImage, m_sourceImageRect, { destinationContext.compositeOperation(), destinationContext.blendMode() });
         return;
     }
 
@@ -98,7 +100,7 @@ void ImageBufferContextSwitcher::endDrawSourceImage(GraphicsContext& destination
 #else
     UNUSED_PARAM(colorSpace);
 #endif
-    destinationContext.drawFilteredImageBuffer(m_sourceImage.get(), m_sourceImageRect, Ref { *m_filter }, m_results ? *m_results : results);
+    destinationContext.drawFilteredImageBuffer(sourceImage.get(), m_sourceImageRect, Ref { *m_filter }, m_results ? *m_results : results);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImmutableImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImmutableImageBuffer.cpp
@@ -1,0 +1,514 @@
+/*
+ * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
+ * Copyright (C) Research In Motion Limited 2011. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ImmutableImageBuffer.h"
+
+#include "Filter.h"
+#include "FilterImage.h"
+#include "FilterResults.h"
+#include "GraphicsContext.h"
+#include "ImageBuffer.h"
+#include "MIMETypeRegistry.h"
+#include "TransparencyLayerContextSwitcher.h"
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/Base64.h>
+#include <wtf/text/MakeString.h>
+
+#if USE(CG)
+#include "ImageBufferUtilitiesCG.h"
+#elif USE(CAIRO)
+#include "ImageBufferUtilitiesCairo.h"
+#elif USE(SKIA)
+#include "ImageBufferUtilitiesSkia.h"
+#endif
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ImmutableImageBuffer);
+
+static const float MaxClampedLength = 4096;
+static const float MaxClampedArea = MaxClampedLength * MaxClampedLength;
+
+ImmutableImageBuffer::ImmutableImageBuffer(Parameters parameters, const ImageBufferBackend::Info& backendInfo, const WebCore::ImageBufferCreationContext&, std::unique_ptr<ImageBufferBackend>&& backend, RenderingResourceIdentifier renderingResourceIdentifier)
+    : m_parameters(parameters)
+    , m_backendInfo(backendInfo)
+    , m_backend(WTFMove(backend))
+    , m_renderingResourceIdentifier(renderingResourceIdentifier)
+{
+}
+
+ImmutableImageBuffer::~ImmutableImageBuffer() = default;
+
+IntSize ImmutableImageBuffer::calculateBackendSize(FloatSize logicalSize, float resolutionScale)
+{
+    FloatSize scaledSize = { ceilf(resolutionScale * logicalSize.width()), ceilf(resolutionScale * logicalSize.height()) };
+    if (scaledSize.isEmpty() || !scaledSize.isExpressibleAsIntSize())
+        return { };
+    return IntSize { scaledSize };
+}
+
+ImageBufferBackendParameters ImmutableImageBuffer::backendParameters(const ImageBufferParameters& parameters)
+{
+    return { calculateBackendSize(parameters.logicalSize, parameters.resolutionScale), parameters.resolutionScale, parameters.colorSpace, parameters.pixelFormat, parameters.purpose };
+}
+
+bool ImmutableImageBuffer::sizeNeedsClamping(const FloatSize& size)
+{
+    if (size.isEmpty())
+        return false;
+
+    return floorf(size.height()) * floorf(size.width()) > MaxClampedArea;
+}
+
+bool ImmutableImageBuffer::sizeNeedsClamping(const FloatSize& size, FloatSize& scale)
+{
+    FloatSize scaledSize(size);
+    scaledSize.scale(scale.width(), scale.height());
+
+    if (!sizeNeedsClamping(scaledSize))
+        return false;
+
+    // The area of scaled size is bigger than the upper limit, adjust the scale to fit.
+    scale.scale(sqrtf(MaxClampedArea / (scaledSize.width() * scaledSize.height())));
+    ASSERT(!sizeNeedsClamping(size, scale));
+    return true;
+}
+
+FloatSize ImmutableImageBuffer::clampedSize(const FloatSize& size)
+{
+    return size.shrunkTo(FloatSize(MaxClampedLength, MaxClampedLength));
+}
+
+FloatSize ImmutableImageBuffer::clampedSize(const FloatSize& size, FloatSize& scale)
+{
+    if (size.isEmpty())
+        return size;
+
+    FloatSize clampedSize = ImmutableImageBuffer::clampedSize(size);
+    scale = clampedSize / size;
+    ASSERT(!sizeNeedsClamping(clampedSize));
+    ASSERT(!sizeNeedsClamping(size, scale));
+    return clampedSize;
+}
+
+FloatRect ImmutableImageBuffer::clampedRect(const FloatRect& rect)
+{
+    return FloatRect(rect.location(), clampedSize(rect.size()));
+}
+
+IntSize ImmutableImageBuffer::backendSize() const
+{
+    return calculateBackendSize(m_parameters.logicalSize, m_parameters.resolutionScale);
+}
+
+GraphicsContext& ImmutableImageBuffer::context() const
+{
+    ASSERT(m_backend);
+    ASSERT(volatilityState() == VolatilityState::NonVolatile);
+    return m_backend->context();
+}
+
+#if HAVE(IOSURFACE)
+IOSurface* ImmutableImageBuffer::surface()
+{
+    return m_backend ? m_backend->surface() : nullptr;
+}
+#endif
+
+#if USE(CAIRO)
+RefPtr<cairo_surface_t> ImmutableImageBuffer::createCairoSurface()
+{
+    auto* backend = ensureBackend();
+    if (!backend)
+        return nullptr;
+
+    auto surface = backend->createCairoSurface();
+
+    ref(); // Balanced by deref below.
+
+    static cairo_user_data_key_t dataKey;
+    cairo_surface_set_user_data(surface.get(), &dataKey, this, [](void *buffer) {
+        static_cast<ImageBuffer*>(buffer)->deref();
+    });
+
+    return surface;
+}
+#endif
+
+#if USE(SKIA)
+const GrDirectContext* ImmutableImageBuffer::skiaGrContext() const
+{
+    auto* backend = ensureBackend();
+    if (!backend)
+        return nullptr;
+    return backend->skiaGrContext();
+}
+#endif
+
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+std::optional<DynamicContentScalingDisplayList> ImmutableImageBuffer::dynamicContentScalingDisplayList()
+{
+    return std::nullopt;
+}
+#endif
+
+RefPtr<GraphicsLayerContentsDisplayDelegate> ImmutableImageBuffer::layerContentsDisplayDelegate()
+{
+    if (auto* backend = ensureBackend())
+        return backend->layerContentsDisplayDelegate();
+    return nullptr;
+}
+
+void ImmutableImageBuffer::setBackend(std::unique_ptr<ImageBufferBackend>&& backend)
+{
+    if (m_backend.get() == backend.get())
+        return;
+
+    m_backend = WTFMove(backend);
+    ++m_backendGeneration;
+}
+
+RefPtr<ImageBuffer> ImmutableImageBuffer::copyImageBuffer(Ref<ImmutableImageBuffer> source, PreserveResolution preserveResolution, std::optional<RenderingMode> renderingMode)
+{
+    if (source->resolutionScale() == 1 || preserveResolution == PreserveResolution::Yes) {
+        if (source->hasOneRef()
+#if USE(SKIA)
+            && (!renderingMode || *renderingMode == source->renderingMode())
+#endif
+        )
+            return RefPtr { reinterpret_cast<ImageBuffer*>(source.ptr()) };
+    }
+    auto copySize = source->logicalSize();
+    auto copyScale = preserveResolution == PreserveResolution::Yes ? source->resolutionScale() : 1.f;
+    auto copyBuffer = source->context().createImageBuffer(copySize, copyScale, source->colorSpace(), renderingMode);
+    if (!copyBuffer)
+        return nullptr;
+    if (source->hasOneRef())
+        copyBuffer->context().drawConsumingImageBuffer(WTFMove(source), FloatRect { { }, copySize }, FloatRect { 0, 0, -1, -1 }, { CompositeOperator::Copy });
+    else
+        copyBuffer->context().drawImageBuffer(source, FloatPoint { }, { CompositeOperator::Copy });
+    return copyBuffer;
+}
+
+static RefPtr<NativeImage> copyImageBufferToNativeImage(Ref<ImmutableImageBuffer> source, BackingStoreCopy copyBehavior, PreserveResolution preserveResolution)
+{
+    if (source->resolutionScale() == 1 || preserveResolution == PreserveResolution::Yes) {
+        if (source->hasOneRef())
+            return ImmutableImageBuffer::sinkIntoNativeImage(WTFMove(source));
+        if (copyBehavior == CopyBackingStore)
+            return source->copyNativeImage();
+        return source->createNativeImageReference();
+    }
+    auto copyBuffer = ImmutableImageBuffer::copyImageBuffer(WTFMove(source), preserveResolution);
+    if (!copyBuffer)
+        return nullptr;
+    return ImmutableImageBuffer::sinkIntoNativeImage(WTFMove(copyBuffer));
+}
+
+static RefPtr<NativeImage> copyImageBufferToOpaqueNativeImage(Ref<ImmutableImageBuffer> source, PreserveResolution preserveResolution)
+{
+    // Composite this ImageBuffer on top of opaque black, because JPEG does not have an alpha channel.
+    auto copyBuffer = ImmutableImageBuffer::copyImageBuffer(WTFMove(source), preserveResolution);
+    if (!copyBuffer)
+        return { };
+    // We composite the copy on top of black by drawing black under the copy.
+    copyBuffer->context().fillRect({ { }, copyBuffer->logicalSize() }, Color::black, CompositeOperator::DestinationOver);
+    return ImmutableImageBuffer::sinkIntoNativeImage(WTFMove(copyBuffer));
+}
+
+RefPtr<ImageBuffer> ImmutableImageBuffer::clone() const
+{
+    return copyImageBuffer(const_cast<ImmutableImageBuffer&>(*this), PreserveResolution::Yes);
+}
+
+RefPtr<NativeImage> ImmutableImageBuffer::copyNativeImage() const
+{
+    if (auto* backend = ensureBackend())
+        return backend->copyNativeImage();
+    return nullptr;
+}
+
+RefPtr<NativeImage> ImmutableImageBuffer::createNativeImageReference() const
+{
+    if (auto* backend = ensureBackend())
+        return backend->createNativeImageReference();
+    return nullptr;
+}
+
+RefPtr<NativeImage> ImmutableImageBuffer::nativeImageForDrawing(GraphicsContext& context) const
+{
+    if (context.isDeferred() == GraphicsContext::IsDeferred::Yes || &this->context() == &context)
+        return copyNativeImage();
+    return createNativeImageReference();
+}
+
+RefPtr<NativeImage> ImmutableImageBuffer::filteredNativeImage(Filter& filter)
+{
+    ASSERT(!filter.filterRenderingModes().contains(FilterRenderingMode::GraphicsContext));
+
+    auto* backend = ensureBackend();
+    if (!backend)
+        return nullptr;
+
+    FilterResults results;
+    auto result = filter.apply(this, { { }, logicalSize() }, results);
+    if (!result)
+        return nullptr;
+
+    RefPtr imageBuffer = result->immutableImageBuffer();
+    if (!imageBuffer)
+        return nullptr;
+
+    return ImmutableImageBuffer::sinkIntoNativeImage(imageBuffer.releaseNonNull());
+}
+
+RefPtr<NativeImage> ImmutableImageBuffer::filteredNativeImage(Filter& filter, Function<void(GraphicsContext&)> drawCallback)
+{
+    std::unique_ptr<GraphicsContextSwitcher> targetSwitcher;
+
+    if (filter.filterRenderingModes().contains(FilterRenderingMode::GraphicsContext)) {
+        targetSwitcher = makeUnique<TransparencyLayerContextSwitcher>(context(), FloatRect { { }, logicalSize() }, &filter);
+        if (!targetSwitcher)
+            return nullptr;
+        targetSwitcher->beginDrawSourceImage(context());
+    }
+
+    drawCallback(context());
+
+    if (filter.filterRenderingModes().contains(FilterRenderingMode::GraphicsContext)) {
+        ASSERT(targetSwitcher);
+        targetSwitcher->endDrawSourceImage(context(), colorSpace());
+        return copyNativeImage();
+        return copyImageBufferToNativeImage(*this, CopyBackingStore, PreserveResolution::No);
+    }
+
+    return filteredNativeImage(filter);
+}
+
+RefPtr<PixelBuffer> ImmutableImageBuffer::getPixelBuffer(const PixelBufferFormat& destinationFormat, const IntRect& sourceRect, const ImageBufferAllocator& allocator) const
+{
+    ASSERT(PixelBuffer::supportedPixelFormat(destinationFormat.pixelFormat));
+    auto sourceRectScaled = sourceRect;
+    sourceRectScaled.scale(resolutionScale());
+    auto destination = allocator.createPixelBuffer(destinationFormat, sourceRectScaled.size());
+    if (!destination)
+        return nullptr;
+    if (auto* backend = ensureBackend())
+        backend->getPixelBuffer(sourceRectScaled, *destination);
+    else
+        destination->zeroFill();
+    return destination;
+}
+
+bool ImmutableImageBuffer::isInUse() const
+{
+    if (auto* backend = ensureBackend())
+        return backend->isInUse();
+    return false;
+}
+
+void ImmutableImageBuffer::releaseGraphicsContext()
+{
+    if (auto* backend = ensureBackend())
+        return backend->releaseGraphicsContext();
+}
+
+bool ImmutableImageBuffer::setVolatile()
+{
+    if (auto* backend = ensureBackend())
+        return backend->setVolatile();
+
+    return true; // Just claim we succeedded.
+}
+
+SetNonVolatileResult ImmutableImageBuffer::setNonVolatile()
+{
+    auto result = SetNonVolatileResult::Valid;
+    if (auto* backend = ensureBackend())
+        result = backend->setNonVolatile();
+
+    if (m_hasForcedPurgeForTesting) {
+        result = SetNonVolatileResult::Empty;
+        m_hasForcedPurgeForTesting = false;
+    }
+
+    return result;
+}
+
+VolatilityState ImmutableImageBuffer::volatilityState() const
+{
+    if (auto* backend = ensureBackend())
+        return backend->volatilityState();
+    return VolatilityState::NonVolatile;
+}
+
+void ImmutableImageBuffer::setVolatilityState(VolatilityState volatilityState)
+{
+    if (auto* backend = ensureBackend())
+        backend->setVolatilityState(volatilityState);
+}
+
+void ImmutableImageBuffer::setVolatileAndPurgeForTesting()
+{
+    releaseGraphicsContext();
+    context().clearRect(FloatRect(FloatPoint::zero(), logicalSize()));
+    releaseGraphicsContext();
+    setVolatile();
+    m_hasForcedPurgeForTesting = true;
+}
+
+std::unique_ptr<ThreadSafeImageBufferFlusher> ImmutableImageBuffer::createFlusher()
+{
+    if (auto* backend = ensureBackend())
+        return backend->createFlusher();
+    return nullptr;
+}
+
+unsigned ImmutableImageBuffer::backendGeneration() const
+{
+    return m_backendGeneration;
+}
+
+ImageBufferBackendSharing* ImmutableImageBuffer::toBackendSharing()
+{
+    if (auto* backend = ensureBackend())
+        return backend->toBackendSharing();
+    return nullptr;
+}
+
+void ImmutableImageBuffer::transferToNewContext(const ImageBufferCreationContext& context)
+{
+    backend()->transferToNewContext(context);
+}
+
+RefPtr<NativeImage> ImmutableImageBuffer::sinkIntoNativeImage()
+{
+    if (auto* backend = ensureBackend())
+        return backend->sinkIntoNativeImage();
+    return nullptr;
+}
+
+RefPtr<NativeImage> ImmutableImageBuffer::sinkIntoNativeImage(RefPtr<ImmutableImageBuffer> source)
+{
+    if (!source)
+        return nullptr;
+    return source->sinkIntoNativeImage();
+}
+
+String ImmutableImageBuffer::toDataURL(const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution) const
+{
+    return toDataURL(Ref { const_cast<ImmutableImageBuffer&>(*this) }, mimeType, quality, preserveResolution);
+}
+
+Vector<uint8_t> ImmutableImageBuffer::toData(const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution) const
+{
+    return toData(Ref { const_cast<ImmutableImageBuffer&>(*this) }, mimeType, quality, preserveResolution);
+}
+
+String ImmutableImageBuffer::toDataURL(Ref<ImmutableImageBuffer> source, const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution)
+{
+    auto encodedData = toData(WTFMove(source), mimeType, quality, preserveResolution);
+    if (encodedData.isEmpty())
+        return "data:,"_s;
+    return makeString("data:"_s, mimeType, ";base64,"_s, base64Encoded(encodedData));
+}
+
+Vector<uint8_t> ImmutableImageBuffer::toData(Ref<ImmutableImageBuffer> source, const String& mimeType, std::optional<double> quality, PreserveResolution preserveResolution)
+{
+    RefPtr<NativeImage> image = MIMETypeRegistry::isJPEGMIMEType(mimeType) ? copyImageBufferToOpaqueNativeImage(WTFMove(source), preserveResolution) : copyImageBufferToNativeImage(WTFMove(source), DontCopyBackingStore, preserveResolution);
+    if (!image)
+        return { };
+    return encodeData(image->platformImage().get(), mimeType, quality);
+}
+
+#if USE(SKIA)
+void ImmutableImageBuffer::finishAcceleratedRenderingAndCreateFence()
+{
+    if (auto* backend = ensureBackend())
+        backend->finishAcceleratedRenderingAndCreateFence();
+}
+
+void ImmutableImageBuffer::waitForAcceleratedRenderingFenceCompletion()
+{
+    if (auto* backend = ensureBackend())
+        backend->waitForAcceleratedRenderingFenceCompletion();
+}
+
+RefPtr<ImageBuffer> ImmutableImageBuffer::copyAcceleratedImageBufferBorrowingBackendRenderTarget() const
+{
+    ASSERT(renderingMode() == RenderingMode::Accelerated);
+
+    auto* backend = ensureBackend();
+    if (!backend)
+        return nullptr;
+    return backend->copyAcceleratedImageBufferBorrowingBackendRenderTarget(*this);
+}
+
+RefPtr<ImageBuffer> ImmutableImageBuffer::sinkIntoImageBufferForCrossThreadTransfer(RefPtr<ImmutableImageBuffer> buffer)
+{
+    if (!buffer || buffer->renderingMode() != RenderingMode::Accelerated)
+        return RefPtr { reinterpret_cast<ImageBuffer*>(buffer.get()) };
+    if (buffer->hasOneRef()) {
+        buffer->finishAcceleratedRenderingAndCreateFence();
+        return RefPtr { reinterpret_cast<ImageBuffer*>(buffer.get()) };
+    }
+    auto bufferCopy = copyImageBuffer(*buffer, PreserveResolution::Yes, RenderingMode::Accelerated);
+    bufferCopy->finishAcceleratedRenderingAndCreateFence();
+    return bufferCopy;
+}
+
+RefPtr<ImageBuffer> ImmutableImageBuffer::sinkIntoImageBufferAfterCrossThreadTransfer(RefPtr<ImmutableImageBuffer> buffer)
+{
+    if (!buffer || buffer->renderingMode() != RenderingMode::Accelerated)
+        return RefPtr { reinterpret_cast<ImageBuffer*>(buffer.get()) };
+    buffer->waitForAcceleratedRenderingFenceCompletion();
+    return buffer->copyAcceleratedImageBufferBorrowingBackendRenderTarget();
+}
+#endif
+
+RefPtr<SharedBuffer> ImmutableImageBuffer::sinkIntoPDFDocument()
+{
+    if (auto* backend = ensureBackend())
+        return backend->sinkIntoPDFDocument();
+    return nullptr;
+}
+
+String ImmutableImageBuffer::debugDescription() const
+{
+    TextStream stream;
+    stream << "ImageBuffer " << this << " " << renderingResourceIdentifier() << " " << logicalSize() << " " << resolutionScale() << "x " << renderingMode() << " backend " << ValueOrNull(m_backend.get());
+    return stream.release();
+}
+
+TextStream& operator<<(TextStream& ts, const ImmutableImageBuffer& imageBuffer)
+{
+    ts << imageBuffer.debugDescription();
+    return ts;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImmutableImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImmutableImageBuffer.h
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2006 Nikolas Zimmermann <zimmermann@kde.org>
+ * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2010 Torch Mobile (Beijing) Co. Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ImageBufferAllocator.h"
+#include "ImageBufferBackend.h"
+#include "ImageBufferPixelFormat.h"
+#include "PlatformScreen.h"
+#include "RenderingMode.h"
+#include "RenderingResourceIdentifier.h"
+#include <wtf/Function.h>
+#include <wtf/OptionSet.h>
+#include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+
+#if HAVE(IOSURFACE)
+#include "IOSurface.h"
+#endif
+
+#if USE(SKIA)
+class GrDirectContext;
+#endif
+
+namespace WTF {
+class TextStream;
+}
+
+namespace WebCore {
+
+class Filter;
+class ImageBuffer;
+
+struct ImageBufferParameters {
+    FloatSize logicalSize;
+    float resolutionScale;
+    DestinationColorSpace colorSpace;
+    ImageBufferPixelFormat pixelFormat;
+    RenderingPurpose purpose;
+};
+
+class ImmutableImageBuffer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ImmutableImageBuffer> {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(ImageBuffer, WEBCORE_EXPORT);
+public:
+    using Parameters = ImageBufferParameters;
+
+    template<typename BackendType>
+    static ImageBufferBackend::Info populateBackendInfo(const ImageBufferBackend::Parameters& parameters)
+    {
+        return {
+            BackendType::renderingMode,
+            ImageBufferBackend::calculateBaseTransform(parameters),
+            BackendType::calculateMemoryCost(parameters),
+        };
+    }
+
+    WEBCORE_EXPORT virtual ~ImmutableImageBuffer();
+
+    WEBCORE_EXPORT static IntSize calculateBackendSize(FloatSize logicalSize, float resolutionScale);
+    WEBCORE_EXPORT static ImageBufferBackendParameters backendParameters(const Parameters&);
+
+    // These functions are used when clamping the ImageBuffer which is created for filter, masker or clipper.
+    static bool sizeNeedsClamping(const FloatSize&);
+    static bool sizeNeedsClamping(const FloatSize&, FloatSize& scale);
+    static FloatSize clampedSize(const FloatSize&);
+    static FloatSize clampedSize(const FloatSize&, FloatSize& scale);
+    static FloatRect clampedRect(const FloatRect&);
+
+    FloatSize logicalSize() const { return m_parameters.logicalSize; }
+    IntSize truncatedLogicalSize() const { return IntSize(m_parameters.logicalSize); } // You probably should be calling logicalSize() instead.
+    float resolutionScale() const { return m_parameters.resolutionScale; }
+    DestinationColorSpace colorSpace() const { return m_parameters.colorSpace; }
+
+    RenderingPurpose renderingPurpose() const { return m_parameters.purpose; }
+    ImageBufferPixelFormat pixelFormat() const { return m_parameters.pixelFormat; }
+    const Parameters& parameters() const { return m_parameters; }
+
+    RenderingMode renderingMode() const { return m_backendInfo.renderingMode; }
+    AffineTransform baseTransform() const { return m_backendInfo.baseTransform; }
+    size_t memoryCost() const { return m_backendInfo.memoryCost; }
+    const ImageBufferBackend::Info& backendInfo() const { return m_backendInfo; }
+
+    WEBCORE_EXPORT IntSize backendSize() const;
+    RenderingResourceIdentifier renderingResourceIdentifier() const { return m_renderingResourceIdentifier; }
+
+    virtual void ensureBackendCreated() const { ensureBackend(); }
+    bool hasBackend() { return !!backend(); }
+
+    WEBCORE_EXPORT RefPtr<ImageBuffer> clone() const;
+
+#if HAVE(IOSURFACE)
+    IOSurface* surface();
+#endif
+
+#if USE(CAIRO)
+    WEBCORE_EXPORT RefPtr<cairo_surface_t> createCairoSurface();
+#endif
+
+#if USE(SKIA)
+    const GrDirectContext* skiaGrContext() const;
+#endif
+
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+    WEBCORE_EXPORT virtual std::optional<DynamicContentScalingDisplayList> dynamicContentScalingDisplayList();
+#endif
+
+    RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate();
+
+    WEBCORE_EXPORT void transferToNewContext(const ImageBufferCreationContext&);
+
+    // Returns NativeImage of the current drawing results. Results in an immutable copy of the current back buffer.
+    WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImage() const;
+
+    // Returns NativeImage referencing the back buffer. Changes to ImageBuffer might be reflected to the NativeImage.
+    // Useful when caller can guarantee the use of the NativeImage ends "immediately", before the next draw to this ImageBuffer.
+    WEBCORE_EXPORT virtual RefPtr<NativeImage> createNativeImageReference() const;
+
+    RefPtr<NativeImage> nativeImageForDrawing(GraphicsContext&) const;
+
+    WEBCORE_EXPORT virtual RefPtr<NativeImage> filteredNativeImage(Filter&);
+    RefPtr<NativeImage> filteredNativeImage(Filter&, Function<void(GraphicsContext&)> drawCallback);
+
+    WEBCORE_EXPORT virtual RefPtr<PixelBuffer> getPixelBuffer(const PixelBufferFormat& outputFormat, const IntRect& srcRect, const ImageBufferAllocator& = ImageBufferAllocator()) const;
+
+    WEBCORE_EXPORT bool isInUse() const;
+    WEBCORE_EXPORT virtual void releaseGraphicsContext();
+    WEBCORE_EXPORT bool setVolatile();
+    WEBCORE_EXPORT SetNonVolatileResult setNonVolatile();
+    WEBCORE_EXPORT VolatilityState volatilityState() const;
+    WEBCORE_EXPORT void setVolatilityState(VolatilityState);
+    WEBCORE_EXPORT void setVolatileAndPurgeForTesting();
+    WEBCORE_EXPORT virtual std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher();
+
+    // This value increments when the ImageBuffer gets a new backend, which can happen if, for example, the GPU Process exits.
+    WEBCORE_EXPORT unsigned backendGeneration() const;
+
+    WEBCORE_EXPORT virtual ImageBufferBackendSharing* toBackendSharing();
+
+    static RefPtr<ImageBuffer> copyImageBuffer(Ref<ImmutableImageBuffer> source, PreserveResolution, std::optional<RenderingMode> = std::nullopt);
+
+    // Returns NativeImage of the current drawing results. Results in an immutable copy of the current back buffer.
+    // Caller is responsible for ensuring that the passed reference is the only reference to the ImageBuffer.
+    // Has better performance than:
+    //     RefPtr<ImageBuffer> buffer = ..;
+    //     ASSERT(buffer.hasOneRef());
+    //     auto nativeImage = buffer.copyNativeImage();
+    //     buffer = nullptr;
+    WEBCORE_EXPORT static RefPtr<NativeImage> sinkIntoNativeImage(RefPtr<ImmutableImageBuffer>);
+
+    WEBCORE_EXPORT String toDataURL(const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No) const;
+    WEBCORE_EXPORT Vector<uint8_t> toData(const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No) const;
+
+    WEBCORE_EXPORT static String toDataURL(Ref<ImmutableImageBuffer> source, const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No);
+    WEBCORE_EXPORT static Vector<uint8_t> toData(Ref<ImmutableImageBuffer> source, const String& mimeType, std::optional<double> quality = std::nullopt, PreserveResolution = PreserveResolution::No);
+
+#if USE(SKIA)
+    // During DisplayList recording a fence is created, so that we can wait until the SkSurface finished rendering
+    // before we attempt to access the GPU resource from a secondary thread during replay (in threaded GPU painting mode).
+    void finishAcceleratedRenderingAndCreateFence();
+    void waitForAcceleratedRenderingFenceCompletion();
+
+    // Use to copy an accelerated ImageBuffer, cloning the ImageBufferSkiaAcceleratedBackend, creating
+    // a new SkSurface tied to the current thread (and thus the thread-local GrDirectContext), but re-using
+    // the existing backend render target, of this ImageBuffer. This avoids any GPU->GPU copies and has the
+    // sole purpose to abe able to access an accelerated ImageBuffer from another thread, that is not
+    // the creation thread.
+    RefPtr<ImageBuffer> copyAcceleratedImageBufferBorrowingBackendRenderTarget() const;
+
+    static RefPtr<ImageBuffer> sinkIntoImageBufferForCrossThreadTransfer(RefPtr<ImmutableImageBuffer>);
+    static RefPtr<ImageBuffer> sinkIntoImageBufferAfterCrossThreadTransfer(RefPtr<ImmutableImageBuffer>);
+#endif
+
+    WEBCORE_EXPORT virtual RefPtr<SharedBuffer> sinkIntoPDFDocument();
+
+    WEBCORE_EXPORT virtual String debugDescription() const;
+
+protected:
+    WEBCORE_EXPORT ImmutableImageBuffer(ImageBufferParameters, const ImageBufferBackend::Info&, const WebCore::ImageBufferCreationContext&, std::unique_ptr<ImageBufferBackend>&& = nullptr, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
+
+    WEBCORE_EXPORT virtual GraphicsContext& context() const;
+
+    WEBCORE_EXPORT void setBackend(std::unique_ptr<ImageBufferBackend>&&);
+    ImageBufferBackend* backend() const { return m_backend.get(); }
+    virtual ImageBufferBackend* ensureBackend() const { return m_backend.get(); }
+
+    WEBCORE_EXPORT virtual RefPtr<NativeImage> sinkIntoNativeImage();
+
+    Parameters m_parameters;
+    ImageBufferBackend::Info m_backendInfo;
+    std::unique_ptr<ImageBufferBackend> m_backend;
+    RenderingResourceIdentifier m_renderingResourceIdentifier;
+    unsigned m_backendGeneration { 0 };
+    bool m_hasForcedPurgeForTesting { false };
+};
+
+WEBCORE_EXPORT TextStream& operator<<(TextStream&, const ImmutableImageBuffer&);
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -130,7 +130,7 @@ private:
 
     void clipRoundedRect(const FloatRoundedRect&) final { }
     void clipOutRoundedRect(const FloatRoundedRect&) final { }
-    void clipToImageBuffer(ImageBuffer&, const FloatRect&) final { }
+    void clipToImageBuffer(ImmutableImageBuffer&, const FloatRect&) final { }
 
     void fillRect(const FloatRect&, Gradient&) final { }
     void fillRect(const FloatRect&, const Color&, CompositeOperator, BlendMode = BlendMode::Normal) final { }

--- a/Source/WebCore/platform/graphics/Pattern.cpp
+++ b/Source/WebCore/platform/graphics/Pattern.cpp
@@ -61,7 +61,7 @@ RefPtr<NativeImage> Pattern::tileNativeImage() const
     return m_tileImage.nativeImage();
 }
 
-RefPtr<ImageBuffer> Pattern::tileImageBuffer() const
+RefPtr<ImmutableImageBuffer> Pattern::tileImageBuffer() const
 {
     return m_tileImage.imageBuffer();
 }

--- a/Source/WebCore/platform/graphics/Pattern.h
+++ b/Source/WebCore/platform/graphics/Pattern.h
@@ -71,7 +71,7 @@ public:
     WEBCORE_EXPORT void setTileImage(SourceImage&&);
 
     RefPtr<NativeImage> tileNativeImage() const;
-    RefPtr<ImageBuffer> tileImageBuffer() const;
+    RefPtr<ImmutableImageBuffer> tileImageBuffer() const;
 
     const Parameters& parameters() const { return m_parameters; }
 

--- a/Source/WebCore/platform/graphics/SourceImage.cpp
+++ b/Source/WebCore/platform/graphics/SourceImage.cpp
@@ -62,11 +62,11 @@ NativeImage* SourceImage::nativeImageIfExists() const
 
 NativeImage* SourceImage::nativeImage() const
 {
-    if (!std::holds_alternative<Ref<ImageBuffer>>(m_imageVariant))
+    if (!std::holds_alternative<Ref<ImmutableImageBuffer>>(m_imageVariant))
         return nativeImageIfExists();
 
     if (!m_transformedImageVariant) {
-        auto imageBuffer = std::get<Ref<ImageBuffer>>(m_imageVariant);
+        auto imageBuffer = std::get<Ref<ImmutableImageBuffer>>(m_imageVariant);
 
         auto nativeImage = imageBuffer->createNativeImageReference();
         if (!nativeImage)
@@ -79,19 +79,19 @@ NativeImage* SourceImage::nativeImage() const
     return nativeImageOf(*m_transformedImageVariant);
 }
 
-static inline ImageBuffer* imageBufferOf(const SourceImage::ImageVariant& imageVariant)
+static inline ImmutableImageBuffer* imageBufferOf(const SourceImage::ImageVariant& imageVariant)
 {
-    if (auto* imageBuffer = std::get_if<Ref<ImageBuffer>>(&imageVariant))
+    if (auto* imageBuffer = std::get_if<Ref<ImmutableImageBuffer>>(&imageVariant))
         return imageBuffer->ptr();
     return nullptr;
 }
 
-ImageBuffer* SourceImage::imageBufferIfExists() const
+ImmutableImageBuffer* SourceImage::imageBufferIfExists() const
 {
     return imageBufferOf(m_imageVariant);
 }
 
-ImageBuffer* SourceImage::imageBuffer() const
+ImmutableImageBuffer* SourceImage::imageBuffer() const
 {
     if (!std::holds_alternative<Ref<NativeImage>>(m_imageVariant))
         return imageBufferIfExists();
@@ -105,7 +105,7 @@ ImageBuffer* SourceImage::imageBuffer() const
             return nullptr;
 
         imageBuffer->context().drawNativeImage(nativeImage, rect, rect);
-        m_transformedImageVariant = { imageBuffer.releaseNonNull() };
+        m_transformedImageVariant = static_reference_cast<ImmutableImageBuffer>(imageBuffer.releaseNonNull());
     }
 
     ASSERT(m_transformedImageVariant);
@@ -118,7 +118,7 @@ RenderingResourceIdentifier SourceImage::imageIdentifier() const
         [&] (const Ref<NativeImage>& nativeImage) {
             return nativeImage->renderingResourceIdentifier();
         },
-        [&] (const Ref<ImageBuffer>& imageBuffer) {
+        [&] (const Ref<ImmutableImageBuffer>& imageBuffer) {
             return imageBuffer->renderingResourceIdentifier();
         },
         [&] (RenderingResourceIdentifier renderingResourceIdentifier) {
@@ -133,7 +133,7 @@ IntSize SourceImage::size() const
         [&] (const Ref<NativeImage>& nativeImage) {
             return nativeImage->size();
         },
-        [&] (const Ref<ImageBuffer>& imageBuffer) {
+        [&] (const Ref<ImmutableImageBuffer>& imageBuffer) {
             return imageBuffer->backendSize();
         },
         [&] (RenderingResourceIdentifier) -> IntSize {

--- a/Source/WebCore/platform/graphics/SourceImage.h
+++ b/Source/WebCore/platform/graphics/SourceImage.h
@@ -30,14 +30,14 @@
 
 namespace WebCore {
 
-class ImageBuffer;
+class ImmutableImageBuffer;
 class NativeImage;
 
 class WEBCORE_EXPORT SourceImage {
 public:
     using ImageVariant = std::variant<
         Ref<NativeImage>,
-        Ref<ImageBuffer>,
+        Ref<ImmutableImageBuffer>,
         RenderingResourceIdentifier
     >;
 
@@ -54,8 +54,8 @@ public:
     NativeImage* nativeImageIfExists() const;
     NativeImage* nativeImage() const;
 
-    ImageBuffer* imageBufferIfExists() const;
-    ImageBuffer* imageBuffer() const;
+    ImmutableImageBuffer* imageBufferIfExists() const;
+    ImmutableImageBuffer* imageBuffer() const;
 
     RenderingResourceIdentifier imageIdentifier() const;
     IntSize size() const;

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp
@@ -560,7 +560,7 @@ void OperationRecorder::drawDecomposedGlyphs(const Font& font, const DecomposedG
     return drawGlyphs(font, positionedGlyphs.glyphs.span(), positionedGlyphs.advances.span(), positionedGlyphs.localAnchor, positionedGlyphs.smoothingMode);
 }
 
-void OperationRecorder::drawImageBuffer(ImageBuffer& buffer, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
+void OperationRecorder::drawImageBuffer(ImmutableImageBuffer& buffer, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
     struct DrawImageBuffer final : PaintingOperation, OperationData<RefPtr<cairo_surface_t>, FloatRect, FloatRect, ImagePaintingOptions, float, Cairo::ShadowState> {
         virtual ~DrawImageBuffer() = default;
@@ -584,7 +584,7 @@ void OperationRecorder::drawImageBuffer(ImageBuffer& buffer, const FloatRect& de
     append(createCommand<DrawImageBuffer>(nativeImage->platformImage(), destRect, srcRect, ImagePaintingOptions(options, state.imageInterpolationQuality()), state.alpha(), Cairo::ShadowState(state)));
 }
 
-void OperationRecorder::drawFilteredImageBuffer(ImageBuffer* srcImage, const FloatRect& srcRect, Filter& filter, FilterResults& results)
+void OperationRecorder::drawFilteredImageBuffer(ImmutableImageBuffer* srcImage, const FloatRect& srcRect, Filter& filter, FilterResults& results)
 {
     struct DrawFilteredImageBuffer final : PaintingOperation, OperationData<RefPtr<cairo_surface_t>, FloatRect, FloatRect, FloatSize, ImagePaintingOptions, float, Cairo::ShadowState> {
         virtual ~DrawFilteredImageBuffer() = default;
@@ -606,7 +606,7 @@ void OperationRecorder::drawFilteredImageBuffer(ImageBuffer* srcImage, const Flo
     if (!result)
         return;
 
-    auto imageBuffer = result->imageBuffer();
+    auto imageBuffer = result->immutableImageBuffer();
     if (!imageBuffer)
         return;
 
@@ -1153,7 +1153,7 @@ IntRect OperationRecorder::clipBounds() const
     return enclosingIntRect(state.ctmInverse.mapRect(state.clipBounds));
 }
 
-void OperationRecorder::clipToImageBuffer(ImageBuffer& buffer, const FloatRect& destRect)
+void OperationRecorder::clipToImageBuffer(ImmutableImageBuffer& buffer, const FloatRect& destRect)
 {
     struct ClipToImageBuffer final: PaintingOperation, OperationData<RefPtr<cairo_surface_t>, FloatRect> {
         virtual ~ClipToImageBuffer() = default;

--- a/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h
@@ -69,8 +69,8 @@ private:
     void drawGlyphs(const WebCore::Font&, std::span<const WebCore::GlyphBufferGlyph>, std::span<const WebCore::GlyphBufferAdvance>, const WebCore::FloatPoint&, WebCore::FontSmoothingMode) override;
     void drawDecomposedGlyphs(const WebCore::Font&, const WebCore::DecomposedGlyphs&) override;
 
-    void drawImageBuffer(WebCore::ImageBuffer&, const WebCore::FloatRect& destination, const WebCore::FloatRect& source, WebCore::ImagePaintingOptions) override;
-    void drawFilteredImageBuffer(WebCore::ImageBuffer*, const WebCore::FloatRect&, WebCore::Filter&, WebCore::FilterResults&) override;
+    void drawImageBuffer(WebCore::ImmutableImageBuffer&, const WebCore::FloatRect& destination, const WebCore::FloatRect& source, WebCore::ImagePaintingOptions) override;
+    void drawFilteredImageBuffer(WebCore::ImmutableImageBuffer*, const WebCore::FloatRect&, WebCore::Filter&, WebCore::FilterResults&) override;
     void drawNativeImageInternal(WebCore::NativeImage&, const WebCore::FloatRect&, const WebCore::FloatRect&, WebCore::ImagePaintingOptions) override;
     void drawPattern(WebCore::NativeImage&, const WebCore::FloatRect&, const WebCore::FloatRect&, const WebCore::AffineTransform&, const WebCore::FloatPoint&, const WebCore::FloatSize&, WebCore::ImagePaintingOptions) override;
 
@@ -103,7 +103,7 @@ private:
     void clipOut(const WebCore::Path&) override;
     void clipPath(const WebCore::Path&, WebCore::WindRule) override;
     WebCore::IntRect clipBounds() const override;
-    void clipToImageBuffer(WebCore::ImageBuffer&, const WebCore::FloatRect&) override;
+    void clipToImageBuffer(WebCore::ImmutableImageBuffer&, const WebCore::FloatRect&) override;
 #if ENABLE(VIDEO)
     void drawVideoFrame(WebCore::VideoFrame&, const WebCore::FloatRect& destination, WebCore::ImageOrientation, bool shouldDiscardAlpha) override;
 #endif

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
@@ -174,14 +174,14 @@ enum PathDrawingStyle {
 
 static void drawShadowLayerBuffer(GraphicsContextCairo& platformContext, ImageBuffer& layerImage, const FloatPoint& layerOrigin, const FloatSize& layerSize, const ShadowState& shadowState)
 {
-    if (auto nativeImage = platformContext.nativeImageForDrawing(layerImage))
+    if (auto nativeImage = layerImage.nativeImageForDrawing(platformContext))
         drawPlatformImage(platformContext, nativeImage->platformImage().get(), FloatRect(roundedIntPoint(layerOrigin), layerSize), FloatRect(FloatPoint(), layerSize), { shadowState.globalCompositeOperator }, shadowState.globalAlpha, ShadowState());
 }
 
 // FIXME: This is mostly same as drawShadowLayerBuffer, so we should merge two.
 static void drawShadowImage(GraphicsContextCairo& platformContext, ImageBuffer& layerImage, const FloatRect& destRect, const FloatRect& srcRect, const ShadowState& shadowState)
 {
-    if (auto nativeImage = platformContext.nativeImageForDrawing(layerImage))
+    if (auto nativeImage = layerImage.nativeImageForDrawing(platformContext))
         drawPlatformImage(platformContext, nativeImage->platformImage().get(), destRect, srcRect, { shadowState.globalCompositeOperator }, shadowState.globalAlpha, ShadowState());
 }
 
@@ -189,7 +189,7 @@ static void fillShadowBuffer(GraphicsContextCairo& platformContext, ImageBuffer&
 {
     platformContext.save();
 
-    if (auto nativeImage = platformContext.nativeImageForDrawing(layerImage))
+    if (auto nativeImage = layerImage.nativeImageForDrawing(platformContext))
         clipToImageBuffer(platformContext, nativeImage->platformImage().get(), FloatRect(layerOrigin, expandedIntSize(layerSize)));
 
     FillSource fillSource;

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
@@ -218,9 +218,9 @@ IntRect GraphicsContextCairo::clipBounds() const
     return Cairo::State::getClipBounds(*platformContext());
 }
 
-void GraphicsContextCairo::clipToImageBuffer(ImageBuffer& buffer, const FloatRect& destRect)
+void GraphicsContextCairo::clipToImageBuffer(ImmutableImageBuffer& buffer, const FloatRect& destRect)
 {
-    if (auto nativeImage = nativeImageForDrawing(buffer))
+    if (auto nativeImage = buffer.nativeImageForDrawing(*this))
         Cairo::clipToImageBuffer(*this, nativeImage->platformImage().get(), destRect);
 }
 

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
@@ -101,7 +101,7 @@ public:
     void clipOut(const Path&) final;
     void clipPath(const Path&, WindRule) final;
     IntRect clipBounds() const final;
-    void clipToImageBuffer(ImageBuffer&, const FloatRect&) final;
+    void clipToImageBuffer(ImmutableImageBuffer&, const FloatRect&) final;
     
     RenderingMode renderingMode() const final;
 
@@ -109,8 +109,6 @@ public:
     Vector<float>& layers();
     void pushImageMask(cairo_surface_t*, const FloatRect&);
 
-    // Exposed as public because freestanding functions use this.
-    using GraphicsContext::nativeImageForDrawing;
 private:
     RefPtr<cairo_t> m_cr;
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1012,7 +1012,7 @@ void GraphicsContextCG::clipPath(const Path& path, WindRule clipRule)
     }
 }
 
-void GraphicsContextCG::clipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect)
+void GraphicsContextCG::clipToImageBuffer(ImmutableImageBuffer& imageBuffer, const FloatRect& destRect)
 {
     auto nativeImage = imageBuffer.createNativeImageReference();
     if (!nativeImage)

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -94,7 +94,7 @@ public:
 
     void clipPath(const Path&, WindRule = WindRule::EvenOdd) final;
 
-    void clipToImageBuffer(ImageBuffer&, const FloatRect&) final;
+    void clipToImageBuffer(ImmutableImageBuffer&, const FloatRect&) final;
 
     IntRect clipBounds() const final;
 

--- a/Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm
@@ -54,21 +54,22 @@ size_t FilterImage::memoryCostOfCIImage() const
     return FloatSize([m_ciImage.get() extent].size).area() * 4;
 }
 
-ImageBuffer* FilterImage::imageBufferFromCIImage()
+ImmutableImageBuffer* FilterImage::imageBufferFromCIImage()
 {
     ASSERT(m_ciImage);
 
     if (m_imageBuffer)
         return m_imageBuffer.get();
 
-    m_imageBuffer = ImageBuffer::create<ImageBufferIOSurfaceBackend>(m_absoluteImageRect.size(), 1, m_colorSpace, ImageBufferPixelFormat::BGRA8, RenderingPurpose::Unspecified, { });
-    if (!m_imageBuffer)
+    RefPtr imageBuffer = ImageBuffer::create<ImageBufferIOSurfaceBackend>(m_absoluteImageRect.size(), 1, m_colorSpace, ImageBufferPixelFormat::BGRA8, RenderingPurpose::Unspecified, { });
+    if (!imageBuffer)
         return nullptr;
 
-    ASSERT(m_imageBuffer->surface());
+    ASSERT(imageBuffer->surface());
     auto destRect = FloatRect { FloatPoint(), m_absoluteImageRect.size() };
-    [sharedCIContext().get() render:m_ciImage.get() toIOSurface:m_imageBuffer->surface()->surface() bounds:destRect colorSpace:m_colorSpace.platformColorSpace()];
+    [sharedCIContext().get() render:m_ciImage.get() toIOSurface:imageBuffer->surface()->surface() bounds:destRect colorSpace:m_colorSpace.platformColorSpace()];
 
+    m_imageBuffer = WTFMove(imageBuffer);
     return m_imageBuffer.get();
 }
 

--- a/Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm
@@ -45,7 +45,7 @@ bool SourceGraphicCoreImageApplier::apply(const Filter&, const FilterImageVector
 {
     auto& input = inputs[0].get();
 
-    RefPtr sourceImage = input.imageBuffer();
+    RefPtr sourceImage = input.immutableImageBuffer();
     if (!sourceImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayList.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayList.cpp
@@ -62,7 +62,7 @@ bool DisplayList::isEmpty() const
     return m_items.isEmpty();
 }
 
-void DisplayList::cacheImageBuffer(ImageBuffer& imageBuffer)
+void DisplayList::cacheImageBuffer(ImmutableImageBuffer& imageBuffer)
 {
     m_resourceHeap.add(Ref { imageBuffer });
 }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayList.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayList.h
@@ -27,6 +27,7 @@
 
 #include "DisplayListItems.h"
 #include "DisplayListResourceHeap.h"
+#include "ImmutableImageBuffer.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
@@ -58,7 +59,7 @@ public:
     Vector<Item>& items() { return m_items; }
     const ResourceHeap& resourceHeap() const { return m_resourceHeap; }
 
-    void cacheImageBuffer(ImageBuffer&);
+    void cacheImageBuffer(ImmutableImageBuffer&);
     void cacheNativeImage(NativeImage&);
     void cacheFont(Font&);
     void cacheDecomposedGlyphs(DecomposedGlyphs&);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class ControlFactory;
 class GraphicsContext;
+class ImmutableImageBuffer;
 
 namespace DisplayList {
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -226,7 +226,7 @@ void ClipOutRoundedRect::dump(TextStream& ts, OptionSet<AsTextFlag>) const
     ts.dumpProperty("rect", rect());
 }
 
-void ClipToImageBuffer::apply(GraphicsContext& context, ImageBuffer& imageBuffer) const
+void ClipToImageBuffer::apply(GraphicsContext& context, ImmutableImageBuffer& imageBuffer) const
 {
     context.clipToImageBuffer(imageBuffer, m_destinationRect);
 }
@@ -276,7 +276,7 @@ NO_RETURN_DUE_TO_ASSERT void DrawFilteredImageBuffer::apply(GraphicsContext&) co
     ASSERT_NOT_REACHED();
 }
 
-void DrawFilteredImageBuffer::apply(GraphicsContext& context, ImageBuffer* sourceImage, FilterResults& results) const
+void DrawFilteredImageBuffer::apply(GraphicsContext& context, ImmutableImageBuffer* sourceImage, FilterResults& results) const
 {
     context.drawFilteredImageBuffer(sourceImage, m_sourceImageRect, m_filter, results);
 }
@@ -355,7 +355,7 @@ void DrawDisplayListItems::dump(TextStream& ts, OptionSet<AsTextFlag>) const
     ts.dumpProperty("destination", destination());
 }
 
-void DrawImageBuffer::apply(GraphicsContext& context, ImageBuffer& imageBuffer) const
+void DrawImageBuffer::apply(GraphicsContext& context, ImmutableImageBuffer& imageBuffer) const
 {
     context.drawImageBuffer(imageBuffer, m_destinationRect, m_srcRect, m_options);
 }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -405,7 +405,7 @@ public:
 
     bool isValid() const { return !!m_imageBufferIdentifier; }
 
-    WEBCORE_EXPORT void apply(GraphicsContext&, ImageBuffer&) const;
+    WEBCORE_EXPORT void apply(GraphicsContext&, ImmutableImageBuffer&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
@@ -486,7 +486,7 @@ public:
     Ref<Filter> filter() const { return m_filter; }
 
     NO_RETURN_DUE_TO_ASSERT void apply(GraphicsContext&) const;
-    WEBCORE_EXPORT void apply(GraphicsContext&, ImageBuffer* sourceImage, FilterResults&) const;
+    WEBCORE_EXPORT void apply(GraphicsContext&, ImmutableImageBuffer* sourceImage, FilterResults&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:
@@ -577,7 +577,7 @@ public:
     // FIXME: We might want to validate ImagePaintingOptions.
     bool isValid() const { return !!m_imageBufferIdentifier; }
 
-    WEBCORE_EXPORT void apply(GraphicsContext&, ImageBuffer&) const;
+    WEBCORE_EXPORT void apply(GraphicsContext&, ImmutableImageBuffer&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -153,7 +153,7 @@ void Recorder::didUpdateSingleState(GraphicsContextState& state, GraphicsContext
     state.didApplyChanges();
 }
 
-void Recorder::drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter, FilterResults& results)
+void Recorder::drawFilteredImageBuffer(ImmutableImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter, FilterResults& results)
 {
     appendStateChangeItemIfNecessary();
 
@@ -166,16 +166,17 @@ void Recorder::drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect
     }
 
     if (!sourceImage) {
-        recordDrawFilteredImageBuffer(nullptr, sourceImageRect, filter);
+        recordDrawFilteredImageBuffer(std::nullopt, sourceImageRect, filter);
         return;
     }
 
-    if (!recordResourceUse(*sourceImage)) {
+    auto renderingResourceIdentifier = recordResourceUse(*sourceImage);
+    if (!renderingResourceIdentifier) {
         GraphicsContext::drawFilteredImageBuffer(sourceImage, sourceImageRect, filter, results);
         return;
     }
 
-    recordDrawFilteredImageBuffer(sourceImage, sourceImageRect, filter);
+    recordDrawFilteredImageBuffer(*renderingResourceIdentifier, sourceImageRect, filter);
 }
 
 bool Recorder::shouldDeconstructDrawGlyphs() const
@@ -234,7 +235,7 @@ void Recorder::drawDisplayListItems(const Vector<Item>& items, const ResourceHea
         WTF::switchOn(resource,
             [](std::monostate) {
                 RELEASE_ASSERT_NOT_REACHED();
-            }, [&](const Ref<ImageBuffer>& imageBuffer) {
+            }, [&](const Ref<ImmutableImageBuffer>& imageBuffer) {
                 recordResourceUse(imageBuffer);
             }, [&](const Ref<RenderingResource>& renderingResource) {
                 if (auto* image = dynamicDowncast<NativeImage>(renderingResource.ptr()))
@@ -258,18 +259,33 @@ void Recorder::drawDisplayListItems(const Vector<Item>& items, const ResourceHea
     recordDrawDisplayListItems(items, destination);
 }
 
-void Recorder::drawImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
+void Recorder::drawImageBuffer(ImmutableImageBuffer& imageBuffer, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
     appendStateChangeItemIfNecessary();
 
-    if (!recordResourceUse(imageBuffer)) {
+    auto renderingResourceIdentifier = recordResourceUse(imageBuffer);
+    if (!renderingResourceIdentifier) {
         GraphicsContext::drawImageBuffer(imageBuffer, destRect, srcRect, options);
         return;
     }
 
-    recordDrawImageBuffer(imageBuffer, destRect, srcRect, options);
+    recordDrawImageBuffer(*renderingResourceIdentifier, destRect, srcRect, options);
 }
-void Recorder::drawConsumingImageBuffer(RefPtr<ImageBuffer> imageBuffer, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
+
+void Recorder::drawImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
+{
+    appendStateChangeItemIfNecessary();
+
+    auto renderingResourceIdentifier = recordResourceUse(imageBuffer);
+    if (!renderingResourceIdentifier) {
+        GraphicsContext::drawImageBuffer(imageBuffer, destRect, srcRect, options);
+        return;
+    }
+
+    recordDrawImageBuffer(*renderingResourceIdentifier, destRect, srcRect, options);
+}
+
+void Recorder::drawConsumingImageBuffer(RefPtr<ImmutableImageBuffer> imageBuffer, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
     // ImageBuffer draws are recorded as ImageBuffer draws, not as NativeImage draws. So for consistency,
     // record this too. This should be removed once NativeImages are the only image types drawn from.
@@ -308,16 +324,30 @@ void Recorder::drawPattern(NativeImage& image, const FloatRect& destRect, const 
     recordDrawPattern(image.renderingResourceIdentifier(), destRect, tileRect, patternTransform, phase, spacing, options);
 }
 
-void Recorder::drawPattern(ImageBuffer& imageBuffer, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
+void Recorder::drawPattern(ImmutableImageBuffer& imageBuffer, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
 {
     appendStateChangeItemIfNecessary();
 
-    if (!recordResourceUse(imageBuffer)) {
+    auto renderingResourceIdentifier = recordResourceUse(imageBuffer);
+    if (!renderingResourceIdentifier) {
         GraphicsContext::drawPattern(imageBuffer, destRect, tileRect, patternTransform, phase, spacing, options);
         return;
     }
 
-    recordDrawPattern(imageBuffer.renderingResourceIdentifier(), destRect, tileRect, patternTransform, phase, spacing, options);
+    recordDrawPattern(*renderingResourceIdentifier, destRect, tileRect, patternTransform, phase, spacing, options);
+}
+
+void Recorder::drawPattern(ImageBuffer& imageBuffer, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
+{
+    appendStateChangeItemIfNecessary();
+
+    auto renderingResourceIdentifier = recordResourceUse(imageBuffer);
+    if (!renderingResourceIdentifier) {
+        GraphicsContext::drawPattern(imageBuffer, destRect, tileRect, patternTransform, phase, spacing, options);
+        return;
+    }
+
+    recordDrawPattern(*renderingResourceIdentifier, destRect, tileRect, patternTransform, phase, spacing, options);
 }
 
 void Recorder::updateStateForSave(GraphicsContextState::Purpose purpose)
@@ -522,12 +552,20 @@ IntRect Recorder::clipBounds() const
     return enclosingIntRect(currentState().clipBounds);
 }
 
+void Recorder::clipToImageBuffer(ImmutableImageBuffer& imageBuffer, const FloatRect& destRect)
+{
+    appendStateChangeItemIfNecessary(); // Conservative: we do not know if the clip application might use state such as antialiasing.
+    currentState().clipBounds.intersect(currentState().ctm.mapRect(destRect));
+    if (auto renderingResourceIdentifier = recordResourceUse(imageBuffer))
+        recordClipToImageBuffer(*renderingResourceIdentifier, destRect);
+}
+
 void Recorder::clipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect)
 {
     appendStateChangeItemIfNecessary(); // Conservative: we do not know if the clip application might use state such as antialiasing.
     currentState().clipBounds.intersect(currentState().ctm.mapRect(destRect));
-    recordResourceUse(imageBuffer);
-    recordClipToImageBuffer(imageBuffer, destRect);
+    if (auto renderingResourceIdentifier = recordResourceUse(imageBuffer))
+        recordClipToImageBuffer(*renderingResourceIdentifier, destRect);
 }
 
 void Recorder::updateStateForApplyDeviceScaleFactor(float deviceScaleFactor)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -75,11 +75,11 @@ protected:
     virtual void recordSetInlineStroke(SetInlineStroke&&) = 0;
     virtual void recordSetState(const GraphicsContextState&) = 0;
     virtual void recordClearDropShadow() = 0;
-    virtual void recordClipToImageBuffer(ImageBuffer&, const FloatRect& destinationRect) = 0;
-    virtual void recordDrawFilteredImageBuffer(ImageBuffer*, const FloatRect& sourceImageRect, Filter&) = 0;
+    virtual void recordClipToImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destinationRect) = 0;
+    virtual void recordDrawFilteredImageBuffer(std::optional<RenderingResourceIdentifier> sourceImageIdentifier, const FloatRect& sourceImageRect, Filter&) = 0;
     virtual void recordDrawGlyphs(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& localAnchor, FontSmoothingMode) = 0;
     virtual void recordDrawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) = 0;
-    virtual void recordDrawImageBuffer(ImageBuffer&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) = 0;
+    virtual void recordDrawImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) = 0;
     virtual void recordDrawNativeImage(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) = 0;
     virtual void recordDrawSystemImage(SystemImage&, const FloatRect&) = 0;
     virtual void recordDrawPattern(RenderingResourceIdentifier, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) = 0;
@@ -104,9 +104,10 @@ protected:
     virtual void recordStrokePath(const Path&) = 0;
     virtual void recordDrawDisplayListItems(const Vector<Item>&, const FloatPoint& destination) = 0;
 
-    virtual bool recordResourceUse(NativeImage&) = 0;
-    virtual bool recordResourceUse(ImageBuffer&) = 0;
-    virtual bool recordResourceUse(const SourceImage&) = 0;
+    virtual std::optional<RenderingResourceIdentifier> recordResourceUse(NativeImage&) = 0;
+    virtual std::optional<RenderingResourceIdentifier> recordResourceUse(ImmutableImageBuffer&) = 0;
+    virtual std::optional<RenderingResourceIdentifier> recordResourceUse(ImageBuffer& imageBuffer) { return recordResourceUse(static_cast<ImmutableImageBuffer&>(imageBuffer)); }
+    virtual std::optional<RenderingResourceIdentifier> recordResourceUse(const SourceImage&) = 0;
     virtual bool recordResourceUse(Font&) = 0;
     virtual bool recordResourceUse(DecomposedGlyphs&) = 0;
     virtual bool recordResourceUse(Gradient&) = 0;
@@ -179,19 +180,22 @@ private:
     WEBCORE_EXPORT void didUpdateSingleState(GraphicsContextState&, GraphicsContextState::ChangeIndex) final;
     WEBCORE_EXPORT void fillPath(const Path&) final;
     WEBCORE_EXPORT void strokePath(const Path&) final;
-    WEBCORE_EXPORT void drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, FilterResults&) final;
+    WEBCORE_EXPORT void drawFilteredImageBuffer(ImmutableImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, FilterResults&) final;
     WEBCORE_EXPORT void drawGlyphs(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& anchorPoint, FontSmoothingMode) final;
     WEBCORE_EXPORT void drawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) override;
     WEBCORE_EXPORT void drawGlyphsAndCacheResources(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& localAnchor, FontSmoothingMode) final;
     WEBCORE_EXPORT void drawDisplayListItems(const Vector<Item>&, const ResourceHeap&, ControlFactory&, const FloatPoint& destination) final;
+    WEBCORE_EXPORT void drawImageBuffer(ImmutableImageBuffer&, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions) final;
     WEBCORE_EXPORT void drawImageBuffer(ImageBuffer&, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions) final;
-    WEBCORE_EXPORT void drawConsumingImageBuffer(RefPtr<ImageBuffer>, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions) final;
+    WEBCORE_EXPORT void drawConsumingImageBuffer(RefPtr<ImmutableImageBuffer>, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions) final;
     WEBCORE_EXPORT void drawNativeImageInternal(NativeImage&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) final;
     WEBCORE_EXPORT void drawSystemImage(SystemImage&, const FloatRect&) final;
     WEBCORE_EXPORT void drawPattern(NativeImage&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions) final;
+    WEBCORE_EXPORT void drawPattern(ImmutableImageBuffer&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions) final;
     WEBCORE_EXPORT void drawPattern(ImageBuffer&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions) final;
     WEBCORE_EXPORT AffineTransform getCTM(GraphicsContext::IncludeDeviceScale = PossiblyIncludeDeviceScale) const final;
     WEBCORE_EXPORT IntRect clipBounds() const final;
+    WEBCORE_EXPORT void clipToImageBuffer(ImmutableImageBuffer&, const FloatRect&) final;
     WEBCORE_EXPORT void clipToImageBuffer(ImageBuffer&, const FloatRect&) final;
 
     void appendStateChangeItem(const GraphicsContextState&);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -175,9 +175,9 @@ void RecorderImpl::clipOutRoundedRect(const FloatRoundedRect& clipRect)
     append(ClipOutRoundedRect(clipRect));
 }
 
-void RecorderImpl::recordClipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destinationRect)
+void RecorderImpl::recordClipToImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destinationRect)
 {
-    append(ClipToImageBuffer(imageBuffer.renderingResourceIdentifier(), destinationRect));
+    append(ClipToImageBuffer(imageBufferIdentifier, destinationRect));
 }
 
 void RecorderImpl::clipOut(const Path& path)
@@ -192,12 +192,9 @@ void RecorderImpl::clipPath(const Path& path, WindRule rule)
     append(ClipPath(path, rule));
 }
 
-void RecorderImpl::recordDrawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter)
+void RecorderImpl::recordDrawFilteredImageBuffer(std::optional<RenderingResourceIdentifier> sourceImageIdentifier, const FloatRect& sourceImageRect, Filter& filter)
 {
-    std::optional<RenderingResourceIdentifier> identifier;
-    if (sourceImage)
-        identifier = sourceImage->renderingResourceIdentifier();
-    append(DrawFilteredImageBuffer(WTFMove(identifier), sourceImageRect, filter));
+    append(DrawFilteredImageBuffer(WTFMove(sourceImageIdentifier), sourceImageRect, filter));
 }
 
 void RecorderImpl::recordDrawGlyphs(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& localAnchor, FontSmoothingMode mode)
@@ -215,9 +212,9 @@ void RecorderImpl::recordDrawDisplayListItems(const Vector<Item>& items, const F
     append(DrawDisplayListItems(items, destination));
 }
 
-void RecorderImpl::recordDrawImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
+void RecorderImpl::recordDrawImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
-    append(DrawImageBuffer(imageBuffer.renderingResourceIdentifier(), destRect, srcRect, options));
+    append(DrawImageBuffer(imageBufferIdentifier, destRect, srcRect, options));
 }
 
 void RecorderImpl::recordDrawNativeImage(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
@@ -499,7 +496,7 @@ void RecorderImpl::endPage()
     append(EndPage());
 }
 
-bool RecorderImpl::recordResourceUse(NativeImage& nativeImage)
+std::optional<RenderingResourceIdentifier> RecorderImpl::recordResourceUse(NativeImage& nativeImage)
 {
 #if USE(SKIA)
     if (m_displayList.replayOptions().contains(ReplayOption::FlushImagesAndWaitForCompletion))
@@ -507,10 +504,10 @@ bool RecorderImpl::recordResourceUse(NativeImage& nativeImage)
 #endif
 
     m_displayList.cacheNativeImage(nativeImage);
-    return true;
+    return nativeImage.renderingResourceIdentifier();
 }
 
-bool RecorderImpl::recordResourceUse(ImageBuffer& imageBuffer)
+std::optional<RenderingResourceIdentifier> RecorderImpl::recordResourceUse(ImmutableImageBuffer& imageBuffer)
 {
 #if USE(SKIA)
     if (m_displayList.replayOptions().contains(ReplayOption::FlushImagesAndWaitForCompletion))
@@ -518,10 +515,24 @@ bool RecorderImpl::recordResourceUse(ImageBuffer& imageBuffer)
 #endif
 
     m_displayList.cacheImageBuffer(imageBuffer);
-    return true;
+    return imageBuffer.renderingResourceIdentifier();
 }
 
-bool RecorderImpl::recordResourceUse(const SourceImage& image)
+std::optional<RenderingResourceIdentifier> RecorderImpl::recordResourceUse(ImageBuffer& imageBuffer)
+{
+#if USE(SKIA)
+    return recordResourceUse(static_cast<ImmutableImageBuffer&>(imageBuffer));
+#else
+    RefPtr clone = imageBuffer.clone();
+    if (!clone)
+        return std::nullopt;
+
+    m_displayList.cacheImageBuffer(*clone);
+    return clone->renderingResourceIdentifier();
+#endif
+}
+
+std::optional<RenderingResourceIdentifier> RecorderImpl::recordResourceUse(const SourceImage& image)
 {
     if (auto imageBuffer = image.imageBufferIfExists())
         return recordResourceUse(*imageBuffer);
@@ -529,7 +540,7 @@ bool RecorderImpl::recordResourceUse(const SourceImage& image)
     if (auto nativeImage = image.nativeImageIfExists())
         return recordResourceUse(*nativeImage);
 
-    return true;
+    return image.imageIdentifier();
 }
 
 bool RecorderImpl::recordResourceUse(Font& font)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -99,11 +99,11 @@ private:
     void recordSetInlineStroke(SetInlineStroke&&) final;
     void recordSetState(const GraphicsContextState&) final;
     void recordClearDropShadow() final;
-    void recordClipToImageBuffer(ImageBuffer&, const FloatRect& destinationRect) final;
-    void recordDrawFilteredImageBuffer(ImageBuffer*, const FloatRect& sourceImageRect, Filter&) final;
+    void recordClipToImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destinationRect) final;
+    void recordDrawFilteredImageBuffer(std::optional<RenderingResourceIdentifier> sourceImageIdentifier, const FloatRect& sourceImageRect, Filter&) final;
     void recordDrawGlyphs(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint& localAnchor, FontSmoothingMode) final;
     void recordDrawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) final;
-    void recordDrawImageBuffer(ImageBuffer&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) final;
+    void recordDrawImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) final;
     void recordDrawNativeImage(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions) final;
     void recordDrawSystemImage(SystemImage&, const FloatRect&) final;
     void recordDrawPattern(RenderingResourceIdentifier, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions = { }) final;
@@ -128,9 +128,10 @@ private:
     void recordStrokePath(const Path&) final;
     void recordDrawDisplayListItems(const Vector<Item>&, const FloatPoint& destination) final;
 
-    bool recordResourceUse(NativeImage&) final;
-    bool recordResourceUse(ImageBuffer&) final;
-    bool recordResourceUse(const SourceImage&) final;
+    std::optional<RenderingResourceIdentifier> recordResourceUse(NativeImage&) final;
+    std::optional<RenderingResourceIdentifier> recordResourceUse(ImmutableImageBuffer&) final;
+    std::optional<RenderingResourceIdentifier> recordResourceUse(ImageBuffer&) final;
+    std::optional<RenderingResourceIdentifier> recordResourceUse(const SourceImage&) final;
     bool recordResourceUse(Font&) final;
     bool recordResourceUse(DecomposedGlyphs&) final;
     bool recordResourceUse(Gradient&) final;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h
@@ -45,16 +45,16 @@ class ResourceHeap {
 public:
     using Resource = std::variant<
         std::monostate,
-        Ref<ImageBuffer>,
+        Ref<ImmutableImageBuffer>,
         Ref<RenderingResource>,
         Ref<Font>,
         Ref<FontCustomPlatformData>
     >;
 
-    void add(Ref<ImageBuffer>&& imageBuffer)
+    void add(Ref<ImmutableImageBuffer>&& imageBuffer)
     {
         auto renderingResourceIdentifier = imageBuffer->renderingResourceIdentifier();
-        add<ImageBuffer>(renderingResourceIdentifier, WTFMove(imageBuffer), m_imageBufferCount);
+        add<ImmutableImageBuffer>(renderingResourceIdentifier, WTFMove(imageBuffer), m_imageBufferCount);
     }
 
     void add(Ref<NativeImage>&& image)
@@ -93,9 +93,9 @@ public:
         add<FontCustomPlatformData>(renderingResourceIdentifier, WTFMove(customPlatformData), m_customPlatformDataCount);
     }
 
-    ImageBuffer* getImageBuffer(RenderingResourceIdentifier renderingResourceIdentifier, OptionSet<ReplayOption> options = { }) const
+    ImmutableImageBuffer* getImageBuffer(RenderingResourceIdentifier renderingResourceIdentifier, OptionSet<ReplayOption> options = { }) const
     {
-        auto* imageBuffer = get<ImageBuffer>(renderingResourceIdentifier);
+        auto* imageBuffer = get<ImmutableImageBuffer>(renderingResourceIdentifier);
 
 #if USE(SKIA)
         if (imageBuffer && options.contains(ReplayOption::FlushImagesAndWaitForCompletion))
@@ -168,7 +168,7 @@ public:
 
     bool removeImageBuffer(RenderingResourceIdentifier renderingResourceIdentifier)
     {
-        return remove<ImageBuffer>(renderingResourceIdentifier, m_imageBufferCount);
+        return remove<ImmutableImageBuffer>(renderingResourceIdentifier, m_imageBufferCount);
     }
 
     bool removeRenderingResource(RenderingResourceIdentifier renderingResourceIdentifier)
@@ -287,7 +287,7 @@ private:
         unsigned fontCount = 0;
         unsigned customPlatformDataCount = 0;
         for (const auto& resource : m_resources) {
-            if (std::holds_alternative<Ref<ImageBuffer>>(resource.value))
+            if (std::holds_alternative<Ref<ImmutableImageBuffer>>(resource.value))
                 ++imageBufferCount;
             else if (std::holds_alternative<Ref<RenderingResource>>(resource.value))
                 ++renderingResourceCount;

--- a/Source/WebCore/platform/graphics/filters/Filter.cpp
+++ b/Source/WebCore/platform/graphics/filters/Filter.cpp
@@ -101,7 +101,7 @@ void Filter::setFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFil
     ASSERT(m_filterRenderingModes.contains(FilterRenderingMode::Software));
 }
 
-RefPtr<FilterImage> Filter::apply(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, FilterResults& results)
+RefPtr<FilterImage> Filter::apply(ImmutableImageBuffer* sourceImage, const FloatRect& sourceImageRect, FilterResults& results)
 {
     RefPtr<FilterImage> input;
 

--- a/Source/WebCore/platform/graphics/filters/Filter.h
+++ b/Source/WebCore/platform/graphics/filters/Filter.h
@@ -26,7 +26,6 @@
 #include "FloatPoint3D.h"
 #include "FloatRect.h"
 #include "GraphicsTypes.h"
-#include "ImageBuffer.h"
 #include "RenderingMode.h"
 
 namespace WebCore {
@@ -34,6 +33,7 @@ namespace WebCore {
 class FilterEffect;
 class FilterImage;
 class FilterResults;
+class ImmutableImageBuffer;
 
 class Filter : public FilterFunction {
     using FilterFunction::apply;
@@ -65,7 +65,7 @@ public:
 
     bool clampFilterRegionIfNeeded();
 
-    WEBCORE_EXPORT RefPtr<FilterImage> apply(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, FilterResults&);
+    WEBCORE_EXPORT RefPtr<FilterImage> apply(ImmutableImageBuffer* sourceImage, const FloatRect& sourceImageRect, FilterResults&);
     WEBCORE_EXPORT FilterStyleVector createFilterStyles(GraphicsContext&, const FloatRect& sourceImageRect) const;
 
 protected:

--- a/Source/WebCore/platform/graphics/filters/FilterImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.cpp
@@ -46,7 +46,7 @@ RefPtr<FilterImage> FilterImage::create(const FloatRect& primitiveSubregion, con
     return adoptRef(new FilterImage(primitiveSubregion, imageRect, absoluteImageRect, isAlphaImage, isValidPremultiplied, renderingMode, colorSpace, allocator));
 }
 
-RefPtr<FilterImage> FilterImage::create(const FloatRect& primitiveSubregion, const FloatRect& imageRect, const IntRect& absoluteImageRect, Ref<ImageBuffer>&& imageBuffer, ImageBufferAllocator& allocator)
+RefPtr<FilterImage> FilterImage::create(const FloatRect& primitiveSubregion, const FloatRect& imageRect, const IntRect& absoluteImageRect, Ref<ImmutableImageBuffer>&& imageBuffer, ImageBufferAllocator& allocator)
 {
     return adoptRef(*new FilterImage(primitiveSubregion, imageRect, absoluteImageRect, WTFMove(imageBuffer), allocator));
 }
@@ -63,7 +63,7 @@ FilterImage::FilterImage(const FloatRect& primitiveSubregion, const FloatRect& i
 {
 }
 
-FilterImage::FilterImage(const FloatRect& primitiveSubregion, const FloatRect& imageRect, const IntRect& absoluteImageRect, Ref<ImageBuffer>&& imageBuffer, ImageBufferAllocator& allocator)
+FilterImage::FilterImage(const FloatRect& primitiveSubregion, const FloatRect& imageRect, const IntRect& absoluteImageRect, Ref<ImmutableImageBuffer>&& imageBuffer, ImageBufferAllocator& allocator)
     : m_primitiveSubregion(primitiveSubregion)
     , m_imageRect(imageRect)
     , m_absoluteImageRect(absoluteImageRect)
@@ -112,6 +112,18 @@ size_t FilterImage::memoryCost() const
 
 ImageBuffer* FilterImage::imageBuffer()
 {
+    ASSERT(!m_imageBuffer);
+
+    RefPtr imageBuffer = m_allocator.createImageBuffer(m_absoluteImageRect.size(), m_colorSpace, m_renderingMode);
+    if (!imageBuffer)
+        return nullptr;
+
+    m_imageBuffer = imageBuffer;
+    return imageBuffer.get();
+}
+
+ImmutableImageBuffer* FilterImage::immutableImageBuffer()
+{
 #if USE(CORE_IMAGE)
     if (m_ciImage)
         return imageBufferFromCIImage();
@@ -119,22 +131,23 @@ ImageBuffer* FilterImage::imageBuffer()
     return imageBufferFromPixelBuffer();
 }
 
-ImageBuffer* FilterImage::imageBufferFromPixelBuffer()
+ImmutableImageBuffer* FilterImage::imageBufferFromPixelBuffer()
 {
     if (m_imageBuffer)
         return m_imageBuffer.get();
 
-    m_imageBuffer = m_allocator.createImageBuffer(m_absoluteImageRect.size(), m_colorSpace, m_renderingMode);
-    if (!m_imageBuffer)
+    RefPtr imageBuffer = m_allocator.createImageBuffer(m_absoluteImageRect.size(), m_colorSpace, m_renderingMode);
+    if (!imageBuffer)
         return nullptr;
 
     auto imageBufferRect = IntRect { { }, m_absoluteImageRect.size() };
 
     if (pixelBufferSlot(AlphaPremultiplication::Premultiplied))
-        m_imageBuffer->putPixelBuffer(*pixelBufferSlot(AlphaPremultiplication::Premultiplied), imageBufferRect);
+        imageBuffer->putPixelBuffer(*pixelBufferSlot(AlphaPremultiplication::Premultiplied), imageBufferRect);
     else if (pixelBufferSlot(AlphaPremultiplication::Unpremultiplied))
-        m_imageBuffer->putPixelBuffer(*pixelBufferSlot(AlphaPremultiplication::Unpremultiplied), imageBufferRect);
+        imageBuffer->putPixelBuffer(*pixelBufferSlot(AlphaPremultiplication::Unpremultiplied), imageBufferRect);
 
+    m_imageBuffer = WTFMove(imageBuffer);
     return m_imageBuffer.get();
 }
 
@@ -199,7 +212,7 @@ static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& de
     }
 }
 
-static RefPtr<PixelBuffer> getConvertedPixelBuffer(ImageBuffer& imageBuffer, AlphaPremultiplication alphaFormat, const IntRect& sourceRect, DestinationColorSpace colorSpace, ImageBufferAllocator& allocator)
+static RefPtr<PixelBuffer> getConvertedPixelBuffer(ImmutableImageBuffer& imageBuffer, AlphaPremultiplication alphaFormat, const IntRect& sourceRect, DestinationColorSpace colorSpace, ImageBufferAllocator& allocator)
 {
     auto clampedSize = ImageBuffer::clampedSize(sourceRect.size());
     auto convertedImageBuffer = allocator.createImageBuffer(clampedSize, colorSpace, RenderingMode::Unaccelerated);

--- a/Source/WebCore/platform/graphics/filters/FilterImage.h
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.h
@@ -38,11 +38,6 @@
 OBJC_CLASS CIImage;
 #endif
 
-#if USE(SKIA)
-#include <skia/core/SkPicture.h>
-#include <skia/core/SkPictureRecorder.h>
-#endif
-
 namespace WebCore {
 
 class Filter;
@@ -51,7 +46,7 @@ class FloatRect;
 class FilterImage : public RefCounted<FilterImage> {
 public:
     static RefPtr<FilterImage> create(const FloatRect& primitiveSubregion, const FloatRect& imageRect, const IntRect& absoluteImageRect, bool isAlphaImage, bool isValidPremultiplied, RenderingMode, const DestinationColorSpace&, ImageBufferAllocator&);
-    static RefPtr<FilterImage> create(const FloatRect& primitiveSubregion, const FloatRect& imageRect, const IntRect& absoluteImageRect, Ref<ImageBuffer>&&, ImageBufferAllocator&);
+    static RefPtr<FilterImage> create(const FloatRect& primitiveSubregion, const FloatRect& imageRect, const IntRect& absoluteImageRect, Ref<ImmutableImageBuffer>&&, ImageBufferAllocator&);
 
     // The return values are in filter coordinates.
     FloatRect primitiveSubregion() const { return m_primitiveSubregion; }
@@ -70,6 +65,7 @@ public:
     size_t memoryCost() const;
 
     WEBCORE_EXPORT ImageBuffer* imageBuffer();
+    WEBCORE_EXPORT ImmutableImageBuffer* immutableImageBuffer();
     PixelBuffer* pixelBuffer(AlphaPremultiplication);
 
     RefPtr<PixelBuffer> getPixelBuffer(AlphaPremultiplication, const IntRect& sourceRect, std::optional<DestinationColorSpace> = std::nullopt);
@@ -86,14 +82,14 @@ public:
 
 private:
     FilterImage(const FloatRect& primitiveSubregion, const FloatRect& imageRect, const IntRect& absoluteImageRect, bool isAlphaImage, bool isValidPremultiplied, RenderingMode, const DestinationColorSpace&, ImageBufferAllocator&);
-    FilterImage(const FloatRect& primitiveSubregion, const FloatRect& imageRect, const IntRect& absoluteImageRect, Ref<ImageBuffer>&&, ImageBufferAllocator&);
+    FilterImage(const FloatRect& primitiveSubregion, const FloatRect& imageRect, const IntRect& absoluteImageRect, Ref<ImmutableImageBuffer>&&, ImageBufferAllocator&);
 
     RefPtr<PixelBuffer>& pixelBufferSlot(AlphaPremultiplication);
 
-    ImageBuffer* imageBufferFromPixelBuffer();
+    ImmutableImageBuffer* imageBufferFromPixelBuffer();
 
 #if USE(CORE_IMAGE)
-    ImageBuffer* imageBufferFromCIImage();
+    ImmutableImageBuffer* imageBufferFromCIImage();
 #endif
 
     bool requiresPixelBufferColorSpaceConversion(std::optional<DestinationColorSpace>) const;
@@ -107,7 +103,7 @@ private:
     RenderingMode m_renderingMode;
     DestinationColorSpace m_colorSpace;
 
-    RefPtr<ImageBuffer> m_imageBuffer;
+    RefPtr<ImmutableImageBuffer> m_imageBuffer;
     RefPtr<PixelBuffer> m_unpremultipliedPixelBuffer;
     RefPtr<PixelBuffer> m_premultipliedPixelBuffer;
 

--- a/Source/WebCore/platform/graphics/filters/skia/FEColorMatrixSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEColorMatrixSkiaApplier.cpp
@@ -49,7 +49,7 @@ bool FEColorMatrixSkiaApplier::apply(const Filter&, const FilterImageVector& inp
     auto& input = inputs[0].get();
 
     RefPtr resultImage = result.imageBuffer();
-    RefPtr sourceImage = input.imageBuffer();
+    RefPtr sourceImage = input.immutableImageBuffer();
     if (!resultImage || !sourceImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.cpp
@@ -49,7 +49,7 @@ bool FEComponentTransferSkiaApplier::apply(const Filter&, const FilterImageVecto
     auto& input = inputs[0].get();
 
     RefPtr resultImage = result.imageBuffer();
-    RefPtr sourceImage = input.imageBuffer();
+    RefPtr sourceImage = input.immutableImageBuffer();
     if (!resultImage || !sourceImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.cpp
@@ -50,7 +50,7 @@ bool FEDropShadowSkiaApplier::apply(const Filter& filter, const FilterImageVecto
     auto& input = inputs[0].get();
 
     RefPtr resultImage = result.imageBuffer();
-    RefPtr sourceImage = input.imageBuffer();
+    RefPtr sourceImage = input.immutableImageBuffer();
     if (!resultImage || !sourceImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.cpp
@@ -49,7 +49,7 @@ bool FEGaussianBlurSkiaApplier::apply(const Filter& filter, const FilterImageVec
     auto& input = inputs[0].get();
 
     RefPtr resultImage = result.imageBuffer();
-    RefPtr sourceImage = input.imageBuffer();
+    RefPtr sourceImage = input.immutableImageBuffer();
     if (!resultImage || !sourceImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.cpp
@@ -47,7 +47,7 @@ bool SourceGraphicSkiaApplier::apply(const Filter&, const FilterImageVector& inp
     auto& input = inputs[0].get();
 
     RefPtr resultImage = result.imageBuffer();
-    RefPtr sourceImage = input.imageBuffer();
+    RefPtr sourceImage = input.immutableImageBuffer();
     if (!resultImage || !sourceImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/FEBlendSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEBlendSoftwareApplier.cpp
@@ -47,8 +47,8 @@ bool FEBlendSoftwareApplier::apply(const Filter&, const FilterImageVector& input
     if (!resultImage)
         return false;
 
-    RefPtr inputImage = input.imageBuffer();
-    RefPtr inputImage2 = input2.imageBuffer();
+    RefPtr inputImage = input.immutableImageBuffer();
+    RefPtr inputImage2 = input2.immutableImageBuffer();
     if (!inputImage || !inputImage2)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
@@ -265,7 +265,7 @@ bool FEColorMatrixSoftwareApplier::apply(const Filter&, const FilterImageVector&
     if (!resultImage)
         return false;
 
-    RefPtr inputImage = input.imageBuffer();
+    RefPtr inputImage = input.immutableImageBuffer();
     if (inputImage) {
         auto inputImageRect = input.absoluteImageRectRelativeTo(result);
         resultImage->context().drawImageBuffer(*inputImage, inputImageRect);

--- a/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "FilterEffectApplier.h"
+#include <array>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
@@ -51,8 +51,8 @@ bool FECompositeSoftwareApplier::apply(const Filter&, const FilterImageVector& i
     if (!resultImage)
         return false;
 
-    RefPtr inputImage = input.imageBuffer();
-    RefPtr inputImage2 = input2.imageBuffer();
+    RefPtr inputImage = input.immutableImageBuffer();
+    RefPtr inputImage2 = input2.immutableImageBuffer();
     if (!inputImage || !inputImage2)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp
@@ -51,7 +51,7 @@ bool FEDropShadowSoftwareApplier::apply(const Filter& filter, const FilterImageV
     FloatRect inputImageRectWithOffset(inputImageRect);
     inputImageRectWithOffset.move(absoluteOffset);
 
-    RefPtr inputImage = input.imageBuffer();
+    RefPtr inputImage = input.immutableImageBuffer();
     if (!inputImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/FEMergeSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEMergeSoftwareApplier.cpp
@@ -43,7 +43,7 @@ bool FEMergeSoftwareApplier::apply(const Filter&, const FilterImageVector& input
     auto& filterContext = resultImage->context();
 
     for (auto& input : inputs) {
-        RefPtr inputImage = input->imageBuffer();
+        RefPtr inputImage = input->immutableImageBuffer();
         if (!inputImage)
             continue;
 

--- a/Source/WebCore/platform/graphics/filters/software/FEOffsetSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEOffsetSoftwareApplier.cpp
@@ -40,7 +40,7 @@ bool FEOffsetSoftwareApplier::apply(const Filter& filter, const FilterImageVecto
     auto& input = inputs[0].get();
 
     RefPtr resultImage = result.imageBuffer();
-    RefPtr inputImage = input.imageBuffer();
+    RefPtr inputImage = input.immutableImageBuffer();
     if (!resultImage || !inputImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/FETileSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FETileSoftwareApplier.cpp
@@ -39,7 +39,7 @@ bool FETileSoftwareApplier::apply(const Filter& filter, const FilterImageVector&
     auto& input = inputs[0].get();
 
     RefPtr resultImage = result.imageBuffer();
-    RefPtr inputImage = input.imageBuffer();
+    RefPtr inputImage = input.immutableImageBuffer();
     if (!resultImage || !inputImage)
         return false;
 
@@ -63,7 +63,7 @@ bool FETileSoftwareApplier::apply(const Filter& filter, const FilterImageVector&
     AffineTransform patternTransform;
     patternTransform.translate(tileRect.location() - maxResultRect.location());
 
-    auto pattern = Pattern::create({ tileImage.releaseNonNull() }, { true, true, patternTransform });
+    auto pattern = Pattern::create({ static_reference_cast<ImmutableImageBuffer>(tileImage.releaseNonNull()) }, { true, true, patternTransform });
 
     auto& resultContext = resultImage->context();
     resultContext.setFillPattern(WTFMove(pattern));

--- a/Source/WebCore/platform/graphics/filters/software/SourceAlphaSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/SourceAlphaSoftwareApplier.cpp
@@ -39,7 +39,7 @@ bool SourceAlphaSoftwareApplier::apply(const Filter&, const FilterImageVector& i
     if (!resultImage)
         return false;
     
-    RefPtr inputImage = input.imageBuffer();
+    RefPtr inputImage = input.immutableImageBuffer();
     if (!inputImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
@@ -35,7 +35,7 @@ bool SourceGraphicSoftwareApplier::apply(const Filter&, const FilterImageVector&
     auto& input = inputs[0].get();
 
     RefPtr resultImage = result.imageBuffer();
-    RefPtr sourceImage = input.imageBuffer();
+    RefPtr sourceImage = input.immutableImageBuffer();
     if (!resultImage || !sourceImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -328,7 +328,7 @@ void GraphicsContextSkia::drawNativeImageInternal(NativeImage& nativeImage, cons
     drawSkiaImage(nativeImage.platformImage(), nativeImage.size(), destRect, srcRect, options);
 }
 
-void GraphicsContextSkia::drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter, FilterResults& results)
+void GraphicsContextSkia::drawFilteredImageBuffer(ImmutableImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter, FilterResults& results)
 {
     auto* sourceImageGrContext = sourceImage ? sourceImage->skiaGrContext() : nullptr;
     if (sourceImageGrContext && sourceImageGrContext != PlatformDisplay::sharedDisplay().skiaGrContext()) {
@@ -645,9 +645,9 @@ IntRect GraphicsContextSkia::clipBounds() const
     return enclosingIntRect(m_canvas.getLocalClipBounds());
 }
 
-void GraphicsContextSkia::clipToImageBuffer(ImageBuffer& buffer, const FloatRect& destRect)
+void GraphicsContextSkia::clipToImageBuffer(ImmutableImageBuffer& buffer, const FloatRect& destRect)
 {
-    if (auto nativeImage = nativeImageForDrawing(buffer))
+    if (auto nativeImage = buffer.nativeImageForDrawing(*this))
         m_canvas.clipShader(nativeImage->platformImage()->makeShader(SkTileMode::kDecal, SkTileMode::kDecal, { }, SkMatrix::Translate(SkFloatToScalar(destRect.x()), SkFloatToScalar(destRect.y()))));
 }
 

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -66,7 +66,7 @@ public:
 
     void drawNativeImageInternal(NativeImage&, const FloatRect&, const FloatRect&, ImagePaintingOptions) final;
     void drawPattern(NativeImage&, const FloatRect& destRect, const FloatRect& srcRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions) final;
-    void drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, FilterResults&) final;
+    void drawFilteredImageBuffer(ImmutableImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, FilterResults&) final;
 
     void drawRect(const FloatRect&, float) final;
     void drawLine(const FloatPoint&, const FloatPoint&) final;
@@ -98,7 +98,7 @@ public:
     void clipOut(const Path&) final;
     void clipPath(const Path&, WindRule) final;
     IntRect clipBounds() const final;
-    void clipToImageBuffer(ImageBuffer&, const FloatRect&) final;
+    void clipToImageBuffer(ImmutableImageBuffer&, const FloatRect&) final;
 
     RenderingMode renderingMode() const final;
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -155,7 +155,7 @@ void ImageBufferSkiaAcceleratedBackend::waitForAcceleratedRenderingFenceCompleti
     m_fence = nullptr;
 }
 
-RefPtr<ImageBuffer> ImageBufferSkiaAcceleratedBackend::copyAcceleratedImageBufferBorrowingBackendRenderTarget(const ImageBuffer& imageBuffer) const
+RefPtr<ImageBuffer> ImageBufferSkiaAcceleratedBackend::copyAcceleratedImageBufferBorrowingBackendRenderTarget(const ImmutableImageBuffer& imageBuffer) const
 {
     auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
     if (!glContext || !glContext->makeContextCurrent())

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
@@ -59,7 +59,7 @@ private:
     void waitForAcceleratedRenderingFenceCompletion() final;
 
     const GrDirectContext* skiaGrContext() const final { return m_skiaGrContext; }
-    RefPtr<ImageBuffer> copyAcceleratedImageBufferBorrowingBackendRenderTarget(const ImageBuffer&) const final;
+    RefPtr<ImageBuffer> copyAcceleratedImageBufferBorrowingBackendRenderTarget(const ImmutableImageBuffer&) const final;
 
 #if USE(COORDINATED_GRAPHICS)
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() const final;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3725,7 +3725,7 @@ static RefPtr<Pattern> patternForDescription(PatternDescription description, Flo
     patternOffsetTransform.translate(contentOffset + description.phase);
     patternOffsetTransform.scale(1 / destContext.scaleFactor());
 
-    return Pattern::create({ imageBuffer.releaseNonNull() }, { true, true, patternOffsetTransform });
+    return Pattern::create({ static_reference_cast<ImmutableImageBuffer>(imageBuffer.releaseNonNull()) }, { true, true, patternOffsetTransform });
 };
 #endif
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
@@ -136,7 +136,7 @@ PatternData* LegacyRenderSVGResourcePattern::buildPattern(RenderElement& rendere
     }
 
     // Build pattern.
-    patternData->pattern = Pattern::create({ tileImage.releaseNonNull() }, { true, true, patternData->transform });
+    patternData->pattern = Pattern::create({ static_reference_cast<ImmutableImageBuffer>(tileImage.releaseNonNull()) }, { true, true, patternData->transform });
 
     // Various calls above may trigger invalidations in some fringe cases (ImageBuffer allocation
     // failures in the SVG image cache for example). To avoid having our PatternData deleted by

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -233,7 +233,7 @@ RefPtr<FilterEffect> SVGFEImageElement::createFilterEffect(const FilterEffectVec
     if (!imageBuffer)
         return nullptr;
 
-    return FEImage::create({ imageBuffer.releaseNonNull() }, imageRect, preserveAspectRatio());
+    return FEImage::create({ static_reference_cast<ImmutableImageBuffer>(imageBuffer.releaseNonNull()) }, imageRect, preserveAspectRatio());
 }
 
 void SVGFEImageElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -222,9 +222,9 @@ void RemoteDisplayListRecorderProxy::clipOutRoundedRect(const FloatRoundedRect& 
     send(Messages::RemoteDisplayListRecorder::ClipOutRoundedRect(rect));
 }
 
-void RemoteDisplayListRecorderProxy::recordClipToImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destinationRect)
+void RemoteDisplayListRecorderProxy::recordClipToImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destinationRect)
 {
-    send(Messages::RemoteDisplayListRecorder::ClipToImageBuffer(imageBuffer.renderingResourceIdentifier(), destinationRect));
+    send(Messages::RemoteDisplayListRecorder::ClipToImageBuffer(imageBufferIdentifier, destinationRect));
 }
 
 void RemoteDisplayListRecorderProxy::clipOut(const Path& path)
@@ -246,17 +246,13 @@ void RemoteDisplayListRecorderProxy::resetClip()
     clip(initialClip());
 }
 
-void RemoteDisplayListRecorderProxy::recordDrawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter)
+void RemoteDisplayListRecorderProxy::recordDrawFilteredImageBuffer(std::optional<RenderingResourceIdentifier> sourceImageIdentifier, const FloatRect& sourceImageRect, Filter& filter)
 {
-    std::optional<RenderingResourceIdentifier> identifier;
-    if (sourceImage)
-        identifier = sourceImage->renderingResourceIdentifier();
-
     auto* svgFilter = dynamicDowncast<SVGFilter>(filter);
     if (svgFilter && svgFilter->hasValidRenderingResourceIdentifier())
         recordResourceUse(filter);
 
-    send(Messages::RemoteDisplayListRecorder::DrawFilteredImageBuffer(WTFMove(identifier), sourceImageRect, filter));
+    send(Messages::RemoteDisplayListRecorder::DrawFilteredImageBuffer(WTFMove(sourceImageIdentifier), sourceImageRect, filter));
 }
 
 void RemoteDisplayListRecorderProxy::recordDrawGlyphs(const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& localAnchor, FontSmoothingMode mode)
@@ -274,9 +270,9 @@ void RemoteDisplayListRecorderProxy::recordDrawDisplayListItems(const Vector<Dis
     send(Messages::RemoteDisplayListRecorder::DrawDisplayListItems(items, destination));
 }
 
-void RemoteDisplayListRecorderProxy::recordDrawImageBuffer(ImageBuffer& imageBuffer, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
+void RemoteDisplayListRecorderProxy::recordDrawImageBuffer(RenderingResourceIdentifier imageBufferIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
-    send(Messages::RemoteDisplayListRecorder::DrawImageBuffer(imageBuffer.renderingResourceIdentifier(), destRect, srcRect, options));
+    send(Messages::RemoteDisplayListRecorder::DrawImageBuffer(imageBufferIdentifier, destRect, srcRect, options));
 }
 
 void RemoteDisplayListRecorderProxy::recordDrawNativeImage(RenderingResourceIdentifier imageIdentifier, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
@@ -570,33 +566,33 @@ void RemoteDisplayListRecorderProxy::endPage()
     send(Messages::RemoteDisplayListRecorder::EndPage());
 }
 
-bool RemoteDisplayListRecorderProxy::recordResourceUse(NativeImage& image)
+std::optional<RenderingResourceIdentifier> RemoteDisplayListRecorderProxy::recordResourceUse(NativeImage& image)
 {
     if (UNLIKELY(!m_renderingBackend)) {
         ASSERT_NOT_REACHED();
-        return false;
+        return std::nullopt;
     }
 
     m_renderingBackend->remoteResourceCacheProxy().recordNativeImageUse(image);
-    return true;
+    return image.renderingResourceIdentifier();
 }
 
-bool RemoteDisplayListRecorderProxy::recordResourceUse(ImageBuffer& imageBuffer)
+std::optional<RenderingResourceIdentifier> RemoteDisplayListRecorderProxy::recordResourceUse(ImmutableImageBuffer& imageBuffer)
 {
     RefPtr renderingBackend = m_renderingBackend.get();
     if (UNLIKELY(!renderingBackend)) {
         ASSERT_NOT_REACHED();
-        return false;
+        return std::nullopt;
     }
 
     if (!renderingBackend->isCached(imageBuffer))
-        return false;
+        return std::nullopt;
 
     renderingBackend->remoteResourceCacheProxy().recordImageBufferUse(imageBuffer);
-    return true;
+    return imageBuffer.renderingResourceIdentifier();
 }
 
-bool RemoteDisplayListRecorderProxy::recordResourceUse(const SourceImage& image)
+std::optional<RenderingResourceIdentifier> RemoteDisplayListRecorderProxy::recordResourceUse(const SourceImage& image)
 {
     if (RefPtr imageBuffer = image.imageBufferIfExists())
         return recordResourceUse(*imageBuffer);
@@ -604,7 +600,7 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(const SourceImage& image)
     if (RefPtr nativeImage = image.nativeImageIfExists())
         return recordResourceUse(*nativeImage);
 
-    return true;
+    return image.imageIdentifier();
 }
 
 bool RemoteDisplayListRecorderProxy::recordResourceUse(Font& font)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -122,12 +122,12 @@ private:
     void recordSetInlineStroke(WebCore::DisplayList::SetInlineStroke&&) final;
     void recordSetState(const WebCore::GraphicsContextState&) final;
     void recordClearDropShadow() final;
-    void recordClipToImageBuffer(WebCore::ImageBuffer&, const WebCore::FloatRect& destinationRect) final;
-    void recordDrawFilteredImageBuffer(WebCore::ImageBuffer*, const WebCore::FloatRect& sourceImageRect, WebCore::Filter&) final;
+    void recordClipToImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, const WebCore::FloatRect& destinationRect) final;
+    void recordDrawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, WebCore::Filter&) final;
     void recordDrawGlyphs(const WebCore::Font&, std::span<const WebCore::GlyphBufferGlyph>, std::span<const WebCore::GlyphBufferAdvance>, const WebCore::FloatPoint& localAnchor, WebCore::FontSmoothingMode) final;
     void recordDrawDecomposedGlyphs(const WebCore::Font&, const WebCore::DecomposedGlyphs&) final;
     void recordDrawDisplayListItems(const Vector<WebCore::DisplayList::Item>&, const WebCore::FloatPoint& destination);
-    void recordDrawImageBuffer(WebCore::ImageBuffer&, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions) final;
+    void recordDrawImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions) final;
     void recordDrawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, WebCore::ImagePaintingOptions) final;
     void recordDrawSystemImage(WebCore::SystemImage&, const WebCore::FloatRect&);
     void recordDrawPattern(WebCore::RenderingResourceIdentifier, const WebCore::FloatRect& destRect, const WebCore::FloatRect& tileRect, const WebCore::AffineTransform&, const WebCore::FloatPoint& phase, const WebCore::FloatSize& spacing, WebCore::ImagePaintingOptions = { }) final;
@@ -151,9 +151,9 @@ private:
     void recordStrokePathSegment(const WebCore::PathSegment&) final;
     void recordStrokePath(const WebCore::Path&) final;
 
-    bool recordResourceUse(WebCore::NativeImage&) final;
-    bool recordResourceUse(WebCore::ImageBuffer&) final;
-    bool recordResourceUse(const WebCore::SourceImage&) final;
+    std::optional<WebCore::RenderingResourceIdentifier> recordResourceUse(WebCore::NativeImage&) final;
+    std::optional<WebCore::RenderingResourceIdentifier> recordResourceUse(WebCore::ImmutableImageBuffer&) final;
+    std::optional<WebCore::RenderingResourceIdentifier> recordResourceUse(const WebCore::SourceImage&) final;
     bool recordResourceUse(WebCore::Font&) final;
     bool recordResourceUse(WebCore::DecomposedGlyphs&) final;
     bool recordResourceUse(WebCore::Gradient&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -587,7 +587,7 @@ void RemoteRenderingBackendProxy::didInitialize(IPC::Semaphore&& wakeUp, IPC::Se
     connection->setSemaphores(WTFMove(wakeUp), WTFMove(clientWait));
 }
 
-bool RemoteRenderingBackendProxy::isCached(const ImageBuffer& imageBuffer) const
+bool RemoteRenderingBackendProxy::isCached(const ImmutableImageBuffer& imageBuffer) const
 {
     if (auto cachedImageBuffer = m_remoteResourceCacheProxy.cachedImageBuffer(imageBuffer.renderingResourceIdentifier())) {
         ASSERT_UNUSED(cachedImageBuffer, cachedImageBuffer == &imageBuffer);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -102,7 +102,7 @@ public:
 #endif
 
     void createRemoteImageBuffer(WebCore::ImageBuffer&);
-    bool isCached(const WebCore::ImageBuffer&) const;
+    bool isCached(const WebCore::ImmutableImageBuffer&) const;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -91,7 +91,7 @@ NativeImage* RemoteResourceCacheProxy::cachedNativeImage(RenderingResourceIdenti
     return dynamicDowncast<NativeImage>(renderingResource.get().get());
 }
 
-void RemoteResourceCacheProxy::recordImageBufferUse(WebCore::ImageBuffer& imageBuffer)
+void RemoteResourceCacheProxy::recordImageBufferUse(ImmutableImageBuffer& imageBuffer)
 {
     auto iterator = m_imageBuffers.find(imageBuffer.renderingResourceIdentifier());
     ASSERT_UNUSED(iterator, iterator != m_imageBuffers.end());
@@ -264,7 +264,7 @@ void RemoteResourceCacheProxy::finalizeRenderingUpdateForFonts()
     unsigned totalFontCount = m_fonts.size();
     RELEASE_ASSERT(m_numberOfFontsUsedInCurrentRenderingUpdate <= totalFontCount);
     if (totalFontCount != m_numberOfFontsUsedInCurrentRenderingUpdate) {
-        HashSet<WebCore::RenderingResourceIdentifier> toRemove;
+        HashSet<RenderingResourceIdentifier> toRemove;
         auto renderingUpdateID = m_renderingUpdateID;
         for (auto& item : m_fonts) {
             if (renderingUpdateID - item.value >= minimumRenderingUpdateCountToKeepFontAlive) {
@@ -281,7 +281,7 @@ void RemoteResourceCacheProxy::finalizeRenderingUpdateForFonts()
     totalFontCount = m_fontCustomPlatformDatas.size();
     RELEASE_ASSERT(m_numberOfFontCustomPlatformDatasUsedInCurrentRenderingUpdate <= totalFontCount);
     if (totalFontCount != m_numberOfFontCustomPlatformDatasUsedInCurrentRenderingUpdate) {
-        HashSet<WebCore::RenderingResourceIdentifier> toRemove;
+        HashSet<RenderingResourceIdentifier> toRemove;
         auto renderingUpdateID = m_renderingUpdateID;
         for (auto& item : m_fontCustomPlatformDatas) {
             if (renderingUpdateID - item.value >= minimumRenderingUpdateCountToKeepFontAlive) {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -37,7 +37,7 @@ class DecomposedGlyphs;
 class Filter;
 class Font;
 class Gradient;
-class ImageBuffer;
+class ImmutableImageBuffer;
 class NativeImage;
 struct FontCustomPlatformData;
 }
@@ -60,7 +60,7 @@ public:
 
     void recordNativeImageUse(WebCore::NativeImage&);
     void recordFontUse(WebCore::Font&);
-    void recordImageBufferUse(WebCore::ImageBuffer&);
+    void recordImageBufferUse(WebCore::ImmutableImageBuffer&);
     void recordDecomposedGlyphsUse(WebCore::DecomposedGlyphs&);
     void recordGradientUse(WebCore::Gradient&);
     void recordFilterUse(WebCore::Filter&);

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
@@ -73,7 +73,7 @@ TEST(DisplayListTests, ReplayWithMissingResource)
 
     {
         ResourceHeap resourceHeap;
-        resourceHeap.add(imageBuffer.releaseNonNull());
+        resourceHeap.add(static_reference_cast<ImmutableImageBuffer>(imageBuffer.releaseNonNull()));
 
         Replayer replayer { context, list.items(), resourceHeap, ControlFactory::shared() };
         auto result = replayer.replay();


### PR DESCRIPTION
#### f6bcbe495cb47aca94d2e21e5e0e9220f593a86d
<pre>
Introduce ImmutableImageBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=285260#">https://bugs.webkit.org/show_bug.cgi?id=285260#</a>
<a href="https://rdar.apple.com/142199138">rdar://142199138</a>

Reviewed by NOBODY (OOPS!).

ImageBuffer is a drawing target. Its life cycle is usually split into two consecutive
phases: (1) destination phase and (2) source phase. In the destination phase,
something is drawn to the ImageBuffer. Usually a fragment of the document is drawn
to ImageBuffer. In the source phase, the ImageBuffer is used as an image which
can be drawn to another destination drawing target. We can call the ImageBuffer
after the destination phase is finished: `ImmutableImageBuffer`.

The canvas ImageBuffer is a special case because it does not work as described
above. The drawing to this ImageBuffer and drawing the ImageBuffer itself can be
interleaved. So this ImageBuffer will always be `MutableImageBuffer`  or for now
`ImageBuffer`.

Recording DisplayListItems which reference MutableImageBuffers such as DrawImageBuffer
and ClipToImageBuffer is problematic. The MutableImageBuffers can change between
recording these items and replaying them back. The fix is to clone these
MutableImageBuffers when recording these DisplayListItems. Cloning MutableImageBuffers
is expensive. If new versions of these drawing methods are introduced for
ImmutableImageBuffers, this cloning will not be needed. So the caller side should
be changed to have references to ImmutableImageBuffers if this is this case.

ImmutableImageBuffer should be the base class of ImageBuffer. ImmutableImageBuffer
does not provide any function that can change the backend. ImageBuffer will provide
the `context()` and the `putPixelBuffer()` functions.

All the GPUProcess RemoteImageBuffers will stay mutable because they are controlled
by the WebProcess. If WebProcess stores an ImageBuffer as ImmutableImageBuffer,
its backend will never be changed even if its backend is remote or shared.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::createPattern):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::clipToImageBuffer):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawImageBuffer):
(WebCore::GraphicsContext::drawConsumingImageBuffer):
(WebCore::GraphicsContext::drawFilteredImageBuffer):
(WebCore::GraphicsContext::drawPattern):
(WebCore::GraphicsContext::clipToImageBuffer):
(WebCore::GraphicsContext::nativeImageForDrawing): Deleted.
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::isDeferred const):
(WebCore::GraphicsContext::drawImageBuffer):
(WebCore::GraphicsContext::drawConsumingImageBuffer):
(WebCore::GraphicsContext::drawPattern):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::ImageBuffer):
(WebCore::ImageBuffer::sinkIntoBufferForDifferentThread):
(WebCore::DefaultSerializedImageBuffer::DefaultSerializedImageBuffer):
(WebCore::ImageBuffer::sinkIntoSerializedImageBuffer):
(WebCore::SerializedImageBuffer::sinkIntoImageBuffer):
(WebCore::ImageBuffer::calculateBackendSize): Deleted.
(WebCore::ImageBuffer::backendParameters): Deleted.
(WebCore::ImageBuffer::sizeNeedsClamping): Deleted.
(WebCore::ImageBuffer::clampedSize): Deleted.
(WebCore::ImageBuffer::clampedRect): Deleted.
(WebCore::copyImageBuffer): Deleted.
(WebCore::copyImageBufferToNativeImage): Deleted.
(WebCore::copyImageBufferToOpaqueNativeImage): Deleted.
(WebCore::ImageBuffer::clone const): Deleted.
(WebCore::ImageBuffer::context const): Deleted.
(WebCore::ImageBuffer::setBackend): Deleted.
(WebCore::ImageBuffer::backendSize const): Deleted.
(WebCore::ImageBuffer::copyNativeImage const): Deleted.
(WebCore::ImageBuffer::createNativeImageReference const): Deleted.
(WebCore::ImageBuffer::sinkIntoNativeImage): Deleted.
(WebCore::ImageBuffer::sinkIntoImageBufferForCrossThreadTransfer): Deleted.
(WebCore::ImageBuffer::sinkIntoImageBufferAfterCrossThreadTransfer): Deleted.
(WebCore::ImageBuffer::filteredNativeImage): Deleted.
(WebCore::ImageBuffer::surface): Deleted.
(WebCore::ImageBuffer::createCairoSurface): Deleted.
(WebCore::ImageBuffer::finishAcceleratedRenderingAndCreateFence): Deleted.
(WebCore::ImageBuffer::waitForAcceleratedRenderingFenceCompletion): Deleted.
(WebCore::ImageBuffer::skiaGrContext const): Deleted.
(WebCore::ImageBuffer::copyAcceleratedImageBufferBorrowingBackendRenderTarget const): Deleted.
(WebCore::ImageBuffer::layerContentsDisplayDelegate): Deleted.
(WebCore::ImageBuffer::toDataURL const): Deleted.
(WebCore::ImageBuffer::toData const): Deleted.
(WebCore::ImageBuffer::toDataURL): Deleted.
(WebCore::ImageBuffer::toData): Deleted.
(WebCore::ImageBuffer::getPixelBuffer const): Deleted.
(WebCore::ImageBuffer::sinkIntoPDFDocument): Deleted.
(WebCore::ImageBuffer::isInUse const): Deleted.
(WebCore::ImageBuffer::releaseGraphicsContext): Deleted.
(WebCore::ImageBuffer::setVolatile): Deleted.
(WebCore::ImageBuffer::setNonVolatile): Deleted.
(WebCore::ImageBuffer::volatilityState const): Deleted.
(WebCore::ImageBuffer::setVolatilityState): Deleted.
(WebCore::ImageBuffer::setVolatileAndPurgeForTesting): Deleted.
(WebCore::ImageBuffer::createFlusher): Deleted.
(WebCore::ImageBuffer::backendGeneration const): Deleted.
(WebCore::ImageBuffer::toBackendSharing): Deleted.
(WebCore::ImageBuffer::dynamicContentScalingDisplayList): Deleted.
(WebCore::ImageBuffer::transferToNewContext): Deleted.
(WebCore::ImageBuffer::debugDescription const): Deleted.
(WebCore::operator&lt;&lt;): Deleted.
* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::ImageBuffer::ensureBackendCreated const): Deleted.
(WebCore::ImageBuffer::hasBackend): Deleted.
(WebCore::ImageBuffer::renderingResourceIdentifier const): Deleted.
(WebCore::ImageBuffer::logicalSize const): Deleted.
(WebCore::ImageBuffer::truncatedLogicalSize const): Deleted.
(WebCore::ImageBuffer::resolutionScale const): Deleted.
(WebCore::ImageBuffer::colorSpace const): Deleted.
(WebCore::ImageBuffer::renderingPurpose const): Deleted.
(WebCore::ImageBuffer::pixelFormat const): Deleted.
(WebCore::ImageBuffer::parameters const): Deleted.
(WebCore::ImageBuffer::renderingMode const): Deleted.
(WebCore::ImageBuffer::baseTransform const): Deleted.
(WebCore::ImageBuffer::memoryCost const): Deleted.
(WebCore::ImageBuffer::backendInfo const): Deleted.
(WebCore::ImageBuffer::backend const): Deleted.
(WebCore::ImageBuffer::ensureBackend const): Deleted.
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::copyAcceleratedImageBufferBorrowingBackendRenderTarget const):
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
* Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp:
(WebCore::ImageBufferContextSwitcher::endDrawSourceImage):
* Source/WebCore/platform/graphics/ImmutableImageBuffer.cpp: Copied from Source/WebCore/platform/graphics/ImageBuffer.cpp.
(WebCore::ImmutableImageBuffer::ImmutableImageBuffer):
(WebCore::ImmutableImageBuffer::calculateBackendSize):
(WebCore::ImmutableImageBuffer::backendParameters):
(WebCore::ImmutableImageBuffer::sizeNeedsClamping):
(WebCore::ImmutableImageBuffer::clampedSize):
(WebCore::ImmutableImageBuffer::clampedRect):
(WebCore::ImmutableImageBuffer::backendSize const):
(WebCore::ImmutableImageBuffer::context const):
(WebCore::ImmutableImageBuffer::surface):
(WebCore::ImmutableImageBuffer::createCairoSurface):
(WebCore::ImmutableImageBuffer::skiaGrContext const):
(WebCore::ImmutableImageBuffer::dynamicContentScalingDisplayList):
(WebCore::ImmutableImageBuffer::layerContentsDisplayDelegate):
(WebCore::ImmutableImageBuffer::setBackend):
(WebCore::ImmutableImageBuffer::copyImageBuffer):
(WebCore::copyImageBufferToNativeImage):
(WebCore::copyImageBufferToOpaqueNativeImage):
(WebCore::ImmutableImageBuffer::clone const):
(WebCore::ImmutableImageBuffer::copyNativeImage const):
(WebCore::ImmutableImageBuffer::createNativeImageReference const):
(WebCore::ImmutableImageBuffer::nativeImageForDrawing const):
(WebCore::ImmutableImageBuffer::filteredNativeImage):
(WebCore::ImmutableImageBuffer::getPixelBuffer const):
(WebCore::ImmutableImageBuffer::isInUse const):
(WebCore::ImmutableImageBuffer::releaseGraphicsContext):
(WebCore::ImmutableImageBuffer::setVolatile):
(WebCore::ImmutableImageBuffer::setNonVolatile):
(WebCore::ImmutableImageBuffer::volatilityState const):
(WebCore::ImmutableImageBuffer::setVolatilityState):
(WebCore::ImmutableImageBuffer::setVolatileAndPurgeForTesting):
(WebCore::ImmutableImageBuffer::createFlusher):
(WebCore::ImmutableImageBuffer::backendGeneration const):
(WebCore::ImmutableImageBuffer::toBackendSharing):
(WebCore::ImmutableImageBuffer::transferToNewContext):
(WebCore::ImmutableImageBuffer::sinkIntoNativeImage):
(WebCore::ImmutableImageBuffer::toDataURL const):
(WebCore::ImmutableImageBuffer::toData const):
(WebCore::ImmutableImageBuffer::toDataURL):
(WebCore::ImmutableImageBuffer::toData):
(WebCore::ImmutableImageBuffer::finishAcceleratedRenderingAndCreateFence):
(WebCore::ImmutableImageBuffer::waitForAcceleratedRenderingFenceCompletion):
(WebCore::ImmutableImageBuffer::copyAcceleratedImageBufferBorrowingBackendRenderTarget const):
(WebCore::ImmutableImageBuffer::sinkIntoImageBufferForCrossThreadTransfer):
(WebCore::ImmutableImageBuffer::sinkIntoImageBufferAfterCrossThreadTransfer):
(WebCore::ImmutableImageBuffer::sinkIntoPDFDocument):
(WebCore::ImmutableImageBuffer::debugDescription const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/ImmutableImageBuffer.h: Copied from Source/WebCore/platform/graphics/ImageBuffer.h.
(WebCore::ImmutableImageBuffer::populateBackendInfo):
(WebCore::ImmutableImageBuffer::logicalSize const):
(WebCore::ImmutableImageBuffer::truncatedLogicalSize const):
(WebCore::ImmutableImageBuffer::resolutionScale const):
(WebCore::ImmutableImageBuffer::colorSpace const):
(WebCore::ImmutableImageBuffer::renderingPurpose const):
(WebCore::ImmutableImageBuffer::pixelFormat const):
(WebCore::ImmutableImageBuffer::parameters const):
(WebCore::ImmutableImageBuffer::renderingMode const):
(WebCore::ImmutableImageBuffer::baseTransform const):
(WebCore::ImmutableImageBuffer::memoryCost const):
(WebCore::ImmutableImageBuffer::backendInfo const):
(WebCore::ImmutableImageBuffer::renderingResourceIdentifier const):
(WebCore::ImmutableImageBuffer::ensureBackendCreated const):
(WebCore::ImmutableImageBuffer::hasBackend):
(WebCore::ImmutableImageBuffer::backend const):
(WebCore::ImmutableImageBuffer::ensureBackend const):
* Source/WebCore/platform/graphics/NullGraphicsContext.h:
* Source/WebCore/platform/graphics/Pattern.cpp:
(WebCore::Pattern::tileImageBuffer const):
* Source/WebCore/platform/graphics/Pattern.h:
* Source/WebCore/platform/graphics/SourceImage.cpp:
(WebCore::SourceImage::nativeImage const):
(WebCore::imageBufferOf):
(WebCore::SourceImage::imageBufferIfExists const):
(WebCore::SourceImage::imageBuffer const):
(WebCore::SourceImage::imageIdentifier const):
(WebCore::SourceImage::size const):
* Source/WebCore/platform/graphics/SourceImage.h:
* Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.cpp:
(WebCore::Cairo::OperationRecorder::drawImageBuffer):
(WebCore::Cairo::OperationRecorder::drawFilteredImageBuffer):
(WebCore::Cairo::OperationRecorder::clipToImageBuffer):
* Source/WebCore/platform/graphics/cairo/CairoOperationRecorder.h:
* Source/WebCore/platform/graphics/cairo/CairoOperations.cpp:
(WebCore::Cairo::drawShadowLayerBuffer):
(WebCore::Cairo::drawShadowImage):
(WebCore::Cairo::fillShadowBuffer):
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp:
(WebCore::GraphicsContextCairo::clipToImageBuffer):
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::clipToImageBuffer):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/coreimage/FilterImageCoreImage.mm:
(WebCore::FilterImage::imageBufferFromCIImage):
* Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm:
(WebCore::SourceGraphicCoreImageApplier::apply const):
* Source/WebCore/platform/graphics/displaylists/DisplayList.cpp:
(WebCore::DisplayList::DisplayList::cacheImageBuffer):
* Source/WebCore/platform/graphics/displaylists/DisplayList.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::ClipToImageBuffer::apply const):
(WebCore::DisplayList::DrawFilteredImageBuffer::apply const):
(WebCore::DisplayList::DrawImageBuffer::apply const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::drawFilteredImageBuffer):
(WebCore::DisplayList::Recorder::drawDisplayListItems):
(WebCore::DisplayList::Recorder::drawImageBuffer):
(WebCore::DisplayList::Recorder::drawConsumingImageBuffer):
(WebCore::DisplayList::Recorder::drawPattern):
(WebCore::DisplayList::Recorder::clipToImageBuffer):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
(WebCore::DisplayList::Recorder::recordResourceUse):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::recordClipToImageBuffer):
(WebCore::DisplayList::RecorderImpl::recordDrawFilteredImageBuffer):
(WebCore::DisplayList::RecorderImpl::recordDrawImageBuffer):
(WebCore::DisplayList::RecorderImpl::recordResourceUse):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h:
(WebCore::DisplayList::ResourceHeap::add):
(WebCore::DisplayList::ResourceHeap::getImageBuffer):
(WebCore::DisplayList::ResourceHeap::removeImageBuffer):
(WebCore::DisplayList::ResourceHeap::checkInvariants const):
* Source/WebCore/platform/graphics/filters/Filter.cpp:
(WebCore::Filter::apply):
* Source/WebCore/platform/graphics/filters/Filter.h:
* Source/WebCore/platform/graphics/filters/FilterImage.cpp:
(WebCore::FilterImage::create):
(WebCore::FilterImage::FilterImage):
(WebCore::FilterImage::imageBuffer):
(WebCore::FilterImage::immutableImageBuffer):
(WebCore::FilterImage::imageBufferFromPixelBuffer):
(WebCore::getConvertedPixelBuffer):
* Source/WebCore/platform/graphics/filters/FilterImage.h:
* Source/WebCore/platform/graphics/filters/skia/FEColorMatrixSkiaApplier.cpp:
(WebCore::FEColorMatrixSkiaApplier::apply const):
* Source/WebCore/platform/graphics/filters/skia/FEComponentTransferSkiaApplier.cpp:
(WebCore::FEComponentTransferSkiaApplier::apply const):
* Source/WebCore/platform/graphics/filters/skia/FEDropShadowSkiaApplier.cpp:
(WebCore::FEDropShadowSkiaApplier::apply const):
* Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.cpp:
(WebCore::FEGaussianBlurSkiaApplier::apply const):
* Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.cpp:
(WebCore::SourceGraphicSkiaApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FEBlendSoftwareApplier.cpp:
(WebCore::FEBlendSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp:
(WebCore::FEColorMatrixSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.h:
* Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp:
(WebCore::FECompositeSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp:
(WebCore::FEDropShadowSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FEMergeSoftwareApplier.cpp:
(WebCore::FEMergeSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FEOffsetSoftwareApplier.cpp:
(WebCore::FEOffsetSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FETileSoftwareApplier.cpp:
(WebCore::FETileSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/SourceAlphaSoftwareApplier.cpp:
(WebCore::SourceAlphaSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp:
(WebCore::SourceGraphicSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::drawFilteredImageBuffer):
(WebCore::GraphicsContextSkia::clipToImageBuffer):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::copyAcceleratedImageBufferBorrowingBackendRenderTarget const):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::patternForDescription):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp:
(WebCore::LegacyRenderSVGResourcePattern::buildPattern):
* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::createFilterEffect const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordClipToImageBuffer):
(WebKit::RemoteDisplayListRecorderProxy::recordDrawFilteredImageBuffer):
(WebKit::RemoteDisplayListRecorderProxy::recordDrawImageBuffer):
(WebKit::RemoteDisplayListRecorderProxy::recordResourceUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::isCached const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordImageBufferUse):
(WebKit::RemoteResourceCacheProxy::finalizeRenderingUpdateForFonts):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
* Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp:
(TestWebKitAPI::TEST(DisplayListTests, ReplayWithMissingResource)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6bcbe495cb47aca94d2e21e5e0e9220f593a86d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87881 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33820 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64484 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22250 "Found 16 new test failures: css3/filters/color-interpolation-filters.html css3/filters/hidpi-feConvolveMatrix.html css3/filters/identity-filters.html css3/filters/invalid-reference-filter-in-chain.html css3/filters/invalid-reference-filter.html css3/filters/reference-filter-color-space.html css3/filters/reference-filter-outsets.html css3/filters/svg-blur-filter-clipped.html css3/filters/svg-morphology-clipped.html fast/canvas/canvas-filter-bounding-rect.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75282 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44760 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29470 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32853 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72982 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89248 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7297 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72900 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72115 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16276 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15134 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1442 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10007 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15528 "Found 2 new failures in platform/graphics/ImmutableImageBuffer.cpp, platform/graphics/cocoa/FontCacheCoreText.cpp and found 1 fixed file: platform/graphics/coreimage/FilterImageCoreImage.mm") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9881 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13346 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11650 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->