### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in Source/WebCore/platform

### DIFF
--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
@@ -41,10 +41,7 @@
 #include <wtf/WorkQueue.h>
 #include <wtf/text/MakeString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
-ALLOW_UNUSED_PARAMETERS_BEGIN
-ALLOW_COMMA_BEGIN
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 
 #include <webrtc/api/environment/environment_factory.h>
 #include <webrtc/modules/video_coding/codecs/vp8/include/vp8.h>
@@ -52,8 +49,7 @@ ALLOW_COMMA_BEGIN
 #include <webrtc/system_wrappers/include/cpu_info.h>
 #include <webrtc/webkit_sdk/WebKit/WebKitDecoder.h>
 
-ALLOW_COMMA_END
-ALLOW_UNUSED_PARAMETERS_END
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 #include "CoreVideoSoftLink.h"
 
@@ -117,7 +113,7 @@ LibWebRTCVPXVideoDecoder::~LibWebRTCVPXVideoDecoder()
 Ref<VideoDecoder::DecodePromise> LibWebRTCVPXVideoDecoder::decode(EncodedFrame&& frame)
 {
     return invokeAsync(vpxDecoderQueueSingleton(), [value = Vector<uint8_t> { frame.data }, isKeyFrame = frame.isKeyFrame, timestamp = frame.timestamp, duration = frame.duration, decoder = m_internalDecoder] {
-        return decoder->decode({ value.data(), value.size() }, isKeyFrame, timestamp, duration);
+        return decoder->decode(value.span(), isKeyFrame, timestamp, duration);
     });
 }
 
@@ -272,7 +268,5 @@ int32_t LibWebRTCVPXInternalVideoDecoder::Decoded(webrtc::VideoFrame& frame)
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(LIBWEBRTC)

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
@@ -46,8 +46,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCVPXVideoEncoder);
@@ -307,7 +305,7 @@ webrtc::EncodedImageCallback::Result LibWebRTCVPXInternalVideoEncoder::OnEncoded
     }
 
     VideoEncoder::EncodedFrame encodedFrame {
-        Vector<uint8_t> { std::span { encodedImage.data(), encodedImage.size() } },
+        Vector<uint8_t> { unsafeMakeSpan(encodedImage.data(), encodedImage.size()) },
         encodedImage._frameType == webrtc::VideoFrameType::kVideoFrameKey,
         m_timestamp,
         m_duration,
@@ -323,7 +321,5 @@ void LibWebRTCVPXInternalVideoEncoder::OnDroppedFrame(DropReason)
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(LIBWEBRTC)

--- a/Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.cpp
+++ b/Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.cpp
@@ -45,8 +45,6 @@
 #include "MediaEngineConfigurationFactoryGStreamer.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static bool& mockEnabled()
@@ -98,6 +96,8 @@ bool MediaEngineConfigurationFactory::hasEncodingConfigurationFactory()
 {
     return mockEnabled() || WTF::anyOf(factories(), [] (auto& factory) { return (bool)factory.createEncodingConfiguration; });
 }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 void MediaEngineConfigurationFactory::createDecodingConfiguration(MediaDecodingConfiguration&& config, DecodingConfigurationCallback&& callback)
 {
@@ -161,6 +161,8 @@ void MediaEngineConfigurationFactory::createEncodingConfiguration(MediaEncodingC
     factoryCallback(factoryCallback, factories().begin(), WTFMove(config), WTFMove(callback));
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
 void MediaEngineConfigurationFactory::enableMock()
 {
     mockEnabled() = true;
@@ -172,5 +174,3 @@ void MediaEngineConfigurationFactory::disableMock()
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -58,8 +58,6 @@
 #include "VideoFrameGStreamer.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 struct VideoFrameAdaptor {
@@ -1509,7 +1507,7 @@ WTFLogChannel& RealtimeMediaSource::logChannel() const
 
 String convertEnumerationToString(RealtimeMediaSource::Type enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 2> values {
         MAKE_STATIC_STRING_IMPL("Audio"),
         MAKE_STATIC_STRING_IMPL("Video")
     };
@@ -1520,7 +1518,5 @@ String convertEnumerationToString(RealtimeMediaSource::Type enumerationValue)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
@@ -36,8 +36,6 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringBuilder.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 RealtimeMediaSourceSettings RealtimeMediaSourceSettings::isolatedCopy() const
@@ -176,7 +174,7 @@ OptionSet<RealtimeMediaSourceSettings::Flag> RealtimeMediaSourceSettings::differ
 
 String convertEnumerationToString(VideoFacingMode enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 5> values {
         MAKE_STATIC_STRING_IMPL("unknown"),
         MAKE_STATIC_STRING_IMPL("user"),
         MAKE_STATIC_STRING_IMPL("environment"),
@@ -194,7 +192,7 @@ String convertEnumerationToString(VideoFacingMode enumerationValue)
 
 String RealtimeMediaSourceSettings::displaySurface(DisplaySurfaceType surface)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 5> values {
         MAKE_STATIC_STRING_IMPL("monitor"),
         MAKE_STATIC_STRING_IMPL("window"),
         MAKE_STATIC_STRING_IMPL("application"),
@@ -212,7 +210,5 @@ String RealtimeMediaSourceSettings::displaySurface(DisplaySurfaceType surface)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
@@ -47,8 +47,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace libyuv {
 extern "C" int I420Copy(const uint8_t* src_y,
              int src_stride_y,
@@ -205,11 +203,13 @@ int32_t Dav1dDecoder::Decode(const webrtc::EncodedImage& encodedImage, bool /*mi
         return WEBRTC_VIDEO_CODEC_ERROR;
     }
 
-    auto* yData = static_cast<uint8_t*>(dav1dPicture.data[0]);
-    auto* uData = static_cast<uint8_t*>(dav1dPicture.data[1]);
-    auto* vData = static_cast<uint8_t*>(dav1dPicture.data[2]);
-    int yStride = dav1dPicture.stride[0];
-    int uvStride = dav1dPicture.stride[1];
+    auto pictureData = std::span { dav1dPicture.data };
+    auto* yData = static_cast<uint8_t*>(pictureData[0]);
+    auto* uData = static_cast<uint8_t*>(pictureData[1]);
+    auto* vData = static_cast<uint8_t*>(pictureData[2]);
+    auto pictureStride = std::span { dav1dPicture.stride };
+    int yStride = pictureStride[0];
+    int uvStride = pictureStride[1];
     libyuv::I420Copy(yData, yStride,
         uData, uvStride,
         vData, uvStride,
@@ -236,7 +236,5 @@ UniqueRef<webrtc::VideoDecoder> createLibWebRTCDav1dDecoder()
 }
 
 } // namespace
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -33,6 +33,7 @@
 #include "CoreAudioCaptureSource.h"
 #include "CoreAudioSharedInternalUnit.h"
 #include "Logging.h"
+#include "SpanCoreAudio.h"
 #include <AudioToolbox/AudioConverter.h>
 #include <AudioUnit/AudioUnit.h>
 #include <CoreMedia/CMSync.h>
@@ -61,8 +62,6 @@
 
 #include <pal/cf/AudioToolboxSoftLink.h>
 #include <pal/cf/CoreMediaSoftLink.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -521,7 +520,7 @@ OSStatus CoreAudioSharedUnit::processMicrophoneSamples(AudioUnitRenderActionFlag
     m_microphoneSampleBuffer->reset();
     AudioBufferList& bufferList = m_microphoneSampleBuffer->bufferList();
     if (auto err = m_ioUnit->render(&ioActionFlags, &timeStamp, inBusNumber, inNumberFrames, &bufferList)) {
-        RELEASE_LOG_ERROR(WebRTC, "CoreAudioSharedUnit::processMicrophoneSamples(%p) AudioUnitRender failed with error %d (%.4s), bufferList size %d, inNumberFrames %d ", this, (int)err, (char*)&err, (int)bufferList.mBuffers[0].mDataByteSize, (int)inNumberFrames);
+        RELEASE_LOG_ERROR(WebRTC, "CoreAudioSharedUnit::processMicrophoneSamples(%p) AudioUnitRender failed with error %d (%.4s), bufferList size %d, inNumberFrames %d ", this, (int)err, (char*)&err, (int)span(bufferList)[0].mDataByteSize, (int)inNumberFrames);
         if (err == kAudio_ParamError && !m_minimumMicrophoneSampleFrames) {
             m_minimumMicrophoneSampleFrames = inNumberFrames;
             // Our buffer might be too small, the preferred buffer size or sample rate might have changed.
@@ -921,7 +920,5 @@ void CoreAudioSharedUnit::setIsInBackground(bool isInBackground)
 #endif
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -44,16 +44,16 @@
 #import <AVFoundation/AVAudioBuffer.h>
 #import <AudioToolbox/AudioConverter.h>
 #import <CoreAudio/CoreAudioTypes.h>
+#import <wtf/IndexedRange.h>
 #import <wtf/RunLoop.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/Vector.h>
 #import <wtf/WorkQueue.h>
+#import <wtf/ZippedRange.h>
 
 #import <pal/cf/AudioToolboxSoftLink.h>
 #import <pal/cf/CoreMediaSoftLink.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -62,32 +62,23 @@ static inline size_t alignTo16Bytes(size_t size)
     return (size + 15) & ~15;
 }
 
-static const double Tau = 2 * M_PI;
-static const double BipBopDuration = 0.07;
-static const double BipBopVolume = 0.5;
-static const double BipFrequency = 1500;
-static const double BopFrequency = 500;
-static const double HumFrequency = 150;
-static const double HumVolume = 0.1;
-static const double NoiseFrequency = 3000;
-static const double NoiseVolume = 0.05;
+static constexpr double Tau = 2 * M_PI;
+static constexpr double BipBopDuration = 0.07;
+static constexpr double BipBopVolume = 0.5;
+static constexpr double BipFrequency = 1500;
+static constexpr double BopFrequency = 500;
+static constexpr double HumFrequency = 150;
+static constexpr double HumVolume = 0.1;
+static constexpr double NoiseFrequency = 3000;
+static constexpr double NoiseVolume = 0.05;
 
 template <typename AudioSampleType>
-static void writeHum(float amplitude, float frequency, float sampleRate, AudioSampleType *p, uint64_t count)
+static void addHum(float amplitude, float frequency, float sampleRate, uint64_t start, std::span<AudioSampleType> p)
 {
     float humPeriod = sampleRate / frequency;
-    for (uint64_t i = 0; i < count; ++i)
-        *p++ = amplitude * sin(i * Tau / humPeriod);
-}
-
-template <typename AudioSampleType>
-static void addHum(float amplitude, float frequency, float sampleRate, uint64_t start, AudioSampleType *p, uint64_t count)
-{
-    float humPeriod = sampleRate / frequency;
-    for (uint64_t i = start, end = start + count; i < end; ++i) {
-        AudioSampleType a = amplitude * sin(i * Tau / humPeriod);
-        a += *p;
-        *p++ = a;
+    for (auto [i, pValue] : indexedRange(p)) {
+        AudioSampleType a = amplitude * sin((start + i) * Tau / humPeriod);
+        pValue += a;
     }
 }
 
@@ -310,10 +301,10 @@ void MockAudioSharedInternalUnit::reconfigure()
     size_t bipStart = 0;
     size_t bopStart = rate;
 
-    addHum(BipBopVolume, BipFrequency, rate, 0, m_bipBopBuffer.data() + bipStart, bipBopSampleCount);
-    addHum(BipBopVolume, BopFrequency, rate, 0, m_bipBopBuffer.data() + bopStart, bipBopSampleCount);
+    addHum(BipBopVolume, BipFrequency, rate, 0, m_bipBopBuffer.mutableSpan().subspan(bipStart, bipBopSampleCount));
+    addHum(BipBopVolume, BopFrequency, rate, 0, m_bipBopBuffer.mutableSpan().subspan(bopStart, bipBopSampleCount));
     if (!m_enableEchoCancellation)
-        addHum(NoiseVolume, NoiseFrequency, rate, 0, m_bipBopBuffer.data(), sampleCount);
+        addHum(NoiseVolume, NoiseFrequency, rate, 0, m_bipBopBuffer.mutableSpan().first(sampleCount));
 }
 
 void MockAudioSharedInternalUnit::emitSampleBuffers(uint32_t frameCount)
@@ -370,8 +361,9 @@ void MockAudioSharedInternalUnit::generateSampleBuffers(MonotonicTime renderTime
         uint32_t bipBopCount = std::min(frameCount, bipBopRemain);
         for (auto& audioBuffer : m_audioBufferList->buffers()) {
             audioBuffer.mDataByteSize = frameCount * m_streamFormat.mBytesPerFrame;
-            memcpySpan(mutableSpan<float>(audioBuffer), m_bipBopBuffer.subspan(bipBopStart, bipBopCount));
-            addHum(HumVolume, HumFrequency, sampleRate(), m_samplesRendered, static_cast<float*>(audioBuffer.mData), bipBopCount);
+            auto audioBufferSpan = mutableSpan<float>(audioBuffer);
+            memcpySpan(audioBufferSpan, m_bipBopBuffer.subspan(bipBopStart, bipBopCount));
+            addHum(HumVolume, HumFrequency, sampleRate(), m_samplesRendered, mutableSpan<float>(audioBuffer).first(bipBopCount));
         }
         emitSampleBuffers(bipBopCount);
         m_samplesRendered += bipBopCount;
@@ -382,27 +374,26 @@ void MockAudioSharedInternalUnit::generateSampleBuffers(MonotonicTime renderTime
 
 OSStatus MockAudioSharedInternalUnit::render(AudioUnitRenderActionFlags*, const AudioTimeStamp*, UInt32, UInt32 frameCount, AudioBufferList* buffer)
 {
+    auto destinationBuffers = span(*buffer);
     if (s_shouldIncreaseBufferSize) {
         auto copySize = frameCount * m_streamFormat.mBytesPerPacket;
-        if (buffer->mNumberBuffers && copySize <= buffer->mBuffers[0].mDataByteSize)
+        if (buffer->mNumberBuffers && copySize <= destinationBuffers[0].mDataByteSize)
             s_shouldIncreaseBufferSize = false;
         // We still return an error in case s_shouldIncreaseBufferSize is false since we do not have enough data to write.
         return kAudio_ParamError;
     }
 
-    auto* sourceBuffer = m_audioBufferList->list();
-    if (buffer->mNumberBuffers > sourceBuffer->mNumberBuffers)
+    auto sourceBuffers = span(*m_audioBufferList->list());
+    if (destinationBuffers.size() > sourceBuffers.size())
         return kAudio_ParamError;
 
+    sourceBuffers = sourceBuffers.first(destinationBuffers.size());
     auto copySize = frameCount * m_streamFormat.mBytesPerPacket;
-    for (uint32_t i = 0; i < buffer->mNumberBuffers; i++) {
-        ASSERT(copySize <= sourceBuffer->mBuffers[i].mDataByteSize);
-        if (copySize > buffer->mBuffers[i].mDataByteSize)
+    for (auto [sourceBuffer, destinationBuffer] : zippedRange(sourceBuffers, destinationBuffers)) {
+        ASSERT(copySize <= sourceBuffer.mDataByteSize);
+        if (copySize > destinationBuffer.mDataByteSize)
             return kAudio_ParamError;
-
-        auto source = span<uint8_t>(sourceBuffer->mBuffers[i]);
-        auto destination = mutableSpan<uint8_t>(buffer->mBuffers[i]);
-        memcpySpan(destination, source.first(copySize));
+        memcpySpan(mutableSpan<uint8_t>(destinationBuffer), span<uint8_t>(sourceBuffer).first(copySize));
     }
 
     return 0;
@@ -472,7 +463,5 @@ OSStatus MockAudioSharedInternalUnit::defaultOutputDevice(uint32_t* device)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
@@ -32,9 +32,8 @@
 #include "LibWebRTCAudioFormat.h"
 #include "LibWebRTCProvider.h"
 #include "Logging.h"
+#include "SpanCoreAudio.h"
 #include <wtf/TZoneMallocInlines.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -140,9 +139,10 @@ void RealtimeOutgoingAudioSourceCocoa::pullAudioData()
 
     AudioBufferList bufferList;
     bufferList.mNumberBuffers = 1;
-    bufferList.mBuffers[0].mNumberChannels = m_outputStreamDescription->numberOfChannels();
-    bufferList.mBuffers[0].mDataByteSize = bufferSize;
-    bufferList.mBuffers[0].mData = m_audioBuffer.data();
+    auto& firstBuffer = span(bufferList)[0];
+    firstBuffer.mNumberChannels = m_outputStreamDescription->numberOfChannels();
+    firstBuffer.mDataByteSize = bufferSize;
+    firstBuffer.mData = m_audioBuffer.data();
 
     if (isSilenced() !=  m_sampleConverter->muted())
         m_sampleConverter->setMuted(isSilenced());
@@ -161,7 +161,5 @@ void RealtimeOutgoingAudioSourceCocoa::sourceUpdated()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(LIBWEBRTC)


### PR DESCRIPTION
#### 4ae4f4ef280ef1eba9111b1233b5187313515124
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in Source/WebCore/platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=285291">https://bugs.webkit.org/show_bug.cgi?id=285291</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::LibWebRTCVPXVideoDecoder::decode):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp:
(WebCore::LibWebRTCVPXInternalVideoEncoder::OnEncodedImage):
* Source/WebCore/platform/mediacapabilities/MediaEngineConfigurationFactory.cpp:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp:
(WebCore::convertEnumerationToString):
(WebCore::RealtimeMediaSourceSettings::displaySurface):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp:
(WebCore::clipAudioBuffer):
(WebCore::clipAudioBufferList):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp:
(WebCore::Dav1dDecoder::Decode):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp:
(WebCore::CoreAudioCaptureDeviceManager::coreAudioCaptureDevices):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm:
(WebCore::addHum):
(WebCore::MockAudioSharedInternalUnit::reconfigure):
(WebCore::MockAudioSharedInternalUnit::generateSampleBuffers):
(WebCore::MockAudioSharedInternalUnit::render):
(WebCore::writeHum): Deleted.
* Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp:

Canonical link: <a href="https://commits.webkit.org/288393@main">https://commits.webkit.org/288393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf51a91ae07465e7aabf787f1fc521e0ca49ac37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82951 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88065 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34002 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64630 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22393 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75452 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44906 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29645 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33036 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30333 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89431 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73067 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72273 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16437 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15190 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12838 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10191 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/15703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10063 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13528 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11831 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->