### PR TITLE
Ensure RemoteRemoteCommandListenerProxy messages are not sent when MediaPlaybackEnabled is false

### DIFF
--- a/Source/WebCore/platform/RemoteCommandListener.cpp
+++ b/Source/WebCore/platform/RemoteCommandListener.cpp
@@ -44,6 +44,12 @@ static RemoteCommandListener::CreationFunction& remoteCommandListenerCreationFun
     return creationFunction;
 }
 
+static bool s_mediaPlaybackEnabled { false };
+void RemoteCommandListener::enableMediaPlayback()
+{
+    s_mediaPlaybackEnabled = true;
+}
+
 void RemoteCommandListener::setCreationFunction(CreationFunction&& function)
 {
     remoteCommandListenerCreationFunction() = WTFMove(function);
@@ -65,8 +71,12 @@ void RemoteCommandListener::resetCreationFunction()
 
 RefPtr<RemoteCommandListener> RemoteCommandListener::create(RemoteCommandListenerClient& client)
 {
+    if (!s_mediaPlaybackEnabled)
+        return nullptr;
+
     if (!remoteCommandListenerCreationFunction())
         resetCreationFunction();
+
     return remoteCommandListenerCreationFunction()(client);
 }
 

--- a/Source/WebCore/platform/RemoteCommandListener.h
+++ b/Source/WebCore/platform/RemoteCommandListener.h
@@ -46,6 +46,7 @@ public:
     using CreationFunction = Function<RefPtr<RemoteCommandListener>(RemoteCommandListenerClient&)>;
     static void setCreationFunction(CreationFunction&&);
     static void resetCreationFunction();
+    static void enableMediaPlayback();
 
     void addSupportedCommand(PlatformMediaSession::RemoteControlCommandType);
     void removeSupportedCommand(PlatformMediaSession::RemoteControlCommandType);

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
@@ -51,8 +51,8 @@ messages -> GPUConnectionToWebProcess WantsDispatchMessage {
     SetMediaOverridesForTesting(struct WebKit::MediaOverridesForTesting configuration)
     CreateAudioHardwareListener(WebKit::RemoteAudioHardwareListenerIdentifier identifier)
     ReleaseAudioHardwareListener(WebKit::RemoteAudioHardwareListenerIdentifier identifier)
-    CreateRemoteCommandListener(WebKit::RemoteRemoteCommandListenerIdentifier identifier)
-    ReleaseRemoteCommandListener(WebKit::RemoteRemoteCommandListenerIdentifier identifier)
+    [EnabledBy=MediaPlaybackEnabled] CreateRemoteCommandListener(WebKit::RemoteRemoteCommandListenerIdentifier identifier)
+    [EnabledBy=MediaPlaybackEnabled] ReleaseRemoteCommandListener(WebKit::RemoteRemoteCommandListenerIdentifier identifier)
     ConfigureLoggingChannel(String channelName, enum:uint8_t WTFLogChannelState state, enum:uint8_t WTFLogLevel level)
 #if USE(GRAPHICS_LAYER_WC)
     CreateWCLayerTreeHost(WebKit::WCLayerTreeHostIdentifier identifier, uint64_t nativeWindow, bool usesOffscreenRendering) AllowedWhenWaitingForSyncReply

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2467,6 +2467,8 @@ void WebProcess::enableMediaPlayback()
 #if ENABLE(ROUTING_ARBITRATION)
     m_routingArbitrator = makeUnique<AudioSessionRoutingArbitrator>(*this);
 #endif
+
+    RemoteCommandListener::enableMediaPlayback();
 }
 
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -208,6 +208,7 @@
 #import <WebCore/ProcessSyncClient.h>
 #import <WebCore/ProgressTracker.h>
 #import <WebCore/Range.h>
+#import <WebCore/RemoteCommandListener.h>
 #import <WebCore/RemoteFrameClient.h>
 #import <WebCore/RemoteUserInputEventData.h>
 #import <WebCore/RenderStyleInlines.h>
@@ -1493,6 +1494,7 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
 #if USE(AUDIO_SESSION)
         WebCore::AudioSession::enableMediaPlayback();
 #endif
+        WebCore::RemoteCommandListener::enableMediaPlayback();
 
 #if ENABLE(VIDEO)
         WebCore::HTMLMediaElement::setMediaCacheDirectory(FileSystem::pathByAppendingComponent(String(NSTemporaryDirectory()), "MediaCache/"_s));


### PR DESCRIPTION
#### 6460f328677439a167f72eab1b002f723ac2e617
<pre>
Ensure RemoteRemoteCommandListenerProxy messages are not sent when MediaPlaybackEnabled is false
<a href="https://bugs.webkit.org/show_bug.cgi?id=285310">https://bugs.webkit.org/show_bug.cgi?id=285310</a>
<a href="https://rdar.apple.com/142279451">rdar://142279451</a>

Reviewed by NOBODY (OOPS!).

RemoteRemoteCommandListenerProxy message endpoints are annotated with MediaPlaybackEnabled, which means GPU process does
not expect to receive these messages when MediaPlaybackEnabled is false (because when MediaPlaybackEnabled is false,
media playback functionalities should be disabled). Accordingly, we need to make sure web process does not send out
these messages. This patch implements that by ensuring RemoteRemoteCommandListenerProxy is not created when
MediaPlaybackEnabled is false.

Also this patch adds the annotation to RemoteRemoteCommandListenerProxy related messages in GPUConnectionToWebProcess.

* Source/WebCore/platform/RemoteCommandListener.cpp:
(WebCore::RemoteCommandListener::enableMediaPlayback):
(WebCore::RemoteCommandListener::create):
* Source/WebCore/platform/RemoteCommandListener.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::enableMediaPlayback):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _commonInitializationWithFrameName:groupName:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6460f328677439a167f72eab1b002f723ac2e617

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33959 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/84998 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10471 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64611 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22372 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1945 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75413 "Found 1 new API test failure: TestWebKitAPI.MediaSessionTest.MinimalCommands (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44886 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1847 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29602 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/32993 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89388 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10195 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7407 "Found 1 new test failure: http/wpt/mediarecorder/record-96KHz-sources.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73029 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10423 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72245 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16407 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15171 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1576 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10148 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15662 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10020 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13485 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->