### PR TITLE
Switch border/background fragmentation to accommodate sideways-lr

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-002-expected.html
@@ -24,8 +24,6 @@ img {
 }
 span.inline {
   border: solid orange;
-  box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
 }
 span.img {
   border: solid blue;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-002.html
@@ -29,8 +29,6 @@ img {
 }
 span {
   border: solid orange;
-  box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
 }
 img, span {
   margin: 2px 4px 6px 8px;

--- a/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.cpp
@@ -39,15 +39,18 @@ InlineBox::InlineBox(PathVariant&& path)
 {
 }
 
-std::pair<bool, bool> InlineBox::hasClosedLeftAndRightEdge() const
+RectEdges<bool> InlineBox::closedEdges() const
 {
     // FIXME: Layout knows the answer to this question so we should consult it.
+    RectEdges<bool> closedEdges { true };
     if (style().boxDecorationBreak() == BoxDecorationBreak::Clone)
-        return { true, true };
-    bool isLTR = style().writingMode().isBidiLTR();
+        return closedEdges;
+    auto writingMode = style().writingMode();
     bool isFirst = !previousInlineBox() && !renderer().isContinuation();
     bool isLast = !nextInlineBox() && !renderer().continuation();
-    return { isLTR ? isFirst : isLast, isLTR ? isLast : isFirst };
+    closedEdges.setStart(isFirst, writingMode);
+    closedEdges.setEnd(isLast, writingMode);
+    return closedEdges;
 };
 
 InlineBoxIterator InlineBox::nextInlineBox() const

--- a/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.h
@@ -39,7 +39,7 @@ public:
 
     const RenderBoxModelObject& renderer() const { return downcast<RenderBoxModelObject>(Box::renderer()); }
 
-    std::pair<bool, bool> hasClosedLeftAndRightEdge() const;
+    RectEdges<bool> closedEdges() const;
 
     // FIXME: Remove. For intermediate porting steps only.
     const LegacyInlineFlowBox* legacyInlineBox() const { return downcast<LegacyInlineFlowBox>(Box::legacyInlineBox()); }

--- a/Source/WebCore/platform/RectEdges.h
+++ b/Source/WebCore/platform/RectEdges.h
@@ -40,6 +40,11 @@ public:
     {
     }
 
+    RectEdges(const T& value)
+        : m_sides { value, value, value, value }
+    {
+    }
+
     RectEdges(const RectEdges&) = default;
     RectEdges& operator=(const RectEdges&) = default;
 

--- a/Source/WebCore/platform/graphics/RoundedRect.cpp
+++ b/Source/WebCore/platform/graphics/RoundedRect.cpp
@@ -104,41 +104,19 @@ void RoundedRect::inflateWithRadii(LayoutUnit amount)
     m_radii.scale(factor);
 }
 
-void RoundedRect::Radii::includeLogicalEdges(const RoundedRect::Radii& edges, bool isHorizontal, bool includeLogicalLeftEdge, bool includeLogicalRightEdge)
+void RoundedRect::Radii::setRadiiForEdges(const RoundedRect::Radii& radii, RectEdges<bool> includeEdges)
 {
-    if (includeLogicalLeftEdge) {
-        if (isHorizontal)
-            m_bottomLeft = edges.bottomLeft();
-        else
-            m_topRight = edges.topRight();
-        m_topLeft = edges.topLeft();
+    if (includeEdges.top()) {
+        if (includeEdges.left())
+            m_topLeft = radii.topLeft();
+        if (includeEdges.right())
+            m_topRight = radii.topRight();
     }
-
-    if (includeLogicalRightEdge) {
-        if (isHorizontal)
-            m_topRight = edges.topRight();
-        else
-            m_bottomLeft = edges.bottomLeft();
-        m_bottomRight = edges.bottomRight();
-    }
-}
-
-void RoundedRect::Radii::excludeLogicalEdges(bool isHorizontal, bool excludeLogicalLeftEdge, bool excludeLogicalRightEdge)
-{
-    if (excludeLogicalLeftEdge) {
-        if (isHorizontal)
-            m_bottomLeft = IntSize();
-        else
-            m_topRight = IntSize();
-        m_topLeft = IntSize();
-    }
-        
-    if (excludeLogicalRightEdge) {
-        if (isHorizontal)
-            m_topRight = IntSize();
-        else
-            m_bottomLeft = IntSize();
-        m_bottomRight = IntSize();
+    if (includeEdges.bottom()) {
+        if (includeEdges.left())
+            m_bottomLeft = radii.bottomLeft();
+        if (includeEdges.right())
+            m_bottomRight = radii.bottomRight();
     }
 }
 
@@ -185,16 +163,6 @@ RoundedRect::RoundedRect(const LayoutRect& rect, const LayoutSize& topLeft, cons
     : m_rect(rect)
     , m_radii(topLeft, topRight, bottomLeft, bottomRight)
 {
-}
-
-void RoundedRect::includeLogicalEdges(const Radii& edges, bool isHorizontal, bool includeLogicalLeftEdge, bool includeLogicalRightEdge)
-{
-    m_radii.includeLogicalEdges(edges, isHorizontal, includeLogicalLeftEdge, includeLogicalRightEdge);
-}
-
-void RoundedRect::excludeLogicalEdges(bool isHorizontal, bool excludeLogicalLeftEdge, bool excludeLogicalRightEdge)
-{
-    m_radii.excludeLogicalEdges(isHorizontal, excludeLogicalLeftEdge, excludeLogicalRightEdge);
 }
 
 bool RoundedRect::isRenderable() const

--- a/Source/WebCore/platform/graphics/RoundedRect.h
+++ b/Source/WebCore/platform/graphics/RoundedRect.h
@@ -52,14 +52,12 @@ public:
     const LayoutSize& topRight() const { return m_topRight; }
     const LayoutSize& bottomLeft() const { return m_bottomLeft; }
     const LayoutSize& bottomRight() const { return m_bottomRight; }
+    void setRadiiForEdges(const RoundedRectRadii&, RectEdges<bool> includeEdges);
 
     bool isZero() const;
 
     bool areRenderableInRect(const LayoutRect&) const;
     void makeRenderableInRect(const LayoutRect&);
-
-    void includeLogicalEdges(const RoundedRectRadii& edges, bool isHorizontal, bool includeLogicalLeftEdge, bool includeLogicalRightEdge);
-    void excludeLogicalEdges(bool isHorizontal, bool excludeLogicalLeftEdge, bool excludeLogicalRightEdge);
 
     void scale(float factor);
     void expand(LayoutUnit topWidth, LayoutUnit bottomWidth, LayoutUnit leftWidth, LayoutUnit rightWidth);
@@ -96,6 +94,7 @@ public:
 
     void setRect(const LayoutRect& rect) { m_rect = rect; }
     void setRadii(const Radii& radii) { m_radii = radii; }
+    void setRadiiForEdges(const Radii& radii, RectEdges<bool> includeEdges) { m_radii.setRadiiForEdges(radii, includeEdges); }
 
     void move(const LayoutSize& size) { m_rect.move(size); }
     void moveBy(const LayoutPoint& offset) { m_rect.moveBy(offset); }
@@ -103,9 +102,6 @@ public:
     void inflateWithRadii(LayoutUnit size);
     void expandRadii(LayoutUnit size) { m_radii.expand(size); }
     void shrinkRadii(LayoutUnit size) { m_radii.shrink(size); }
-
-    void includeLogicalEdges(const Radii& edges, bool isHorizontal, bool includeLogicalLeftEdge, bool includeLogicalRightEdge);
-    void excludeLogicalEdges(bool isHorizontal, bool excludeLogicalLeftEdge, bool excludeLogicalRightEdge);
 
     bool isRenderable() const;
     void adjustRadii();

--- a/Source/WebCore/rendering/BackgroundPainter.h
+++ b/Source/WebCore/rendering/BackgroundPainter.h
@@ -73,7 +73,7 @@ public:
     void paintFillLayers(const Color&, const FillLayer&, const LayoutRect&, BleedAvoidance, CompositeOperator, RenderElement* backgroundObject = nullptr) const;
     void paintFillLayer(const Color&, const FillLayer&, const LayoutRect&, BleedAvoidance, const InlineIterator::InlineBoxIterator&, const LayoutRect& backgroundImageStrip = { }, CompositeOperator = CompositeOperator::SourceOver, RenderElement* backgroundObject = nullptr, BaseBackgroundColorUsage = BaseBackgroundColorUse) const;
 
-    void paintBoxShadow(const LayoutRect&, const RenderStyle&, ShadowStyle, bool includeLogicalLeftEdge = true, bool includeLogicalRightEdge = true) const;
+    void paintBoxShadow(const LayoutRect&, const RenderStyle&, ShadowStyle, RectEdges<bool> closedEdges = { true, true, true, true }) const;
 
     static bool paintsOwnBackground(const RenderBoxModelObject&);
     static BackgroundImageGeometry calculateBackgroundImageGeometry(const RenderBoxModelObject&, const RenderLayerModelObject* paintContainer, const FillLayer&, const LayoutPoint& paintOffset, const LayoutRect& borderBoxRect, std::optional<FillBox> overrideOrigin = std::nullopt);

--- a/Source/WebCore/rendering/BorderEdge.cpp
+++ b/Source/WebCore/rendering/BorderEdge.cpp
@@ -46,20 +46,18 @@ BorderEdge::BorderEdge(float edgeWidth, Color edgeColor, BorderStyle edgeStyle, 
     m_flooredToDevicePixelWidth = floorf(edgeWidth * devicePixelRatio) / devicePixelRatio;
 }
 
-BorderEdges borderEdges(const RenderStyle& style, float deviceScaleFactor, bool setColorsToBlack, bool includeLogicalLeftEdge, bool includeLogicalRightEdge)
+BorderEdges borderEdges(const RenderStyle& style, float deviceScaleFactor, RectEdges<bool> closedEdges, bool setColorsToBlack)
 {
-    bool horizontal = style.writingMode().isHorizontal();
-
     auto constructBorderEdge = [&](float width, CSSPropertyID borderColorProperty, BorderStyle borderStyle, bool isTransparent, bool isPresent) {
         auto color = setColorsToBlack ? Color::black : style.visitedDependentColorWithColorFilter(borderColorProperty);
         return BorderEdge(width, color, borderStyle, !setColorsToBlack && isTransparent, isPresent, deviceScaleFactor);
     };
 
     return {
-        constructBorderEdge(style.borderTopWidth(), CSSPropertyBorderTopColor, style.borderTopStyle(), style.borderTopIsTransparent(), horizontal || includeLogicalLeftEdge),
-        constructBorderEdge(style.borderRightWidth(), CSSPropertyBorderRightColor, style.borderRightStyle(), style.borderRightIsTransparent(), !horizontal || includeLogicalRightEdge),
-        constructBorderEdge(style.borderBottomWidth(), CSSPropertyBorderBottomColor, style.borderBottomStyle(), style.borderBottomIsTransparent(), horizontal || includeLogicalRightEdge),
-        constructBorderEdge(style.borderLeftWidth(), CSSPropertyBorderLeftColor, style.borderLeftStyle(), style.borderLeftIsTransparent(), !horizontal || includeLogicalLeftEdge)
+        constructBorderEdge(style.borderTopWidth(), CSSPropertyBorderTopColor, style.borderTopStyle(), style.borderTopIsTransparent(), closedEdges.top()),
+        constructBorderEdge(style.borderRightWidth(), CSSPropertyBorderRightColor, style.borderRightStyle(), style.borderRightIsTransparent(), closedEdges.right()),
+        constructBorderEdge(style.borderBottomWidth(), CSSPropertyBorderBottomColor, style.borderBottomStyle(), style.borderBottomIsTransparent(), closedEdges.bottom()),
+        constructBorderEdge(style.borderLeftWidth(), CSSPropertyBorderLeftColor, style.borderLeftStyle(), style.borderLeftIsTransparent(), closedEdges.left())
     };
 }
 

--- a/Source/WebCore/rendering/BorderEdge.h
+++ b/Source/WebCore/rendering/BorderEdge.h
@@ -67,7 +67,7 @@ private:
 };
 
 using BorderEdges = RectEdges<BorderEdge>;
-BorderEdges borderEdges(const RenderStyle&, float deviceScaleFactor, bool setColorsToBlack = false, bool includeLogicalLeftEdge = true, bool includeLogicalRightEdge = true);
+BorderEdges borderEdges(const RenderStyle&, float deviceScaleFactor, RectEdges<bool> closedEdges = { true }, bool setColorsToBlack = false);
 BorderEdges borderEdgesForOutline(const RenderStyle&, float deviceScaleFactor);
 
 inline bool edgesShareColor(const BorderEdge& firstEdge, const BorderEdge& secondEdge) { return firstEdge.color() == secondEdge.color(); }

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -130,10 +130,8 @@ struct BorderPainter::Sides {
     const BorderEdges& edges;
     bool haveAllSolidEdges { true };
     BleedAvoidance bleedAvoidance { BleedAvoidance::None };
-    bool includeLogicalLeftEdge { true };
-    bool includeLogicalRightEdge { true };
+    RectEdges<bool> closedEdges = { true };
     bool appliedClipAlready { false };
-    bool isHorizontal { true };
 };
 
 BorderPainter::BorderPainter(const RenderElement& renderer, const PaintInfo& paintInfo)
@@ -173,13 +171,13 @@ bool BorderPainter::allCornersClippedOut(const RoundedRect& border, const Layout
     return true;
 }
 
-std::optional<Path> BorderPainter::pathForBorderArea(const LayoutRect& rect, const RenderStyle& style, float deviceScaleFactor, bool includeLogicalLeftEdge, bool includeLogicalRightEdge)
+std::optional<Path> BorderPainter::pathForBorderArea(const LayoutRect& rect, const RenderStyle& style, float deviceScaleFactor, RectEdges<bool> closedEdges)
 {
-    auto edges = borderEdges(style, deviceScaleFactor, includeLogicalLeftEdge, includeLogicalRightEdge);
+    auto edges = borderEdges(style, deviceScaleFactor, closedEdges);
     if (!decorationHasAllSimpleEdges(edges))
         return std::nullopt;
 
-    auto borderShape = BorderShape::shapeForBorderRect(style, rect, includeLogicalLeftEdge, includeLogicalRightEdge);
+    auto borderShape = BorderShape::shapeForBorderRect(style, rect, closedEdges);
     return borderShape.pathForBorderArea(deviceScaleFactor);
 }
 
@@ -229,7 +227,7 @@ static bool decorationHasAllSolidEdges(const RectEdges<BorderEdge>& edges)
     return true;
 }
 
-void BorderPainter::paintBorder(const LayoutRect& rect, const RenderStyle& style, BleedAvoidance bleedAvoidance, bool includeLogicalLeftEdge, bool includeLogicalRightEdge) const
+void BorderPainter::paintBorder(const LayoutRect& rect, const RenderStyle& style, BleedAvoidance bleedAvoidance, RectEdges<bool> closedEdges) const
 {
     GraphicsContext& graphicsContext = m_paintInfo.context();
 
@@ -265,7 +263,7 @@ void BorderPainter::paintBorder(const LayoutRect& rect, const RenderStyle& style
     if (paintNinePieceImage(rect, style, style.borderImage()))
         return;
 
-    auto borderShape = BorderShape::shapeForBorderRect(style, rect, includeLogicalLeftEdge, includeLogicalRightEdge);
+    auto borderShape = BorderShape::shapeForBorderRect(style, rect, closedEdges);
 
     // To handle corner styles other than `round`, we'll have to plumb the borderShape through all the border painting functions.
     auto outerBorder = borderShape.deprecatedRoundedRect();
@@ -279,13 +277,13 @@ void BorderPainter::paintBorder(const LayoutRect& rect, const RenderStyle& style
         break;
     case BleedAvoidance::BackgroundOverBorder: {
         auto shrunkBorderRect = borderRectAdjustedForBleedAvoidance(rect, bleedAvoidance);
-        auto shrunkBorderShape = BorderShape::shapeForBorderRect(style, shrunkBorderRect, includeLogicalLeftEdge, includeLogicalRightEdge);
+        auto shrunkBorderShape = BorderShape::shapeForBorderRect(style, shrunkBorderRect, closedEdges);
         innerBorder = shrunkBorderShape.deprecatedInnerRoundedRect();
         break;
     }
     }
 
-    auto edges = borderEdges(style, document().deviceScaleFactor(), m_paintInfo.paintBehavior.contains(PaintBehavior::ForceBlackBorder), includeLogicalLeftEdge, includeLogicalRightEdge);
+    auto edges = borderEdges(style, document().deviceScaleFactor(), closedEdges, m_paintInfo.paintBehavior.contains(PaintBehavior::ForceBlackBorder));
     bool haveAllSolidEdges = decorationHasAllSolidEdges(edges);
 
     if (haveAllSolidEdges && outerBorder.isRounded() && allCornersClippedOut(outerBorder, m_paintInfo.rect))
@@ -299,10 +297,8 @@ void BorderPainter::paintBorder(const LayoutRect& rect, const RenderStyle& style
         edges,
         haveAllSolidEdges,
         bleedAvoidance,
-        includeLogicalLeftEdge,
-        includeLogicalRightEdge,
+        closedEdges,
         appliedClipAlready,
-        style.writingMode().isHorizontal()
     });
 }
 
@@ -334,10 +330,7 @@ void BorderPainter::paintOutline(const LayoutRect& paintRect) const
     if (outer.isEmpty())
         return;
 
-    auto isHorizontal = styleToUse.writingMode().isHorizontal();
     auto hasBorderRadius = styleToUse.hasBorderRadius();
-    auto includeLogicalLeftEdge = true;
-    auto includeLogicalRightEdge = true;
     auto roundedBorderRectFor = [&] (auto& borderRect, auto borderOffset) {
         auto adjustedRadius = [&] (auto& radius, auto offset) {
             auto widthValue = radius.width.isAuto() ? 0 : intValueForLength(radius.width, paintRect.width());
@@ -358,7 +351,7 @@ void BorderPainter::paintOutline(const LayoutRect& paintRect) const
                 adjustedRadius(styleToUse.borderBottomRightRadius(), borderOffset)
             };
         }
-        return RenderStyle::getRoundedInnerBorderFor(borderRect, { }, { }, { }, { }, borderRadii, isHorizontal, includeLogicalLeftEdge, includeLogicalRightEdge);
+        return RenderStyle::getRoundedInnerBorderFor(borderRect, { }, { }, { }, { }, borderRadii, { true });
     };
     auto innerRectForOutline = paintRect;
     innerRectForOutline.inflate(outlineOffset);
@@ -377,10 +370,8 @@ void BorderPainter::paintOutline(const LayoutRect& paintRect) const
         edges,
         haveAllSolidEdges,
         bleedAvoidance,
-        includeLogicalLeftEdge,
-        includeLogicalRightEdge,
+        { true },
         appliedClipAlready,
-        isHorizontal
     });
 }
 
@@ -577,9 +568,9 @@ void BorderPainter::paintSides(const Sides& sides) const
     bool antialias = shouldAntialiasLines(graphicsContext) || numEdgesVisible == 1;
     IntPoint innerBorderAdjustment(sides.innerBorder.rect().x() - sides.unadjustedInnerBorder.rect().x(), sides.innerBorder.rect().y() - sides.unadjustedInnerBorder.rect().y());
     if (haveAlphaColor)
-        paintTranslucentBorderSides(sides.outerBorder, sides.unadjustedInnerBorder, innerBorderAdjustment, sides.edges, edgesToDraw, sides.radii, sides.bleedAvoidance, sides.includeLogicalLeftEdge, sides.includeLogicalRightEdge, antialias, sides.isHorizontal);
+        paintTranslucentBorderSides(sides.outerBorder, sides.unadjustedInnerBorder, innerBorderAdjustment, sides.edges, edgesToDraw, sides.radii, sides.bleedAvoidance, sides.closedEdges, antialias);
     else
-        paintBorderSides(sides.outerBorder, sides.unadjustedInnerBorder, innerBorderAdjustment, sides.edges, edgesToDraw, sides.radii, sides.bleedAvoidance, sides.includeLogicalLeftEdge, sides.includeLogicalRightEdge, antialias, sides.isHorizontal);
+        paintBorderSides(sides.outerBorder, sides.unadjustedInnerBorder, innerBorderAdjustment, sides.edges, edgesToDraw, sides.radii, sides.bleedAvoidance, sides.closedEdges, antialias);
 }
 
 bool BorderPainter::paintNinePieceImage(const LayoutRect& rect, const RenderStyle& style, const NinePieceImage& ninePieceImage, CompositeOperator op) const
@@ -616,7 +607,7 @@ bool BorderPainter::paintNinePieceImage(const LayoutRect& rect, const RenderStyl
 }
 
 void BorderPainter::paintTranslucentBorderSides(const RoundedRect& outerBorder, const RoundedRect& innerBorder, const IntPoint& innerBorderAdjustment,
-    const BorderEdges& edges, BoxSideSet edgesToDraw, std::optional<BorderData::Radii> radii, BleedAvoidance bleedAvoidance, bool includeLogicalLeftEdge, bool includeLogicalRightEdge, bool antialias, bool isHorizontal) const
+    const BorderEdges& edges, BoxSideSet edgesToDraw, std::optional<BorderData::Radii> radii, BleedAvoidance bleedAvoidance, RectEdges<bool> closedEdges, bool antialias) const
 {
     // willBeOverdrawn assumes that we draw in order: top, bottom, left, right.
     // This is different from BoxSide enum order.
@@ -649,7 +640,7 @@ void BorderPainter::paintTranslucentBorderSides(const RoundedRect& outerBorder, 
             commonColor = commonColor.opaqueColor();
         }
 
-        paintBorderSides(outerBorder, innerBorder, innerBorderAdjustment, edges, commonColorEdgeSet, radii, bleedAvoidance, includeLogicalLeftEdge, includeLogicalRightEdge, antialias, isHorizontal, &commonColor);
+        paintBorderSides(outerBorder, innerBorder, innerBorderAdjustment, edges, commonColorEdgeSet, radii, bleedAvoidance, closedEdges, antialias, &commonColor);
 
         if (useTransparencyLayer)
             m_paintInfo.context().endTransparencyLayer();
@@ -773,8 +764,7 @@ static bool joinRequiresMitre(BoxSide side, BoxSide adjacentSide, const BorderEd
 }
 
 void BorderPainter::paintBorderSides(const RoundedRect& outerBorder, const RoundedRect& innerBorder,
-    const IntPoint& innerBorderAdjustment, const BorderEdges& edges, BoxSideSet edgeSet, std::optional<BorderData::Radii> radii, BleedAvoidance bleedAvoidance,
-    bool includeLogicalLeftEdge, bool includeLogicalRightEdge, bool antialias, bool isHorizontal, const Color* overrideColor) const
+    const IntPoint& innerBorderAdjustment, const BorderEdges& edges, BoxSideSet edgeSet, std::optional<BorderData::Radii> radii, BleedAvoidance bleedAvoidance, RectEdges<bool> closedEdges, bool antialias, const Color* overrideColor) const
 {
     bool renderRadii = outerBorder.isRounded();
 
@@ -820,7 +810,7 @@ void BorderPainter::paintBorderSides(const RoundedRect& outerBorder, const Round
         }
 
         bool usePath = renderRadii && (borderStyleHasInnerDetail(edge.style()) || borderWillArcInnerEdge(firstRadius, secondRadius));
-        paintOneBorderSide(outerBorder, innerBorder, sideRect, side, adjacentSide1, adjacentSide2, edges, radii, usePath ? &roundedPath : nullptr, bleedAvoidance, includeLogicalLeftEdge, includeLogicalRightEdge, antialias, isHorizontal, overrideColor);
+        paintOneBorderSide(outerBorder, innerBorder, sideRect, side, adjacentSide1, adjacentSide2, edges, radii, usePath ? &roundedPath : nullptr, bleedAvoidance, closedEdges, antialias, overrideColor);
     };
 
     paintOneSide(BoxSide::Top, BoxSide::Left, BoxSide::Right);
@@ -831,7 +821,7 @@ void BorderPainter::paintBorderSides(const RoundedRect& outerBorder, const Round
 
 void BorderPainter::paintOneBorderSide(const RoundedRect& outerBorder, const RoundedRect& innerBorder,
     const LayoutRect& sideRect, BoxSide side, BoxSide adjacentSide1, BoxSide adjacentSide2, const BorderEdges& edges, std::optional<BorderData::Radii> radii, const Path* path,
-    BleedAvoidance bleedAvoidance, bool includeLogicalLeftEdge, bool includeLogicalRightEdge, bool antialias, bool isHorizontal, const Color* overrideColor) const
+    BleedAvoidance bleedAvoidance, RectEdges<bool> closedEdges, bool antialias, const Color* overrideColor) const
 {
     auto& edgeToRender = edges.at(side);
     ASSERT(edgeToRender.widthForPainting());
@@ -855,7 +845,7 @@ void BorderPainter::paintOneBorderSide(const RoundedRect& outerBorder, const Rou
 
         float thickness = std::max(std::max(edgeToRender.widthForPainting(), adjacentEdge1.widthForPainting()), adjacentEdge2.widthForPainting());
         drawBoxSideFromPath(outerBorder.rect(), *path, edges, radii, edgeToRender.widthForPainting(), thickness, side,
-            colorToPaint, edgeToRender.style(), bleedAvoidance, includeLogicalLeftEdge, includeLogicalRightEdge, isHorizontal);
+            colorToPaint, edgeToRender.style(), bleedAvoidance, closedEdges);
     } else {
         bool clipForStyle = styleRequiresClipPolygon(edgeToRender.style()) && (mitreAdjacentSide1 || mitreAdjacentSide2);
         bool clipAdjacentSide1 = colorNeedsAntiAliasAtCorner(side, adjacentSide1, edges) && mitreAdjacentSide1;
@@ -876,8 +866,7 @@ void BorderPainter::paintOneBorderSide(const RoundedRect& outerBorder, const Rou
 }
 
 void BorderPainter::drawBoxSideFromPath(const LayoutRect& borderRect, const Path& borderPath, const BorderEdges& edges,
-    std::optional<BorderData::Radii> radii, float thickness, float drawThickness, BoxSide side, Color color, BorderStyle borderStyle, BleedAvoidance bleedAvoidance,
-    bool includeLogicalLeftEdge, bool includeLogicalRightEdge, bool isHorizontal) const
+    std::optional<BorderData::Radii> radii, float thickness, float drawThickness, BoxSide side, Color color, BorderStyle borderStyle, BleedAvoidance bleedAvoidance, RectEdges<bool> closedEdges) const
 {
     if (thickness <= 0)
         return;
@@ -953,11 +942,10 @@ void BorderPainter::drawBoxSideFromPath(const LayoutRect& borderRect, const Path
             GraphicsContextStateSaver stateSaver(graphicsContext);
             auto innerClip = RenderStyle::getRoundedInnerBorderFor(borderRect,
                 innerBorderTopWidth, innerBorderBottomWidth, innerBorderLeftWidth, innerBorderRightWidth,
-                radii, isHorizontal,
-                includeLogicalLeftEdge, includeLogicalRightEdge);
+                radii, closedEdges);
 
             graphicsContext.clipRoundedRect(FloatRoundedRect(innerClip));
-            drawBoxSideFromPath(borderRect, borderPath, edges, radii, thickness, drawThickness, side, color, BorderStyle::Solid, bleedAvoidance, includeLogicalLeftEdge, includeLogicalRightEdge, isHorizontal);
+            drawBoxSideFromPath(borderRect, borderPath, edges, radii, thickness, drawThickness, side, color, BorderStyle::Solid, bleedAvoidance, closedEdges);
         }
 
         // Draw outer border line
@@ -974,10 +962,9 @@ void BorderPainter::drawBoxSideFromPath(const LayoutRect& borderRect, const Path
 
             auto outerClip = RenderStyle::getRoundedInnerBorderFor(outerRect,
                 outerBorderTopWidth, outerBorderBottomWidth, outerBorderLeftWidth, outerBorderRightWidth,
-                radii, isHorizontal,
-                includeLogicalLeftEdge, includeLogicalRightEdge);
+                radii, closedEdges);
             graphicsContext.clipOutRoundedRect(FloatRoundedRect(outerClip));
-            drawBoxSideFromPath(borderRect, borderPath, edges, radii,  thickness, drawThickness, side, color, BorderStyle::Solid, bleedAvoidance, includeLogicalLeftEdge, includeLogicalRightEdge, isHorizontal);
+            drawBoxSideFromPath(borderRect, borderPath, edges, radii,  thickness, drawThickness, side, color, BorderStyle::Solid, bleedAvoidance, closedEdges);
         }
         return;
     }
@@ -995,7 +982,7 @@ void BorderPainter::drawBoxSideFromPath(const LayoutRect& borderRect, const Path
         }
 
         // Paint full border
-        drawBoxSideFromPath(borderRect, borderPath, edges, radii,  thickness, drawThickness, side, color, s1, bleedAvoidance, includeLogicalLeftEdge, includeLogicalRightEdge, isHorizontal);
+        drawBoxSideFromPath(borderRect, borderPath, edges, radii,  thickness, drawThickness, side, color, s1, bleedAvoidance, closedEdges);
 
         // Paint inner only
         GraphicsContextStateSaver stateSaver(graphicsContext);
@@ -1006,11 +993,10 @@ void BorderPainter::drawBoxSideFromPath(const LayoutRect& borderRect, const Path
 
         auto clipRect = RenderStyle::getRoundedInnerBorderFor(borderRect,
             topWidth, bottomWidth, leftWidth, rightWidth,
-            radii, isHorizontal,
-            includeLogicalLeftEdge, includeLogicalRightEdge);
+            radii, closedEdges);
 
         graphicsContext.clipRoundedRect(FloatRoundedRect(clipRect));
-        drawBoxSideFromPath(borderRect, borderPath, edges, radii,  thickness, drawThickness, side, color, s2, bleedAvoidance, includeLogicalLeftEdge, includeLogicalRightEdge, isHorizontal);
+        drawBoxSideFromPath(borderRect, borderPath, edges, radii,  thickness, drawThickness, side, color, s2, bleedAvoidance, closedEdges);
         return;
     }
     case BorderStyle::Inset:

--- a/Source/WebCore/rendering/BorderPainter.h
+++ b/Source/WebCore/rendering/BorderPainter.h
@@ -32,14 +32,14 @@ class BorderPainter {
 public:
     BorderPainter(const RenderElement&, const PaintInfo&);
 
-    void paintBorder(const LayoutRect&, const RenderStyle&, BleedAvoidance = BleedAvoidance::None, bool includeLogicalLeftEdge = true, bool includeLogicalRightEdge = true) const;
+    void paintBorder(const LayoutRect&, const RenderStyle&, BleedAvoidance = BleedAvoidance::None, RectEdges<bool> closedEdges = { true }) const;
     void paintOutline(const LayoutRect&) const;
     void paintOutline(const LayoutPoint& paintOffset, const Vector<LayoutRect>& lineRects) const;
 
     bool paintNinePieceImage(const LayoutRect&, const RenderStyle&, const NinePieceImage&, CompositeOperator = CompositeOperator::SourceOver) const;
     static void drawLineForBoxSide(GraphicsContext&, const Document&, const FloatRect&, BoxSide, Color, BorderStyle, float adjacentWidth1, float adjacentWidth2, bool antialias = false);
 
-    static std::optional<Path> pathForBorderArea(const LayoutRect&, const RenderStyle&, float deviceScaleFactor, bool includeLogicalLeftEdge = true, bool includeLogicalRightEdge = true);
+    static std::optional<Path> pathForBorderArea(const LayoutRect&, const RenderStyle&, float deviceScaleFactor, RectEdges<bool> closedEdges = { true });
 
     static bool allCornersClippedOut(const RoundedRect&, const LayoutRect&);
     static bool shouldAntialiasLines(GraphicsContext&);
@@ -49,11 +49,11 @@ private:
     void paintSides(const Sides&) const;
 
     void paintTranslucentBorderSides(const RoundedRect& outerBorder, const RoundedRect& innerBorder, const IntPoint& innerBorderAdjustment,
-        const BorderEdges&, BoxSideSet edgesToDraw, std::optional<BorderDataRadii>, BleedAvoidance, bool includeLogicalLeftEdge, bool includeLogicalRightEdge, bool antialias, bool isHorizontal) const;
-    void paintBorderSides(const RoundedRect& outerBorder, const RoundedRect& innerBorder, const IntPoint& innerBorderAdjustment, const BorderEdges&, BoxSideSet edgeSet, std::optional<BorderDataRadii>, BleedAvoidance, bool includeLogicalLeftEdge, bool includeLogicalRightEdge, bool antialias, bool isHorizontal, const Color* overrideColor = nullptr) const;
+        const BorderEdges&, BoxSideSet edgesToDraw, std::optional<BorderDataRadii>, BleedAvoidance, RectEdges<bool> closedEdges, bool antialias) const;
+    void paintBorderSides(const RoundedRect& outerBorder, const RoundedRect& innerBorder, const IntPoint& innerBorderAdjustment, const BorderEdges&, BoxSideSet edgeSet, std::optional<BorderDataRadii>, BleedAvoidance, RectEdges<bool> closedEdges, bool antialias, const Color* overrideColor = nullptr) const;
     void paintOneBorderSide(const RoundedRect& outerBorder, const RoundedRect& innerBorder,
-        const LayoutRect& sideRect, BoxSide, BoxSide adjacentSide1, BoxSide adjacentSide2, const BorderEdges&, std::optional<BorderDataRadii>, const Path*, BleedAvoidance, bool includeLogicalLeftEdge, bool includeLogicalRightEdge, bool antialias, bool isHorizontal, const Color* overrideColor) const;
-    void drawBoxSideFromPath(const LayoutRect& borderRect, const Path& borderPath, const BorderEdges&, std::optional<BorderDataRadii>, float thickness, float drawThickness, BoxSide, Color, BorderStyle, BleedAvoidance, bool includeLogicalLeftEdge, bool includeLogicalRightEdge, bool isHorizontal) const;
+        const LayoutRect& sideRect, BoxSide, BoxSide adjacentSide1, BoxSide adjacentSide2, const BorderEdges&, std::optional<BorderDataRadii>, const Path*, BleedAvoidance, RectEdges<bool> closedEdges, bool antialias, const Color* overrideColor) const;
+    void drawBoxSideFromPath(const LayoutRect& borderRect, const Path& borderPath, const BorderEdges&, std::optional<BorderDataRadii>, float thickness, float drawThickness, BoxSide, Color, BorderStyle, BleedAvoidance, RectEdges<bool> closedEdges) const;
     void clipBorderSidePolygon(const RoundedRect& outerBorder, const RoundedRect& innerBorder, BoxSide, bool firstEdgeMatches, bool secondEdgeMatches) const;
 
     LayoutRect borderRectAdjustedForBleedAvoidance(const LayoutRect&, BleedAvoidance) const;

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -47,9 +47,9 @@ class RenderStyle;
 // are deprecated.
 class BorderShape {
 public:
-    static BorderShape shapeForBorderRect(const RenderStyle&, const LayoutRect& borderRect, bool includeLogicalLeftEdge = true, bool includeLogicalRightEdge = true);
+    static BorderShape shapeForBorderRect(const RenderStyle&, const LayoutRect& borderRect, RectEdges<bool> closedEdges = { true });
     // overrideBorderWidths describe custom insets from the border box, used instead of the border widths from the style.
-    static BorderShape shapeForBorderRect(const RenderStyle&, const LayoutRect& borderRect, const RectEdges<LayoutUnit>& overrideBorderWidths, bool includeLogicalLeftEdge = true, bool includeLogicalRightEdge = true);
+    static BorderShape shapeForBorderRect(const RenderStyle&, const LayoutRect& borderRect, const RectEdges<LayoutUnit>& overrideBorderWidths, RectEdges<bool> closedEdges = { true });
 
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths);
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths, const RoundedRectRadii&);

--- a/Source/WebCore/rendering/InlineBoxPainter.cpp
+++ b/Source/WebCore/rendering/InlineBoxPainter.cpp
@@ -122,24 +122,24 @@ static LayoutRect clipRectForNinePieceImageStrip(const InlineIterator::InlineBox
     LayoutRect clipRect(paintRect);
     auto& style = box.renderer().style();
     LayoutBoxExtent outsets = style.imageOutsets(image);
-    auto [hasClosedLeftEdge, hasClosedRightEdge] = box.hasClosedLeftAndRightEdge();
+    auto closedEdges = box.closedEdges();
     if (box.isHorizontal()) {
         clipRect.setY(paintRect.y() - outsets.top());
         clipRect.setHeight(paintRect.height() + outsets.top() + outsets.bottom());
-        if (hasClosedLeftEdge) {
+        if (closedEdges.left()) {
             clipRect.setX(paintRect.x() - outsets.left());
             clipRect.setWidth(paintRect.width() + outsets.left());
         }
-        if (hasClosedRightEdge)
+        if (closedEdges.right())
             clipRect.setWidth(clipRect.width() + outsets.right());
     } else {
         clipRect.setX(paintRect.x() - outsets.left());
         clipRect.setWidth(paintRect.width() + outsets.left() + outsets.right());
-        if (hasClosedLeftEdge) {
+        if (closedEdges.top()) {
             clipRect.setY(paintRect.y() - outsets.top());
             clipRect.setHeight(paintRect.height() + outsets.top());
         }
-        if (hasClosedRightEdge)
+        if (closedEdges.bottom())
             clipRect.setHeight(clipRect.height() + outsets.bottom());
     }
     return clipRect;
@@ -261,8 +261,8 @@ void InlineBoxPainter::paintDecorations()
 
     bool hasSingleLine = !m_inlineBox.previousInlineBox() && !m_inlineBox.nextInlineBox();
     if (!hasBorderImage || hasSingleLine) {
-        auto [hasClosedLeftEdge, hasClosedRightEdge] = m_inlineBox.hasClosedLeftAndRightEdge();
-        borderPainter.paintBorder(paintRect, style, BleedAvoidance::None, hasClosedLeftEdge, hasClosedRightEdge);
+        auto closedEdges = m_inlineBox.closedEdges();
+        borderPainter.paintBorder(paintRect, style, BleedAvoidance::None, closedEdges);
         return;
     }
 
@@ -368,8 +368,8 @@ void InlineBoxPainter::paintBoxShadow(ShadowStyle shadowStyle, const LayoutRect&
 
     // FIXME: We can do better here in the multi-line case. We want to push a clip so that the shadow doesn't
     // protrude incorrectly at the edges, and we want to possibly include shadows cast from the previous/following lines
-    auto [hasClosedLeftEdge, hasClosedRightEdge] = m_inlineBox.hasClosedLeftAndRightEdge();
-    backgroundPainter.paintBoxShadow(paintRect, style(), shadowStyle, hasClosedLeftEdge, hasClosedRightEdge);
+    auto closedEdges = m_inlineBox.closedEdges();
+    backgroundPainter.paintBoxShadow(paintRect, style(), shadowStyle, closedEdges);
 }
 
 const RenderStyle& InlineBoxPainter::style() const

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -837,7 +837,7 @@ bool RenderBoxModelObject::borderObscuresBackground() const
     return true;
 }
 
-BorderShape RenderBoxModelObject::borderShapeForContentClipping(const LayoutRect& borderBoxRect, bool includeLeftEdge, bool includeRightEdge) const
+BorderShape RenderBoxModelObject::borderShapeForContentClipping(const LayoutRect& borderBoxRect, RectEdges<bool> closedEdges) const
 {
     auto borderWidths = this->borderWidths();
     auto padding = this->padding();
@@ -849,7 +849,7 @@ BorderShape RenderBoxModelObject::borderShapeForContentClipping(const LayoutRect
         borderWidths.left() + padding.left(),
     };
 
-    return BorderShape::shapeForBorderRect(style(), borderBoxRect, contentBoxInsets, includeLeftEdge, includeRightEdge);
+    return BorderShape::shapeForBorderRect(style(), borderBoxRect, contentBoxInsets, closedEdges);
 }
 
 LayoutUnit RenderBoxModelObject::containingBlockLogicalWidthForContent() const

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -181,7 +181,7 @@ public:
     LayoutUnit marginLogicalHeight() const { return marginBefore() + marginAfter(); }
     LayoutUnit marginLogicalWidth() const { return marginStart() + marginEnd(); }
 
-    BorderShape borderShapeForContentClipping(const LayoutRect& borderBoxRect, bool includeLeftEdge = true, bool includeRightEdge = true) const;
+    BorderShape borderShapeForContentClipping(const LayoutRect& borderBoxRect, RectEdges<bool> closedEdges = { true }) const;
 
     inline bool hasInlineDirectionBordersPaddingOrMargin() const;
     inline bool hasInlineDirectionBordersOrPadding() const;

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1234,10 +1234,10 @@ public:
     inline void setHasExplicitlySetBorderTopLeftRadius(bool);
     inline void setHasExplicitlySetBorderTopRightRadius(bool);
 
-    RoundedRect getRoundedInnerBorderFor(const LayoutRect& borderRect, bool includeLogicalLeftEdge = true, bool includeLogicalRightEdge = true) const;
+    RoundedRect getRoundedInnerBorderFor(const LayoutRect& borderRect, RectEdges<bool> closedEdges) const;
 
-    RoundedRect getRoundedInnerBorderFor(const LayoutRect& borderRect, LayoutUnit topWidth, LayoutUnit bottomWidth, LayoutUnit leftWidth, LayoutUnit rightWidth, bool includeLogicalLeftEdge = true, bool includeLogicalRightEdge = true) const;
-    static RoundedRect getRoundedInnerBorderFor(const LayoutRect&, LayoutUnit topWidth, LayoutUnit bottomWidth, LayoutUnit leftWidth, LayoutUnit rightWidth, std::optional<BorderDataRadii>, bool isHorizontal, bool includeLogicalLeftEdge, bool includeLogicalRightEdge);
+    RoundedRect getRoundedInnerBorderFor(const LayoutRect& borderRect, LayoutUnit topWidth, LayoutUnit bottomWidth, LayoutUnit leftWidth, LayoutUnit rightWidth, RectEdges<bool> closedEdges) const;
+    static RoundedRect getRoundedInnerBorderFor(const LayoutRect&, LayoutUnit topWidth, LayoutUnit bottomWidth, LayoutUnit leftWidth, LayoutUnit rightWidth, std::optional<BorderDataRadii>, RectEdges<bool> closedEdges);
 
     inline void setBorderLeftWidth(float);
     inline void setBorderLeftStyle(BorderStyle);


### PR DESCRIPTION
#### cb550060dd71424174b84691489eab222e7109a9
<pre>
Switch border/background fragmentation to accommodate sideways-lr
<a href="https://bugs.webkit.org/show_bug.cgi?id=285285">https://bugs.webkit.org/show_bug.cgi?id=285285</a>
<a href="https://rdar.apple.com/problem/142246277">rdar://problem/142246277</a>

Reviewed by Alan Baradlay.

Converts border/background fragmentation handling to use a phyiscal
RectEdges&lt;bool&gt; instead of passing around the logical building blocks
and making the painting code figure it out over and over again.
Also updates the now-unified conversion logic to handle sideways-lr.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-002-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-002.html:
* Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.cpp:
(WebCore::InlineIterator::InlineBox::closedEdges const):
(WebCore::InlineIterator::InlineBox::hasClosedLeftAndRightEdge const): Deleted.
* Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.h:
* Source/WebCore/platform/RectEdges.h:
* Source/WebCore/platform/graphics/RoundedRect.cpp:
(WebCore::RoundedRect::Radii::setRadiiForEdges):
(WebCore::RoundedRect::Radii::includeLogicalEdges): Deleted.
(WebCore::RoundedRect::Radii::excludeLogicalEdges): Deleted.
(WebCore::RoundedRect::includeLogicalEdges): Deleted.
(WebCore::RoundedRect::excludeLogicalEdges): Deleted.
* Source/WebCore/platform/graphics/RoundedRect.h:
(WebCore::RoundedRect::setRadiiForEdges):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer const):
(WebCore::BackgroundPainter::paintBoxShadow const):
* Source/WebCore/rendering/BackgroundPainter.h:
(WebCore::BackgroundPainter::paintBoxShadow):
* Source/WebCore/rendering/BorderEdge.cpp:
(WebCore::borderEdges):
* Source/WebCore/rendering/BorderEdge.h:
(WebCore::borderEdges):
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::pathForBorderArea):
(WebCore::BorderPainter::paintBorder const):
(WebCore::BorderPainter::paintOutline const):
(WebCore::BorderPainter::paintSides const):
(WebCore::BorderPainter::paintTranslucentBorderSides const):
(WebCore::BorderPainter::paintBorderSides const):
(WebCore::BorderPainter::paintOneBorderSide const):
(WebCore::BorderPainter::drawBoxSideFromPath const):
* Source/WebCore/rendering/BorderPainter.h:
(WebCore::BorderPainter::paintBorder):
(WebCore::BorderPainter::pathForBorderArea):
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::shapeForBorderRect):
* Source/WebCore/rendering/BorderShape.h:
(WebCore::BorderShape::shapeForBorderRect):
* Source/WebCore/rendering/InlineBoxPainter.cpp:
(WebCore::clipRectForNinePieceImageStrip):
(WebCore::InlineBoxPainter::paintDecorations):
(WebCore::InlineBoxPainter::paintBoxShadow):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::borderShapeForContentClipping const):
* Source/WebCore/rendering/RenderBoxModelObject.h:
(WebCore::RenderBoxModelObject::borderShapeForContentClipping):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::getRoundedInnerBorderFor const):
(WebCore::RenderStyle::getRoundedInnerBorderFor):
* Source/WebCore/rendering/style/RenderStyle.h:

Canonical link: <a href="https://commits.webkit.org/288383@main">https://commits.webkit.org/288383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdb89fb775d13af1a480de147090600f44a026f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82973 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/2616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37266 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/34021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85065 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/2691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10536 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/88084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/34021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86028 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/1972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/75455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/1880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/29649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/33055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/30337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/89450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/10257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/89450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/10485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/71265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/89450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12831 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/10210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/15722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/10082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/13547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/11850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->