### PR TITLE
Further reduce use of std::span::subspan() by leveraging ParsingUtilities

### DIFF
--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -24,6 +24,7 @@
 #include "PrivateName.h"
 #include "VM.h"
 #include <wtf/text/CString.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/UniquedStringImpl.h>
 #include <wtf/text/WTFString.h>
 
@@ -53,7 +54,7 @@ ALWAYS_INLINE std::optional<uint32_t> parseIndex(std::span<const CharType> chara
     if (!value && characters.size() > 1)
         return std::nullopt;
 
-    characters = characters.subspan(1);
+    skip(characters, 1);
     while (!characters.empty()) {
         // Multiply value by 10, checking for overflow out of 32 bits.
         if (value > 0xFFFFFFFFU / 10)
@@ -70,7 +71,7 @@ ALWAYS_INLINE std::optional<uint32_t> parseIndex(std::span<const CharType> chara
         if (newValue < value)
             return std::nullopt;
         value = newValue;
-        characters = characters.subspan(1);
+        skip(characters, 1);
     }
 
     if (!isIndex(value))

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -262,11 +262,11 @@ template <typename CharType>
 static double jsBinaryIntegerLiteral(std::span<const CharType>& data)
 {
     // Binary number.
-    data = data.subspan(2);
+    skip(data, 2);
     auto firstDigitPosition = data;
     double number = 0;
     while (true) {
-        number = number * 2 + (consumeSingleElement(data) - '0');
+        number = number * 2 + (consume(data) - '0');
         if (data.empty())
             break;
         if (!isASCIIBinaryDigit(data.front()))
@@ -283,11 +283,11 @@ template <typename CharType>
 static double jsOctalIntegerLiteral(std::span<const CharType>& data)
 {
     // Octal number.
-    data = data.subspan(2);
+    skip(data, 2);
     auto firstDigitPosition = data;
     double number = 0;
     while (true) {
-        number = number * 8 + (consumeSingleElement(data) - '0');
+        number = number * 8 + (consume(data) - '0');
         if (data.empty())
             break;
         if (!isASCIIOctalDigit(data.front()))
@@ -304,11 +304,11 @@ template <typename CharType>
 static double jsHexIntegerLiteral(std::span<const CharType>& data)
 {
     // Hex number.
-    data = data.subspan(2);
+    skip(data, 2);
     auto firstDigitPosition = data;
     double number = 0;
     while (true) {
-        number = number * 16 + toASCIIHexValue(consumeSingleElement(data));
+        number = number * 16 + toASCIIHexValue(consume(data));
         if (data.empty())
             break;
         if (!isASCIIHexDigit(data.front()))
@@ -329,7 +329,7 @@ static double jsStrDecimalLiteral(std::span<const CharType>& data)
     size_t parsedLength;
     double number = parseDouble(data, parsedLength);
     if (parsedLength) {
-        data = data.subspan(parsedLength);
+        skip(data, parsedLength);
         return number;
     }
 
@@ -337,21 +337,21 @@ static double jsStrDecimalLiteral(std::span<const CharType>& data)
     switch (data.front()) {
     case 'I':
         if (isInfinity(data)) {
-            data = data.subspan(SizeOfInfinity);
+            skip(data, SizeOfInfinity);
             return std::numeric_limits<double>::infinity();
         }
         break;
 
     case '+':
         if (isInfinity(data.subspan(1))) {
-            data = data.subspan(SizeOfInfinity + 1);
+            skip(data, SizeOfInfinity + 1);
             return std::numeric_limits<double>::infinity();
         }
         break;
 
     case '-':
         if (isInfinity(data.subspan(1))) {
-            data = data.subspan(SizeOfInfinity + 1);
+            skip(data, SizeOfInfinity + 1);
             return -std::numeric_limits<double>::infinity();
         }
         break;

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1307,7 +1307,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
                 WTF::appendEscapedJSONStringContent(output, string.data.span16());
         } else
             WTF::appendEscapedJSONStringContent(output, string.data.span8());
-        consumeSingleElement(output) = '"';
+        consume(output) = '"';
         m_length = output.data() - buffer();
         return;
     }

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -29,6 +29,7 @@
 #include "JSString.h"
 #include "KeyAtomStringCacheInlines.h"
 #include <wtf/text/MakeString.h>
+#include <wtf/text/ParsingUtilities.h>
 
 namespace JSC {
 
@@ -287,11 +288,11 @@ inline void JSRopeString::resolveToBuffer(JSString* fiber0, JSString* fiber1, JS
                     MUST_TAIL_CALL return JSRopeString::resolveToBufferSlow(fiber0, fiber1, fiber2, buffer, stackLimit);
                 resolveToBuffer(rope0->fiber0(), rope0->fiber1(), rope0->fiber2(), buffer.first(rope0Length), stackLimit);
             }
-            buffer = buffer.subspan(rope0Length);
+            skip(buffer, rope0Length);
         } else {
             StringView view0 = fiber0->valueInternal().impl();
             view0.getCharacters(buffer);
-            buffer = buffer.subspan(view0.length());
+            skip(buffer, view0.length());
         }
         fiber0 = fiber1;
         fiber1 = fiber2;
@@ -314,7 +315,7 @@ inline void JSRopeString::resolveToBuffer(JSString* fiber0, JSString* fiber1, JS
                     view0.substring(offset, rope0Length).getCharacters(buffer);
                 } else
                     resolveToBuffer(rope0->fiber0(), rope0->fiber1(), rope0->fiber2(), buffer.first(rope0Length), stackLimit);
-                buffer = buffer.subspan(rope0Length);
+                skip(buffer, rope0Length);
 
                 auto* rope1 = static_cast<const JSRopeString*>(fiber1);
                 auto rope1Length = rope1->length();
@@ -349,7 +350,7 @@ inline void JSRopeString::resolveToBuffer(JSString* fiber0, JSString* fiber1, JS
             {
                 StringView view0 = fiber0->valueInternal().impl();
                 view0.getCharacters(buffer);
-                buffer = buffer.subspan(view0.length());
+                skip(buffer, view0.length());
             }
             if (rope1->isSubstring()) {
                 StringView view1 = *rope1->substringBase()->valueInternal().impl();

--- a/Source/JavaScriptCore/runtime/JSStringJoiner.cpp
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.cpp
@@ -43,14 +43,14 @@ static inline void appendStringToData(std::span<CharacterType>& data, StringView
         string.getCharacters8(data);
     } else
         string.getCharacters(data);
-    data = data.subspan(string.length());
+    skip(data, string.length());
 }
 
 template<typename OutputCharacterType, typename SeparatorCharacterType>
 static inline void appendStringToData(std::span<OutputCharacterType>& data, std::span<const SeparatorCharacterType> separator)
 {
     StringImpl::copyCharacters(data.data(), separator);
-    data = data.subspan(separator.size());
+    skip(data, separator.size());
 }
 
 template<typename CharacterType>
@@ -67,7 +67,7 @@ static inline void appendStringToDataWithOneCharacterSeparatorRepeatedly(std::sp
                 string.getCharacters8(std::span { pattern }.subspan(1));
                 size_t fillLength = count * 16;
                 memset_pattern16(data.data(), pattern, fillLength);
-                data = data.subspan(fillLength);
+                skip(data, fillLength);
                 return;
             }
             case 8: {
@@ -76,7 +76,7 @@ static inline void appendStringToDataWithOneCharacterSeparatorRepeatedly(std::sp
                 string.getCharacters8(std::span { pattern }.subspan(1));
                 size_t fillLength = count * 8;
                 memset_pattern8(data.data(), pattern, fillLength);
-                data = data.subspan(fillLength);
+                skip(data, fillLength);
                 return;
             }
             case 4: {
@@ -85,7 +85,7 @@ static inline void appendStringToDataWithOneCharacterSeparatorRepeatedly(std::sp
                 string.getCharacters8(std::span { pattern }.subspan(1));
                 size_t fillLength = count * 4;
                 memset_pattern4(data.data(), pattern, fillLength);
-                data = data.subspan(fillLength);
+                skip(data, fillLength);
                 return;
             }
             default:
@@ -96,7 +96,7 @@ static inline void appendStringToDataWithOneCharacterSeparatorRepeatedly(std::sp
 #endif
 
     while (count--) {
-        consumeSingleElement(data) = separatorCharacter;
+        consume(data) = separatorCharacter;
         appendStringToData(data, string);
     }
 }

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -33,6 +33,7 @@
 #include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/CString.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 
 #if !OS(WINDOWS)
@@ -481,8 +482,7 @@ MappedFileData mapToFile(const String& path, size_t bytesSize, Function<void(con
     auto mapData = mappedFile.mutableSpan();
 
     apply([&mapData](std::span<const uint8_t> chunk) {
-        memcpySpan(mapData, chunk);
-        mapData = mapData.subspan(chunk.size());
+        memcpySpan(consumeSpan(mapData, chunk.size()), chunk);
         return true;
     });
 

--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -34,9 +34,11 @@
 #include <wtf/JSONValues.h>
 
 #include <functional>
+#include <wtf/ASCIICType.h>
 #include <wtf/CommaPrinter.h>
 #include <wtf/ZippedRange.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WTF {
@@ -86,17 +88,15 @@ bool readInt(std::span<const CodeUnit> data, std::span<const CodeUnit>& tokenEnd
     if (data.empty())
         return false;
 
-    bool haveLeadingZero = '0' == data.front();
-    int length = 0;
-    while (!data.empty() && '0' <= data.front() && data.front() <= '9') {
-        data = data.subspan(1);
-        ++length;
-    }
+    bool hasLeadingZero = data[0] == '0';
+    size_t originalSize = data.size();
+    skipWhile<isASCIIDigit>(data);
 
+    size_t length = originalSize - data.size();
     if (!length)
         return false;
 
-    if (!canHaveLeadingZeros && length > 1 && haveLeadingZero)
+    if (!canHaveLeadingZeros && length > 1 && hasLeadingZero)
         return false;
 
     tokenEnd = data;
@@ -111,9 +111,7 @@ bool parseNumberToken(std::span<const CodeUnit> data, std::span<const CodeUnit>&
     if (data.empty())
         return false;
 
-    CodeUnit c = data.front();
-    if ('-' == c)
-        data = data.subspan(1);
+    skipExactly(data, '-');
 
     if (!readInt(data, data, false))
         return false;
@@ -124,26 +122,20 @@ bool parseNumberToken(std::span<const CodeUnit> data, std::span<const CodeUnit>&
     }
 
     // Optional fraction part.
-    c = data.front();
-    if ('.' == c) {
-        data = data.subspan(1);
+    if (skipExactly(data, '.')) {
         if (!readInt(data, data, true))
             return false;
         if (data.empty()) {
             tokenEnd = data;
             return true;
         }
-        c = data.front();
     }
 
     // Optional exponent part.
-    if ('e' == c || 'E' == c) {
-        data = data.subspan(1);
+    if (skipExactly(data, 'e') || skipExactly(data, 'E')) {
         if (data.empty())
             return false;
-        c = data.front();
-        if ('-' == c || '+' == c) {
-            data = data.subspan(1);
+        if (skipExactly(data, '-') || skipExactly(data, '+')) {
             if (data.empty())
                 return false;
         }
@@ -164,7 +156,7 @@ bool readHexDigits(std::span<const CodeUnit> data, std::span<const CodeUnit>& to
     for (unsigned i = 0; i < digits; ++i) {
         if (!isASCIIHexDigit(data.front()))
             return false;
-        data = data.subspan(1);
+        skip(data, 1);
     }
 
     tokenEnd = data;
@@ -175,11 +167,9 @@ template<typename CodeUnit>
 bool parseStringToken(std::span<const CodeUnit> data, std::span<const CodeUnit>& tokenEnd)
 {
     while (!data.empty()) {
-        CodeUnit c = data.front();
-        data = data.subspan(1);
+        CodeUnit c = consume(data);
         if ('\\' == c && !data.empty()) {
-            c = data.front();
-            data = data.subspan(1);
+            c = consume(data);
             // Make sure the escaped char is valid.
             switch (c) {
             case 'x':
@@ -215,8 +205,7 @@ bool parseStringToken(std::span<const CodeUnit> data, std::span<const CodeUnit>&
 template<typename CodeUnit>
 Token parseToken(std::span<const CodeUnit> data, std::span<const CodeUnit>& tokenStart, std::span<const CodeUnit>& tokenEnd)
 {
-    while (!data.empty() && isASCIIWhitespaceWithoutFF(data.front()))
-        data = data.subspan(1);
+    skipWhile<isASCIIWhitespaceWithoutFF>(data);
 
     if (data.empty())
         return Token::Invalid;
@@ -281,16 +270,14 @@ template<typename CodeUnit>
 bool decodeString(std::span<const CodeUnit> data, StringBuilder& output)
 {
     while (!data.empty()) {
-        UChar c = data.front();
-        data = data.subspan(1);
+        UChar c = consume(data);
         if ('\\' != c) {
             output.append(c);
             continue;
         }
         if (UNLIKELY(data.empty()))
             return false;
-        c = data.front();
-        data = data.subspan(1);
+        c = consume(data);
         switch (c) {
         case '"':
         case '/':
@@ -318,13 +305,13 @@ bool decodeString(std::span<const CodeUnit> data, StringBuilder& output)
             if (UNLIKELY(data.size() < 2))
                 return false;
             c = toASCIIHexValue(data[0], data[1]);
-            data = data.subspan(2);
+            skip(data, 2);
             break;
         case 'u':
             if (UNLIKELY(data.size() < 4))
                 return false;
             c = toASCIIHexValue(data[0], data[1]) << 8 | toASCIIHexValue(data[2], data[3]);
-            data = data.subspan(4);
+            skip(data, 4);
             break;
         default:
             return false;

--- a/Source/WTF/wtf/StreamBuffer.h
+++ b/Source/WTF/wtf/StreamBuffer.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <wtf/Deque.h>
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WTF {
 
@@ -62,8 +63,7 @@ public:
             if (!m_buffer.size() || m_buffer.last()->size() == BlockSize)
                 m_buffer.append(makeUnique<Block>());
             size_t appendSize = std::min(BlockSize - m_buffer.last()->size(), data.size());
-            m_buffer.last()->append(data.first(appendSize));
-            data = data.subspan(appendSize);
+            m_buffer.last()->append(consumeSpan(data, appendSize));
         }
     }
 

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -36,6 +36,7 @@
 #include <unicode/uscript.h>
 #include <wtf/IteratorRange.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTF {
@@ -941,14 +942,14 @@ String userVisibleURL(const CString& url)
         memmoveSpan(p, after.span().first(afterlength + 1)); // copies trailing '\0'
         afterIndex = 0;
         while (p.front()) {
-            unsigned char c = p.front();
-            if (c > 0x7f) {
+            unsigned char c = consume(p);
+            if (isASCII(c))
+                after[afterIndex++] = c;
+            else {
                 after[afterIndex++] = '%';
                 after[afterIndex++] = upperNibbleToASCIIHexDigit(c);
                 after[afterIndex++] = lowerNibbleToASCIIHexDigit(c);
-            } else
-                after[afterIndex++] = p.front();
-            p = p.subspan(1);
+            }
         }
         after[afterIndex] = '\0';
         // Note: after.data() points to a null-terminated, pure ASCII string.

--- a/Source/WTF/wtf/darwin/OSLogPrintStream.mm
+++ b/Source/WTF/wtf/darwin/OSLogPrintStream.mm
@@ -27,6 +27,7 @@
 #include "OSLogPrintStream.h"
 
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/ParsingUtilities.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -76,7 +77,7 @@ ALLOW_NONLITERAL_FORMAT_END
             // Set the new line to a null character so os_log stops copying there.
             buffer[offset] = '\0';
             os_log_with_type(m_log, m_logType, "%{public}s", buffer.data());
-            buffer = buffer.subspan(offset + 1);
+            skip(buffer, offset + 1);
             newOffset -= offset + 1;
             offset = 0;
             loggedText = true;

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -44,6 +44,7 @@
 #include <wtf/SafeStrerror.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
 
@@ -330,7 +331,7 @@ bool makeAllDirectories(const String& path)
     auto p = fullPath.mutableSpanIncludingNullTerminator().subspan(1);
     if (p[length - 1] == '/')
         p[length - 1] = '\0';
-    for (; p[0]; p = p.subspan(1)) {
+    for (; p[0]; skip(p, 1)) {
         if (p[0] == '/') {
             p[0] = '\0';
             if (access(fullPath.data(), F_OK)) {

--- a/Source/WTF/wtf/text/Base64.cpp
+++ b/Source/WTF/wtf/text/Base64.cpp
@@ -371,7 +371,7 @@ static std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64SlowImpl
                 if (lastChunkHandling == LastChunkHandling::Strict && decoded[chunkLength - 1])
                     return { FromBase64ShouldThrowError::Yes, read, write };
 
-                decoded = decoded.subspan(0, chunkLength - 1);
+                decoded = decoded.first(chunkLength - 1);
             }
 
             memcpySpan(output.subspan(write), decoded);
@@ -434,7 +434,7 @@ static std::tuple<FromBase64ShouldThrowError, size_t, size_t> fromBase64SlowImpl
         auto decoded = decodedVector->span();
 
         if (chunkLength == 2 || chunkLength == 3)
-            decoded = decoded.subspan(0, chunkLength - 1);
+            decoded = decoded.first(chunkLength - 1);
 
         memcpySpan(output.subspan(write), decoded);
         write += decoded.size();

--- a/Source/WTF/wtf/text/CodePointIterator.h
+++ b/Source/WTF/wtf/text/CodePointIterator.h
@@ -28,6 +28,7 @@
 #include <unicode/utypes.h>
 #include <wtf/Assertions.h>
 #include <wtf/text/LChar.h>
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WTF {
 
@@ -85,7 +86,7 @@ ALWAYS_INLINE char32_t CodePointIterator<LChar>::operator*() const
 template<>
 ALWAYS_INLINE auto CodePointIterator<LChar>::operator++() -> CodePointIterator&
 {
-    m_data = m_data.subspan(1);
+    skip(m_data, 1);
     return *this;
 }
 
@@ -104,7 +105,7 @@ ALWAYS_INLINE auto CodePointIterator<UChar>::operator++() -> CodePointIterator&
     unsigned i = 0;
     size_t length = m_data.size();
     U16_FWD_1(m_data, i, length);
-    m_data = m_data.subspan(i);
+    skip(m_data, i);
     return *this;
 }
 

--- a/Source/WTF/wtf/text/StringBuilderJSON.cpp
+++ b/Source/WTF/wtf/text/StringBuilderJSON.cpp
@@ -13,6 +13,7 @@
 #include <wtf/text/StringBuilderJSON.h>
 
 #include <wtf/text/EscapedFormsForJSON.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTF {
@@ -38,25 +39,21 @@ void StringBuilder::appendQuotedJSONString(const String& string)
     if (is8Bit() && string.is8Bit()) {
         if (auto output = extendBufferForAppending<LChar>(saturatedSum<int32_t>(m_length, stringLengthValue)); output.data()) {
             output = output.first(stringLengthValue);
-            output[0] = '"';
-            output = output.subspan(1);
+            consume(output) = '"';
             appendEscapedJSONStringContent(output, string.span8());
-            output[0] = '"';
-            output = output.subspan(1);
+            consume(output) = '"';
             if (!output.empty())
                 shrink(m_length - output.size());
         }
     } else {
         if (auto output = extendBufferForAppendingWithUpconvert(saturatedSum<int32_t>(m_length, stringLengthValue)); output.data()) {
             output = output.first(stringLengthValue);
-            output[0] = '"';
-            output = output.subspan(1);
+            consume(output) = '"';
             if (string.is8Bit())
                 appendEscapedJSONStringContent(output, string.span8());
             else
                 appendEscapedJSONStringContent(output, string.span16());
-            output[0] = '"';
-            output = output.subspan(1);
+            consume(output) = '"';
             if (!output.empty())
                 shrink(m_length - output.size());
         }

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -30,6 +30,7 @@
 #include <wtf/text/AtomString.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/ExternalStringImpl.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuffer.h>
 #include <wtf/text/StringView.h>
 #include <wtf/text/SymbolImpl.h>
@@ -801,14 +802,11 @@ template<typename CharacterType, class UCharPredicate> inline Ref<StringImpl> St
     
     while (true) {
         while (!from.empty() && predicate(from.front())) {
-            if (from.front() != ' ')
+            if (consume(from) != ' ')
                 changedToSpace = true;
-            from = from.subspan(1);
         }
-        while (!from.empty() && !predicate(from.front())) {
-            to[outc++] = from.front();
-            from = from.subspan(1);
-        }
+        while (!from.empty() && !predicate(from.front()))
+            to[outc++] = consume(from);
         if (!from.empty())
             to[outc++] = ' ';
         else

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -44,6 +44,7 @@
 #include <wtf/StringExtras.h>
 #include <wtf/URLParser.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WebCore {
 
@@ -205,12 +206,12 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
         size_t currentBoundaryIndex = memmemSpan(data, boundary.span());
         if (currentBoundaryIndex == notFound)
             return nullptr;
-        data = data.subspan(currentBoundaryIndex + boundaryLength);
+        skip(data, currentBoundaryIndex + boundaryLength);
         size_t nextBoundaryIndex;
         while ((nextBoundaryIndex = memmemSpan(data, boundary.span())) != notFound) {
             parseMultipartPart(data.first(nextBoundaryIndex - strlen("\r\n")), form.get());
             currentBoundaryIndex = nextBoundaryIndex;
-            data = data.subspan(nextBoundaryIndex + boundaryLength);
+            skip(data, nextBoundaryIndex + boundaryLength);
         }
     } else if (mimeType && equalLettersIgnoringASCIICase(mimeType->type, "application"_s) && equalLettersIgnoringASCIICase(mimeType->subtype, "x-www-form-urlencoded"_s)) {
         auto dataString = String::fromUTF8(data);

--- a/Source/WebCore/Modules/mediastream/STUNMessageParsing.cpp
+++ b/Source/WebCore/Modules/mediastream/STUNMessageParsing.cpp
@@ -30,6 +30,7 @@
 
 #include <LibWebRTCMacros.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/ParsingUtilities.h>
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <webrtc/rtc_base/byte_order.h>
@@ -83,7 +84,7 @@ static inline Vector<uint8_t> extractSTUNOrTURNMessages(Vector<uint8_t>&& buffer
 
         processMessage(data.first(lengths->messageLength));
 
-        data = data.subspan(lengths->messageLengthWithPadding);
+        skip(data, lengths->messageLengthWithPadding);
     }
 }
 
@@ -105,11 +106,9 @@ static inline Vector<uint8_t> extractDataMessages(Vector<uint8_t>&& buffered, co
             return WTFMove(buffered);
         }
 
-        data = data.subspan(lengthFieldSize);
+        skip(data, lengthFieldSize);
 
-        processMessage(data.first(length));
-
-        data = data.subspan(length);
+        processMessage(consumeSpan(data, length));
     }
 }
 

--- a/Source/WebCore/Modules/webaudio/OscillatorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/OscillatorNode.cpp
@@ -35,6 +35,7 @@
 #include "VectorMath.h"
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WebCore {
 
@@ -400,7 +401,7 @@ void OscillatorNode::process(size_t framesToProcess)
     auto phaseIncrements = m_phaseIncrements.span();
 
     // Start rendering at the correct offset.
-    destination = destination.subspan(quantumFrameOffset);
+    skip(destination, quantumFrameOffset);
     int n = nonSilentFramesToProcess;
 
     // If startFrameOffset is not 0, that means the oscillator doesn't actually
@@ -408,7 +409,7 @@ void OscillatorNode::process(size_t framesToProcess)
     // to reflect that, and adjust virtualReadIndex to start the value at
     // startFrameOffset.
     if (startFrameOffset > 0) {
-        destination = destination.subspan(1);
+        skip(destination, 1);
         --n;
         virtualReadIndex += (1 - startFrameOffset) * frequency * rateScale;
         ASSERT(virtualReadIndex < m_periodicWave->periodicWaveSize());

--- a/Source/WebCore/Modules/websockets/WebSocketFrame.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketFrame.cpp
@@ -26,6 +26,7 @@
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/MathExtras.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WebCore {
 
@@ -55,7 +56,7 @@ WebSocketFrame::ParseFrameResult WebSocketFrame::parseFrame(std::span<uint8_t> d
     auto firstByte = data[0];
     auto secondByte = data[1];
 
-    data = data.subspan(2);
+    skip(data, 2);
 
     bool final = firstByte & finalBit;
     bool compress = firstByte & compressBit;
@@ -80,7 +81,7 @@ WebSocketFrame::ParseFrameResult WebSocketFrame::parseFrame(std::span<uint8_t> d
             payloadLength64 <<= 8;
             payloadLength64 |= data[i];
         }
-        data = data.subspan(extendedPayloadLengthSize);
+        skip(data, extendedPayloadLengthSize);
 
         if (extendedPayloadLengthSize == 2 && payloadLength64 <= maxPayloadLengthWithoutExtendedLengthField) {
             errorString = "The minimal number of bytes MUST be used to encode the length"_s;

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -56,6 +56,7 @@
 #include <wtf/text/Base64.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/StringView.h>
 #include <wtf/text/WTFString.h>
@@ -444,7 +445,7 @@ std::span<const uint8_t> WebSocketHandshake::readHTTPHeaders(std::span<const uin
         size_t consumedLength = parseHTTPHeader(data, m_failureReason, name, value);
         if (!consumedLength)
             return { };
-        data = data.subspan(consumedLength);
+        skip(data, consumedLength);
 
         // Stop once we consumed an empty line.
         if (name.isEmpty())

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -35,6 +35,7 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Threading.h>
 #include <wtf/text/CString.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/unicode/CharacterNames.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
@@ -182,7 +183,7 @@ int TextCodecICU::decodeToBuffer(std::span<UChar> targetSpan, std::span<const ui
     auto* target = targetSpan.data();
     auto* targetLimit = std::to_address(targetSpan.end());
     ucnv_toUnicode(m_converter.get(), &target, targetLimit, &source, sourceLimit, offsets, flush, &error);
-    sourceSpan = sourceSpan.subspan(byteCast<uint8_t>(source) - sourceSpan.data());
+    skip(sourceSpan, byteCast<uint8_t>(source) - sourceSpan.data());
     return target - targetStart;
 }
 

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
@@ -30,6 +30,7 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuffer.h>
 #include <wtf/text/WTFString.h>
 #include <wtf/unicode/CharacterNames.h>
@@ -170,13 +171,12 @@ static inline std::span<UChar> appendCharacter(std::span<UChar> destination, int
 {
     ASSERT(character != nonCharacter);
     ASSERT(!U_IS_SURROGATE(character));
-    if (U_IS_BMP(character)) {
-        destination[0] = character;
-        destination = destination.subspan(1);
-    } else {
+    if (U_IS_BMP(character))
+        consume(destination) = character;
+    else {
         destination[0] = U16_LEAD(character);
         destination[1] = U16_TRAIL(character);
-        destination = destination.subspan(2);
+        skip(destination, 2);
     }
     return destination;
 }
@@ -192,8 +192,7 @@ bool TextCodecUTF8::handlePartialSequence(std::span<LChar>& destination, std::sp
     ASSERT(m_partialSequenceSize);
     do {
         if (isASCII(m_partialSequence[0])) {
-            destination[0] = m_partialSequence[0];
-            destination = destination.subspan(1);
+            consume(destination) = m_partialSequence[0];
             consumePartialSequenceByte();
             continue;
         }
@@ -204,8 +203,7 @@ bool TextCodecUTF8::handlePartialSequence(std::span<LChar>& destination, std::sp
         // Copy from `source` until we have `count` bytes.
         if (count > m_partialSequenceSize && !source.empty()) {
             size_t additionalBytes = std::min<size_t>(count - m_partialSequenceSize, source.size());
-            memcpySpan(std::span { m_partialSequence }.subspan(m_partialSequenceSize), source.first(additionalBytes));
-            source = source.subspan(additionalBytes);
+            memcpySpan(std::span { m_partialSequence }.subspan(m_partialSequenceSize), consumeSpan(source, additionalBytes));
             m_partialSequenceSize += additionalBytes;
         }
 
@@ -233,8 +231,7 @@ bool TextCodecUTF8::handlePartialSequence(std::span<LChar>& destination, std::sp
             return true;
 
         m_partialSequenceSize -= count;
-        destination[0] = character;
-        destination = destination.subspan(1);
+        consume(destination) = character;
     } while (m_partialSequenceSize);
 
     return false;
@@ -245,8 +242,7 @@ void TextCodecUTF8::handlePartialSequence(std::span<UChar>& destination, std::sp
     ASSERT(m_partialSequenceSize);
     do {
         if (isASCII(m_partialSequence[0])) {
-            destination[0] = m_partialSequence[0];
-            destination = destination.subspan(1);
+            consume(destination) = m_partialSequence[0];
             consumePartialSequenceByte();
             continue;
         }
@@ -255,8 +251,7 @@ void TextCodecUTF8::handlePartialSequence(std::span<UChar>& destination, std::sp
             sawError = true;
             if (stopOnError)
                 return;
-            destination[0] = replacementCharacter;
-            destination = destination.subspan(1);
+            consume(destination) = replacementCharacter;
             consumePartialSequenceByte();
             continue;
         }
@@ -264,8 +259,7 @@ void TextCodecUTF8::handlePartialSequence(std::span<UChar>& destination, std::sp
         // Copy from `source` until we have `count` bytes.
         if (count > m_partialSequenceSize && !source.empty()) {
             size_t additionalBytes = std::min<size_t>(count - m_partialSequenceSize, source.size());
-            memcpySpan(std::span { m_partialSequence }.subspan(m_partialSequenceSize), source.first(additionalBytes));
-            source = source.subspan(additionalBytes);
+            memcpySpan(std::span { m_partialSequence }.subspan(m_partialSequenceSize), consumeSpan(source, additionalBytes));
             m_partialSequenceSize += additionalBytes;
         }
 
@@ -293,8 +287,7 @@ void TextCodecUTF8::handlePartialSequence(std::span<UChar>& destination, std::sp
             sawError = true;
             if (stopOnError)
                 return;
-            destination[0] = replacementCharacter;
-            destination = destination.subspan(1);
+            consume(destination) = replacementCharacter;
             m_partialSequenceSize -= count;
             memmoveSpan(std::span { m_partialSequence }, std::span { m_partialSequence }.subspan(count, m_partialSequenceSize));
             continue;
@@ -346,17 +339,15 @@ String TextCodecUTF8::decode(std::span<const uint8_t> bytes, bool flush, bool st
                         if (!WTF::containsOnlyASCII<LChar>(chunk))
                             break;
                         copyASCIIMachineWord(destination, source);
-                        source = source.subspan(sizeof(WTF::MachineWord));
-                        destination = destination.subspan(sizeof(WTF::MachineWord));
+                        skip(source, sizeof(WTF::MachineWord));
+                        skip(destination, sizeof(WTF::MachineWord));
                     }
                     if (source.empty())
                         break;
                     if (!isASCII(source[0]))
                         continue;
                 }
-                destination[0] = source[0];
-                destination = destination.subspan(1);
-                source = source.subspan(1);
+                consume(destination) = consume(source);
                 continue;
             }
             auto count = nonASCIISequenceLength(source[0]);
@@ -384,9 +375,8 @@ String TextCodecUTF8::decode(std::span<const uint8_t> bytes, bool flush, bool st
             if (!isLatin1(character))
                 goto upConvertTo16Bit;
 
-            source = source.subspan(count);
-            destination[0] = character;
-            destination = destination.subspan(1);
+            skip(source, count);
+            consume(destination) = character;
         }
     } while (m_partialSequenceSize);
 
@@ -407,7 +397,7 @@ upConvertTo16Bit:
     size_t charactersToCopy = destination.data() - buffer.characters();
     for (size_t i = 0; i < charactersToCopy; ++i)
         destination16[i] = converted8[i];
-    destination16 = destination16.subspan(charactersToCopy);
+    skip(destination16, charactersToCopy);
 
     do {
         if (m_partialSequenceSize) {
@@ -430,17 +420,15 @@ upConvertTo16Bit:
                         if (!WTF::containsOnlyASCII<LChar>(chunk))
                             break;
                         copyASCIIMachineWord(destination16, source);
-                        source = source.subspan(sizeof(WTF::MachineWord));
-                        destination16 = destination16.subspan(sizeof(WTF::MachineWord));
+                        skip(source, sizeof(WTF::MachineWord));
+                        skip(destination16, sizeof(WTF::MachineWord));
                     }
                     if (source.empty())
                         break;
                     if (!isASCII(source[0]))
                         continue;
                 }
-                destination16[0] = source[0];
-                destination16 = destination16.subspan(1);
-                source = source.subspan(1);
+                consume(destination16) = consume(source);
                 continue;
             }
             auto count = nonASCIISequenceLength(source[0]);
@@ -462,12 +450,11 @@ upConvertTo16Bit:
                 sawError = true;
                 if (stopOnError)
                     break;
-                destination16[0] = replacementCharacter;
-                destination16 = destination16.subspan(1);
-                source = source.subspan(count ? count : 1);
+                consume(destination16) = replacementCharacter;
+                skip(source, count ? count : 1);
                 continue;
             }
-            source = source.subspan(count);
+            skip(source, count);
             if (character == byteOrderMark && destination16.data() == buffer16.characters() && std::exchange(m_shouldStripByteOrderMark, false))
                 continue;
             destination16 = appendCharacter(destination16, character);

--- a/Source/WebCore/contentextensions/SerializedNFA.cpp
+++ b/Source/WebCore/contentextensions/SerializedNFA.cpp
@@ -27,6 +27,7 @@
 #include "SerializedNFA.h"
 
 #include "NFA.h"
+#include <wtf/text/ParsingUtilities.h>
 
 #if ENABLE(CONTENT_EXTENSIONS)
 
@@ -41,7 +42,7 @@ bool writeAllToFile(FileSystem::PlatformFileHandle file, const T& container)
         auto written = FileSystem::writeToFile(file, bytes);
         if (written == -1)
             return false;
-        bytes = bytes.subspan(written);
+        skip(bytes, written);
     }
     return true;
 }

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCBCMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCBCMac.cpp
@@ -29,6 +29,7 @@
 #include "CryptoAlgorithmAesCbcCfbParams.h"
 #include "CryptoKeyAES.h"
 #include <CommonCrypto/CommonCrypto.h>
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WebCore {
 
@@ -50,7 +51,7 @@ static ExceptionOr<Vector<uint8_t>> transformAESCBC(CCOperation operation, const
     auto p = result.mutableSpan().subspan(bytesWritten);
     if (padding == CryptoAlgorithmAESCBC::Padding::Yes) {
         status = CCCryptorFinal(cryptor, p.data(), p.size(), &bytesWritten);
-        p = p.subspan(bytesWritten);
+        skip(p, bytesWritten);
         if (status)
             return Exception { ExceptionCode::OperationError };
     }

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCFBMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCFBMac.cpp
@@ -48,7 +48,7 @@ static ExceptionOr<Vector<uint8_t>> transformAESCFB(CCOperation operation, const
 
     auto p = result.mutableSpan().subspan(bytesWritten);
     status = CCCryptorFinal(cryptor, p.data(), p.size(), &bytesWritten);
-    p = p.subspan(bytesWritten);
+    skip(p, bytesWritten);
     if (status)
         return Exception { ExceptionCode::OperationError };
 

--- a/Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.cpp
@@ -69,7 +69,7 @@ ExceptionOr<Vector<uint8_t>> transformAESCTR(CCOperation operation, const Vector
 
     auto p = head.mutableSpan().subspan(bytesWritten);
     status = CCCryptorFinal(cryptor, p.data(), p.size(), &bytesWritten);
-    p = p.subspan(bytesWritten);
+    skip(p, bytesWritten);
     if (status)
         return Exception { ExceptionCode::OperationError };
 
@@ -97,7 +97,7 @@ ExceptionOr<Vector<uint8_t>> transformAESCTR(CCOperation operation, const Vector
 
     p = tail.mutableSpan().subspan(bytesWritten);
     status = CCCryptorFinal(cryptor, p.data(), p.size(), &bytesWritten);
-    p = p.subspan(bytesWritten);
+    skip(p, bytesWritten);
     if (status)
         return Exception { ExceptionCode::OperationError };
 

--- a/Source/WebCore/css/CSSMarkup.cpp
+++ b/Source/WebCore/css/CSSMarkup.cpp
@@ -29,6 +29,7 @@
 
 #include "CSSParserIdioms.h"
 #include <wtf/HexNumber.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/unicode/CharacterNames.h>
 
@@ -38,21 +39,16 @@ template <typename CharacterType>
 static inline bool isCSSTokenizerIdentifier(std::span<const CharacterType> characters)
 {
     // -?
-    while (!characters.empty() && characters.front() == '-')
-        characters = characters.subspan(1);
+    skipWhile(characters, '-');
 
     // {nmstart}
-    if (characters.empty() || !isNameStartCodePoint(characters.front()))
+    if (!skipExactly<isNameStartCodePoint>(characters))
         return false;
-    characters = characters.subspan(1);
 
     // {nmchar}*
-    for (; !characters.empty(); characters = characters.subspan(1)) {
-        if (!isNameCodePoint(characters.front()))
-            return false;
-    }
+    skipWhile<isNameCodePoint>(characters);
 
-    return true;
+    return characters.empty();
 }
 
 // "ident" from the CSS tokenizer, minus backslash-escape sequences

--- a/Source/WebCore/css/CSSVariableData.cpp
+++ b/Source/WebCore/css/CSSVariableData.cpp
@@ -35,6 +35,7 @@
 #include "CSSValuePool.h"
 #include "RenderStyle.h"
 #include <wtf/text/AtomStringHash.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringView.h>
 
@@ -48,8 +49,7 @@ template<typename CharacterType> void CSSVariableData::updateBackingStringsInTok
         if (!token.hasStringBacking() || token.isBackedByStringLiteral())
             continue;
         unsigned length = token.value().length();
-        token.updateCharacters(currentOffset.first(length));
-        currentOffset = currentOffset.subspan(length);
+        token.updateCharacters(consumeSpan(currentOffset, length));
     }
     ASSERT(currentOffset.empty());
 }

--- a/Source/WebCore/dom/SpaceSplitString.cpp
+++ b/Source/WebCore/dom/SpaceSplitString.cpp
@@ -25,6 +25,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomStringHash.h>
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WebCore {
 
@@ -178,7 +179,7 @@ public:
             new (NotNull, m_memoryBucket.data()) AtomString(m_keyString);
         else
             new (NotNull, m_memoryBucket.data()) AtomString(characters);
-        m_memoryBucket = m_memoryBucket.subspan(1);
+        skip(m_memoryBucket, 1);
         return true;
     }
 

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -136,6 +136,7 @@
 #include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/unicode/CharacterNames.h>
 
 #if PLATFORM(MAC)
@@ -4120,7 +4121,7 @@ static Vector<SimpleRange> scanForTelephoneNumbers(const SimpleRange& range)
         auto scannerPosition = span.data() - characters.span().data();
         ASSERT(scannerPosition + relativeEndPosition <= text.length());
         result.append(resolveCharacterRange(range, CharacterRange(scannerPosition + relativeStartPosition, relativeEndPosition - relativeStartPosition)));
-        span = span.subspan(relativeEndPosition);
+        skip(span, relativeEndPosition);
     }
     return result;
 }

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -72,6 +72,7 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/TextBreakIterator.h>
 #include <wtf/unicode/CharacterNames.h>
@@ -2178,10 +2179,8 @@ inline bool SearchBuffer::isBadMatch(const UChar* match, size_t matchLength) con
         // correctly handle strings where the target and match have different-length
         // runs of characters that match, while still double checking the correctness
         // of matches of kana letters with other kana letters.
-        while (!a.empty() && !isKanaLetter(a.front()))
-            a = a.subspan(1);
-        while (!b.empty() && !isKanaLetter(b.front()))
-            b = b.subspan(1);
+        skipUntil<isKanaLetter>(a);
+        skipUntil<isKanaLetter>(b);
 
         // If we reached the end of either the target or the match, we should have
         // reached the end of both; both should have the same number of kana letters.
@@ -2196,8 +2195,8 @@ inline bool SearchBuffer::isBadMatch(const UChar* match, size_t matchLength) con
             return true;
         if (composedVoicedSoundMark(a.front()) != composedVoicedSoundMark(b.front()))
             return true;
-        a = a.subspan(1);
-        b = b.subspan(1);
+        skip(a, 1);
+        skip(b, 1);
 
         // Check for differences in combining voiced sound marks found after the letter.
         while (1) {
@@ -2210,8 +2209,8 @@ inline bool SearchBuffer::isBadMatch(const UChar* match, size_t matchLength) con
                 return true;
             if (a.front() != b.front())
                 return true;
-            a = a.subspan(1);
-            b = b.subspan(1);
+            skip(a, 1);
+            skip(b, 1);
         }
     }
 }

--- a/Source/WebCore/editing/cocoa/DataDetection.mm
+++ b/Source/WebCore/editing/cocoa/DataDetection.mm
@@ -61,6 +61,7 @@
 #import <wtf/WorkQueue.h>
 #import <wtf/cf/TypeCastsCF.h>
 #import <wtf/text/MakeString.h>
+#import <wtf/text/ParsingUtilities.h>
 #import <wtf/text/StringBuilder.h>
 #import <wtf/text/StringToIntegerConversion.h>
 
@@ -408,7 +409,7 @@ static void buildQuery(DDScanQueryRef scanQuery, const SimpleRange& contextRange
             } else
                 nbspCount = 0;
 
-            upconvertedCharacters = upconvertedCharacters.subspan(1);
+            skip(upconvertedCharacters, 1);
         }
         if (containsOnlyWhiteSpace) {
             if (hasNewline) {

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -77,6 +77,7 @@
 #import <wtf/ASCIICType.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/text/MakeString.h>
+#import <wtf/text/ParsingUtilities.h>
 #import <wtf/text/StringBuilder.h>
 #import <wtf/text/StringToIntegerConversion.h>
 
@@ -1458,13 +1459,6 @@ void HTMLConverter::_fillInBlock(NSTextBlock *block, Element& element, PlatformC
         [block setBorderColor:color.get() forEdge:NSMaxXEdge];
     if ((color = _colorForElement(element, CSSPropertyBorderBottomColor)))
         [block setBorderColor:color.get() forEdge:NSMaxYEdge];
-}
-
-static char consume(std::span<const char>& span)
-{
-    auto character = span.front();
-    span = span.subspan(1);
-    return character;
 }
 
 static inline BOOL read2DigitNumber(std::span<const char>& p, int8_t& outval)

--- a/Source/WebCore/html/HTMLFontElement.cpp
+++ b/Source/WebCore/html/HTMLFontElement.cpp
@@ -81,11 +81,11 @@ static bool parseFontSize(std::span<const CharacterType> characters, int& size)
     switch (characters.front()) {
     case '+':
         mode = RelativePlus;
-        characters = characters.subspan(1);
+        skip(characters, 1);
         break;
     case '-':
         mode = RelativeMinus;
-        characters = characters.subspan(1);
+        skip(characters, 1);
         break;
     default:
         mode = Absolute;
@@ -98,7 +98,7 @@ static bool parseFontSize(std::span<const CharacterType> characters, int& size)
     while (!characters.empty()) {
         if (!isASCIIDigit(characters.front()))
             break;
-        digits.append(consumeSingleElement(characters));
+        digits.append(consume(characters));
     }
 
     // Step 7

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
@@ -77,7 +77,7 @@ static void tokenizeDescriptors(std::span<const CharType>& position, Vector<Stri
     DescriptorTokenizerState state = Initial;
     const CharType* descriptorsStart = position.data();
     const CharType* currentDescriptorStart = descriptorsStart;
-    for (; ; position = position.subspan(1)) {
+    for (; ; skip(position, 1)) {
         switch (state) {
         case Initial:
             if (position.empty()) {
@@ -86,7 +86,7 @@ static void tokenizeDescriptors(std::span<const CharType>& position, Vector<Stri
             }
             if (isComma(position.front())) {
                 appendDescriptorAndReset(currentDescriptorStart, position.data(), descriptors);
-                position = position.subspan(1);
+                skip(position, 1);
                 return;
             }
             if (isASCIIWhitespace(position.front())) {

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -55,6 +55,7 @@
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/unicode/CharacterNames.h>
 
 #if ENABLE(TELEPHONE_NUMBER_DETECTION) && PLATFORM(IOS_FAMILY)
@@ -2489,7 +2490,7 @@ void HTMLTreeBuilder::linkifyPhoneNumbers(const String& string)
         m_tree.insertTextNode(string.substring(scannerPosition, relativeStartPosition));
         insertPhoneNumberLink(string.substring(scannerPosition + relativeStartPosition, relativeEndPosition - relativeStartPosition + 1));
 
-        span = span.subspan(relativeEndPosition + 1);
+        skip(span, relativeEndPosition + 1);
     }
 
     // Append the rest as a text node.

--- a/Source/WebCore/html/track/VTTScanner.h
+++ b/Source/WebCore/html/track/VTTScanner.h
@@ -246,9 +246,9 @@ inline UChar VTTScanner::currentChar() const
 inline void VTTScanner::advance(size_t amount)
 {
     if (m_is8Bit)
-        m_data.characters8 = m_data.characters8.subspan(amount);
+        skip(m_data.characters8, amount);
     else
-        m_data.characters16 = m_data.characters16.subspan(amount);
+        skip(m_data.characters16, amount);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -41,6 +41,7 @@
 #include "WidthIterator.h"
 #include <unicode/ubidi.h>
 #include <wtf/text/CharacterProperties.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/TextBreakIterator.h>
 
 namespace WebCore {
@@ -518,7 +519,7 @@ bool TextUtil::containsStrongDirectionalityText(StringView text)
             };
 
             auto result = SIMD::splat<UnsignedType>(0);
-            for (; span.size() < stride; span = span.subspan(stride))
+            for (; span.size() < stride; skip(span, stride))
                 result = SIMD::bitOr(result, maybeBidiRTL(span));
             if (!span.empty())
                 result = SIMD::bitOr(result, maybeBidiRTL(span.last(stride)));

--- a/Source/WebCore/platform/SharedMemory.cpp
+++ b/Source/WebCore/platform/SharedMemory.cpp
@@ -28,6 +28,7 @@
 
 #include "SharedBuffer.h"
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WebCore {
 
@@ -60,8 +61,7 @@ RefPtr<SharedMemory> SharedMemory::copyBuffer(const FragmentedSharedBuffer& buff
 
     auto destination = sharedMemory->mutableSpan();
     buffer.forEachSegment([&] (std::span<const uint8_t> segment) mutable {
-        memcpySpan(destination, segment);
-        destination = destination.subspan(segment.size());
+        memcpySpan(consumeSpan(destination, segment.size()), segment);
     });
 
     return sharedMemory;

--- a/Source/WebCore/platform/audio/FFTConvolver.cpp
+++ b/Source/WebCore/platform/audio/FFTConvolver.cpp
@@ -35,6 +35,7 @@
 #include "VectorMath.h"
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WebCore {
     
@@ -62,7 +63,7 @@ void FFTConvolver::process(FFTFrame* fftKernel, std::span<const float> source, s
     size_t numberOfDivisions = halfSize <= source.size() ? (source.size() / halfSize) : 1;
     size_t divisionSize = numberOfDivisions == 1 ? source.size() : halfSize;
 
-    for (size_t i = 0; i < numberOfDivisions; ++i, source = source.subspan(divisionSize), destination = destination.subspan(divisionSize)) {
+    for (size_t i = 0; i < numberOfDivisions; ++i, skip(source, divisionSize), skip(destination, divisionSize)) {
         // Copy samples to input buffer (note contraint above!)
         auto inputP = m_inputBuffer.span();
 

--- a/Source/WebCore/platform/audio/SincResampler.cpp
+++ b/Source/WebCore/platform/audio/SincResampler.cpp
@@ -37,6 +37,7 @@
 #include <wtf/Algorithms.h>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/ParsingUtilities.h>
 
 #if USE(ACCELERATE)
 #include <Accelerate/Accelerate.h>
@@ -219,13 +220,12 @@ void SincResampler::processBuffer(std::span<const float> source, std::span<float
         if (framesToCopy < framesToProcess)
             zeroSpan(buffer.subspan(framesToCopy, framesToProcess - framesToCopy));
 
-        source = source.subspan(framesToCopy);
+        skip(source, framesToCopy);
     });
 
     while (!destination.empty()) {
         unsigned framesThisTime = std::min<size_t>(destination.size(), AudioUtilities::renderQuantumSize);
-        resampler.process(destination, framesThisTime);
-        destination = destination.subspan(framesThisTime);
+        resampler.process(consumeSpan(destination, framesThisTime), framesThisTime);
     }
 }
 

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
@@ -34,6 +34,7 @@
 #include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/persistence/PersistentCoders.h>
+#include <wtf/text/ParsingUtilities.h>
 
 #if USE(LIBWEBRTC)
 
@@ -172,7 +173,7 @@ static std::span<const uint8_t> copyToCVPixelBufferPlane(CVPixelBufferRef pixelB
     uint32_t bytesPerRowDestination = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, planeIndex);
     for (unsigned i = 0; i < height; ++i) {
         std::memcpy(destination, source.data(), std::min(bytesPerRowSource, bytesPerRowDestination));
-        source = source.subspan(bytesPerRowSource);
+        skip(source, bytesPerRowSource);
         destination += bytesPerRowDestination;
     }
     return source;
@@ -231,7 +232,7 @@ bool SharedVideoFrameInfo::writePixelBuffer(CVPixelBufferRef pixelBuffer, std::s
     });
 
     encode(data);
-    data = data.subspan(sizeof(SharedVideoFrameInfo));
+    skip(data, sizeof(SharedVideoFrameInfo));
 
     auto* planeA = static_cast<const uint8_t*>(CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 0));
     if (!planeA) {

--- a/Source/WebCore/platform/graphics/filters/FilterImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.cpp
@@ -31,6 +31,7 @@
 #include "ImageBuffer.h"
 #include "PixelBuffer.h"
 #include "PixelBufferConversion.h"
+#include <wtf/text/ParsingUtilities.h>
 
 #if HAVE(ARM_NEON_INTRINSICS)
 #include <arm_neon.h>
@@ -192,8 +193,8 @@ static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& de
 
     for (int y = 0; y < sourceRectClipped.height(); ++y) {
         if (y) {
-            destinationPixel = destinationPixel.subspan(destinationBytesPerRow);
-            sourcePixel = sourcePixel.subspan(sourceBytesPerRow);
+            skip(destinationPixel, destinationBytesPerRow);
+            skip(sourcePixel, sourceBytesPerRow);
         }
         memcpySpan(destinationPixel, sourcePixel.first(size));
     }

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -45,6 +45,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/OptionSet.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/unicode/CharacterNames.h>
@@ -716,8 +717,8 @@ size_t parseHTTPHeader(std::span<const uint8_t> data, String& failureReason, Str
     nameStr = StringView();
     valueStr = String();
 
-    for (; !p.empty(); p = p.subspan(1)) {
-        switch (p.front()) {
+    for (; !p.empty(); skip(p, 1)) {
+        switch (p[0]) {
         case '\r':
             if (name.isEmpty()) {
                 if (p.size() > 1 && p[1] == '\n')
@@ -733,33 +734,31 @@ size_t parseHTTPHeader(std::span<const uint8_t> data, String& failureReason, Str
         case ':':
             break;
         default:
-            if (!isValidHeaderNameCharacter(p.front())) {
+            if (!isValidHeaderNameCharacter(p[0])) {
                 if (name.size() < 1)
                     failureReason = "Unexpected start character in header name"_s;
                 else
                     failureReason = makeString("Unexpected character in header name at "_s, trimInputSample(name.span()));
                 return 0;
             }
-            name.append(p.front());
+            name.append(p[0]);
             if (!foundFirstNameChar) {
                 namePtr = p;
                 foundFirstNameChar = true;
             }
             continue;
         }
-        if (p.front() == ':') {
-            p = p.subspan(1);
+        if (skipExactly(p, ':'))
             break;
-        }
     }
 
     nameSize = name.size();
     nameStr = namePtr.first(nameSize);
 
-    for (; !p.empty() && p.front() == 0x20; p = p.subspan(1)) { }
+    WTF::skipWhile(p, ' ');
 
-    for (; !p.empty(); p = p.subspan(1)) {
-        switch (p.front()) {
+    for (; !p.empty(); skip(p, 1)) {
+        switch (p[0]) {
         case '\r':
             break;
         case '\n':
@@ -769,14 +768,14 @@ size_t parseHTTPHeader(std::span<const uint8_t> data, String& failureReason, Str
             }
             break;
         default:
-            value.append(p.front());
+            value.append(p[0]);
         }
-        if (p.front() == '\r' || (!strict && p.front() == '\n')) {
-            p = p.subspan(1);
+        if (p[0] == '\r' || (!strict && p[0] == '\n')) {
+            skip(p, 1);
             break;
         }
     }
-    if (p.empty() || (strict && p.front() != '\n')) {
+    if (p.empty() || (strict && p[0] != '\n')) {
         failureReason = makeString("CR doesn't follow LF after header value at "_s, trimInputSample(p));
         return 0;
     }

--- a/Source/WebCore/platform/text/SegmentedString.cpp
+++ b/Source/WebCore/platform/text/SegmentedString.cpp
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "SegmentedString.h"
 
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/TextPosition.h>
 
@@ -167,7 +168,7 @@ String SegmentedString::toString() const
 
 void SegmentedString::advanceWithoutUpdatingLineNumber16()
 {
-    m_currentSubstring.s.currentCharacter16 = m_currentSubstring.s.currentCharacter16.subspan(1);
+    skip(m_currentSubstring.s.currentCharacter16, 1);
     m_currentCharacter = m_currentSubstring.s.currentCharacter16.front();
     updateAdvanceFunctionPointersIfNecessary();
 }
@@ -176,7 +177,7 @@ void SegmentedString::advanceAndUpdateLineNumber16()
 {
     ASSERT(m_currentSubstring.doNotExcludeLineNumbers);
     processPossibleNewline();
-    m_currentSubstring.s.currentCharacter16 = m_currentSubstring.s.currentCharacter16.subspan(1);
+    skip(m_currentSubstring.s.currentCharacter16, 1);
     m_currentCharacter = m_currentSubstring.s.currentCharacter16.front();
     updateAdvanceFunctionPointersIfNecessary();
 }

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -40,6 +40,7 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WebCore {
 
@@ -1859,7 +1860,7 @@ void GridTrackSizingAlgorithm::resolveIntrinsicTrackSizes(GridLayoutState& gridL
         auto upperBound = std::upper_bound(itemSpan.begin(), itemSpan.end(), itemSpan[0]);
         size_t rangeSize = upperBound - itemSpan.begin();
         increaseSizesToAccommodateSpanningItems<TrackSizeComputationVariant::NotCrossingFlexibleTracks>(itemSpan.first(rangeSize), gridLayoutState);
-        itemSpan = itemSpan.subspan(rangeSize);
+        skip(itemSpan, rangeSize);
     }
     increaseSizesToAccommodateSpanningItems<TrackSizeComputationVariant::CrossingFlexibleTracks>(itemsCrossingFlexibleTracks.mutableSpan(), gridLayoutState);
     handleInfinityGrowthLimit();

--- a/Source/WebCore/svg/SVGPathByteStreamSource.h
+++ b/Source/WebCore/svg/SVGPathByteStreamSource.h
@@ -23,6 +23,7 @@
 #include "SVGPathByteStream.h"
 #include "SVGPathSource.h"
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WebCore {
 
@@ -54,8 +55,7 @@ private:
     {
         DataType data;
         size_t dataSize = sizeof(DataType);
-        memcpySpan(asMutableByteSpan(data), m_streamCurrent.first(dataSize));
-        m_streamCurrent = m_streamCurrent.subspan(dataSize);
+        memcpySpan(asMutableByteSpan(data), consumeSpan(m_streamCurrent, dataSize));
         return data;
     }
 

--- a/Source/WebGPU/WGSL/AST/ASTBuilder.h
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.h
@@ -29,6 +29,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/Nonmovable.h>
 #include <wtf/Vector.h>
+#include <wtf/text/ParsingUtilities.h>
 
 #define WGSL_AST_BUILDER_NODE(Node) \
 protected: \
@@ -68,7 +69,7 @@ public:
             allocateArena();
 
         auto* node = new (m_arena.data()) T(std::forward<Arguments>(arguments)...);
-        m_arena = m_arena.subspan(alignedSize);
+        skip(m_arena, alignedSize);
         m_nodes.append(node);
         return *node;
     }

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -34,6 +34,7 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/cf/TypeCastsCF.h>
 #include <wtf/cf/VectorCF.h>
+#include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringView.h>
 
 namespace WebKit {
@@ -630,9 +631,7 @@ public:
         if (!alignBufferPosition(1, size))
             return *this;
 
-        value.append(m_buffer.first(size));
-        m_buffer = m_buffer.subspan(size);
-
+        value.append(consumeSpan(m_buffer, size));
         return *this;
     }
 
@@ -646,8 +645,7 @@ public:
         if (!alignBufferPosition(1, size))
             return *this;
 
-        value.append(m_buffer.first(size));
-        m_buffer = m_buffer.subspan(size);
+        value.append(consumeSpan(m_buffer, size));
         return *this;
     }
 
@@ -760,8 +758,7 @@ private:
         if (!alignBufferPosition(alignment, data.size()))
             return;
 
-        memcpySpan(data, m_buffer.first(data.size()));
-        m_buffer = m_buffer.subspan(data.size());
+        memcpySpan(data, consumeSpan(m_buffer, data.size()));
     }
 
     bool alignBufferPosition(unsigned alignment, size_t size)
@@ -773,7 +770,7 @@ private:
             return false;
         }
 
-        m_buffer = m_buffer.subspan(alignedPosition - m_buffer.data());
+        skip(m_buffer, alignedPosition - m_buffer.data());
         return true;
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -42,6 +42,7 @@
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/PixelBufferConversion.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/ParsingUtilities.h>
 
 #if ENABLE(VIDEO)
 #include "RemoteVideoFrameObjectHeapProxy.h"
@@ -308,7 +309,7 @@ void RemoteGraphicsContextGLProxy::getBufferSubData(GCGLenum target, GCGLintptr 
             if (!valid)
                 return;
             std::ranges::copy(replyBuffer->span().subspan(0, transferSize), data.begin());
-            data = data.subspan(transferSize);
+            skip(data, transferSize);
             offset += transferSize;
         }
         return;
@@ -326,7 +327,7 @@ inlineCase:
             return;
         RELEASE_ASSERT(transferSize == inlineBuffer.size());
         std::ranges::copy(inlineBuffer, data.begin());
-        data = data.subspan(transferSize);
+        skip(data, transferSize);
         offset += transferSize;
     }
 }
@@ -364,7 +365,7 @@ void RemoteGraphicsContextGLProxy::readPixels(IntRect rect, GCGLenum format, GCG
         // Will not overflow, because rect.size() * { dataStoreRowBytes, bytesPerGroup } is validated and it will fit to the uint32_t.
         // bottomLeftOutOfBounds must be smaller than rect.size() in case adjusted rect is non-empty.
         unsigned skipRowBytes = bottomLeftOutOfBounds.width() * bytesPerGroup;
-        dataStore = dataStore.subspan(dataStoreRowBytes * bottomLeftOutOfBounds.height() + skipRowBytes);
+        skip(dataStore, dataStoreRowBytes * bottomLeftOutOfBounds.height() + skipRowBytes);
     }
 
     static constexpr size_t readPixelsInlineSizeLimit = 64 * KB; // NOTE: when changing, change the value in RemoteGraphicsContextGL too.

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPageCoverage.h
@@ -28,6 +28,7 @@
 #if ENABLE(UNIFIED_PDF)
 
 #include "PDFDocumentLayout.h"
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WTF {
 class TextStream;
@@ -58,17 +59,12 @@ inline PDFPageCoverage unite(const PDFPageCoverage& a, const PDFPageCoverage& b)
     auto bs = b.span();
     while (!as.empty() && !bs.empty()) {
         auto cmp = as.front().pageIndex <=> bs.front().pageIndex;
-        if (cmp < 0) {
-            result.append(as.front());
-            as = as.subspan(1);
-        } else if (cmp > 0) {
-            result.append(bs.front());
-            bs = bs.subspan(1);
-        } else {
-            result.append(unite(as.front(), bs.front()));
-            as = as.subspan(1);
-            bs = bs.subspan(1);
-        }
+        if (cmp < 0)
+            result.append(consume(as));
+        else if (cmp > 0)
+            result.append(consume(bs));
+        else
+            result.append(unite(consume(as), consume(bs)));
     }
     result.append(as);
     result.append(bs);


### PR DESCRIPTION
#### 4e98b4d7345d77ada364888535ef651e7dc53f70
<pre>
Further reduce use of std::span::subspan() by leveraging ParsingUtilities
<a href="https://bugs.webkit.org/show_bug.cgi?id=285283">https://bugs.webkit.org/show_bug.cgi?id=285283</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/DateMath.cpp:
(WTF::parseDate):
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::mapToFile):
* Source/WTF/wtf/JSONValues.cpp:
* Source/WTF/wtf/StreamBuffer.h:
(WTF::StreamBuffer::append):
* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::userVisibleURL):
* Source/WTF/wtf/text/Base64.cpp:
(WTF::fromBase64SlowImpl):
* Source/WTF/wtf/text/ParsingUtilities.h:
(WTF::skipUntil):
(WTF::skipWhile):
(WTF::consumeSpan):
(WTF::consumeSingleElementOfType):
* Source/WTF/wtf/text/StringBuilderJSON.cpp:
(WTF::StringBuilder::appendQuotedJSONString):
* Source/WTF/wtf/text/StringBuilderJSON.h:
(WTF::appendEscapedJSONStringContent):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::simplifyMatchedCharactersToSpace):
* Source/WTF/wtf/text/StringToIntegerConversion.h:
(WTF::parseInteger):
* Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp:
(WebCore::readLittleEndian):
(WebCore::decodeKey):
(WebCore::deserializeIDBKeyData):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp:
(WebCore::parseSFrameHeader):
* Source/WebCore/Modules/mediastream/STUNMessageParsing.cpp:
(WebCore::WebRTC::extractDataMessages):
* Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp:
(WebCore::isSpaceOrTab):
(WebCore::WebSocketExtensionParser::skipSpaces):
(WebCore::WebSocketExtensionParser::consumeToken):
(WebCore::WebSocketExtensionParser::consumeQuotedString):
(WebCore::WebSocketExtensionParser::consumeCharacter):
* Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp:
(PAL::TextCodecLatin1::decode):
* Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp:
(PAL::TextCodecUTF8::handlePartialSequence):
(PAL::TextCodecUTF8::decode):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readLittleEndian):
(WebCore::CloneDeserializer::readTag):
(WebCore::CloneDeserializer::readArrayBufferViewSubtag):
(WebCore::CloneDeserializer::readResizableNonSharedArrayBuffer):
(WebCore::CloneDeserializer::read):
* Source/WebCore/css/CSSMarkup.cpp:
(WebCore::isCSSTokenizerIdentifier):
* Source/WebCore/css/CSSStyleDeclaration.cpp:
* Source/WebCore/css/CSSVariableData.cpp:
(WebCore::CSSVariableData::updateBackingStringsInTokens):
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::parseColorIntOrPercentage):
(WebCore::parseRGBAlphaValue):
(WebCore::parseLegacyHSL):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::SearchBuffer::isBadMatch const):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(consume):
* Source/WebCore/html/parser/HTMLParserIdioms.cpp:
(WebCore::isHTMLSpaceOrDelimiterOrNumberStart):
(WebCore::parseHTMLListOfOfFloatingPointNumberValuesInternal):
(WebCore::isASCIIDigitOrPeriod):
(WebCore::parseHTTPRefreshInternal):
* Source/WebCore/loader/TextResourceDecoder.cpp:
(WebCore::TextResourceDecoder::checkForCSSCharset):
(WebCore::TextResourceDecoder::checkForHeadCharset):
* Source/WebCore/platform/SharedMemory.cpp:
(WebCore::SharedMemory::copyBuffer):
* Source/WebCore/platform/audio/SincResampler.cpp:
(WebCore::SincResampler::processBuffer):
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::parseHTTPHeader):
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::popDescriptorAndAdvance):
(IPC::Connection::sendOutgoingMessage):
(IPC::createMessageDecoder):
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::HistoryEntryDataDecoder::operator&gt;&gt;):
(WebKit::HistoryEntryDataDecoder::decodeFixedLengthData):

Canonical link: <a href="https://commits.webkit.org/288387@main">https://commits.webkit.org/288387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3b6c3e9835ef620976b4768f892792bbd7dd6e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88061 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33998 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64628 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/22391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75450 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44904 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1876 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29643 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33032 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/75933 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89427 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/81996 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10234 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7429 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73050 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10462 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71258 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72270 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16435 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15189 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12833 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10187 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/15699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/104400 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10059 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25287 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13524 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->