### PR TITLE
Adjust background clip when local attachment is used with non-visible overflow

### DIFF
--- a/LayoutTests/compositing/background-color/background-color-text-clip-expected.html
+++ b/LayoutTests/compositing/background-color/background-color-text-clip-expected.html
@@ -5,19 +5,13 @@
                 width: 100px;
                 height: 100px;
                 background-color: green;
-                display: block;
-                padding: 10px;                
+                padding: 10px;
                 -webkit-background-clip: text;
             }
             .blue {
                 width: 50px;
                 height: 50px;
                 background-color: blue;
-                display: block;
-            }
-
-            .composited {
-                -webkit-transform: translateZ(0);
             }
         </style>
     </head>

--- a/LayoutTests/compositing/background-color/background-color-text-clip.html
+++ b/LayoutTests/compositing/background-color/background-color-text-clip.html
@@ -6,7 +6,7 @@
                 height: 100px;
                 background-color: green;
                 display: block;
-                padding: 10px;                
+                padding: 10px;
                 -webkit-background-clip: text;
             }
             .blue {
@@ -17,7 +17,7 @@
             }
 
             .composited {
-                -webkit-transform: translateZ(0);
+                will-change: transform;
             }
         </style>
     </head>

--- a/LayoutTests/compositing/backgrounds/local-background-expected.html
+++ b/LayoutTests/compositing/backgrounds/local-background-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+div {
+    background: green local;
+    border: 50px solid rgba(0, 127, 0, 0.5);
+    overflow: scroll;
+    width: 200px;
+    height: 200px;
+}
+</style>
+<div></div>

--- a/LayoutTests/compositing/backgrounds/local-background.html
+++ b/LayoutTests/compositing/backgrounds/local-background.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+div {
+    background: green local;
+    border: 50px solid rgba(0, 127, 0, 0.5);
+    overflow: scroll;
+    will-change: transform;
+    width: 200px;
+    height: 200px;
+}
+</style>
+<div></div>

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -2,6 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2016 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -122,6 +123,8 @@ public:
     IntRect absoluteContentBox() const;
     // The content box converted to absolute coords (taking transforms into account).
     WEBCORE_EXPORT FloatQuad absoluteContentQuad() const;
+    // The clip rect of the background.
+    LayoutRect backgroundClipRect() const;
 
     // This returns the content area of the box (excluding padding and border). The only difference with contentBoxRect is that computedCSSContentBoxRect
     // does include the intrinsic padding in the content box as this is what some callers expect (like getComputedStyle).

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2016 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -3364,30 +3365,13 @@ LayoutRect RenderLayerBacking::contentsBox() const
     return contentsRect;
 }
 
-static LayoutRect backgroundRectForBox(const RenderBox& box)
-{
-    switch (box.style().backgroundClip()) {
-    case FillBox::BorderBox:
-        return box.borderBoxRect();
-    case FillBox::PaddingBox:
-        return box.paddingBoxRect();
-    case FillBox::ContentBox:
-        return box.contentBoxRect();
-    default:
-        break;
-    }
-
-    ASSERT_NOT_REACHED();
-    return { };
-}
-
 FloatRect RenderLayerBacking::backgroundBoxForSimpleContainerPainting() const
 {
     CheckedPtr box = dynamicDowncast<RenderBox>(renderer());
     if (!box)
         return FloatRect();
 
-    LayoutRect backgroundBox = backgroundRectForBox(*box);
+    LayoutRect backgroundBox = box->backgroundClipRect();
     backgroundBox.move(contentOffsetInCompositingLayer());
     return snapRectToDevicePixels(backgroundBox, deviceScaleFactor());
 }


### PR DESCRIPTION
#### 45bc0d8851b924e239cf81222796787c7a1014bf
<pre>
Adjust background clip when local attachment is used with non-visible overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=285284">https://bugs.webkit.org/show_bug.cgi?id=285284</a>
<a href="https://rdar.apple.com/problem/142245990">rdar://problem/142245990</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox, Blink / Chromium and Web Specification [1]:

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/e3a98dc7050d4e575967177edaca49742024e8c8">https://chromium.googlesource.com/chromium/src.git/+/e3a98dc7050d4e575967177edaca49742024e8c8</a>

[1] <a href="https://www.w3.org/TR/css-backgrounds-3/#the-background-attachment">https://www.w3.org/TR/css-backgrounds-3/#the-background-attachment</a>

&quot;Because the scrollable overflow area does not include the border area, for scroll containers
the border-box value of background-clip may be treated the same as padding-box.&quot;

In case of non-visible overflow, while the background attachment is local, this patch now
return `paddingBoxRect` as specified. Additionally, it remove duplication of code by consolidating
it in `backgroundClipRect` and using across `backgroundIsKnownToBeOpaqueInRect` and
`backgroundBoxForSimpleContainerPainting`.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::backgroundClipRect const):
(WebCore::RenderBox::backgroundIsKnownToBeOpaqueInRect const):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::backgroundBoxForSimpleContainerPainting const):
(WebCore::backgroundRectForBox): Deleted.
* LayoutTests/compositing/backgrounds/local-background-expected.html:
* LayoutTests/compositing/backgrounds/local-background.html:
* LayoutTests/compositing/background-color/background-color-text-clip.html: Updated to be more robust similar to Blink Source
* LayoutTests/compositing/background-color/background-color-text-clip-expected.html: Ditto
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45bc0d8851b924e239cf81222796787c7a1014bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88004 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33941 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10453 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64600 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22363 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44874 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29622 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32975 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73063 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89370 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7890 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73015 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71203 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72229 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16393 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15165 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1558 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10130 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15644 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10002 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13467 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11770 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->