### PR TITLE
Ensure MediaSessionHelperProxy messages are not sent when MediaPlaybackEnabled is false

### DIFF
--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
@@ -73,6 +73,7 @@ public:
     static MediaSessionHelper& sharedHelper();
     static void setSharedHelper(Ref<MediaSessionHelper>&&);
     static void resetSharedHelper();
+    static void enableMediaPlayback();
 
     MediaSessionHelper() = default;
     explicit MediaSessionHelper(bool isExternalOutputDeviceAvailable);

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -112,14 +112,43 @@ private:
 #endif
 };
 
+class DummyMediaSessionHelper final : public MediaSessionHelper {
+public:
+    static Ref<DummyMediaSessionHelper> create()
+    {
+        return adoptRef(*new DummyMediaSessionHelper);
+    }
+
+private:
+    DummyMediaSessionHelper() = default;
+    void providePresentingApplicationPID(int, ShouldOverride) final { }
+    void startMonitoringWirelessRoutesInternal() final { }
+    void stopMonitoringWirelessRoutesInternal() final { }
+};
+
 static RefPtr<MediaSessionHelper>& sharedHelperInstance()
 {
     static NeverDestroyed<RefPtr<MediaSessionHelper>> helper;
     return helper;
 }
 
+static Ref<MediaSessionHelper>& dummyHelperInstance()
+{
+    static NeverDestroyed<Ref<MediaSessionHelper>> dummyHelper = DummyMediaSessionHelper::create();
+    return dummyHelper;
+}
+
+static bool s_mediaPlaybackEnabled { false };
+void MediaSessionHelper::enableMediaPlayback()
+{
+    s_mediaPlaybackEnabled = true;
+}
+
 MediaSessionHelper& MediaSessionHelper::sharedHelper()
 {
+    if (!s_mediaPlaybackEnabled)
+        return dummyHelperInstance();
+
     auto& helper = sharedHelperInstance();
     if (!helper)
         resetSharedHelper();

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.messages.in
@@ -29,14 +29,8 @@
     EnabledBy=MediaPlaybackEnabled
 ]
 messages -> RemoteMediaSessionHelperProxy {
-#if !PLATFORM(WATCHOS)
-    [EnabledBy=MediaSessionEnabled] StartMonitoringWirelessRoutes()
-    [EnabledBy=MediaSessionEnabled] StopMonitoringWirelessRoutes()
-#endif
-#if PLATFORM(WATCHOS)
     StartMonitoringWirelessRoutes()
     StopMonitoringWirelessRoutes()
-#endif
     ProvidePresentingApplicationPID(int pid, WebCore::MediaSessionHelper::ShouldOverride shouldOverride)
 }
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2467,6 +2467,10 @@ void WebProcess::enableMediaPlayback()
 #if ENABLE(ROUTING_ARBITRATION)
     m_routingArbitrator = makeUnique<AudioSessionRoutingArbitrator>(*this);
 #endif
+
+#if PLATFORM(IOS_FAMILY)
+    MediaSessionHelper::enableMediaPlayback();
+#endif
 }
 
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -369,6 +369,7 @@
 #if PLATFORM(IOS_FAMILY)
 #import <UIKit/UIColor.h>
 #import <UIKit/UIImage.h>
+#import <WebCore/MediaSessionHelperIOS.h>
 #import <pal/ios/UIKitSoftLink.h>
 #endif
 
@@ -1492,6 +1493,9 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
 #endif
 #if USE(AUDIO_SESSION)
         WebCore::AudioSession::enableMediaPlayback();
+#endif
+#if PLATFORM(IOS_FAMILY)
+        WebCore::MediaSessionHelper::enableMediaPlayback();
 #endif
 
 #if ENABLE(VIDEO)


### PR DESCRIPTION
#### f7de5f471fab0e8479d16f4a99e30367a5fbba08
<pre>
Ensure MediaSessionHelperProxy messages are not sent when MediaPlaybackEnabled is false
<a href="https://bugs.webkit.org/show_bug.cgi?id=285302">https://bugs.webkit.org/show_bug.cgi?id=285302</a>
<a href="https://rdar.apple.com/142276222">rdar://142276222</a>

Reviewed by NOBODY (OOPS!).

MediaSessionHelperProxy message endpoints are annotated with MediaPlaybackEnabled, which means GPU process does not
expect to receive these messages when MediaPlaybackEnabled is false (because when MediaPlaybackEnabled is false, media
playback functionalities should be disabled). Accordingly, we need to make sure web process does not send out these
messages. This patch implements that by ensuring RemoteMediaSessionHelper is not used (DummyMediaSessionHelper will
be created and used instead) when MediaPlaybackEnabled is false.

Also this patch removes MediaSessionEnabled annotation for MediaSessionHelperProxy message endpoints because the
messages can be sent when MediaSessionEnabled is false (MediaSessionEnabled currently guards availability of Media
Session API, but does not guard media session functionalities of media elements).

* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(dummyHelperInstance):
(MediaSessionHelper::enableMediaPlayback):
(MediaSessionHelper::sharedHelper):
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.messages.in:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::enableMediaPlayback):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _commonInitializationWithFrameName:groupName:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7de5f471fab0e8479d16f4a99e30367a5fbba08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88026 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33963 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85002 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64613 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22376 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44902 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1848 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29721 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32997 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73071 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30297 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89392 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73034 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10427 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72252 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16416 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15173 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1580 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10152 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15666 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10024 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11792 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->