### PR TITLE
Convert (non-bidi) inline content coordinates for writing-mode: sideways-lr

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4912,9 +4912,6 @@ webkit.org/b/279419 [ Debug ] imported/w3c/web-platform-tests/css/css-transforms
 
 webkit.org/b/208396 http/tests/misc/object-embedding-svg-delayed-size-negotiation-2.htm [ Pass Failure ]
 
-# writing-mode failures
-webkit.org/b/285222 imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-sideways-002.html [ ImageOnlyFailure ]
-
 # Untriaged writing-mode failures.
 webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/abs-pos-border-offset-001.html [ ImageOnlyFailure ]
 webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/abs-pos-border-offset-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-001-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>Reference for Sideways Inline Layout: Basic Case</title>
+<meta charset=utf-8>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body > div {
+  /* styling */
+  border: solid silver;
+  font: 30px/1 Ahem;
+  color: blue;
+  float: left;
+
+  /* test */
+  padding: 2px 4px 6px 8px;
+  margin: 2px 4px 6px 8px;
+}
+div > div {
+  transform: rotate(180deg);
+}
+</style>
+
+<div style="writing-mode: vertical-lr"><div>ApÉx</div></div>
+
+<div style="writing-mode: vertical-rl">ApÉx</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-001-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>Reference for Sideways Inline Layout: Basic Case</title>
+<meta charset=utf-8>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body > div {
+  /* styling */
+  border: solid silver;
+  font: 30px/1 Ahem;
+  color: blue;
+  float: left;
+
+  /* test */
+  padding: 2px 4px 6px 8px;
+  margin: 2px 4px 6px 8px;
+}
+div > div {
+  transform: rotate(180deg);
+}
+</style>
+
+<div style="writing-mode: vertical-lr"><div>ApÉx</div></div>
+
+<div style="writing-mode: vertical-rl">ApÉx</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-001.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>Sideways Inline Layout: Basic Case</title>
+<meta charset=utf-8>
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#block-flow">
+
+<link rel="match" href="sideways-inline-001-ref.html">
+
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+div {
+  /* styling */
+  border: solid silver;
+  font: 30px/1 Ahem;
+  color: blue;
+  float: left;
+
+  /* test */
+  padding: 2px 4px 6px 8px;
+  margin: 2px 4px 6px 8px;
+}
+</style>
+
+<div style="writing-mode: sideways-lr">ApÉx</div>
+
+<div style="writing-mode: sideways-rl">ApÉx</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-002-expected.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<title>Reference for Sideways Inline Layout: Text Decoration</title>
+<meta charset=utf-8>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body > div {
+  border: solid black;
+  font: 30px/1 Ahem;
+  color: silver;
+  float: left;
+  margin: 8px;
+  width: 5em;
+  height: 6em;
+}
+.wrapper {
+  width: 6em;
+  height: 5em;
+}
+
+img {
+  height: 30px;
+  image-rendering: crisp-edges;
+  display: block;
+}
+span.inline {
+  border: solid orange;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+span.img {
+  border: solid blue;
+  display: inline-block;
+}
+sup, sub {
+  color: blue;
+}
+
+/* reference hacking */
+.lr .wrapper {
+  transform: rotate(-90deg) translate(-0.5em, -0.5em);
+}
+.rl .wrapper {
+  transform: rotate(90deg) translate(0.5em, 0.5em);
+}
+.lr span {
+  margin: 8px 2px 4px 6px;
+  border-width: 4px 1px 2px 3px;
+  padding: 4px 1px 2px 3px;
+}
+.lr img {
+  transform: rotate(90deg);
+}
+.rl span {
+  margin: 4px 6px 8px 2px;
+  border-width: 2px 3px 4px 1px;
+  padding: 2px 3px 4px 1px;
+}
+.rl img {
+  transform: rotate(-90deg);
+}
+</style>
+
+<div class=lr>
+  <div class=wrapper>
+    <span class=inline>X</span>XX<span class=inline>XX
+    X</span>É<span class=img><img src="4color.png"></span>É
+    p<sup>x</sup>É<sub>x</sub>p
+  </div>
+</div>
+
+<div class=rl>
+  <div class=wrapper>
+    <span class=inline>X</span>XX<span class=inline>XX
+    X</span>É<span class=img><img src="4color.png"></span>É
+    p<sup>x</sup>É<sub>x</sub>p
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-002-ref.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<title>Reference for Sideways Inline Layout: Text Decoration</title>
+<meta charset=utf-8>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body > div {
+  border: solid black;
+  font: 30px/1 Ahem;
+  color: silver;
+  float: left;
+  margin: 8px;
+  width: 5em;
+  height: 6em;
+}
+.wrapper {
+  width: 6em;
+  height: 5em;
+}
+
+img {
+  height: 30px;
+  image-rendering: crisp-edges;
+  display: block;
+}
+span.inline {
+  border: solid orange;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+span.img {
+  border: solid blue;
+  display: inline-block;
+}
+sup, sub {
+  color: blue;
+}
+
+/* reference hacking */
+.lr .wrapper {
+  transform: rotate(-90deg) translate(-0.5em, -0.5em);
+}
+.rl .wrapper {
+  transform: rotate(90deg) translate(0.5em, 0.5em);
+}
+.lr span {
+  margin: 8px 2px 4px 6px;
+  border-width: 4px 1px 2px 3px;
+  padding: 4px 1px 2px 3px;
+}
+.lr img {
+  transform: rotate(90deg);
+}
+.rl span {
+  margin: 4px 6px 8px 2px;
+  border-width: 2px 3px 4px 1px;
+  padding: 2px 3px 4px 1px;
+}
+.rl img {
+  transform: rotate(-90deg);
+}
+</style>
+
+<div class=lr>
+  <div class=wrapper>
+    <span class=inline>X</span>XX<span class=inline>XX
+    X</span>É<span class=img><img src="4color.png"></span>É
+    p<sup>x</sup>É<sub>x</sub>p
+  </div>
+</div>
+
+<div class=rl>
+  <div class=wrapper>
+    <span class=inline>X</span>XX<span class=inline>XX
+    X</span>É<span class=img><img src="4color.png"></span>É
+    p<sup>x</sup>É<sub>x</sub>p
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-002.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<title>Sideways Inline Layout: Inline Boxes</title>
+<meta charset=utf-8>
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#block-flow">
+
+<link rel="match" href="sideways-inline-002-ref.html">
+
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body > div {
+  border: solid black;
+  font: 30px/1 Ahem;
+  color: silver;
+  float: left;
+  margin: 8px;
+  height: 6em;
+  width: 5em;
+}
+.lr {
+  writing-mode: sideways-lr;
+}
+.rl {
+  writing-mode: sideways-rl;
+}
+img {
+  height: 30px;
+  border: solid blue;
+  image-rendering: crisp-edges;
+}
+span {
+  border: solid orange;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+img, span {
+  margin: 2px 4px 6px 8px;
+  border-width: 1px 2px 3px 4px;
+  padding: 1px 2px 3px 4px;
+}
+sup, sub {
+  color: blue;
+}
+</style>
+
+<div class=lr>
+  <span>X</span>XX<span>XX
+  X</span>É<img src="4color.png">É
+  p<sup>x</sup>É<sub>x</sub>p
+</div>
+
+<div class=rl>
+  <span>X</span>XX<span>XX
+  X</span>É<img src="4color.png">É
+  p<sup>x</sup>É<sub>x</sub>p
+</div>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingConstraints.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingConstraints.h
@@ -31,17 +31,20 @@ namespace WebCore {
 namespace Layout {
 
 struct ConstraintsForInlineContent : public ConstraintsForInFlowContent {
-    ConstraintsForInlineContent(const ConstraintsForInFlowContent&, LayoutUnit visualLeft);
+    ConstraintsForInlineContent(const ConstraintsForInFlowContent&, LayoutUnit visualLeft, LayoutSize containerRenderSize);
 
     LayoutUnit visualLeft() const { return m_visualLeft; }
+    LayoutSize containerRenderSize() const { return m_containerRenderSize; }
 
 private:
     LayoutUnit m_visualLeft;
+    LayoutSize m_containerRenderSize;
 };
 
-inline ConstraintsForInlineContent::ConstraintsForInlineContent(const ConstraintsForInFlowContent& genericContraints, LayoutUnit visualLeft)
+inline ConstraintsForInlineContent::ConstraintsForInlineContent(const ConstraintsForInFlowContent& genericContraints, LayoutUnit visualLeft, LayoutSize containerRenderSize)
     : ConstraintsForInFlowContent(genericContraints.horizontal(), genericContraints.logicalTop(), InlineContent)
     , m_visualLeft(visualLeft)
+    , m_containerRenderSize(containerRenderSize)
 {
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -402,11 +402,15 @@ void InlineDisplayContentBuilder::processNonBidiContent(const LineLayoutResult& 
 #endif
     auto& lineBox = this->lineBox();
     auto writingMode = root().style().writingMode();
-    auto contentStartInVisualOrder = m_displayLine.topLeft();
+    auto lineBoxLogicalRect = lineBox.logicalRect();
+    auto lineBoxVisualOffset = m_displayLine.topLeft();
+
+    auto rootLogicalRect = lineBox.logicalRectForRootInlineBox();
+    auto rootVisualRect = mapInlineRectLogicalToVisual(rootLogicalRect, lineBoxLogicalRect, writingMode);
+    rootVisualRect.moveBy(lineBoxVisualOffset);
+    appendRootInlineBoxDisplayBox(rootVisualRect, lineBox.rootInlineBox().hasContent(), boxes);
+
     Vector<size_t> blockLevelOutOfFlowBoxList;
-
-    appendRootInlineBoxDisplayBox(flipRootInlineBoxRectToVisualForWritingMode(lineBox.logicalRectForRootInlineBox(), writingMode), lineBox.rootInlineBox().hasContent(), boxes);
-
     auto textSpacingAdjustment = 0.f;
     for (size_t index = 0; index < lineLayoutResult.inlineContent.size(); ++index) {
         auto& lineRun = lineLayoutResult.inlineContent[index];
@@ -458,9 +462,10 @@ void InlineDisplayContentBuilder::processNonBidiContent(const LineLayoutResult& 
             ASSERT_NOT_REACHED();
             return { };
         }();
+
         auto visualRectRelativeToRoot = [&] {
-            auto visualRect = flipLogicalRectToVisualForWritingModeWithinLine(logicalRect, lineBox.logicalRect(), writingMode);
-            visualRect.moveBy(contentStartInVisualOrder);
+            auto visualRect = mapInlineRectLogicalToVisual(logicalRect, lineBoxLogicalRect, writingMode);
+            visualRect.moveBy(lineBoxVisualOffset);
             return visualRect;
         }();
 

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
@@ -64,6 +64,8 @@ private:
     size_t processRubyBase(size_t rubyBaseStart, InlineDisplay::Boxes&, Vector<WTF::Range<size_t>>& interlinearRubyColumnRangeList, Vector<size_t>& rubyBaseStartIndexListWithAnnotation);
     void processRubyContent(InlineDisplay::Boxes&, const LineLayoutResult&);
 
+    inline InlineRect mapInlineRectLogicalToVisual(const InlineRect& logicalRect, const InlineRect& containerLogicalRect, WritingMode);
+
     void setInlineBoxGeometry(const Box& inlineBox, Layout::BoxGeometry&, const InlineRect&, bool isFirstInlineBoxFragment);
     void adjustVisualGeometryForDisplayBox(size_t displayBoxNodeIndex, InlineLayoutUnit& accumulatedOffset, InlineLayoutUnit lineBoxLogicalTop, const DisplayBoxTree&, InlineDisplay::Boxes&, const UncheckedKeyHashMap<const Box*, IsFirstLastIndex>&);
     size_t ensureDisplayBoxForContainer(const ElementBox&, DisplayBoxTree&, AncestorStack&, InlineDisplay::Boxes&);
@@ -99,6 +101,46 @@ private:
     bool m_hasSeenRubyBase { false };
     bool m_hasSeenTextDecoration { false };
 };
+
+inline InlineRect InlineDisplayContentBuilder::mapInlineRectLogicalToVisual(const InlineRect& logicalRect, const InlineRect& containerLogicalRect, WritingMode writingMode)
+{
+    InlineRect visualRect = logicalRect;
+    switch (writingMode.computedWritingMode()) {
+    case StyleWritingMode::HorizontalTb:
+        return visualRect;
+
+    case StyleWritingMode::HorizontalBt:
+        visualRect.setLeft(logicalRect.left());
+        visualRect.setTop(containerLogicalRect.height() - logicalRect.bottom());
+        return visualRect;
+
+    case StyleWritingMode::VerticalRl:
+    case StyleWritingMode::SidewaysRl:
+        visualRect.setLeft(logicalRect.top());
+        visualRect.setTop(logicalRect.left());
+        visualRect.setWidth(logicalRect.height());
+        visualRect.setHeight(logicalRect.width());
+        return visualRect;
+
+    case StyleWritingMode::VerticalLr:
+        visualRect.setLeft(containerLogicalRect.height() - logicalRect.bottom());
+        visualRect.setTop(logicalRect.left());
+        visualRect.setWidth(logicalRect.height());
+        visualRect.setHeight(logicalRect.width());
+        return visualRect;
+
+    case StyleWritingMode::SidewaysLr:
+        visualRect.setLeft(logicalRect.top());
+        visualRect.setTop(containerLogicalRect.width() - logicalRect.right());
+        visualRect.setWidth(logicalRect.height());
+        visualRect.setHeight(logicalRect.width());
+        return visualRect;
+
+    default:
+        ASSERT_NOT_REACHED();
+        return visualRect;
+    }
+}
 
 }
 }

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
@@ -34,21 +34,19 @@
 namespace WebCore {
 namespace Layout {
 
-static InlineRect flipLogicalLineRectToVisualForWritingMode(const InlineRect& lineLogicalRect, WritingMode writingMode)
+static InlineRect mapLineRectLogicalToVisual(const InlineRect& lineLogicalRect, const LayoutSize containerRenderSize, WritingMode writingMode)
 {
-    switch (writingMode.blockDirection()) {
-    case FlowDirection::TopToBottom:
-    case FlowDirection::BottomToTop:
+    if (writingMode.isHorizontal())
         return lineLogicalRect;
-    case FlowDirection::LeftToRight:
-    case FlowDirection::RightToLeft:
-        // See InlineFormattingUtils for more info.
+    if (writingMode.isLogicalLeftLineLeft())
         return { lineLogicalRect.left(), lineLogicalRect.top(), lineLogicalRect.height(), lineLogicalRect.width() };
-    default:
-        ASSERT_NOT_REACHED();
-        break;
-    }
-    return lineLogicalRect;
+
+    return {
+        containerRenderSize.height() - lineLogicalRect.right(),
+        lineLogicalRect.top(),
+        lineLogicalRect.height(),
+        lineLogicalRect.width()
+    };
 }
 
 InlineDisplayLineBuilder::InlineDisplayLineBuilder(InlineFormattingContext& inlineFormattingContext, const ConstraintsForInlineContent& constraints)
@@ -141,8 +139,8 @@ InlineDisplay::Line InlineDisplayLineBuilder::build(const LineLayoutResult& line
 
     auto writingMode = root().writingMode();
     return InlineDisplay::Line { lineBoxLogicalRect
-        , flipLogicalLineRectToVisualForWritingMode(lineBoxLogicalRect, writingMode)
-        , flipLogicalLineRectToVisualForWritingMode(enclosingLineGeometry.contentOverflowRect, writingMode)
+        , mapLineRectLogicalToVisual(lineBoxLogicalRect, constraints.containerRenderSize(), writingMode)
+        , mapLineRectLogicalToVisual(enclosingLineGeometry.contentOverflowRect, constraints.containerRenderSize(), writingMode)
         , enclosingLineGeometry.enclosingTopAndBottom
         , rootInlineBox.logicalTop() + rootInlineBox.ascent()
         , lineBox.baselineType()

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -432,7 +432,7 @@ Layout::ConstraintsForInlineContent BoxGeometryUpdater::formattingContextConstra
 
     if (rootRenderer.isRenderSVGText()) {
         auto horizontalConstraints = Layout::HorizontalConstraints { 0_lu, LayoutUnit::max() };
-        return { { horizontalConstraints, 0_lu }, 0_lu };
+        return { { horizontalConstraints, 0_lu }, 0_lu, rootRenderer.size() };
     }
 
     auto padding = logicalPadding(rootRenderer, availableWidth, writingMode);
@@ -459,7 +459,7 @@ Layout::ConstraintsForInlineContent BoxGeometryUpdater::formattingContextConstra
         ? border.horizontal.end + scrollbarSize.width() + padding.horizontal.end
         : contentBoxLeft;
 
-    return { { horizontalConstraints, contentBoxTop }, visualLeft };
+    return { { horizontalConstraints, contentBoxTop }, visualLeft, rootRenderer.size() };
 }
 
 void BoxGeometryUpdater::updateBoxGeometryAfterIntegrationLayout(const Layout::ElementBox& layoutBox, LayoutUnit availableWidth)

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -503,7 +503,7 @@ std::optional<LayoutRect> LineLayout::layout()
             return *m_inlineContentConstraints;
         }
         auto constraintsForInFlowContent = Layout::ConstraintsForInFlowContent { m_inlineContentConstraints->horizontal(), m_lineDamage->layoutStartPosition()->partialContentTop };
-        return { constraintsForInFlowContent, m_inlineContentConstraints->visualLeft() };
+        return { constraintsForInFlowContent, m_inlineContentConstraints->visualLeft(), m_inlineContentConstraints->containerRenderSize() };
     };
 
     auto parentBlockLayoutState = Layout::BlockLayoutState {


### PR DESCRIPTION
#### 9963f7fab8f9156a29f96c55da97e46f29178040
<pre>
Convert (non-bidi) inline content coordinates for writing-mode: sideways-lr
<a href="https://bugs.webkit.org/show_bug.cgi?id=285222">https://bugs.webkit.org/show_bug.cgi?id=285222</a>
<a href="https://rdar.apple.com/142128843">rdar://142128843</a>

Reviewed by Alan Baradlay.

Defines mapping functions for writing-mode: sideways-lr and uses them
to convert logical to RenderBox coordinates for non-bidi inline content.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-002-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-002.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingConstraints.h:
(WebCore::Layout::ConstraintsForInlineContent::containerRenderSize const):
(WebCore::Layout::ConstraintsForInlineContent::ConstraintsForInlineContent):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::processNonBidiContent):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h:
(WebCore::Layout::InlineDisplayContentBuilder::mapInlineRectLogicalToVisual):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp:
(WebCore::Layout::mapLineRectLogicalToVisual):
(WebCore::Layout::InlineDisplayLineBuilder::build const):
(WebCore::Layout::flipLogicalLineRectToVisualForWritingMode): Deleted.
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::BoxGeometryUpdater::formattingContextConstraints):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::layout):

Canonical link: <a href="https://commits.webkit.org/288381@main">https://commits.webkit.org/288381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f568ecd854779d34d0bd0a17824794eb56432dc4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82965 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/2609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37259 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/34014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85058 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/2684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/10529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/88077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/34014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86021 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/2684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/75446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/2684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/29639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/33048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/2684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/30323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/89443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/10250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/10529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/89443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/10478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/71254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/89443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12829 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/10203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/15715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/10075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/13540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/11843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->