### PR TITLE
Reduce use of std::span::subspan() by leveraging ParsingUtilities

### DIFF
--- a/Source/JavaScriptCore/API/JSScript.mm
+++ b/Source/JavaScriptCore/API/JSScript.mm
@@ -45,6 +45,7 @@
 #import <wtf/SHA1.h>
 #import <wtf/SafeStrerror.h>
 #import <wtf/Scope.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/spi/darwin/DataVaultSPI.h>
 #import <wtf/text/MakeString.h>
@@ -184,12 +185,12 @@ static bool validateBytecodeCachePath(NSURL* cachePath, NSError** error)
 
     SHA1::Digest computedHash;
     SHA1 sha1;
-    sha1.addBytes(fileData.subspan(0, fileDataSize));
+    sha1.addBytes(fileData.first(fileDataSize));
     sha1.computeHash(computedHash);
 
     SHA1::Digest fileHash;
     auto hashSpan = fileData.subspan(fileDataSize, sizeof(SHA1::Digest));
-    memcpy(&fileHash, hashSpan.data(), hashSpan.size());
+    memcpySpan(std::span { fileHash }, hashSpan);
 
     if (computedHash != fileHash) {
         FileSystem::deleteFile(cacheFilename);

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -1239,7 +1239,7 @@ CallArguments::CallArguments(BytecodeGenerator& generator, ArgumentsNode* argume
     // We initialize 0 based on offset. And adjust m_argv based on that.
     if ((-m_allocatedRegisters[1]->index() + CallFrame::headerSizeInRegisters) % stackAlignmentRegisters()) {
         m_allocatedRegisters[0] = generator.newTemporary();
-        m_argv = m_allocatedRegisters.mutableSpan().subspan(0, argumentCountIncludingThis);
+        m_argv = m_allocatedRegisters.mutableSpan().first(argumentCountIncludingThis);
     } else
         m_argv = m_allocatedRegisters.mutableSpan().subspan(1, argumentCountIncludingThis);
 }

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -49,6 +49,7 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/UUID.h>
 #include <wtf/text/AtomStringImpl.h>
+#include <wtf/text/ParsingUtilities.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -166,12 +167,9 @@ public:
         size_t size = m_baseOffset + m_currentPage->size();
         auto buffer = MallocSpan<uint8_t, VMMalloc>::malloc(size);
         auto bufferSpan = buffer.mutableSpan();
-        unsigned offset = 0;
-        for (const auto& page : m_pages) {
-            memcpySpan(bufferSpan.subspan(offset), page.span());
-            offset += page.size();
-        }
-        RELEASE_ASSERT(offset == size);
+        for (const auto& page : m_pages)
+            memcpySpan(consumeSpan(bufferSpan, page.size()), page.span());
+        RELEASE_ASSERT(bufferSpan.empty());
         return CachedBytecode::create(WTFMove(buffer), WTFMove(m_leafExecutables));
     }
 

--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -113,7 +113,7 @@ void LocaleIDBuilder::overrideLanguageScriptRegion(StringView language, StringVi
 {
     unsigned length = strlen(m_buffer.data());
 
-    StringView localeIDView { m_buffer.subspan(0, length) };
+    StringView localeIDView { m_buffer.span().first(length) };
 
     auto endOfLanguageScriptRegionVariant = localeIDView.find(ULOC_KEYWORD_SEPARATOR);
     if (endOfLanguageScriptRegionVariant == notFound)

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -351,7 +351,7 @@ Vector<char, 32> canonicalizeUnicodeExtensionsAfterICULocaleCanonicalization(Vec
         end++;
     }
 
-    Vector<char, 32> result(buffer.subspan(0, extensionIndex + 2)); // "-u" is included.
+    Vector<char, 32> result(buffer.span().first(extensionIndex + 2)); // "-u" is included.
     StringView extension = locale.substring(extensionIndex, extensionLength);
     ASSERT(extension.is8Bit());
     auto subtags = unicodeExtensionComponents(extension);

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp
@@ -99,8 +99,7 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayConstructorFromBase64, (JSGlobalObject* globa
     JSUint8Array* uint8Array = JSUint8Array::createUninitialized(globalObject, globalObject->typedArrayStructure(TypeUint8, false), writeLength);
     RETURN_IF_EXCEPTION(scope, { });
 
-    uint8_t* data = uint8Array->typedVector();
-    memcpySpan(std::span { data, data + writeLength }, output.span().subspan(0, writeLength));
+    memcpySpan(uint8Array->typedSpan(), output.span().first(writeLength));
     return JSValue::encode(uint8Array);
 }
 

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp
@@ -140,9 +140,9 @@ JSC_DEFINE_HOST_FUNCTION(uint8ArrayPrototypeSetFromHex, (JSGlobalObject* globalO
 
     bool success = false;
     if (view.is8Bit())
-        success = decodeHex(view.span8().subspan(0, readCount), result) == WTF::notFound;
+        success = decodeHex(view.span8().first(readCount), result) == WTF::notFound;
     else
-        success = decodeHex(view.span16().subspan(0, readCount), result) == WTF::notFound;
+        success = decodeHex(view.span16().first(readCount), result) == WTF::notFound;
 
     if (UNLIKELY(!success))
         return JSValue::encode(throwSyntaxError(globalObject, scope, "Uint8Array.prototype.setFromHex requires a string containing only \"0123456789abcdefABCDEF\""_s));

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -43,6 +43,7 @@
 #include <wtf/dragonbox/dragonbox_to_chars.h>
 #include <wtf/text/EscapedFormsForJSON.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringBuilderJSON.h>
 #include <wtf/text/StringCommon.h>
@@ -1306,8 +1307,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
                 WTF::appendEscapedJSONStringContent(output, string.data.span16());
         } else
             WTF::appendEscapedJSONStringContent(output, string.data.span8());
-        output[0] = '"';
-        output = output.subspan(1);
+        consumeSingleElement(output) = '"';
         m_length = output.data() - buffer();
         return;
     }

--- a/Source/JavaScriptCore/runtime/JSStringJoiner.cpp
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.cpp
@@ -27,6 +27,7 @@
 #include "JSStringJoiner.h"
 
 #include "JSCJSValueInlines.h"
+#include <wtf/text/ParsingUtilities.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -95,8 +96,7 @@ static inline void appendStringToDataWithOneCharacterSeparatorRepeatedly(std::sp
 #endif
 
     while (count--) {
-        data[0] = separatorCharacter;
-        data = data.subspan(1);
+        consumeSingleElement(data) = separatorCharacter;
         appendStringToData(data, string);
     }
 }

--- a/Source/JavaScriptCore/runtime/ParseInt.h
+++ b/Source/JavaScriptCore/runtime/ParseInt.h
@@ -95,9 +95,12 @@ static double parseIntOverflow(std::span<const UChar> s, int radix)
     return number;
 }
 
-ALWAYS_INLINE static bool isStrWhiteSpace(UChar c)
+template<typename CharacterType>
+ALWAYS_INLINE static bool isStrWhiteSpace(CharacterType c)
 {
     // https://tc39.github.io/ecma262/#sec-tonumber-applied-to-the-string-type
+    if constexpr (sizeof(c) == 1)
+        return Lexer<LChar>::isWhiteSpace(c) || Lexer<LChar>::isLineTerminator(c);
     return Lexer<UChar>::isWhiteSpace(c) || Lexer<UChar>::isLineTerminator(c);
 }
 

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		465F34932CD824AF000963B1 /* ObjCRuntimeExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = 465F34922CD824AF000963B1 /* ObjCRuntimeExtras.mm */; };
 		466D69112BA4E433005D43F4 /* SpanCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 466D69102BA4E433005D43F4 /* SpanCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		467DCD532CD4689A0040C644 /* UnicodeExtras.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 467DCD522CD4689A0040C644 /* UnicodeExtras.cpp */; };
+		46B0FB5D2D24BFBA0012184C /* ParsingUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 46B0FB5C2D24BFBA0012184C /* ParsingUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46BEB6EB22FFE24900269867 /* RefCounted.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD500269867 /* RefCounted.cpp */; };
 		46BEB6EB22FFE24900269868 /* RefTrackerMixin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD500269868 /* RefTrackerMixin.cpp */; };
 		46CEA3FA2CC2D39B00FE325C /* SpanCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 46CEA3F92CC2D39B00FE325C /* SpanCocoa.mm */; };
@@ -1240,6 +1241,7 @@
 		465F34922CD824AF000963B1 /* ObjCRuntimeExtras.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjCRuntimeExtras.mm; sourceTree = "<group>"; };
 		466D69102BA4E433005D43F4 /* SpanCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpanCocoa.h; sourceTree = "<group>"; };
 		467DCD522CD4689A0040C644 /* UnicodeExtras.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnicodeExtras.cpp; sourceTree = "<group>"; };
+		46B0FB5C2D24BFBA0012184C /* ParsingUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParsingUtilities.h; sourceTree = "<group>"; };
 		46BA9EAB1F4CD61E009A2BBC /* CompletionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompletionHandler.h; sourceTree = "<group>"; };
 		46BEB6E922FFDDD500269867 /* RefCounted.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RefCounted.cpp; sourceTree = "<group>"; };
 		46BEB6E922FFDDD500269868 /* RefTrackerMixin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RefTrackerMixin.cpp; sourceTree = "<group>"; };
@@ -2707,6 +2709,7 @@
 				BC5267662C2726D600E422DD /* MakeString.h */,
 				DD4901ED27B474D900D7E50D /* NullTextBreakIterator.h */,
 				14E785E71DFB330100209BD1 /* OrdinalNumber.h */,
+				46B0FB5C2D24BFBA0012184C /* ParsingUtilities.h */,
 				0F95B63620CB5EFD00479635 /* StringBuffer.cpp */,
 				A8A47323151A825B004123FF /* StringBuffer.h */,
 				A8A47324151A825B004123FF /* StringBuilder.cpp */,
@@ -3509,6 +3512,7 @@
 				DD3DC95C27A4BF8E007E5B61 /* ParallelVectorIterator.h in Headers */,
 				DD3DC99827A4BF8E007E5B61 /* ParkingLot.h in Headers */,
 				E361DB62289115D000B2A2B8 /* parse_number.h in Headers */,
+				46B0FB5D2D24BFBA0012184C /* ParsingUtilities.h in Headers */,
 				DDF3077A27C086CD006A526F /* PersistentCoders.h in Headers */,
 				DDF3074E27C086CD006A526F /* PersistentDecoder.h in Headers */,
 				DDF3078B27C086CD006A526F /* PersistentEncoder.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -449,6 +449,7 @@ set(WTF_PUBLIC_HEADERS
     text/MakeString.h
     text/NullTextBreakIterator.h
     text/OrdinalNumber.h
+    text/ParsingUtilities.h
     text/StringBuffer.h
     text/StringBuilder.h
     text/StringBuilderInternals.h

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1409,7 +1409,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/parser/HTMLDocumentParserFastPath.h
     html/parser/HTMLParserIdioms.h
     html/parser/HTMLParserScriptingFlagPolicy.h
-    html/parser/ParsingUtilities.h
 
     html/track/AudioTrack.h
     html/track/AudioTrackClient.h

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -112,6 +112,7 @@
 #include <wtf/StackCheck.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/threads/BinarySemaphore.h>
 
 #if USE(CG)
@@ -3502,10 +3503,9 @@ private:
             if (span.size() < length)
                 return false;
             if (shouldAtomize == ShouldAtomize::Yes)
-                str = AtomString(span.first(length));
+                str = AtomString(consumeSpan(span, length));
             else
-                str = String(span.first(length));
-            span = span.subspan(length);
+                str = String(consumeSpan(span, length));
             return true;
         }
 
@@ -3514,12 +3514,11 @@ private:
             return false;
 
 #if ASSUME_LITTLE_ENDIAN
-        size_t lengthInBytes = length * sizeof(UChar);
+        auto stringSpan = consumeSpan(span, size);
         if (shouldAtomize == ShouldAtomize::Yes)
-            str = AtomString(spanReinterpretCast<const UChar>(span.first(lengthInBytes)));
+            str = AtomString(spanReinterpretCast<const UChar>(stringSpan));
         else
-            str = String(spanReinterpretCast<const UChar>(span.first(lengthInBytes)));
-        span = span.subspan(lengthInBytes);
+            str = String(spanReinterpretCast<const UChar>(stringSpan));
 #else
         std::span<UChar> characters;
         str = String::createUninitialized(length, characters);

--- a/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
+++ b/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
@@ -28,8 +28,8 @@
 #include "CSSParserIdioms.h"
 #include "CSSParserTokenRange.h"
 #include "CSSTokenizer.h"
-#include "ParsingUtilities.h"
 #include <wtf/SortedArrayMap.h>
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -83,7 +83,6 @@
 #include "CSSVariableReferenceValue.h"
 #include "ComputedStyleDependencies.h"
 #include "FontFace.h"
-#include "ParsingUtilities.h"
 #include "Rect.h"
 #include "StyleBuilder.h"
 #include "StyleBuilderConverter.h"
@@ -93,6 +92,7 @@
 #include "TransformOperationsBuilder.h"
 #include <memory>
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -66,8 +66,8 @@
 #include "Document.h"
 #include "FontCustomPlatformData.h"
 #include "FontFace.h"
-#include "ParsingUtilities.h"
 #include "WebKitFontFamilyNames.h"
+#include <wtf/text/ParsingUtilities.h>
 
 #if ENABLE(VARIATION_FONTS)
 #include "CSSFontStyleRangeValue.h"

--- a/Source/WebCore/html/HTMLFontElement.cpp
+++ b/Source/WebCore/html/HTMLFontElement.cpp
@@ -33,6 +33,7 @@
 #include "NodeName.h"
 #include "StyleProperties.h"
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
@@ -62,9 +63,8 @@ static bool parseFontSize(std::span<const CharacterType> characters, int& size)
     // Step 2
     // Step 3
     while (!characters.empty()) {
-        if (!isASCIIWhitespace(characters.front()))
+        if (!skipExactly<isASCIIWhitespace>(characters))
             break;
-        characters = characters.subspan(1);
     }
 
     // Step 4
@@ -98,8 +98,7 @@ static bool parseFontSize(std::span<const CharacterType> characters, int& size)
     while (!characters.empty()) {
         if (!isASCIIDigit(characters.front()))
             break;
-        digits.append(characters.front());
-        characters = characters.subspan(1);
+        digits.append(consumeSingleElement(characters));
     }
 
     // Step 7

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -53,7 +53,6 @@
 #include "HTMLUListElement.h"
 #include "NodeName.h"
 #include "ParserContentPolicy.h"
-#include "ParsingUtilities.h"
 #include "QualifiedName.h"
 #include "Settings.h"
 #include <span>
@@ -62,6 +61,7 @@
 #include <wtf/WeakRef.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/FastCharacterComparison.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringParsingBuffer.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/WebCore/html/parser/HTMLParserIdioms.cpp
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.cpp
@@ -27,13 +27,13 @@
 #include "HTMLParserIdioms.h"
 
 #include "Decimal.h"
-#include "ParsingUtilities.h"
 #include "QualifiedName.h"
 #include <limits>
 #include <wtf/MathExtras.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 #include <wtf/dtoa.h>
+#include <wtf/text/ParsingUtilities.h>
 
 #if PLATFORM(COCOA)
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
@@ -132,18 +132,16 @@ double parseToDoubleForNumberType(StringView string)
 template <typename CharacterType>
 static Expected<int, HTMLIntegerParsingError> parseHTMLIntegerInternal(std::span<const CharacterType> data)
 {
-    while (!data.empty() && isASCIIWhitespace(data.front()))
-        data = data.subspan(1);
+    skipWhile<isASCIIWhitespace>(data);
 
     if (data.empty())
         return makeUnexpected(HTMLIntegerParsingError::Other);
 
     bool isNegative = false;
-    if (data.front() == '-') {
+    if (skipExactly(data, '-'))
         isNegative = true;
-        data = data.subspan(1);
-    } else if (data.front() == '+')
-        data = data.subspan(1);
+    else
+        skipExactly(data, '+');
 
     if (data.empty() || !isASCIIDigit(data.front()))
         return makeUnexpected(HTMLIntegerParsingError::Other);
@@ -154,13 +152,12 @@ static Expected<int, HTMLIntegerParsingError> parseHTMLIntegerInternal(std::span
 
     unsigned result = 0;
     do {
-        int digitValue = data.front() - '0';
+        int digitValue = consumeSingleElement(data) - '0';
 
         if (result > maxMultiplier || (result == maxMultiplier && digitValue > (intMax % base) + isNegative))
             return makeUnexpected(isNegative ? HTMLIntegerParsingError::NegativeOverflow : HTMLIntegerParsingError::PositiveOverflow);
 
         result = base * result + digitValue;
-        data = data.subspan(1);
     } while (!data.empty() && isASCIIDigit(data.front()));
 
     return isNegative ? -result : result;
@@ -271,7 +268,8 @@ double parseHTMLFloatingPointNumberValue(StringView input, double fallbackValue)
     return parseHTMLFloatingPointNumberValueInternal(input.span16(), input.length(), fallbackValue);
 }
 
-static inline bool isHTMLSpaceOrDelimiter(UChar character)
+template<typename CharacterType>
+static inline bool isHTMLSpaceOrDelimiter(CharacterType character)
 {
     return isASCIIWhitespace(character) || character == ',' || character == ';';
 }
@@ -288,8 +286,7 @@ static Vector<double> parseHTMLListOfOfFloatingPointNumberValuesInternal(std::sp
     Vector<double> numbers;
 
     // This skips past any leading delimiters.
-    while (!data.empty() && isHTMLSpaceOrDelimiter(data.front()))
-        data = data.subspan(1);
+    skipWhile<isHTMLSpaceOrDelimiter>(data);
 
     while (!data.empty()) {
         // This skips past leading garbage.
@@ -297,16 +294,14 @@ static Vector<double> parseHTMLListOfOfFloatingPointNumberValuesInternal(std::sp
             data = data.subspan(1);
 
         auto* numberStart = data.data();
-        while (!data.empty() && !isHTMLSpaceOrDelimiter(data.front()))
-            data = data.subspan(1);
+        skipUntil<isHTMLSpaceOrDelimiter>(data);
 
         size_t parsedLength = 0;
         double number = parseDouble(std::span { numberStart, data.data() }, parsedLength);
         numbers.append(parsedLength > 0 && std::isfinite(number) ? number : 0);
 
         // This skips past the delimiter.
-        while (!data.empty() && isHTMLSpaceOrDelimiter(data.front()))
-            data = data.subspan(1);
+        skipWhile<isHTMLSpaceOrDelimiter>(data);
     }
 
     return numbers;
@@ -346,14 +341,12 @@ String parseCORSSettingsAttribute(const AtomString& value)
 template <typename CharacterType>
 static bool parseHTTPRefreshInternal(std::span<const CharacterType> data, double& parsedDelay, String& parsedURL)
 {
-    while (!data.empty() && isASCIIWhitespace(data.front()))
-        data = data.subspan(1);
+    skipWhile<isASCIIWhitespace>(data);
 
     unsigned time = 0;
 
     auto* numberStart = data.data();
-    while (!data.empty() && isASCIIDigit(data.front()))
-        data = data.subspan(1);
+    skipWhile<isASCIIDigit>(data);
 
     StringView timeString(std::span(numberStart, data.data()));
     if (timeString.isEmpty()) {
@@ -379,14 +372,12 @@ static bool parseHTTPRefreshInternal(std::span<const CharacterType> data, double
 
     parsedDelay = time;
 
-    while (!data.empty() && isASCIIWhitespace(data.front()))
-        data = data.subspan(1);
+    skipWhile<isASCIIWhitespace>(data);
 
     if (!data.empty() && (data.front() == ';' || data.front() == ','))
         data = data.subspan(1);
 
-    while (!data.empty() && isASCIIWhitespace(data.front()))
-        data = data.subspan(1);
+    skipWhile<isASCIIWhitespace>(data);
 
     if (data.empty())
         return true;
@@ -396,39 +387,30 @@ static bool parseHTTPRefreshInternal(std::span<const CharacterType> data, double
 
         data = data.subspan(1);
 
-        if (!data.empty() && (data.front() == 'R' || data.front() == 'r'))
-            data = data.subspan(1);
-        else {
+        if (!skipExactly(data, 'R') && !skipExactly(data, 'r')) {
             parsedURL = url.toString();
             return true;
         }
 
-        if (!data.empty() && (data.front() == 'L' || data.front() == 'l'))
-            data = data.subspan(1);
-        else {
+        if (!skipExactly(data, 'L') && !skipExactly(data, 'l')) {
             parsedURL = url.toString();
             return true;
         }
 
-        while (!data.empty() && isASCIIWhitespace(data.front()))
-            data = data.subspan(1);
+        skipWhile<isASCIIWhitespace>(data);
 
-        if (!data.empty() && data.front() == '=')
-            data = data.subspan(1);
-        else {
+        if (!skipExactly(data, '=')) {
             parsedURL = url.toString();
             return true;
         }
 
-        while (!data.empty() && isASCIIWhitespace(data.front()))
-            data = data.subspan(1);
+        skipWhile<isASCIIWhitespace>(data);
     }
 
     CharacterType quote;
-    if (!data.empty() && (data.front() == '\'' || data.front() == '"')) {
-        quote = data.front();
-        data = data.subspan(1);
-    } else
+    if (!data.empty() && (data.front() == '\'' || data.front() == '"'))
+        quote = consumeSingleElement(data);
+    else
         quote = '\0';
 
     StringView url(data);

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
@@ -34,9 +34,9 @@
 
 #include "Element.h"
 #include "HTMLParserIdioms.h"
-#include "ParsingUtilities.h"
 #include <wtf/ListHashSet.h>
 #include <wtf/URL.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/WebCore/html/track/VTTScanner.h
+++ b/Source/WebCore/html/track/VTTScanner.h
@@ -29,7 +29,7 @@
 
 #pragma once
 
-#include "ParsingUtilities.h"
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -168,10 +168,6 @@ protected:
     void seekTo(Position);
     UChar currentChar() const;
     void advance(size_t amount = 1);
-    // Adapt a UChar-predicate to an LChar-predicate.
-    // (For use with skipWhile/Until from ParsingUtilities.h).
-    template<bool characterPredicate(UChar)>
-    static inline bool LCharPredicateAdapter(LChar c) { return characterPredicate(c); }
     union Characters {
         Characters()
             : characters8()
@@ -187,18 +183,18 @@ template<bool characterPredicate(UChar)>
 inline void VTTScanner::skipWhile()
 {
     if (m_is8Bit)
-        WebCore::skipWhile<LCharPredicateAdapter<characterPredicate>>(m_data.characters8);
+        WTF::skipWhile<LCharPredicateAdapter<characterPredicate>>(m_data.characters8);
     else
-        WebCore::skipWhile<characterPredicate>(m_data.characters16);
+        WTF::skipWhile<characterPredicate>(m_data.characters16);
 }
 
 template<bool characterPredicate(UChar)>
 inline void VTTScanner::skipUntil()
 {
     if (m_is8Bit)
-        WebCore::skipUntil<LCharPredicateAdapter<characterPredicate>>(m_data.characters8);
+        WTF::skipUntil<LCharPredicateAdapter<characterPredicate>>(m_data.characters8);
     else
-        WebCore::skipUntil<characterPredicate>(m_data.characters16);
+        WTF::skipUntil<characterPredicate>(m_data.characters16);
 }
 
 template<bool characterPredicate(UChar)>
@@ -206,11 +202,11 @@ inline VTTScanner::Run VTTScanner::collectWhile()
 {
     if (m_is8Bit) {
         auto current = m_data.characters8;
-        WebCore::skipWhile<LCharPredicateAdapter<characterPredicate>>(current);
+        WTF::skipWhile<LCharPredicateAdapter<characterPredicate>>(current);
         return Run { m_data.characters8.first(current.data() - m_data.characters8.data()) };
     }
     auto current = m_data.characters16;
-    WebCore::skipWhile<characterPredicate>(current);
+    WTF::skipWhile<characterPredicate>(current);
     return Run { m_data.characters16.first(current.data() - m_data.characters16.data()) };
 }
 
@@ -219,11 +215,11 @@ inline VTTScanner::Run VTTScanner::collectUntil()
 {
     if (m_is8Bit) {
         auto current = m_data.characters8;
-        WebCore::skipUntil<LCharPredicateAdapter<characterPredicate>>(current);
+        WTF::skipUntil<LCharPredicateAdapter<characterPredicate>>(current);
         return Run { m_data.characters8.first(current.data() - m_data.characters8.data()) };
     }
     auto current = m_data.characters16;
-    WebCore::skipUntil<characterPredicate>(current);
+    WTF::skipUntil<characterPredicate>(current);
     return Run { m_data.characters16.first(current.data() - m_data.characters16.data()) };
 }
 

--- a/Source/WebCore/loader/LinkHeader.cpp
+++ b/Source/WebCore/loader/LinkHeader.cpp
@@ -28,7 +28,7 @@
 #include "config.h"
 #include "LinkHeader.h"
 
-#include "ParsingUtilities.h"
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/loader/ResourceCryptographicDigest.cpp
+++ b/Source/WebCore/loader/ResourceCryptographicDigest.cpp
@@ -26,10 +26,10 @@
 #include "config.h"
 #include "ResourceCryptographicDigest.h"
 
-#include "ParsingUtilities.h"
 #include "SharedBuffer.h"
 #include <pal/crypto/CryptoDigest.h>
 #include <wtf/text/Base64.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringParsingBuffer.h>
 
 namespace WebCore {

--- a/Source/WebCore/loader/SubresourceIntegrity.cpp
+++ b/Source/WebCore/loader/SubresourceIntegrity.cpp
@@ -27,10 +27,10 @@
 #include "SubresourceIntegrity.h"
 
 #include "CachedResource.h"
-#include "ParsingUtilities.h"
 #include "ResourceCryptographicDigest.h"
 #include "SharedBuffer.h"
 #include <wtf/text/MakeString.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringParsingBuffer.h>
 
 namespace WebCore {

--- a/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
@@ -26,8 +26,8 @@
 #include "config.h"
 #include "ApplicationCacheManifestParser.h"
 
-#include "ParsingUtilities.h"
 #include "TextResourceDecoder.h"
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/StringParsingBuffer.h>
 #include <wtf/text/StringView.h>

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -47,7 +47,6 @@
 #include "LegacySchemeRegistry.h"
 #include "LocalFrame.h"
 #include "OriginAccessPatterns.h"
-#include "ParsingUtilities.h"
 #include "PingLoader.h"
 #include "Report.h"
 #include "ReportingClient.h"
@@ -66,6 +65,7 @@
 #include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringParsingBuffer.h>
 #include <wtf/text/TextPosition.h>

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -31,10 +31,10 @@
 #include "Document.h"
 #include "HTTPParsers.h"
 #include "LocalFrame.h"
-#include "ParsingUtilities.h"
 #include "SecurityContext.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringParsingBuffer.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/csp/ContentSecurityPolicyMediaListDirective.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyMediaListDirective.cpp
@@ -29,8 +29,8 @@
 
 #include "ContentSecurityPolicy.h"
 #include "ContentSecurityPolicyDirectiveList.h"
-#include "ParsingUtilities.h"
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/StringParsingBuffer.h>
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -29,13 +29,13 @@
 
 #include "ContentSecurityPolicy.h"
 #include "ContentSecurityPolicyDirectiveNames.h"
-#include "ParsingUtilities.h"
 #include "PublicSuffixStore.h"
 #include <pal/text/TextEncoding.h>
 #include <wtf/ASCIICType.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/URL.h>
 #include <wtf/text/Base64.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringParsingBuffer.h>
 #include <wtf/text/StringToIntegerConversion.h>
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
@@ -28,8 +28,8 @@
 
 #include "ContentSecurityPolicy.h"
 #include "ContentSecurityPolicyDirectiveList.h"
-#include "ParsingUtilities.h"
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringCommon.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/platform/DateComponents.cpp
+++ b/Source/WebCore/platform/DateComponents.cpp
@@ -31,12 +31,12 @@
 #include "config.h"
 #include "DateComponents.h"
 
-#include "ParsingUtilities.h"
 #include <limits.h>
 #include <wtf/ASCIICType.h>
 #include <wtf/DateMath.h>
 #include <wtf/MathExtras.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringParsingBuffer.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/network/RFC8941.cpp
+++ b/Source/WebCore/platform/network/RFC8941.cpp
@@ -26,16 +26,14 @@
 #include "config.h"
 #include "RFC8941.h"
 
-#include "ParsingUtilities.h"
 #include "RFC7230.h"
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/StringParsingBuffer.h>
 #include <wtf/text/StringView.h>
 
 namespace RFC8941 {
-
-using namespace WebCore;
 
 template<typename CharacterType> constexpr bool isEndOfToken(CharacterType character)
 {

--- a/Source/WebCore/svg/SVGParserUtilities.h
+++ b/Source/WebCore/svg/SVGParserUtilities.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
-#include "ParsingUtilities.h"
 #include <wtf/Forward.h>
+#include <wtf/text/ParsingUtilities.h>
 
 typedef std::pair<char32_t, char32_t> UnicodeRange;
 typedef Vector<UnicodeRange> UnicodeRanges;


### PR DESCRIPTION
#### 7a78d638b1637b95deaa1750b82e1dc0ca9b7d2d
<pre>
Reduce use of std::span::subspan() by leveraging ParsingUtilities
<a href="https://bugs.webkit.org/show_bug.cgi?id=285271">https://bugs.webkit.org/show_bug.cgi?id=285271</a>

Reviewed by Darin Adler.

A lot more code can be ported but this is a step in this direction.

* Source/JavaScriptCore/API/JSScript.mm:
(-[JSScript readCache]):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::CallArguments::CallArguments):
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::Encoder::release):
* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::LocaleIDBuilder::overrideLanguageScriptRegion):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::canonicalizeUnicodeExtensionsAfterICULocaleCanonicalization):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::jsBinaryIntegerLiteral):
(JSC::jsOctalIntegerLiteral):
(JSC::jsHexIntegerLiteral):
(JSC::toDouble):
(JSC::parseFloat):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::bufferMode&gt;::append):
* Source/JavaScriptCore/runtime/JSStringJoiner.cpp:
(JSC::appendStringToDataWithOneCharacterSeparatorRepeatedly):
* Source/JavaScriptCore/runtime/ParseInt.h:
(JSC::isStrWhiteSpace):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/DateMath.cpp:
(WTF::parseES5DatePortion):
(WTF::parseES5TimePortion):
(WTF::parseDate):
* Source/WTF/wtf/text/ParsingUtilities.h: Renamed from Source/WebCore/html/parser/ParsingUtilities.h.
(WTF::isNotASCIISpace):
(WTF::skipExactly):
(WTF::characterPredicate):
(WTF::skipUntil):
(WTF::skipWhile):
(WTF::skipExactlyIgnoringASCIICase):
(WTF::skipLettersExactlyIgnoringASCIICase):
(WTF::skipCharactersExactly):
(WTF::consumeSingleElement):
(WTF::consumeSpan):
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readString):
* Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
* Source/WebCore/html/HTMLFontElement.cpp:
(WebCore::parseFontSize):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
* Source/WebCore/html/parser/HTMLParserIdioms.cpp:
(WebCore::parseHTMLIntegerInternal):
(WebCore::isHTMLSpaceOrDelimiter):
(WebCore::parseHTMLListOfOfFloatingPointNumberValuesInternal):
(WebCore::parseHTTPRefreshInternal):
* Source/WebCore/html/parser/HTMLSrcsetParser.cpp:
* Source/WebCore/html/track/VTTScanner.h:
(WebCore::characterPredicate):
(WebCore::VTTScanner::characterPredicate): Deleted.
* Source/WebCore/loader/LinkHeader.cpp:
* Source/WebCore/loader/ResourceCryptographicDigest.cpp:
* Source/WebCore/loader/SubresourceIntegrity.cpp:
* Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp:
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
* Source/WebCore/page/csp/ContentSecurityPolicyMediaListDirective.cpp:
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp:
* Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp:
* Source/WebCore/platform/DateComponents.cpp:
* Source/WebCore/platform/network/RFC8941.cpp:
* Source/WebCore/svg/SVGParserUtilities.h:

Canonical link: <a href="https://commits.webkit.org/288353@main">https://commits.webkit.org/288353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc07060094f36f1b7918381e4dabc2632c1cb10d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87901 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33840 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84875 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10346 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64500 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22266 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75297 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44776 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1738 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29485 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32873 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75767 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72996 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89268 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81830 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10074 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7313 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72917 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10302 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72132 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16294 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12816 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10027 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15548 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/104235 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9901 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25262 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13366 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11670 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->