### PR TITLE
[SwiftUI] Find-in-Page integration (macOS)

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/View+WebViewModifiers.swift
+++ b/Source/WebKit/UIProcess/API/Swift/View+WebViewModifiers.swift
@@ -24,7 +24,7 @@
 #if ENABLE_SWIFTUI && compiler(>=6.0)
 
 import Foundation
-import SwiftUI
+public import SwiftUI
 
 extension EnvironmentValues {
     @Entry var webViewAllowsBackForwardNavigationGestures = false

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -25,6 +25,7 @@
 
 import Foundation
 import Observation
+internal import WebKit_Private
 
 @MainActor
 final class WebPageWebView: WKWebView {
@@ -257,6 +258,9 @@ public class WebPage_v0 {
     @ObservationIgnored
     lazy var backingWebView: WebPageWebView = {
         let webView = WebPageWebView(frame: .zero, configuration: WKWebViewConfiguration(configuration))
+#if os(macOS)
+        webView._usePlatformFindUI = false
+#endif
         webView.navigationDelegate = backingNavigationDelegate
         webView.uiDelegate = backingUIDelegate
         return webView

--- a/Source/WebKit/UIProcess/API/Swift/WebView/CocoaWebViewAdapter.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebView/CocoaWebViewAdapter.swift
@@ -1,0 +1,252 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI && compiler(>=6.0)
+
+internal import WebKit_Internal
+internal import SwiftUI // FIXME: (283455) Do not import SwiftUI in WebKit proper.
+
+#if canImport(UIKit)
+typealias PlatformView = UIView
+#else
+typealias PlatformView = NSView
+#endif
+
+@MainActor
+class CocoaWebViewAdapter: PlatformView, PlatformTextSearching {
+    // MARK: PlatformTextSearching conformance
+
+#if os(macOS)
+    typealias FindInteraction = NSTextFinderAdapter
+#else
+    typealias FindInteraction = UIFindInteractionAdapter
+#endif
+
+    var isFindNavigatorVisible: Bool {
+#if os(macOS)
+        isFindBarVisible
+#else
+        webView?.findInteraction?.isFindNavigatorVisible ?? false
+#endif
+    }
+
+    lazy var findInteraction: FindInteraction? = {
+#if os(macOS)
+        let interaction = NSTextFinder()
+        interaction.isIncrementalSearchingEnabled = true
+        interaction.incrementalSearchingShouldDimContentView = false
+        interaction.client = webView
+        interaction.findBarContainer = self
+#else
+        guard let interaction = webView?.findInteraction else {
+            return nil
+        }
+#endif
+
+        return .init(wrapped: interaction)
+    }()
+
+#if os(macOS)
+    var isFindBarVisible: Bool = false {
+        didSet {
+            guard oldValue != isFindBarVisible else {
+                return
+            }
+
+            if let isPresented = findContext?.isPresented {
+                isPresented.wrappedValue = isFindBarVisible
+            }
+
+            if isFindBarVisible {
+                findBarDidBecomeVisible()
+            } else {
+                findBarDidBecomeHidden()
+            }
+        }
+    }
+
+    var findBarView: PlatformView? = nil
+#endif
+
+    // MARK: Find-in-Page support
+
+    var findContext: FindContext?
+
+#if os(macOS)
+    // This is called by the Find menu items in the Menu Bar
+    @objc(performFindPanelAction:)
+    func performFindPanelAction(_ sender: Any!) {
+        guard let item = sender as? NSMenuItem, let action = NSTextFinder.Action(rawValue: item.tag) else {
+            fatalError()
+        }
+
+        onNextMainRunLoop { [weak self] in
+            self?.findInteraction?.wrapped.performAction(action)
+        }
+    }
+
+    private func findBarDidBecomeVisible() {
+        guard let webView else {
+            return
+        }
+
+        guard let findBarView else {
+            preconditionFailure("find bar view was nil")
+        }
+
+        findBarView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(findBarView)
+
+        findBarConstraints = [
+            findBarView.widthAnchor.constraint(equalTo: widthAnchor),
+            findBarView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            findBarView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            findBarView.topAnchor.constraint(equalTo: topAnchor),
+            webView.topAnchor.constraint(equalTo: findBarView.bottomAnchor),
+        ]
+
+        NSLayoutConstraint.activate(findBarConstraints)
+
+        webViewHeightConstraint?.isActive = false
+    }
+
+    private func findBarDidBecomeHidden() {
+        findBarView?.translatesAutoresizingMaskIntoConstraints = true
+
+        for constraint in findBarConstraints {
+            constraint.isActive = false
+        }
+
+        findBarConstraints = []
+
+        webViewHeightConstraint?.isActive = true
+
+        findBarView?.removeFromSuperview()
+        webView?._hideFindUI()
+
+        onNextMainRunLoop { [weak self] in
+            guard let webView = self?.webView else {
+                return
+            }
+
+            webView.window?.makeFirstResponder(webView)
+        }
+    }
+#endif
+
+    // MARK: Constraints
+
+    private var webViewConstraints: [NSLayoutConstraint] = []
+    private var findBarConstraints: [NSLayoutConstraint] = []
+    private var webViewHeightConstraint: NSLayoutConstraint? = nil
+
+    private func removeConstraints() {
+        for constraint in webViewConstraints + findBarConstraints {
+            constraint.isActive = false
+        }
+
+        webViewHeightConstraint?.isActive = false
+
+        webViewConstraints = []
+        findBarConstraints = []
+        webViewHeightConstraint = nil
+    }
+
+    private func activateConstraints() {
+        guard let webView else {
+            preconditionFailure("web view was nil")
+        }
+
+        webViewConstraints = [
+            webView.widthAnchor.constraint(equalTo: widthAnchor),
+            webView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            webView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ]
+
+        webViewHeightConstraint = webView.heightAnchor.constraint(equalTo: heightAnchor)
+
+        NSLayoutConstraint.activate(webViewConstraints + [webViewHeightConstraint!])
+    }
+
+    // MARK: Main content view
+
+    var webView: WebPageWebView? = nil {
+        willSet {
+            guard webView != newValue else {
+                return
+            }
+
+            removeConstraints()
+
+            webView?.removeFromSuperview()
+        }
+        didSet {
+            guard oldValue != webView, let webView else {
+                return
+            }
+
+            webView.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(webView)
+
+            activateConstraints()
+
+            webView.delegate = self
+#if os(macOS)
+            findInteraction?.wrapped.client = webView
+#endif
+        }
+    }
+}
+
+#if os(macOS)
+extension CocoaWebViewAdapter: @preconcurrency NSTextFinderBarContainer {
+    func contentView() -> PlatformView? {
+        webView
+    }
+
+    func findBarViewDidChangeHeight() {
+    }
+}
+#endif
+
+extension CocoaWebViewAdapter: WebPageWebView.Delegate {
+#if os(iOS)
+    func findInteraction(_ interaction: UIFindInteraction, didBegin session: UIFindSession) {
+        if let isPresented = findContext?.isPresented {
+            isPresented.wrappedValue = true
+        }
+    }
+
+    func findInteraction(_ interaction: UIFindInteraction, didEnd session: UIFindSession) {
+        if let isPresented = findContext?.isPresented {
+            isPresented.wrappedValue = false
+        }
+    }
+
+    func supportsTextReplacement() -> Bool {
+        findContext?.canReplace ?? false
+    }
+#endif
+}
+
+#endif

--- a/Source/WebKit/UIProcess/API/Swift/WebView/WebView.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebView/WebView.swift
@@ -21,46 +21,21 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-import SwiftUI
-@_spi(Private) import WebKit
+#if ENABLE_SWIFTUI && compiler(>=6.0)
 
-@main
-struct SwiftBrowserApp: App {
-    @FocusedValue(BrowserViewModel.self) var focusedBrowserViewModel
+public import SwiftUI // FIXME: (283455) Do not import SwiftUI in WebKit proper.
 
-    @State private var mostRecentURL: URL? = nil
+@_spi(Private)
+public struct WebView_v0: View {
+    public init(_ page: WebPage_v0) {
+        self.page = page
+    }
 
-    var body: some Scene {
-        WindowGroup {
-            BrowserView(url: $mostRecentURL)
-        }
-        .commands {
-            CommandGroup(after: .sidebar) {
-                Button("Reload Page") {
-                    focusedBrowserViewModel!.page.reload()
-                }
-                .keyboardShortcut("r")
-                .disabled(focusedBrowserViewModel == nil)
-            }
+    let page: WebPage_v0
 
-            CommandGroup(replacing: .importExport) {
-                Button("Export as PDF…") {
-                    focusedBrowserViewModel!.exportAsPDF()
-                }
-                .disabled(focusedBrowserViewModel == nil)
-            }
-
-            TextEditingCommands()
-        }
-
-        #if os(macOS)
-        UtilityWindow("Downloads", id: "downloads") {
-            DownloadsList(downloads: focusedBrowserViewModel?.downloadCoordinator.downloads ?? [])
-        }
-
-        Settings {
-            SettingsView(currentURL: mostRecentURL)
-        }
-        #endif
+    public var body: some View {
+        WebViewRepresentable(owner: self)
     }
 }
+
+#endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -146,6 +146,9 @@
 		07297F9F1C17BBEA003F0735 /* UserMediaPermissionCheckProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 07297F9D1C17BBEA003F0735 /* UserMediaPermissionCheckProxy.h */; };
 		07297F9F1C17BBEA015F0735 /* DeviceIdHashSaltStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 07297F9D1C17BBEA223F0735 /* DeviceIdHashSaltStorage.h */; };
 		07297FA31C186ADB003F0735 /* WKUserMediaPermissionCheck.h in Headers */ = {isa = PBXBuildFile; fileRef = 07297FA11C186ADB003F0735 /* WKUserMediaPermissionCheck.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0735DC7F2D273D1700AF06D1 /* CocoaWebViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0735DC7E2D273D1700AF06D1 /* CocoaWebViewAdapter.swift */; };
+		0735DC812D273D4E00AF06D1 /* WebViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0735DC802D273D4E00AF06D1 /* WebViewRepresentable.swift */; };
+		0735DC842D273F1D00AF06D1 /* PlatformTextSearching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0735DC832D273F1D00AF06D1 /* PlatformTextSearching.swift */; };
 		0744DA552CE05FE400AACC81 /* WebKitInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 0744DA542CE05FE400AACC81 /* WebKitInternal.h */; };
 		074879B92373A90900F5678E /* AppKitSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 074879B72373A90900F5678E /* AppKitSoftLink.h */; };
 		074E75FE1DF2211900D318EC /* UserMediaProcessManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 074E75FB1DF1FD1300D318EC /* UserMediaProcessManager.h */; };
@@ -154,7 +157,6 @@
 		075A9CF326169BAB006DFA3A /* MediaSessionCoordinatorProxyPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 077BA570260E8F630072F19F /* MediaSessionCoordinatorProxyPrivate.h */; };
 		076897EE2D07B0BE006F9FA7 /* WebPage+DialogPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076897ED2D07B0BE006F9FA7 /* WebPage+DialogPresenting.swift */; };
 		076897F02D07B330006F9FA7 /* WKUIDelegateAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076897EF2D07B330006F9FA7 /* WKUIDelegateAdapter.swift */; };
-		076CEF0C2CEEE79900E4ABD6 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076CEF0B2CEEE79900E4ABD6 /* WebView.swift */; };
 		076E884E1A13CADF005E90FC /* APIContextMenuClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 076E884D1A13CADF005E90FC /* APIContextMenuClient.h */; };
 		0772811D21234FF600C8EF2E /* UserMediaPermissionRequestManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A410F4319AF7B27002EBAB5 /* UserMediaPermissionRequestManager.h */; };
 		077FD1A02CC7569200C5D9E0 /* WKIntelligenceTextEffectCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077FD19F2CC7569200C5D9E0 /* WKIntelligenceTextEffectCoordinator.swift */; };
@@ -164,6 +166,7 @@
 		078B04A02CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B049F2CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift */; };
 		078B04B42CF1A27F00B453A6 /* WebPage+FrameInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04B32CF1A27F00B453A6 /* WebPage+FrameInfo.swift */; };
 		078B04B62CF2B4D300B453A6 /* View+WebViewModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04B52CF2B4D300B453A6 /* View+WebViewModifiers.swift */; };
+		078F11832D2878EB00B3582D /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078F11822D2878EB00B3582D /* WebView.swift */; };
 		0792314C239CBCB8009598E2 /* RemoteMediaPlayerManagerProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 07923146239CBCB7009598E2 /* RemoteMediaPlayerManagerProxyMessages.h */; };
 		079D1D9A26960CD300883577 /* SystemStatusSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 079D1D9926960CD300883577 /* SystemStatusSPI.h */; };
 		07A58C882D068CAE00CAB4ED /* WebPage+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A58C872D068CAE00CAB4ED /* WebPage+SwiftUI.swift */; };
@@ -3073,6 +3076,9 @@
 		07297F9D1C17BBEA223F0735 /* DeviceIdHashSaltStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceIdHashSaltStorage.h; sourceTree = "<group>"; };
 		07297FA01C186ADB003F0735 /* WKUserMediaPermissionCheck.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKUserMediaPermissionCheck.cpp; sourceTree = "<group>"; };
 		07297FA11C186ADB003F0735 /* WKUserMediaPermissionCheck.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKUserMediaPermissionCheck.h; sourceTree = "<group>"; };
+		0735DC7E2D273D1700AF06D1 /* CocoaWebViewAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CocoaWebViewAdapter.swift; sourceTree = "<group>"; };
+		0735DC802D273D4E00AF06D1 /* WebViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewRepresentable.swift; sourceTree = "<group>"; };
+		0735DC832D273F1D00AF06D1 /* PlatformTextSearching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformTextSearching.swift; sourceTree = "<group>"; };
 		0736B753260D039F00E06994 /* RemoteMediaSessionCoordinator.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteMediaSessionCoordinator.messages.in; sourceTree = "<group>"; };
 		0736B754260D039F00E06994 /* RemoteMediaSessionCoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaSessionCoordinator.h; sourceTree = "<group>"; };
 		0736B755260D03A000E06994 /* RemoteMediaSessionCoordinator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaSessionCoordinator.cpp; sourceTree = "<group>"; };
@@ -3093,7 +3099,6 @@
 		074F34802CC5F7D500CA5301 /* WKIntelligenceTextEffectCoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKIntelligenceTextEffectCoordinator.h; sourceTree = "<group>"; };
 		076897ED2D07B0BE006F9FA7 /* WebPage+DialogPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+DialogPresenting.swift"; sourceTree = "<group>"; };
 		076897EF2D07B330006F9FA7 /* WKUIDelegateAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKUIDelegateAdapter.swift; sourceTree = "<group>"; };
-		076CEF0B2CEEE79900E4ABD6 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 		076E884D1A13CADF005E90FC /* APIContextMenuClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIContextMenuClient.h; sourceTree = "<group>"; };
 		076E884F1A13CBC6005E90FC /* APIInjectedBundlePageContextMenuClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIInjectedBundlePageContextMenuClient.h; sourceTree = "<group>"; };
 		077BA570260E8F630072F19F /* MediaSessionCoordinatorProxyPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSessionCoordinatorProxyPrivate.h; sourceTree = "<group>"; };
@@ -3104,6 +3109,7 @@
 		078B049F2CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+NavigationPreferences.swift"; sourceTree = "<group>"; };
 		078B04B32CF1A27F00B453A6 /* WebPage+FrameInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+FrameInfo.swift"; sourceTree = "<group>"; };
 		078B04B52CF2B4D300B453A6 /* View+WebViewModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+WebViewModifiers.swift"; sourceTree = "<group>"; };
+		078F11822D2878EB00B3582D /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 		07923130239B3B0C009598E2 /* RemoteMediaPlayerManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaPlayerManager.cpp; sourceTree = "<group>"; };
 		07923131239B3B0C009598E2 /* MediaPlayerPrivateRemote.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MediaPlayerPrivateRemote.cpp; sourceTree = "<group>"; };
 		07923132239B3B0C009598E2 /* MediaPlayerPrivateRemote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaPlayerPrivateRemote.h; sourceTree = "<group>"; };
@@ -8514,6 +8520,17 @@
 			tabWidth = 8;
 			usesTabs = 0;
 		};
+		0735DC822D273D9300AF06D1 /* WebView */ = {
+			isa = PBXGroup;
+			children = (
+				0735DC7E2D273D1700AF06D1 /* CocoaWebViewAdapter.swift */,
+				0735DC832D273F1D00AF06D1 /* PlatformTextSearching.swift */,
+				078F11822D2878EB00B3582D /* WebView.swift */,
+				0735DC802D273D4E00AF06D1 /* WebViewRepresentable.swift */,
+			);
+			path = WebView;
+			sourceTree = "<group>";
+		};
 		0736B752260D039F00E06994 /* MediaSession */ = {
 			isa = PBXGroup;
 			children = (
@@ -8750,6 +8767,7 @@
 		07CB79942CE9432D00199C49 /* Swift */ = {
 			isa = PBXGroup;
 			children = (
+				0735DC822D273D9300AF06D1 /* WebView */,
 				07259B282D1E4BAE00B45C4E /* DownloadCoordinator.swift */,
 				078B04432CF1149200B453A6 /* URLSchemeHandler.swift */,
 				078B04B52CF2B4D300B453A6 /* View+WebViewModifiers.swift */,
@@ -8764,7 +8782,6 @@
 				078B049F2CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift */,
 				07A58C872D068CAE00CAB4ED /* WebPage+SwiftUI.swift */,
 				07CB79952CE9435700199C49 /* WebPage.swift */,
-				076CEF0B2CEEE79900E4ABD6 /* WebView.swift */,
 				0718F1162D1C73450060C030 /* WKDownloadDelegateAdapter.swift */,
 				07CB79972CE943E400199C49 /* WKNavigationDelegateAdapter.swift */,
 				076897EF2D07B330006F9FA7 /* WKUIDelegateAdapter.swift */,
@@ -19711,6 +19728,7 @@
 				E326E357284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm in Sources */,
 				413E5C9229B0CF7C002F4987 /* BackgroundFetchStateCocoa.mm in Sources */,
 				1C62747E288B4C3E00CED3A2 /* CocoaHelpers.mm in Sources */,
+				0735DC7F2D273D1700AF06D1 /* CocoaWebViewAdapter.swift in Sources */,
 				49DC1DE127E5129100C1CB36 /* CSPExtensionUtilities.mm in Sources */,
 				522F792C28D531970069B45B /* CtapAuthenticator.cpp in Sources */,
 				526C5723284ADCBC00E08955 /* CtapCcidDriver.cpp in Sources */,
@@ -19741,6 +19759,7 @@
 				C1C1B30F2540F50D00D9100B /* NetworkConnectionToWebProcessMac.mm in Sources */,
 				41E242E026E0C908009A8C64 /* NetworkRTCUtilitiesCocoa.mm in Sources */,
 				DD4BDE7B2CA38213001A3339 /* ObjectiveCBlockConversions.swift in Sources */,
+				0735DC842D273F1D00AF06D1 /* PlatformTextSearching.swift in Sources */,
 				A1D4D2092B7DE6D00008C40E /* PlaybackSessionInterfaceLMK.mm in Sources */,
 				C15CBB3723F37ECB00300CC7 /* PreferenceObserver.mm in Sources */,
 				2D54C31B212F4DA60049C174 /* ProcessLauncher.cpp in Sources */,
@@ -20096,7 +20115,8 @@
 				9356F2DF2152B72300E6D5DF /* WebSWOriginStore.cpp in Sources */,
 				9356F2E12152B76600E6D5DF /* WebSWServerConnection.cpp in Sources */,
 				9356F2E02152B75200E6D5DF /* WebSWServerToContextConnection.cpp in Sources */,
-				076CEF0C2CEEE79900E4ABD6 /* WebView.swift in Sources */,
+				078F11832D2878EB00B3582D /* WebView.swift in Sources */,
+				0735DC812D273D4E00AF06D1 /* WebViewRepresentable.swift in Sources */,
 				C6A4CA0C2252899800169289 /* WKBundlePageMac.mm in Sources */,
 				2D931169212F61B200044BFE /* WKContentView.mm in Sources */,
 				2D93116A212F61B500044BFE /* WKContentViewInteraction.mm in Sources */,

--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -273,7 +273,9 @@ struct ContentView: View {
                             viewModel.page.load(backForwardItem: $0)
                         }
 
+                        #if os(iOS)
                         Spacer()
+                        #endif
 
                         ToolbarBackForwardMenuView(
                             list: viewModel.page.backForwardList.forwardList,
@@ -293,6 +295,8 @@ struct ContentView: View {
                                 .labelStyle(.iconOnly)
                         }
 
+                        #endif
+
                         Spacer()
 
                         Button {
@@ -302,8 +306,6 @@ struct ContentView: View {
                                 .labelStyle(.iconOnly)
                         }
                         .keyboardShortcut("f")
-
-                        #endif
                     }
                     
                     ToolbarItemGroup(placement: .principal) {


### PR DESCRIPTION
#### c728b84463466fdcbc5215809c205d8fed589862
<pre>
[SwiftUI] Find-in-Page integration (macOS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=285290">https://bugs.webkit.org/show_bug.cgi?id=285290</a>
<a href="https://rdar.apple.com/141503355">rdar://141503355</a>

Reviewed by Wenson Hsieh.

Use NSTextFinder with the backing WKWebView to integrate find-in-page capabilities in SwiftUI.

* Use autolayout instead of manual frame adjustment for `CocoaWebViewAdapter` so that the subviews can
easily adjust based on the presence or lack of find bar.

* Refactor CocoaWebViewAdapter a bit to be as platform agnostic as possible by introducing two helper protocols.

* Re-arrange and rename some files and types for better organization.

* Source/WebKit/UIProcess/API/Swift/View+WebViewModifiers.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(backingWebView):
* Source/WebKit/UIProcess/API/Swift/WebView/CocoaWebViewAdapter.swift: Added.
(CocoaWebViewAdapter.isFindNavigatorVisible):
(CocoaWebViewAdapter.findInteraction):
(CocoaWebViewAdapter.isFindBarVisible):
(CocoaWebViewAdapter.findBarView):
(CocoaWebViewAdapter.findContext):
(CocoaWebViewAdapter.performFindPanelAction(_:)):
(CocoaWebViewAdapter.findBarDidBecomeVisible):
(CocoaWebViewAdapter.findBarDidBecomeHidden):
(CocoaWebViewAdapter.webViewConstraints):
(CocoaWebViewAdapter.findBarConstraints):
(CocoaWebViewAdapter.webViewHeightConstraint):
(CocoaWebViewAdapter.removeConstraints):
(CocoaWebViewAdapter.activateConstraints):
(CocoaWebViewAdapter.webView):
(CocoaWebViewAdapter.contentView):
(CocoaWebViewAdapter.findBarViewDidChangeHeight):
(CocoaWebViewAdapter.findInteraction(_:didBegin:)):
(CocoaWebViewAdapter.findInteraction(_:didEnd:)):
(CocoaWebViewAdapter.supportsTextReplacement):
* Source/WebKit/UIProcess/API/Swift/WebView/PlatformTextSearching.swift: Copied from Tools/SwiftBrowser/Source/SwiftBrowser.swift.
(PlatformTextSearching.isFindNavigatorVisible):
(PlatformTextSearching.findInteraction):
(PlatformFindInteraction.presentFindNavigator(_:)):
(PlatformFindInteraction.dismissFindNavigator):
(NSTextFinderAdapter.presentFindNavigator(_:)):
(NSTextFinderAdapter.dismissFindNavigator):
(UIFindInteractionAdapter.presentFindNavigator(_:)):
(UIFindInteractionAdapter.dismissFindNavigator):
* Source/WebKit/UIProcess/API/Swift/WebView/WebView.swift: Copied from Tools/SwiftBrowser/Source/SwiftBrowser.swift.
(WebView_v0.body):
* Source/WebKit/UIProcess/API/Swift/WebView/WebViewRepresentable.swift: Renamed from Source/WebKit/UIProcess/API/Swift/WebView.swift.
(WebViewRepresentable.makePlatformView(_:)):
(WebViewRepresentable.updatePlatformView(_:context:)):
(WebViewCoordinator.update(_:configuration:environment:)):
(WebViewCoordinator.updateFindInteraction(_:environment:)):
(WebViewRepresentable.makeUIView(_:)):
(WebViewRepresentable.updateUIView(_:context:)):
(WebViewRepresentable.makeNSView(_:)):
(WebViewRepresentable.updateNSView(_:context:)):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/SwiftBrowser/Source/SwiftBrowser.swift:
(SwiftBrowserApp.body):

Canonical link: <a href="https://commits.webkit.org/288418@main">https://commits.webkit.org/288418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e4322e4de98261108b2782e6fc2e7d324bd9027

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37463 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/34204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10733 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/88268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/34204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86223 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/2112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75613 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/2017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29814 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33241 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30522 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/89637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10448 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/89637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10677 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71426 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/89637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/16591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12858 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10402 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/15892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/10266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/13734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/12035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->