### PR TITLE
Fix isLineInverted to handle sideways-lr correctly

### DIFF
--- a/Source/WebCore/platform/text/WritingMode.h
+++ b/Source/WebCore/platform/text/WritingMode.h
@@ -290,7 +290,10 @@ constexpr bool WritingMode::isSidewaysOrientation() const
 
 constexpr bool WritingMode::isLineInverted() const
 {
-    return isBlockFlipped() != isVertical();
+    auto bits = m_bits & kWritingModeMask;
+    bool isHorizontalBt = kIsFlippedBlock == bits;
+    bool isVerticalLr = (kIsVerticalText | kIsVerticalType) == bits;
+    return isHorizontalBt | isVerticalLr;
 }
 
 constexpr bool WritingMode::isLineOverRight() const

--- a/Tools/TestWebKitAPI/Tests/WebCore/WritingModeTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/WritingModeTests.cpp
@@ -154,4 +154,14 @@ TEST(WritingMode, BoxAxis)
     }
 }
 
+TEST(WritingMode, LineQueries)
+{
+    EXPECT_EQ(false, (WritingMode { StyleWritingMode::HorizontalTb, TextDirection::LTR, TextOrientation::Mixed }.isLineInverted()));
+    EXPECT_EQ(true, (WritingMode { StyleWritingMode::HorizontalBt, TextDirection::LTR, TextOrientation::Mixed }.isLineInverted()));
+    EXPECT_EQ(false, (WritingMode { StyleWritingMode::VerticalRl, TextDirection::LTR, TextOrientation::Mixed }.isLineInverted()));
+    EXPECT_EQ(true, (WritingMode { StyleWritingMode::VerticalLr, TextDirection::LTR, TextOrientation::Mixed }.isLineInverted()));
+    EXPECT_EQ(false, (WritingMode { StyleWritingMode::SidewaysRl, TextDirection::LTR, TextOrientation::Mixed }.isLineInverted()));
+    EXPECT_EQ(false, (WritingMode { StyleWritingMode::SidewaysLr, TextDirection::LTR, TextOrientation::Mixed }.isLineInverted()));
+}
+
 }


### PR DESCRIPTION
#### f4b48e25beaecc5003f8b62bbbfa34055e7c0e80
<pre>
Fix isLineInverted to handle sideways-lr correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=285270">https://bugs.webkit.org/show_bug.cgi?id=285270</a>
<a href="https://rdar.apple.com/problem/142223524">rdar://problem/142223524</a>

Reviewed by Tim Nguyen.

Adjusts logic in WritingMode::isLineInverted() to distinguish vertical-lr and
sideways-lr correctly.

* Source/WebCore/platform/text/WritingMode.h:
(WebCore::WritingMode::isLineInverted const): Adjust logic to distinguish vertical-lr and sideways-lr.
* Tools/TestWebKitAPI/Tests/WebCore/WritingModeTests.cpp:
(TestWebKitAPI::TEST(WritingMode, LineQueries)):

Canonical link: <a href="https://commits.webkit.org/288371@main">https://commits.webkit.org/288371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/566b1a5619e221fbd53755f406bb1504679a7993

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87998 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33935 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64593 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22357 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75392 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1828 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29581 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32969 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73061 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89364 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7396 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73012 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10399 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71198 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72226 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17926 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16388 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10124 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/15638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9996 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13461 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->