### PR TITLE
AX: Remove redundant properties AXProperty::{ARIATreeRows, HeaderContainer}

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -566,6 +566,67 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::selectedListItems()
     return selectedListItems;
 }
 
+void AXCoreObject::ariaTreeRows(AccessibilityChildrenVector& rows, AccessibilityChildrenVector& ancestors)
+{
+    auto ownedObjects = this->ownedObjects();
+    ancestors.append(*this);
+
+    // The ordering of rows is first DOM children *not* in aria-owns, followed by all specified
+    // in aria-owns.
+    for (const auto& child : unignoredChildren()) {
+        // Add tree items as the rows.
+        if (child->roleValue() == AccessibilityRole::TreeItem) {
+            // Child appears both as a direct child and aria-owns, we should use the ordering as
+            // described in aria-owns for this child.
+            if (ownedObjects.contains(child))
+                continue;
+
+            // The result set may already contain the child through aria-owns. For example,
+            // a treeitem sitting under the tree root, which is owned elsewhere in the tree.
+            if (rows.contains(child))
+                continue;
+
+            rows.append(child);
+        }
+
+        // Now see if this item also has rows hiding inside of it.
+        child->ariaTreeRows(rows, ancestors);
+    }
+
+    // Now go through the aria-owns elements.
+    for (const auto& child : ownedObjects) {
+        // Avoid a circular reference via aria-owns by checking if our parent
+        // path includes this child. Currently, looking up the aria-owns parent
+        // path itself could be expensive, so we track it separately.
+        if (ancestors.contains(child))
+            continue;
+
+        // Add tree items as the rows.
+        if (child->roleValue() == AccessibilityRole::TreeItem) {
+            // Hopefully a flow that does not occur often in practice, but if someone were to include
+            // the owned child ealier in the top level of the tree, then reference via aria-owns later,
+            // move it to the right place.
+            if (rows.contains(child))
+                rows.removeFirst(child);
+
+            rows.append(child);
+        }
+
+        // Now see if this item also has rows hiding inside of it.
+        child->ariaTreeRows(rows, ancestors);
+    }
+
+    ancestors.removeLast();
+}
+
+AXCoreObject::AccessibilityChildrenVector AXCoreObject::ariaTreeRows()
+{
+    AccessibilityChildrenVector rows;
+    AccessibilityChildrenVector ancestors;
+    ariaTreeRows(rows, ancestors);
+    return rows;
+}
+
 bool AXCoreObject::isActiveDescendantOfFocusedContainer() const
 {
     auto containers = activeDescendantOfObjects();

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1342,7 +1342,7 @@ public:
 
     // Used by an ARIA tree to get all its rows.
     // FIXME: this should be folded into rows().
-    virtual AccessibilityChildrenVector ariaTreeRows() = 0;
+    AccessibilityChildrenVector ariaTreeRows();
     // Used by an ARIA tree item to get only its content, and not its child tree items and groups.
     AccessibilityChildrenVector ariaTreeItemContent();
 
@@ -1475,6 +1475,8 @@ private:
     // Detaches this object from the objects it references and it is referenced by.
     virtual void detachRemoteParts(AccessibilityDetachmentType) = 0;
     virtual void detachPlatformWrapper(AccessibilityDetachmentType) = 0;
+
+    void ariaTreeRows(AXCoreObject::AccessibilityChildrenVector& rows, AXCoreObject::AccessibilityChildrenVector& ancestors);
 
     AXID m_id;
 #if PLATFORM(COCOA)

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -624,9 +624,6 @@ WTF::TextStream& operator<<(WTF::TextStream& stream, const AXPropertyMap& map)
 TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
 {
     switch (property) {
-    case AXProperty::ARIATreeRows:
-        stream << "ARIATreeRows";
-        break;
 #if !ENABLE(AX_THREAD_TEXT_APIS)
     case AXProperty::AttributedText:
         stream << "AttributedText";
@@ -806,9 +803,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
         break;
     case AXProperty::HasUnderline:
         stream << "HasUnderline";
-        break;
-    case AXProperty::HeaderContainer:
-        stream << "HeaderContainer";
         break;
     case AXProperty::HeadingLevel:
         stream << "HeadingLevel";

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -633,9 +633,6 @@ public:
     bool isValueAutofillAvailable() const final;
     AutoFillButtonType valueAutofillButtonType() const final;
 
-    // Used by an ARIA tree to get all its rows.
-    AccessibilityChildrenVector ariaTreeRows() final;
-
     // ARIA live-region features.
     AccessibilityObject* liveRegionAncestor(bool excludeIfOff = true) const final { return Accessibility::liveRegionAncestor(*this, excludeIfOff); }
     const String liveRegionStatus() const override { return String(); }
@@ -928,7 +925,6 @@ private:
     // Note that "withoutCache" refers to the lack of referencing AXComputedObjectAttributeCache in the function, not the AXObjectCache parameter we pass in here.
     bool isIgnoredWithoutCache(AXObjectCache*) const;
     void setLastKnownIsIgnoredValue(bool);
-    void ariaTreeRows(AccessibilityChildrenVector& rows, AccessibilityChildrenVector& ancestors);
 
     // Special handling of click point for links.
     IntPoint linkClickPoint();

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -285,7 +285,6 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
         setObjectVectorProperty(AXProperty::Rows, object.rows());
         setObjectVectorProperty(AXProperty::Cells, object.cells());
         setObjectVectorProperty(AXProperty::VisibleRows, object.visibleRows());
-        setObjectProperty(AXProperty::HeaderContainer, object.headerContainer());
         setProperty(AXProperty::AXColumnCount, object.axColumnCount());
         setProperty(AXProperty::AXRowCount, object.axRowCount());
         setProperty(AXProperty::CellSlots, object.cellSlots());
@@ -324,11 +323,7 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
         setObjectVectorProperty(AXProperty::DisclosedRows, object.disclosedRows());
     }
 
-    if (object.isTree()) {
-        setProperty(AXProperty::IsTree, true);
-        setObjectVectorProperty(AXProperty::ARIATreeRows, object.ariaTreeRows());
-    }
-
+    setProperty(AXProperty::IsTree, object.isTree());
     if (object.isRadioButton()) {
         setProperty(AXProperty::NameAttribute, object.nameAttribute().isolatedCopy());
         // FIXME: This property doesn't get updated when a page changes dynamically.
@@ -2126,6 +2121,15 @@ AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::rowHeaders()
         }
     }
     return headers;
+}
+
+AXIsolatedObject* AXIsolatedObject::headerContainer()
+{
+    for (const auto& child : unignoredChildren()) {
+        if (child->roleValue() == AccessibilityRole::TableHeaderContainer)
+            return downcast<AXIsolatedObject>(child.ptr());
+    }
+    return nullptr;
 }
 
 #if !PLATFORM(MAC)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -180,7 +180,7 @@ private:
     AXIsolatedObject* cellForColumnAndRow(unsigned, unsigned) final;
     AccessibilityChildrenVector rowHeaders() final;
     AccessibilityChildrenVector visibleRows() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::VisibleRows)); }
-    AXIsolatedObject* headerContainer() final { return objectAttributeValue(AXProperty::HeaderContainer); }
+    AXIsolatedObject* headerContainer() final;
     int axColumnCount() const final { return intAttributeValue(AXProperty::AXColumnCount); }
     int axRowCount() const final { return intAttributeValue(AXProperty::AXRowCount); }
 
@@ -297,7 +297,6 @@ private:
     String computedRoleString() const final;
     bool isValueAutofillAvailable() const final { return boolAttributeValue(AXProperty::IsValueAutofillAvailable); }
     AutoFillButtonType valueAutofillButtonType() const final { return static_cast<AutoFillButtonType>(intAttributeValue(AXProperty::ValueAutofillButtonType)); }
-    AccessibilityChildrenVector ariaTreeRows() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::ARIATreeRows)); }
     URL url() const final { return urlAttributeValue(AXProperty::URL); }
     String accessKey() const final { return stringAttributeValueNullIfMissing(AXProperty::AccessKey); }
     String localizedActionVerb() const final { return stringAttributeValue(AXProperty::LocalizedActionVerb); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -617,9 +617,6 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
             propertyMap.set(AXProperty::AccessibilityText, axTextValue);
             break;
         }
-        case AXProperty::ARIATreeRows:
-            propertyMap.set(AXProperty::ARIATreeRows, axIDs(axObject.ariaTreeRows()));
-            break;
         case AXProperty::ValueAutofillButtonType:
             propertyMap.set(AXProperty::ValueAutofillButtonType, static_cast<int>(axObject.valueAutofillButtonType()));
             propertyMap.set(AXProperty::IsValueAutofillAvailable, axObject.isValueAutofillAvailable());
@@ -882,12 +879,6 @@ void AXIsolatedTree::updateDependentProperties(AccessibilityObject& axObject)
     updateTableAncestorColumns = updateTableAncestorColumns || isRowGroup(axObject.node());
 #endif
     for (RefPtr ancestor = axObject.parentObject(); ancestor; ancestor = ancestor->parentObject()) {
-        if (ancestor->isTree()) {
-            queueNodeUpdate(ancestor->objectID(), { AXProperty::ARIATreeRows });
-            if (!updateTableAncestorColumns)
-                break;
-        }
-
         if (updateTableAncestorColumns && is<AccessibilityTable>(*ancestor)) {
             // Only `updateChildren` if the table is unignored, because otherwise `updateChildren` will ascend and update the next highest unignored ancestor, which doesn't accomplish our goal of updating table columns.
             if (ancestor->isIgnored())

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -81,7 +81,6 @@ enum class AXPropertyFlag : uint32_t {
 };
 
 enum class AXProperty : uint16_t {
-    ARIATreeRows,
 #if !ENABLE(AX_THREAD_TEXT_APIS)
     // Rather than caching text content as property when ENABLE(AX_THREAD_TEXT_APIS), we should
     // synthesize it on-the-fly using AXProperty::TextRuns.
@@ -148,7 +147,6 @@ enum class AXProperty : uint16_t {
     IsSuperscript,
     HasTextShadow,
     HasUnderline,
-    HeaderContainer,
     HeadingLevel,
     HierarchicalLevel,
     HorizontalScrollBar,


### PR DESCRIPTION
#### e63f322ad08cc0655764be295df3a6ceab91367c
<pre>
AX: Remove redundant properties AXProperty::{ARIATreeRows, HeaderContainer}
<a href="https://bugs.webkit.org/show_bug.cgi?id=285156">https://bugs.webkit.org/show_bug.cgi?id=285156</a>
<a href="https://rdar.apple.com/142043300">rdar://142043300</a>

Reviewed by Chris Fleizach.

We can compute this property on-demand with information we have already cached off the main-thread. This change allows
us to do less up-front work when creating each object, guarantees these properties can never get stale (because they don&apos;t exist),
and saves memory.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::ariaTreeRows):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::ariaTreeRows): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
(WebCore::AXIsolatedObject::headerContainer):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::AXIsolatedTree::updateDependentProperties):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:

Canonical link: <a href="https://commits.webkit.org/288373@main">https://commits.webkit.org/288373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fed7eb1977b451e5376caa9eaba32df741ca164

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/87984 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33921 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84957 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10429 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64581 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22345 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75374 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44855 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29563 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32955 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73053 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89350 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7385 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72995 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71179 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72209 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17928 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16373 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1538 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10109 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15624 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/9982 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13447 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11750 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->