### PR TITLE
[GStreamer][GL] Video frame conversion handling

### DIFF
--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1465,6 +1465,8 @@ webkit.org/b/266577 webgl/2.0.0/conformance2/textures/video/tex-3d-rgba8-rgba-un
 
 webkit.org/b/266671 http/wpt/webcodecs/videoFrame-rect.html [ Failure ]
 
+webkit.org/b/285298 imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource.html [ Failure ]
+
 # [WPE] Missing implementation of TestController::setHidden()
 webkit.org/b/268470 fast/mediastream/device-change-event-2.html [ Timeout ]
 

--- a/Source/WebCore/platform/SourcesGStreamer.txt
+++ b/Source/WebCore/platform/SourcesGStreamer.txt
@@ -55,6 +55,7 @@ platform/graphics/gstreamer/GStreamerAudioMixer.cpp
 platform/graphics/gstreamer/GStreamerCommon.cpp
 platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
 platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
+platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp
 platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
 platform/graphics/gstreamer/GstAllocatorFastMalloc.cpp
 platform/graphics/gstreamer/ImageDecoderGStreamer.cpp

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -353,6 +353,8 @@ void gstStructureFilterAndMapInPlace(GstStructure*, Function<bool(GstId, GValue*
 WARN_UNUSED_RETURN GRefPtr<GstCaps> buildDMABufCaps();
 #endif
 
+bool setGstElementGLContext(GstElement*, const char* contextType);
+
 } // namespace WebCore
 
 #ifndef GST_BUFFER_DTS_OR_PTS

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025 Igalia S.L
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "GStreamerVideoFrameConverter.h"
+
+#if USE(GSTREAMER)
+
+#include "GStreamerCommon.h"
+#include <gst/app/gstappsink.h>
+#include <gst/app/gstappsrc.h>
+#include <gst/gl/gl.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/Scope.h>
+
+namespace WebCore {
+
+GST_DEBUG_CATEGORY_STATIC(webkit_gst_video_frame_converter_debug);
+#define GST_CAT_DEFAULT webkit_gst_video_frame_converter_debug
+
+GStreamerVideoFrameConverter& GStreamerVideoFrameConverter::singleton()
+{
+    static NeverDestroyed<GStreamerVideoFrameConverter> sharedInstance;
+    return sharedInstance;
+}
+
+GStreamerVideoFrameConverter::GStreamerVideoFrameConverter()
+{
+    ensureGStreamerInitialized();
+    GST_DEBUG_CATEGORY_INIT(webkit_gst_video_frame_converter_debug, "webkitvideoframeconverter", 0, "WebKit GStreamer Video Frame Converter");
+    m_pipeline = gst_element_factory_make("pipeline", "video-frame-converter");
+    m_src = makeGStreamerElement("appsrc", nullptr);
+    auto gldownload = makeGStreamerElement("gldownload", nullptr);
+    auto videoconvert = makeGStreamerElement("videoconvert", nullptr);
+    auto videoscale = makeGStreamerElement("videoscale", nullptr);
+    m_sink = makeGStreamerElement("appsink", nullptr);
+
+    if (webkitGstCheckVersion(1, 24, 0)) {
+        g_object_set(m_sink.get(), "emit-signals", TRUE, nullptr);
+        g_signal_connect(m_sink.get(), "propose-allocation", G_CALLBACK(+[](GstElement*, GstQuery* query) -> gboolean {
+            gst_query_add_allocation_meta(query, GST_VIDEO_META_API_TYPE, nullptr);
+            return TRUE;
+        }), nullptr);
+    }
+
+    gst_bin_add_many(GST_BIN_CAST(m_pipeline.get()), m_src.get(), gldownload, videoconvert, videoscale, m_sink.get(), nullptr);
+    gst_element_link_many(m_src.get(), gldownload, videoconvert, videoscale, m_sink.get(), nullptr);
+}
+
+GRefPtr<GstSample> GStreamerVideoFrameConverter::convert(const GRefPtr<GstSample>& sample, const GRefPtr<GstCaps>& destinationCaps)
+{
+    auto inputCaps = gst_sample_get_caps(sample.get());
+    if (gst_caps_is_equal(inputCaps, destinationCaps.get()))
+        return GRefPtr(sample);
+
+    if (!setGstElementGLContext(m_sink.get(), GST_GL_DISPLAY_CONTEXT_TYPE))
+        return nullptr;
+    if (!setGstElementGLContext(m_sink.get(), "gst.gl.app_context"))
+        return nullptr;
+
+    unsigned capsSize = gst_caps_get_size(destinationCaps.get());
+    auto newCaps = adoptGRef(gst_caps_new_empty());
+    for (unsigned i = 0; i < capsSize; i++) {
+        auto structure = gst_caps_get_structure(destinationCaps.get(), i);
+        auto modifiedStructure = gst_structure_copy(structure);
+        gst_structure_remove_field(modifiedStructure, "framerate");
+        gst_caps_append_structure(newCaps.get(), modifiedStructure);
+    }
+
+    GST_TRACE_OBJECT(m_pipeline.get(), "Converting sample with caps %" GST_PTR_FORMAT " to %" GST_PTR_FORMAT, inputCaps, newCaps.get());
+    g_object_set(m_sink.get(), "caps", newCaps.get(), nullptr);
+
+    auto scopeExit = WTF::makeScopeExit([&] {
+        gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
+    });
+
+    gst_element_set_state(m_pipeline.get(), GST_STATE_PAUSED);
+    gst_app_src_push_sample(GST_APP_SRC_CAST(m_src.get()), sample.get());
+
+    auto bus = adoptGRef(gst_element_get_bus(m_pipeline.get()));
+    auto message = adoptGRef(gst_bus_timed_pop_filtered(bus.get(), GST_CLOCK_TIME_NONE, static_cast<GstMessageType>(GST_MESSAGE_ERROR | GST_MESSAGE_ASYNC_DONE)));
+    RELEASE_ASSERT(message);
+    if (GST_MESSAGE_TYPE(message.get()) == GST_MESSAGE_ERROR) {
+        GST_ERROR_OBJECT(m_pipeline.get(), "Unable to convert video frame. Error: %" GST_PTR_FORMAT, message.get());
+        return nullptr;
+    }
+
+    auto convertedSample = adoptGRef(gst_app_sink_pull_preroll(GST_APP_SINK_CAST(m_sink.get())));
+    gst_sample_set_caps(convertedSample.get(), destinationCaps.get());
+    return convertedSample;
+}
+
+#undef GST_CAT_DEFAULT
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.h
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2025 Igalia, S.L
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#pragma once
+
+#if ENABLE(VIDEO) && USE(GSTREAMER)
+
+#include "GRefPtrGStreamer.h"
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class GStreamerVideoFrameConverter {
+    friend NeverDestroyed<GStreamerVideoFrameConverter>;
+
+public:
+    static GStreamerVideoFrameConverter& singleton();
+
+    WARN_UNUSED_RETURN GRefPtr<GstSample> convert(const GRefPtr<GstSample>&, const GRefPtr<GstCaps>&);
+
+private:
+    GStreamerVideoFrameConverter();
+
+    GRefPtr<GstElement> m_pipeline;
+    GRefPtr<GstElement> m_src;
+    GRefPtr<GstElement> m_sink;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(VIDEO) && USE(GSTREAMER)


### PR DESCRIPTION
#### 38504740eae569f9f858947f78d9759862893462
<pre>
[GStreamer][GL] Video frame conversion handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=285280">https://bugs.webkit.org/show_bug.cgi?id=285280</a>

Reviewed by Xabier Rodriguez-Calvar.

This patch introduces a GStreamerVideoFrameConverter singleton that is responsible for optionally
downloading frames from the GPU and convert them to a new format. The pipeline used for this relies
on the WebKit GL context.

* Source/WebCore/platform/SourcesGStreamer.txt:
* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(webKitGLVideoSinkChangeState):
(requestGLContext): Deleted.
(setGLContext): Deleted.
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::requestGLContext):
(WebCore::setGstElementGLContext):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp: Added.
(WebCore::GStreamerVideoFrameConverter::singleton):
(WebCore::GStreamerVideoFrameConverter::GStreamerVideoFrameConverter):
(WebCore::GStreamerVideoFrameConverter::convert):
* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.h: Added.
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::convertSampleToImage):
(WebCore::VideoFrameGStreamer::createFromPixelBuffer):
(WebCore::VideoFrameGStreamer::convert):

Canonical link: <a href="https://commits.webkit.org/288686@main">https://commits.webkit.org/288686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4593177e74a36a5944f95b83dd184aef96d51691

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89132 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35065 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11643 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65379 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23220 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2810 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45672 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2750 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30599 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34114 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73700 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90512 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73834 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11546 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73047 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18074 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17342 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2669 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11274 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16746 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11122 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12894 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->