### PR TITLE
Convert coordinates properly for floats in writing-mode: sideways-lr

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-003-expected.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<title>Reference for Sideways Inline Layout: Float Wrapping</title>
+<meta charset=utf-8>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body > div {
+  /* styling */
+  border: solid black;
+  font: 10px/1 Ahem;
+  float: left;
+  color: silver;
+  width: 5em;
+  height: 8em;
+  margin: 2px 4px 6px 8px;
+  padding: 2px 4px 6px 8px;
+}
+.wrapper {
+  width: 8em;
+  height: 5em;
+  text-align: right;
+}
+.lr .wrapper {
+  transform: rotate(-90deg) translate(-1.5em, -1.5em);
+}
+.rl .wrapper {
+  transform: rotate(90deg) translate(1.5em, 1.5em);
+}
+.float {
+  border: solid orange 8px;
+  float: right;
+}
+.lr .float {
+  margin: 8px 2px 4px 6px;
+}
+.rl .float {
+  margin: 4px 6px 8px 2px;
+}
+</style>
+
+<div class="lr">
+  <div class="wrapper">
+    <div class="float"></div>
+    x xx xxx <u>xxxx</u> xxx xx x
+  </div>
+</div>
+
+<div class="rl">
+  <div class="wrapper">
+    <div class="float"></div>
+    x xx xxx <u>xxxx</u> xxx xx x
+  </div>
+</div>
+
+<div class="lr">
+  <div class="wrapper">
+    <div class="float"></div>
+    x xx xxx <u>xxxx</u> xxx xx x
+  </div>
+</div>
+
+<div class="rl">
+  <div class="wrapper">
+    <div class="float"></div>
+    x xx xxx <u>xxxx</u> xxx xx x
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-003-ref.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<title>Reference for Sideways Inline Layout: Float Wrapping</title>
+<meta charset=utf-8>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body > div {
+  /* styling */
+  border: solid black;
+  font: 10px/1 Ahem;
+  float: left;
+  color: silver;
+  width: 5em;
+  height: 8em;
+  margin: 2px 4px 6px 8px;
+  padding: 2px 4px 6px 8px;
+}
+.wrapper {
+  width: 8em;
+  height: 5em;
+  text-align: right;
+}
+.lr .wrapper {
+  transform: rotate(-90deg) translate(-1.5em, -1.5em);
+}
+.rl .wrapper {
+  transform: rotate(90deg) translate(1.5em, 1.5em);
+}
+.float {
+  border: solid orange 8px;
+  float: right;
+}
+.lr .float {
+  margin: 8px 2px 4px 6px;
+}
+.rl .float {
+  margin: 4px 6px 8px 2px;
+}
+</style>
+
+<div class="lr">
+  <div class="wrapper">
+    <div class="float"></div>
+    x xx xxx <u>xxxx</u> xxx xx x
+  </div>
+</div>
+
+<div class="rl">
+  <div class="wrapper">
+    <div class="float"></div>
+    x xx xxx <u>xxxx</u> xxx xx x
+  </div>
+</div>
+
+<div class="lr">
+  <div class="wrapper">
+    <div class="float"></div>
+    x xx xxx <u>xxxx</u> xxx xx x
+  </div>
+</div>
+
+<div class="rl">
+  <div class="wrapper">
+    <div class="float"></div>
+    x xx xxx <u>xxxx</u> xxx xx x
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-003.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<title>Sideways Inline Layout: Float Wrapping</title>
+<meta charset=utf-8>
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#block-flow">
+
+<link rel="match" href="sideways-inline-003-ref.html">
+
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body > div {
+  /* styling */
+  border: solid black;
+  font: 10px/1 Ahem;
+  float: left;
+  color: silver;
+  width: 5em;
+
+  /* test */
+  padding: 2px 4px 6px 8px;
+  margin: 2px 4px 6px 8px;
+  height: 8em;
+  text-align: right;
+}
+.lr {
+  writing-mode: sideways-lr;
+}
+.rl {
+  writing-mode: sideways-rl;
+}
+.float {
+  border: solid orange 8px;
+  margin: 2px 4px 6px 8px;
+  float: right;
+}
+</style>
+
+<div class="lr">
+  x xx <div class="float"></div> xxx <u>xxxx</u> xxx xx x
+</div>
+
+<div class="rl">
+  x xx <div class="float"></div> xxx <u>xxxx</u> xxx xx x
+</div>
+
+<div class="lr">
+  <div class="float"></div>
+  <div>x xx xxx <u>xxxx</u> xxx xx x</div>
+</div>
+
+<div class="rl">
+  <div class="float"></div>
+  <di>x xx xxx <u>xxxx</u> xxx xx x</div>
+</div>


### PR DESCRIPTION
#### 7ec5fd966ea9fb4de524645666d6dbafcbaa0cea
<pre>
Convert coordinates properly for floats in writing-mode: sideways-lr
<a href="https://bugs.webkit.org/show_bug.cgi?id=285276">https://bugs.webkit.org/show_bug.cgi?id=285276</a>
<a href="https://rdar.apple.com/142227732">rdar://142227732</a>

Reviewed by Alan Baradlay.

Updates preparePlacedFloats to convert external floats to logical coordinates,
and toMarginAndBorderBoxVisualRect to convert logical coordinates out to
RenderBox coordinates in sideways-lr mode.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-003-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-003.html: Added.
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::toMarginAndBorderBoxVisualRect):
(WebCore::LayoutIntegration::LineLayout::updateRenderTreePositions):
(WebCore::LayoutIntegration::LineLayout::preparePlacedFloats):

Canonical link: <a href="https://commits.webkit.org/288382@main">https://commits.webkit.org/288382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e39ba38d1419272b4d426ef1b4c236ca66eec85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82970 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/2613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/37263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/34018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85062 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/2688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/10533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/88081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/34018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86025 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/2688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/37263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/2688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/37263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/33052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/2688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/37263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/89447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/10254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/10533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/89447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/10482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/37263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/89447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/37263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12830 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/10207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/15719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/10079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/13544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/11847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->