### PR TITLE
[WPE] WPE Platform: Use default values from WPESettings

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.cpp
@@ -25,6 +25,8 @@
 
 #include "config.h"
 #include "WPEGestureDetector.h"
+#include "WPEDisplay.h"
+#include "WPESettings.h"
 
 #include <cmath>
 
@@ -49,6 +51,8 @@ void GestureDetector::handleEvent(WPEEvent* event)
         break;
     case WPE_EVENT_TOUCH_MOVE:
         if (double x, y; wpe_event_get_position(event, &x, &y) && m_position) {
+            auto* settings = wpe_display_get_settings(wpe_view_get_display(wpe_event_get_view(event)));
+            auto dragActivationThresholdPx = wpe_settings_get_uint32(settings, WPE_SETTING_DRAG_THRESHOLD, nullptr);
             if (m_gesture != WPE_GESTURE_DRAG && std::hypot(x - m_position->x, y - m_position->y) > dragActivationThresholdPx) {
                 m_gesture = WPE_GESTURE_DRAG;
                 m_nextDeltaReferencePosition = m_position;

--- a/Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.h
@@ -47,10 +47,6 @@ public:
     bool dragBegin() const { return m_dragBegin && *m_dragBegin; }
 
 private:
-    // FIXME: These ought to be either configurable or derived from system
-    //        properties, such as screen size and pixel density.
-    static constexpr uint32_t dragActivationThresholdPx { 8 };
-
     WPEGesture m_gesture { WPE_GESTURE_NONE };
     std::optional<uint32_t> m_sequenceId;
     std::optional<Position> m_position;

--- a/Source/WebKit/WPEPlatform/wpe/WPESettings.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPESettings.h
@@ -195,6 +195,48 @@ typedef enum {
  * Default: 400
  */
 #define WPE_SETTING_DOUBLE_CLICK_TIME "/wpe-platform/events/double-click/time"
+/**
+ * WPE_SETTING_DRAG_THRESHOLD:
+ *
+ * The number of pixels the cursor travelled to activate a drag gesture.
+ *
+ * VariantType: uint32
+ *
+ * Default: 8
+ */
+#define WPE_SETTING_DRAG_THRESHOLD "/wpe-platform/events/gestures/drag-thresold"
+/**
+ * WPE_SETTING_KEY_REPEAT_DELAY:
+ *
+ * The allowed delay in milliseconds to begin listening to a key repeat
+ * event since the start of handling the key.
+ *
+ * VariantType: uint32
+ *
+ * Default: 400
+ */
+#define WPE_SETTING_KEY_REPEAT_DELAY "/wpe-platform/events/key-repeat/delay"
+/**
+ * WPE_SETTING_KEY_REPEAT_INTERVAL:
+ *
+ * The allowed interval in milliseconds on top of the key repeat delay to
+ * listen to a key repeat event.
+ *
+ * VariantType: uint32
+ *
+ * Default: 80
+ */
+#define WPE_SETTING_KEY_REPEAT_INTERVAL "/wpe-platform/events/key-repeat/interval"
+/**
+ * WPE_SETTING_DRM_SCALE:
+ *
+ * The scale size of the DRM screen.
+ *
+ * VariantType: double
+ *
+ * Default: 1.0
+ */
+#define WPE_SETTING_DRM_SCALE "/wpe-platform/drm/scale"
 
 /**
  * WPESettingsSource:

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.cpp
@@ -28,6 +28,7 @@
 
 #include "WPEDRMSession.h"
 #include "WPEKeymapXKB.h"
+#include "WPESettings.h"
 #include "WPEViewDRMPrivate.h"
 #include <linux/input.h>
 #include <wtf/MonotonicTime.h>
@@ -416,9 +417,9 @@ void Seat::handleKey(uint32_t time, uint32_t key, bool pressed, bool fromRepeat)
         g_source_attach(m_keyboard.repeat.source.get(), g_main_context_get_thread_default());
     }
 
-    // FIXME: make this configurable.
-    static const Seconds delay = 400_ms;
-    static const Seconds interval = 80_ms;
+    auto* settings = wpe_display_get_settings(wpe_view_get_display(view.get()));
+    Seconds delay = Seconds::fromMilliseconds(wpe_settings_get_uint32(settings, WPE_SETTING_KEY_REPEAT_DELAY, nullptr));
+    Seconds interval = Seconds::fromMilliseconds(wpe_settings_get_uint32(settings, WPE_SETTING_KEY_REPEAT_INTERVAL, nullptr));
 
     auto now = MonotonicTime::now().secondsSinceEpoch();
     if (!fromRepeat)


### PR DESCRIPTION
#### f693d4f45ae4c940c4c04f4e53f207da059b221d
<pre>
[WPE] WPE Platform: Use default values from WPESettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=285287">https://bugs.webkit.org/show_bug.cgi?id=285287</a>

Reviewed by Carlos Garcia Campos.

Grab default values from WPESettings for drag gesture
threshold, as well as key repeat delay and interval.

* Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.cpp:
(WPE::GestureDetector::handleEvent):
* Source/WebKit/WPEPlatform/wpe/WPEGestureDetector.h:
* Source/WebKit/WPEPlatform/wpe/WPESettings.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDRMSeat.cpp:
(WPE::DRM::Seat::handleKey):

Canonical link: <a href="https://commits.webkit.org/288922@main">https://commits.webkit.org/288922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68002f90e4ef631cc35732b9296eb776c580cf5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89909 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35822 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65958 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23788 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3476 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77031 "Found 3 new API test failures: TestWebKitAPI.WKWebExtensionAPIMenus.MacVideoContextMenuItems, TestWebKitAPI.WKWebExtensionAPIMenus.MacImageContextMenuItems, TestWebKitAPI.WKWebExtensionAPIMenus.MacAudioContextMenuItems (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46232 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3355 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34896 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91285 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12109 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74438 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73564 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17943 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16385 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/3557 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13215 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12061 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17501 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11895 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15389 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13641 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->