### PR TITLE
[Remote Inspection] youtube.com: targeting 'Try searching to get started' selects the entire app

### DIFF
--- a/LayoutTests/fast/element-targeting/target-container-with-visual-overflow-expected.txt
+++ b/LayoutTests/fast/element-targeting/target-container-with-visual-overflow-expected.txt
@@ -1,0 +1,8 @@
+Right Wrong
+Wrong
+Wrong
+PASS selector is "#expected"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/element-targeting/target-container-with-visual-overflow.html
+++ b/LayoutTests/fast/element-targeting/target-container-with-visual-overflow.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+body, html {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    font-size: 18px;
+    font-family: system-ui;
+    text-align: right;
+}
+
+.visible-overflow {
+    width: 100%;
+    height: 150px;
+    text-align: left;
+    border-bottom: 1px solid lightgray;
+}
+
+.main-content {
+    width: 100%;
+    height: 100vh;
+}
+
+.target {
+    width: 160px;
+    height: 150px;
+    display: inline-block;
+    text-align: center;
+    color: white;
+    line-height: 150px;
+    border-radius: 6px;
+    margin-right: 4px;
+}
+
+.red {
+    background: red;
+}
+
+.green {
+    background: green;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+addEventListener("load", async () => {
+    selector = await UIHelper.adjustVisibilityForFrontmostTarget(50, 50);
+    shouldBeEqualToString("selector", "#expected");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="visible-overflow">
+        <div class="main-content">
+            <span id="expected" class="green target">Right</span>
+            <span class="red target">Wrong</span>
+        </div>
+        <span class="red target">Wrong</span>
+    </div>
+    <span class="red target">Wrong</span>
+    <p id="console"></p>
+</body>
+</html>

--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -89,7 +89,9 @@ private:
     std::pair<Vector<Ref<Node>>, RefPtr<Element>> findNodes(const String& searchText);
     std::pair<Vector<Ref<Node>>, RefPtr<Element>> findNodes(const TargetedElementSelectors&);
 
-    Vector<TargetedElementInfo> extractTargets(Vector<Ref<Node>>&&, RefPtr<Element>&& innerElement, bool canIncludeNearbyElements);
+    enum class IncludeNearbyElements : bool { No, Yes };
+    enum class CheckViewportAreaRatio : bool { No, Yes };
+    Vector<TargetedElementInfo> extractTargets(Vector<Ref<Node>>&&, RefPtr<Element>&& innerElement, CheckViewportAreaRatio, IncludeNearbyElements);
 
     void recomputeAdjustedElementsIfNeeded();
 


### PR DESCRIPTION
#### 6687e347f6f9a0538b3bb2902a530161a1201195
<pre>
[Remote Inspection] youtube.com: targeting &apos;Try searching to get started&apos; selects the entire app
<a href="https://bugs.webkit.org/show_bug.cgi?id=285265">https://bugs.webkit.org/show_bug.cgi?id=285265</a>
<a href="https://rdar.apple.com/133476860">rdar://133476860</a>

Reviewed by Richard Robinson.

Make a couple small adjustments to element targeting heuristics:

1.  When computing viewport area ratio for targeted elements, expand the bounds of containers with
    visual overflow to include the bounds of their children. Ideally, this would recurse down the
    DOM tree to include all descendants, but simply taking immediate children into account (with
    a caching strategy to avoid repeating work) seems to work well in practice, without requiring us
    to compute the absolute bounds for all elements in the document when targeting.

2.  Don&apos;t consider viewport area ratio when performing selector-based targeting. This allows element
    targeting to properly reveal visually dissimilar elements that were previously hidden through
    element targeting, in the case where they&apos;re no longer candidates for targeting due to being too
    large or small relative to the viewport.

* LayoutTests/fast/element-targeting/target-container-with-visual-overflow-expected.txt: Added.
* LayoutTests/fast/element-targeting/target-container-with-visual-overflow.html: Added.

Add a layout test to exercise the fix, by verifying that a container with visual overflow covering
the entire viewport gets skipped when targeting.

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::ElementTargetingController::findTargets):
(WebCore::ElementTargetingController::findAllTargets):
(WebCore::absoluteBoundsForTargetAreaRatio):
(WebCore::ElementTargetingController::extractTargets):

See above for more details.

* Source/WebCore/page/ElementTargetingController.h:

Canonical link: <a href="https://commits.webkit.org/288365@main">https://commits.webkit.org/288365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b483c89f0732de683f04a1281201b901348614e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36958 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87899 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33838 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10344 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64498 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22262 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1839 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75295 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44774 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1733 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29483 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32871 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89266 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7311 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72913 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72128 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17922 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16292 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1460 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10025 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15546 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9899 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13364 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11668 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->