### PR TITLE
Refuse to break inside replaced content

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7116,7 +7116,6 @@ imported/w3c/web-platform-tests/css/css-break/float-015.tentative.html [ ImageOn
 imported/w3c/web-platform-tests/css/css-break/float-016.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-break/float-017.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-break/forced-break-at-fragmentainer-start-000.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-break/form-control.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-break/fragmented-autowidth-fc-root-beside-floats.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-break/inline-with-float-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-break/line-after-unbreakable-float-after-padding.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -6983,6 +6983,8 @@ http/tests/security/clipboard/copy-paste-html-across-origin-sanitizes-html.html 
 http/tests/security/clipboard/copy-paste-html-across-origin-strips-mso-list.html [ Pass Failure ]
 imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-report-only-policy-works-with-external-hash-policy.html [ Pass Failure ]
 
+imported/w3c/web-platform-tests/css/css-break/form-control.html [ ImageOnlyFailure ]
+
 webkit.org/b/271445 fast/events/ios/rotation/resize-iframe-after-orientation-change.html [ Pass Failure ]
 
 webkit.org/b/271682 imported/w3c/web-platform-tests/css/css-content/quotes-007.html [ ImageOnlyFailure ] # TODO: uncomment line above with explicit pass expectation for this test when issue is resolved.

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -466,7 +466,7 @@ public:
     bool hasUnsplittableScrollingOverflow() const;
     bool isUnsplittableForPagination() const;
 
-    bool shouldTreatChildAsReplacedInTableCells() const;
+    bool shouldTreatChildAsReplaced() const;
 
     virtual LayoutRect overflowClipRect(const LayoutPoint& location, OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize, PaintPhase = PaintPhase::BlockBackground) const;
     virtual LayoutRect overflowClipRectForChildLayers(const LayoutPoint& location, OverlayScrollbarSizeRelevancy relevancy) const { return overflowClipRect(location, relevancy); }

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -4,7 +4,7 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  *
  * This library is free software; you can redistribute it and/or
@@ -473,7 +473,7 @@ static bool shouldFlexCellChild(const RenderTableCell& cell, const RenderBox& ce
         return false;
     if (cellDescendant.scrollsOverflowY())
         return true;
-    return cellDescendant.shouldTreatChildAsReplacedInTableCells();
+    return cellDescendant.shouldTreatChildAsReplaced();
 }
 
 void RenderTableSection::relayoutCellIfFlexed(RenderTableCell& cell, int rowIndex, int rowHeight)


### PR DESCRIPTION
#### 2cee38b913b5098080ec2c65e018c76386a42073
<pre>
Refuse to break inside replaced content

<a href="https://bugs.webkit.org/show_bug.cgi?id=285272">https://bugs.webkit.org/show_bug.cgi?id=285272</a>
<a href="https://rdar.apple.com/142224455">rdar://142224455</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/1587887">https://chromium-review.googlesource.com/c/chromium/src/+/1587887</a>

To determine if a renderer is either block-fragmentable or
monolithic, we used to check isReplacedOrAtomicInline(). This is slightly
inadequate, since what we really want to test, is whether the element is
replaced or not (+ some other things, such as scrollbars and
containment, which we&apos;re already taking care of well).

We relied on the fact that isReplacedOrAtomicInline() doesn&apos;t really behave
as one would expect: In addition to returning true for atomic inline
level content, it will also return true for certain types of *block*
level content, such as images (which is totally non-intuitive). For
many types of form controls, on the other hand, it will return false,
because many form controls are implemented using RenderBlockFlow-derived
types (and thereby they&apos;d be mistaken for regular non-replaced content).

Use shouldTreatChildAsReplaced() renamed from `shouldTreatChildAsReplacedInTableCells`
instead of isReplacedOrAtomicInline(). While the former actually calls the latter
(so in a sense we&apos;re still indirectly calling isReplacedOrAtomicInline()),
shouldTreatChildAsReplaced() additionally includes form elements manually
implementation, and this is what makes the difference and fixes the problem.

Due to rename, we have to modify all call-sites such as in `RenderTableSection`.

Additionally, to handle fall out for `fieldset`, we need to special case it by merging below:

Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/a5837f4be0f68ff9155ab6a0c46d6afdb1991a44">https://source.chromium.org/chromium/chromium/src/+/a5837f4be0f68ff9155ab6a0c46d6afdb1991a44</a>

* LayoutTests/TestExpectations:
* LayoutTests/platform/ios/TestExpectations: Add Platform Specific Expectation
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::shouldTreatChildAsReplaced const):
(WebCore::tableCellShouldHaveZeroInitialSize):
(WebCore::RenderBox::isUnsplittableForPagination const):
(WebCore::RenderBox::shouldTreatChildAsReplacedInTableCells const): Deleted.
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::shouldFlexCellChild):

Canonical link: <a href="https://commits.webkit.org/288354@main">https://commits.webkit.org/288354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c73486aed3eadd2d143da7c58df04a55f7e323d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/36956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87897 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33836 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84871 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64496 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22264 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44772 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1736 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29482 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32869 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/72995 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89264 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72914 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72129 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17913 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16291 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10023 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15544 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9897 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13362 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->