### PR TITLE
Text controls: Intrinsic widths should not be smaller than averageCharWidth() * n

### DIFF
--- a/LayoutTests/fast/forms/text-control-intrinsic-widths.html
+++ b/LayoutTests/fast/forms/text-control-intrinsic-widths.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
@@ -40,6 +40,5 @@ for (var j = 0; j < fonts.length; j++) {
     debug('');
 }
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/textarea/textarea-cols-lucida-console-expected.txt
+++ b/LayoutTests/fast/forms/textarea/textarea-cols-lucida-console-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS The first Textaera should not be wrapped.
+

--- a/LayoutTests/fast/forms/textarea/textarea-cols-lucida-console.html
+++ b/LayoutTests/fast/forms/textarea/textarea-cols-lucida-console.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<!-- This test depends on fonts of which the fractional part of AvgCharWidth()
+     is less than 0.5. crbug.com/1227341 -->
+<style>
+textarea {
+  font-family: lucida console, monospace;
+  font-size: 14px;
+}
+</style>
+<textarea cols="41">123456789 123456789 123456789 123456789 1
+</textarea>
+<textarea cols="30">123456789 123456789 123456789 123456789 1
+</textarea>
+<script>
+if (window.testRunner && window.testRunner.setTextSubpixelPositioning)
+  window.testRunner.setTextSubpixelPositioning(true);
+test(() => {
+  const areas = document.querySelectorAll('textarea');
+  assert_less_than(areas[0].scrollHeight, areas[1].scrollHeight);
+}, 'The first Textaera should not be wrapped.');
+</script>

--- a/LayoutTests/platform/ios/fast/forms/text-control-intrinsic-widths-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/text-control-intrinsic-widths-expected.txt
@@ -141,43 +141,43 @@ cols=1000 clientWidth=5526
 Andale Mono
 input
 size=1 clientWidth=17
-size=2 clientWidth=21
-size=3 clientWidth=25
-size=4 clientWidth=29
-size=5 clientWidth=33
-size=10 clientWidth=53
-size=20 clientWidth=93
-size=50 clientWidth=213
-size=100 clientWidth=413
-size=500 clientWidth=2013
-size=1000 clientWidth=4013
+size=2 clientWidth=22
+size=3 clientWidth=26
+size=4 clientWidth=31
+size=5 clientWidth=35
+size=10 clientWidth=57
+size=20 clientWidth=101
+size=50 clientWidth=234
+size=100 clientWidth=455
+size=500 clientWidth=2224
+size=1000 clientWidth=4435
 
 textarea
-cols=1 clientWidth=30
-cols=2 clientWidth=34
-cols=3 clientWidth=38
-cols=4 clientWidth=42
-cols=5 clientWidth=46
-cols=10 clientWidth=66
-cols=20 clientWidth=106
-cols=50 clientWidth=226
-cols=100 clientWidth=426
-cols=500 clientWidth=2026
-cols=1000 clientWidth=4026
+cols=1 clientWidth=31
+cols=2 clientWidth=35
+cols=3 clientWidth=40
+cols=4 clientWidth=44
+cols=5 clientWidth=49
+cols=10 clientWidth=71
+cols=20 clientWidth=115
+cols=50 clientWidth=248
+cols=100 clientWidth=469
+cols=500 clientWidth=2237
+cols=1000 clientWidth=4448
 
 Arial
 input
 size=1 clientWidth=18
 size=2 clientWidth=23
 size=3 clientWidth=28
-size=4 clientWidth=33
-size=5 clientWidth=38
-size=10 clientWidth=63
-size=20 clientWidth=113
-size=50 clientWidth=263
-size=100 clientWidth=513
-size=500 clientWidth=2513
-size=1000 clientWidth=5013
+size=4 clientWidth=32
+size=5 clientWidth=37
+size=10 clientWidth=62
+size=20 clientWidth=110
+size=50 clientWidth=256
+size=100 clientWidth=499
+size=500 clientWidth=2443
+size=1000 clientWidth=4872
 
 textarea
 cols=1 clientWidth=31
@@ -185,80 +185,80 @@ cols=2 clientWidth=36
 cols=3 clientWidth=41
 cols=4 clientWidth=46
 cols=5 clientWidth=51
-cols=10 clientWidth=76
-cols=20 clientWidth=126
-cols=50 clientWidth=276
-cols=100 clientWidth=526
-cols=500 clientWidth=2526
-cols=1000 clientWidth=5026
+cols=10 clientWidth=75
+cols=20 clientWidth=124
+cols=50 clientWidth=269
+cols=100 clientWidth=512
+cols=500 clientWidth=2456
+cols=1000 clientWidth=4886
 
 Comic Sans MS
 input
 size=1 clientWidth=17
-size=2 clientWidth=21
-size=3 clientWidth=25
-size=4 clientWidth=29
-size=5 clientWidth=33
-size=10 clientWidth=53
-size=20 clientWidth=93
-size=50 clientWidth=213
-size=100 clientWidth=413
-size=500 clientWidth=2013
-size=1000 clientWidth=4013
+size=2 clientWidth=22
+size=3 clientWidth=26
+size=4 clientWidth=31
+size=5 clientWidth=35
+size=10 clientWidth=57
+size=20 clientWidth=101
+size=50 clientWidth=234
+size=100 clientWidth=455
+size=500 clientWidth=2224
+size=1000 clientWidth=4435
 
 textarea
-cols=1 clientWidth=30
-cols=2 clientWidth=34
-cols=3 clientWidth=38
-cols=4 clientWidth=42
-cols=5 clientWidth=46
-cols=10 clientWidth=66
-cols=20 clientWidth=106
-cols=50 clientWidth=226
-cols=100 clientWidth=426
-cols=500 clientWidth=2026
-cols=1000 clientWidth=4026
+cols=1 clientWidth=31
+cols=2 clientWidth=35
+cols=3 clientWidth=40
+cols=4 clientWidth=44
+cols=5 clientWidth=49
+cols=10 clientWidth=71
+cols=20 clientWidth=115
+cols=50 clientWidth=248
+cols=100 clientWidth=469
+cols=500 clientWidth=2237
+cols=1000 clientWidth=4448
 
 Courier New
 input
 size=1 clientWidth=20
-size=2 clientWidth=27
-size=3 clientWidth=34
-size=4 clientWidth=41
-size=5 clientWidth=48
-size=10 clientWidth=83
-size=20 clientWidth=153
-size=50 clientWidth=363
-size=100 clientWidth=713
-size=500 clientWidth=3513
-size=1000 clientWidth=7013
+size=2 clientWidth=26
+size=3 clientWidth=33
+size=4 clientWidth=39
+size=5 clientWidth=46
+size=10 clientWidth=79
+size=20 clientWidth=145
+size=50 clientWidth=343
+size=100 clientWidth=674
+size=500 clientWidth=3318
+size=1000 clientWidth=6622
 
 textarea
 cols=1 clientWidth=33
 cols=2 clientWidth=40
-cols=3 clientWidth=47
-cols=4 clientWidth=54
-cols=5 clientWidth=61
-cols=10 clientWidth=96
-cols=20 clientWidth=166
-cols=50 clientWidth=376
-cols=100 clientWidth=726
-cols=500 clientWidth=3526
-cols=1000 clientWidth=7026
+cols=3 clientWidth=46
+cols=4 clientWidth=53
+cols=5 clientWidth=60
+cols=10 clientWidth=93
+cols=20 clientWidth=159
+cols=50 clientWidth=357
+cols=100 clientWidth=687
+cols=500 clientWidth=3331
+cols=1000 clientWidth=6636
 
 Georgia
 input
 size=1 clientWidth=18
 size=2 clientWidth=23
 size=3 clientWidth=28
-size=4 clientWidth=33
-size=5 clientWidth=38
-size=10 clientWidth=63
-size=20 clientWidth=113
-size=50 clientWidth=263
-size=100 clientWidth=513
-size=500 clientWidth=2513
-size=1000 clientWidth=5013
+size=4 clientWidth=32
+size=5 clientWidth=37
+size=10 clientWidth=61
+size=20 clientWidth=110
+size=50 clientWidth=255
+size=100 clientWidth=497
+size=500 clientWidth=2435
+size=1000 clientWidth=4857
 
 textarea
 cols=1 clientWidth=31
@@ -266,39 +266,39 @@ cols=2 clientWidth=36
 cols=3 clientWidth=41
 cols=4 clientWidth=46
 cols=5 clientWidth=51
-cols=10 clientWidth=76
-cols=20 clientWidth=126
-cols=50 clientWidth=276
-cols=100 clientWidth=526
-cols=500 clientWidth=2526
-cols=1000 clientWidth=5026
+cols=10 clientWidth=75
+cols=20 clientWidth=123
+cols=50 clientWidth=269
+cols=100 clientWidth=511
+cols=500 clientWidth=2448
+cols=1000 clientWidth=4870
 
 Times New Roman
 input
 size=1 clientWidth=17
-size=2 clientWidth=21
-size=3 clientWidth=25
-size=4 clientWidth=29
-size=5 clientWidth=33
-size=10 clientWidth=53
-size=20 clientWidth=93
-size=50 clientWidth=213
-size=100 clientWidth=413
-size=500 clientWidth=2013
-size=1000 clientWidth=4013
+size=2 clientWidth=22
+size=3 clientWidth=26
+size=4 clientWidth=31
+size=5 clientWidth=35
+size=10 clientWidth=57
+size=20 clientWidth=101
+size=50 clientWidth=234
+size=100 clientWidth=455
+size=500 clientWidth=2224
+size=1000 clientWidth=4435
 
 textarea
-cols=1 clientWidth=30
-cols=2 clientWidth=34
-cols=3 clientWidth=38
-cols=4 clientWidth=42
-cols=5 clientWidth=46
-cols=10 clientWidth=66
-cols=20 clientWidth=106
-cols=50 clientWidth=226
-cols=100 clientWidth=426
-cols=500 clientWidth=2026
-cols=1000 clientWidth=4026
+cols=1 clientWidth=31
+cols=2 clientWidth=35
+cols=3 clientWidth=40
+cols=4 clientWidth=44
+cols=5 clientWidth=49
+cols=10 clientWidth=71
+cols=20 clientWidth=115
+cols=50 clientWidth=248
+cols=100 clientWidth=469
+cols=500 clientWidth=2237
+cols=1000 clientWidth=4448
 
 Trebuchet MS
 input
@@ -330,56 +330,56 @@ cols=1000 clientWidth=5026
 Verdana
 input
 size=1 clientWidth=19
-size=2 clientWidth=25
-size=3 clientWidth=31
-size=4 clientWidth=37
-size=5 clientWidth=43
-size=10 clientWidth=73
-size=20 clientWidth=133
-size=50 clientWidth=313
-size=100 clientWidth=613
-size=500 clientWidth=3013
-size=1000 clientWidth=6013
+size=2 clientWidth=24
+size=3 clientWidth=30
+size=4 clientWidth=35
+size=5 clientWidth=41
+size=10 clientWidth=69
+size=20 clientWidth=125
+size=50 clientWidth=293
+size=100 clientWidth=572
+size=500 clientWidth=2810
+size=1000 clientWidth=5607
 
 textarea
 cols=1 clientWidth=32
 cols=2 clientWidth=38
-cols=3 clientWidth=44
-cols=4 clientWidth=50
-cols=5 clientWidth=56
-cols=10 clientWidth=86
-cols=20 clientWidth=146
-cols=50 clientWidth=326
-cols=100 clientWidth=626
-cols=500 clientWidth=3026
-cols=1000 clientWidth=6026
+cols=3 clientWidth=43
+cols=4 clientWidth=49
+cols=5 clientWidth=54
+cols=10 clientWidth=82
+cols=20 clientWidth=138
+cols=50 clientWidth=306
+cols=100 clientWidth=586
+cols=500 clientWidth=2823
+cols=1000 clientWidth=5620
 
 Webdings
 input
 size=1 clientWidth=17
-size=2 clientWidth=21
-size=3 clientWidth=25
-size=4 clientWidth=29
-size=5 clientWidth=33
-size=10 clientWidth=53
-size=20 clientWidth=93
-size=50 clientWidth=213
-size=100 clientWidth=413
-size=500 clientWidth=2013
-size=1000 clientWidth=4013
+size=2 clientWidth=22
+size=3 clientWidth=26
+size=4 clientWidth=31
+size=5 clientWidth=35
+size=10 clientWidth=57
+size=20 clientWidth=101
+size=50 clientWidth=234
+size=100 clientWidth=455
+size=500 clientWidth=2224
+size=1000 clientWidth=4435
 
 textarea
-cols=1 clientWidth=30
-cols=2 clientWidth=34
-cols=3 clientWidth=38
-cols=4 clientWidth=42
-cols=5 clientWidth=46
-cols=10 clientWidth=66
-cols=20 clientWidth=106
-cols=50 clientWidth=226
-cols=100 clientWidth=426
-cols=500 clientWidth=2026
-cols=1000 clientWidth=4026
+cols=1 clientWidth=31
+cols=2 clientWidth=35
+cols=3 clientWidth=40
+cols=4 clientWidth=44
+cols=5 clientWidth=49
+cols=10 clientWidth=71
+cols=20 clientWidth=115
+cols=50 clientWidth=248
+cols=100 clientWidth=469
+cols=500 clientWidth=2237
+cols=1000 clientWidth=4448
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/platform/ios/fast/forms/textarea-width-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/textarea-width-expected.txt
@@ -10,11 +10,11 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,40) size 784x306
         RenderBR {BR} at (0,0) size 0x19
         RenderText {#text} at (0,0) size 0x0
-layer at (8,68) size 467x286 clip at (9,69) size 465x284
-  RenderTextControl {TEXTAREA} at (0,20) size 467x286 [color=#333333] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
-    RenderBlock {DIV} at (6,3) size 455x42
-      RenderText {#text} at (0,0) size 454x28
-        text run at (0,0) width 454: "1234567890abcdefghijABCDEFGHIJ1234567890abcdefghijABCDEFGHIJ12345X7890abcde"
-        text run at (0,14) width 267: "fghijABCDEFGXIJ1234567890abcdefghijABCDEFGHIJ"
-        text run at (266,14) width 1: " "
+layer at (8,68) size 475x286 clip at (9,69) size 473x284
+  RenderTextControl {TEXTAREA} at (0,20) size 475x286 [color=#333333] [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
+    RenderBlock {DIV} at (6,3) size 463x42
+      RenderText {#text} at (0,0) size 458x28
+        text run at (0,0) width 458: "1234567890abcdefghijABCDEFGHIJ1234567890abcdefghijABCDEFGHIJ12345X7890abcdef"
+        text run at (0,14) width 263: "ghijABCDEFGXIJ1234567890abcdefghijABCDEFGHIJ"
+        text run at (262,14) width 1: " "
       RenderBR {BR} at (0,28) size 0x14

--- a/LayoutTests/platform/mac-ventura/fast/forms/text-control-intrinsic-widths-expected.txt
+++ b/LayoutTests/platform/mac-ventura/fast/forms/text-control-intrinsic-widths-expected.txt
@@ -198,26 +198,26 @@ size=1 clientWidth=17
 size=2 clientWidth=22
 size=3 clientWidth=27
 size=4 clientWidth=32
-size=5 clientWidth=37
-size=10 clientWidth=62
-size=20 clientWidth=112
-size=50 clientWidth=262
-size=100 clientWidth=512
-size=500 clientWidth=2512
-size=1000 clientWidth=5012
+size=5 clientWidth=38
+size=10 clientWidth=63
+size=20 clientWidth=115
+size=50 clientWidth=269
+size=100 clientWidth=527
+size=500 clientWidth=2587
+size=1000 clientWidth=5163
 
 textarea
-cols=1 clientWidth=24
-cols=2 clientWidth=29
-cols=3 clientWidth=34
-cols=4 clientWidth=39
-cols=5 clientWidth=44
-cols=10 clientWidth=69
-cols=20 clientWidth=119
-cols=50 clientWidth=269
-cols=100 clientWidth=519
-cols=500 clientWidth=2519
-cols=1000 clientWidth=5019
+cols=1 clientWidth=25
+cols=2 clientWidth=30
+cols=3 clientWidth=35
+cols=4 clientWidth=40
+cols=5 clientWidth=45
+cols=10 clientWidth=71
+cols=20 clientWidth=123
+cols=50 clientWidth=277
+cols=100 clientWidth=535
+cols=500 clientWidth=2595
+cols=1000 clientWidth=5170
 
 Courier New
 input
@@ -277,28 +277,28 @@ Times New Roman
 input
 size=1 clientWidth=31
 size=2 clientWidth=35
-size=3 clientWidth=39
-size=4 clientWidth=43
-size=5 clientWidth=47
-size=10 clientWidth=67
-size=20 clientWidth=107
-size=50 clientWidth=227
-size=100 clientWidth=427
-size=500 clientWidth=2027
-size=1000 clientWidth=4027
+size=3 clientWidth=40
+size=4 clientWidth=44
+size=5 clientWidth=49
+size=10 clientWidth=71
+size=20 clientWidth=115
+size=50 clientWidth=247
+size=100 clientWidth=468
+size=500 clientWidth=2231
+size=1000 clientWidth=4436
 
 textarea
-cols=1 clientWidth=23
-cols=2 clientWidth=27
-cols=3 clientWidth=31
-cols=4 clientWidth=35
-cols=5 clientWidth=39
-cols=10 clientWidth=59
-cols=20 clientWidth=99
-cols=50 clientWidth=219
-cols=100 clientWidth=419
-cols=500 clientWidth=2019
-cols=1000 clientWidth=4019
+cols=1 clientWidth=24
+cols=2 clientWidth=28
+cols=3 clientWidth=33
+cols=4 clientWidth=37
+cols=5 clientWidth=42
+cols=10 clientWidth=64
+cols=20 clientWidth=108
+cols=50 clientWidth=240
+cols=100 clientWidth=460
+cols=500 clientWidth=2224
+cols=1000 clientWidth=4429
 
 Trebuchet MS
 input

--- a/LayoutTests/platform/mac/fast/forms/text-control-intrinsic-widths-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/text-control-intrinsic-widths-expected.txt
@@ -5,17 +5,17 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 Lucida Grande
 input
-size=1 clientWidth=26
-size=2 clientWidth=31
-size=3 clientWidth=36
-size=4 clientWidth=41
-size=5 clientWidth=46
-size=10 clientWidth=71
-size=20 clientWidth=121
-size=50 clientWidth=271
-size=100 clientWidth=521
-size=500 clientWidth=2521
-size=1000 clientWidth=5021
+size=1 clientWidth=25
+size=2 clientWidth=30
+size=3 clientWidth=35
+size=4 clientWidth=40
+size=5 clientWidth=45
+size=10 clientWidth=70
+size=20 clientWidth=120
+size=50 clientWidth=270
+size=100 clientWidth=520
+size=500 clientWidth=2520
+size=1000 clientWidth=5020
 
 textarea
 cols=1 clientWidth=26
@@ -32,17 +32,17 @@ cols=1000 clientWidth=7019
 
 Courier
 input
-size=1 clientWidth=11
-size=2 clientWidth=17
-size=3 clientWidth=24
-size=4 clientWidth=30
-size=5 clientWidth=37
-size=10 clientWidth=70
-size=20 clientWidth=136
-size=50 clientWidth=334
-size=100 clientWidth=664
-size=500 clientWidth=3305
-size=1000 clientWidth=6605
+size=1 clientWidth=10
+size=2 clientWidth=16
+size=3 clientWidth=23
+size=4 clientWidth=29
+size=5 clientWidth=36
+size=10 clientWidth=69
+size=20 clientWidth=135
+size=50 clientWidth=333
+size=100 clientWidth=663
+size=500 clientWidth=3304
+size=1000 clientWidth=6604
 
 textarea
 cols=1 clientWidth=26
@@ -59,17 +59,17 @@ cols=1000 clientWidth=6621
 
 Helvetica
 input
-size=1 clientWidth=10
-size=2 clientWidth=16
-size=3 clientWidth=22
-size=4 clientWidth=28
-size=5 clientWidth=35
-size=10 clientWidth=65
-size=20 clientWidth=126
-size=50 clientWidth=310
-size=100 clientWidth=616
-size=500 clientWidth=3063
-size=1000 clientWidth=6122
+size=1 clientWidth=9
+size=2 clientWidth=15
+size=3 clientWidth=21
+size=4 clientWidth=27
+size=5 clientWidth=34
+size=10 clientWidth=64
+size=20 clientWidth=125
+size=50 clientWidth=309
+size=100 clientWidth=615
+size=500 clientWidth=3062
+size=1000 clientWidth=6121
 
 textarea
 cols=1 clientWidth=26
@@ -86,17 +86,17 @@ cols=1000 clientWidth=6137
 
 Monaco
 input
-size=1 clientWidth=11
-size=2 clientWidth=17
-size=3 clientWidth=24
-size=4 clientWidth=30
-size=5 clientWidth=37
-size=10 clientWidth=70
-size=20 clientWidth=136
-size=50 clientWidth=334
-size=100 clientWidth=664
-size=500 clientWidth=3305
-size=1000 clientWidth=6605
+size=1 clientWidth=10
+size=2 clientWidth=16
+size=3 clientWidth=23
+size=4 clientWidth=29
+size=5 clientWidth=36
+size=10 clientWidth=69
+size=20 clientWidth=135
+size=50 clientWidth=333
+size=100 clientWidth=663
+size=500 clientWidth=3304
+size=1000 clientWidth=6604
 
 textarea
 cols=1 clientWidth=26
@@ -113,17 +113,17 @@ cols=1000 clientWidth=6621
 
 Times
 input
-size=1 clientWidth=10
-size=2 clientWidth=15
-size=3 clientWidth=21
-size=4 clientWidth=26
-size=5 clientWidth=32
-size=10 clientWidth=59
-size=20 clientWidth=114
-size=50 clientWidth=279
-size=100 clientWidth=554
-size=500 clientWidth=2754
-size=1000 clientWidth=5504
+size=1 clientWidth=9
+size=2 clientWidth=14
+size=3 clientWidth=20
+size=4 clientWidth=25
+size=5 clientWidth=31
+size=10 clientWidth=58
+size=20 clientWidth=113
+size=50 clientWidth=278
+size=100 clientWidth=553
+size=500 clientWidth=2753
+size=1000 clientWidth=5503
 
 textarea
 cols=1 clientWidth=25
@@ -140,44 +140,44 @@ cols=1000 clientWidth=5519
 
 Andale Mono
 input
-size=1 clientWidth=11
-size=2 clientWidth=18
-size=3 clientWidth=25
-size=4 clientWidth=32
-size=5 clientWidth=39
-size=10 clientWidth=74
-size=20 clientWidth=144
-size=50 clientWidth=354
-size=100 clientWidth=704
-size=500 clientWidth=3504
-size=1000 clientWidth=7004
+size=1 clientWidth=10
+size=2 clientWidth=17
+size=3 clientWidth=23
+size=4 clientWidth=30
+size=5 clientWidth=36
+size=10 clientWidth=69
+size=20 clientWidth=136
+size=50 clientWidth=334
+size=100 clientWidth=664
+size=500 clientWidth=3308
+size=1000 clientWidth=6613
 
 textarea
 cols=1 clientWidth=26
 cols=2 clientWidth=33
-cols=3 clientWidth=40
-cols=4 clientWidth=47
-cols=5 clientWidth=54
-cols=10 clientWidth=89
-cols=20 clientWidth=159
-cols=50 clientWidth=369
-cols=100 clientWidth=719
-cols=500 clientWidth=3519
-cols=1000 clientWidth=7019
+cols=3 clientWidth=39
+cols=4 clientWidth=46
+cols=5 clientWidth=53
+cols=10 clientWidth=86
+cols=20 clientWidth=152
+cols=50 clientWidth=350
+cols=100 clientWidth=680
+cols=500 clientWidth=3324
+cols=1000 clientWidth=6629
 
 Arial
 input
-size=1 clientWidth=33
-size=2 clientWidth=38
-size=3 clientWidth=43
-size=4 clientWidth=48
-size=5 clientWidth=53
-size=10 clientWidth=78
-size=20 clientWidth=128
-size=50 clientWidth=278
-size=100 clientWidth=528
-size=500 clientWidth=2528
-size=1000 clientWidth=5028
+size=1 clientWidth=32
+size=2 clientWidth=37
+size=3 clientWidth=42
+size=4 clientWidth=47
+size=5 clientWidth=51
+size=10 clientWidth=76
+size=20 clientWidth=124
+size=50 clientWidth=270
+size=100 clientWidth=513
+size=500 clientWidth=2457
+size=1000 clientWidth=4887
 
 textarea
 cols=1 clientWidth=24
@@ -185,134 +185,134 @@ cols=2 clientWidth=29
 cols=3 clientWidth=34
 cols=4 clientWidth=39
 cols=5 clientWidth=44
-cols=10 clientWidth=69
-cols=20 clientWidth=119
-cols=50 clientWidth=269
-cols=100 clientWidth=519
-cols=500 clientWidth=2519
-cols=1000 clientWidth=5019
+cols=10 clientWidth=68
+cols=20 clientWidth=117
+cols=50 clientWidth=262
+cols=100 clientWidth=505
+cols=500 clientWidth=2449
+cols=1000 clientWidth=4879
 
 Comic Sans MS
-input
-size=1 clientWidth=18
-size=2 clientWidth=23
-size=3 clientWidth=28
-size=4 clientWidth=33
-size=5 clientWidth=38
-size=10 clientWidth=63
-size=20 clientWidth=113
-size=50 clientWidth=263
-size=100 clientWidth=513
-size=500 clientWidth=2513
-size=1000 clientWidth=5013
-
-textarea
-cols=1 clientWidth=24
-cols=2 clientWidth=29
-cols=3 clientWidth=34
-cols=4 clientWidth=39
-cols=5 clientWidth=44
-cols=10 clientWidth=69
-cols=20 clientWidth=119
-cols=50 clientWidth=269
-cols=100 clientWidth=519
-cols=500 clientWidth=2519
-cols=1000 clientWidth=5019
-
-Courier New
-input
-size=1 clientWidth=12
-size=2 clientWidth=19
-size=3 clientWidth=26
-size=4 clientWidth=33
-size=5 clientWidth=40
-size=10 clientWidth=75
-size=20 clientWidth=145
-size=50 clientWidth=355
-size=100 clientWidth=705
-size=500 clientWidth=3505
-size=1000 clientWidth=7005
-
-textarea
-cols=1 clientWidth=26
-cols=2 clientWidth=33
-cols=3 clientWidth=40
-cols=4 clientWidth=47
-cols=5 clientWidth=54
-cols=10 clientWidth=89
-cols=20 clientWidth=159
-cols=50 clientWidth=369
-cols=100 clientWidth=719
-cols=500 clientWidth=3519
-cols=1000 clientWidth=7019
-
-Georgia
-input
-size=1 clientWidth=29
-size=2 clientWidth=34
-size=3 clientWidth=39
-size=4 clientWidth=44
-size=5 clientWidth=49
-size=10 clientWidth=74
-size=20 clientWidth=124
-size=50 clientWidth=274
-size=100 clientWidth=524
-size=500 clientWidth=2524
-size=1000 clientWidth=5024
-
-textarea
-cols=1 clientWidth=24
-cols=2 clientWidth=29
-cols=3 clientWidth=34
-cols=4 clientWidth=39
-cols=5 clientWidth=44
-cols=10 clientWidth=69
-cols=20 clientWidth=119
-cols=50 clientWidth=269
-cols=100 clientWidth=519
-cols=500 clientWidth=2519
-cols=1000 clientWidth=5019
-
-Times New Roman
-input
-size=1 clientWidth=32
-size=2 clientWidth=36
-size=3 clientWidth=40
-size=4 clientWidth=44
-size=5 clientWidth=48
-size=10 clientWidth=68
-size=20 clientWidth=108
-size=50 clientWidth=228
-size=100 clientWidth=428
-size=500 clientWidth=2028
-size=1000 clientWidth=4028
-
-textarea
-cols=1 clientWidth=23
-cols=2 clientWidth=27
-cols=3 clientWidth=31
-cols=4 clientWidth=35
-cols=5 clientWidth=39
-cols=10 clientWidth=59
-cols=20 clientWidth=99
-cols=50 clientWidth=219
-cols=100 clientWidth=419
-cols=500 clientWidth=2019
-cols=1000 clientWidth=4019
-
-Trebuchet MS
 input
 size=1 clientWidth=17
 size=2 clientWidth=22
 size=3 clientWidth=27
 size=4 clientWidth=32
+size=5 clientWidth=38
+size=10 clientWidth=63
+size=20 clientWidth=115
+size=50 clientWidth=270
+size=100 clientWidth=527
+size=500 clientWidth=2590
+size=1000 clientWidth=5168
+
+textarea
+cols=1 clientWidth=25
+cols=2 clientWidth=30
+cols=3 clientWidth=35
+cols=4 clientWidth=40
+cols=5 clientWidth=45
+cols=10 clientWidth=71
+cols=20 clientWidth=123
+cols=50 clientWidth=277
+cols=100 clientWidth=535
+cols=500 clientWidth=2598
+cols=1000 clientWidth=5176
+
+Courier New
+input
+size=1 clientWidth=11
+size=2 clientWidth=18
+size=3 clientWidth=24
+size=4 clientWidth=31
 size=5 clientWidth=37
-size=10 clientWidth=62
-size=20 clientWidth=112
-size=50 clientWidth=262
-size=100 clientWidth=512
-size=500 clientWidth=2512
-size=1000 clientWidth=5012
+size=10 clientWidth=70
+size=20 clientWidth=137
+size=50 clientWidth=335
+size=100 clientWidth=665
+size=500 clientWidth=3309
+size=1000 clientWidth=6614
+
+textarea
+cols=1 clientWidth=26
+cols=2 clientWidth=33
+cols=3 clientWidth=39
+cols=4 clientWidth=46
+cols=5 clientWidth=53
+cols=10 clientWidth=86
+cols=20 clientWidth=152
+cols=50 clientWidth=350
+cols=100 clientWidth=680
+cols=500 clientWidth=3324
+cols=1000 clientWidth=6629
+
+Georgia
+input
+size=1 clientWidth=28
+size=2 clientWidth=33
+size=3 clientWidth=38
+size=4 clientWidth=43
+size=5 clientWidth=47
+size=10 clientWidth=72
+size=20 clientWidth=120
+size=50 clientWidth=265
+size=100 clientWidth=508
+size=500 clientWidth=2445
+size=1000 clientWidth=4867
+
+textarea
+cols=1 clientWidth=24
+cols=2 clientWidth=29
+cols=3 clientWidth=34
+cols=4 clientWidth=39
+cols=5 clientWidth=44
+cols=10 clientWidth=68
+cols=20 clientWidth=116
+cols=50 clientWidth=262
+cols=100 clientWidth=504
+cols=500 clientWidth=2441
+cols=1000 clientWidth=4863
+
+Times New Roman
+input
+size=1 clientWidth=31
+size=2 clientWidth=35
+size=3 clientWidth=40
+size=4 clientWidth=44
+size=5 clientWidth=49
+size=10 clientWidth=71
+size=20 clientWidth=115
+size=50 clientWidth=248
+size=100 clientWidth=469
+size=500 clientWidth=2238
+size=1000 clientWidth=4448
+
+textarea
+cols=1 clientWidth=24
+cols=2 clientWidth=28
+cols=3 clientWidth=33
+cols=4 clientWidth=37
+cols=5 clientWidth=42
+cols=10 clientWidth=64
+cols=20 clientWidth=108
+cols=50 clientWidth=241
+cols=100 clientWidth=462
+cols=500 clientWidth=2230
+cols=1000 clientWidth=4441
+
+Trebuchet MS
+input
+size=1 clientWidth=16
+size=2 clientWidth=21
+size=3 clientWidth=26
+size=4 clientWidth=31
+size=5 clientWidth=36
+size=10 clientWidth=61
+size=20 clientWidth=111
+size=50 clientWidth=261
+size=100 clientWidth=511
+size=500 clientWidth=2511
+size=1000 clientWidth=5011
 
 textarea
 cols=1 clientWidth=24
@@ -329,57 +329,57 @@ cols=1000 clientWidth=5019
 
 Verdana
 input
-size=1 clientWidth=25
-size=2 clientWidth=31
-size=3 clientWidth=37
-size=4 clientWidth=43
-size=5 clientWidth=49
-size=10 clientWidth=79
-size=20 clientWidth=139
-size=50 clientWidth=319
-size=100 clientWidth=619
-size=500 clientWidth=3019
-size=1000 clientWidth=6019
+size=1 clientWidth=24
+size=2 clientWidth=30
+size=3 clientWidth=35
+size=4 clientWidth=41
+size=5 clientWidth=46
+size=10 clientWidth=74
+size=20 clientWidth=130
+size=50 clientWidth=298
+size=100 clientWidth=578
+size=500 clientWidth=2815
+size=1000 clientWidth=5612
 
 textarea
 cols=1 clientWidth=25
 cols=2 clientWidth=31
-cols=3 clientWidth=37
-cols=4 clientWidth=43
-cols=5 clientWidth=49
-cols=10 clientWidth=79
-cols=20 clientWidth=139
-cols=50 clientWidth=319
-cols=100 clientWidth=619
-cols=500 clientWidth=3019
-cols=1000 clientWidth=6019
+cols=3 clientWidth=36
+cols=4 clientWidth=42
+cols=5 clientWidth=47
+cols=10 clientWidth=75
+cols=20 clientWidth=131
+cols=50 clientWidth=299
+cols=100 clientWidth=579
+cols=500 clientWidth=2816
+cols=1000 clientWidth=5613
 
 Webdings
 input
-size=1 clientWidth=48
-size=2 clientWidth=59
-size=3 clientWidth=70
-size=4 clientWidth=81
-size=5 clientWidth=92
-size=10 clientWidth=147
-size=20 clientWidth=257
-size=50 clientWidth=587
-size=100 clientWidth=1137
-size=500 clientWidth=5537
-size=1000 clientWidth=11037
+size=1 clientWidth=47
+size=2 clientWidth=58
+size=3 clientWidth=68
+size=4 clientWidth=79
+size=5 clientWidth=90
+size=10 clientWidth=143
+size=20 clientWidth=250
+size=50 clientWidth=571
+size=100 clientWidth=1105
+size=500 clientWidth=5380
+size=1000 clientWidth=10724
 
 textarea
 cols=1 clientWidth=30
 cols=2 clientWidth=41
 cols=3 clientWidth=52
-cols=4 clientWidth=63
-cols=5 clientWidth=74
-cols=10 clientWidth=129
-cols=20 clientWidth=239
-cols=50 clientWidth=569
-cols=100 clientWidth=1119
-cols=500 clientWidth=5519
-cols=1000 clientWidth=11019
+cols=4 clientWidth=62
+cols=5 clientWidth=73
+cols=10 clientWidth=126
+cols=20 clientWidth=233
+cols=50 clientWidth=554
+cols=100 clientWidth=1088
+cols=500 clientWidth=5363
+cols=1000 clientWidth=10707
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/platform/mac/fast/forms/textarea-width-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/textarea-width-expected.txt
@@ -10,11 +10,11 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,36) size 784x264
         RenderBR {BR} at (0,0) size 0x18
         RenderText {#text} at (0,0) size 0x0
-layer at (8,62) size 461x246 clip at (9,63) size 459x244
-  RenderTextControl {TEXTAREA} at (0,18) size 461x246 [color=#333333] [bgcolor=#FFFFFF] [border: (1px solid #333333)]
-    RenderBlock {DIV} at (3,3) size 455x36
-      RenderText {#text} at (0,0) size 454x24
-        text run at (0,0) width 454: "1234567890abcdefghijABCDEFGHIJ1234567890abcdefghijABCDEFGHIJ12345X7890abcde"
-        text run at (0,12) width 267: "fghijABCDEFGXIJ1234567890abcdefghijABCDEFGHIJ"
-        text run at (266,12) width 1: " "
+layer at (8,62) size 469x246 clip at (9,63) size 467x244
+  RenderTextControl {TEXTAREA} at (0,18) size 469x246 [color=#333333] [bgcolor=#FFFFFF] [border: (1px solid #333333)]
+    RenderBlock {DIV} at (3,3) size 463x36
+      RenderText {#text} at (0,0) size 458x24
+        text run at (0,0) width 458: "1234567890abcdefghijABCDEFGHIJ1234567890abcdefghijABCDEFGHIJ12345X7890abcdef"
+        text run at (0,12) width 263: "ghijABCDEFGXIJ1234567890abcdefghijABCDEFGHIJ"
+        text run at (262,12) width 1: " "
       RenderBR {BR} at (0,24) size 0x12

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -521,7 +521,7 @@ bool FontCascade::fastAverageCharWidthIfAvailable(float& width) const
 {
     bool success = hasValidAverageCharWidth();
     if (success)
-        width = roundf(primaryFont().avgCharWidth()); // FIXME: primaryFont() might not correspond to firstFamily().
+        width = primaryFont().avgCharWidth(); // FIXME: primaryFont() might not correspond to firstFamily().
     return success;
 }
 


### PR DESCRIPTION
#### fae1b87b037b33725fc665867d88024c20b02f5f
<pre>
Text controls: Intrinsic widths should not be smaller than averageCharWidth() * n
<a href="https://bugs.webkit.org/show_bug.cgi?id=264897">https://bugs.webkit.org/show_bug.cgi?id=264897</a>
<a href="https://rdar.apple.com/118727006">rdar://118727006</a>

Reviewed by NOBODY (OOPS!).

This patch is to align WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src/+/a00094b9b640c10fff554af6dcb4a68d78300321">https://chromium.googlesource.com/chromium/src/+/a00094b9b640c10fff554af6dcb4a68d78300321</a>

RenderTextControl::getAverageCharWidth(), which is the source of intrinsic
widths of INPUT/TEXTAREA calls for FontCascade::fastAverageCharWidthIfAvailable().
It should return a maximum value of &apos;width&apos; and rounded &apos;width&apos;.

In this patch, we removed `roundf` from FontCascade::fastAverageCharWidthIfAvailable()
to RenderTextControl::getAverageCharWidth() for more control and also leverage `font`
local variable throughout function. From previous attempt feedback, this also tackled
to keep the change in `RenderTextControl`.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::fastAverageCharWidthIfAvailable const): Remove `roundf` here
* Source/WebCore/rendering/RenderTextControl.cpp:
(WebCore::RenderTextControl::getAverageCharWidth): Move `rounding` here for control
* LayoutTests/fast/forms/text-control-intrinsic-widths.html: Rebaselined
* LayoutTests/platform/ios/fast/forms/text-control-intrinsic-widths-expected.txt: Ditto
* LayoutTests/platform/ios/fast/forms/textarea-width-expected.txt: Ditto
* LayoutTests/platform/mac/fast/forms/text-control-intrinsic-widths-expected.txt: Ditto
* LayoutTests/platform/mac/fast/forms/textarea-width-expected.txt: Ditto
* LayoutTests/platform/ios/fast/forms/text-control-intrinsic-widths-expected.txt: Ditto
* LayoutTests/platform/mac-ventura/fast/forms/text-control-intrinsic-widths-expected.txt: Ditto
* LayoutTests/fast/forms/textarea/textarea-cols-lucida-console.html: Add Test Case
* LayoutTests/fast/forms/textarea/textarea-cols-lucida-console-expected.txt: Add Test Case Expectation
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fae1b87b037b33725fc665867d88024c20b02f5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87824 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33763 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64438 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22203 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85761 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1785 "Found 4 new test failures: fast/forms/auto-fill-button/input-strong-password-auto-fill-button.html fast/forms/auto-fill-button/input-strong-password-viewable.html fast/forms/search-styled.html fast/forms/textarea-width.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75231 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44713 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1667 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-relevancy-updates.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29417 "Found 6 new test failures: fast/forms/auto-fill-button/input-strong-password-auto-fill-button.html fast/forms/auto-fill-button/input-strong-password-viewable.html fast/forms/search-styled.html fast/forms/text-control-intrinsic-widths.html fast/forms/textarea-width.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32796 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72939 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30080 "Found 6 new test failures: fast/forms/auto-fill-button/input-strong-password-auto-fill-button.html fast/forms/auto-fill-button/input-strong-password-viewable.html fast/forms/search-styled.html fast/forms/text-control-intrinsic-widths.html fast/forms/textarea-width.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89191 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9997 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7249 "Found 7 new test failures: fast/forms/auto-fill-button/input-strong-password-auto-fill-button.html fast/forms/auto-fill-button/input-strong-password-viewable.html fast/forms/search-styled.html fast/forms/text-control-intrinsic-widths.html fast/forms/textarea-width.html http/wpt/mediarecorder/record-96KHz-sources.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72855 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10225 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71040 "Exiting early after 10 failures. 107 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72069 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16224 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15127 "Found 6 new test failures: fast/forms/auto-fill-button/input-strong-password-auto-fill-button.html fast/forms/auto-fill-button/input-strong-password-viewable.html fast/forms/search-styled.html fast/forms/text-control-intrinsic-widths.html fast/forms/textarea-width.html imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1386 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/9950 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15471 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9824 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13289 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11593 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->