### PR TITLE
[WebGPU] CommandEncoder is set to nullptr on a different thread

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-285311-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-285311-expected.txt
@@ -1,0 +1,36 @@
+CONSOLE MESSAGE: promises created
+CONSOLE MESSAGE: A VideoFrame was destroyed without having been closed explicitly
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: device0 lost!
+CONSOLE MESSAGE:
+CONSOLE MESSAGE: error
+CONSOLE MESSAGE: GPUPipelineError
+CONSOLE MESSAGE: GPUPipelineError
+CONSOLE MESSAGE: _
+CONSOLE MESSAGE: GPUPipelineError - validation
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 784x584
+      RenderImage {IMG} at (0,172) size 16x1
+      RenderImage {IMG} at (16,84) size 20x89
+      RenderImage {IMG} at (36,169) size 105x4
+      RenderImage {IMG} at (141,55) size 80x118
+      RenderImage {IMG} at (221,157) size 7x16
+      RenderImage {IMG} at (228,166) size 45x7
+layer at (281,8) size 300x173
+  RenderHTMLCanvas {CANVAS} at (273,0) size 300x173

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-285311.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-285311.html
@@ -1,0 +1,19129 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxUniformBufferBindingSize: 25383437,
+    maxStorageBufferBindingSize: 144870969,
+    maxInterStageShaderVariables: 16,
+  },
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture0 = device0.createTexture({
+  size: [246, 1, 1],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView0 = texture0.createView({dimension: '2d-array'});
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let texture1 = device0.createTexture({
+  size: {width: 615},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView1 = texture0.createView({aspect: 'depth-only'});
+let textureView2 = texture1.createView({format: 'r32uint', baseMipLevel: 0});
+let texture2 = device0.createTexture({size: [40, 45, 2], mipLevelCount: 3, format: 'r32uint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let sampler0 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.34,
+  compare: 'greater-equal',
+});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(131).fill(83), /* required buffer size: 131 */
+{offset: 131}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer0 = device0.createBuffer({
+  size: 2085,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+});
+let texture3 = device0.createTexture({
+  size: [492, 1, 389],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler1 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 35.20});
+try {
+device0.queue.submit([]);
+} catch {}
+let veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 144,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 323,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView3 = texture2.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let sampler2 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 94.36,
+  compare: 'less-equal',
+});
+await gc();
+let veryExplicitBindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 144,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 323,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let textureView4 = texture1.createView({arrayLayerCount: 1});
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let imageData0 = new ImageData(28, 88);
+let buffer1 = device0.createBuffer({
+  size: 11438,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder0 = device0.createCommandEncoder();
+let textureView5 = texture1.createView({});
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 5},
+  aspect: 'all',
+}, new Uint8Array(687_909).fill(66), /* required buffer size: 687_909 */
+{offset: 117, bytesPerRow: 267, rowsPerImage: 28}, {width: 61, height: 0, depthOrArrayLayers: 93});
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout1, veryExplicitBindGroupLayout0]});
+let buffer2 = device0.createBuffer({
+  size: 1096,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder1 = device0.createCommandEncoder({});
+let texture4 = device0.createTexture({
+  size: [153],
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler3 = device0.createSampler({addressModeU: 'repeat', lodMinClamp: 62.03, lodMaxClamp: 69.93});
+await gc();
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let texture5 = device0.createTexture({
+  size: {width: 32},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder0 = commandEncoder1.beginComputePass({});
+try {
+commandEncoder0.clearBuffer(buffer2);
+} catch {}
+let imageData1 = new ImageData(64, 8);
+try {
+adapter0.label = '\uc132\ucee8\u051e\ue648\u7929\u0c35\u0660\u{1fc2f}';
+} catch {}
+let commandEncoder2 = device0.createCommandEncoder({});
+let textureView6 = texture0.createView({dimension: '2d-array', mipLevelCount: 1});
+let texture6 = device0.createTexture({
+  size: [246, 1, 307],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder1 = commandEncoder2.beginComputePass({});
+let textureView7 = texture4.createView({});
+let texture7 = device0.createTexture({
+  size: [940, 5, 1],
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder2 = commandEncoder0.beginComputePass({});
+let veryExplicitBindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 39, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+  ],
+});
+let commandEncoder3 = device0.createCommandEncoder({});
+let texture8 = device0.createTexture({
+  size: {width: 1880, height: 10, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler4 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 49.71,
+  compare: 'always',
+  maxAnisotropy: 2,
+});
+try {
+commandEncoder3.copyBufferToBuffer(buffer0, 748, buffer2, 92, 48);
+} catch {}
+let commandEncoder4 = device0.createCommandEncoder({});
+let textureView8 = texture8.createView({baseMipLevel: 0});
+let promise0 = device0.queue.onSubmittedWorkDone();
+let commandEncoder5 = device0.createCommandEncoder({});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], stencilReadOnly: true});
+let renderBundle0 = renderBundleEncoder0.finish({});
+try {
+  await promise0;
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+/* zero global variables used */
+fn fn2() -> mat4x3h {
+  var out: mat4x3h;
+  fn1(mat2x4f(bitcast<vec4f>(firstTrailingBit(vec2u(unconst_u32(499), unconst_u32(29))).yxyx), bitcast<vec4f>(firstTrailingBit(vec2u(unconst_u32(499), unconst_u32(29))).rrgr)));
+  if bool(unpack2x16unorm(unconst_u32(9)).y) {
+}
+  let vf12: vec4i = unpack4xI8(unconst_u32(348));
+  var vf13: vec4h = fract(vec4h(unconst_f16(5515.2), unconst_f16(2051.9), unconst_f16(4877.5), unconst_f16(4683.7)));
+  let ptr0: ptr<function, vec4h> = &vf13;
+  return out;
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T2 {
+  @size(32) f0: array<array<array<mat3x3h, 1>, 1>, 1>,
+  @size(32) f1: vec2f,
+  @align(32) f2: array<mat2x4h, 8>,
+  @align(16) f3: array<mat2x2f, 22>,
+  @size(224) f4: array<array<array<array<f32, 12>, 2>, 1>, 1>,
+  @size(96) f5: array<array<array<mat4x3h, 1>, 1>, 1>,
+  @align(32) @size(288) f6: mat3x3f,
+  @align(32) f7: array<mat4x2f, 1>,
+  @align(32) @size(32) f8: f16,
+  @size(640) f9: array<mat2x2f, 16>,
+  f10: mat2x3f,
+  @size(32) f11: array<mat3x3h, 1>,
+  @align(16) @size(32) f12: mat2x3h,
+  @align(8) f13: array<array<vec2h, 1>, 8>,
+  @align(32) @size(64) f14: array<u32, 1>,
+  @align(32) @size(32) f15: array<array<i32, 4>, 1>,
+  @align(32) f16: array<vec2f, 4>,
+  @align(32) @size(160) f17: mat3x2h,
+  @align(16) @size(448) f18: array<array<array<array<f16, 1>, 6>, 8>, 1>,
+}
+
+struct VertexOutput0 {
+  @builtin(position) f0: vec4f,
+}
+
+@group(0) @binding(323) var<storage, read> buffer3: array<array<array<array<array<array<f16, 3>, 1>, 1>, 1>, 36>, 4>;
+
+alias vec3b = vec3<bool>;
+
+@group(0) @binding(144) var st0: texture_storage_1d<r32uint, read_write>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+/* zero global variables used */
+fn fn0(a0: ptr<storage, array<f16, 62>, read_write>) -> vec2u {
+  var out: vec2u;
+  let vf0: vec3u = (vec3u(unconst_u32(928), unconst_u32(56), unconst_u32(114)) << vec3u(unconst_u32(95), unconst_u32(180), unconst_u32(194)));
+  let vf1: vec3i = (vec3i(unconst_i32(133), unconst_i32(85), unconst_i32(-50)) % unconst_i32(171));
+  var vf2: vec3i = sign(vec3i(unconst_i32(260), unconst_i32(118), unconst_i32(-105)));
+  out = vec2u(unpack2x16unorm(unconst_u32(220)));
+  var vf3: f16 = determinant(mat2x2h(unconst_f16(1009.2), unconst_f16(20713.9), unconst_f16(893.5), unconst_f16(-7742.7)));
+  vf3 = (*a0)[61];
+  let vf4: vec2f = log2(vec2f(unconst_f32(0.1547), unconst_f32(0.2949)));
+  return out;
+}
+
+struct FragmentOutput0 {
+  @location(7) @interpolate(flat) f0: i32,
+  @location(0) f1: vec2f,
+}
+
+/* zero global variables used */
+fn fn1(a0: mat2x4f) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  var vf5: u32 = pack2x16snorm(vec2f(unconst_f32(-0.1187), unconst_f32(0.4261)));
+  var vf6: f16 = cosh(unconst_f16(17565.5));
+  vf5 = pack4xI8(unpack4xI8(unconst_u32(85)));
+  let vf7: u32 = (unconst_u32(149) >> unconst_u32(136));
+  let vf8: u32 = pack2x16snorm(vec2f(unconst_f32(0.3459), unconst_f32(0.2375)));
+  vf6 *= f16((bitcast<vec4f>(unpack4xI8(unconst_u32(192))) + a0[unconst_u32(265)])[3]);
+  vf5 *= vf8;
+  while bool(cosh(unconst_f16(548.2))) {
+  let vf9: mat2x4f = a0;
+  out.f0 *= bitcast<i32>(a0[unconst_u32(164)][unconst_u32(45)]);
+  out.f0 |= bitcast<i32>(determinant(mat2x2f()));
+  while bool(faceForward(vec2f(unconst_f32(-0.1467), unconst_f32(0.1254)), vec2f(unconst_f32(0.04802), unconst_f32(0.02589)), vec2f(unconst_f32(0.00437), unconst_f32(0.3803)))[1]) {
+  out.f0 = i32(pack2x16snorm(vec2f(unconst_f32(0.3062), unconst_f32(0.1661))));
+  out.f1 = reflect(vec4f(unconst_f32(0.06079), unconst_f32(-0.1079), unconst_f32(0.3512), unconst_f32(0.02669)), vec4f(unconst_f32(0.4370), unconst_f32(-0.04797), unconst_f32(0.1101), unconst_f32(0.1270))).xy;
+  out.f1 = bitcast<vec2f>(countOneBits(vec3i(unconst_i32(271), unconst_i32(95), unconst_i32(27))).rg);
+  for (var it0=u32(cross(vec3f(unconst_f32(0.00855), unconst_f32(0.05515), unconst_f32(0.03448)), vec3f(unconst_f32(0.01159), unconst_f32(0.2301), unconst_f32(0.00686))).g); it0<bitcast<u32>(cross(vec3f(unconst_f32(0.1055), unconst_f32(-0.00803), unconst_f32(0.02509)), vec3f(unconst_f32(0.2434), unconst_f32(0.2189), unconst_f32(0.09950))).b); it0++) {
+  out.f1 = bitcast<vec2f>((vec2u(u32(any(vec2<bool>(unconst_bool(false), unconst_bool(true))))) << vec2u(unconst_u32(234), unconst_u32(34))));
+}
+  var vf10: f16 = exp(unconst_f16(17989.7));
+  return out;
+}
+  out.f1 *= faceForward(vec2f(unconst_f32(-0.2950), unconst_f32(0.00151)), vec2f(unconst_f32(0.06799), unconst_f32(0.2408)), vec2f(unconst_f32(0.2159), unconst_f32(0.6899)));
+  break;
+}
+  var vf11: vec2f = trunc(vec2f(unconst_f32(0.02276), unconst_f32(0.1710)));
+  return out;
+}
+
+struct T1 {
+  @align(16) @size(864) f0: array<atomic<u32>>,
+}
+
+struct T0 {
+  @size(864) f0: array<u32>,
+}
+
+/* used global variables: buffer3 */
+@vertex
+fn vertex0(@location(13) @interpolate(flat, sample) a0: vec4u, @location(0) @interpolate(flat, center) a1: u32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  out = VertexOutput0(vec4f(f32(buffer3[unconst_u32(120)][unconst_u32(96)][unconst_u32(166)][unconst_u32(207)][0][2])));
+  fn1(mat2x4f(f32(buffer3[3][u32(buffer3[3][unconst_u32(4)][unconst_u32(109)][unconst_u32(33)][0][2])][0][0][0][2]), f32(buffer3[3][u32(buffer3[3][unconst_u32(4)][unconst_u32(109)][unconst_u32(33)][0][2])][0][0][0][2]), f32(buffer3[3][u32(buffer3[3][unconst_u32(4)][unconst_u32(109)][unconst_u32(33)][0][2])][0][0][0][2]), f32(buffer3[3][u32(buffer3[3][unconst_u32(4)][unconst_u32(109)][unconst_u32(33)][0][2])][0][0][0][2]), f32(buffer3[3][u32(buffer3[3][unconst_u32(4)][unconst_u32(109)][unconst_u32(33)][0][2])][0][0][0][2]), f32(buffer3[3][u32(buffer3[3][unconst_u32(4)][unconst_u32(109)][unconst_u32(33)][0][2])][0][0][0][2]), f32(buffer3[3][u32(buffer3[3][unconst_u32(4)][unconst_u32(109)][unconst_u32(33)][0][2])][0][0][0][2]), f32(buffer3[3][u32(buffer3[3][unconst_u32(4)][unconst_u32(109)][unconst_u32(33)][0][2])][0][0][0][2])));
+  let ptr1: ptr<storage, f16, read> = &buffer3[3][unconst_u32(56)][0][unconst_u32(125)][0][2];
+  loop {
+  let ptr2: ptr<storage, f16, read> = &(*&buffer3)[3][35][0][unconst_u32(515)][unconst_u32(586)][unconst_u32(90)];
+  break;
+  _ = buffer3;
+}
+  out.f0 = vec4f(f32((*&buffer3)[unconst_u32(216)][35][(vec3u(unconst_u32(98), unconst_u32(141), unconst_u32(573)) ^ vec3u(unconst_u32(176), unconst_u32(200), unconst_u32(107)))[0]][0][0][unconst_u32(91)]));
+  return out;
+  _ = buffer3;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  while any((vec3i(unconst_i32(235), unconst_i32(231), unconst_i32(69)) <= vec3i(unconst_i32(31), unconst_i32(201), unconst_i32(-132)))) {
+  switch i32(fract(vec3f(unconst_f32(-0.2123), unconst_f32(0.00404), unconst_f32(0.05033)))[0]) { 
+  default {
+  let vf14: vec2h = exp(vec2h(unconst_f16(23580.6), unconst_f16(9140.8)));
+  break;
+}
+  }
+  var vf15 = fn2();
+  break;
+}
+  var vf16 = fn2();
+  let vf17: vec4i = unpack4xI8(u32(exp2(vec3h(unconst_f16(2704.6), unconst_f16(-7565.7), unconst_f16(3556.6))).x));
+  fn2();
+  return out;
+}
+
+/* used global variables: st0 */
+@compute @workgroup_size(1, 1, 1)
+fn compute0() {
+  let vf18: i32 = dot4I8Packed(unconst_u32(111), unconst_u32(157));
+  let vf19: i32 =  ~unconst_i32(103);
+  let vf20: u32 = textureDimensions(st0);
+  var vf21: i32 = vf19;
+  let vf22: i32 = dot4I8Packed(unconst_u32(81), unconst_u32(73));
+  textureStore(st0, unconst_i32(21), vec4u(vec4u(unconst_u32(31), unconst_u32(60), unconst_u32(52), unconst_u32(230))));
+  {
+  var vf23: u32 = pack4x8snorm(vec4f(unconst_f32(-0.3193), unconst_f32(0.03785), unconst_f32(0.1991), unconst_f32(0.01304)));
+  vf23 <<= pack4xU8(vec4u((mat4x4h(unconst_f16(22299.3), unconst_f16(14176.8), unconst_f16(2124.1), unconst_f16(843.7), unconst_f16(1254.6), unconst_f16(4748.2), unconst_f16(3191.4), unconst_f16(-29884.2), unconst_f16(4274.8), unconst_f16(6203.8), unconst_f16(1572.7), unconst_f16(12483.6), unconst_f16(-3127.1), unconst_f16(10151.4), unconst_f16(22907.2), unconst_f16(6185.1)) + mat4x4h(bitcast<vec4h>(ldexp(vec2f(unconst_f32(0.1216), unconst_f32(0.00192)), vec2i(unconst_i32(1), unconst_i32(39)))), bitcast<vec4h>(ldexp(vec2f(unconst_f32(0.1216), unconst_f32(0.00192)), vec2i(unconst_i32(1), unconst_i32(39)))), bitcast<vec4h>(ldexp(vec2f(unconst_f32(0.1216), unconst_f32(0.00192)), vec2i(unconst_i32(1), unconst_i32(39)))), bitcast<vec4h>(ldexp(vec2f(unconst_f32(0.1216), unconst_f32(0.00192)), vec2i(unconst_i32(1), unconst_i32(39))))))[unconst_i32(0)]));
+  vf23 |= textureDimensions(st0);
+  vf23 ^= textureLoad(st0, unconst_i32(84)).a;
+  var vf24: vec4i = (vec4i(unconst_i32(405), unconst_i32(419), unconst_i32(202), unconst_i32(-189)) << vec4u(unconst_u32(281), unconst_u32(408), unconst_u32(193), unconst_u32(121)));
+  _ = st0;
+}
+  var vf25: i32 = vf22;
+  vf21 = bitcast<i32>(exp2(vec2h(unconst_f16(7497.9), unconst_f16(13424.6))));
+  let vf26: vec3<bool> = (vec3f(unconst_f32(0.1332), unconst_f32(0.08108), unconst_f32(0.1406)) > vec3f(unconst_f32(0.3195), unconst_f32(0.08953), unconst_f32(0.3006)));
+  var vf27: i32 = vf18;
+  var vf28: i32 = vf22;
+  var vf29: vec2f = atan(vec2f(unconst_f32(0.2721), unconst_f32(0.06034)));
+  let vf30: vec2f = unpack2x16snorm(unconst_u32(62));
+  _ = st0;
+}`,
+});
+let buffer4 = device0.createBuffer({size: 4276, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView9 = texture4.createView({});
+let textureView10 = texture4.createView({});
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+let buffer5 = device0.createBuffer({
+  size: 18635,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder6 = device0.createCommandEncoder({});
+let textureView11 = texture5.createView({aspect: 'all', format: 'rgba8snorm'});
+let computePassEncoder3 = commandEncoder6.beginComputePass({});
+let computePassEncoder4 = commandEncoder3.beginComputePass({});
+let sampler5 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', minFilter: 'linear', lodMaxClamp: 93.17});
+let shaderModule1 = device0.createShaderModule({
+  label: '\ue846\u{1f75b}\u9f4b\u7d7b\u9948\u084b\ue6ac\u{1fdd5}\u{1fcca}\u0fb5\u74e2',
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct FragmentOutput1 {
+  @location(0) f0: vec2f,
+  @location(1) f1: u32,
+}
+
+var<workgroup> vw1: mat3x4f;
+
+struct T2 {
+  @size(32) f0: mat3x2f,
+  @size(32) f1: array<atomic<u32>, 1>,
+  @size(352) f2: array<atomic<u32>, 2>,
+  @align(32) @size(448) f3: array<u32>,
+}
+
+var<workgroup> vw5: atomic<u32>;
+
+var<workgroup> vw8: array<T0, 1>;
+
+var<workgroup> vw6: array<mat2x4h, 1>;
+
+struct T1 {
+  @align(32) @size(864) f0: array<u32>,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+alias vec3b = vec3<bool>;
+
+var<private> vp2 = modf(vec2f(0.05758, 0.2194));
+
+var<private> vp0: T0 = T0(vec2h(11208.4, 4794.4));
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw3: atomic<i32>;
+
+@group(0) @binding(144) var st1: texture_storage_1d<r32uint, read_write>;
+
+var<workgroup> vw2: array<FragmentOutput1, 10>;
+
+var<workgroup> vw10: vec4<bool>;
+
+var<workgroup> vw7: atomic<u32>;
+
+/* zero global variables used */
+fn fn2() -> T0 {
+  var out: T0;
+  switch i32(any((vec3u(unconst_u32(766), unconst_u32(69), unconst_u32(40)) >= vec3u(unconst_u32(148), unconst_u32(68), unconst_u32(61))))) { 
+  default {
+  let ptr4: ptr<workgroup, mat3x4f> = &vw1;
+  var vf34 = fn1();
+  let vf35: f32 = log2(f32(all((vec3f(unconst_f32(0.1487), unconst_f32(0.02642), unconst_f32(0.2936)) <= vec3f(unconst_f32(0.00357), unconst_f32(0.01827), unconst_f32(0.02726))))));
+  while bool(asin(unconst_f16(7991.0))) {
+  if bool(extractBits(vec3u(unconst_u32(23), unconst_u32(175), unconst_u32(132)), unconst_u32(113), unconst_u32(60)).z) {
+  var vf36: f16 = vw8[unconst_u32(126)].f0[atomicExchange(&(*&vw4), unconst_u32(63))];
+}
+  vw9[u32(vw6[unconst_u32(7)][unconst_u32(42)][unconst_u32(133)])][unconst_u32(94)] ^= vec2i(bitcast<i32>(vw2[9].f0[unconst_u32(118)]));
+  var vf37 = fn1();
+  let ptr5: ptr<workgroup, vec2f> = &(*&vw2)[unconst_u32(48)].f0;
+}
+  while bool(vf34[0][3].f0.g) {
+  vp0 = T0(vec2h((*&vw9)[unconst_u32(202)][0]));
+}
+  break;
+}
+  }
+  return out;
+}
+
+struct T0 {
+  @size(36) f0: vec2h,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw0: T0;
+
+var<workgroup> vw11: atomic<i32>;
+
+var<private> vp1: T0 = T0();
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<private> vp3 = modf(f16(15817.4));
+
+var<workgroup> vw4: atomic<u32>;
+
+var<workgroup> vw9: array<array<vec2i, 1>, 1>;
+
+/* zero global variables used */
+fn fn1() -> array<array<FragmentOutput1, 4>, 1> {
+  var out: array<array<FragmentOutput1, 4>, 1>;
+  {
+  vw2[vec4u((*&vw6)[bitcast<u32>((*&vw9)[(*&vw2)[9].f1][unconst_u32(72)][1])][unconst_u32(97)]).b] = FragmentOutput1(vw2[9].f0, pack2x16unorm(vw2[9].f0));
+  atomicStore(&vw5, unconst_u32(281));
+  let vf31: u32 = dot4U8Packed(unconst_u32(137), bitcast<u32>(vp1.f0));
+  fn0();
+  fn0();
+  fn0();
+  fn0();
+}
+  var vf32: vec4<bool> = workgroupUniformLoad(&vw10);
+  fn0();
+  vw2[unconst_u32(268)].f1 <<= bitcast<u32>((*&vw8)[0].f0);
+  vf32 = vec4<bool>(vw8[unconst_u32(239)].f0.grrr);
+  let ptr3: ptr<workgroup, array<vec2i, 1>> = &vw9[unconst_u32(279)];
+  atomicMax(&vw11, unconst_i32(185));
+  fn0();
+  vp1 = T0(vec2h(vw2[unconst_u32(42)].f0));
+  fn0();
+  let vf33: i32 = countLeadingZeros(unconst_i32(-27));
+  return out;
+}
+
+/* zero global variables used */
+fn fn0() {
+  vp3.whole -= vp3.fract;
+  vp0 = T0(vec2h(vp3.fract));
+}
+
+/* used global variables: st1 */
+@fragment
+fn fragment1() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  let vf38: vec2<bool> = (vec2f(unconst_f32(0.1055), unconst_f32(0.2407)) > vec2f(unconst_f32(0.3525), unconst_f32(0.00792)));
+  fn0();
+  for (var it1=(vec3u(unconst_u32(54), unconst_u32(15), unconst_u32(149)) - vec3u(unconst_u32(2), unconst_u32(80), unconst_u32(284)))[0]; it1<bitcast<u32>(vp1.f0); it1++) {
+  let vf39: vec4f = acosh(vec4f(unconst_f32(0.03707), unconst_f32(0.1577), unconst_f32(0.3955), unconst_f32(0.1252)));
+  let ptr6 = &vp2;
+  fn0();
+  {
+  vp0.f0 += bitcast<vec2h>(pack4xU8Clamp(vec4u(unconst_u32(287), unconst_u32(159), unconst_u32(80), unconst_u32(553))));
+  fn0();
+  fn0();
+  var vf40: u32 = pack2x16snorm(vec2f(unconst_f32(0.05871), unconst_f32(0.2275)));
+}
+  var vf41: vec2f = unpack2x16float(unconst_u32(203));
+  fn0();
+  fn0();
+  break;
+}
+  vp3.fract *= f16(vf38[unconst_u32(351)]);
+  var vf42: vec2f = unpack2x16unorm(unconst_u32(398));
+  textureStore(st1, unconst_i32(218), vec4u(vec4u(unconst_u32(333), unconst_u32(173), unconst_u32(41), unconst_u32(87))));
+  out.f1 = bitcast<vec2u>(unpack2x16unorm(unconst_u32(51))).x;
+  out.f1 = pack4xI8Clamp((vec4i(unconst_i32(18), unconst_i32(103), unconst_i32(85), unconst_i32(207)) & vec4i(unconst_i32(22), unconst_i32(-165), unconst_i32(141), unconst_i32(-314))));
+  fn0();
+  fn0();
+  let vf43: vec4i = (vec4i(unconst_i32(195), unconst_i32(77), unconst_i32(153), unconst_i32(276)) & vec4i(unconst_i32(86), unconst_i32(-6), unconst_i32(259), unconst_i32(163)));
+  var vf44: vec4f = cos(vec4f(unconst_f32(0.1538), unconst_f32(0.1635), unconst_f32(0.5199), unconst_f32(0.00432)));
+  out.f1 |= pack4x8unorm(unpack4x8unorm(unconst_u32(7)));
+  discard;
+  if bool(vp2.whole[1]) {
+  fn0();
+  fn0();
+}
+  return out;
+  _ = st1;
+}
+
+/* used global variables: st1 */
+@compute @workgroup_size(1, 1, 1)
+fn compute1() {
+  vw10 = vec4<bool>(bool(atomicExchange(&vw4, textureLoad(st1, unconst_i32(51)).y)));
+  var vf45: vec2i = reverseBits(vec2i(unconst_i32(405), unconst_i32(119)));
+  var vf46 = fn1();
+  fn1();
+  vw10 = vec4<bool>(bool((*&vw2)[9].f1));
+  fn1();
+  let vf47: f16 = dot(vec2h(unconst_f16(22655.3), unconst_f16(1401.4)), vec2h(unconst_f16(16951.4), unconst_f16(7204.6)));
+  fn1();
+  fn0();
+  _ = st1;
+}`,
+});
+let bindGroup0 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [
+    {binding: 41, resource: textureView8},
+    {binding: 39, resource: {buffer: buffer5, offset: 256, size: 5516}},
+  ],
+});
+let commandEncoder7 = device0.createCommandEncoder();
+let textureView12 = texture7.createView({dimension: '2d-array'});
+let computePassEncoder5 = commandEncoder4.beginComputePass({});
+let sampler6 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 99.36,
+  maxAnisotropy: 1,
+});
+try {
+commandEncoder5.clearBuffer(buffer2, 56, 832);
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({});
+let texture9 = device0.createTexture({
+  size: [32, 32, 21],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView13 = texture9.createView({dimension: 'cube', baseArrayLayer: 6, arrayLayerCount: 6});
+let computePassEncoder6 = commandEncoder8.beginComputePass({});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let buffer7 = device0.createBuffer({
+  label: '\ub32c\u{1fea1}\u{1fa69}\ue24b\u{1fa03}',
+  size: 555,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder9 = device0.createCommandEncoder();
+let textureView14 = texture5.createView({});
+let textureView15 = texture0.createView({label: '\u6e0c\u86c3\u{1ff65}\u5160\u8194\u0b37\u8f3d\ufe0e\udc63\u05dc\uc549'});
+let computePassEncoder7 = commandEncoder9.beginComputePass({});
+let sampler7 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 88.02,
+  compare: 'equal',
+  maxAnisotropy: 10,
+});
+let imageData2 = new ImageData(60, 24);
+let bindGroup1 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 144, resource: textureView5}, {binding: 323, resource: {buffer: buffer2, offset: 0}}],
+});
+let buffer8 = device0.createBuffer({
+  size: 3020,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder10 = device0.createCommandEncoder({});
+let textureView16 = texture9.createView({dimension: '2d'});
+let textureView17 = texture7.createView({format: 'rg8unorm'});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+  await buffer4.mapAsync(GPUMapMode.WRITE, 0, 52);
+} catch {}
+let pipeline0 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {module: shaderModule1, targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL}]},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 96,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 2, shaderLocation: 0},
+          {format: 'uint16x2', offset: 12, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup0, new Uint32Array(1161), 208, 0);
+} catch {}
+try {
+commandEncoder5.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 478, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 223, y: 0, z: 182},
+  aspect: 'all',
+},
+{width: 75, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 323, resource: {buffer: buffer5, offset: 2048, size: 13364}},
+    {binding: 144, resource: textureView2},
+  ],
+});
+let texture10 = device0.createTexture({
+  size: {width: 307, height: 7, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder8 = commandEncoder5.beginComputePass({});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup2, new Uint32Array(3161), 10, 0);
+} catch {}
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1804 */
+  offset: 1804,
+  bytesPerRow: 11008,
+  rowsPerImage: 336,
+  buffer: buffer8,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 21, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer9 = device0.createBuffer({size: 350, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder11 = device0.createCommandEncoder({});
+let sampler8 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup1, new Uint32Array(2897), 516, 0);
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 68, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 100, y: 0, z: 121},
+  aspect: 'all',
+},
+{width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline1 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule0, constants: {}}});
+let pipeline2 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment1',
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 2048,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32', offset: 392, shaderLocation: 13},
+          {format: 'uint32', offset: 308, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+let bindGroup3 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 323, resource: {buffer: buffer2, offset: 0}}, {binding: 144, resource: textureView4}],
+});
+let commandEncoder12 = device0.createCommandEncoder({});
+let computePassEncoder9 = commandEncoder11.beginComputePass({});
+let sampler9 = device0.createSampler({
+  label: '\u020a\u98b6\u02a2\ue2b8\u0666\u0192\ud788\u0693\u0e97\u{1fb4a}\u0755',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup1, new Uint32Array(52), 3, 0);
+} catch {}
+let buffer10 = device0.createBuffer({size: 17576, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+let sampler10 = device0.createSampler({
+  label: '\u{1f73d}\ua3f9\u1d11\ucbae\u{1ff5e}\ubc5f\u5826\u8c44\ue4f8\u20d8\u20e1',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 60.44,
+});
+let offscreenCanvas0 = new OffscreenCanvas(145, 399);
+let bindGroup4 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 323, resource: {buffer: buffer5, offset: 3328, size: 1200}},
+    {binding: 144, resource: textureView2},
+  ],
+});
+let commandEncoder13 = device0.createCommandEncoder({});
+let computePassEncoder10 = commandEncoder13.beginComputePass({});
+let arrayBuffer0 = buffer4.getMappedRange(0, 4);
+try {
+commandEncoder12.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 312, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 596 widthInBlocks: 149 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1264 */
+  offset: 1264,
+  bytesPerRow: 36096,
+  rowsPerImage: 1028,
+  buffer: buffer5,
+}, {width: 149, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView18 = texture0.createView({aspect: 'all'});
+let computePassEncoder11 = commandEncoder7.beginComputePass({});
+let sampler11 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', lodMaxClamp: 99.64});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 123, height: 1, depthOrArrayLayers: 153}
+*/
+{
+  source: imageData0,
+  origin: { x: 6, y: 87 },
+  flipY: false,
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 44, y: 0, z: 34},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture11 = device0.createTexture({
+  size: [1880, 10, 1],
+  mipLevelCount: 1,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture12 = device0.createTexture({
+  size: [307, 7, 256],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm'],
+});
+let computePassEncoder12 = commandEncoder12.beginComputePass({});
+try {
+computePassEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 123, height: 1, depthOrArrayLayers: 153}
+*/
+{
+  source: imageData1,
+  origin: { x: 1, y: 2 },
+  flipY: true,
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 15, y: 1, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+sampler8.label = '\u06ae\uc71d\u505f\u9722';
+} catch {}
+let textureView19 = texture9.createView({dimension: 'cube'});
+let sampler12 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMinClamp: 72.45,
+  lodMaxClamp: 86.90,
+});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(0, bindGroup2, new Uint32Array(4186), 73, 0);
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder({label: '\u0259\u{1f63b}\u58af\u{1fe26}\u2594\u{1f710}\u{1fdb5}'});
+let texture13 = device0.createTexture({
+  label: '\uf69e\u886d\ufa68\uadf5\u2a4a',
+  size: {width: 1968, height: 1, depthOrArrayLayers: 94},
+  format: 'r32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder13 = commandEncoder10.beginComputePass({});
+let sampler13 = device0.createSampler({
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 83.88,
+  compare: 'always',
+  maxAnisotropy: 18,
+});
+try {
+commandEncoder14.copyBufferToTexture({
+  /* bytesInLastRow: 246 widthInBlocks: 123 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 820 */
+  offset: 820,
+  bytesPerRow: 27904,
+  buffer: buffer1,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 264, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 123, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 376, new DataView(new ArrayBuffer(32932)), 501, 260);
+} catch {}
+try {
+device0.queue.label = '\u82d0\u0c66\u0573\u7260';
+} catch {}
+let texture14 = device0.createTexture({
+  size: [984, 1, 32],
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView20 = texture3.createView({
+  label: '\u{1f7e4}\u{1fd43}\u83f5\u80e2\u0406\u802e\ua655\u0fae\u{1f941}\u{1fc22}\u{1fda0}',
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+var<workgroup> vw13: atomic<i32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(144) var st2: texture_storage_1d<r32uint, read_write>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw18: array<array<atomic<u32>, 1>, 39>;
+
+struct T2 {
+  @align(16) @size(1008) f0: array<atomic<u32>>,
+}
+
+var<workgroup> vw16: VertexOutput1;
+
+struct T1 {
+  @size(128) f0: vec2i,
+  @align(8) @size(736) f1: array<atomic<i32>>,
+}
+
+@group(0) @binding(323) var<storage, read> buffer11: array<array<array<array<f16, 1>, 3>, 8>, 18>;
+
+struct FragmentOutput2 {
+  @location(0) f0: vec2f,
+  @location(5) @interpolate(linear) f1: f32,
+}
+
+var<workgroup> vw17: vec2i;
+
+var<workgroup> vw20: FragmentOutput2;
+
+var<private> vp4: FragmentOutput2 = FragmentOutput2(vec2f(0.1685, 0.2553), f32(-0.03630));
+
+struct VertexOutput1 {
+  @builtin(position) f1: vec4f,
+}
+
+var<workgroup> vw15: mat4x4h;
+
+var<workgroup> vw14: array<mat4x2h, 1>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<workgroup> vw19: array<atomic<i32>, 6>;
+
+struct T0 {
+  @size(864) f0: array<u32>,
+}
+
+var<workgroup> vw21: array<array<atomic<u32>, 1>, 3>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T3 {
+  @align(32) @size(864) f0: array<f16>,
+}
+
+var<workgroup> vw12: atomic<u32>;
+
+/* used global variables: buffer11 */
+fn fn0(a0: ptr<uniform, VertexOutput1>) -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  let vf48: u32 = pack2x16float(vec2f(unconst_f32(-0.1590), unconst_f32(0.2879)));
+  out.f1 = f32((vec3i(unconst_i32(43), unconst_i32(100), unconst_i32(131)) ^ vec3i(unconst_i32(364), unconst_i32(75), unconst_i32(29)))[1]);
+  let ptr7: ptr<storage, array<f16, 1>, read> = &(*&buffer11)[unconst_u32(1)][unconst_u32(720)][unconst_u32(209)];
+  vp4 = FragmentOutput2(vec2f(f32((*&buffer11)[17][7][u32(buffer11[pack2x16float(vec2f(unconst_f32(0.1295), unconst_f32(0.06867)))][unconst_u32(29)][2][u32((*&buffer11)[unconst_u32(2)][7][2][0])])][0])), f32((*&buffer11)[17][7][u32(buffer11[pack2x16float(vec2f(unconst_f32(0.1295), unconst_f32(0.06867)))][unconst_u32(29)][2][u32((*&buffer11)[unconst_u32(2)][7][2][0])])][0]));
+  let ptr8: ptr<storage, array<f16, 1>, read> = &buffer11[17][7][2];
+  let ptr9: ptr<storage, f16, read> = &buffer11[unconst_u32(124)][7][2][unconst_u32(16)];
+  let ptr10: ptr<storage, f16, read> = &buffer11[unconst_u32(174)][u32(buffer11[17][7][2][0])][unconst_u32(16)][0];
+  {
+  out.f1 += f32((*&buffer11)[17][7][2][0]);
+  switch i32(buffer11[17][unconst_u32(37)][u32(buffer11[unconst_u32(72)][7][2][unconst_u32(80)])][0]) { 
+  default {
+  let ptr11: ptr<storage, array<array<f16, 1>, 3>, read> = &(*&buffer11)[17][7];
+  let vf49: vec4<bool> = (vec4f(unconst_f32(0.1032), unconst_f32(0.1105), unconst_f32(0.04588), unconst_f32(0.2258)) < vec4f(unconst_f32(0.09814), unconst_f32(0.03240), unconst_f32(0.1214), unconst_f32(0.03619)));
+  let ptr12: ptr<storage, f16, read> = &(*&buffer11)[17][7][2][unconst_u32(52)];
+  let ptr13: ptr<storage, array<array<f16, 1>, 3>, read> = &buffer11[17][unconst_u32(18)];
+  _ = buffer11;
+}
+  }
+  out.f0 = vec2f(f32((*&buffer11)[17][unconst_u32(272)][2][unconst_u32(244)]));
+  var vf50: vec2u = insertBits(vec2u(unconst_u32(12), unconst_u32(48)), vec2u(bitcast<u32>(vp4.f1)), unconst_u32(109), unconst_u32(243));
+  let ptr14: ptr<storage, array<f16, 1>, read> = &(*&buffer11)[unconst_u32(80)][unconst_u32(106)][2];
+  vp4 = FragmentOutput2(vec2f(f32((*&buffer11)[unconst_u32(237)][7][unconst_u32(115)][unconst_u32(81)])), f32((*&buffer11)[unconst_u32(237)][7][unconst_u32(115)][unconst_u32(81)]));
+  return out;
+  _ = buffer11;
+}
+  let ptr15: ptr<storage, array<array<f16, 1>, 3>, read> = &buffer11[17][7];
+  return out;
+  _ = buffer11;
+}
+
+override override0 = true;
+
+/* used global variables: buffer11 */
+@vertex
+fn vertex1(@location(0) a0: f32) -> VertexOutput1 {
+  var out: VertexOutput1;
+  out.f1 += vec4f(f32(buffer11[unconst_u32(79)][7][u32((*&buffer11)[unconst_u32(190)][7][unconst_u32(250)][0])][unconst_u32(457)]));
+  vp4.f1 = f32(buffer11[17][unconst_u32(324)][2][0]);
+  out = VertexOutput1(vec4f(f32((*&buffer11)[unconst_u32(315)][unconst_u32(19)][u32(buffer11[17][7][2][0])][0])));
+  let ptr16: ptr<storage, f16, read> = &(*&buffer11)[unconst_u32(12)][7][2][0];
+  vp4.f0 = vec2f(f32((*&buffer11)[unconst_u32(691)][unconst_u32(303)][2][0]));
+  vp4.f0 += vec2f(f32(buffer11[17][7][unconst_u32(19)][0]));
+  out = VertexOutput1(vec4f(f32((*&buffer11)[17][7][2][0])));
+  out = VertexOutput1(vec4f(f32(buffer11[17][u32(buffer11[unconst_u32(38)][7][2][0])][2][0])));
+  out.f1 -= vec4f(f32(buffer11[17][7][unconst_u32(28)][unconst_u32(49)]));
+  return out;
+  _ = buffer11;
+}
+
+/* used global variables: st2 */
+@fragment
+fn fragment2() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  let vf51: bool = override0;
+  vp4 = FragmentOutput2(vec2f(log(vec2h(unconst_f16(-6222.3), unconst_f16(12486.8)))), bitcast<f32>(log(vec2h(unconst_f16(-6222.3), unconst_f16(12486.8)))));
+  var vf52: vec4f = pow(pow(vec4f(unconst_f32(0.1774), unconst_f32(-0.02059), unconst_f32(-0.1334), unconst_f32(-0.1585)), vec4f(unconst_f32(0.1541), unconst_f32(-0.06037), unconst_f32(0.1825), unconst_f32(0.03583))), vec4f(unconst_f32(-0.00619), unconst_f32(0.05903), unconst_f32(0.3068), unconst_f32(0.03372)));
+  var vf53: f32 = vp4.f0[unconst_u32(388)];
+  var vf54: vec4<bool> = (vec4i(unconst_i32(107), unconst_i32(501), unconst_i32(244), unconst_i32(27)) > vec4i(unconst_i32(24), unconst_i32(-143), unconst_i32(228), unconst_i32(63)));
+  var vf55: vec2f = sign(vec2f(unconst_f32(0.2010), unconst_f32(0.03168)));
+  let vf56: mat2x3f = transpose(mat3x2f(vec2f(countOneBits(vec4i(unconst_i32(39), unconst_i32(488), unconst_i32(108), unconst_i32(169))).bg), vec2f(countOneBits(vec4i(unconst_i32(39), unconst_i32(488), unconst_i32(108), unconst_i32(169))).yy), vec2f(countOneBits(vec4i(unconst_i32(39), unconst_i32(488), unconst_i32(108), unconst_i32(169))).ar)));
+  switch bitcast<i32>(vp4.f0[unconst_u32(156)]) { 
+  default {
+  let vf57: f32 = inverseSqrt(unconst_f32(0.1448));
+}
+  }
+  let vf58: f16 = determinant(mat2x2h());
+  var vf59: vec3f = reflect(vec3f(unconst_f32(0.06366), unconst_f32(1.000), unconst_f32(0.2202)), vec3f(unconst_f32(-0.1147), unconst_f32(-0.02535), unconst_f32(0.08317)));
+  var vf60: u32 = pack4x8unorm(vec4f(unconst_f32(0.1792), unconst_f32(0.02724), unconst_f32(0.1626), unconst_f32(0.1549)));
+  vf60 >>= textureLoad(st2, unconst_i32(-50)).w;
+  let vf61: vec2i = countTrailingZeros(vec2i(unconst_i32(-52), unconst_i32(19)));
+  let vf62: f16 = ldexp(unconst_f16(6932.8), unconst_i32(221));
+  vf60 &= bitcast<vec4u>(quantizeToF16(vec4f(unconst_f32(0.4013), unconst_f32(0.00949), unconst_f32(0.2278), unconst_f32(0.00304)))).w;
+  return out;
+  _ = override0;
+  _ = st2;
+}
+
+/* used global variables: st2 */
+@compute @workgroup_size(1, 1, 1)
+fn compute2(@builtin(workgroup_id) a0: vec3u) {
+  if bool(atomicLoad(&vw18[unconst_u32(166)][0])) {
+  vw16.f1 = vec4f(f32(atomicLoad(&(*&vw13))));
+  vw20 = FragmentOutput2(unpack2x16unorm(atomicExchange(&(*&vw21)[unconst_u32(120)][unconst_u32(185)], unconst_u32(767))), f32(atomicExchange(&(*&vw21)[unconst_u32(120)][unconst_u32(185)], unconst_u32(767))));
+  var vf63: u32 = atomicLoad(&(*&vw21)[unconst_u32(195)][unconst_u32(728)]);
+  var vf64: i32 = atomicLoad(&(*&vw19)[5]);
+}
+  let ptr17: ptr<workgroup, array<array<atomic<u32>, 1>, 39>> = &vw18;
+  let ptr18: ptr<workgroup, atomic<u32>> = &vw18[38][0];
+  var vf65: vec4h = vw15[unconst_u32(204)];
+  vw20.f1 = vec2f(vw17)[0];
+  atomicCompareExchangeWeak(&vw21[unconst_u32(333)][unconst_u32(445)], unconst_u32(168), unconst_u32(407));
+  vw17 = vec2i(bitcast<i32>(vw20.f1));
+  let ptr19: ptr<workgroup, array<atomic<i32>, 6>> = &vw19;
+  switch bitcast<i32>((*&vw14)[0][unconst_i32(2)]) { 
+  default {
+  var vf66: u32 = atomicExchange(&(*&vw21)[unconst_u32(148)][unconst_u32(52)], unconst_u32(502));
+  while bool(atomicLoad(&(*&vw18)[unconst_u32(258)][unconst_u32(167)])) {
+  let ptr20: ptr<private, f32> = &vp4.f1;
+  return;
+}
+  textureStore(st2, unconst_i32(706), vec4u(vec4u(unconst_u32(65), unconst_u32(139), unconst_u32(88), unconst_u32(223))));
+  _ = st2;
+}
+  }
+  let vf67: f16 = (*&vw14)[unconst_u32(19)][unconst_u32(49)][unconst_u32(2)];
+  vw17 = vec2i(i32(atomicExchange(&(*ptr17)[38][unconst_u32(251)], unconst_u32(412))));
+  _ = st2;
+}`,
+});
+let buffer12 = device0.createBuffer({
+  size: 32580,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let textureView21 = texture13.createView({baseArrayLayer: 19, arrayLayerCount: 9});
+let texture15 = device0.createTexture({
+  size: {width: 940},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder14 = commandEncoder14.beginComputePass({});
+try {
+computePassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+let buffer13 = device0.createBuffer({
+  size: 4086,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle1 = renderBundleEncoder1.finish({});
+let sampler14 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder7.setPipeline(pipeline1);
+} catch {}
+let commandEncoder15 = device0.createCommandEncoder({});
+let texture16 = device0.createTexture({
+  size: [153, 3, 1],
+  mipLevelCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView22 = texture14.createView({dimension: '2d'});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer1, 2688, buffer12, 2516, 792);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 524, new Float32Array(19788), 901, 952);
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let buffer14 = device0.createBuffer({
+  label: '\u{1fe03}\u0c82\uc6d3\u0cd3\u9ba7\u0e55\ub34f',
+  size: 33683,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView23 = texture16.createView({});
+let textureView24 = texture2.createView({baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder15 = commandEncoder15.beginComputePass({});
+try {
+computePassEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(7).fill(105), /* required buffer size: 7 */
+{offset: 7, rowsPerImage: 24}, {width: 92, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 376, new Float32Array(24745), 4037, 136);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(72).fill(36), /* required buffer size: 72 */
+{offset: 72, bytesPerRow: 331}, {width: 120, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 144,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 323,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let commandEncoder16 = device0.createCommandEncoder({});
+let textureView25 = texture7.createView({dimension: '2d-array', format: 'rg8unorm', mipLevelCount: 1});
+let texture17 = device0.createTexture({
+  size: [492, 1, 1],
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder16 = commandEncoder16.beginComputePass();
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup4, new Uint32Array(4870), 1_211, 0);
+} catch {}
+let textureView26 = texture2.createView({dimension: '2d', mipLevelCount: 1});
+let renderBundle2 = renderBundleEncoder2.finish();
+try {
+computePassEncoder4.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(1, bindGroup3, new Uint32Array(583), 126, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 432, new DataView(new ArrayBuffer(3079)), 417, 372);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 41, resource: textureView8}, {binding: 39, resource: {buffer: buffer2, offset: 0}}],
+});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 74, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(143).fill(120), /* required buffer size: 143 */
+{offset: 143, bytesPerRow: 3858}, {width: 952, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 39, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+  ],
+});
+let sampler15 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 41.93,
+  lodMaxClamp: 87.15,
+  maxAnisotropy: 20,
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let veryExplicitBindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 33,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {binding: 54, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {binding: 77, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 119,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+    {binding: 155, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+let buffer15 = device0.createBuffer({size: 1293, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let commandEncoder17 = device0.createCommandEncoder();
+let textureView27 = texture14.createView({dimension: '2d', baseArrayLayer: 9});
+let computePassEncoder17 = commandEncoder17.beginComputePass({});
+try {
+computePassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(2, bindGroup3, []);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline1);
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let recycledExplicitBindGroupLayout0 = pipeline0.getBindGroupLayout(1);
+try {
+computePassEncoder4.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroups(2); };
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise1;
+} catch {}
+let buffer16 = device0.createBuffer({
+  size: 1673,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let textureView28 = texture8.createView({baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder14.insertDebugMarker('\u0f75');
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [
+    {binding: 41, resource: textureView8},
+    {binding: 39, resource: {buffer: buffer5, offset: 1792, size: 544}},
+  ],
+});
+let buffer17 = device0.createBuffer({label: '\ud11e\u{1f603}', size: 7388, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder18 = device0.createCommandEncoder({});
+let texture18 = device0.createTexture({
+  size: [32, 32, 50],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+computePassEncoder3.setBindGroup(0, bindGroup1, new Uint32Array(3930), 8, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroupsIndirect(buffer12, 5_840); };
+} catch {}
+let pipeline3 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule1, constants: {}}});
+let bindGroup7 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 39, resource: {buffer: buffer10, offset: 512}}, {binding: 41, resource: textureView28}],
+});
+let commandEncoder19 = device0.createCommandEncoder();
+let textureView29 = texture18.createView({aspect: 'all'});
+let computePassEncoder18 = commandEncoder18.beginComputePass({label: '\u{1f67c}\u42c8\u096e\u88c4\u{1ff21}'});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder4); computePassEncoder4.dispatchWorkgroups(2, 1, 1); };
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline3);
+} catch {}
+let buffer18 = device0.createBuffer({size: 2718, usage: GPUBufferUsage.INDEX});
+let computePassEncoder19 = commandEncoder19.beginComputePass({});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], stencilReadOnly: true});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup1, new Uint32Array(257), 35, 0);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup5);
+} catch {}
+let buffer19 = device0.createBuffer({
+  size: 7226,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 488});
+let textureView30 = texture10.createView({mipLevelCount: 1});
+let sampler16 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 69.53,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup5, new Uint32Array(96), 20, 0);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 80, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(230).fill(112), /* required buffer size: 230 */
+{offset: 230}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder11.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder17.setBindGroup(0, bindGroup3, new Uint32Array(285), 80, 0);
+} catch {}
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline2);
+} catch {}
+let imageData3 = new ImageData(12, 52);
+let buffer20 = device0.createBuffer({
+  size: 26025,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder20 = device0.createCommandEncoder({});
+let commandBuffer0 = commandEncoder3.finish();
+let texture19 = device0.createTexture({
+  size: [80, 90, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder20 = commandEncoder20.beginComputePass({});
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup5, new Uint32Array(1436), 12, 0);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint32', 40, 558);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(6, buffer14, 364, 8_884);
+} catch {}
+let img0 = await imageWithData(20, 89, '#10101010', '#20202020');
+let buffer21 = device0.createBuffer({size: 39542, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder16.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder3.setPipeline(pipeline2);
+} catch {}
+let texture20 = device0.createTexture({size: [984, 1, 1], format: 'rg8unorm', usage: GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(0, undefined, 0, 367_731_839);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 123, height: 1, depthOrArrayLayers: 153}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 44, y: 35 },
+  flipY: false,
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 77},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 31, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 45, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {
+      binding: 64,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 68, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 97,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let bindGroup8 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [
+    {binding: 144, resource: textureView5},
+    {binding: 323, resource: {buffer: buffer20, offset: 6400, size: 3044}},
+  ],
+});
+let renderBundle3 = renderBundleEncoder3.finish({});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(0, bindGroup2, new Uint32Array(10000), 2_039, 0);
+} catch {}
+let pipeline4 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 48,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32', offset: 0, shaderLocation: 13}, {format: 'uint32x4', offset: 0, shaderLocation: 0}],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front'},
+});
+let buffer22 = device0.createBuffer({
+  size: 2724,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let texture21 = device0.createTexture({
+  size: [80, 90, 1],
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder10.setPipeline(pipeline3);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 1700, new DataView(new ArrayBuffer(3443)), 603, 236);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData4 = new ImageData(76, 4);
+let buffer23 = device0.createBuffer({size: 2592, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture22 = device0.createTexture({
+  size: {width: 40, height: 45, depthOrArrayLayers: 5},
+  mipLevelCount: 1,
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 246, height: 1, depthOrArrayLayers: 307}
+*/
+{
+  source: img0,
+  origin: { x: 0, y: 8 },
+  flipY: true,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 178, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer24 = device0.createBuffer({
+  size: 395,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder20.setPipeline(pipeline1);
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [
+    {binding: 144, resource: textureView5},
+    {binding: 323, resource: {buffer: buffer15, offset: 0, size: 940}},
+  ],
+});
+let commandEncoder21 = device0.createCommandEncoder({});
+let texture23 = device0.createTexture({
+  size: [984, 1, 302],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder21 = commandEncoder21.beginComputePass();
+let sampler17 = device0.createSampler({
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.33,
+  compare: 'not-equal',
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup6);
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+var<workgroup> vw22: VertexOutput2;
+
+struct FragmentOutput3 {
+  @location(0) f0: vec4f,
+}
+
+struct T1 {
+  @align(32) @size(864) f0: array<vec4h>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<private> vp5 = modf(vec4h(14954.3, 932.9, 15541.3, 10579.1));
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(323) var<storage, read> buffer25: array<array<array<vec2h, 1>, 216>>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<private> vp6: array<array<f16, 1>, 1> = array(array<f16, 1>());
+
+struct VertexOutput2 {
+  @invariant @builtin(position) f2: vec4f,
+}
+
+/* used global variables: st3 */
+fn fn0() -> array<VertexOutput2, 1> {
+  var out: array<VertexOutput2, 1>;
+  textureStore(st3, unconst_i32(502), vec4u(vec4u(unconst_u32(177), unconst_u32(397), unconst_u32(92), unconst_u32(28))));
+  vp6[unconst_u32(660)][unconst_u32(100)] *= f16(atomicLoad(&(*&vw24)));
+  let vf68: vec4h = exp(vec4h(unconst_f16(44.79), unconst_f16(4496.1), unconst_f16(1447.5), unconst_f16(2668.9)));
+  let ptr21: ptr<private, array<f16, 1>> = &vp6[0];
+  let ptr22: ptr<workgroup, vec4f> = &vw23.f0;
+  vw22 = VertexOutput2(vec4f(bitcast<f32>(atomicLoad(&vw24))));
+  let vf69: vec4f = step(vec4f(unconst_f32(-0.00363), unconst_f32(0.2203), unconst_f32(-0.04871), unconst_f32(0.03188)), vw22.f2);
+  {
+  let ptr23: ptr<private, f16> = &vp6[0][0];
+  out[unconst_u32(521)].f2 = unpack4x8unorm(pack4xI8(vec4i(unconst_i32(180), unconst_i32(147), unconst_i32(189), unconst_i32(217))));
+  let ptr24: ptr<private, f16> = &vp6[unconst_u32(156)][u32(vp6[0][unconst_u32(2)])];
+  textureStore(st3, vec3i(ceil(vec3h(unconst_f16(21984.8), unconst_f16(9705.5), unconst_f16(8135.0))))[1], vec4u(vec4u(unconst_u32(165), unconst_u32(26), unconst_u32(353), unconst_u32(393))));
+  let ptr25: ptr<private, array<f16, 1>> = &vp6[unconst_u32(18)];
+  vw22 = VertexOutput2(workgroupUniformLoad(&vw23).f0);
+  vp6[unconst_u32(141)][unconst_u32(136)] = vec4h((*&vw22).f2).g;
+  _ = st3;
+}
+  var vf70: vec3h = asinh(vec3h(unconst_f16(2048.5), unconst_f16(4942.9), unconst_f16(732.7)));
+  workgroupBarrier();
+  return out;
+  _ = st3;
+}
+
+alias vec3b = vec3<bool>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T0 {
+  @align(16) @size(864) f0: array<atomic<u32>>,
+}
+
+var<workgroup> vw23: FragmentOutput3;
+
+var<workgroup> vw24: atomic<i32>;
+
+@id(33144) override override1: i32 = 68;
+
+@group(0) @binding(144) var st3: texture_storage_1d<r32uint, read_write>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+override override2 = 0.1454;
+
+/* used global variables: buffer25 */
+@vertex
+fn vertex2(@builtin(instance_index) a0: u32) -> VertexOutput2 {
+  var out: VertexOutput2;
+  vp5.fract = buffer25[unconst_u32(132)][unconst_u32(5)][0].grgr;
+  out.f2 += vec4f(f32((*&buffer25)[arrayLength(&(*&buffer25))][unconst_u32(23)][bitcast<u32>((*&buffer25)[arrayLength(&(*&buffer25))][unconst_u32(13)][0])][bitcast<u32>((*&buffer25)[unconst_u32(111)][unconst_u32(475)][unconst_u32(53)])]));
+  vp5.whole = vec4h(countOneBits(vec4u(unconst_u32(47), unconst_u32(114), unconst_u32(72), unconst_u32(12))));
+  let ptr26: ptr<storage, array<array<vec2h, 1>, 216>, read> = &(*&buffer25)[arrayLength(&(*&buffer25))];
+  return out;
+  _ = buffer25;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment3() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  out.f0 *= quantizeToF16(vec4f(unconst_f32(0.00463), unconst_f32(0.1476), unconst_f32(0.00235), unconst_f32(0.1956)));
+  let ptr27: ptr<private, f16> = &vp6[0][unconst_u32(38)];
+  let vf71: vec4u = unpack4xU8(unconst_u32(105));
+  return out;
+}
+
+/* used global variables: st3 */
+@compute @workgroup_size(2, 1, 2)
+fn compute3() {
+  vp5.whole -= vec4h(f16(override2));
+  fn0();
+  let ptr28: ptr<workgroup, vec4f> = &vw22.f2;
+  var vf72: vec4f = saturate(vec4f(floor(unconst_f32(0.07633))));
+  textureStore(st3, unconst_i32(294), vec4u(vec4u(unconst_u32(16), unconst_u32(20), unconst_u32(69), unconst_u32(112))));
+  vw23.f0 -= vec4f(tan(unconst_f32(0.1676)));
+  vp6[0][unconst_u32(25)] = f16(acos(unconst_f32(-0.02863)));
+  let ptr29: ptr<workgroup, atomic<i32>> = &(*&vw24);
+  var vf73 = fn0();
+  var vf74 = fn0();
+  _ = override2;
+  _ = st3;
+}`,
+});
+let textureView31 = texture21.createView({dimension: '2d-array'});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 784, new Float32Array(1139), 687, 8);
+} catch {}
+let imageData5 = new ImageData(16, 8);
+try {
+commandEncoder11.label = '\u2bbe\u{1fa74}\u9d64\u3ff3\u8a3b\ue2dc\u{1fca3}\u07e2\ua28f\u5642';
+} catch {}
+let textureView32 = texture9.createView({dimension: 'cube', mipLevelCount: 1});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer26 = device0.createBuffer({size: 3461, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture24 = device0.createTexture({
+  size: [307, 7, 1],
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let sampler18 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.53,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder5.setPipeline(pipeline3);
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  code: `
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+var<private> vp8: mat3x4f = mat3x4f();
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<private> vp9: VertexOutput3 = VertexOutput3();
+
+struct FragmentOutput4 {
+  @location(4) @interpolate(flat) f0: u32,
+  @location(0) @interpolate(perspective) f1: vec4f,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T0 {
+  @align(16) @size(864) f0: array<u32>,
+}
+
+var<private> vp7: VertexOutput3 = VertexOutput3(vec4f(0.1044, 0.04199, 0.2290, 0.09493), vec2f(0.00896, 0.08359));
+
+struct T1 {
+  @align(32) @size(864) f0: array<u32>,
+}
+
+/* zero global variables used */
+fn fn0() -> mat4x2f {
+  var out: mat4x2f;
+  let ptr30: ptr<private, bool> = &vp10[unconst_u32(113)];
+  vp9 = VertexOutput3(vp9.f4.yyyx, vp9.f4);
+  var vf75: u32 = pack2x16snorm(vec2f(unconst_f32(0.1435), unconst_f32(-0.00751)));
+  if bool(asinh(unconst_f32(0.05180))) {
+  while bool(vp7.f3[1]) {
+  let vf76: vec2i = (bitcast<vec2i>(sin(vec4h(unconst_f16(7791.3), unconst_f16(13437.8), unconst_f16(5190.1), unconst_f16(-18448.9)))) >> vec2u(unconst_u32(5), unconst_u32(483)));
+  let vf77: vec2<bool> = (vec2f(unconst_f32(0.2938), unconst_f32(0.1716)) <= vec2f(unconst_f32(-0.4423), unconst_f32(0.1726)));
+  var vf78: vec3u = (vec3u(unconst_u32(293), unconst_u32(114), unconst_u32(461)) | vec3u(abs(vec4h((vec4i(unconst_i32(280), unconst_i32(518), unconst_i32(93), unconst_i32(-3)) << vec4u(unconst_u32(21), unconst_u32(115), unconst_u32(149), unconst_u32(79))))).wyz));
+  vp9 = VertexOutput3(bitcast<vec4f>( ~vec4i(unconst_i32(208), unconst_i32(-169), unconst_i32(199), unconst_i32(203))), vec2f( ~vec4i(unconst_i32(208), unconst_i32(-169), unconst_i32(199), unconst_i32(203)).bg));
+  let vf79: u32 = pack4xU8Clamp(vec4u(unconst_u32(223), unconst_u32(289), unconst_u32(88), unconst_u32(101)));
+}
+}
+  return out;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(323) var<storage, read> buffer27: array<array<array<array<i32, 9>, 12>, 2>>;
+
+alias vec3b = vec3<bool>;
+
+@group(0) @binding(144) var st4: texture_storage_1d<r32uint, read_write>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<private> vp10: array<bool, 1> = array(bool(false));
+
+struct VertexOutput3 {
+  @builtin(position) f3: vec4f,
+  @location(1) @interpolate(perspective, either) f4: vec2f,
+}
+
+/* used global variables: buffer27 */
+@vertex
+fn vertex3() -> VertexOutput3 {
+  var out: VertexOutput3;
+  let ptr31: ptr<storage, i32, read> = &(*&buffer27)[arrayLength(&(*&buffer27))][1][11][8];
+  for (var it2=u32(buffer27[unconst_u32(3)][1][11][8]); it2<u32((*&buffer27)[unconst_u32(157)][1][11][8]); it2++) {
+  out = VertexOutput3(vec4f(f32((*&buffer27)[unconst_i32(196)][1][11][8])), vec2f(bitcast<f32>((*&buffer27)[unconst_i32(196)][1][11][8])));
+  {
+  let vf80: f16 = asinh(unconst_f16(4935.4));
+  let ptr32: ptr<private, VertexOutput3> = &vp7;
+}
+  let ptr33: ptr<storage, i32, read> = &buffer27[arrayLength(&buffer27)][1][11][8];
+  break;
+  _ = buffer27;
+}
+  out.f3 *= vec4f(bitcast<f32>((*&buffer27)[u32(buffer27[arrayLength(&buffer27)][unconst_u32(261)][11][8])][unconst_u32(58)][unconst_u32(68)][unconst_u32(127)]));
+  let ptr34: ptr<storage, array<i32, 9>, read> = &(*&buffer27)[bitcast<u32>((*&buffer27)[arrayLength(&(*&buffer27))][1][11][8])][1][11];
+  let ptr35: ptr<storage, i32, read> = &buffer27[arrayLength(&buffer27)][1][unconst_u32(138)][8];
+  var vf81: f32 = determinant(mat4x4f(vp9.f4[unconst_u32(88)], vp9.f4[unconst_u32(88)], vp9.f4[unconst_u32(88)], vp9.f4[unconst_u32(88)], vp9.f4[unconst_u32(88)], vp9.f4[unconst_u32(88)], vp9.f4[unconst_u32(88)], vp9.f4[unconst_u32(88)], vp9.f4[unconst_u32(88)], vp9.f4[unconst_u32(88)], vp9.f4[unconst_u32(88)], vp9.f4[unconst_u32(88)], vp9.f4[unconst_u32(88)], vp9.f4[unconst_u32(88)], vp9.f4[unconst_u32(88)], vp9.f4[unconst_u32(88)]));
+  out.f3 = vec4f(bitcast<f32>(buffer27[u32((*&buffer27)[arrayLength(&(*&buffer27))][1][11][8])][unconst_u32(173)][11][8]));
+  let ptr36: ptr<storage, array<i32, 9>, read> = &(*&buffer27)[arrayLength(&(*&buffer27))][unconst_u32(68)][unconst_u32(137)];
+  let ptr37: ptr<storage, array<array<array<i32, 9>, 12>, 2>, read> = &(*&buffer27)[arrayLength(&(*&buffer27))];
+  let ptr38: ptr<storage, array<i32, 9>, read> = &(*ptr37)[unconst_u32(24)][11];
+  vp9 = VertexOutput3(vec4f(bitcast<f32>(buffer27[unconst_u32(237)][u32((*ptr34)[8])][unconst_u32(115)][unconst_u32(286)])), vec2f(f32(buffer27[unconst_u32(237)][u32((*ptr34)[8])][unconst_u32(115)][unconst_u32(286)])));
+  let ptr39: ptr<storage, i32, read> = &buffer27[unconst_u32(372)][unconst_u32(37)][unconst_u32(125)][unconst_u32(102)];
+  let ptr40: ptr<storage, i32, read> = &(*ptr36)[unconst_u32(93)];
+  return out;
+  _ = buffer27;
+}
+
+/* used global variables: st4 */
+@fragment
+fn fragment4() -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  vp8 -= mat3x4f(bitcast<f32>(textureDimensions(st4)), bitcast<f32>(textureDimensions(st4)), bitcast<f32>(textureDimensions(st4)), f32(textureDimensions(st4)), f32(textureDimensions(st4)), f32(textureDimensions(st4)), f32(textureDimensions(st4)), bitcast<f32>(textureDimensions(st4)), bitcast<f32>(textureDimensions(st4)), bitcast<f32>(textureDimensions(st4)), f32(textureDimensions(st4)), bitcast<f32>(textureDimensions(st4)));
+  var vf82: vec2f = quantizeToF16(vec2f(unconst_f32(0.05966), unconst_f32(0.07439)));
+  let vf83: vec3h =  -vec3h(unconst_f16(30128.8), unconst_f16(4335.3), unconst_f16(-47587.8));
+  var vf84: vec3<bool> = (vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(false)) == vec3<bool>(unconst_bool(true), unconst_bool(false), unconst_bool(true)));
+  var vf85: bool = (unconst_bool(false) && unconst_bool(true));
+  loop {
+  let ptr41: ptr<private, bool> = &vp10[unconst_u32(102)];
+  out.f1 = vec4f((vec4h(unconst_f16(2942.8), unconst_f16(8496.0), unconst_f16(29266.0), unconst_f16(7458.1)) <= vec4h(unconst_f16(857.9), unconst_f16(18223.3), unconst_f16(1996.0), unconst_f16(24212.4))));
+  vp8 = mat3x4f(vec4f(unpack4xI8(unconst_u32(302))), vec4f(unpack4xI8(unconst_u32(302))), vec4f(unpack4xI8(unconst_u32(302))));
+  break;
+}
+  let ptr42: ptr<function, vec2f> = &vf82;
+  var vf86: f32 = vp7.f3[unconst_u32(132)];
+  vp7 = VertexOutput3(mix(vec3f(unconst_f32(0.1117), unconst_f32(0.2858), unconst_f32(0.01980)), vec3f(unconst_f32(0.1881), unconst_f32(0.1059), unconst_f32(0.1839)), unconst_f32(0.1015)).zyzy, mix(vec3f(unconst_f32(0.1117), unconst_f32(0.2858), unconst_f32(0.01980)), vec3f(unconst_f32(0.1881), unconst_f32(0.1059), unconst_f32(0.1839)), unconst_f32(0.1015)).zy);
+  let vf87: vec3h = acosh(vec3h(f16((bool(vp9.f4[unconst_u32(462)]) && bool((unconst_u32(209) >> unconst_u32(214)))))));
+  let vf88: f16 = length(vec2h(unconst_f16(858.8), unconst_f16(5426.9)));
+  let vf89: vec3<bool> = (vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(true)) == vec3<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(false)));
+  let vf90: vec2f = quantizeToF16(vec2f(f32(vp10[bitcast<u32>((vec2i(i32(tan(unconst_f16(45892.6)))) / vec2i(unconst_i32(92), unconst_i32(-110))).y)])));
+  let vf91: vec3h = vf83;
+  return out;
+  _ = st4;
+}`,
+});
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout6]});
+let texture25 = device0.createTexture({
+  size: [80, 90, 1],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture26 = device0.createTexture({
+  size: {width: 40, height: 45, depthOrArrayLayers: 1},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline1);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+} catch {}
+let pipeline5 = device0.createRenderPipeline({
+  layout: pipelineLayout2,
+  fragment: {module: shaderModule0, constants: {}, targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA}]},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 512,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 60, shaderLocation: 13},
+          {format: 'uint8x2', offset: 0, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let bindGroup10 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 39, resource: {buffer: buffer12, offset: 7168}}, {binding: 41, resource: textureView8}],
+});
+let texture27 = device0.createTexture({
+  size: {width: 153, height: 3, depthOrArrayLayers: 1},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView33 = texture18.createView({});
+try {
+computePassEncoder21.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(3).fill(31), /* required buffer size: 3 */
+{offset: 3, bytesPerRow: 55}, {width: 1, height: 17, depthOrArrayLayers: 0});
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let bindGroup11 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [
+    {binding: 39, resource: {buffer: buffer16, offset: 256, size: 604}},
+    {binding: 41, resource: textureView28},
+  ],
+});
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout2]});
+let textureView34 = texture25.createView({mipLevelCount: 1});
+let texture28 = device0.createTexture({
+  size: [153],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView35 = texture7.createView({});
+try {
+computePassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder20.insertDebugMarker('\u6723');
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.append(img0);
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'bt470m', transfer: 'iec6196624'} });
+let texture29 = device0.createTexture({
+  size: [20, 22, 39],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture30 = device0.createTexture({
+  size: [20],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView36 = texture6.createView({mipLevelCount: 1});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(1, bindGroup8, new Uint32Array(9), 2, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer14, 2_188); };
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let imageData6 = new ImageData(32, 8);
+let recycledExplicitBindGroupLayout1 = pipeline3.getBindGroupLayout(0);
+let textureView37 = texture24.createView({});
+let textureView38 = texture15.createView({dimension: '1d'});
+try {
+computePassEncoder11.pushDebugGroup('\ufd36');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 123, height: 1, depthOrArrayLayers: 153}
+*/
+{
+  source: imageData1,
+  origin: { x: 8, y: 1 },
+  flipY: false,
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 36, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpte170m', transfer: 'smpteSt4281'} });
+let textureView39 = texture27.createView({});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder11); computePassEncoder11.dispatchWorkgroupsIndirect(buffer22, 32); };
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline1);
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(10, 63);
+let bindGroup12 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 144, resource: textureView5}, {binding: 323, resource: {buffer: buffer12, offset: 0}}],
+});
+let commandEncoder22 = device0.createCommandEncoder({});
+let textureView40 = texture24.createView({baseMipLevel: 0});
+let textureView41 = texture13.createView({arrayLayerCount: 8});
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout6]});
+let buffer28 = device0.createBuffer({size: 13233, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let commandEncoder23 = device0.createCommandEncoder({});
+let texture31 = device0.createTexture({
+  size: {width: 153},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder12.setPipeline(pipeline3);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer24, 8, 24);
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder({});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 442});
+let renderPassEncoder0 = commandEncoder23.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  depthSlice: 17,
+  clearValue: { r: -888.1, g: -775.2, b: -587.4, a: -48.25, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet1,
+});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(2, bindGroup11, new Uint32Array(2600), 272, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint32', 3_488, 800);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer2, 0);
+} catch {}
+try {
+commandEncoder24.copyBufferToBuffer(buffer20, 1956, buffer24, 28, 108);
+} catch {}
+let buffer29 = device0.createBuffer({size: 6777, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let commandEncoder25 = device0.createCommandEncoder({});
+let renderPassEncoder1 = commandEncoder25.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  depthSlice: 41,
+  clearValue: { r: -664.3, g: -119.6, b: -206.6, a: -997.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup1, new Uint32Array(63), 5, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer14, 1_348, 812);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 172, y: 0, z: 12},
+  aspect: 'all',
+}, new Uint8Array(4_827).fill(249), /* required buffer size: 4_827 */
+{offset: 71, bytesPerRow: 116, rowsPerImage: 41}, {width: 23, height: 0, depthOrArrayLayers: 2});
+} catch {}
+let buffer30 = device0.createBuffer({size: 849, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder26 = device0.createCommandEncoder({});
+let texture32 = device0.createTexture({
+  size: [3760],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder22 = commandEncoder24.beginComputePass();
+let sampler19 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 96.85,
+  compare: 'less',
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer22, 'uint32', 24, 113);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder27 = device0.createCommandEncoder({});
+let texture33 = gpuCanvasContext0.getCurrentTexture();
+let computePassEncoder23 = commandEncoder27.beginComputePass({});
+let renderPassEncoder2 = commandEncoder26.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  depthSlice: 207,
+  clearValue: { r: -70.14, g: 668.7, b: -994.3, a: -130.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup11, new Uint32Array(1997), 98, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 280, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(95).fill(240), /* required buffer size: 95 */
+{offset: 95}, {width: 568, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder24 = commandEncoder22.beginComputePass({});
+try {
+computePassEncoder24.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(0, bindGroup9, new Uint32Array(239), 51, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer20, 6_640); };
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup11, new Uint32Array(117), 42, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle0]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 24, new Float32Array(10533), 2779, 156);
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder({});
+let texture34 = device0.createTexture({
+  size: {width: 307, height: 7, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder3 = commandEncoder28.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  depthSlice: 264,
+  clearValue: { r: 205.2, g: 221.6, b: 163.9, a: 54.07, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 760797,
+});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup9, new Uint32Array(2448), 29, 0);
+} catch {}
+let buffer31 = device0.createBuffer({size: 3356, usage: GPUBufferUsage.INDIRECT});
+let sampler20 = device0.createSampler({addressModeV: 'repeat', minFilter: 'nearest'});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder15.setBindGroup(3, bindGroup5, new Uint32Array(1335), 36, 0);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer24, 'uint16', 84, 61);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(4, buffer1, 0);
+} catch {}
+let imageData7 = new ImageData(32, 32);
+let autogeneratedBindGroupLayout0 = pipeline4.getBindGroupLayout(0);
+let textureView42 = texture25.createView({aspect: 'all'});
+let texture35 = device0.createTexture({size: [40], dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame1});
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder1.setViewport(137.98719807818688, 0.2474324897073923, 62.91178043480473, 0.42233059870196976, 0.39115170891367546, 0.617714441671543);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer14, 8_700, 2_832);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline3);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+let buffer32 = device0.createBuffer({
+  size: 14445,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture36 = device0.createTexture({
+  size: {width: 984, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder24.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer21, 5_844);
+} catch {}
+try {
+computePassEncoder13.setBindGroup(0, bindGroup2, new Uint32Array(6232), 1_916, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer2, 'uint32', 88, 291);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder({});
+let texture37 = device0.createTexture({
+  size: [615, 15, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder25 = commandEncoder29.beginComputePass({});
+try {
+computePassEncoder25.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup4, new Uint32Array(1435), 453, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer14, 'uint32', 6_184, 11_670);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let texture38 = device0.createTexture({
+  size: [615, 15, 140],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let sampler21 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.95,
+  compare: 'greater',
+  maxAnisotropy: 13,
+});
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(8, 0, 59, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+await gc();
+let sampler22 = device0.createSampler({addressModeV: 'mirror-repeat', compare: 'greater-equal'});
+try {
+renderPassEncoder0.executeBundles([renderBundle2, renderBundle1, renderBundle2, renderBundle2]);
+} catch {}
+try {
+    await gc();
+buffer9.destroy();
+await gc();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise2;
+} catch {}
+let img1 = await imageWithData(45, 7, '#10101010', '#20202020');
+let commandEncoder30 = device0.createCommandEncoder();
+let texture39 = device0.createTexture({
+  size: {width: 246, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler23 = device0.createSampler({lodMaxClamp: 96.98, compare: 'never'});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup1, new Uint32Array(388), 57, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup4, new Uint32Array(3879), 702, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(110.56935899706683, 0.8348473471649053, 45.30448687541059, 0.11561609407429727, 0.3388181383471299, 0.5345513268054743);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'smpteRp431', transfer: 'smpteSt4281'} });
+let veryExplicitBindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let buffer33 = device0.createBuffer({
+  size: 3903,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 172});
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer22, 'uint16', 470, 269);
+} catch {}
+let arrayBuffer1 = buffer4.getMappedRange(8, 8);
+try {
+computePassEncoder11.popDebugGroup();
+} catch {}
+let textureView43 = texture30.createView({});
+let renderPassEncoder4 = commandEncoder30.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  depthSlice: 165,
+  clearValue: { r: 117.6, g: 190.3, b: 487.0, a: 866.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer18, 'uint32', 316, 69);
+} catch {}
+let pipeline6 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule3, entryPoint: 'compute3'}});
+let texture40 = device0.createTexture({
+  size: [10, 11, 1],
+  sampleCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView44 = texture40.createView({});
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer5, 716, 2_163);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55); };
+} catch {}
+try {
+computePassEncoder1.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder3); computePassEncoder3.dispatchWorkgroupsIndirect(buffer1, 772); };
+} catch {}
+let pipeline7 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'constant', dstFactor: 'zero'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'zero'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex1',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 124,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x2', offset: 16, shaderLocation: 0}],
+      },
+    ],
+  },
+});
+let bindGroup13 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 41, resource: textureView28},
+    {binding: 39, resource: {buffer: buffer16, offset: 512, size: 716}},
+  ],
+});
+let texture41 = device0.createTexture({
+  size: {width: 1230, height: 30, depthOrArrayLayers: 41},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture42 = device0.createTexture({
+  size: {width: 246, height: 1, depthOrArrayLayers: 42},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView45 = texture20.createView({dimension: '2d-array', arrayLayerCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline2);
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({label: '\u3aa5\u{1fee6}\u0b39\u0963\uc411'});
+let texture43 = device0.createTexture({
+  size: {width: 307, height: 7, depthOrArrayLayers: 22},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(58, 0, 17, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer18, 'uint32', 508, 131);
+} catch {}
+try {
+commandEncoder31.copyBufferToTexture({
+  /* bytesInLastRow: 22 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1456 */
+  offset: 1456,
+  bytesPerRow: 65280,
+  buffer: buffer26,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView46 = texture36.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder26 = commandEncoder28.beginComputePass();
+let sampler24 = device0.createSampler({addressModeV: 'repeat', mipmapFilter: 'nearest', maxAnisotropy: 1});
+try {
+renderPassEncoder2.setViewport(12.859589232338454, 0.02642375300329103, 87.98263855924348, 0.1455144423072313, 0.3335643426348581, 0.9904383824052189);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer12, 1604, new BigUint64Array(877));
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext1 = offscreenCanvas1.getContext('webgpu');
+let commandEncoder32 = device0.createCommandEncoder();
+let texture44 = device0.createTexture({
+  size: {width: 470, height: 2, depthOrArrayLayers: 6},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder5 = commandEncoder31.beginRenderPass({
+  colorAttachments: [{
+  view: textureView46,
+  clearValue: { r: -801.3, g: 609.6, b: 201.1, a: -831.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder2.setBlendConstant({ r: -445.5, g: 675.7, b: -79.01, a: -367.2, });
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder32.copyBufferToBuffer(buffer32, 2036, buffer19, 2288, 508);
+} catch {}
+try {
+commandEncoder32.resolveQuerySet(querySet0, 145, 38, buffer12, 9472);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+@group(0) @binding(144) var st5: texture_storage_1d<r32uint, read_write>;
+
+struct T0 {
+  @size(288) f0: vec2i,
+  @align(32) @size(32) f1: atomic<u32>,
+  @align(32) @size(544) f2: array<array<array<mat2x2h, 1>, 1>>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T2 {
+  @align(32) @size(384) f0: mat4x4f,
+  @align(32) @size(32) f1: mat4x2h,
+  @size(448) f2: array<u32>,
+}
+
+var<private> vp11: S2 = S2();
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct S0 {
+  @location(7) @interpolate(perspective, first) f0: vec2h,
+  @location(10) f1: f16,
+  @location(12) @interpolate(flat, center) f2: vec4u,
+  @location(0) f3: i32,
+  @builtin(vertex_index) f4: u32,
+  @location(5) f5: vec2i,
+  @location(2) @interpolate(flat) f6: vec2u,
+  @location(9) f7: vec4f,
+}
+
+@group(0) @binding(323) var<storage, read> buffer34: array<VertexOutput5, 54>;
+
+struct VertexOutput5 {
+  @invariant @builtin(position) f6: vec4f,
+}
+
+struct FragmentOutput5 {
+  @location(0) @interpolate(linear) f0: vec4f,
+  @location(6) f1: vec2f,
+}
+
+struct S3 {
+  @location(11) @interpolate(flat, centroid) f0: vec4i,
+}
+
+var<workgroup> vw26: f32;
+
+var<workgroup> vw27: atomic<i32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct S4 {
+  @builtin(sample_mask) f0: u32,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct S1 {
+  @location(14) f0: vec4h,
+  @location(1) f1: vec4h,
+  @location(8) @interpolate(perspective) f2: vec4f,
+  @location(3) @interpolate(flat, first) f3: vec2i,
+}
+
+struct T1 {
+  @size(864) f0: array<mat2x4h>,
+}
+
+struct VertexOutput4 {
+  @invariant @builtin(position) f5: vec4f,
+}
+
+var<workgroup> vw25: S2;
+
+struct S2 {
+  @location(15) f0: f16,
+}
+
+/* used global variables: buffer34 */
+@vertex
+fn vertex4(@location(13) @interpolate(linear, center) a0: f32, @builtin(instance_index) a1: u32, a2: S0, a3: S1, @location(4) a4: vec2f, @location(6) a5: f16, a6: S2, a7: S3) -> VertexOutput4 {
+  var out: VertexOutput4;
+  out = VertexOutput4(unpack4x8snorm(a2.f6[unconst_u32(131)]));
+  let ptr43: ptr<storage, VertexOutput5, read> = &(*&buffer34)[53];
+  let ptr44: ptr<storage, VertexOutput5, read> = &(*ptr43);
+  let vf92: vec4h = a3.f1;
+  let ptr45: ptr<storage, VertexOutput5, read> = &buffer34[unconst_u32(6)];
+  out = VertexOutput4(bitcast<vec4f>(a2.f6.yyyy));
+  out.f5 -= vec4f((*ptr43).f6[unconst_u32(60)]);
+  {
+  out.f5 *= vec4f(a2.f0.gggg);
+  vp11.f0 = vec4h(unpack4x8unorm(unconst_u32(9)))[0];
+  for (var it3=bitcast<u32>(a2.f0); it3<a2.f4; it3++) {
+  let vf93: u32 = dot4U8Packed(unconst_u32(65), unconst_u32(208));
+  var vf94: u32 = a1;
+  let vf95: vec2h = a2.f0;
+  break;
+}
+  var vf96: vec4f = a2.f7;
+  vf96 = vec4f(a0);
+  let vf97: f16 = a2.f1;
+  out = VertexOutput4(vec4f(f32(vp11.f0)));
+}
+  out = VertexOutput4((*&buffer34)[u32(a2.f3)].f6);
+  let vf98: vec4h = tan(vec4h(unconst_f16(7402.7), unconst_f16(-15738.9), unconst_f16(8561.4), unconst_f16(707.1)));
+  var vf99: f32 = (*ptr43).f6[unconst_u32(7)];
+  let vf100: vec2h = a2.f0;
+  var vf101: vec2u = a2.f6;
+  return out;
+  _ = buffer34;
+}
+
+/* used global variables: buffer34 */
+@vertex
+fn vertex5() -> VertexOutput5 {
+  var out: VertexOutput5;
+  let ptr46: ptr<private, f16> = &vp11.f0;
+  out.f6 = buffer34[53].f6;
+  let ptr47: ptr<storage, vec4f, read> = &buffer34[unconst_u32(872)].f6;
+  let ptr48: ptr<storage, vec4f, read> = &(*&buffer34)[unconst_u32(52)].f6;
+  out = buffer34[unconst_u32(108)];
+  out = VertexOutput5(faceForward(vec2f(unconst_f32(0.09349), unconst_f32(0.1547)), vec2f(f32((*ptr46))), vec2f(unconst_f32(-0.1480), unconst_f32(0.1702))).gggr);
+  out.f6 = vec4f((*ptr48)[pack4xU8(vec4u((vec4u(unconst_u32(38), unconst_u32(33), unconst_u32(72), unconst_u32(328)) > vec4u(unconst_u32(153), unconst_u32(373), unconst_u32(1000), unconst_u32(294)))))]);
+  var vf102: vec3f = fma(vec3f(unconst_f32(0.1452), unconst_f32(0.1724), unconst_f32(0.2533)), vec3f(unconst_f32(0.1083), unconst_f32(0.3187), unconst_f32(0.00035)), vec3f(unconst_f32(0.2419), unconst_f32(-0.1092), unconst_f32(0.1509)));
+  var vf103: vec3f = normalize(unpack2x16float(unconst_u32(543)).rgr);
+  var vf104: vec4h = (vec4h(unconst_f16(2311.9), unconst_f16(22588.5), unconst_f16(-3080.6), unconst_f16(2483.1)) * unconst_f16(2536.9));
+  let ptr49: ptr<storage, vec4f, read> = &(*&buffer34)[53].f6;
+  vf103 = (*ptr49).rrb;
+  return out;
+  _ = buffer34;
+}
+
+/* used global variables: st5 */
+@fragment
+fn fragment5(@location(1) @interpolate(perspective, either) a0: vec2f, @builtin(front_facing) a1: bool, @builtin(sample_index) a2: u32, @invariant @builtin(position) a3: vec4f, a4: S4) -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  textureStore(st5, (vec4i(unconst_i32(110), unconst_i32(182), unconst_i32(211), unconst_i32(278)) >> vec4u(unconst_u32(26), unconst_u32(160), unconst_u32(835), unconst_u32(137)))[0], vec4u(unpack4xU8(u32((bool((vec4i(unconst_i32(63), unconst_i32(28), unconst_i32(89), unconst_i32(74)) >> vec4u(unconst_u32(119), unconst_u32(38), unconst_u32(816), unconst_u32(184))).y) || unconst_bool(true))))));
+  var vf105: vec4h = reflect(vec4h(unconst_f16(1390.8), unconst_f16(12449.6), unconst_f16(-25190.0), unconst_f16(13656.6)), vec4h(unconst_f16(5524.6), unconst_f16(2519.5), unconst_f16(4418.9), unconst_f16(4909.4)));
+  var vf106: vec4<bool> = (vec4u(a4.f0) >= vec4u(exp(vec4h(unconst_f16(13833.1), unconst_f16(23958.7), unconst_f16(11827.5), unconst_f16(24011.7)))));
+  return out;
+  _ = st5;
+}
+
+/* used global variables: st5 */
+@compute @workgroup_size(1, 1, 1)
+fn compute4() {
+  var vf107: vec4i = extractBits(vec4i(unconst_i32(141), unconst_i32(17), unconst_i32(166), unconst_i32(19)), bitcast<u32>(atomicLoad(&vw27)), unconst_u32(90));
+  var vf108: f32 = workgroupUniformLoad(&vw26);
+  let ptr50: ptr<private, f16> = &vp11.f0;
+  vw25 = S2(f16(length(unconst_f32(0.00609))));
+  let ptr51: ptr<function, f32> = &vf108;
+  let vf109: vec2u = (vec2u(unconst_u32(9), unconst_u32(24)) << vec2u(unconst_u32(11), unconst_u32(233)));
+  var vf110: u32 = textureDimensions(st5);
+  switch atomicLoad(&(*&vw27)) { 
+  default {
+  let vf111: vec3h = fma(vec3h(unconst_f16(17271.6), unconst_f16(5564.3), unconst_f16(3376.9)), vec3h(unconst_f16(3980.1), unconst_f16(27549.0), unconst_f16(7676.0)), vec3h(unconst_f16(3072.0), unconst_f16(5840.0), unconst_f16(8524.8)));
+  let vf112: vec3h = fma(vec3h(unconst_f16(3071.7), unconst_f16(-8731.3), unconst_f16(-3095.8)), vec3h(unconst_f16(1562.8), unconst_f16(19654.8), unconst_f16(1346.4)), vec3h(unconst_f16(-9478.1), unconst_f16(40098.8), unconst_f16(10210.2)));
+  textureStore(st5, unconst_i32(66), vec4u(vec4u(unconst_u32(45), unconst_u32(92), unconst_u32(49), unconst_u32(43))));
+  _ = st5;
+}
+  }
+  vf108 = bitcast<f32>(vf109[1]);
+  let ptr52: ptr<function, f32> = &(*ptr51);
+  var vf113: i32 = atomicExchange(&vw27, unconst_i32(51));
+  vw25.f0 *= vw25.f0;
+  let vf114: u32 = pack4xU8(vec4u(unconst_u32(186), unconst_u32(180), unconst_u32(60), unconst_u32(100)));
+  let ptr53: ptr<function, f32> = &(*ptr51);
+  _ = st5;
+}
+
+/* used global variables: st5 */
+@compute @workgroup_size(1, 1, 1)
+fn compute5() {
+  let ptr54: ptr<workgroup, S2> = &(*&vw25);
+  vw25.f0 -= (*ptr54).f0;
+  {
+  textureStore(st5, unconst_i32(450), vec4u(vec4u(unconst_u32(325), unconst_u32(62), unconst_u32(36), unconst_u32(264))));
+  _ = st5;
+}
+  _ = st5;
+}`,
+});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup2, new Uint32Array(10000), 844, 0);
+} catch {}
+let arrayBuffer2 = buffer4.getMappedRange(16, 24);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 123, height: 1, depthOrArrayLayers: 153}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 9, y: 288 },
+  flipY: false,
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer35 = device0.createBuffer({size: 11440, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroupsIndirect(buffer31, 108); };
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+commandEncoder32.resolveQuerySet(querySet1, 240, 18, buffer12, 11520);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+  await promise3;
+} catch {}
+let textureView47 = texture18.createView({});
+let texture45 = device0.createTexture({
+  size: {width: 470, height: 2, depthOrArrayLayers: 1},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder27 = commandEncoder32.beginComputePass({});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup3, new Uint32Array(927), 10, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle1, renderBundle2]);
+} catch {}
+try {
+commandEncoder6.copyBufferToTexture({
+  /* bytesInLastRow: 52 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 772 */
+  offset: 772,
+  bytesPerRow: 5120,
+  buffer: buffer26,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise4;
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [{binding: 323, resource: {buffer: buffer10, offset: 256}}, {binding: 144, resource: textureView4}],
+});
+let commandBuffer1 = commandEncoder6.finish();
+let texture46 = device0.createTexture({
+  size: {width: 1880, height: 10, depthOrArrayLayers: 1},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup8, new Uint32Array(365), 22, 0);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(97);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer19, 'uint16', 570, 5);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer5);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer2, 'uint32', 92, 248);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 4, y: 17, z: 0},
+  aspect: 'all',
+}, new Uint8Array(98).fill(6), /* required buffer size: 98 */
+{offset: 98, bytesPerRow: 287, rowsPerImage: 60}, {width: 71, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 125,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 166,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture47 = device0.createTexture({
+  size: [80],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm']});
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer18, 'uint16', 170, 41);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer32);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView48 = texture46.createView({arrayLayerCount: 1});
+let sampler25 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  lodMaxClamp: 62.80,
+});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup8, new Uint32Array(22), 2, 0);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(203);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup13);
+} catch {}
+let veryExplicitBindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 144,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 323,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup6, new Uint32Array(409), 6, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup5, []);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle2, renderBundle2, renderBundle1, renderBundle2, renderBundle2, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint16', 3_892, 1_031);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup6, new Uint32Array(748), 20, 0);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(7, buffer24, 72, 11);
+} catch {}
+await gc();
+let commandEncoder33 = device0.createCommandEncoder({});
+let computePassEncoder28 = commandEncoder33.beginComputePass({});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup1, new Uint32Array(5012), 448, 0);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(3, buffer14, 1_612, 12_445);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 3704, new DataView(new ArrayBuffer(19102)), 804, 2852);
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout5]});
+let buffer36 = device0.createBuffer({size: 7116, usage: GPUBufferUsage.MAP_WRITE});
+let renderBundle4 = renderBundleEncoder5.finish({});
+let sampler26 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 66.55,
+  compare: 'greater',
+});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup4, new Uint32Array(939), 182, 0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder34 = device0.createCommandEncoder({});
+let texture48 = device0.createTexture({
+  size: {width: 940, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder29 = commandEncoder34.beginComputePass({});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(0, bindGroup8, new Uint32Array(2711), 155, 0);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle1, renderBundle2, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(0, bindGroup13, new Uint32Array(6851), 659, 0);
+} catch {}
+let arrayBuffer3 = buffer4.getMappedRange(40, 0);
+let pipeline8 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment2',
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}],
+},
+  vertex: {module: shaderModule5, entryPoint: 'vertex5', constants: {}, buffers: []},
+  primitive: {topology: 'line-list', cullMode: 'back', unclippedDepth: true},
+});
+document.body.append(img0);
+let commandEncoder35 = device0.createCommandEncoder({});
+let texture49 = device0.createTexture({
+  size: [246, 1, 5],
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder30 = commandEncoder35.beginComputePass();
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline5);
+} catch {}
+let img2 = await imageWithData(7, 16, '#10101010', '#20202020');
+let bindGroup15 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 68, resource: {buffer: buffer12, offset: 1280, size: 2096}},
+    {binding: 45, resource: {buffer: buffer0, offset: 256, size: 748}},
+    {binding: 97, resource: externalTexture0},
+    {binding: 64, resource: {buffer: buffer19, offset: 2560, size: 360}},
+  ],
+});
+let buffer37 = device0.createBuffer({
+  size: 11131,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder36 = device0.createCommandEncoder();
+let computePassEncoder31 = commandEncoder36.beginComputePass({});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(52).fill(43), /* required buffer size: 52 */
+{offset: 52}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer38 = device0.createBuffer({size: 421, usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let textureView49 = texture25.createView({});
+let texture50 = device0.createTexture({
+  size: [246],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView50 = texture13.createView({dimension: '2d', baseArrayLayer: 25});
+try {
+{ clearResourceUsages(device0, computePassEncoder1); computePassEncoder1.dispatchWorkgroupsIndirect(buffer12, 1_028); };
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(75);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderBundleEncoder4.setPipeline(pipeline5);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 20, new Float32Array(10768), 1326, 24);
+} catch {}
+let texture51 = gpuCanvasContext1.getCurrentTexture();
+let textureView51 = texture16.createView({dimension: '2d-array', aspect: 'all'});
+let renderBundle5 = renderBundleEncoder4.finish({});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(2, bindGroup6, new Uint32Array(383), 6, 0);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup2, new Uint32Array(107), 41, 0);
+} catch {}
+let bindGroup16 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 9, resource: textureView30}]});
+let buffer39 = device0.createBuffer({size: 4475, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder37 = device0.createCommandEncoder();
+let texture52 = device0.createTexture({
+  size: {width: 1230},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+computePassEncoder12.setBindGroup(0, bindGroup12, new Uint32Array(402), 20, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(23);
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder();
+let textureView52 = texture44.createView({mipLevelCount: 1});
+let textureView53 = texture8.createView({aspect: 'depth-only', baseMipLevel: 0, arrayLayerCount: 1});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup15);
+} catch {}
+let buffer40 = device0.createBuffer({size: 47796, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder39 = device0.createCommandEncoder({});
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 1098});
+let renderPassEncoder6 = commandEncoder37.beginRenderPass({
+  colorAttachments: [{
+  view: textureView46,
+  clearValue: { r: 323.7, g: -103.6, b: 550.7, a: 777.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler27 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'repeat', magFilter: 'linear'});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup2, new Uint32Array(200), 62, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroupsIndirect(buffer33, 868); };
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup13, new Uint32Array(3385), 1_821, 0);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer19, 'uint16', 758, 341);
+} catch {}
+try {
+commandEncoder38.copyBufferToTexture({
+  /* bytesInLastRow: 392 widthInBlocks: 49 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2176 */
+  offset: 2176,
+  buffer: buffer37,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 49, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder39.clearBuffer(buffer40);
+} catch {}
+let buffer41 = device0.createBuffer({size: 34651, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let commandEncoder40 = device0.createCommandEncoder({});
+let computePassEncoder32 = commandEncoder39.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroups(2, 1); };
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer8, 'uint16', 24, 247);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder40.copyBufferToTexture({
+  /* bytesInLastRow: 420 widthInBlocks: 210 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1650 */
+  offset: 1650,
+  rowsPerImage: 14,
+  buffer: buffer21,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 1260, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 210, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder38.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 168, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 444 widthInBlocks: 111 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1260 */
+  offset: 1260,
+  buffer: buffer19,
+}, {width: 111, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline9 = await device0.createComputePipelineAsync({layout: pipelineLayout3, compute: {module: shaderModule2}});
+let textureView54 = texture40.createView({});
+let renderPassEncoder7 = commandEncoder38.beginRenderPass({
+  colorAttachments: [{
+  view: textureView46,
+  clearValue: { r: 395.9, g: 417.6, b: -619.1, a: 93.93, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroupsIndirect(buffer31, 1_956); };
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup12, new Uint32Array(4178), 369, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 44, y: 1, z: 20},
+  aspect: 'all',
+}, new Uint8Array(2_159).fill(181), /* required buffer size: 2_159 */
+{offset: 555, bytesPerRow: 64, rowsPerImage: 25}, {width: 2, height: 1, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 123, height: 1, depthOrArrayLayers: 153}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderPassEncoder8 = commandEncoder40.beginRenderPass({
+  colorAttachments: [{
+  view: textureView46,
+  clearValue: { r: -262.4, g: 502.6, b: -818.1, a: -610.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup2, new Uint32Array(2246), 45, 0);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(86);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer22, 'uint32', 16, 298);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let commandEncoder41 = device0.createCommandEncoder();
+let texture53 = device0.createTexture({
+  size: {width: 246, height: 1, depthOrArrayLayers: 70},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder33 = commandEncoder41.beginComputePass({});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup1, new Uint32Array(113), 56, 0);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer5);
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+  /* bytesInLastRow: 324 widthInBlocks: 162 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 224 */
+  offset: 224,
+  buffer: buffer35,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 162, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({});
+let texture54 = device0.createTexture({
+  size: {width: 307, height: 7, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView55 = texture49.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(37, 0, 15, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer13);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let buffer42 = device0.createBuffer({
+  size: 6756,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder43 = device0.createCommandEncoder({});
+let texture55 = device0.createTexture({
+  size: {width: 153},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder34 = commandEncoder42.beginComputePass({});
+let renderPassEncoder9 = commandEncoder43.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  depthSlice: 118,
+  clearValue: { r: -737.1, g: 723.4, b: -718.8, a: -188.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 241943496,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroupsIndirect(buffer32, 6_312); };
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder5.draw(317, 1, 131_187_321, 1);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer1, 220);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer39, 340, new BigUint64Array(1351), 262, 28);
+} catch {}
+let buffer43 = device0.createBuffer({size: 414, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandBuffer2 = commandEncoder30.finish();
+let texture56 = device0.createTexture({
+  size: {width: 80, height: 90, depthOrArrayLayers: 14},
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: false});
+let renderBundle6 = renderBundleEncoder6.finish({});
+let sampler28 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup11, []);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(27, 0, 67, 37_461_592);
+} catch {}
+try {
+  await buffer26.mapAsync(GPUMapMode.WRITE, 32, 256);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 24, new Float32Array(13834), 7178, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 83, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(47).fill(59), /* required buffer size: 47 */
+{offset: 47, bytesPerRow: 57}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder44 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder12); computePassEncoder12.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup15, new Uint32Array(1432), 7, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(253, 0, 321_980_350, 1);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer22, 52);
+} catch {}
+try {
+  await shaderModule4.getCompilationInfo();
+} catch {}
+try {
+commandEncoder44.copyBufferToTexture({
+  /* bytesInLastRow: 298 widthInBlocks: 149 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 5970 */
+  offset: 5970,
+  buffer: buffer35,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 149, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame3 = new VideoFrame(videoFrame1, {timestamp: 0});
+let texture57 = device0.createTexture({size: [940, 5, 1], format: 'rg8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let textureView56 = texture30.createView({});
+try {
+computePassEncoder26.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer42, 704);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline7);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise5;
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder();
+let sampler29 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 6,
+});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder5.draw(139, 1, 228_395_748, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(7, 1, 3, 201_007_460, 1);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer22, 572);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer1, 'uint32', 2_628, 4_718);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, undefined, 295_040_850);
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder({});
+let commandBuffer3 = commandEncoder7.finish();
+let texture58 = device0.createTexture({
+  size: [1968, 1, 1],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture59 = device0.createTexture({size: [20, 22, 9], format: 'rg8unorm', usage: GPUTextureUsage.COPY_SRC});
+let renderPassEncoder10 = commandEncoder46.beginRenderPass({
+  colorAttachments: [{
+  view: textureView46,
+  clearValue: { r: -618.6, g: 176.5, b: 844.3, a: -156.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroupsIndirect(buffer20, 848); };
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle0, renderBundle1, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(35, 0, 353, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(10, 1, 7, 349_796_677);
+} catch {}
+try {
+buffer33.unmap();
+} catch {}
+try {
+commandEncoder45.resolveQuerySet(querySet3, 331, 6, buffer2, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture60 = device0.createTexture({
+  size: [80, 90, 12],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder35 = commandEncoder45.beginComputePass({});
+try {
+computePassEncoder35.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(260, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(5, 0, 13, 431_223_658);
+} catch {}
+try {
+commandEncoder44.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 476 */
+  offset: 476,
+  buffer: buffer15,
+}, {
+  texture: texture48,
+  mipLevel: 6,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+document.body.prepend(img0);
+let imageData8 = new ImageData(72, 12);
+let shaderModule6 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires unrestricted_pointer_parameters;
+
+enable f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(323) var<storage, read> buffer44: array<array<array<array<array<f16, 3>, 1>, 4>, 36>>;
+
+struct FragmentOutput6 {
+  @location(2) @interpolate(flat, sample) f0: vec4u,
+  @builtin(sample_mask) f1: u32,
+  @location(0) @interpolate(linear, center) f2: vec2f,
+}
+
+var<workgroup> vw28: mat4x2f;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+alias vec3b = vec3<bool>;
+
+/* zero global variables used */
+fn fn1(a0: vec4f) -> array<f16, 1> {
+  var out: array<f16, 1>;
+  var vf127: vec4h = trunc(vec4h(unconst_f16(6427.9), unconst_f16(22657.9), unconst_f16(4149.7), unconst_f16(2190.5)));
+  let vf128: vec4<bool> = (vec4h(unconst_f16(6684.3), unconst_f16(13732.6), unconst_f16(12233.1), unconst_f16(22894.3)) > vec4h(unconst_f16(7486.1), unconst_f16(16228.9), unconst_f16(4616.5), unconst_f16(4841.2)));
+  var vf129: bool = (unconst_bool(false) && unconst_bool(true));
+  vf127 = vec4h(inverseSqrt(vec4f(unconst_f32(0.00953), unconst_f32(0.06479), unconst_f32(0.1578), unconst_f32(0.1030))));
+  vf129 = any( !vec2<bool>(unconst_bool(false), unconst_bool(false)));
+  let ptr56: ptr<function, vec4h> = &vf127;
+  return out;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw29: array<array<array<vec4u, 1>, 1>, 1>;
+
+/* zero global variables used */
+fn fn0(a0: ptr<storage, atomic<i32>, read_write>) -> array<mat3x3h, 1> {
+  var out: array<mat3x3h, 1>;
+  var vf115: vec2i = abs(vec2i(unconst_i32(26), unconst_i32(321)));
+  var vf116: vec3<bool> = (vec3f(f32(dot4I8Packed(unconst_u32(168), countTrailingZeros(vec3u(unconst_u32(163), unconst_u32(93), unconst_u32(4))).b))) > vec3f((vec3i(unconst_i32(24), unconst_i32(65), unconst_i32(57)) | vec3i(unconst_i32(76), unconst_i32(141), unconst_i32(29)))));
+  let vf117: vec4i =  ~vec4i(unconst_i32(78), unconst_i32(109), unconst_i32(122), unconst_i32(310));
+  let ptr55: ptr<storage, atomic<i32>, read_write> = &(*a0);
+  loop {
+  let vf118: vec2h = cos(vec2h(unconst_f16(28171.7), unconst_f16(1622.6)));
+  out[unconst_u32(277)] = mat3x3h(max(vec3h(unconst_f16(16515.4), unconst_f16(-11294.9), unconst_f16(16595.4)), smoothstep(vec2h(unconst_f16(4613.0), unconst_f16(2523.6)), cos(vec2h(unconst_f16(22363.0), unconst_f16(2064.3))), max(vec3h(unconst_f16(958.5), unconst_f16(55124.1), unconst_f16(5410.7)), vec3h(unconst_f16(199.3), unconst_f16(-18853.3), unconst_f16(9539.2))).rb).rgr), max(vec3h(unconst_f16(16515.4), unconst_f16(-11294.9), unconst_f16(16595.4)), smoothstep(vec2h(unconst_f16(4613.0), unconst_f16(2523.6)), cos(vec2h(unconst_f16(22363.0), unconst_f16(2064.3))), max(vec3h(unconst_f16(958.5), unconst_f16(55124.1), unconst_f16(5410.7)), vec3h(unconst_f16(199.3), unconst_f16(-18853.3), unconst_f16(9539.2))).rb).rgr), max(vec3h(unconst_f16(16515.4), unconst_f16(-11294.9), unconst_f16(16595.4)), smoothstep(vec2h(unconst_f16(4613.0), unconst_f16(2523.6)), cos(vec2h(unconst_f16(22363.0), unconst_f16(2064.3))), max(vec3h(unconst_f16(958.5), unconst_f16(55124.1), unconst_f16(5410.7)), vec3h(unconst_f16(199.3), unconst_f16(-18853.3), unconst_f16(9539.2))).rb).rgr));
+  let vf119: vec3h = step(vec3h(unconst_f16(5214.5), unconst_f16(4438.1), unconst_f16(6044.8)), vec3h(unconst_f16(22832.8), unconst_f16(37632.0), unconst_f16(11373.8)));
+  atomicAnd(&(*a0), bitcast<i32>(smoothstep(vec2h(unconst_f16(2449.1), unconst_f16(3669.7)), vec2h(unconst_f16(33652.4), unconst_f16(3919.4)), vec2h(unconst_f16(563.9), unconst_f16(29498.6)))));
+  var vf120: f16 = vf119[unconst_u32(23)];
+  break;
+}
+  let vf121: f16 = fract(unconst_f16(13063.4));
+  {
+  atomicAnd(&(*a0), unconst_i32(-59));
+  var vf122: vec3f = exp(vec3f(unconst_f32(-0.4193), unconst_f32(0.04075), unconst_f32(0.2412)));
+  var vf123: vec2u = insertBits(vec2u(unconst_u32(43), unconst_u32(218)), vec2u(unconst_u32(46), unconst_u32(120)), unconst_u32(249), unconst_u32(286));
+  var vf124: bool = any(unconst_bool(true));
+  let vf125: mat3x2h = (mat3x2h(unconst_f16(15027.0), unconst_f16(22816.4), unconst_f16(30502.1), unconst_f16(3888.8), unconst_f16(22543.5), unconst_f16(13183.2)) - mat3x2h());
+}
+  atomicAdd(&(*a0), unconst_i32(149));
+  var vf126: vec4h = exp2(vec4h(unconst_f16(2236.0), unconst_f16(1626.9), unconst_f16(631.7), unconst_f16(3.393)));
+  vf115 *= vec2i(i32(all(vec2<bool>(unconst_bool(false), unconst_bool(true)))));
+  out[unconst_u32(72)] = mat3x3h(f16(length(vec4f(unconst_f32(0.1178), unconst_f32(-0.2225), unconst_f32(0.1992), unconst_f32(0.1880)))), f16(length(vec4f(unconst_f32(0.1178), unconst_f32(-0.2225), unconst_f32(0.1992), unconst_f32(0.1880)))), f16(length(vec4f(unconst_f32(0.1178), unconst_f32(-0.2225), unconst_f32(0.1992), unconst_f32(0.1880)))), f16(length(vec4f(unconst_f32(0.1178), unconst_f32(-0.2225), unconst_f32(0.1992), unconst_f32(0.1880)))), f16(length(vec4f(unconst_f32(0.1178), unconst_f32(-0.2225), unconst_f32(0.1992), unconst_f32(0.1880)))), f16(length(vec4f(unconst_f32(0.1178), unconst_f32(-0.2225), unconst_f32(0.1992), unconst_f32(0.1880)))), f16(length(vec4f(unconst_f32(0.1178), unconst_f32(-0.2225), unconst_f32(0.1992), unconst_f32(0.1880)))), f16(length(vec4f(unconst_f32(0.1178), unconst_f32(-0.2225), unconst_f32(0.1992), unconst_f32(0.1880)))), f16(length(vec4f(unconst_f32(0.1178), unconst_f32(-0.2225), unconst_f32(0.1992), unconst_f32(0.1880)))));
+  return out;
+}
+
+var<workgroup> vw30: atomic<u32>;
+
+@group(0) @binding(144) var st6: texture_storage_1d<r32uint, read_write>;
+
+var<workgroup> vw31: array<f16, 20>;
+
+struct T0 {
+  @align(32) @size(864) f0: array<u32>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+/* used global variables: buffer44 */
+@vertex
+fn vertex6(@location(4) a0: vec2u, @location(14) @interpolate(flat, first) a1: vec4u, @location(12) a2: i32, @builtin(instance_index) a3: u32, @location(7) a4: vec2f, @location(9) a5: vec2f, @location(3) a6: vec4u) -> @builtin(position) vec4f {
+  var out: vec4f;
+  out = vec4f(f32(buffer44[unconst_u32(436)][unconst_u32(9)][3][0][2]));
+  let ptr57: ptr<storage, array<array<array<array<f16, 3>, 1>, 4>, 36>, read> = &buffer44[unconst_u32(39)];
+  var vf130 = fn1(vec4f(f32((*ptr57)[35][3][unconst_u32(196)][2])));
+  var vf131: vec3i = reverseBits(vec3i(i32((*&buffer44)[arrayLength(&(*&buffer44))][unconst_u32(28)][3][unconst_u32(115)][2])));
+  fn1(vec4f(f32((*ptr57)[unconst_u32(211)][3][unconst_u32(121)][2])));
+  out = vec4f(f32(buffer44[unconst_u32(34)][unconst_u32(6)][3][0][2]));
+  vf130[unconst_u32(192)] = (*&buffer44)[unconst_u32(104)][unconst_u32(155)][3][0][2];
+  var vf132 = fn1(vec4f(f32(buffer44[arrayLength(&buffer44)][unconst_u32(121)][3][unconst_u32(299)][2])));
+  return out;
+  _ = buffer44;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment6() -> FragmentOutput6 {
+  var out: FragmentOutput6;
+  loop {
+  let vf133: vec2h = ldexp(vec2h(unconst_f16(1242.0), unconst_f16(5351.9)), vec2i(unconst_i32(343), unconst_i32(57)));
+  if bool(pack2x16float(vec2f(unconst_f32(0.08194), unconst_f32(0.01941)))) {
+  var vf134: u32 = firstTrailingBit(unconst_u32(33));
+  let vf135: vec2h = saturate(vec2h(unconst_f16(9959.1), unconst_f16(47280.8)));
+  let vf136: i32 = max(unconst_i32(89), unconst_i32(26));
+  return out;
+}
+  out.f1 <<= vec3u(sin(vec3h(unconst_f16(9232.6), unconst_f16(1055.3), unconst_f16(11219.3))))[1];
+  let vf137: u32 = pack4x8snorm(vec4f(unconst_f32(0.6363), unconst_f32(0.1649), unconst_f32(0.03280), unconst_f32(0.06223)));
+  break;
+}
+  for (var it4=vec3u(sqrt(vec3h(unconst_f16(23264.2), unconst_f16(7368.5), unconst_f16(1653.3)))).x; it4<u32((vec3i(unconst_i32(-486), unconst_i32(-456), unconst_i32(45)) % unconst_i32(-517)).g); it4++) {
+  out.f0 = vec4u(u32((unconst_bool(true) || unconst_bool(false))));
+  var vf138: vec2h = faceForward(vec2h(unconst_f16(20928.8), unconst_f16(2836.2)), vec2h(unconst_f16(5871.7), unconst_f16(19636.2)), vec2h(unconst_f16(1830.6), unconst_f16(9390.3)));
+  let vf139: bool = (unconst_bool(false) || unconst_bool(false));
+  out.f2 = vec2f(extractBits(vec2i(unconst_i32(25), unconst_i32(221)), bitcast<u32>(unpack2x16float(countTrailingZeros(vec2u(unconst_u32(114), unconst_u32(126)))[1]).r), unconst_u32(15)));
+  break;
+}
+  discard;
+  return out;
+}
+
+/* used global variables: st6 */
+@compute @workgroup_size(3, 1, 1)
+fn compute6() {
+  let ptr58: ptr<workgroup, f16> = &vw31[19];
+  var vf140: vec2f = vw28[unconst_u32(89)];
+  let ptr59: ptr<workgroup, vec4u> = &vw29[0][unconst_u32(111)][unconst_u32(283)];
+  var vf141 = fn1(bitcast<vec4f>(vw29[0][unconst_u32(221)][0]));
+  fn1(vec4f((*&vw29)[unconst_u32(458)][0][unconst_u32(96)]));
+  let ptr60: ptr<workgroup, array<array<array<vec4u, 1>, 1>, 1>> = &vw29;
+  var vf142 = fn1(vec4f(vw29[unconst_u32(617)][(*ptr60)[0][0][pack4xU8((*ptr60)[unconst_u32(64)][0][unconst_u32(38)])][unconst_u32(26)]][0]));
+  fn1(bitcast<vec4f>((*ptr60)[unconst_u32(103)][0][0]));
+  while bool((vec2u(unconst_u32(96), unconst_u32(416)) % vec2u(unconst_u32(76), unconst_u32(87)))[1]) {
+  textureStore(st6, unconst_i32(74), vec4u(vec4u(unconst_u32(406), unconst_u32(210), unconst_u32(154), unconst_u32(157))));
+  let vf143: u32 = (*&vw29)[0][u32(quantizeToF16(unconst_f32(0.3625)))][unconst_u32(171)][unconst_u32(194)];
+  _ = st6;
+}
+  vw31[unconst_u32(85)] = f16(transpose(mat4x4f())[unconst_i32(2)].r);
+  let ptr61: ptr<workgroup, array<array<vec4u, 1>, 1>> = &vw29[0];
+  textureStore(st6, unconst_i32(47), vec4u(vec4u(unconst_u32(109), unconst_u32(109), unconst_u32(297), unconst_u32(421))));
+  atomicCompareExchangeWeak(&vw30, unconst_u32(351), unconst_u32(375));
+  var vf144: vec4f = mix(vec4f(unconst_f32(0.4628), unconst_f32(0.03794), unconst_f32(0.04814), unconst_f32(0.1048)), vec4f(unconst_f32(0.1297), unconst_f32(0.2993), unconst_f32(0.04617), unconst_f32(0.05888)), unconst_f32(0.01531));
+  fn1(unpack4x8unorm(atomicLoad(&vw30)));
+  _ = st6;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(2, 2, 1)
+fn compute7() {
+  vw29[unconst_u32(514)][unconst_u32(110)][unconst_u32(357)] = vw29[0][unconst_u32(16)][0];
+  vw29[unconst_u32(239)][unconst_u32(186)][unconst_u32(30)] = unpack4xU8(u32(vw31[19]));
+  fn1(vw28[unconst_u32(286)].grgr);
+  vw31[unconst_u32(595)] = f16(vw29[0][unconst_u32(50)][0][unconst_u32(533)]);
+  var vf145: vec4h = tanh(vec4h(unconst_f16(-8023.0), unconst_f16(619.2), unconst_f16(254.1), unconst_f16(5090.1)));
+  let ptr62: ptr<workgroup, f16> = &vw31[unconst_u32(93)];
+  vf145 += vec4h((*&vw31)[19]);
+  if bool(vw29[unconst_u32(44)][0][unconst_u32(9)][unconst_u32(267)]) {
+  fn1(unpack4x8snorm(vw29[0][unconst_u32(101)][unconst_u32(88)][u32((*&vw31)[19])]));
+  var vf146 = fn1(vec4f((*&vw29)[unconst_u32(25)][0][0]));
+  fn1(vec4f(vw29[unconst_u32(305)][0][0]));
+  let ptr63: ptr<workgroup, array<vec4u, 1>> = &vw29[0][unconst_u32(448)];
+}
+  var vf147 = fn1(vec4f((*&vw29)[unconst_u32(271)][unconst_u32(248)][unconst_u32(53)]));
+  var vf148 = fn1(vec4f(f32(firstTrailingBit(unconst_i32(309)))));
+  fn1(bitcast<vec4f>((*&vw29)[0][0][unconst_u32(492)]));
+  let ptr64: ptr<workgroup, mat4x2f> = &(*&vw28);
+  return;
+}`,
+});
+let textureView57 = texture58.createView({dimension: '2d-array', baseMipLevel: 0});
+try {
+renderPassEncoder5.draw(326, 2, 722_779_560, 1);
+} catch {}
+let pipeline10 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule1,
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex6',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 140,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 16, shaderLocation: 9},
+          {format: 'uint16x4', offset: 36, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 4, shaderLocation: 7},
+          {format: 'uint32x3', offset: 4, shaderLocation: 3},
+          {format: 'uint16x2', offset: 8, shaderLocation: 14},
+          {format: 'sint16x2', offset: 0, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+});
+let imageData9 = new ImageData(36, 60);
+let textureView58 = texture58.createView({mipLevelCount: 1});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup13, new Uint32Array(2074), 74, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroupsIndirect(buffer2, 36); };
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer24, 'uint16', 28, 49);
+} catch {}
+let arrayBuffer4 = buffer4.getMappedRange(48, 0);
+try {
+commandEncoder44.copyBufferToBuffer(buffer26, 732, buffer24, 4, 40);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let buffer45 = device0.createBuffer({size: 555, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let renderPassEncoder11 = commandEncoder44.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: 384.0, g: 3.701, b: -14.07, a: 848.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 139302822,
+});
+let sampler30 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'clamp-to-edge', compare: 'less'});
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer7, 56);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer15, 204);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer24, 'uint32', 16, 27);
+} catch {}
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt470m', transfer: 'log'} });
+let buffer46 = device0.createBuffer({size: 11779, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture61 = gpuCanvasContext0.getCurrentTexture();
+let externalTexture1 = device0.importExternalTexture({source: videoFrame1});
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(702, 0, 33, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(30, 0, 18, 546_223_565, 1);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer20, 13_884);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline8);
+} catch {}
+let veryExplicitBindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 45, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform', hasDynamicOffset: false }},
+    {
+      binding: 64,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {binding: 68, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 97,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let texture62 = device0.createTexture({
+  size: [1230, 30, 1],
+  mipLevelCount: 4,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup4, []);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(0, 0, 12, 18_355_077);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer33, 1_360);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer21, 10_672);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let buffer47 = device0.createBuffer({size: 13032, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(19, 0, 151, 968_981_948, 2);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer2, 176);
+} catch {}
+offscreenCanvas1.height = 80;
+let buffer48 = device0.createBuffer({
+  size: 5886,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let textureView59 = texture34.createView({mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup3, []);
+} catch {}
+try {
+computePassEncoder30.setBindGroup(2, bindGroup5, new Uint32Array(1847), 5, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(60, 0, 6, 427_869_387, 2);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer12, 18_440);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer2, 28);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer8, 'uint32', 8, 24);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer39, 1312, new Int16Array(671), 255, 48);
+} catch {}
+await gc();
+try {
+globalThis.someLabel = externalTexture1.label;
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+/* zero global variables used */
+fn fn1() -> array<u32, 48> {
+  var out: array<u32, 48>;
+  var vf151: f32 = tanh(unconst_f32(-0.00428));
+  if bool((vec2u(unconst_u32(530), unconst_u32(334)) + unconst_u32(233)).g) {
+  var vf152: vec2<bool> = (vec2h(unconst_f16(6920.8), unconst_f16(4406.0)) >= vec2h(unconst_f16(360.6), unconst_f16(5574.1)));
+  out[47] ^= pack4x8snorm((vec4f(unconst_f32(0.1657), unconst_f32(0.03885), unconst_f32(0.3547), unconst_f32(0.08484)) - unconst_f32(0.05353)));
+  var vf153: vec3i = (vec3i(unconst_i32(218), unconst_i32(16), unconst_i32(61)) << vec3u(unconst_u32(137), unconst_u32(21), unconst_u32(191)));
+  var vf154: u32 = pack4xI8(vec4i(unconst_i32(1), unconst_i32(128), unconst_i32(216), unconst_i32(278)));
+  vf152 = vec2<bool>((vec3i(unconst_i32(71), unconst_i32(-210), unconst_i32(238)) << vec3u(unconst_u32(118), unconst_u32(656), unconst_u32(48))).xx);
+}
+  vf151 = bitcast<f32>(reverseBits(vec2u(unconst_u32(175), unconst_u32(359)))[1]);
+  vf151 = tan(vec4f(unconst_f32(0.1808), unconst_f32(0.3295), unconst_f32(0.3726), unconst_f32(0.1871)))[2];
+  vf151 = acosh(vec3f(unconst_f32(0.1828), unconst_f32(0.00138), unconst_f32(0.02276)))[0];
+  let ptr65: ptr<function, f32> = &vf151;
+  let ptr66: ptr<function, f32> = &(*ptr65);
+  var vf155: vec3f = log(vec3f(unconst_f32(0.5618), unconst_f32(0.09101), unconst_f32(0.02027)));
+  {
+  let vf156: u32 = pack2x16snorm(vec2f((vec3f(unconst_f32(0.1343), unconst_f32(0.1344), unconst_f32(0.1523)) >= min(vec3f(unconst_f32(0.2705), unconst_f32(-0.2801), unconst_f32(-0.00394)), vec3f(unconst_f32(0.1096), unconst_f32(0.1386), unconst_f32(0.1936)))).rb));
+  for (var it5=pack4xU8Clamp(vec4u(reflect((mat3x2h() * vec3h(unconst_f16(-7615.8), unconst_f16(8825.0), unconst_f16(2407.9))).yxyx, vec4h(unconst_f16(-9662.0), unconst_f16(11518.2), unconst_f16(46853.0), unconst_f16(3628.6))))); it5<u32(radians(vec4f(unconst_f32(0.2895), unconst_f32(0.00665), unconst_f32(0.1046), unconst_f32(0.06190)))[3]); it5++) {
+  out[unconst_u32(164)] = reverseBits(vec4u(unconst_u32(145), unconst_u32(159), unconst_u32(27), unconst_u32(74)))[2];
+  out[47] >>= pack4xU8(vec4u(unconst_u32(25), unconst_u32(57), unconst_u32(257), unconst_u32(140)));
+  var vf157: vec2f = unpack2x16snorm(unconst_u32(91));
+  out[unconst_u32(202)] += insertBits(vec4u(unconst_u32(169), unconst_u32(45), unconst_u32(41), unconst_u32(3)), vec4u(unconst_u32(153), unconst_u32(26), unconst_u32(10), unconst_u32(116)), unconst_u32(158), unconst_u32(192))[0];
+  var vf158: vec2h = abs(vec2h(unconst_f16(8017.3), unconst_f16(28588.6)));
+}
+}
+  var vf159: vec4h = ldexp(vec4h(unconst_f16(12028.8), unconst_f16(862.5), unconst_f16(5532.2), unconst_f16(8521.2)), vec4i(unconst_i32(63), unconst_i32(259), unconst_i32(87), unconst_i32(422)));
+  return out;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(144) var st7: texture_storage_1d<r32uint, read_write>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct FragmentOutput7 {
+  @location(7) @interpolate(flat, either) f0: vec4f,
+  @location(0) @interpolate(flat) f1: u32,
+  @location(4) f2: u32,
+  @location(1) f3: vec2i,
+}
+
+struct T0 {
+  @align(32) @size(864) f0: array<array<array<vec2h, 1>, 13>>,
+}
+
+/* zero global variables used */
+fn fn0() -> array<f32, 48> {
+  var out: array<f32, 48>;
+  out[unconst_u32(4)] = bitcast<f32>(dot4I8Packed(unconst_u32(153), unconst_u32(1)));
+  out[unconst_u32(139)] = tan(vec2f(unconst_f32(0.3520), unconst_f32(0.6529))).x;
+  var vf149: vec4i = insertBits(vec4i(unconst_i32(85), unconst_i32(137), unconst_i32(81), unconst_i32(12)), vec4i(unconst_i32(230), unconst_i32(54), unconst_i32(98), unconst_i32(48)), unconst_u32(190), unconst_u32(141));
+  var vf150: vec2f = unpack2x16snorm(unconst_u32(7));
+  out[unconst_u32(201)] = sinh(unconst_f32(0.07436));
+  return out;
+}
+
+/* zero global variables used */
+fn fn2() -> VertexOutput6 {
+  var out: VertexOutput6;
+  let vf160: vec4u = (vec4u(unconst_u32(269), unconst_u32(32), unconst_u32(126), unconst_u32(79)) % unconst_u32(271));
+  while bool(pack4xU8(vec4u(unconst_u32(111), unconst_u32(702), unconst_u32(148), unconst_u32(561)))) {
+  out.f7 -= vec4f(f32( !unconst_bool(false)));
+  var vf161 = fn0();
+  if bool(min(vec2u(unconst_u32(276), unconst_u32(102)), vec2u(unconst_u32(327), unconst_u32(224)))[1]) {
+  out = VertexOutput6(unpack2x16float(unconst_u32(61)).xxxx);
+  var vf162 = fn0();
+  fn0();
+  out.f7 += vec4f(ceil(vec4h(unconst_f16(10224.6), unconst_f16(7221.9), unconst_f16(-938.9), unconst_f16(177.9))));
+  break;
+}
+  for (var it6=u32(vf161[47]); it6<u32(tanh(vec4h(unconst_f16(51791.7), unconst_f16(10827.8), unconst_f16(14899.6), unconst_f16(8283.5))).a); it6++) {
+  let vf163: vec2u = (unconst_u32(55) + vec2u(unconst_u32(60), unconst_u32(16)));
+  {
+  var vf164 = fn0();
+  break;
+}
+  break;
+}
+  let vf165: vec3f = clamp(vec3f(unconst_f32(0.7826), unconst_f32(0.2204), unconst_f32(0.3156)), vec3f(unconst_f32(0.5195), unconst_f32(0.00039), unconst_f32(0.01459)), vec3f(unconst_f32(0.07251), unconst_f32(0.01514), unconst_f32(0.08111)));
+  var vf166 = fn1();
+  var vf167 = fn1();
+  break;
+}
+  out.f7 = bitcast<vec4f>((vec2u(unconst_u32(6), unconst_u32(138)) ^ vec2u(unconst_u32(53), unconst_u32(413))).xyxx);
+  let vf168: i32 = dot4I8Packed(unconst_u32(32), unconst_u32(35));
+  out.f7 *= vec4f(f32(pack4xU8(vec4u(unconst_u32(454), unconst_u32(82), unconst_u32(449), unconst_u32(106)))));
+  fn0();
+  fn0();
+  out.f7 = vec4f((vec2u(unconst_u32(102), unconst_u32(55)) ^ vec2u(unconst_u32(38), unconst_u32(155))).rgrg);
+  out = VertexOutput6(vec4f(f32(pack2x16snorm(vec2f(bitcast<f32>(pack4x8unorm(vec4f(unconst_f32(0.1145), unconst_f32(0.1097), unconst_f32(0.3078), unconst_f32(0.2213)))))))));
+  {
+  let vf169: vec3f = ldexp(vec3f(unconst_f32(0.03879), unconst_f32(0.08090), unconst_f32(-0.05693)), bitcast<vec3i>(acos(vec2f(unconst_f32(-0.4558), unconst_f32(0.02800))).rrr));
+  out.f7 = vec4f(f32(any(unconst_bool(false))));
+  fn0();
+  out.f7 = vec4f(ceil(vec3h(unconst_f16(10860.5), unconst_f16(10411.5), unconst_f16(18026.3))).zyyz);
+  var vf170: vec4h = sin(vec4h(unconst_f16(4156.6), unconst_f16(26621.0), unconst_f16(-793.6), unconst_f16(16509.0)));
+  out.f7 = bitcast<vec4f>( ~bitcast<vec2i>(extractBits(vec2u(unconst_u32(59), unconst_u32(11)), unconst_u32(310), unconst_u32(133))).xxyx);
+  let vf171: vec2i =  ~vec2i(unconst_i32(58), unconst_i32(1000));
+  return out;
+}
+  fn0();
+  loop {
+  var vf172: vec3i = firstLeadingBit(vec3i(asin(vec4f(unconst_f32(0.01306), unconst_f32(0.5135), unconst_f32(0.00156), unconst_f32(0.07843))).rgg));
+  out = VertexOutput6(vec4f(max(vec3i(unconst_i32(82), unconst_i32(454), unconst_i32(4)), vec3i(faceForward(vec2h(unconst_f16(7952.2), unconst_f16(604.4)), vec2h(unconst_f16(16084.2), unconst_f16(5479.3)), bitcast<vec2h>(pack2x16snorm(vec2f(unconst_f32(0.06661), unconst_f32(0.2020))))).xxx)).rrrg));
+  break;
+}
+  fn1();
+  let vf173: i32 = (unconst_i32(30) - bitcast<vec4i>((vec4u(unconst_u32(277), unconst_u32(77), unconst_u32(10), unconst_u32(6)) % pack4xU8Clamp(vf160))).y);
+  out.f7 += vec4f(f32((unconst_f16(6194.6) == unconst_f16(8120.5))));
+  return out;
+}
+
+struct VertexOutput6 {
+  @builtin(position) f7: vec4f,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+/* zero global variables used */
+@vertex
+fn vertex7() -> VertexOutput6 {
+  var out: VertexOutput6;
+  var vf174 = fn1();
+  out = VertexOutput6(vec4f(saturate(vec3h(unconst_f16(60000.0), unconst_f16(7064.6), unconst_f16(13992.1))).bbgg));
+  fn2();
+  var vf175 = fn1();
+  return out;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment7(@invariant @builtin(position) a0: vec4f) -> FragmentOutput7 {
+  var out: FragmentOutput7;
+  let vf176: f16 = sinh(unconst_f16(17850.1));
+  fn2();
+  out.f2 -= bitcast<u32>(mix(vec2h(unconst_f16(9196.8), unconst_f16(24262.3)), vec2h(unconst_f16(16743.3), unconst_f16(6303.0)), vec2h(unconst_f16(2440.8), unconst_f16(1018.3))));
+  out = FragmentOutput7(vec4f((vec4u(unconst_u32(17), unconst_u32(287), unconst_u32(47), unconst_u32(287)) | bitcast<vec4u>(a0))), (vec4u(unconst_u32(17), unconst_u32(287), unconst_u32(47), unconst_u32(287)) | bitcast<vec4u>(a0)).w, pack4xU8((vec4u(unconst_u32(17), unconst_u32(287), unconst_u32(47), unconst_u32(287)) | bitcast<vec4u>(a0))), bitcast<vec2i>((vec4u(unconst_u32(17), unconst_u32(287), unconst_u32(47), unconst_u32(287)) | bitcast<vec4u>(a0)).aa));
+  let vf177: vec4i = unpack4xI8(unconst_u32(226));
+  if bool(pack4xI8(vec4i(unconst_i32(164), unconst_i32(-139), unconst_i32(8), unconst_i32(321)))) {
+  fn1();
+}
+  var vf178 = fn1();
+  out = FragmentOutput7(vec4f(f32(vf176)), u32(vf176), u32(vf176), vec2i(i32(vf176)));
+  var vf179: vec2f = degrees(vec2f(unconst_f32(0.04505), unconst_f32(0.03644)));
+  fn0();
+  vf179 = unpack2x16snorm(pack4xI8(vec4i(unconst_i32(356), unconst_i32(92), unconst_i32(-22), unconst_i32(213))));
+  return out;
+}
+
+/* used global variables: st7 */
+@compute @workgroup_size(4, 1, 3)
+fn compute8() {
+  var vf180 = fn1();
+  textureStore(st7, unconst_i32(735), vec4u(vec4u(unconst_u32(66), unconst_u32(400), unconst_u32(88), unconst_u32(321))));
+  let vf181: u32 = pack4xU8(vec4u(unconst_u32(127), unconst_u32(253), unconst_u32(302), unconst_u32(915)));
+  vf180[unconst_u32(238)] = u32(any((vec2h(unconst_f16(9833.8), unconst_f16(12084.6)) == vec2h(unconst_f16(-11696.8), unconst_f16(6244.5)))));
+  var vf182: vec2<bool> = (vec2h(tan(unconst_f16(1420.5))) == vec2h(unconst_f16(5651.7), unconst_f16(42374.8)));
+  let vf183: f16 = tan(unconst_f16(21965.6));
+  let vf184: vec2h = cosh(vec2h(unconst_f16(848.6), unconst_f16(10933.2)));
+  fn1();
+  let vf185: vec4<bool> = (vec4u(unconst_u32(110), unconst_u32(90), unconst_u32(105), unconst_u32(171)) <= vec4u(unconst_u32(259), unconst_u32(226), unconst_u32(159), unconst_u32(152)));
+  var vf186 = fn1();
+  _ = st7;
+}`,
+});
+let bindGroup17 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [
+    {binding: 323, resource: {buffer: buffer5, offset: 1792, size: 14300}},
+    {binding: 144, resource: textureView5},
+  ],
+});
+let commandEncoder47 = device0.createCommandEncoder();
+try {
+computePassEncoder16.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder5.draw(13, 0, 1_486_251_930);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(73, 0, 10, 648_210_709, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer14, 3_672);
+} catch {}
+try {
+computePassEncoder20.pushDebugGroup('\u01a5');
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 97, resource: externalTexture1},
+    {binding: 45, resource: {buffer: buffer1, offset: 1792, size: 118}},
+    {binding: 64, resource: {buffer: buffer47, offset: 1024}},
+    {binding: 68, resource: {buffer: buffer12, offset: 4864}},
+  ],
+});
+let commandEncoder48 = device0.createCommandEncoder({});
+let computePassEncoder36 = commandEncoder47.beginComputePass({});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup9, new Uint32Array(946), 92, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: -856.1, g: -833.3, b: 742.5, a: 200.2, });
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer2, 348);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 69, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 123, height: 1, depthOrArrayLayers: 153}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 41, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup19 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 144, resource: textureView2},
+    {binding: 323, resource: {buffer: buffer16, offset: 0, size: 988}},
+  ],
+});
+let commandEncoder49 = device0.createCommandEncoder({});
+let texture63 = device0.createTexture({
+  size: {width: 246, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder37 = commandEncoder48.beginComputePass();
+let sampler31 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+});
+try {
+computePassEncoder36.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder5.draw(15, 0, 694_471_199);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer12, 688);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer24, 'uint16', 30, 21);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3, buffer43, 0);
+} catch {}
+try {
+computePassEncoder20.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+await gc();
+let videoFrame5 = new VideoFrame(img0, {timestamp: 0});
+let bindGroup20 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [
+    {binding: 323, resource: {buffer: buffer5, offset: 3072, size: 936}},
+    {binding: 144, resource: textureView2},
+  ],
+});
+let textureView60 = texture25.createView({dimension: '2d-array', format: 'r32uint'});
+let computePassEncoder38 = commandEncoder49.beginComputePass({});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup1, new Uint32Array(13), 6, 0);
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle0, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder5.setBlendConstant({ r: -549.2, g: -60.70, b: -571.7, a: -385.1, });
+} catch {}
+try {
+renderPassEncoder5.draw(45, 32, 34_910_729);
+} catch {}
+let arrayBuffer5 = buffer26.getMappedRange(56, 0);
+let buffer50 = device0.createBuffer({size: 464, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView61 = texture11.createView({dimension: '2d-array'});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+computePassEncoder28.setBindGroup(2, bindGroup11, new Uint32Array(717), 114, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(243, 4, 1_032_973_949);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer20, 8_800);
+} catch {}
+let commandEncoder50 = device0.createCommandEncoder({});
+let texture64 = gpuCanvasContext1.getCurrentTexture();
+let textureView62 = texture20.createView({dimension: '2d'});
+let renderPassEncoder12 = commandEncoder50.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: -314.0, g: 155.4, b: 874.9, a: -869.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler32 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', magFilter: 'nearest', lodMaxClamp: 95.74});
+try {
+renderPassEncoder7.setBlendConstant({ r: 144.8, g: -823.2, b: -942.4, a: -143.0, });
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(0, 4, 113, 372_856_005, 5);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline10);
+} catch {}
+let veryExplicitBindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 39, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+  ],
+});
+let bindGroup21 = device0.createBindGroup({
+  label: '\u{1fdf6}\u{1fd53}\u{1fd9e}\u{1fa9f}\u0be0\u3313\u0257\u{1f96a}\u0b35\uc621',
+  layout: veryExplicitBindGroupLayout2,
+  entries: [
+    {binding: 41, resource: textureView8},
+    {binding: 39, resource: {buffer: buffer15, offset: 0, size: 852}},
+  ],
+});
+let textureView63 = texture16.createView({dimension: '2d-array', arrayLayerCount: 1});
+let texture65 = device0.createTexture({
+  size: {width: 1230, height: 30, depthOrArrayLayers: 1},
+  format: 'astc-6x6-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-6x6-unorm-srgb'],
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder23.setBindGroup(0, bindGroup8, new Uint32Array(186), 0, 0);
+} catch {}
+try {
+computePassEncoder22.end();
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle2, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer37, 'uint32', 1_752, 2_260);
+} catch {}
+let buffer51 = device0.createBuffer({
+  size: 3253,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder51 = device0.createCommandEncoder({});
+let textureView64 = texture11.createView({baseArrayLayer: 0});
+let computePassEncoder39 = commandEncoder24.beginComputePass({});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup15, new Uint32Array(143), 47, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder12); computePassEncoder12.dispatchWorkgroupsIndirect(buffer32, 3_464); };
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer2, 'uint16', 70, 215);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(4, buffer38, 0, 3);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 41, resource: textureView8},
+    {binding: 39, resource: {buffer: buffer33, offset: 2560, size: 456}},
+  ],
+});
+let texture66 = device0.createTexture({
+  size: [470, 2, 1],
+  mipLevelCount: 5,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView65 = texture7.createView({arrayLayerCount: 1});
+let computePassEncoder40 = commandEncoder51.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -643.6, g: -270.7, b: 300.7, a: 469.7, });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer52 = device0.createBuffer({size: 1152, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let texture67 = device0.createTexture({
+  size: [984],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView66 = texture67.createView({arrayLayerCount: 1});
+try {
+computePassEncoder40.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup22, new Uint32Array(2543), 304, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer5, 0, 2_149);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 120, new Float32Array(4058), 1659, 60);
+} catch {}
+let autogeneratedBindGroupLayout1 = pipeline4.getBindGroupLayout(0);
+let commandEncoder52 = device0.createCommandEncoder({});
+let textureView67 = texture63.createView({mipLevelCount: 1});
+let sampler33 = device0.createSampler({addressModeV: 'repeat', mipmapFilter: 'linear', lodMaxClamp: 94.91, compare: 'never'});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder2.draw(318, 0, 69_761_831);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 0, 1, 736_064_943, 2);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(0, buffer22, 0);
+} catch {}
+let bindGroup23 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 97, resource: externalTexture0},
+    {binding: 45, resource: {buffer: buffer2, offset: 512}},
+    {binding: 68, resource: {buffer: buffer20, offset: 4352, size: 2460}},
+    {binding: 64, resource: {buffer: buffer37, offset: 0, size: 280}},
+  ],
+});
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: [autogeneratedBindGroupLayout0]});
+let buffer53 = device0.createBuffer({
+  size: 912,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture68 = device0.createTexture({
+  size: [1968, 1, 43],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder41 = commandEncoder52.beginComputePass({});
+let sampler34 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+computePassEncoder41.setBindGroup(1, bindGroup5, new Uint32Array(807), 17, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder6); computePassEncoder6.dispatchWorkgroupsIndirect(buffer13, 1_040); };
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle6, renderBundle6, renderBundle6, renderBundle0, renderBundle2, renderBundle6, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(4, 0, 0, 1_533_328_693, 1);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer31, 360);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer48, 872);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline0);
+} catch {}
+let texture69 = device0.createTexture({
+  size: [940, 5, 1],
+  mipLevelCount: 1,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView68 = texture13.createView({dimension: '2d', baseArrayLayer: 1});
+let computePassEncoder42 = commandEncoder31.beginComputePass({});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm']});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup1);
+} catch {}
+let imageData10 = new ImageData(80, 8);
+try {
+renderPassEncoder12.setViewport(168.77384961753623, 0.7784968900512585, 51.79570103668932, 0.11262016576285468, 0.4260844069190286, 0.5072620521942122);
+} catch {}
+try {
+renderPassEncoder2.draw(165, 0, 961_634_382);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer47, 2_168);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer38, 0, 16);
+} catch {}
+let recycledExplicitBindGroupLayout2 = pipeline2.getBindGroupLayout(0);
+let bindGroup24 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 39, resource: {buffer: buffer15, offset: 512, size: 540}},
+    {binding: 41, resource: textureView53},
+  ],
+});
+let commandEncoder53 = device0.createCommandEncoder({});
+let textureView69 = texture44.createView({});
+let computePassEncoder43 = commandEncoder53.beginComputePass({});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer24, 'uint16', 66, 82);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder15.resolveQuerySet(querySet2, 61, 3, buffer29, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 104, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(158).fill(11), /* required buffer size: 158 */
+{offset: 158}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup25 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [
+    {binding: 323, resource: {buffer: buffer47, offset: 1024, size: 1780}},
+    {binding: 144, resource: textureView2},
+  ],
+});
+let commandEncoder54 = device0.createCommandEncoder({});
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 1432});
+let commandBuffer4 = commandEncoder15.finish();
+let texture70 = device0.createTexture({
+  size: {width: 40, height: 45, depthOrArrayLayers: 34},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder44 = commandEncoder54.beginComputePass({});
+try {
+computePassEncoder44.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer1, 1_704);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup21, new Uint32Array(1777), 230, 0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer22, 'uint32', 144, 158);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let buffer54 = device0.createBuffer({size: 196, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture71 = device0.createTexture({
+  size: [1880, 10, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView70 = texture0.createView({});
+try {
+renderPassEncoder7.executeBundles([renderBundle6, renderBundle5, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(8, 0, 0, 41_150_979);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer20, 16);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup20, new Uint32Array(1714), 71, 0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer52, 'uint32', 132, 85);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline4);
+} catch {}
+let textureView71 = texture67.createView({});
+let sampler35 = device0.createSampler({addressModeV: 'mirror-repeat', magFilter: 'linear', mipmapFilter: 'linear'});
+try {
+computePassEncoder43.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup4, new Uint32Array(1565), 109, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle1, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(2, 0, 0, 135_469_115);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer22, 440);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer33, 76);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer13, 'uint16', 244, 1_629);
+} catch {}
+let arrayBuffer6 = buffer26.getMappedRange(32, 0);
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline11 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule3}});
+let buffer55 = device0.createBuffer({size: 1551, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let texture72 = device0.createTexture({
+  size: {width: 470, height: 2, depthOrArrayLayers: 1},
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame5});
+try {
+renderPassEncoder2.draw(11, 0, 204_579_557);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(4, 0, 0, 2_147_483_647);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, undefined, 0, 130_218_354);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(2, buffer22, 40);
+} catch {}
+await gc();
+let commandEncoder55 = device0.createCommandEncoder({});
+let computePassEncoder45 = commandEncoder55.beginComputePass({});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup4, new Uint32Array(1363), 80, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(8, 0, 3, -1_780_492_896);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer32, 2_912);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup4, new Uint32Array(310), 49, 0);
+} catch {}
+try {
+renderBundleEncoder7.draw(46, 18, 502_744_259, 1_325_795_533);
+} catch {}
+try {
+renderBundleEncoder7.drawIndexed(118, 66, 2, 27_535_057, 50_502_357);
+} catch {}
+try {
+renderBundleEncoder7.drawIndexedIndirect(buffer2, 72);
+} catch {}
+try {
+renderBundleEncoder7.drawIndirect(buffer33, 748);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView72 = texture27.createView({dimension: '2d-array', aspect: 'all'});
+let sampler36 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder45.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder2.draw(51, 0, 164_097_941);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer47, 1_204);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder7.draw(327, 106, 1_278_578_936, 703_126_413);
+} catch {}
+try {
+renderBundleEncoder7.drawIndexed(46, 234, 514, 629_251_389, 4_001_056_179);
+} catch {}
+try {
+renderBundleEncoder7.drawIndexedIndirect(buffer12, 5_456);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline0);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let textureView73 = texture46.createView({label: '\u5968\u2e58\u3981\ua96b\u{1f69a}\u6125\u0961\u{1ff53}', dimension: '2d-array'});
+let texture73 = device0.createTexture({
+  size: {width: 1230, height: 30, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint', 'r8sint'],
+});
+try {
+computePassEncoder36.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(189);
+} catch {}
+try {
+renderPassEncoder2.draw(36, 0, 229_201_233);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer52, 332);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(4, buffer42, 888, 859);
+} catch {}
+let pipeline12 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule2,
+  constants: {override0: 1},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}],
+},
+  vertex: {
+    module: shaderModule2,
+    constants: {},
+    buffers: [{arrayStride: 16, attributes: [{format: 'snorm16x2', offset: 4, shaderLocation: 0}]}],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroup26 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [
+    {binding: 144, resource: textureView2},
+    {binding: 323, resource: {buffer: buffer37, offset: 0, size: 5544}},
+  ],
+});
+let commandEncoder56 = device0.createCommandEncoder({});
+let renderPassEncoder13 = commandEncoder56.beginRenderPass({
+  colorAttachments: [{
+  view: textureView46,
+  clearValue: { r: 167.3, g: 456.4, b: -457.9, a: 701.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 608946359,
+});
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(3, 0, 4, -1_678_080_045);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer12, 5_960);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(3, buffer7);
+} catch {}
+let commandEncoder57 = device0.createCommandEncoder({});
+let textureView74 = texture14.createView({baseArrayLayer: 1, arrayLayerCount: 1});
+try {
+computePassEncoder29.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup2, new Uint32Array(1809), 412, 0);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(88, 0, 36, 0);
+} catch {}
+try {
+renderPassEncoder0.draw(24, 5, 351_054_413, 1_166_255_423);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer13, 360);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(1, buffer55, 0, 652);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder57.clearBuffer(buffer45, 96, 68);
+} catch {}
+let computePassEncoder46 = commandEncoder57.beginComputePass();
+let renderPassEncoder14 = commandEncoder37.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  depthSlice: 285,
+  clearValue: { r: -436.4, g: -191.7, b: -172.3, a: 654.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 59718792,
+});
+try {
+computePassEncoder46.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+computePassEncoder46.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup26, new Uint32Array(1022), 250, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle6, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.draw(36, 0, 443_564_580);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(114, 226, 71, 65_121_707, 1_202_222_214);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer33, 704);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer40, 0);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer38, 'uint32', 108);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let pipeline13 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule0, constants: {}}});
+let veryExplicitBindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 125,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 166,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup27 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 97, resource: externalTexture2},
+    {binding: 45, resource: {buffer: buffer24, offset: 0, size: 121}},
+    {binding: 64, resource: {buffer: buffer51, offset: 0, size: 868}},
+    {binding: 68, resource: {buffer: buffer20, offset: 7168, size: 2952}},
+  ],
+});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup11, new Uint32Array(401), 62, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(391, 0, 326_708_995);
+} catch {}
+try {
+computePassEncoder7.insertDebugMarker('\u69bc');
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let veryExplicitBindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 39, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+  ],
+});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 0, 1, 244_302_270);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(5, buffer51, 0, 279);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer22, 'uint16', 244, 166);
+} catch {}
+try {
+computePassEncoder18.insertDebugMarker('\uc27f');
+} catch {}
+let buffer56 = device0.createBuffer({size: 4570, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let commandEncoder58 = device0.createCommandEncoder({});
+let texture74 = device0.createTexture({size: {width: 80}, dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.COPY_DST});
+let textureView75 = texture29.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 2});
+try {
+computePassEncoder46.setBindGroup(1, bindGroup24, new Uint32Array(3843), 336, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer38, 28, 89);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer22, 'uint32', 324, 731);
+} catch {}
+let arrayBuffer7 = buffer26.getMappedRange(40, 0);
+try {
+commandEncoder58.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 928 */
+  offset: 928,
+  buffer: buffer37,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder58.copyTextureToBuffer({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 396, y: 6, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 208 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3888 */
+  offset: 3888,
+  buffer: buffer37,
+}, {width: 78, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder58.clearBuffer(buffer23);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture75 = device0.createTexture({
+  size: [246, 1, 1],
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture76 = gpuCanvasContext0.getCurrentTexture();
+let textureView76 = texture14.createView({dimension: '2d-array', baseMipLevel: 0, baseArrayLayer: 2, arrayLayerCount: 1});
+let renderPassEncoder15 = commandEncoder58.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  depthSlice: 189,
+  clearValue: { r: 178.1, g: 415.4, b: 647.5, a: -324.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler37 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMinClamp: 19.26});
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup8, new Uint32Array(2471), 329, 0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup3, new Uint32Array(237), 18, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder59 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroupsIndirect(buffer12, 564); };
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup22, new Uint32Array(454), 41, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer20, 1_768);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer21, 7_504, 1_654);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer0, 'uint16', 48, 853);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u0741');
+} catch {}
+let texture77 = device0.createTexture({
+  size: [246, 1, 92],
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView77 = texture49.createView({dimension: '2d', mipLevelCount: 1});
+let computePassEncoder47 = commandEncoder13.beginComputePass({});
+let sampler38 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 52.15,
+  lodMaxClamp: 75.89,
+  compare: 'never',
+});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup13, []);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup20, new Uint32Array(4254), 2_215, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle0, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder0.draw(284, 130, 724_180_047, 731_260_958);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer7, 36);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer52, 'uint32', 652, 42);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline8);
+} catch {}
+let computePassEncoder48 = commandEncoder59.beginComputePass({});
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup8, new Uint32Array(1310), 123, 0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer47, 3_068);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer51, 716);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder7.drawIndexedIndirect(buffer52, 84);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline12);
+} catch {}
+let promise6 = shaderModule3.getCompilationInfo();
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true});
+try {
+computePassEncoder48.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder0.draw(309, 294, 421_682_223, 385_157_652);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(2, 0, 2, 373_586_229);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer21, 12_856);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline7);
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+let pipeline14 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {module: shaderModule3, buffers: []},
+});
+let commandEncoder60 = device0.createCommandEncoder();
+let computePassEncoder49 = commandEncoder60.beginComputePass();
+let renderBundle7 = renderBundleEncoder7.finish();
+try {
+computePassEncoder35.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+computePassEncoder32.setBindGroup(1, bindGroup4, new Uint32Array(2242), 603, 0);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(528);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer2, 740);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer48, 784);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, undefined);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 144 widthInBlocks: 36 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 200 */
+  offset: 200,
+  buffer: buffer35,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 36, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder61 = device0.createCommandEncoder({});
+let texture78 = device0.createTexture({
+  size: {width: 470, height: 2, depthOrArrayLayers: 645},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView78 = texture28.createView({baseMipLevel: 0});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], stencilReadOnly: true});
+let sampler39 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 35.49,
+  lodMaxClamp: 36.93,
+  compare: 'always',
+});
+try {
+renderPassEncoder13.setBlendConstant({ r: 251.2, g: -51.07, b: -599.8, a: 141.4, });
+} catch {}
+try {
+renderPassEncoder2.draw(270, 0, 14_167_836);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(5, 0, 2, 776_567_538);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer22, 152);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer5, 7_164, 2_956);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 206 widthInBlocks: 103 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4794 */
+  offset: 4794,
+  buffer: buffer17,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 228, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 103, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView79 = texture43.createView({mipLevelCount: 1});
+let renderPassEncoder16 = commandEncoder23.beginRenderPass({
+  colorAttachments: [{
+  view: textureView67,
+  clearValue: { r: -710.1, g: 439.6, b: -839.5, a: -115.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 86115252,
+});
+let sampler40 = device0.createSampler({addressModeU: 'repeat'});
+try {
+renderPassEncoder15.setVertexBuffer(3, buffer38);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(6, buffer1, 1_712, 1_838);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+buffer29.destroy();
+} catch {}
+try {
+  await promise6;
+} catch {}
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'jedecP22Phosphors', transfer: 'gamma28curve'} });
+let commandEncoder62 = device0.createCommandEncoder({});
+let computePassEncoder50 = commandEncoder62.beginComputePass({});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder50.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.draw(156, 0, 1_907_823_602);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer52, 200);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer13, 'uint32', 224, 559);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup11, []);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer52, 'uint16', 468, 33);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline10);
+} catch {}
+try {
+    await gc();
+buffer29.destroy();
+await gc();
+} catch {}
+try {
+commandEncoder61.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+},
+{width: 246, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline15 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {module: shaderModule4, entryPoint: 'vertex3', constants: {}, buffers: []},
+  primitive: {topology: 'triangle-strip', cullMode: 'front', unclippedDepth: true},
+});
+await gc();
+let texture79 = device0.createTexture({
+  size: {width: 3760, height: 20, depthOrArrayLayers: 1},
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture80 = device0.createTexture({
+  size: {width: 940, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+computePassEncoder24.end();
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(319, 0, 21, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 0, 2, -1_206_657_170, 0);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(5, buffer32, 252, 262);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(3, bindGroup8, new Uint32Array(3310), 941, 0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(1, buffer21, 3_664, 4_897);
+} catch {}
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'bt470bg', transfer: 'iec61966-2-1'} });
+let texture81 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 21},
+  mipLevelCount: 1,
+  format: 'astc-8x8-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder17 = commandEncoder22.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  depthSlice: 29,
+  clearValue: { r: -642.8, g: 4.867, b: -627.9, a: 936.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 456257210,
+});
+let sampler41 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 88.62,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder47.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup22, new Uint32Array(1698), 309, 0);
+} catch {}
+try {
+renderPassEncoder16.setViewport(50.28739921621562, 0.36440031198676737, 96.5280012780812, 0.2636675869432258, 0.6255790711552413, 0.8402284544791379);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(0, 0, 2, 44_424_465);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer31, 784);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer1, 784);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer38, 'uint32', 176, 90);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(1, buffer38);
+} catch {}
+let commandEncoder63 = device0.createCommandEncoder({});
+let texture82 = device0.createTexture({
+  size: [10, 11, 8],
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder18 = commandEncoder63.beginRenderPass({
+  colorAttachments: [{view: textureView36, depthSlice: 117, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 12753001,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder31); computePassEncoder31.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder35); computePassEncoder35.dispatchWorkgroupsIndirect(buffer47, 520); };
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle3, renderBundle2, renderBundle2, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer47, 2_260);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer8, 'uint32', 216, 438);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(1, buffer43, 292, 1);
+} catch {}
+try {
+commandEncoder61.copyBufferToTexture({
+  /* bytesInLastRow: 1088 widthInBlocks: 136 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 344 */
+  offset: 344,
+  buffer: buffer56,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 136, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder61.resolveQuerySet(querySet4, 184, 11, buffer53, 0);
+} catch {}
+let pipeline16 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0, constants: {}}});
+let bindGroup28 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 97, resource: externalTexture3},
+    {binding: 64, resource: {buffer: buffer40, offset: 15872}},
+    {binding: 68, resource: {buffer: buffer37, offset: 7680, size: 600}},
+    {binding: 45, resource: {buffer: buffer16, offset: 256, size: 104}},
+  ],
+});
+let buffer57 = device0.createBuffer({
+  size: 5022,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder64 = device0.createCommandEncoder({});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 117});
+let texture83 = device0.createTexture({
+  size: {width: 307, height: 7, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture84 = device0.createTexture({
+  size: {width: 40, height: 45, depthOrArrayLayers: 1},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle8 = renderBundleEncoder8.finish({});
+try {
+{ clearResourceUsages(device0, computePassEncoder31); computePassEncoder31.dispatchWorkgroups(2); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroupsIndirect(buffer2, 236); };
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup27, []);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+let textureView80 = texture41.createView({mipLevelCount: 1});
+let renderPassEncoder19 = commandEncoder64.beginRenderPass({
+  colorAttachments: [{
+  view: textureView77,
+  clearValue: { r: -483.4, g: -730.3, b: 310.1, a: -710.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer48, 376);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer56, 'uint16', 2, 791);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer21, 1_384, 9_585);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup24, new Uint32Array(7260), 2_340, 0);
+} catch {}
+try {
+commandEncoder61.copyTextureToBuffer({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 82 widthInBlocks: 41 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2152 */
+  offset: 2152,
+  bytesPerRow: 2304,
+  rowsPerImage: 203,
+  buffer: buffer40,
+}, {width: 41, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img3 = await imageWithData(80, 118, '#10101010', '#20202020');
+let buffer58 = device0.createBuffer({size: 7009, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder65 = device0.createCommandEncoder();
+let texture85 = device0.createTexture({
+  size: [615],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture86 = device0.createTexture({
+  size: {width: 1968, height: 1, depthOrArrayLayers: 67},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder51 = commandEncoder61.beginComputePass();
+let sampler42 = device0.createSampler({
+  label: '\u8998\u{1f9d1}\u{1f8bd}\udf0d\u3421\u05d9\u{1f733}\u2125\u02da',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 92.07,
+  compare: 'less',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder38.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup25, []);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer32, 4_400);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer14, 'uint16', 1_458, 5_416);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer37, 'uint32', 1_136, 913);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(5, buffer37, 0, 2_332);
+} catch {}
+let arrayBuffer8 = buffer26.getMappedRange(48, 0);
+try {
+buffer38.unmap();
+} catch {}
+try {
+commandEncoder65.copyTextureToTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 25},
+  aspect: 'all',
+},
+{
+  texture: texture80,
+  mipLevel: 0,
+  origin: {x: 130, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer57, 1264, new BigUint64Array(3274), 334, 304);
+} catch {}
+let imageData11 = new ImageData(16, 40);
+let autogeneratedBindGroupLayout2 = pipeline16.getBindGroupLayout(0);
+let commandEncoder66 = device0.createCommandEncoder({});
+let texture87 = device0.createTexture({
+  size: [984, 1, 1],
+  mipLevelCount: 2,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder20 = commandEncoder66.beginRenderPass({
+  colorAttachments: [{
+  view: textureView77,
+  clearValue: { r: -942.3, g: -591.3, b: -135.4, a: -794.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet5,
+  maxDrawCount: 313806939,
+});
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer1, 1_700);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+buffer48.unmap();
+} catch {}
+try {
+commandEncoder65.copyTextureToBuffer({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 504, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 784 widthInBlocks: 49 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2448 */
+  offset: 2448,
+  bytesPerRow: 12288,
+  buffer: buffer33,
+}, {width: 294, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img3);
+let textureView81 = texture85.createView({});
+let texture88 = device0.createTexture({
+  size: [246, 1, 29],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup5, []);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup26, new Uint32Array(2629), 301, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle4, renderBundle3, renderBundle1, renderBundle3, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(1, 6, 1, -2_003_345_413, 1_403_539_600);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer1, 1_284);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer57, 'uint32', 156, 879);
+} catch {}
+let bindGroup29 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 77, resource: {buffer: buffer42, offset: 2048, size: 624}},
+    {binding: 119, resource: textureView16},
+    {binding: 33, resource: {buffer: buffer37, offset: 1024, size: 2452}},
+    {binding: 54, resource: sampler22},
+    {binding: 155, resource: externalTexture2},
+  ],
+});
+let commandEncoder67 = device0.createCommandEncoder({});
+let textureView82 = texture81.createView({dimension: 'cube-array', baseMipLevel: 0, baseArrayLayer: 1, arrayLayerCount: 6});
+let texture89 = device0.createTexture({
+  size: {width: 1230, height: 30, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView83 = texture81.createView({dimension: '2d', baseArrayLayer: 11, arrayLayerCount: 1});
+let computePassEncoder52 = commandEncoder65.beginComputePass({});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup25, new Uint32Array(500), 8, 0);
+} catch {}
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(0, 176, 1, 297_812_143, 353_210_029);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer14, 7_184);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer8, 'uint32', 312, 79);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer24, 0, 17);
+} catch {}
+let imageBitmap0 = await createImageBitmap(videoFrame7);
+let commandEncoder68 = device0.createCommandEncoder();
+let texture90 = device0.createTexture({
+  size: {width: 40, height: 45, depthOrArrayLayers: 45},
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder53 = commandEncoder67.beginComputePass({});
+let renderBundle9 = renderBundleEncoder9.finish({});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup26, new Uint32Array(3913), 103, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder12); computePassEncoder12.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+adapter0.label = '\u{1fd3e}\u01bc\u13d6\u0bf6\u{1f859}\ub106';
+} catch {}
+let buffer59 = device0.createBuffer({size: 6103, usage: GPUBufferUsage.MAP_READ});
+let commandEncoder69 = device0.createCommandEncoder({});
+let texture91 = device0.createTexture({
+  size: {width: 10, height: 11, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder2.setIndexBuffer(buffer57, 'uint16', 1_042, 52);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline2);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let arrayBuffer9 = buffer26.getMappedRange(64, 72);
+document.body.prepend(img1);
+let bindGroup30 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [
+    {binding: 323, resource: {buffer: buffer37, offset: 256, size: 2460}},
+    {binding: 144, resource: textureView2},
+  ],
+});
+let commandBuffer5 = commandEncoder10.finish();
+let textureView84 = texture79.createView({dimension: '2d-array', baseArrayLayer: 0});
+let texture92 = device0.createTexture({
+  size: {width: 80, height: 90, depthOrArrayLayers: 1},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder54 = commandEncoder68.beginComputePass({});
+try {
+computePassEncoder35.setBindGroup(2, bindGroup26, new Uint32Array(1524), 243, 0);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer0, 'uint32', 616, 14);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder25.copyBufferToTexture({
+  /* bytesInLastRow: 984 widthInBlocks: 984 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 4040 */
+  offset: 4040,
+  bytesPerRow: 14848,
+  buffer: buffer48,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 984, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline17 = device0.createRenderPipeline({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule2,
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule6,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 208,
+        attributes: [
+          {format: 'uint16x4', offset: 0, shaderLocation: 4},
+          {format: 'uint16x4', offset: 24, shaderLocation: 3},
+          {format: 'sint32', offset: 24, shaderLocation: 12},
+          {format: 'float16x2', offset: 56, shaderLocation: 7},
+          {format: 'uint32', offset: 20, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 48, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+});
+let bindGroup31 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [
+    {binding: 144, resource: textureView5},
+    {binding: 323, resource: {buffer: buffer16, offset: 0, size: 924}},
+  ],
+});
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout3]});
+let commandEncoder70 = device0.createCommandEncoder();
+let texture93 = device0.createTexture({
+  size: [40, 45, 1],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture94 = device0.createTexture({
+  size: [246, 1, 38],
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView85 = texture42.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 7});
+let computePassEncoder55 = commandEncoder70.beginComputePass();
+let sampler43 = device0.createSampler({addressModeV: 'repeat', lodMinClamp: 76.47, lodMaxClamp: 90.37, compare: 'never'});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(2, bindGroup5, new Uint32Array(2481), 992, 0);
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer22, 'uint32', 1_408, 186);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.STORAGE_BINDING});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 257, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(297).fill(201), /* required buffer size: 297 */
+{offset: 297, bytesPerRow: 407}, {width: 50, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline18 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule2, constants: {}}});
+let commandEncoder71 = device0.createCommandEncoder({});
+let textureView86 = texture91.createView({dimension: '2d-array', format: 'rgba16float', baseArrayLayer: 0});
+let computePassEncoder56 = commandEncoder25.beginComputePass();
+try {
+computePassEncoder44.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(6, buffer21, 0, 1_930);
+} catch {}
+let arrayBuffer10 = buffer26.getMappedRange(192, 4);
+let bindGroup32 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [{binding: 323, resource: {buffer: buffer42, offset: 768}}, {binding: 144, resource: textureView2}],
+});
+let commandEncoder72 = device0.createCommandEncoder({});
+let textureView87 = texture81.createView({dimension: 'cube'});
+let computePassEncoder57 = commandEncoder72.beginComputePass({});
+let renderPassEncoder21 = commandEncoder69.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  depthSlice: 130,
+  clearValue: { r: -855.4, g: 374.1, b: 446.7, a: 706.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 200863693,
+});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+computePassEncoder49.setBindGroup(2, bindGroup16, new Uint32Array(3617), 1_157, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder12); computePassEncoder12.dispatchWorkgroupsIndirect(buffer12, 4_776); };
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer1, 'uint16', 5_976, 435);
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 118},
+  aspect: 'all',
+}, new Uint8Array(74_493).fill(205), /* required buffer size: 74_493 */
+{offset: 255, bytesPerRow: 160, rowsPerImage: 66}, {width: 79, height: 2, depthOrArrayLayers: 8});
+} catch {}
+let commandEncoder73 = device0.createCommandEncoder({});
+let texture95 = device0.createTexture({
+  size: [1230, 30, 1],
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView88 = texture74.createView({dimension: '1d', format: 'rg8unorm'});
+let computePassEncoder58 = commandEncoder71.beginComputePass();
+try {
+computePassEncoder32.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(2, bindGroup11, new Uint32Array(946), 8, 0);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder({});
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 150});
+let textureView89 = texture91.createView({dimension: '2d-array', format: 'rgba16float', mipLevelCount: 1});
+let renderPassEncoder22 = commandEncoder73.beginRenderPass({
+  colorAttachments: [{
+  view: textureView46,
+  clearValue: { r: 132.0, g: -522.7, b: 942.1, a: -680.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+});
+try {
+commandEncoder74.copyBufferToBuffer(buffer10, 13000, buffer53, 104, 132);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 548, new Float32Array(9351), 854, 196);
+} catch {}
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 359});
+let textureView90 = texture82.createView({baseArrayLayer: 0});
+let renderPassEncoder23 = commandEncoder74.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: -847.1, g: -288.0, b: 462.9, a: 715.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup27, []);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline14);
+} catch {}
+document.body.prepend(img2);
+let bindGroup33 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 45, resource: {buffer: buffer2, offset: 0}},
+    {binding: 97, resource: externalTexture4},
+    {binding: 68, resource: {buffer: buffer5, offset: 1536, size: 2184}},
+    {binding: 64, resource: {buffer: buffer40, offset: 2048}},
+  ],
+});
+let texture96 = device0.createTexture({
+  size: {width: 492, height: 1, depthOrArrayLayers: 46},
+  mipLevelCount: 3,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture97 = device0.createTexture({
+  size: {width: 153, height: 3, depthOrArrayLayers: 1},
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture98 = gpuCanvasContext0.getCurrentTexture();
+let externalTexture5 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(6, buffer14, 12_684);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 11, y: 4, z: 0},
+  aspect: 'all',
+}, new Uint8Array(215).fill(129), /* required buffer size: 215 */
+{offset: 215, bytesPerRow: 467}, {width: 444, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup34 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [
+    {binding: 144, resource: textureView2},
+    {binding: 323, resource: {buffer: buffer42, offset: 256, size: 2352}},
+  ],
+});
+let buffer60 = device0.createBuffer({
+  size: 7883,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let textureView91 = texture41.createView({});
+let computePassEncoder59 = commandEncoder0.beginComputePass({});
+let externalTexture6 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline16);
+} catch {}
+try {
+commandEncoder2.copyBufferToTexture({
+  /* bytesInLastRow: 1304 widthInBlocks: 163 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3744 */
+  offset: 3744,
+  buffer: buffer57,
+}, {
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 66, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 163, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 3224, new DataView(new ArrayBuffer(7629)), 1153, 572);
+} catch {}
+document.body.append(img3);
+let autogeneratedBindGroupLayout3 = pipeline4.getBindGroupLayout(0);
+let bindGroup35 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 41, resource: textureView53},
+    {binding: 39, resource: {buffer: buffer5, offset: 2560, size: 2240}},
+  ],
+});
+let texture99 = device0.createTexture({
+  size: {width: 153, height: 3, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView92 = texture31.createView({format: 'rg8unorm'});
+let renderPassEncoder24 = commandEncoder2.beginRenderPass({
+  colorAttachments: [{
+  view: textureView67,
+  clearValue: { r: -964.2, g: 571.1, b: -249.3, a: -917.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet4,
+});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 90, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData3,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 14, y: 18, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 17, depthOrArrayLayers: 0});
+} catch {}
+let texture100 = device0.createTexture({
+  size: {width: 153, height: 3, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder56.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+computePassEncoder19.setBindGroup(3, bindGroup0, new Uint32Array(852), 263, 0);
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup13, new Uint32Array(5610), 1_268, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle1, renderBundle1, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline7);
+} catch {}
+let videoFrame8 = new VideoFrame(img1, {timestamp: 0});
+let texture101 = device0.createTexture({
+  size: {width: 153, height: 3, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder49.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(6, buffer51, 0, 15);
+} catch {}
+let arrayBuffer11 = buffer26.getMappedRange(152, 12);
+let promise7 = device0.queue.onSubmittedWorkDone();
+let pipeline19 = device0.createComputePipeline({layout: pipelineLayout9, compute: {module: shaderModule3}});
+try {
+adapter0.label = '\u{1fc64}\u0975\u78ef\u{1fac7}\u0a75\u{1facf}\u5ae8\u625a\u{1fd29}\u01e9\u95d6';
+} catch {}
+let recycledExplicitBindGroupLayout3 = pipeline3.getBindGroupLayout(0);
+let buffer61 = device0.createBuffer({size: 3256, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder75 = device0.createCommandEncoder({});
+let texture102 = device0.createTexture({
+  size: [307, 7, 1],
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder25 = commandEncoder75.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  depthSlice: 153,
+  clearValue: { r: -340.2, g: -940.2, b: -657.0, a: -885.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup9, new Uint32Array(835), 45, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroupsIndirect(buffer7, 24); };
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(62);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle0, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline7);
+} catch {}
+let videoFrame9 = new VideoFrame(img1, {timestamp: 0});
+let commandEncoder76 = device0.createCommandEncoder({});
+let texture103 = device0.createTexture({
+  size: [20, 22, 28],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView93 = texture89.createView({mipLevelCount: 1});
+try {
+computePassEncoder23.setPipeline(pipeline9);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(4, buffer5, 0);
+} catch {}
+try {
+  await buffer28.mapAsync(GPUMapMode.READ, 0, 4824);
+} catch {}
+try {
+commandEncoder76.copyTextureToTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 18, y: 20, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 71, y: 0, z: 316},
+  aspect: 'all',
+},
+{width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'bt2020', transfer: 'smpte170m'} });
+let autogeneratedBindGroupLayout4 = pipeline14.getBindGroupLayout(0);
+let bindGroup36 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout13,
+  entries: [
+    {binding: 41, resource: textureView53},
+    {binding: 39, resource: {buffer: buffer7, offset: 0, size: 476}},
+  ],
+});
+let texture104 = device0.createTexture({
+  size: [307, 7, 1],
+  mipLevelCount: 2,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture105 = device0.createTexture({
+  size: [307, 7, 386],
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView94 = texture87.createView({
+  label: '\u5f9c\u{1fd00}\ufb50\u0e46\u8c65\u45eb',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup34);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer1, 'uint16', 4_100, 3_376);
+} catch {}
+try {
+commandEncoder12.copyBufferToTexture({
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 444 */
+  offset: 444,
+  bytesPerRow: 512,
+  buffer: buffer15,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 14, y: 18, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder76.resolveQuerySet(querySet0, 7, 20, buffer19, 256);
+} catch {}
+document.body.append(img3);
+let buffer62 = device0.createBuffer({
+  size: 5435,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture106 = device0.createTexture({
+  size: [10, 11, 29],
+  mipLevelCount: 1,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder60 = commandEncoder76.beginComputePass();
+try {
+computePassEncoder29.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle1, renderBundle1, renderBundle4, renderBundle0, renderBundle4, renderBundle7, renderBundle4, renderBundle9, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline10);
+} catch {}
+try {
+commandEncoder12.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1780 */
+  offset: 1780,
+  bytesPerRow: 5632,
+  buffer: buffer12,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 37, y: 26, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 20, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup37 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 323, resource: {buffer: buffer12, offset: 7680}}, {binding: 144, resource: textureView2}],
+});
+let commandEncoder77 = device0.createCommandEncoder({});
+let texture107 = device0.createTexture({
+  size: [470, 2, 1],
+  mipLevelCount: 4,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView95 = texture85.createView({dimension: '1d', mipLevelCount: 1});
+try {
+computePassEncoder51.setBindGroup(0, bindGroup9, new Uint32Array(427), 3, 0);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(1, buffer32);
+} catch {}
+try {
+  await promise7;
+} catch {}
+let img4 = await imageWithData(16, 1, '#10101010', '#20202020');
+let commandEncoder78 = device0.createCommandEncoder({});
+let texture108 = device0.createTexture({
+  size: {width: 40, height: 45, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture109 = device0.createTexture({
+  size: [80, 90, 69],
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder61 = commandEncoder78.beginComputePass({});
+let sampler44 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', lodMaxClamp: 44.91});
+try {
+computePassEncoder48.setBindGroup(0, bindGroup25, new Uint32Array(1540), 89, 0);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle4, renderBundle9, renderBundle6, renderBundle9, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer22, 'uint16', 1_434, 344);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer22, 88, 12);
+} catch {}
+let bindGroup38 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 68, resource: {buffer: buffer47, offset: 6144, size: 804}},
+    {binding: 97, resource: externalTexture6},
+    {binding: 64, resource: {buffer: buffer47, offset: 7168, size: 148}},
+    {binding: 45, resource: {buffer: buffer57, offset: 512, size: 1717}},
+  ],
+});
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout10]});
+let buffer63 = device0.createBuffer({
+  size: 8031,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let texture110 = device0.createTexture({
+  size: [470, 2, 1],
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder26 = commandEncoder77.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  depthSlice: 157,
+  clearValue: { r: -185.9, g: -185.4, b: -708.4, a: -601.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 113017289,
+});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup0, new Uint32Array(1666), 45, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle2]);
+} catch {}
+let buffer64 = device0.createBuffer({size: 10161, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder79 = device0.createCommandEncoder({});
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 53});
+let texture111 = device0.createTexture({
+  label: '\ud601\u7282\u5206\u6c2b\u{1fb81}\uc8d7\u9085\u{1fe06}\u2262\u75ba',
+  size: {width: 246, height: 1, depthOrArrayLayers: 9},
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder62 = commandEncoder79.beginComputePass();
+let sampler45 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'always',
+});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup1, new Uint32Array(3460), 350, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer57, 'uint32', 1_296, 441);
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer23);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 133, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(39_321).fill(68), /* required buffer size: 39_321 */
+{offset: 9, bytesPerRow: 504, rowsPerImage: 39}, {width: 125, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout2]});
+let buffer65 = device0.createBuffer({
+  label: '\u7713\u62ce\u4469\u35db\u65ab\u0a47\u{1f6ca}',
+  size: 8803,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture112 = device0.createTexture({
+  size: [246, 1, 1],
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture113 = device0.createTexture({
+  size: [20, 22, 70],
+  mipLevelCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder31); computePassEncoder31.dispatchWorkgroupsIndirect(buffer2, 152); };
+} catch {}
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup29, new Uint32Array(2394), 582, 0);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline12);
+} catch {}
+let imageData12 = new ImageData(32, 28);
+try {
+device0.label = '\udddb\u0c7e\u0f37\u0754\u07d9\ue034\u{1fa4b}';
+} catch {}
+let texture114 = device0.createTexture({
+  size: [3760, 20, 1],
+  mipLevelCount: 5,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder13.setVertexBuffer(4, buffer37, 0, 3_389);
+} catch {}
+let veryExplicitBindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+  ],
+});
+let texture115 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 21},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder63 = commandEncoder12.beginComputePass({});
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup25, new Uint32Array(3512), 1_098, 0);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 516 */
+  offset: 516,
+  bytesPerRow: 95232,
+  buffer: buffer42,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 31, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 102, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 102, y: 6, z: 0},
+  aspect: 'all',
+},
+{width: 96, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder80 = device0.createCommandEncoder({});
+let textureView96 = texture115.createView({dimension: 'cube-array', format: 'rgba32uint', mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 6});
+let texture116 = device0.createTexture({
+  size: {width: 615, height: 15, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder64 = commandEncoder26.beginComputePass({});
+let renderPassEncoder27 = commandEncoder8.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: 694.4, g: 364.4, b: 149.2, a: -739.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 282124339,
+});
+try {
+renderPassEncoder23.setIndexBuffer(buffer60, 'uint16', 570, 170);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(3, buffer24);
+} catch {}
+let commandEncoder81 = device0.createCommandEncoder({});
+let texture117 = device0.createTexture({
+  size: [40, 45, 68],
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView97 = texture1.createView({});
+let computePassEncoder65 = commandEncoder81.beginComputePass({});
+let sampler46 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMaxClamp: 88.09});
+try {
+computePassEncoder64.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder80.copyBufferToTexture({
+  /* bytesInLastRow: 90 widthInBlocks: 45 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 154 */
+  offset: 154,
+  bytesPerRow: 14592,
+  buffer: buffer50,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 5, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 45, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder82 = device0.createCommandEncoder();
+let texture118 = device0.createTexture({
+  size: {width: 1880, height: 10, depthOrArrayLayers: 1},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView98 = texture31.createView({});
+let computePassEncoder66 = commandEncoder80.beginComputePass({});
+let sampler47 = device0.createSampler({
+  label: '\u0018\u3e90\u{1f86d}\u7d22\u{1fe49}\u5eaf',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 88.90,
+});
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(0, buffer55);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder82.copyBufferToTexture({
+  /* bytesInLastRow: 224 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 400 */
+  offset: 400,
+  bytesPerRow: 22272,
+  buffer: buffer48,
+}, {
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 28, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup39 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 41, resource: textureView53},
+    {binding: 39, resource: {buffer: buffer32, offset: 0, size: 2824}},
+  ],
+});
+let commandEncoder83 = device0.createCommandEncoder();
+let texture119 = device0.createTexture({
+  size: [1968, 1, 1],
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture120 = device0.createTexture({
+  size: {width: 1968, height: 1, depthOrArrayLayers: 140},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder16.setBindGroup(1, bindGroup29, new Uint32Array(2092), 607, 0);
+} catch {}
+try {
+renderPassEncoder9.draw(326, 0, 164_228_066);
+} catch {}
+try {
+renderPassEncoder9.drawIndexedIndirect(buffer42, 1_364);
+} catch {}
+try {
+renderPassEncoder9.drawIndirect(buffer31, 440);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer62, 'uint32', 3_204);
+} catch {}
+try {
+commandEncoder83.copyTextureToBuffer({
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 320 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 152 */
+  offset: 152,
+  rowsPerImage: 566,
+  buffer: buffer33,
+}, {width: 40, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture121 = device0.createTexture({
+  size: {width: 10, height: 11, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture122 = device0.createTexture({
+  size: [3760],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView99 = texture94.createView({mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 1});
+let computePassEncoder67 = commandEncoder83.beginComputePass();
+let renderPassEncoder28 = commandEncoder82.beginRenderPass({colorAttachments: [{view: textureView93, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup24, new Uint32Array(1028), 49, 0);
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(1);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle6, renderBundle8, renderBundle4]);
+} catch {}
+try {
+commandEncoder43.copyTextureToTexture({
+  texture: texture48,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 98, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder43.clearBuffer(buffer40);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer53, 276, new DataView(new ArrayBuffer(12847)), 1163, 168);
+} catch {}
+let veryExplicitBindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 183,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder84 = device0.createCommandEncoder({});
+let texture123 = device0.createTexture({
+  size: [153, 3, 1],
+  mipLevelCount: 2,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame5});
+try {
+computePassEncoder63.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer62, 'uint16', 480, 19);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3, buffer1);
+} catch {}
+try {
+commandEncoder43.copyBufferToBuffer(buffer33, 628, buffer65, 844, 896);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup40 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 166, resource: {buffer: buffer57, offset: 768, size: 824}},
+    {binding: 125, resource: textureView61},
+  ],
+});
+let buffer66 = device0.createBuffer({size: 30408, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let commandEncoder85 = device0.createCommandEncoder({});
+let texture124 = device0.createTexture({
+  size: {width: 20, height: 22, depthOrArrayLayers: 33},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView100 = texture13.createView({dimension: '2d', baseArrayLayer: 15, arrayLayerCount: 1});
+let computePassEncoder68 = commandEncoder84.beginComputePass({});
+let renderPassEncoder29 = commandEncoder43.beginRenderPass({
+  colorAttachments: [{
+  view: textureView67,
+  clearValue: { r: -821.8, g: 514.4, b: 395.0, a: -802.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler48 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 99.29,
+});
+try {
+computePassEncoder65.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup16, new Uint32Array(558), 197, 0);
+} catch {}
+try {
+renderPassEncoder10.setViewport(255.7142562674074, 0.006477133565259585, 511.33464688516983, 0.3142693230289368, 0.6169244098550516, 0.865015494021779);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline2);
+} catch {}
+let buffer67 = device0.createBuffer({
+  size: 4973,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+});
+let texture125 = device0.createTexture({
+  size: [984, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder69 = commandEncoder85.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder51); computePassEncoder51.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder18); computePassEncoder18.dispatchWorkgroupsIndirect(buffer47, 460); };
+} catch {}
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder10.setViewport(204.43655821118082, 0.0135238988219889, 445.00026974789597, 0.7612203188600888, 0.30354488976725613, 0.816936146327412);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder5.copyBufferToTexture({
+  /* bytesInLastRow: 38 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4244 */
+  offset: 4244,
+  bytesPerRow: 22016,
+  buffer: buffer42,
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+}, {width: 19, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 1744, new Float32Array(4573), 580, 148);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 984, height: 1, depthOrArrayLayers: 140}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture120,
+  mipLevel: 1,
+  origin: {x: 78, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup41 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout4,
+  entries: [
+    {binding: 144, resource: textureView97},
+    {binding: 323, resource: {buffer: buffer37, offset: 256, size: 2548}},
+  ],
+});
+let commandEncoder86 = device0.createCommandEncoder();
+let texture126 = device0.createTexture({
+  size: {width: 246, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView101 = texture84.createView({});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup12, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder23); computePassEncoder23.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(3, buffer56, 12);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 123, height: 1, depthOrArrayLayers: 153}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 32, y: 0, z: 152},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup42 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 125, resource: textureView61},
+    {binding: 166, resource: {buffer: buffer1, offset: 512, size: 142}},
+  ],
+});
+let commandEncoder87 = device0.createCommandEncoder({});
+let texture127 = device0.createTexture({
+  size: {width: 307, height: 7, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture128 = device0.createTexture({
+  size: [80, 90, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderPassEncoder30 = commandEncoder5.beginRenderPass({colorAttachments: [{view: textureView79, depthSlice: 0, loadOp: 'load', storeOp: 'store'}]});
+let sampler49 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 50.70,
+  maxAnisotropy: 17,
+});
+try {
+renderPassEncoder20.setIndexBuffer(buffer63, 'uint16', 204, 3_025);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline10);
+} catch {}
+try {
+commandEncoder86.resolveQuerySet(querySet4, 229, 6, buffer57, 0);
+} catch {}
+try {
+commandEncoder87.insertDebugMarker('\uf5bb');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 144, resource: textureView5},
+    {binding: 323, resource: {buffer: buffer32, offset: 3072, size: 2620}},
+  ],
+});
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let texture129 = device0.createTexture({size: [80, 90, 6], format: 'rg8sint', usage: GPUTextureUsage.TEXTURE_BINDING, viewFormats: []});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup29, new Uint32Array(2644), 64, 0);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder87.resolveQuerySet(querySet6, 5, 49, buffer55, 256);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture130 = device0.createTexture({
+  size: [80, 90, 102],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture131 = device0.createTexture({
+  size: {width: 153},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder70 = commandEncoder86.beginComputePass({});
+let renderPassEncoder31 = commandEncoder87.beginRenderPass({
+  colorAttachments: [{
+  view: textureView79,
+  depthSlice: 6,
+  clearValue: { r: 204.6, g: 870.5, b: -363.2, a: -424.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 28925414,
+});
+let sampler50 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', magFilter: 'linear', minFilter: 'linear'});
+try {
+computePassEncoder45.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder48); computePassEncoder48.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder31); computePassEncoder31.dispatchWorkgroupsIndirect(buffer31, 692); };
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup25, new Uint32Array(3359), 126, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer53, 80, new DataView(new ArrayBuffer(15423)), 1333, 192);
+} catch {}
+let bindGroup44 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 166, resource: {buffer: buffer65, offset: 2816, size: 1537}},
+    {binding: 125, resource: textureView31},
+  ],
+});
+let buffer68 = device0.createBuffer({
+  size: 9520,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder88 = device0.createCommandEncoder({});
+let texture132 = device0.createTexture({
+  size: {width: 3760, height: 20, depthOrArrayLayers: 1},
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture133 = device0.createTexture({
+  size: {width: 1968, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView102 = texture14.createView({baseArrayLayer: 27, arrayLayerCount: 4});
+let computePassEncoder71 = commandEncoder88.beginComputePass({});
+let sampler51 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', minFilter: 'nearest'});
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle0, renderBundle7, renderBundle6, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer19, 'uint32', 5_156, 489);
+} catch {}
+document.body.prepend(img0);
+let commandEncoder89 = device0.createCommandEncoder({});
+let texture134 = device0.createTexture({
+  size: {width: 10, height: 11, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture135 = device0.createTexture({size: [80], dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.COPY_SRC});
+try {
+computePassEncoder42.setBindGroup(0, bindGroup42);
+} catch {}
+try {
+renderPassEncoder23.setBlendConstant({ r: 255.3, g: 864.3, b: 187.2, a: -265.2, });
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer13, 'uint32', 128, 671);
+} catch {}
+try {
+commandEncoder89.copyBufferToTexture({
+  /* bytesInLastRow: 104 widthInBlocks: 26 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2500 */
+  offset: 2500,
+  buffer: buffer60,
+}, {
+  texture: texture111,
+  mipLevel: 1,
+  origin: {x: 24, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 26, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer23, 568, new BigUint64Array(5744), 420, 0);
+} catch {}
+let imageData13 = new ImageData(48, 40);
+let commandEncoder90 = device0.createCommandEncoder();
+let texture136 = device0.createTexture({
+  size: [80, 90, 1],
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup30, new Uint32Array(3178), 1_092, 0);
+} catch {}
+try {
+commandEncoder89.clearBuffer(buffer47);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let commandEncoder91 = device0.createCommandEncoder({});
+let texture137 = device0.createTexture({
+  size: {width: 615, height: 15, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder72 = commandEncoder89.beginComputePass({});
+try {
+computePassEncoder68.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer22, 'uint16', 100, 533);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let texture138 = device0.createTexture({
+  size: [940, 5, 1],
+  mipLevelCount: 1,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView103 = texture2.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder73 = commandEncoder91.beginComputePass({});
+try {
+computePassEncoder45.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+computePassEncoder35.setBindGroup(1, bindGroup17, new Uint32Array(249), 6, 0);
+} catch {}
+try {
+computePassEncoder48.end();
+} catch {}
+try {
+computePassEncoder70.setPipeline(pipeline18);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+let texture139 = device0.createTexture({
+  size: {width: 1968, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture140 = device0.createTexture({
+  size: {width: 153},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder74 = commandEncoder59.beginComputePass({label: '\ud336\u{1f92a}\u1cc8\u{1faae}\ub046\u{1f920}\u{1fc0e}\u{1fc8f}'});
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder22.beginOcclusionQuery(26);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline14);
+} catch {}
+try {
+commandEncoder90.copyBufferToTexture({
+  /* bytesInLastRow: 403 widthInBlocks: 403 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 286 */
+  offset: 286,
+  buffer: buffer0,
+}, {
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 163, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 403, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder90.copyTextureToBuffer({
+  texture: texture39,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 108 widthInBlocks: 54 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4106 */
+  offset: 4106,
+  bytesPerRow: 512,
+  buffer: buffer62,
+}, {width: 54, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture141 = device0.createTexture({
+  size: {width: 615},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView104 = texture52.createView({});
+let computePassEncoder75 = commandEncoder36.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder17); computePassEncoder17.dispatchWorkgroupsIndirect(buffer47, 284); };
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline8);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let pipeline20 = device0.createRenderPipeline({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule1,
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {module: shaderModule5, entryPoint: 'vertex5', constants: {}, buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+let bindGroup45 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 323, resource: {buffer: buffer40, offset: 8192, size: 5528}},
+    {binding: 144, resource: textureView5},
+  ],
+});
+let textureView105 = texture141.createView({aspect: 'all'});
+let textureView106 = texture77.createView({baseArrayLayer: 51, arrayLayerCount: 2});
+let recycledExplicitBindGroupLayout4 = pipeline7.getBindGroupLayout(0);
+let commandEncoder92 = device0.createCommandEncoder({});
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 261});
+let texture142 = device0.createTexture({
+  size: [940, 5, 1],
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder76 = commandEncoder90.beginComputePass({});
+try {
+computePassEncoder75.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup5, new Uint32Array(1955), 32, 0);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer56, 'uint16', 2_600, 245);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer67, 4756, new BigUint64Array(19944), 13422, 8);
+} catch {}
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 493});
+let texture143 = device0.createTexture({
+  size: {width: 492, height: 1, depthOrArrayLayers: 1},
+  format: 'r8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture144 = device0.createTexture({
+  size: {width: 307},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder11.setVertexBuffer(1, buffer22, 596);
+} catch {}
+let texture145 = device0.createTexture({
+  size: {width: 1968, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder77 = commandEncoder92.beginComputePass({});
+try {
+renderPassEncoder18.setBindGroup(1, bindGroup43, new Uint32Array(50), 16, 0);
+} catch {}
+try {
+renderPassEncoder22.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer41, 'uint16', 10_836, 1_757);
+} catch {}
+try {
+renderPassEncoder23.setVertexBuffer(4, buffer22, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let texture146 = device0.createTexture({
+  size: {width: 984, height: 1, depthOrArrayLayers: 63},
+  mipLevelCount: 2,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder17); computePassEncoder17.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup44, new Uint32Array(788), 267, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer13, 'uint16', 320, 582);
+} catch {}
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'film', transfer: 'smpte240m'} });
+let textureView107 = texture0.createView({dimension: '2d-array', aspect: 'all'});
+let computePassEncoder78 = commandEncoder18.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder35); computePassEncoder35.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer24, 'uint16', 246, 4);
+} catch {}
+let recycledExplicitBindGroupLayout5 = pipeline5.getBindGroupLayout(0);
+let texture147 = device0.createTexture({
+  label: '\u0d8b\u4258\u{1fdad}\ue999\uab22\u052f\u0978\ua6a5\u0ba8\u68c3',
+  size: {width: 940, height: 5, depthOrArrayLayers: 1},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView108 = texture96.createView({mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 35});
+let sampler52 = device0.createSampler({addressModeW: 'mirror-repeat', lodMaxClamp: 56.10});
+try {
+computePassEncoder72.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup24, new Uint32Array(149), 21, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT, colorSpace: 'srgb'});
+} catch {}
+let texture148 = device0.createTexture({
+  size: {width: 1880, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture149 = device0.createTexture({
+  size: {width: 3760, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder62.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(0, bindGroup30, new Uint32Array(930), 154, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(1, bindGroup38);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer69 = device0.createBuffer({
+  size: 2977,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder93 = device0.createCommandEncoder();
+let texture150 = device0.createTexture({
+  size: {width: 1880, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView109 = texture111.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let sampler53 = device0.createSampler({addressModeU: 'repeat', magFilter: 'linear', minFilter: 'nearest', mipmapFilter: 'linear'});
+try {
+renderPassEncoder28.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(2, buffer14);
+} catch {}
+try {
+commandEncoder93.copyBufferToTexture({
+  /* bytesInLastRow: 147 widthInBlocks: 147 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 846 */
+  offset: 846,
+  bytesPerRow: 14080,
+  buffer: buffer51,
+}, {
+  texture: texture73,
+  mipLevel: 1,
+  origin: {x: 61, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 147, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img2);
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'bt2020', transfer: 'iec61966-2-1'} });
+let recycledExplicitBindGroupLayout6 = pipeline15.getBindGroupLayout(0);
+let bindGroup46 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [
+    {binding: 39, resource: {buffer: buffer20, offset: 4864, size: 824}},
+    {binding: 41, resource: textureView8},
+  ],
+});
+let texture151 = device0.createTexture({
+  size: [153, 3, 1],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture152 = device0.createTexture({
+  size: [307, 7, 1],
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler54 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder25.setVertexBuffer(4, buffer51, 100);
+} catch {}
+let arrayBuffer12 = buffer28.getMappedRange(0, 320);
+try {
+computePassEncoder33.insertDebugMarker('\u{1f9dc}');
+} catch {}
+let veryExplicitBindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 34,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 73, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 133,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: true },
+    },
+    {
+      binding: 430,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let buffer70 = device0.createBuffer({
+  size: 68,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture153 = device0.createTexture({
+  size: [80, 90, 3],
+  mipLevelCount: 2,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder79 = commandEncoder93.beginComputePass({});
+let sampler55 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 47.79,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder23.setBindGroup(0, bindGroup43, new Uint32Array(162), 11, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder23); computePassEncoder23.dispatchWorkgroupsIndirect(buffer62, 2_440); };
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer67, 'uint32', 1_212, 295);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(6, buffer38, 4, 77);
+} catch {}
+let pipeline21 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  fragment: {module: shaderModule1, constants: {}, targets: [{format: 'rg8unorm'}]},
+  vertex: {
+    module: shaderModule6,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 148,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 16, shaderLocation: 3},
+          {format: 'uint16x4', offset: 0, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 816,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 108, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 7},
+          {format: 'uint32', offset: 572, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 148, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let texture154 = device0.createTexture({
+  size: {width: 20, height: 22, depthOrArrayLayers: 49},
+  sampleCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder38); computePassEncoder38.dispatchWorkgroupsIndirect(buffer12, 11_028); };
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer62, 'uint16', 116, 224);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(2, buffer51, 452, 722);
+} catch {}
+try {
+renderPassEncoder20.insertDebugMarker('\u048d');
+} catch {}
+let pipeline22 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout9,
+  multisample: {mask: 0x3d79c9b5},
+  fragment: {
+  module: shaderModule3,
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule4, buffers: []},
+  primitive: {unclippedDepth: true},
+});
+let bindGroup47 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [
+    {binding: 323, resource: {buffer: buffer63, offset: 0, size: 1600}},
+    {binding: 144, resource: textureView97},
+  ],
+});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 2000});
+let texture155 = device0.createTexture({
+  size: [40, 45, 21],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder27.setIndexBuffer(buffer8, 'uint16', 186, 670);
+} catch {}
+try {
+computePassEncoder36.insertDebugMarker('\ube81');
+} catch {}
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'jedecP22Phosphors', transfer: 'gamma22curve'} });
+let texture156 = device0.createTexture({
+  size: [1230, 30, 1],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture157 = device0.createTexture({
+  size: [40, 45, 34],
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle5, renderBundle6, renderBundle4]);
+} catch {}
+let pipeline23 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule5, entryPoint: 'compute5'}});
+let texture158 = device0.createTexture({
+  size: {width: 1968, height: 1, depthOrArrayLayers: 47},
+  mipLevelCount: 2,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView110 = texture32.createView({});
+try {
+computePassEncoder79.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer37, 'uint16', 2_212, 2_568);
+} catch {}
+let bindGroup48 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [
+    {binding: 323, resource: {buffer: buffer65, offset: 768, size: 1524}},
+    {binding: 144, resource: textureView97},
+  ],
+});
+let commandEncoder94 = device0.createCommandEncoder({});
+let texture159 = device0.createTexture({
+  size: {width: 10, height: 11, depthOrArrayLayers: 1},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder80 = commandEncoder94.beginComputePass({});
+try {
+computePassEncoder51.end();
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup47, new Uint32Array(633), 187, 0);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(177, 1, 335, 0);
+} catch {}
+try {
+commandEncoder61.copyBufferToTexture({
+  /* bytesInLastRow: 2138 widthInBlocks: 1069 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 144 */
+  offset: 144,
+  rowsPerImage: 818,
+  buffer: buffer21,
+}, {
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1069, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture160 = device0.createTexture({
+  size: [615, 15, 1],
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder81 = commandEncoder61.beginComputePass();
+let sampler56 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMaxClamp: 85.15,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder42.setBindGroup(0, bindGroup47);
+} catch {}
+try {
+computePassEncoder78.setPipeline(pipeline19);
+} catch {}
+document.body.prepend(img0);
+let buffer71 = device0.createBuffer({
+  size: 39902,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture161 = device0.createTexture({
+  size: [984, 1, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture162 = device0.createTexture({
+  size: {width: 40, height: 45, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  dimension: '2d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder63.setBindGroup(3, bindGroup46);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder23); computePassEncoder23.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup4, new Uint32Array(341), 176, 0);
+} catch {}
+let commandEncoder95 = device0.createCommandEncoder({});
+let texture163 = device0.createTexture({
+  size: {width: 153, height: 3, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder82 = commandEncoder95.beginComputePass({});
+try {
+computePassEncoder82.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder28.end();
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(2, buffer20, 5_584, 1_755);
+} catch {}
+try {
+buffer54.unmap();
+} catch {}
+try {
+computePassEncoder32.pushDebugGroup('\ueecb');
+} catch {}
+document.body.append(img2);
+let bindGroup49 = device0.createBindGroup({
+  label: '\u6840\ud0ea\ub0ab\u{1ffac}\u2af5',
+  layout: veryExplicitBindGroupLayout16,
+  entries: [
+    {binding: 430, resource: sampler44},
+    {binding: 133, resource: {buffer: buffer68, offset: 768, size: 1790}},
+    {binding: 73, resource: sampler13},
+    {binding: 34, resource: textureView96},
+  ],
+});
+let buffer72 = device0.createBuffer({size: 3265, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder96 = device0.createCommandEncoder({});
+let commandBuffer6 = commandEncoder82.finish();
+let texture164 = device0.createTexture({
+  size: {width: 246, height: 1, depthOrArrayLayers: 48},
+  mipLevelCount: 2,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture165 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder83 = commandEncoder96.beginComputePass({});
+let sampler57 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder47.setBindGroup(2, bindGroup21, new Uint32Array(3796), 1_561, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder35); computePassEncoder35.dispatchWorkgroupsIndirect(buffer69, 664); };
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(0, buffer21);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 45, depthOrArrayLayers: 1}
+*/
+{
+  source: img4,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture166 = device0.createTexture({
+  size: {width: 40, height: 45, depthOrArrayLayers: 38},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder75.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+computePassEncoder19.setBindGroup(2, bindGroup27, new Uint32Array(386), 131, 0);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline7);
+} catch {}
+try {
+  await shaderModule2.getCompilationInfo();
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(41, 119);
+let texture167 = device0.createTexture({
+  size: [470, 2, 1],
+  dimension: '2d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder74.setBindGroup(0, bindGroup25, new Uint32Array(1081), 123, 0);
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup8, new Uint32Array(1264), 52, 0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(6, buffer55, 0, 584);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'bt470m', transfer: 'smpte240m'} });
+let bindGroup50 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 9, resource: textureView65}]});
+let texture168 = device0.createTexture({
+  size: {width: 80, height: 90, depthOrArrayLayers: 1},
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder7.setIndexBuffer(buffer52, 'uint32', 284, 90);
+} catch {}
+let bindGroup51 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 9, resource: textureView18}]});
+let commandEncoder97 = device0.createCommandEncoder({});
+let textureView111 = texture115.createView({dimension: 'cube-array', baseArrayLayer: 6, arrayLayerCount: 6});
+let renderPassEncoder32 = commandEncoder97.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: 400.5, g: 889.4, b: -666.5, a: 933.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 80008217,
+});
+let sampler58 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 61.80,
+});
+try {
+computePassEncoder72.setBindGroup(2, bindGroup51, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder16); computePassEncoder16.dispatchWorkgroupsIndirect(buffer20, 4_864); };
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: 928.5, g: 840.0, b: 440.2, a: 518.8, });
+} catch {}
+let bindGroup52 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [
+    {binding: 125, resource: textureView21},
+    {binding: 166, resource: {buffer: buffer57, offset: 512, size: 3905}},
+  ],
+});
+let texture169 = device0.createTexture({
+  size: [1230, 30, 1],
+  mipLevelCount: 1,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder79.setBindGroup(1, bindGroup31, new Uint32Array(158), 25, 0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline8);
+} catch {}
+let texture170 = device0.createTexture({
+  size: {width: 615, height: 15, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView112 = texture14.createView({dimension: '2d', baseArrayLayer: 13});
+try {
+computePassEncoder57.setBindGroup(1, bindGroup35, []);
+} catch {}
+try {
+computePassEncoder35.end();
+} catch {}
+try {
+renderPassEncoder8.draw(151, 184, 454_454_892, 883_555_986);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(7, buffer70, 0, 5);
+} catch {}
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'bt2020', transfer: 'gamma28curve'} });
+let bindGroup53 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 9, resource: textureView1}]});
+let textureView113 = texture53.createView({});
+let sampler59 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 94.70,
+  compare: 'greater',
+});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup8, new Uint32Array(114), 5, 0);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(0, 52, 40, 402_679_497, 145_092_889);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer65, 2_400);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer70, 0);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer13, 'uint32', 196, 534);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(1, buffer37, 84, 731);
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas2.getContext('webgpu');
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 652});
+let commandBuffer7 = commandEncoder45.finish({});
+let texture171 = device0.createTexture({
+  size: [40, 45, 1],
+  mipLevelCount: 2,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder21); computePassEncoder21.dispatchWorkgroupsIndirect(buffer14, 8_736); };
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(6, buffer43, 0, 33);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup54 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout0,
+  entries: [
+    {binding: 144, resource: textureView5},
+    {binding: 323, resource: {buffer: buffer51, offset: 0, size: 1292}},
+  ],
+});
+let commandEncoder98 = device0.createCommandEncoder({});
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 652});
+let texture172 = device0.createTexture({
+  size: [615, 15, 1],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder84 = commandEncoder98.beginComputePass();
+try {
+computePassEncoder81.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderPassEncoder8.draw(68, 386, 820_498_439, 49_991_776);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(1, 61, 67, -2_082_215_954, 470_214_812);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer60, 4);
+} catch {}
+try {
+computePassEncoder32.popDebugGroup();
+} catch {}
+let texture173 = device0.createTexture({
+  size: [1230, 30, 1],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture174 = device0.createTexture({
+  size: {width: 492, height: 1, depthOrArrayLayers: 6},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder84.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder7.draw(256, 66, 104_525_186, 255_863_518);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline0);
+} catch {}
+let pipeline24 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout9,
+  fragment: {module: shaderModule3, targets: [{format: 'rg8unorm', writeMask: 0}]},
+  vertex: {module: shaderModule3, constants: {}, buffers: []},
+});
+let imageData14 = new ImageData(4, 4);
+let texture175 = device0.createTexture({
+  size: {width: 10, height: 11, depthOrArrayLayers: 1},
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture176 = device0.createTexture({
+  size: {width: 470, height: 2, depthOrArrayLayers: 1},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture127,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture171,
+  mipLevel: 1,
+  origin: {x: 3, y: 4, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup55 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout3,
+  entries: [
+    {binding: 323, resource: {buffer: buffer33, offset: 0, size: 1668}},
+    {binding: 144, resource: textureView5},
+  ],
+});
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout4, autogeneratedBindGroupLayout4]});
+let buffer73 = device0.createBuffer({
+  size: 1789,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture177 = device0.createTexture({
+  size: [470, 2, 1],
+  dimension: '2d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView114 = texture85.createView({});
+let computePassEncoder85 = commandEncoder16.beginComputePass({});
+try {
+computePassEncoder42.setBindGroup(2, bindGroup49, new Uint32Array(753), 174, 1);
+} catch {}
+try {
+renderPassEncoder7.draw(37, 584, 1_122_973_271, 145_753_121);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer33, 1_804);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer14, 1_876);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer1, 'uint32', 5_040, 190);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+device0.queue.submit([commandBuffer7, commandBuffer6]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(21).fill(225), /* required buffer size: 21 */
+{offset: 21}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder99 = device0.createCommandEncoder({});
+let texture178 = device0.createTexture({
+  size: {width: 615, height: 15, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView115 = texture135.createView({
+  label: '\u0f46\u18f8\u{1fcaf}\ucf48\ub5f3\u307c\u{1ffbb}\u75e8\u050b',
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder62.setBindGroup(2, bindGroup1, new Uint32Array(4330), 506, 0);
+} catch {}
+try {
+computePassEncoder85.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder7.draw(156, 32, 1_124_961_095, 893_035_784);
+} catch {}
+let bindGroup56 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout12,
+  entries: [
+    {binding: 166, resource: {buffer: buffer69, offset: 512, size: 216}},
+    {binding: 125, resource: textureView61},
+  ],
+});
+let texture179 = device0.createTexture({
+  size: [940, 5, 1],
+  mipLevelCount: 3,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture180 = gpuCanvasContext1.getCurrentTexture();
+let textureView116 = texture91.createView({dimension: '2d-array'});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u0ca3\ub64f\u5dcd\uedbc\u{1fb74}\ua19b\u0c9b\u0163\u51bd\u6e53\u{1feea}',
+  colorFormats: ['rg8unorm'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder70.setBindGroup(1, bindGroup30, []);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(11, 0, 7, 0);
+} catch {}
+try {
+renderPassEncoder7.draw(120, 182, 329_665_677, 828_091_665);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer66, 'uint16', 4_218, 3_642);
+} catch {}
+try {
+renderBundleEncoder10.setPipeline(pipeline0);
+} catch {}
+let texture181 = device0.createTexture({
+  size: [1880, 10, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture182 = device0.createTexture({
+  size: {width: 940, height: 5, depthOrArrayLayers: 1},
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder86 = commandEncoder99.beginComputePass({});
+try {
+computePassEncoder45.dispatchWorkgroups(1);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder8.draw(439, 96, 275_380_152, 718_430_461);
+} catch {}
+try {
+renderPassEncoder7.drawIndirect(buffer33, 648);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer56, 'uint32', 168, 544);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let pipeline25 = await device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule3}});
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'smpteSt4281', transfer: 'smpte170m'} });
+let texture183 = device0.createTexture({
+  size: {width: 80, height: 90, depthOrArrayLayers: 14},
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture184 = device0.createTexture({size: [470], dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.COPY_SRC});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true});
+let renderBundle10 = renderBundleEncoder10.finish({});
+let sampler60 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', minFilter: 'linear', lodMaxClamp: 86.10});
+try {
+computePassEncoder72.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder7.drawIndexedIndirect(buffer7, 20);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(2, buffer20, 136, 1_676);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup43, []);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 45, depthOrArrayLayers: 3}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture153,
+  mipLevel: 1,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline26 = device0.createRenderPipeline({
+  layout: pipelineLayout0,
+  fragment: {module: shaderModule0, targets: [{format: 'rg8unorm', writeMask: 0}]},
+  vertex: {module: shaderModule7, buffers: []},
+  primitive: {unclippedDepth: true},
+});
+let commandEncoder100 = device0.createCommandEncoder({});
+let texture185 = device0.createTexture({
+  size: [470, 2, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture186 = device0.createTexture({size: [153, 3, 116], dimension: '3d', format: 'r8sint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder87 = commandEncoder100.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder38); computePassEncoder38.dispatchWorkgroupsIndirect(buffer12, 25_528); };
+} catch {}
+try {
+computePassEncoder87.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup1, new Uint32Array(1132), 126, 0);
+} catch {}
+try {
+renderPassEncoder15.setViewport(235.99979558657384, 0.2176417643044678, 3.816494775741497, 0.42278211372255237, 0.2987209770656566, 0.565899449460517);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer41, 'uint32', 8_644, 8_937);
+} catch {}
+let bindGroup57 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 144, resource: textureView97},
+    {binding: 323, resource: {buffer: buffer37, offset: 2816, size: 1684}},
+  ],
+});
+let commandEncoder101 = device0.createCommandEncoder({});
+let texture187 = device0.createTexture({
+  size: [153, 3, 1],
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture188 = device0.createTexture({
+  size: [1880, 10, 1],
+  mipLevelCount: 3,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let computePassEncoder88 = commandEncoder101.beginComputePass();
+try {
+computePassEncoder39.setBindGroup(1, bindGroup40, new Uint32Array(2301), 354, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup57, new Uint32Array(4666), 2_569, 0);
+} catch {}
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder27.beginOcclusionQuery(165);
+} catch {}
+try {
+renderPassEncoder20.setViewport(172.1290316073837, 0.3090693898578025, 32.27046356503438, 0.006455227368975552, 0.7598275241028215, 0.9691579396317894);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer71, 712);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer65, 1_444);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer66, 'uint32', 3_292, 6_304);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(3, buffer60, 28, 33);
+} catch {}
+try {
+commandEncoder38.copyBufferToBuffer(buffer53, 220, buffer13, 476, 48);
+} catch {}
+try {
+commandEncoder38.copyBufferToTexture({
+  /* bytesInLastRow: 10 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1006 */
+  offset: 1006,
+  bytesPerRow: 36864,
+  buffer: buffer67,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder38.clearBuffer(buffer24, 4, 32);
+} catch {}
+try {
+renderPassEncoder19.pushDebugGroup('\ud064');
+} catch {}
+try {
+renderPassEncoder19.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(206).fill(155), /* required buffer size: 206 */
+{offset: 206}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture189 = device0.createTexture({
+  size: {width: 3760, height: 20, depthOrArrayLayers: 1},
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder88.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(64, 180, 9, 899_643_309, 172_897_643);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer21, 3_728);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer7, 32);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'bt470bg', transfer: 'smpte170m'} });
+let commandEncoder102 = device0.createCommandEncoder({});
+let commandBuffer8 = commandEncoder38.finish({});
+let texture190 = device0.createTexture({
+  size: {width: 153, height: 3, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture191 = device0.createTexture({
+  size: [615, 15, 1],
+  mipLevelCount: 2,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView117 = texture149.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder89 = commandEncoder102.beginComputePass({});
+try {
+computePassEncoder89.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer21, 1_048);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer19, 'uint32', 1_452, 533);
+} catch {}
+let arrayBuffer13 = buffer28.getMappedRange(320, 3068);
+let texture192 = device0.createTexture({
+  size: {width: 1968, height: 1, depthOrArrayLayers: 58},
+  mipLevelCount: 4,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture193 = device0.createTexture({size: [1230], sampleCount: 1, dimension: '1d', format: 'r8sint', usage: GPUTextureUsage.COPY_SRC});
+let textureView118 = texture152.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderBundle11 = renderBundleEncoder11.finish({});
+try {
+{ clearResourceUsages(device0, computePassEncoder38); computePassEncoder38.dispatchWorkgroupsIndirect(buffer62, 712); };
+} catch {}
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder25.executeBundles([renderBundle4, renderBundle10, renderBundle3, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(0, buffer21);
+} catch {}
+try {
+commandEncoder40.copyBufferToTexture({
+  /* bytesInLastRow: 44 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3088 */
+  offset: 3088,
+  buffer: buffer21,
+}, {
+  texture: texture167,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 1432, new Int16Array(39), 1, 4);
+} catch {}
+let pipeline27 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule5, entryPoint: 'compute4', constants: {}}});
+let buffer74 = device0.createBuffer({
+  size: 5076,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder103 = device0.createCommandEncoder({});
+let texture194 = device0.createTexture({
+  size: [1968, 1, 53],
+  mipLevelCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder11.setVertexBuffer(3, buffer1);
+} catch {}
+let texture195 = device0.createTexture({
+  size: {width: 1880, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView119 = texture28.createView({});
+let computePassEncoder90 = commandEncoder103.beginComputePass({});
+let renderPassEncoder33 = commandEncoder40.beginRenderPass({
+  colorAttachments: [{
+  view: textureView93,
+  clearValue: { r: -3.059, g: -210.3, b: -49.26, a: -568.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 69579579,
+});
+try {
+computePassEncoder83.setBindGroup(1, bindGroup49, [0]);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline25);
+} catch {}
+try {
+computePassEncoder90.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup11, new Uint32Array(6799), 807, 0);
+} catch {}
+try {
+renderPassEncoder27.endOcclusionQuery();
+} catch {}
+let arrayBuffer14 = buffer26.getMappedRange(136, 0);
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 220});
+let texture196 = device0.createTexture({
+  size: [246, 1, 1],
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture197 = device0.createTexture({
+  size: [3760, 20, 1],
+  mipLevelCount: 6,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView120 = texture70.createView({mipLevelCount: 1});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup41);
+} catch {}
+try {
+computePassEncoder45.setBindGroup(3, bindGroup47, new Uint32Array(512), 136, 0);
+} catch {}
+try {
+computePassEncoder74.end();
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer38, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder59.copyBufferToTexture({
+  /* bytesInLastRow: 448 widthInBlocks: 56 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2168 */
+  offset: 2168,
+  bytesPerRow: 6400,
+  buffer: buffer56,
+}, {
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 137, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 56, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(333).fill(2), /* required buffer size: 333 */
+{offset: 333, bytesPerRow: 760}, {width: 366, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 123, height: 1, depthOrArrayLayers: 153}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 35, y: 0, z: 11},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData15 = new ImageData(96, 8);
+let commandEncoder104 = device0.createCommandEncoder({});
+let texture198 = device0.createTexture({
+  size: {width: 246, height: 1, depthOrArrayLayers: 16},
+  mipLevelCount: 3,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView121 = texture101.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder91 = commandEncoder59.beginComputePass();
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true});
+try {
+renderPassEncoder32.setBindGroup(3, bindGroup22, new Uint32Array(8), 1, 0);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer74, 'uint32', 636, 1_002);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(5, buffer22, 0);
+} catch {}
+try {
+commandEncoder104.copyBufferToBuffer(buffer32, 5796, buffer71, 1760, 608);
+} catch {}
+let texture199 = device0.createTexture({
+  size: [3760, 20, 1],
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle12 = renderBundleEncoder12.finish({});
+let sampler61 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 89.34,
+  compare: 'always',
+  maxAnisotropy: 1,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder33); computePassEncoder33.dispatchWorkgroupsIndirect(buffer60, 868); };
+} catch {}
+try {
+commandEncoder104.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5940 */
+  offset: 5940,
+  buffer: buffer64,
+}, {
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 0, y: 6, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup58 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout6,
+  entries: [
+    {binding: 323, resource: {buffer: buffer60, offset: 256, size: 1192}},
+    {binding: 144, resource: textureView2},
+  ],
+});
+let buffer75 = device0.createBuffer({size: 3174, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let texture200 = device0.createTexture({
+  size: [492, 1, 1],
+  sampleCount: 1,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture201 = device0.createTexture({
+  size: {width: 1230, height: 30, depthOrArrayLayers: 721},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture202 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder92 = commandEncoder104.beginComputePass({});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(1, bindGroup41, new Uint32Array(1542), 535, 0);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: 251.9, g: -387.8, b: 770.4, a: -225.1, });
+} catch {}
+try {
+buffer71.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+document.body.append(img1);
+let recycledExplicitBindGroupLayout7 = pipeline18.getBindGroupLayout(1);
+let bindGroup59 = device0.createBindGroup({layout: veryExplicitBindGroupLayout14, entries: [{binding: 21, resource: textureView60}]});
+let texture203 = device0.createTexture({
+  size: [20, 22, 1],
+  sampleCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView122 = texture111.createView({mipLevelCount: 1, arrayLayerCount: 2});
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle8, renderBundle1, renderBundle8]);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3176 */
+  offset: 3176,
+  buffer: buffer10,
+}, {
+  texture: texture111,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture197,
+  mipLevel: 1,
+  origin: {x: 227, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(45).fill(199), /* required buffer size: 45 */
+{offset: 45, rowsPerImage: 2}, {width: 566, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 470, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 71, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+texture34.label = '\u46d3\u5195\u830b\u4def\u{1f89b}\ue225\u05a2\u0dee\u5440\u0d75\u0cea';
+} catch {}
+let veryExplicitBindGroupLayout17 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 21,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder105 = device0.createCommandEncoder();
+let texture204 = device0.createTexture({
+  size: [40, 45, 14],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler62 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.76,
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder13.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(3, buffer21, 0, 5_997);
+} catch {}
+let arrayBuffer15 = buffer26.getMappedRange(200, 36);
+try {
+commandEncoder105.copyBufferToTexture({
+  /* bytesInLastRow: 520 widthInBlocks: 130 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1684 */
+  offset: 1684,
+  buffer: buffer10,
+}, {
+  texture: texture173,
+  mipLevel: 0,
+  origin: {x: 136, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 130, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer47, 784, new Int16Array(8895), 324, 24);
+} catch {}
+let buffer76 = device0.createBuffer({
+  size: 544,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let texture205 = device0.createTexture({
+  size: [246, 1, 1],
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder34 = commandEncoder105.beginRenderPass({
+  colorAttachments: [{
+  view: textureView93,
+  clearValue: { r: 24.70, g: 60.70, b: -85.06, a: -815.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 282169661,
+});
+try {
+computePassEncoder59.setBindGroup(3, bindGroup38);
+} catch {}
+try {
+computePassEncoder91.setBindGroup(0, bindGroup2, new Uint32Array(273), 5, 0);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(19);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture87,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8Array(174).fill(57), /* required buffer size: 174 */
+{offset: 174}, {width: 492, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture206 = device0.createTexture({
+  size: {width: 153, height: 3, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture207 = device0.createTexture({
+  size: [615],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm'],
+});
+let renderPassEncoder35 = commandEncoder21.beginRenderPass({
+  colorAttachments: [{
+  view: textureView101,
+  clearValue: { r: -782.1, g: -419.8, b: 451.9, a: 258.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 142532300,
+});
+try {
+computePassEncoder80.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer74, 'uint32', 1_808, 104);
+} catch {}
+try {
+externalTexture4.label = '\u7af0\udeae';
+} catch {}
+let commandEncoder106 = device0.createCommandEncoder({});
+let texture208 = device0.createTexture({
+  size: {width: 940, height: 5, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder92.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer0, 'uint32', 376, 162);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(3, buffer21, 10_900, 10_186);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 470, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 3, y: 0 },
+  flipY: false,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 227, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55); };
+} catch {}
+let commandEncoder107 = device0.createCommandEncoder({});
+let texture209 = device0.createTexture({
+  size: [32, 32, 21],
+  mipLevelCount: 1,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler63 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle9, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder30.setBlendConstant({ r: 574.2, g: -515.2, b: 422.7, a: -769.0, });
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer63, 'uint32', 396, 571);
+} catch {}
+let textureView123 = texture209.createView({dimension: 'cube-array', baseArrayLayer: 2, arrayLayerCount: 6});
+let textureView124 = texture191.createView({dimension: '2d', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder93 = commandEncoder107.beginComputePass();
+let renderPassEncoder36 = commandEncoder106.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: -830.4, g: 568.3, b: -933.5, a: -343.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+try {
+computePassEncoder75.setBindGroup(0, bindGroup57);
+} catch {}
+try {
+globalThis.someLabel = externalTexture5.label;
+} catch {}
+let veryExplicitBindGroupLayout18 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 775,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder108 = device0.createCommandEncoder();
+let texture210 = device0.createTexture({
+  size: [1968, 1, 9],
+  mipLevelCount: 5,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+renderPassEncoder26.beginOcclusionQuery(82);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle5]);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 1472, new Int16Array(11497), 1447, 56);
+} catch {}
+await gc();
+let buffer77 = device0.createBuffer({size: 9592, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let computePassEncoder94 = commandEncoder49.beginComputePass({});
+let renderPassEncoder37 = commandEncoder108.beginRenderPass({
+  colorAttachments: [{
+  view: textureView120,
+  depthSlice: 14,
+  clearValue: { r: -454.7, g: 947.0, b: -891.6, a: 532.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 1444098,
+});
+try {
+renderPassEncoder29.setIndexBuffer(buffer41, 'uint32', 2_160, 2_579);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline24);
+} catch {}
+let buffer78 = device0.createBuffer({size: 40445, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+computePassEncoder63.setBindGroup(1, bindGroup22, new Uint32Array(1424), 639, 0);
+} catch {}
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+computePassEncoder94.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup50, new Uint32Array(654), 48, 0);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer57, 'uint32', 20, 938);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(2, buffer71, 0);
+} catch {}
+try {
+commandEncoder17.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1644 */
+  offset: 1644,
+  bytesPerRow: 30720,
+  buffer: buffer57,
+}, {
+  texture: texture100,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder109 = device0.createCommandEncoder({});
+let textureView125 = texture79.createView({dimension: '2d-array'});
+let texture211 = device0.createTexture({
+  size: {width: 153, height: 3, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder95 = commandEncoder17.beginComputePass({});
+let sampler64 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 92.43});
+try {
+computePassEncoder60.setBindGroup(1, bindGroup36, new Uint32Array(2328), 519, 0);
+} catch {}
+try {
+computePassEncoder93.setPipeline(pipeline19);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+commandEncoder109.copyBufferToBuffer(buffer32, 264, buffer66, 1052, 5952);
+} catch {}
+try {
+commandEncoder109.copyTextureToTexture({
+  texture: texture126,
+  mipLevel: 1,
+  origin: {x: 71, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture196,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img3);
+let computePassEncoder96 = commandEncoder109.beginComputePass({});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup42, new Uint32Array(1974), 72, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder45); computePassEncoder45.dispatchWorkgroupsIndirect(buffer20, 820); };
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup13, new Uint32Array(4282), 171, 0);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup20, new Uint32Array(478), 3, 0);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer24, 'uint32', 48, 34);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let texture212 = device0.createTexture({
+  size: {width: 246, height: 1, depthOrArrayLayers: 104},
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView126 = texture130.createView({dimension: '2d', baseArrayLayer: 15});
+let renderBundle13 = renderBundleEncoder13.finish({});
+try {
+renderPassEncoder23.setVertexBuffer(1, undefined, 248_651_288);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55); };
+} catch {}
+await gc();
+let sampler65 = device0.createSampler({magFilter: 'linear', minFilter: 'linear', mipmapFilter: 'linear', lodMaxClamp: 81.25, maxAnisotropy: 2});
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup36);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup56, new Uint32Array(1754), 543, 0);
+} catch {}
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline10);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 246, height: 1, depthOrArrayLayers: 307}
+*/
+{
+  source: imageData4,
+  origin: { x: 4, y: 0 },
+  flipY: false,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 17},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let bindGroup60 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [
+    {binding: 323, resource: {buffer: buffer37, offset: 2304, size: 1312}},
+    {binding: 144, resource: textureView97},
+  ],
+});
+let texture213 = device0.createTexture({size: [307, 7, 1], format: 'rg8unorm', usage: GPUTextureUsage.COPY_DST});
+let textureView127 = texture38.createView({baseMipLevel: 0, mipLevelCount: 1});
+try {
+renderPassEncoder34.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout14 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout7]});
+let textureView128 = texture203.createView({dimension: '2d-array', format: 'rgba8sint'});
+let textureView129 = texture191.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup4, new Uint32Array(1322), 73, 0);
+} catch {}
+try {
+renderPassEncoder32.beginOcclusionQuery(11);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([renderBundle11, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer66, 'uint32', 3_840, 4_597);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(1, buffer40);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer37, 660, new BigUint64Array(2134), 618, 192);
+} catch {}
+let bindGroup61 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [
+    {binding: 144, resource: textureView2},
+    {binding: 323, resource: {buffer: buffer47, offset: 1536, size: 968}},
+  ],
+});
+let buffer79 = device0.createBuffer({
+  size: 9647,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let textureView130 = texture208.createView({dimension: '2d-array'});
+let sampler66 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.33,
+  compare: 'greater',
+});
+try {
+computePassEncoder78.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+computePassEncoder23.setBindGroup(2, bindGroup29, new Uint32Array(8657), 1_145, 0);
+} catch {}
+try {
+computePassEncoder95.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle1, renderBundle3, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder23.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(7, buffer32, 1_732, 3_141);
+} catch {}
+let buffer80 = device0.createBuffer({
+  size: 3354,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder110 = device0.createCommandEncoder({});
+let texture214 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder96.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(2, buffer24, 0, 123);
+} catch {}
+try {
+commandEncoder110.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 9656 */
+  offset: 9656,
+  bytesPerRow: 23040,
+  buffer: buffer12,
+}, {
+  texture: texture168,
+  mipLevel: 0,
+  origin: {x: 3, y: 22, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let buffer81 = device0.createBuffer({
+  size: 18614,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder111 = device0.createCommandEncoder();
+let texture215 = device0.createTexture({
+  size: [153, 3, 11],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder97 = commandEncoder110.beginComputePass({});
+try {
+computePassEncoder97.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder37.setViewport(25.37568470455248, 31.68210002388615, 4.1808338615647695, 3.8966770339722827, 0.7460416486058818, 0.9986797655597477);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline14);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1968, height: 1, depthOrArrayLayers: 140}
+*/
+{
+  source: imageData7,
+  origin: { x: 6, y: 0 },
+  flipY: false,
+}, {
+  texture: texture120,
+  mipLevel: 0,
+  origin: {x: 222, y: 0, z: 15},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img4);
+let textureView131 = texture141.createView({});
+let texture216 = device0.createTexture({
+  size: {width: 470, height: 2, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView132 = texture85.createView({});
+let computePassEncoder98 = commandEncoder111.beginComputePass({});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['r8uint', 'r8sint'], stencilReadOnly: true});
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroupsIndirect(buffer52, 232); };
+} catch {}
+try {
+computePassEncoder98.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup43, new Uint32Array(6970), 152, 0);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup46, new Uint32Array(963), 174, 0);
+} catch {}
+let texture217 = device0.createTexture({
+  size: {width: 307},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder36.setBindGroup(3, bindGroup38, new Uint32Array(1150), 92, 0);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(0, buffer60, 0, 493);
+} catch {}
+document.body.prepend(img1);
+let bindGroup62 = device0.createBindGroup({layout: autogeneratedBindGroupLayout2, entries: [{binding: 144, resource: textureView2}]});
+let commandEncoder112 = device0.createCommandEncoder({});
+let renderBundle14 = renderBundleEncoder14.finish({});
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup9, new Uint32Array(4158), 290, 0);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([renderBundle5, renderBundle10, renderBundle12, renderBundle12, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder34.setStencilReference(187);
+} catch {}
+document.body.append(img4);
+let recycledExplicitBindGroupLayout8 = pipeline24.getBindGroupLayout(0);
+let commandEncoder113 = device0.createCommandEncoder({});
+let texture218 = device0.createTexture({
+  size: {width: 940, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'r8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder99 = commandEncoder113.beginComputePass({});
+try {
+computePassEncoder82.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup36, new Uint32Array(1538), 232, 0);
+} catch {}
+try {
+commandEncoder112.resolveQuerySet(querySet1, 88, 5, buffer2, 256);
+} catch {}
+let bindGroup63 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 64, resource: {buffer: buffer71, offset: 4096, size: 3936}},
+    {binding: 97, resource: externalTexture3},
+    {binding: 68, resource: {buffer: buffer40, offset: 5632}},
+    {binding: 45, resource: {buffer: buffer1, offset: 1536, size: 1936}},
+  ],
+});
+let commandEncoder114 = device0.createCommandEncoder({});
+let texture219 = device0.createTexture({
+  size: {width: 940, height: 5, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView133 = texture131.createView({});
+let computePassEncoder100 = commandEncoder112.beginComputePass({});
+try {
+renderPassEncoder12.setIndexBuffer(buffer66, 'uint32', 15_376, 1_325);
+} catch {}
+try {
+renderPassEncoder31.setPipeline(pipeline26);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder114.copyBufferToTexture({
+  /* bytesInLastRow: 22 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 166 */
+  offset: 166,
+  buffer: buffer17,
+}, {
+  texture: texture212,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 8},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder115 = device0.createCommandEncoder({});
+let texture220 = device0.createTexture({
+  size: {width: 1968, height: 1, depthOrArrayLayers: 26},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder99.setPipeline(pipeline19);
+} catch {}
+try {
+commandEncoder27.copyBufferToBuffer(buffer32, 372, buffer24, 20, 0);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 50 widthInBlocks: 25 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1654 */
+  offset: 1654,
+  buffer: buffer57,
+}, {
+  texture: texture213,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 25, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder15.insertDebugMarker('\u4f8a');
+} catch {}
+let pipeline28 = device0.createRenderPipeline({
+  layout: 'auto',
+  multisample: {mask: 0x796ed45},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment3',
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule7, entryPoint: 'vertex7', constants: {}, buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+let buffer82 = device0.createBuffer({
+  size: 274,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView134 = texture68.createView({format: 'rg8unorm', mipLevelCount: 1});
+let computePassEncoder101 = commandEncoder114.beginComputePass({});
+let sampler67 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'linear',
+  compare: 'less',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder33); computePassEncoder33.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(2, buffer14, 0, 11_737);
+} catch {}
+document.body.append(img2);
+let texture221 = device0.createTexture({
+  size: [10, 11, 32],
+  mipLevelCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder102 = commandEncoder115.beginComputePass({});
+let renderPassEncoder38 = commandEncoder27.beginRenderPass({colorAttachments: [{view: textureView101, loadOp: 'clear', storeOp: 'discard'}]});
+let sampler68 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 61.85,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup31, new Uint32Array(753), 38, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(0, bindGroup57, new Uint32Array(2827), 141, 0);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer42, 1_740);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer51, 12);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder26.insertDebugMarker('\u2e94');
+} catch {}
+let pipeline29 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule7,
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 928,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 8, shaderLocation: 13},
+          {format: 'uint8x2', offset: 16, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+});
+let bindGroup64 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout16,
+  entries: [
+    {binding: 34, resource: textureView111},
+    {binding: 73, resource: sampler33},
+    {binding: 430, resource: sampler31},
+    {binding: 133, resource: {buffer: buffer20, offset: 8960, size: 6495}},
+  ],
+});
+let buffer83 = device0.createBuffer({
+  size: 10167,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+try {
+computePassEncoder64.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+computePassEncoder100.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer69, 276);
+} catch {}
+try {
+renderPassEncoder23.drawIndirect(buffer81, 3_584);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(2, buffer22, 0, 1_275);
+} catch {}
+let veryExplicitBindGroupLayout19 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 44,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let buffer84 = device0.createBuffer({
+  size: 26119,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder81.setBindGroup(2, bindGroup54, new Uint32Array(1004), 322, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder23.draw(504, 594, 1_409_897_769, 104_628_798);
+} catch {}
+try {
+renderPassEncoder23.drawIndexed(12, 71, 33, 838_837_730, 596_381_921);
+} catch {}
+try {
+renderPassEncoder23.drawIndexedIndirect(buffer20, 7_636);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer73, 0, 571);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+let bindGroup65 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [{binding: 144, resource: textureView2}, {binding: 323, resource: {buffer: buffer74, offset: 512}}],
+});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup58, new Uint32Array(601), 113, 0);
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder23.end();
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder74.copyTextureToBuffer({
+  texture: texture119,
+  mipLevel: 0,
+  origin: {x: 155, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 524 widthInBlocks: 131 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5144 */
+  offset: 5144,
+  bytesPerRow: 2560,
+  buffer: buffer65,
+}, {width: 131, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer85 = device0.createBuffer({
+  size: 5026,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture222 = gpuCanvasContext1.getCurrentTexture();
+let textureView135 = texture118.createView({dimension: '2d', format: 'rgba32sint', baseArrayLayer: 0});
+let computePassEncoder103 = commandEncoder74.beginComputePass();
+try {
+computePassEncoder0.setBindGroup(2, bindGroup41, new Uint32Array(302), 9, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder33); computePassEncoder33.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder45.end();
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline15);
+} catch {}
+let veryExplicitBindGroupLayout20 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 51,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 60,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 67,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 80,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 114,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: true },
+    },
+    {
+      binding: 160,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 188,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 390,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let computePassEncoder104 = commandEncoder55.beginComputePass({});
+try {
+computePassEncoder101.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup61);
+} catch {}
+try {
+renderPassEncoder32.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer52, 'uint16', 274, 395);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder38.pushDebugGroup('\u8bf4');
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+let buffer86 = device0.createBuffer({
+  size: 27119,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture223 = device0.createTexture({
+  size: [984, 1, 1],
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg8unorm', 'rg8unorm'],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder33); computePassEncoder33.dispatchWorkgroupsIndirect(buffer1, 448); };
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(1, buffer51, 268, 2_484);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let videoFrame18 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+try {
+computePassEncoder104.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup6, new Uint32Array(2718), 768, 0);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle2]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(92).fill(107), /* required buffer size: 92 */
+{offset: 92}, {width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55); };
+} catch {}
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte170m', primaries: 'bt709', transfer: 'linear'} });
+try {
+computePassEncoder103.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder33.setBlendConstant({ r: -587.4, g: -323.4, b: 87.13, a: -432.1, });
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer8, 'uint32', 1_004, 20);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline4);
+} catch {}
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['r8uint', 'r8sint'], depthReadOnly: true});
+try {
+{ clearResourceUsages(device0, computePassEncoder75); computePassEncoder75.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup30, []);
+} catch {}
+try {
+renderPassEncoder18.draw(170, 34, 629_999_836, 302_944_534);
+} catch {}
+try {
+renderPassEncoder18.drawIndirect(buffer71, 10_184);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(1, buffer7, 128);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer74, 'uint32', 308, 114);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(68).fill(94), /* required buffer size: 68 */
+{offset: 68, bytesPerRow: 106}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 615, height: 15, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 17, y: 60 },
+  flipY: false,
+}, {
+  texture: texture89,
+  mipLevel: 1,
+  origin: {x: 54, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 28, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder116 = device0.createCommandEncoder({});
+let textureView136 = texture53.createView({});
+let computePassEncoder105 = commandEncoder116.beginComputePass();
+try {
+computePassEncoder105.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle10, renderBundle11, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder18.draw(22, 373, 798_951_637, 2_575_700_424);
+} catch {}
+try {
+renderPassEncoder18.drawIndirect(buffer20, 1_848);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer81, 'uint16', 136, 1_833);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(1, buffer73);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle1, renderBundle4, renderBundle12, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder18.drawIndirect(buffer71, 3_680);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup20, new Uint32Array(519), 98, 0);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer74, 'uint32', 2_112, 800);
+} catch {}
+let textureView137 = texture27.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder34.setBindGroup(3, bindGroup42, new Uint32Array(2137), 666, 0);
+} catch {}
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder18.draw(186, 149, 988_399_350, 51_548_223);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer0, 'uint32', 1_584, 174);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(5, buffer86, 0);
+} catch {}
+try {
+commandEncoder11.copyBufferToBuffer(buffer55, 116, buffer66, 528, 572);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer70, 4, new Int16Array(7544), 1926, 12);
+} catch {}
+try {
+computePassEncoder89.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+renderPassEncoder26.beginOcclusionQuery(79);
+} catch {}
+try {
+renderPassEncoder37.executeBundles([renderBundle0, renderBundle4, renderBundle8, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder18.draw(297, 72, 310_753_450, 1_233_899_501);
+} catch {}
+try {
+renderPassEncoder18.drawIndirect(buffer82, 40);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer37, 'uint32', 332, 1_154);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline20);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(0, bindGroup60, new Uint32Array(259), 79, 0);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer14, 'uint32', 2_016, 15_656);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(2, buffer86);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer47, 120, new Float32Array(946));
+} catch {}
+let imageData16 = new ImageData(24, 8);
+let computePassEncoder106 = commandEncoder11.beginComputePass({});
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer67, 'uint16', 766, 189);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline10);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer47, 5736, new Int16Array(5433), 400, 2048);
+} catch {}
+document.body.append(img4);
+let bindGroup66 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 41, resource: textureView8}, {binding: 39, resource: {buffer: buffer68, offset: 4352}}],
+});
+let commandEncoder117 = device0.createCommandEncoder({});
+let computePassEncoder107 = commandEncoder117.beginComputePass({});
+let renderBundle15 = renderBundleEncoder15.finish({});
+let sampler69 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 77.50,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder30.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder106.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup58);
+} catch {}
+try {
+renderPassEncoder18.draw(1, 72, 578_547_956, 580_306_040);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline24);
+} catch {}
+let arrayBuffer16 = buffer28.getMappedRange(3392, 236);
+let promise8 = device0.queue.onSubmittedWorkDone();
+let texture224 = device0.createTexture({
+  size: {width: 1968, height: 1, depthOrArrayLayers: 195},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler70 = device0.createSampler({addressModeU: 'repeat', lodMinClamp: 72.40, lodMaxClamp: 86.49, compare: 'equal'});
+try {
+computePassEncoder107.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup35, new Uint32Array(503), 113, 0);
+} catch {}
+try {
+renderPassEncoder18.end();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder118 = device0.createCommandEncoder({});
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 498});
+let commandBuffer9 = commandEncoder63.finish();
+let textureView138 = texture216.createView({
+  label: '\u{1fcfc}\u{1fa68}\u02e7\u5a1f\u4237\ued43\u0ae7\u{1fccf}\u{1f99e}',
+  dimension: '2d',
+  aspect: 'all',
+  format: 'r8sint',
+});
+let computePassEncoder108 = commandEncoder118.beginComputePass();
+try {
+computePassEncoder89.setBindGroup(1, bindGroup54, new Uint32Array(1146), 279, 0);
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder37.setIndexBuffer(buffer0, 'uint16', 32, 193);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(1, buffer32, 76);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+renderPassEncoder14.insertDebugMarker('\u39f2');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 230, y: 0, z: 13},
+  aspect: 'all',
+}, new Uint8Array(151_656).fill(24), /* required buffer size: 151_656 */
+{offset: 43, bytesPerRow: 179, rowsPerImage: 77}, {width: 27, height: 0, depthOrArrayLayers: 12});
+} catch {}
+let commandEncoder119 = device0.createCommandEncoder({});
+let computePassEncoder109 = commandEncoder119.beginComputePass();
+let sampler71 = device0.createSampler({});
+try {
+computePassEncoder109.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle5, renderBundle1, renderBundle0, renderBundle8, renderBundle4, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer18, 'uint32', 64, 94);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1968, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 578, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer87 = device0.createBuffer({
+  size: 706,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let textureView139 = texture209.createView({dimension: 'cube-array', baseArrayLayer: 1, arrayLayerCount: 6});
+let textureView140 = texture46.createView({dimension: '2d-array'});
+try {
+renderPassEncoder37.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(3, buffer13, 92, 1_519);
+} catch {}
+let imageData17 = new ImageData(72, 12);
+try {
+renderPassEncoder30.setIndexBuffer(buffer66, 'uint16', 8_180, 985);
+} catch {}
+let arrayBuffer17 = buffer28.getMappedRange(3632, 340);
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 615, height: 15, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 12, y: 0 },
+  flipY: true,
+}, {
+  texture: texture89,
+  mipLevel: 1,
+  origin: {x: 35, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img3);
+let bindGroup67 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout4,
+  entries: [
+    {binding: 323, resource: {buffer: buffer16, offset: 0, size: 920}},
+    {binding: 144, resource: textureView2},
+  ],
+});
+let buffer88 = device0.createBuffer({size: 3850, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder120 = device0.createCommandEncoder();
+let textureView141 = texture65.createView({dimension: '2d', arrayLayerCount: 1});
+try {
+renderPassEncoder33.setVertexBuffer(5, buffer24, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+renderPassEncoder38.popDebugGroup();
+} catch {}
+try {
+  await promise8;
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let textureView142 = texture19.createView({mipLevelCount: 1});
+let computePassEncoder110 = commandEncoder120.beginComputePass();
+try {
+computePassEncoder110.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup49, new Uint32Array(223), 20, 1);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(7, buffer79, 628);
+} catch {}
+let arrayBuffer18 = buffer28.getMappedRange(4024, 0);
+offscreenCanvas1.width = 860;
+let bindGroup68 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [
+    {binding: 144, resource: textureView5},
+    {binding: 323, resource: {buffer: buffer37, offset: 1024, size: 1780}},
+  ],
+});
+let commandEncoder121 = device0.createCommandEncoder({});
+let texture225 = device0.createTexture({
+  size: {width: 80, height: 90, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let texture226 = gpuCanvasContext0.getCurrentTexture();
+let textureView143 = texture67.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder75); computePassEncoder75.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle3, renderBundle1, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder27.setStencilReference(878);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline14);
+} catch {}
+let commandBuffer10 = commandEncoder20.finish();
+let renderPassEncoder39 = commandEncoder121.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: -256.6, g: 774.9, b: -78.31, a: 463.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let sampler72 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 88.55,
+});
+try {
+renderPassEncoder34.setVertexBuffer(6, buffer33, 0, 7);
+} catch {}
+let commandEncoder122 = device0.createCommandEncoder({});
+let texture227 = device0.createTexture({
+  size: [10, 11, 8],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView144 = texture144.createView({baseMipLevel: 0});
+let computePassEncoder111 = commandEncoder122.beginComputePass({});
+try {
+computePassEncoder81.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder111.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup38, []);
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline4);
+} catch {}
+let arrayBuffer19 = buffer28.getMappedRange(4056, 4);
+try {
+device0.queue.writeTexture({
+  texture: texture198,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(224_693).fill(151), /* required buffer size: 224_693 */
+{offset: 21, bytesPerRow: 238, rowsPerImage: 236}, {width: 49, height: 0, depthOrArrayLayers: 5});
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer13, 'uint32', 936, 901);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(5, buffer51);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+let bindGroup69 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout4,
+  entries: [
+    {binding: 323, resource: {buffer: buffer63, offset: 768, size: 3556}},
+    {binding: 144, resource: textureView4},
+  ],
+});
+let commandEncoder123 = device0.createCommandEncoder({});
+try {
+renderPassEncoder30.setBindGroup(3, bindGroup46, []);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle5, renderBundle6, renderBundle4, renderBundle5, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(1528);
+} catch {}
+try {
+commandEncoder123.copyBufferToTexture({
+  /* bytesInLastRow: 163 widthInBlocks: 163 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2232 */
+  offset: 2232,
+  buffer: buffer71,
+}, {
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 163, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder123.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 15, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 51},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 11});
+} catch {}
+let buffer89 = device0.createBuffer({
+  size: 4315,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder124 = device0.createCommandEncoder({});
+let computePassEncoder112 = commandEncoder124.beginComputePass({});
+let arrayBuffer20 = buffer28.getMappedRange(3984, 16);
+try {
+commandEncoder123.copyBufferToTexture({
+  /* bytesInLastRow: 782 widthInBlocks: 391 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 798 */
+  offset: 798,
+  buffer: buffer53,
+}, {
+  texture: texture116,
+  mipLevel: 0,
+  origin: {x: 62, y: 11, z: 0},
+  aspect: 'all',
+}, {width: 391, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 90, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture128,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup70 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 39, resource: {buffer: buffer87, offset: 0, size: 452}},
+    {binding: 41, resource: textureView8},
+  ],
+});
+let textureView145 = texture1.createView({dimension: '1d', mipLevelCount: 1});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame19});
+try {
+computePassEncoder112.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle11, renderBundle3, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder34.setPipeline(pipeline5);
+} catch {}
+try {
+  await buffer72.mapAsync(GPUMapMode.READ, 0, 1048);
+} catch {}
+let autogeneratedBindGroupLayout5 = pipeline6.getBindGroupLayout(0);
+let texture228 = device0.createTexture({
+  size: {width: 1968, height: 1, depthOrArrayLayers: 1},
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView146 = texture119.createView({arrayLayerCount: 1});
+try {
+computePassEncoder110.setBindGroup(2, bindGroup68, new Uint32Array(1734), 565, 0);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(0, buffer38, 160, 3);
+} catch {}
+try {
+commandEncoder123.copyBufferToBuffer(buffer71, 4248, buffer33, 1532, 256);
+} catch {}
+try {
+commandEncoder123.copyBufferToTexture({
+  /* bytesInLastRow: 758 widthInBlocks: 379 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2018 */
+  offset: 2018,
+  buffer: buffer37,
+}, {
+  texture: texture167,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 379, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder125 = device0.createCommandEncoder({});
+let textureView147 = texture5.createView({});
+try {
+computePassEncoder92.setBindGroup(0, bindGroup4, new Uint32Array(2186), 549, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder75); computePassEncoder75.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(0, buffer2, 0, 55);
+} catch {}
+let bindGroup71 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout7,
+  entries: [
+    {binding: 144, resource: textureView97},
+    {binding: 323, resource: {buffer: buffer20, offset: 256, size: 1412}},
+  ],
+});
+let pipelineLayout15 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout7]});
+let buffer90 = device0.createBuffer({size: 2880, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let texture229 = device0.createTexture({
+  size: [470],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView148 = texture129.createView({aspect: 'all', arrayLayerCount: 1});
+let computePassEncoder113 = commandEncoder123.beginComputePass();
+let renderPassEncoder40 = commandEncoder125.beginRenderPass({
+  colorAttachments: [{
+  view: textureView101,
+  clearValue: { r: -235.4, g: -821.6, b: 669.8, a: 628.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame12, colorSpace: 'display-p3'});
+try {
+renderPassEncoder10.setIndexBuffer(buffer38, 'uint16', 128, 3);
+} catch {}
+try {
+renderPassEncoder35.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(0, buffer55);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let imageData18 = new ImageData(8, 64);
+let bindGroup72 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 39, resource: {buffer: buffer19, offset: 256, size: 1168}},
+    {binding: 41, resource: textureView8},
+  ],
+});
+let commandEncoder126 = device0.createCommandEncoder();
+let texture230 = device0.createTexture({
+  size: {width: 1968, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder114 = commandEncoder126.beginComputePass({});
+let sampler73 = device0.createSampler({
+  label: '\u02d1\u0d26\u2ba9\uf22c\u{1fbdf}\u362c\u09e1\uefcb\u00c9',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 90.49,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder54.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+computePassEncoder114.setPipeline(pipeline11);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer40, 24400, new BigUint64Array(6167), 8, 40);
+} catch {}
+document.body.prepend(img0);
+let recycledExplicitBindGroupLayout9 = pipeline15.getBindGroupLayout(0);
+let buffer91 = device0.createBuffer({size: 3356, usage: GPUBufferUsage.UNIFORM});
+let textureView149 = texture41.createView({baseArrayLayer: 0});
+try {
+computePassEncoder113.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup71);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(4, buffer51);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup73 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 323, resource: {buffer: buffer5, offset: 0, size: 4684}},
+    {binding: 144, resource: textureView145},
+  ],
+});
+let commandEncoder127 = device0.createCommandEncoder({});
+let texture231 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder76.setBindGroup(1, bindGroup54);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder75); computePassEncoder75.dispatchWorkgroupsIndirect(buffer21, 6_516); };
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup35, []);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(5, buffer38);
+} catch {}
+try {
+commandEncoder127.copyBufferToBuffer(buffer78, 1836, buffer53, 312, 40);
+} catch {}
+try {
+commandEncoder127.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2722 */
+  offset: 2722,
+  bytesPerRow: 25088,
+  buffer: buffer69,
+}, {
+  texture: texture227,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder127.copyTextureToTexture({
+  texture: texture110,
+  mipLevel: 1,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture110,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let img5 = await imageWithData(105, 4, '#10101010', '#20202020');
+try {
+textureView139.label = '\ue0c3\u{1f77c}\u0d5c\u0eff\u4165\u7280\ufb36\u6bf4';
+} catch {}
+let commandEncoder128 = device0.createCommandEncoder();
+let texture232 = device0.createTexture({size: [32, 32, 21], mipLevelCount: 2, format: 'rgb10a2unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder115 = commandEncoder128.beginComputePass({});
+let sampler74 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', mipmapFilter: 'nearest'});
+let externalTexture10 = device0.importExternalTexture({source: videoFrame17, colorSpace: 'srgb'});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup54, new Uint32Array(4185), 689, 0);
+} catch {}
+try {
+renderPassEncoder35.setBlendConstant({ r: -736.2, g: 682.4, b: -122.5, a: 260.8, });
+} catch {}
+try {
+commandEncoder127.copyBufferToTexture({
+  /* bytesInLastRow: 1290 widthInBlocks: 645 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 502 */
+  offset: 502,
+  buffer: buffer17,
+}, {
+  texture: texture133,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 645, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline30 = await device0.createComputePipelineAsync({layout: pipelineLayout9, compute: {module: shaderModule3, constants: {}}});
+document.body.append(img3);
+let texture233 = device0.createTexture({
+  size: [1880, 10, 1],
+  mipLevelCount: 2,
+  format: 'astc-8x5-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder116 = commandEncoder127.beginComputePass({});
+try {
+computePassEncoder93.setBindGroup(0, bindGroup39, new Uint32Array(1955), 375, 0);
+} catch {}
+try {
+computePassEncoder115.setPipeline(pipeline27);
+} catch {}
+try {
+globalThis.someLabel = externalTexture4.label;
+} catch {}
+let commandEncoder129 = device0.createCommandEncoder({});
+let texture234 = device0.createTexture({size: [32, 32, 21], sampleCount: 1, format: 'r8sint', usage: GPUTextureUsage.COPY_DST, viewFormats: []});
+let textureView150 = texture32.createView({});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup61);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(67);
+} catch {}
+let computePassEncoder117 = commandEncoder129.beginComputePass({});
+try {
+computePassEncoder26.setBindGroup(3, bindGroup42, new Uint32Array(2268), 794, 0);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(2, bindGroup50, new Uint32Array(1917), 36, 0);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle8, renderBundle10, renderBundle4]);
+} catch {}
+let bindGroup74 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout11,
+  entries: [
+    {binding: 41, resource: textureView8},
+    {binding: 39, resource: {buffer: buffer65, offset: 512, size: 1776}},
+  ],
+});
+let buffer92 = device0.createBuffer({
+  size: 17802,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture235 = device0.createTexture({
+  size: {width: 307, height: 7, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder99.setBindGroup(2, bindGroup49, [3584]);
+} catch {}
+try {
+computePassEncoder117.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(6, buffer43, 20, 94);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+let buffer93 = device0.createBuffer({
+  size: 988,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView151 = texture227.createView({mipLevelCount: 1});
+try {
+renderPassEncoder37.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(0, buffer13, 900);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let commandEncoder130 = device0.createCommandEncoder();
+let computePassEncoder118 = commandEncoder130.beginComputePass();
+try {
+computePassEncoder79.setBindGroup(1, bindGroup70);
+} catch {}
+try {
+computePassEncoder116.setPipeline(pipeline30);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup50, new Uint32Array(817), 154, 0);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder37.setBlendConstant({ r: -824.9, g: -594.5, b: 239.0, a: 622.2, });
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(2, buffer56, 1_524, 214);
+} catch {}
+try {
+renderPassEncoder32.insertDebugMarker('\u0955');
+} catch {}
+let bindGroup75 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout5,
+  entries: [
+    {binding: 323, resource: {buffer: buffer33, offset: 256, size: 972}},
+    {binding: 144, resource: textureView145},
+  ],
+});
+let pipelineLayout16 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder131 = device0.createCommandEncoder();
+let computePassEncoder119 = commandEncoder131.beginComputePass({});
+try {
+computePassEncoder92.setBindGroup(3, bindGroup41);
+} catch {}
+try {
+computePassEncoder96.setBindGroup(2, bindGroup57, new Uint32Array(709), 240, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder40); computePassEncoder40.dispatchWorkgroupsIndirect(buffer62, 776); };
+} catch {}
+try {
+computePassEncoder118.setPipeline(pipeline19);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture150,
+  mipLevel: 0,
+  origin: {x: 270, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(203).fill(156), /* required buffer size: 203 */
+{offset: 203}, {width: 172, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1230, height: 30, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData10,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 340, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder132 = device0.createCommandEncoder({});
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 340});
+let textureView152 = texture223.createView({dimension: '2d-array', baseMipLevel: 0});
+let computePassEncoder120 = commandEncoder132.beginComputePass({});
+let sampler75 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 80.62,
+  lodMaxClamp: 87.75,
+  compare: 'equal',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder75); computePassEncoder75.dispatchWorkgroupsIndirect(buffer83, 980); };
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle6, renderBundle2, renderBundle13, renderBundle6, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(3, buffer86, 2_508);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+let bindGroup76 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout16,
+  entries: [
+    {binding: 73, resource: sampler75},
+    {binding: 34, resource: textureView96},
+    {binding: 133, resource: {buffer: buffer68, offset: 1280}},
+    {binding: 430, resource: sampler12},
+  ],
+});
+let commandEncoder133 = device0.createCommandEncoder({});
+let computePassEncoder121 = commandEncoder133.beginComputePass({});
+let sampler76 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 67.24,
+});
+try {
+computePassEncoder119.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(3, bindGroup5, new Uint32Array(316), 31, 0);
+} catch {}
+try {
+renderPassEncoder32.setIndexBuffer(buffer41, 'uint32', 1_696, 10_694);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline31 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment3',
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {module: shaderModule3, buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw'},
+});
+try {
+globalThis.someLabel = externalTexture4.label;
+} catch {}
+let commandEncoder134 = device0.createCommandEncoder({});
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 169});
+let texture236 = device0.createTexture({
+  size: [80, 90, 69],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView153 = texture204.createView({dimension: '2d', baseArrayLayer: 2});
+let renderPassEncoder41 = commandEncoder134.beginRenderPass({
+  label: '\ubecc\u0f3a\udd1b\ue72d\u683f',
+  colorAttachments: [{
+  view: textureView36,
+  depthSlice: 288,
+  clearValue: { r: 513.3, g: 386.9, b: 713.9, a: -783.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet14,
+});
+try {
+computePassEncoder121.setPipeline(pipeline11);
+} catch {}
+let bindGroup77 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 323, resource: {buffer: buffer47, offset: 512}}, {binding: 144, resource: textureView2}],
+});
+let pipelineLayout17 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout20]});
+let commandEncoder135 = device0.createCommandEncoder({});
+let computePassEncoder122 = commandEncoder135.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder89); computePassEncoder89.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder89); computePassEncoder89.dispatchWorkgroupsIndirect(buffer85, 2_020); };
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer85, 'uint32', 720, 56);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline14);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+await gc();
+let texture237 = device0.createTexture({
+  size: {width: 940, height: 5, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup60);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle4, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer82, 'uint32', 124, 9);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline22);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 322, y: 7, z: 8},
+  aspect: 'all',
+}, new Uint8Array(174_593).fill(154), /* required buffer size: 174_593 */
+{offset: 79, bytesPerRow: 975, rowsPerImage: 59}, {width: 241, height: 2, depthOrArrayLayers: 4});
+} catch {}
+let commandEncoder136 = device0.createCommandEncoder({});
+let computePassEncoder123 = commandEncoder136.beginComputePass({});
+try {
+computePassEncoder47.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder75); computePassEncoder75.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle3, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(1, buffer80, 908, 69);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline32 = device0.createComputePipeline({layout: pipelineLayout9, compute: {module: shaderModule0}});
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 1390});
+let sampler77 = device0.createSampler({addressModeU: 'mirror-repeat', lodMaxClamp: 68.79});
+try {
+computePassEncoder123.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup59, new Uint32Array(4131), 576, 0);
+} catch {}
+try {
+renderPassEncoder30.end();
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline20);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 90, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 17, y: 5 },
+  flipY: false,
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 33, height: 7, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup78 = device0.createBindGroup({layout: autogeneratedBindGroupLayout2, entries: [{binding: 144, resource: textureView145}]});
+let texture238 = device0.createTexture({
+  size: {width: 20, height: 22, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView154 = texture111.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+let computePassEncoder124 = commandEncoder5.beginComputePass({});
+try {
+computePassEncoder124.setPipeline(pipeline23);
+} catch {}
+try {
+device0.queue.submit([commandBuffer10]);
+} catch {}
+let videoFrame20 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'bt709', transfer: 'iec6196624'} });
+let commandEncoder137 = device0.createCommandEncoder();
+let textureView155 = texture148.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder107.setBindGroup(0, bindGroup40, new Uint32Array(1028), 41, 0);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline11);
+} catch {}
+try {
+computePassEncoder120.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup22, new Uint32Array(422), 22, 0);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle6, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder39.setScissorRect(23, 0, 15, 0);
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer45, 120, new Int16Array(19667), 5776, 12);
+} catch {}
+try {
+  await promise9;
+} catch {}
+let buffer94 = device0.createBuffer({size: 8361, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView156 = texture194.createView({aspect: 'all', arrayLayerCount: 15});
+try {
+computePassEncoder86.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+computePassEncoder122.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(7, buffer73);
+} catch {}
+let buffer95 = device0.createBuffer({
+  size: 2704,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder138 = device0.createCommandEncoder({});
+let textureView157 = texture38.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder125 = commandEncoder137.beginComputePass({});
+let sampler78 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.23,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder40.end();
+} catch {}
+try {
+computePassEncoder125.setPipeline(pipeline3);
+} catch {}
+let arrayBuffer21 = buffer26.getMappedRange(144, 0);
+let commandEncoder139 = device0.createCommandEncoder({});
+try {
+renderPassEncoder34.setBindGroup(0, bindGroup30, new Uint32Array(2523), 188, 0);
+} catch {}
+try {
+renderPassEncoder34.draw(39, 0, 372_826_944);
+} catch {}
+try {
+commandEncoder138.copyBufferToBuffer(buffer61, 356, buffer13, 592, 1244);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 984, height: 1, depthOrArrayLayers: 140}
+*/
+{
+  source: img4,
+  origin: { x: 5, y: 0 },
+  flipY: true,
+}, {
+  texture: texture120,
+  mipLevel: 1,
+  origin: {x: 62, y: 0, z: 138},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder140 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder33); computePassEncoder33.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder34.end();
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline10);
+} catch {}
+try {
+commandEncoder139.copyBufferToBuffer(buffer64, 1796, buffer71, 4008, 2352);
+} catch {}
+await gc();
+try {
+computePassEncoder117.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder33); computePassEncoder33.dispatchWorkgroupsIndirect(buffer71, 1_664); };
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(1, bindGroup40, new Uint32Array(4502), 263, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle4, renderBundle4, renderBundle6, renderBundle10, renderBundle6, renderBundle1, renderBundle4, renderBundle12, renderBundle4, renderBundle8]);
+} catch {}
+let commandEncoder141 = device0.createCommandEncoder({});
+let texture239 = device0.createTexture({
+  size: {width: 307, height: 7, depthOrArrayLayers: 1},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView158 = texture181.createView({aspect: 'all'});
+try {
+computePassEncoder116.setBindGroup(0, bindGroup58);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder86); computePassEncoder86.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(85, 0, 63, 0);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer13, 'uint32', 1_692, 82);
+} catch {}
+try {
+renderPassEncoder39.insertDebugMarker('\ua1f3');
+} catch {}
+let bindGroup79 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [{binding: 125, resource: textureView21}, {binding: 166, resource: {buffer: buffer70, offset: 0}}],
+});
+let texture240 = device0.createTexture({
+  size: {width: 3760, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView159 = texture126.createView({format: 'rg16sint', mipLevelCount: 1});
+try {
+computePassEncoder50.setBindGroup(0, bindGroup35, []);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder75); computePassEncoder75.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder86.end();
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup42, new Uint32Array(9875), 833, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let bindGroup80 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [
+    {binding: 323, resource: {buffer: buffer20, offset: 9216, size: 4900}},
+    {binding: 144, resource: textureView2},
+  ],
+});
+let commandBuffer11 = commandEncoder105.finish({});
+let textureView160 = texture171.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder126 = commandEncoder139.beginComputePass({});
+let sampler79 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', magFilter: 'nearest', compare: 'not-equal'});
+try {
+{ clearResourceUsages(device0, computePassEncoder116); computePassEncoder116.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder126.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder38.setBlendConstant({ r: -898.9, g: 756.8, b: -40.63, a: -903.6, });
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer2, 'uint16', 586, 34);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder141.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 25339 */
+  offset: 250,
+  bytesPerRow: 3584,
+  buffer: buffer21,
+}, {
+  texture: texture157,
+  mipLevel: 0,
+  origin: {x: 9, y: 5, z: 3},
+  aspect: 'all',
+}, {width: 1, height: 8, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder141.resolveQuerySet(querySet13, 13, 122, buffer32, 9216);
+} catch {}
+try {
+commandEncoder138.insertDebugMarker('\u0c57');
+} catch {}
+let bindGroup81 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout8,
+  entries: [
+    {binding: 323, resource: {buffer: buffer68, offset: 1280, size: 5740}},
+    {binding: 144, resource: textureView97},
+  ],
+});
+let buffer96 = device0.createBuffer({
+  size: 1724,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder142 = device0.createCommandEncoder();
+let computePassEncoder127 = commandEncoder142.beginComputePass({});
+try {
+computePassEncoder66.setPipeline(pipeline18);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise10;
+} catch {}
+let commandEncoder143 = device0.createCommandEncoder({});
+let computePassEncoder128 = commandEncoder51.beginComputePass({});
+try {
+renderPassEncoder14.setIndexBuffer(buffer52, 'uint16', 364, 188);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(1, buffer86, 0, 3_272);
+} catch {}
+let arrayBuffer22 = buffer28.getMappedRange(3976, 0);
+try {
+commandEncoder99.resolveQuerySet(querySet18, 164, 12, buffer53, 0);
+} catch {}
+let texture241 = gpuCanvasContext1.getCurrentTexture();
+let computePassEncoder129 = commandEncoder141.beginComputePass();
+try {
+computePassEncoder97.setBindGroup(1, bindGroup48);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder89); computePassEncoder89.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup52);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle5, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer85, 'uint32', 640, 561);
+} catch {}
+try {
+commandEncoder99.copyBufferToTexture({
+  /* bytesInLastRow: 10 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 488 */
+  offset: 488,
+  bytesPerRow: 8960,
+  rowsPerImage: 1468,
+  buffer: buffer78,
+}, {
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 2, y: 12, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 14, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup82 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [
+    {binding: 144, resource: textureView97},
+    {binding: 323, resource: {buffer: buffer95, offset: 512, size: 876}},
+  ],
+});
+let commandEncoder144 = device0.createCommandEncoder({});
+let texture242 = device0.createTexture({
+  label: '\uf5c1\u0eae',
+  size: {width: 307},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView161 = texture177.createView({});
+let computePassEncoder130 = commandEncoder143.beginComputePass({});
+let sampler80 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 42.22,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder127.setPipeline(pipeline30);
+} catch {}
+try {
+commandEncoder144.copyTextureToTexture({
+  texture: texture166,
+  mipLevel: 0,
+  origin: {x: 7, y: 12, z: 12},
+  aspect: 'all',
+},
+{
+  texture: texture145,
+  mipLevel: 0,
+  origin: {x: 963, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView162 = texture81.createView({dimension: 'cube-array', baseMipLevel: 0, baseArrayLayer: 1, arrayLayerCount: 6});
+let computePassEncoder131 = commandEncoder140.beginComputePass({label: '\u0c35\ucd53\ucf51\u{1fdc7}\u0659\u1a22'});
+try {
+commandEncoder144.copyTextureToTexture({
+  texture: texture194,
+  mipLevel: 0,
+  origin: {x: 70, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 6, y: 11, z: 0},
+  aspect: 'all',
+},
+{width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 90, depthOrArrayLayers: 1}
+*/
+{
+  source: img5,
+  origin: { x: 6, y: 0 },
+  flipY: true,
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 20, y: 26, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout21 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 34,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 73, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+    {
+      binding: 133,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: true },
+    },
+    {
+      binding: 430,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let computePassEncoder132 = commandEncoder99.beginComputePass({});
+try {
+computePassEncoder127.setBindGroup(2, bindGroup27, new Uint32Array(3991), 641, 0);
+} catch {}
+try {
+computePassEncoder89.end();
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(5, buffer74, 0);
+} catch {}
+try {
+commandEncoder102.copyBufferToTexture({
+  /* bytesInLastRow: 64 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 20 */
+  offset: 20,
+  bytesPerRow: 256,
+  buffer: buffer64,
+}, {
+  texture: texture153,
+  mipLevel: 0,
+  origin: {x: 5, y: 33, z: 1},
+  aspect: 'all',
+}, {width: 16, height: 15, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+let texture243 = device0.createTexture({
+  size: {width: 1968, height: 1, depthOrArrayLayers: 63},
+  mipLevelCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup55, new Uint32Array(1372), 425, 0);
+} catch {}
+try {
+computePassEncoder132.setPipeline(pipeline23);
+} catch {}
+try {
+commandEncoder102.copyBufferToTexture({
+  /* bytesInLastRow: 160 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 160 */
+  offset: 160,
+  bytesPerRow: 70656,
+  buffer: buffer71,
+}, {
+  texture: texture233,
+  mipLevel: 1,
+  origin: {x: 168, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 80, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img1);
+let commandBuffer12 = commandEncoder102.finish();
+let texture244 = device0.createTexture({
+  size: [1968, 1, 746],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder133 = commandEncoder138.beginComputePass();
+try {
+computePassEncoder120.setBindGroup(3, bindGroup67, new Uint32Array(2085), 197, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder75); computePassEncoder75.dispatchWorkgroupsIndirect(buffer32, 1_200); };
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(6, buffer73, 176);
+} catch {}
+try {
+commandEncoder144.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 6412 */
+  offset: 6412,
+  rowsPerImage: 1402,
+  buffer: buffer32,
+}, {
+  texture: texture39,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder134 = commandEncoder144.beginComputePass();
+try {
+computePassEncoder125.setBindGroup(0, bindGroup57, new Uint32Array(1350), 118, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup12, new Uint32Array(871), 240, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+document.body.prepend(img3);
+let buffer97 = device0.createBuffer({size: 10716, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let commandEncoder145 = device0.createCommandEncoder({});
+let textureView163 = texture206.createView({mipLevelCount: 1});
+let texture245 = device0.createTexture({
+  label: '\u0298\u2609\u82de\uc3ca\u437d\ub76e',
+  size: [470],
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder42 = commandEncoder145.beginRenderPass({
+  colorAttachments: [{view: textureView93, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 32821574,
+});
+let sampler81 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.52,
+  lodMaxClamp: 53.32,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+computePassEncoder107.setBindGroup(2, bindGroup16, new Uint32Array(3750), 905, 0);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(2, bindGroup40);
+} catch {}
+try {
+renderPassEncoder27.setViewport(35.86780413991016, 0.48667952937090464, 46.79085458745626, 0.03390787672240354, 0.7653656853802696, 0.9273250006151104);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer52, 'uint16', 318, 162);
+} catch {}
+try {
+buffer69.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer63, 2264, new Float32Array(3907), 1442, 172);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55); };
+} catch {}
+await gc();
+let videoFrame21 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'smpte240m', transfer: 'linear'} });
+try {
+computePassEncoder53.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+computePassEncoder58.setBindGroup(0, bindGroup49, new Uint32Array(972), 21, 1);
+} catch {}
+try {
+computePassEncoder130.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup69);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 45, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame20,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 0, y: 32, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas2.width = 254;
+let commandEncoder146 = device0.createCommandEncoder({});
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup64, [256]);
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(4, buffer96, 0);
+} catch {}
+try {
+commandEncoder146.copyBufferToTexture({
+  /* bytesInLastRow: 10112 widthInBlocks: 632 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 608 */
+  offset: 608,
+  rowsPerImage: 120,
+  buffer: buffer57,
+}, {
+  texture: texture118,
+  mipLevel: 0,
+  origin: {x: 296, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 632, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder146.copyTextureToTexture({
+  texture: texture201,
+  mipLevel: 1,
+  origin: {x: 97, y: 4, z: 6},
+  aspect: 'all',
+},
+{
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 354, y: 0, z: 136},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 24});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture131,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(508).fill(118), /* required buffer size: 508 */
+{offset: 508, rowsPerImage: 10}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView164 = texture111.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+let textureView165 = texture50.createView({aspect: 'all', arrayLayerCount: 1});
+let computePassEncoder135 = commandEncoder146.beginComputePass({});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+computePassEncoder128.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer83, 'uint16', 1_232, 6_332);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline14);
+} catch {}
+let adapter1 = await navigator.gpu.requestAdapter({});
+let recycledExplicitBindGroupLayout10 = pipeline18.getBindGroupLayout(0);
+let commandEncoder147 = device0.createCommandEncoder();
+let computePassEncoder136 = commandEncoder147.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder125); computePassEncoder125.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder131.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle0, renderBundle11, renderBundle12, renderBundle1, renderBundle3, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(653);
+} catch {}
+let buffer98 = device0.createBuffer({size: 32033, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE});
+let texture246 = device0.createTexture({
+  size: [20, 22, 17],
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView166 = texture172.createView({});
+try {
+computePassEncoder119.setBindGroup(1, bindGroup80);
+} catch {}
+try {
+computePassEncoder99.setBindGroup(0, bindGroup43, new Uint32Array(5513), 749, 0);
+} catch {}
+try {
+computePassEncoder33.end();
+} catch {}
+try {
+computePassEncoder92.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder29.setIndexBuffer(buffer14, 'uint16', 46, 2_098);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(1, buffer56);
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder41.resolveQuerySet(querySet2, 0, 4, buffer84, 0);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 90});
+let textureView167 = texture15.createView({});
+try {
+computePassEncoder61.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer8, 'uint32', 388, 325);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer42, 0);
+} catch {}
+try {
+commandEncoder41.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 128 */
+  offset: 128,
+  rowsPerImage: 11,
+  buffer: buffer77,
+}, {
+  texture: texture111,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture208,
+  mipLevel: 0,
+  origin: {x: 494, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(58).fill(144), /* required buffer size: 58 */
+{offset: 58}, {width: 68, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 90, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture128,
+  mipLevel: 0,
+  origin: {x: 7, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img5);
+let shaderModule8 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+/* zero global variables used */
+fn fn0() -> array<mat2x3f, 1> {
+  var out: array<mat2x3f, 1>;
+  var vf187: f32 = distance(vec4f(unconst_f32(0.1426), unconst_f32(0.2141), unconst_f32(-0.5179), unconst_f32(0.01555)), vec4f(unconst_f32(0.2508), unconst_f32(0.02161), unconst_f32(0.6303), unconst_f32(0.02479)));
+  out[unconst_u32(41)] += mat2x3f(vec3f(acosh(vec4h(unconst_f16(1199.5), unconst_f16(1185.4), unconst_f16(7777.7), unconst_f16(4120.0))).xwy), vec3f(acosh(vec4h(unconst_f16(1199.5), unconst_f16(1185.4), unconst_f16(7777.7), unconst_f16(4120.0))).xzy));
+  let vf188: vec2h = fma(vec2h(unconst_f16(1508.1), unconst_f16(9742.6)), vec2h(unconst_f16(7866.9), unconst_f16(20435.3)), vec2h(unconst_f16(12304.4), unconst_f16(28123.8)));
+  switch bitcast<i32>(min(vec2h(unconst_f16(9183.8), unconst_f16(10926.1)), vec2h(unconst_f16(5930.3), unconst_f16(7019.8)))) { 
+  default {
+  var vf189: bool = all(vec3<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(true)));
+  let vf190: f16 = length(vec4h(unconst_f16(25.27), unconst_f16(6248.2), unconst_f16(358.7), unconst_f16(18122.3)));
+  break;
+}
+  }
+  let vf191: vec2f = ldexp(vec2f(unconst_f32(0.2186), unconst_f32(0.09342)), vec2i(unconst_i32(50), unconst_i32(14)));
+  vf187 += vec2f((vec2i(unconst_i32(99), unconst_i32(2)) < vec2i(unconst_i32(4), unconst_i32(466)))).g;
+  var vf192: vec2h = (unconst_f16(4919.0) - vec2h(unconst_f16(11149.0), unconst_f16(20827.1)));
+  out[unconst_u32(25)] += mat2x3f(vec3f((unconst_f16(1857.1) - vec2h(unconst_f16(10329.9), unconst_f16(-6715.1))).yyx), vec3f((unconst_f16(1857.1) - vec2h(unconst_f16(10329.9), unconst_f16(-6715.1))).xxx));
+  let vf193: vec2h = (unconst_f16(7091.0) - vec2h(unconst_f16(8809.4), unconst_f16(16966.0)));
+  vf192 = vec2h(inverseSqrt(vec4f(unconst_f32(-0.5249), unconst_f32(0.2988), unconst_f32(0.2150), unconst_f32(0.02225))).ga);
+  out[0] = mat2x3f(vec3f(mix(vec4h(unconst_f16(15335.9), unconst_f16(2558.0), unconst_f16(1855.0), unconst_f16(9500.9)), vf188.grgr, unconst_f16(16979.5)).zzw), vec3f(mix(vec4h(unconst_f16(15335.9), unconst_f16(2558.0), unconst_f16(1855.0), unconst_f16(9500.9)), vf188.grgr, unconst_f16(16979.5)).bgb));
+  let ptr67: ptr<function, f32> = &vf187;
+  let vf194: vec4h = acosh(vec4h(unconst_f16(11699.7), unconst_f16(9217.7), unconst_f16(23200.0), unconst_f16(-18276.2)));
+  var vf195: vec2f = exp2(vec2f(unconst_f32(0.09077), unconst_f32(0.02163)));
+  let ptr68: ptr<function, vec2h> = &vf192;
+  return out;
+}
+
+var<workgroup> vw33: mat2x4h;
+
+@group(0) @binding(323) var<storage, read> buffer99: array<array<mat2x4f, 27>, 1>;
+
+struct T0 {
+  @align(8) @size(104) f0: array<u32>,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw37: atomic<i32>;
+
+var<workgroup> vw39: atomic<i32>;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct VertexOutput7 {
+  @location(1) f8: vec4f,
+  @location(13) @interpolate(flat, centroid) f9: vec4i,
+  @location(10) f10: f32,
+  @location(5) f11: i32,
+  @invariant @builtin(position) f12: vec4f,
+  @location(9) @interpolate(flat, first) f13: vec2i,
+  @location(6) @interpolate(flat, either) f14: vec4i,
+}
+
+var<workgroup> vw32: atomic<u32>;
+
+var<workgroup> vw35: u32;
+
+struct T1 {
+  @size(8) f0: array<atomic<i32>>,
+}
+
+var<workgroup> vw36: mat3x4f;
+
+struct S5 {
+  @builtin(vertex_index) f0: u32,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw34: VertexOutput7;
+
+var<workgroup> vw38: array<atomic<u32>, 1>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+/* used global variables: buffer99 */
+@vertex
+fn vertex8(a0: S5, @location(4) @interpolate(linear, center) a1: vec4f, @location(13) a2: vec2h) -> VertexOutput7 {
+  var out: VertexOutput7;
+  out.f14 = bitcast<vec4i>((*&buffer99)[pack4xI8Clamp((vec4i(unconst_i32(169), unconst_i32(2), unconst_i32(92), unconst_i32(218)) & vec4i(unconst_i32(24), unconst_i32(-4), unconst_i32(22), unconst_i32(68))))][bitcast<u32>(fma(vec2h(unconst_f16(7545.9), unconst_f16(5154.9)), vec2h(insertBits(vec4i(unconst_i32(25), unconst_i32(20), unconst_i32(301), unconst_i32(193)), vec4i(unconst_i32(30), unconst_i32(74), unconst_i32(118), unconst_i32(193)), unconst_u32(185), unconst_u32(39)).bb), vec2h(unconst_f16(8610.0), unconst_f16(12327.2))))][unconst_i32(0)]);
+  var vf196 = fn0();
+  fn0();
+  if (unconst_f16(6229.6) == unconst_f16(1003.3)) {
+  var vf197 = fn0();
+  fn0();
+  fn0();
+  out.f9 &= bitcast<vec4i>(buffer99[0][26][unconst_i32(0)]);
+  out.f10 *= log2(vec2f(unconst_f32(0.01979), unconst_f32(0.2767))).x;
+  fn0();
+  let vf198: vec4f = buffer99[0][unconst_u32(60)][unconst_u32(17)];
+  _ = buffer99;
+}
+  out.f14 = vec4i(i32(vf196[0][unconst_u32(1)][unconst_u32(523)]));
+  if bool(buffer99[unconst_u32(87)][26][vec4u((*&buffer99)[0][26][unconst_i32(0)]).b][unconst_u32(101)]) {
+  var vf199 = fn0();
+  out.f12 += vf199[0][unconst_u32(219)].xzzy;
+  let ptr69: ptr<storage, array<mat2x4f, 27>, read> = &buffer99[pack4x8unorm((*&buffer99)[0][26][unconst_i32(0)])];
+  fn0();
+  let ptr70: ptr<storage, array<mat2x4f, 27>, read> = &buffer99[u32(buffer99[0][unconst_u32(175)][unconst_u32(102)][unconst_u32(76)])];
+  return out;
+  _ = buffer99;
+}
+  vf196[unconst_u32(24)] = mat2x3f((*&buffer99)[0][26][unconst_i32(0)].aaa, (*&buffer99)[0][26][unconst_i32(0)].xwx);
+  out.f14 = bitcast<vec4i>(a1);
+  var vf200: vec2h = tan(vec2h(unconst_f16(8112.9), unconst_f16(12942.1)));
+  for (var it7=u32(refract(vec4f(unconst_f32(0.05019), unconst_f32(0.03637), unconst_f32(0.4191), unconst_f32(0.2650)), vec4f(unconst_f32(0.09097), unconst_f32(0.1405), unconst_f32(-0.04434), unconst_f32(0.02508)), unconst_f32(0.02851)).z); it7<u32(vf196[0][unconst_i32(0)][1]); it7++) {
+  fn0();
+  var vf201 = fn0();
+}
+  out.f8 = vec4f(pow(vec2h(buffer99[0][26][unconst_i32(0)].ba), vec2h(unconst_f16(6381.7), unconst_f16(3251.8))).rrgr);
+  fn0();
+  fn0();
+  let vf202: vec4f = (*&buffer99)[unconst_u32(12)][26][unconst_u32(64)];
+  return out;
+  _ = buffer99;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 1, 1)
+fn compute9() {
+  fn0();
+  let vf203: u32 = atomicExchange(&(*&vw38)[0], unconst_u32(44));
+  let ptr71: ptr<workgroup, vec4i> = &vw34.f9;
+}`,
+});
+let texture247 = device0.createTexture({
+  label: '\ucef3\u0890\u{1ff65}\u076c',
+  size: [40, 45, 4],
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder137 = commandEncoder41.beginComputePass({});
+try {
+computePassEncoder117.setBindGroup(1, bindGroup51, new Uint32Array(1008), 81, 0);
+} catch {}
+try {
+computePassEncoder135.setPipeline(pipeline30);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle13, renderBundle2, renderBundle10, renderBundle11, renderBundle4]);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+adapter1.label = '\u0c59\ua64b\u0b57';
+} catch {}
+let bindGroup83 = device0.createBindGroup({
+  label: '\u9feb\u002f\u8fe3\uad9d\u0bba',
+  layout: veryExplicitBindGroupLayout11,
+  entries: [{binding: 41, resource: textureView28}, {binding: 39, resource: {buffer: buffer66, offset: 1536}}],
+});
+let texture248 = device0.createTexture({
+  size: {width: 20, height: 22, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler82 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', minFilter: 'linear', lodMaxClamp: 95.17});
+try {
+computePassEncoder83.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(3, bindGroup60, new Uint32Array(840), 61, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture234,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 6},
+  aspect: 'all',
+}, new Uint8Array(2_341).fill(166), /* required buffer size: 2_341 */
+{offset: 229, bytesPerRow: 162}, {width: 6, height: 14, depthOrArrayLayers: 1});
+} catch {}
+let promise12 = adapter1.requestDevice({
+  defaultQueue: {},
+  requiredLimits: {maxUniformBufferBindingSize: 21932530, maxStorageBufferBindingSize: 140703806},
+});
+let imageData19 = new ImageData(4, 4);
+let buffer100 = device0.createBuffer({
+  size: 9801,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup19, new Uint32Array(1472), 294, 0);
+} catch {}
+try {
+computePassEncoder134.setPipeline(pipeline30);
+} catch {}
+try {
+renderPassEncoder35.setBlendConstant({ r: 370.0, g: 698.5, b: 104.6, a: 960.2, });
+} catch {}
+try {
+renderPassEncoder26.setStencilReference(55);
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline28);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let recycledExplicitBindGroupLayout11 = pipeline9.getBindGroupLayout(0);
+try {
+computePassEncoder52.setBindGroup(1, bindGroup43);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(0, bindGroup71, new Uint32Array(21), 0, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder99); computePassEncoder99.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder22.drawIndirect(buffer85, 340);
+} catch {}
+try {
+renderPassEncoder32.setPipeline(pipeline5);
+} catch {}
+let bindGroup84 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 68, resource: {buffer: buffer37, offset: 256, size: 2392}},
+    {binding: 45, resource: {buffer: buffer16, offset: 0, size: 505}},
+    {binding: 97, resource: externalTexture5},
+    {binding: 64, resource: {buffer: buffer87, offset: 0, size: 192}},
+  ],
+});
+let textureView168 = texture2.createView({mipLevelCount: 1, arrayLayerCount: 1});
+try {
+computePassEncoder53.setBindGroup(3, bindGroup73);
+} catch {}
+try {
+computePassEncoder133.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder22.end();
+} catch {}
+try {
+commandEncoder73.copyBufferToTexture({
+  /* bytesInLastRow: 22 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 152 */
+  offset: 152,
+  bytesPerRow: 1792,
+  buffer: buffer61,
+}, {
+  texture: texture210,
+  mipLevel: 3,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder73.copyTextureToBuffer({
+  texture: texture128,
+  mipLevel: 0,
+  origin: {x: 13, y: 29, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 10 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 708 */
+  offset: 708,
+  bytesPerRow: 8704,
+  rowsPerImage: 514,
+  buffer: buffer16,
+}, {width: 5, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder73.copyTextureToTexture({
+  texture: texture199,
+  mipLevel: 0,
+  origin: {x: 225, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture173,
+  mipLevel: 0,
+  origin: {x: 773, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 4, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture164,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+}, new Uint8Array(56_547).fill(216), /* required buffer size: 56_547 */
+{offset: 3, bytesPerRow: 62, rowsPerImage: 57}, {width: 30, height: 0, depthOrArrayLayers: 17});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 45, depthOrArrayLayers: 3}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 4 },
+  flipY: true,
+}, {
+  texture: texture153,
+  mipLevel: 1,
+  origin: {x: 16, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 7, height: 14, depthOrArrayLayers: 0});
+} catch {}
+let buffer101 = device0.createBuffer({size: 5336, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let computePassEncoder138 = commandEncoder73.beginComputePass();
+let sampler83 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder44.setBindGroup(1, bindGroup71, new Uint32Array(2884), 1_007, 0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline21);
+} catch {}
+try {
+  await promise11;
+} catch {}
+let commandEncoder148 = device0.createCommandEncoder({});
+let texture249 = device0.createTexture({size: {width: 153}, dimension: '1d', format: 'rg32uint', usage: GPUTextureUsage.COPY_SRC});
+let textureView169 = texture88.createView({baseArrayLayer: 1, arrayLayerCount: 2});
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup21, new Uint32Array(112), 1, 0);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer56, 'uint16', 832, 449);
+} catch {}
+try {
+  await shaderModule8.getCompilationInfo();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55); };
+} catch {}
+let buffer102 = device0.createBuffer({
+  size: 15553,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder149 = device0.createCommandEncoder({});
+let computePassEncoder139 = commandEncoder148.beginComputePass({});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame6});
+try {
+{ clearResourceUsages(device0, computePassEncoder99); computePassEncoder99.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(2, buffer1, 0, 1_799);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 90, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData10,
+  origin: { x: 8, y: 1 },
+  flipY: false,
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 15, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 5, height: 4, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap1 = await createImageBitmap(videoFrame11);
+let computePassEncoder140 = commandEncoder149.beginComputePass({});
+try {
+computePassEncoder105.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer56, 'uint16', 124, 536);
+} catch {}
+await gc();
+let sampler84 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 94.63,
+  compare: 'always',
+});
+try {
+computePassEncoder140.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup42, new Uint32Array(2503), 84, 0);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle10]);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline26);
+} catch {}
+let canvas0 = document.createElement('canvas');
+let sampler85 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.29,
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup58);
+} catch {}
+try {
+computePassEncoder129.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([renderBundle1, renderBundle6, renderBundle11, renderBundle1, renderBundle4]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer69, 92, new Float32Array(1329), 148, 28);
+} catch {}
+let pipeline33 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule8, entryPoint: 'compute9', constants: {}}});
+try {
+computePassEncoder56.setBindGroup(1, bindGroup45, new Uint32Array(1188), 449, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup79);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer52, 'uint16', 58, 0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer12, commandBuffer11]);
+} catch {}
+let bindGroup85 = device0.createBindGroup({layout: veryExplicitBindGroupLayout17, entries: [{binding: 21, resource: textureView57}]});
+let texture250 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 666},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup56, new Uint32Array(79), 3, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder52); computePassEncoder52.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder137.setPipeline(pipeline33);
+} catch {}
+try {
+renderPassEncoder14.setViewport(178.16121554089094, 0.38851293122108743, 59.803231844452434, 0.3250737418924507, 0.765936257503689, 0.8122943214842925);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline12);
+} catch {}
+let commandEncoder150 = device0.createCommandEncoder();
+try {
+computePassEncoder136.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+computePassEncoder133.setBindGroup(0, bindGroup25, new Uint32Array(3013), 836, 0);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline17);
+} catch {}
+try {
+computePassEncoder50.setBindGroup(0, bindGroup19, new Uint32Array(542), 47, 0);
+} catch {}
+try {
+computePassEncoder139.setPipeline(pipeline32);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup81);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup81, new Uint32Array(315), 39, 0);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer62, 'uint32', 952, 1_249);
+} catch {}
+try {
+commandEncoder150.copyBufferToBuffer(buffer84, 10872, buffer37, 1344, 2952);
+} catch {}
+try {
+commandEncoder150.copyBufferToTexture({
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 428 */
+  offset: 428,
+  bytesPerRow: 19200,
+  buffer: buffer35,
+}, {
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 145, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer100, 860, new Float32Array(3360), 344, 524);
+} catch {}
+let buffer103 = device0.createBuffer({
+  size: 5635,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let textureView170 = texture238.createView({});
+let computePassEncoder141 = commandEncoder150.beginComputePass({});
+let sampler86 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 99.40,
+  lodMaxClamp: 99.85,
+});
+try {
+computePassEncoder81.setBindGroup(1, bindGroup71, new Uint32Array(6197), 397, 0);
+} catch {}
+try {
+computePassEncoder99.end();
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(1, bindGroup35);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(24);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer79, 1_204, 516);
+} catch {}
+document.body.prepend(img0);
+try {
+adapter1.label = '\u0905\u35e9\u9a5d\u8a56';
+} catch {}
+let buffer104 = device0.createBuffer({
+  size: 28589,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder151 = device0.createCommandEncoder();
+let texture251 = device0.createTexture({
+  size: [1968, 1, 220],
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder7.setBindGroup(2, bindGroup72, new Uint32Array(828), 39, 0);
+} catch {}
+document.body.prepend(img4);
+let bindGroup86 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout4,
+  entries: [
+    {binding: 323, resource: {buffer: buffer19, offset: 0, size: 2792}},
+    {binding: 144, resource: textureView5},
+  ],
+});
+let computePassEncoder142 = commandEncoder151.beginComputePass({});
+try {
+computePassEncoder138.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup11, new Uint32Array(1335), 41, 0);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer38, 'uint32', 0, 87);
+} catch {}
+try {
+commandEncoder113.copyBufferToBuffer(buffer15, 192, buffer24, 60, 0);
+} catch {}
+try {
+commandEncoder113.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 940 */
+  offset: 940,
+  buffer: buffer33,
+}, {
+  texture: texture102,
+  mipLevel: 0,
+  origin: {x: 51, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 600, new BigUint64Array(2539), 5, 52);
+} catch {}
+let commandEncoder152 = device0.createCommandEncoder();
+let computePassEncoder143 = commandEncoder152.beginComputePass({});
+let sampler87 = device0.createSampler({magFilter: 'linear', minFilter: 'linear', mipmapFilter: 'linear', lodMaxClamp: 92.50});
+try {
+computePassEncoder136.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer14, 'uint32', 5_564, 3_646);
+} catch {}
+let commandEncoder153 = device0.createCommandEncoder({});
+let texture252 = device0.createTexture({
+  size: {width: 615, height: 15, depthOrArrayLayers: 17},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder43 = commandEncoder113.beginRenderPass({
+  colorAttachments: [{
+  view: textureView93,
+  clearValue: { r: 784.4, g: 289.6, b: -570.1, a: 467.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet17,
+  maxDrawCount: 35322159,
+});
+try {
+computePassEncoder125.end();
+} catch {}
+try {
+computePassEncoder143.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(1, buffer22);
+} catch {}
+try {
+buffer101.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture210,
+  mipLevel: 2,
+  origin: {x: 157, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(20).fill(114), /* required buffer size: 20 */
+{offset: 20}, {width: 70, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext3 = canvas0.getContext('webgpu');
+let buffer105 = device0.createBuffer({
+  size: 14329,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder154 = device0.createCommandEncoder({});
+let texture253 = device0.createTexture({
+  size: {width: 10, height: 11, depthOrArrayLayers: 134},
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder44.setBindGroup(0, bindGroup75);
+} catch {}
+try {
+computePassEncoder94.setBindGroup(0, bindGroup71, new Uint32Array(2168), 2_168, 0);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(2, buffer2);
+} catch {}
+canvas0.height = 173;
+let commandEncoder155 = device0.createCommandEncoder();
+let computePassEncoder144 = commandEncoder154.beginComputePass({});
+try {
+computePassEncoder85.setBindGroup(0, bindGroup8, new Uint32Array(49), 5, 0);
+} catch {}
+try {
+computePassEncoder75.end();
+} catch {}
+try {
+computePassEncoder141.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup78, []);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline15);
+} catch {}
+let arrayBuffer23 = buffer26.getMappedRange(168, 8);
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let bindGroup87 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 97, resource: externalTexture3},
+    {binding: 45, resource: {buffer: buffer43, offset: 0, size: 182}},
+    {binding: 68, resource: {buffer: buffer60, offset: 1536, size: 1044}},
+    {binding: 64, resource: {buffer: buffer60, offset: 1536, size: 268}},
+  ],
+});
+let buffer106 = device0.createBuffer({
+  size: 16135,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let texture254 = device0.createTexture({
+  size: {width: 1230, height: 30, depthOrArrayLayers: 3},
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder145 = commandEncoder155.beginComputePass({});
+try {
+computePassEncoder144.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup82, []);
+} catch {}
+try {
+renderPassEncoder32.beginOcclusionQuery(96);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(916, 1, 135, 2_147_483_647);
+} catch {}
+try {
+renderPassEncoder32.drawIndexedIndirect(buffer69, 16);
+} catch {}
+try {
+renderPassEncoder26.setVertexBuffer(3, buffer79, 0, 324);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1968, height: 1, depthOrArrayLayers: 746}
+*/
+{
+  source: imageData16,
+  origin: { x: 14, y: 2 },
+  flipY: false,
+}, {
+  texture: texture244,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline34 = device0.createRenderPipeline({
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment7',
+  targets: [{format: 'r8uint'}, {format: 'r8sint', writeMask: 0}],
+},
+  vertex: {module: shaderModule7, buffers: []},
+  primitive: {topology: 'line-list', cullMode: 'front', unclippedDepth: false},
+});
+let buffer107 = device0.createBuffer({
+  size: 25136,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder156 = device0.createCommandEncoder({});
+let commandBuffer13 = commandEncoder137.finish({});
+try {
+computePassEncoder142.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder32.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.submit([commandBuffer13]);
+} catch {}
+let bindGroup88 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 64, resource: {buffer: buffer47, offset: 8192}},
+    {binding: 97, resource: externalTexture4},
+    {binding: 45, resource: {buffer: buffer8, offset: 0}},
+    {binding: 68, resource: {buffer: buffer75, offset: 0, size: 568}},
+  ],
+});
+let buffer108 = device0.createBuffer({
+  label: '\u{1f872}\ufad4\u1a32\u2467\u80db\u2275\u{1fe0e}',
+  size: 1765,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX,
+});
+let commandEncoder157 = device0.createCommandEncoder({});
+let textureView171 = texture193.createView({arrayLayerCount: 1});
+let computePassEncoder146 = commandEncoder157.beginComputePass({});
+try {
+computePassEncoder145.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder32.drawIndexedIndirect(buffer21, 268);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(2, buffer74);
+} catch {}
+let arrayBuffer24 = buffer72.getMappedRange(224, 288);
+try {
+commandEncoder36.insertDebugMarker('\u{1f685}');
+} catch {}
+await gc();
+let commandBuffer14 = commandEncoder36.finish();
+let sampler88 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 92.18,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder46); computePassEncoder46.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(132, 506, 23, 315_026_510, 484_159_141);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer62, 952, new Float32Array(2201), 251, 204);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55); };
+} catch {}
+let bindGroup89 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [
+    {binding: 144, resource: textureView2},
+    {binding: 323, resource: {buffer: buffer104, offset: 6912, size: 2124}},
+  ],
+});
+let computePassEncoder147 = commandEncoder156.beginComputePass({});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder50); computePassEncoder50.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder146.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder32.draw(40, 0, 857_937_993);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(0, 1, 467, 114_040_420, 0);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup54);
+} catch {}
+let pipeline35 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule8, entryPoint: 'compute9'}});
+let textureView172 = texture57.createView({});
+let renderBundle16 = renderBundleEncoder16.finish({});
+try {
+computePassEncoder134.setBindGroup(2, bindGroup34);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder44); computePassEncoder44.dispatchWorkgroups(4); };
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup89, new Uint32Array(63), 7, 0);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(192);
+} catch {}
+try {
+renderPassEncoder32.draw(360, 0, 54_253_529);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer12, 9_784);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline31);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 265, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(316).fill(216), /* required buffer size: 316 */
+{offset: 316}, {width: 45, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 90, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData8,
+  origin: { x: 7, y: 1 },
+  flipY: false,
+}, {
+  texture: texture128,
+  mipLevel: 0,
+  origin: {x: 32, y: 13, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder158 = device0.createCommandEncoder({});
+let textureView173 = texture35.createView({});
+let renderPassEncoder44 = commandEncoder153.beginRenderPass({
+  colorAttachments: [{
+  view: textureView55,
+  clearValue: { r: 643.7, g: -393.4, b: -34.12, a: 262.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder116); computePassEncoder116.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder12.draw(309, 10, 994_146_366, 2_268_513_823);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder158.copyBufferToTexture({
+  /* bytesInLastRow: 486 widthInBlocks: 243 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3280 */
+  offset: 3280,
+  bytesPerRow: 12800,
+  buffer: buffer65,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 243, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder158.insertDebugMarker('\u7b3a');
+} catch {}
+let bindGroup90 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [
+    {binding: 39, resource: {buffer: buffer20, offset: 256, size: 3100}},
+    {binding: 41, resource: textureView8},
+  ],
+});
+let buffer109 = device0.createBuffer({size: 26749, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder159 = device0.createCommandEncoder({});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup69, new Uint32Array(611), 250, 0);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(87);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(12, 0, 180, 451_990_484);
+} catch {}
+try {
+renderPassEncoder32.drawIndirect(buffer21, 3_356);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer2, 'uint16', 212, 91);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(3, undefined, 0, 173_226_635);
+} catch {}
+try {
+commandEncoder159.copyTextureToTexture({
+  texture: texture166,
+  mipLevel: 0,
+  origin: {x: 2, y: 11, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout12 = pipeline20.getBindGroupLayout(0);
+let buffer110 = device0.createBuffer({size: 2608, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let renderPassEncoder45 = commandEncoder158.beginRenderPass({
+  colorAttachments: [{
+  view: textureView101,
+  clearValue: { r: -418.2, g: 612.6, b: 488.0, a: -784.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder50); computePassEncoder50.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder12.draw(374, 270, 214_886_257, 882_002_545);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(265, 0, 105, 373_096_869);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer1, 1_328);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(5, buffer2, 208, 114);
+} catch {}
+let pipeline36 = await device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule1, constants: {}}});
+let textureView174 = texture123.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder148 = commandEncoder159.beginComputePass({});
+try {
+computePassEncoder104.setBindGroup(0, bindGroup75, new Uint32Array(728), 19, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder137); computePassEncoder137.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder147.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder45.executeBundles([renderBundle4, renderBundle4, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder32.draw(35, 0, 410_554_684);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer19, 'uint16', 4_066, 510);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(4, buffer42, 0, 1_427);
+} catch {}
+try {
+pipeline29.label = '\u3b85\ue3f9\ub3f8';
+} catch {}
+try {
+computePassEncoder148.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder38.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder12.draw(30, 53, 1_258_039_412, 121_431_764);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(627, 0, 367, 333_211_435);
+} catch {}
+try {
+renderPassEncoder32.drawIndexedIndirect(buffer51, 56);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(1, buffer93, 24, 115);
+} catch {}
+document.body.prepend(canvas0);
+let textureView175 = texture125.createView({mipLevelCount: 1});
+let sampler89 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder37.executeBundles([renderBundle6, renderBundle12, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder12.draw(8, 146, 33_748_607, 311_722_382);
+} catch {}
+try {
+renderPassEncoder12.drawIndirect(buffer83, 564);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline28);
+} catch {}
+let imageData20 = new ImageData(32, 12);
+let commandEncoder160 = device0.createCommandEncoder();
+let textureView176 = texture209.createView({dimension: 'cube-array', baseArrayLayer: 7, arrayLayerCount: 6});
+let textureView177 = texture168.createView({});
+try {
+computePassEncoder47.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder39.executeBundles([renderBundle1, renderBundle10, renderBundle13, renderBundle11, renderBundle13, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder43.setViewport(441.8342173626416, 6.59340067610229, 622.7759592962082, 22.405200916217765, 0.45820810876216744, 0.6374612529568464);
+} catch {}
+try {
+renderPassEncoder26.draw(31, 89, 322_769_769, 408_060_598);
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(819, 0, 568, 662_552_769);
+} catch {}
+try {
+renderPassEncoder26.drawIndirect(buffer81, 2_588);
+} catch {}
+try {
+computePassEncoder138.pushDebugGroup('\ua011');
+} catch {}
+let imageData21 = new ImageData(40, 20);
+let buffer111 = device0.createBuffer({
+  size: 28442,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let textureView178 = texture81.createView({dimension: 'cube', baseArrayLayer: 1});
+let computePassEncoder149 = commandEncoder160.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroupsIndirect(buffer102, 6_728); };
+} catch {}
+try {
+renderPassEncoder26.draw(31, 19, 391_769_119, 265_814_448);
+} catch {}
+try {
+renderPassEncoder26.drawIndexed(51, 294, 11, 284_811_949, 793_833_973);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(2, buffer43, 0, 10);
+} catch {}
+let buffer112 = device0.createBuffer({size: 12726, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder161 = device0.createCommandEncoder({});
+let texture255 = device0.createTexture({
+  size: {width: 984, height: 1, depthOrArrayLayers: 31},
+  mipLevelCount: 3,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView179 = texture97.createView({dimension: '2d-array', baseMipLevel: 0});
+let renderPassEncoder46 = commandEncoder161.beginRenderPass({
+  colorAttachments: [{
+  view: textureView134,
+  depthSlice: 9,
+  clearValue: { r: 244.1, g: 937.7, b: 610.7, a: 987.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder32.drawIndexedIndirect(buffer92, 3_684);
+} catch {}
+try {
+renderPassEncoder26.drawIndirect(buffer12, 1_264);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(3, buffer40, 8_408, 14_758);
+} catch {}
+try {
+commandEncoder50.resolveQuerySet(querySet10, 105, 0, buffer8, 1024);
+} catch {}
+try {
+device0.queue.submit([commandBuffer14]);
+} catch {}
+document.body.append(canvas0);
+let commandBuffer15 = commandEncoder50.finish();
+let texture256 = device0.createTexture({
+  size: {width: 1968, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder52.end();
+} catch {}
+try {
+renderPassEncoder32.drawIndexedIndirect(buffer87, 12);
+} catch {}
+try {
+commandEncoder65.copyBufferToBuffer(buffer46, 4308, buffer24, 28, 32);
+} catch {}
+try {
+commandEncoder65.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2520 */
+  offset: 2520,
+  bytesPerRow: 5888,
+  rowsPerImage: 1403,
+  buffer: buffer48,
+}, {
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 7, y: 29, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder65.copyTextureToBuffer({
+  texture: texture36,
+  mipLevel: 2,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 48 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1134 */
+  offset: 1134,
+  bytesPerRow: 39936,
+  buffer: buffer37,
+}, {width: 24, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 123, height: 1, depthOrArrayLayers: 153}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 15, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule9 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+/* zero global variables used */
+fn fn1() {
+  var vf216 = fn0();
+  var vf217: vec2f = unpack2x16float(unconst_u32(372));
+  var vf218: vec2f = unpack2x16float(unconst_u32(148));
+  vf217 = vec2f(sinh(unconst_f32(0.09020)));
+  if bool((vec4i(unconst_i32(88), unconst_i32(35), unconst_i32(-127), unconst_i32(510)) << vec4u(unconst_u32(256), unconst_u32(2), unconst_u32(60), unconst_u32(282)))[3]) {
+}
+  loop {
+  let vf219: vec3f = saturate(vec3f(unconst_f32(0.01449), unconst_f32(-0.01685), unconst_f32(0.01552)));
+  var vf220: bool = (unconst_f16(8164.5) < unconst_f16(2399.4));
+  vf220 = bool(pack4x8unorm(vec4f(unconst_f32(-0.6885), unconst_f32(0.05012), unconst_f32(0.5448), unconst_f32(0.1845))));
+  break;
+}
+  vf217 = vec2f(f32(length(vec2h(unconst_f16(5598.8), unconst_f16(1483.2)))));
+  switch i32(vf216.f15[2]) { 
+  default {
+  var vf221 = fn0();
+  let vf222: f16 = asin(unconst_f16(3102.2));
+  break;
+  _ = override3;
+}
+  }
+  vf217 = cross(vec3f(unconst_f32(0.1592), unconst_f32(0.03913), unconst_f32(0.06845)), vec3f(unconst_f32(0.6021), unconst_f32(0.08388), unconst_f32(-0.2612))).bg;
+  var vf223 = fn0();
+  let ptr72: ptr<function, i32> = &vf223.f16;
+  vf218 = vec2f(bitcast<f32>(vf223.f16));
+  _ = override3;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T0 {
+  f0: f32,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct VertexOutput8 {
+  @invariant @builtin(position) f15: vec4f,
+  @location(7) f16: i32,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+/* zero global variables used */
+fn fn0() -> VertexOutput8 {
+  var out: VertexOutput8;
+  let vf204: vec4i = unpack4xI8(unconst_u32(18));
+  out.f16 ^= vec2i( !vec2<bool>(unconst_bool(true), unconst_bool(false))).x;
+  out = VertexOutput8(bitcast<vec4f>(unpack4xI8(u32(log(unconst_f16(8526.7))))), unpack4xI8(u32(log(unconst_f16(8526.7))))[2]);
+  out.f16 += vf204[unconst_u32(193)];
+  out = VertexOutput8(log2(unpack4x8unorm(unconst_u32(80)).br).xxxy, bitcast<vec2i>(log2(unpack4x8unorm(unconst_u32(80)).br))[0]);
+  var vf205: u32 = pack4xI8Clamp(vec4i(unconst_i32(310), unconst_i32(-150), unconst_i32(93), unconst_i32(403)));
+  let vf206: vec2<bool> = select(vec2<bool>(unconst_bool(true), unconst_bool(true)), vec2<bool>(unconst_bool(false), unconst_bool(false)), vec2<bool>(unconst_bool(true), unconst_bool(true)));
+  let vf207: u32 = pack4x8snorm(vec4f(unconst_f32(-0.03361), unconst_f32(-0.00133), unconst_f32(0.2899), unconst_f32(0.3913)));
+  while bool(pack4x8snorm(unpack4x8unorm(unconst_u32(137)))) {
+  var vf208: vec2f = unpack2x16unorm(unconst_u32(12));
+  let vf209: vec2u = insertBits(vec2u(pack4x8snorm(vec4f(unconst_f32(0.06249), unconst_f32(0.1804), unconst_f32(0.04796), unconst_f32(0.09093)))), vec2u(unconst_u32(68), unconst_u32(32)), unconst_u32(52),  ~vec4u(unconst_u32(85), unconst_u32(323), unconst_u32(143), unconst_u32(914)).a);
+  let vf210: f32 = distance(vec3f(unconst_f32(0.3098), unconst_f32(0.05215), unconst_f32(0.01388)), vec3f(unconst_f32(0.1648), unconst_f32(0.1415), unconst_f32(0.07508)));
+  if bool(faceForward(vec3f(unconst_f32(-0.00126), unconst_f32(-0.07049), unconst_f32(0.5806)), fma(vec3f(unconst_f32(0.1924), unconst_f32(0.1859), unconst_f32(-0.1756)), vec3f(unconst_f32(0.2901), unconst_f32(0.08623), unconst_f32(0.00388)), vec3f(unconst_f32(0.00506), unconst_f32(0.06619), unconst_f32(0.1299))), vec3f(unconst_f32(0.1247), unconst_f32(0.3422), unconst_f32(0.3592))).z) {
+  out.f15 = vec4f(tanh(unconst_f32(0.09897)));
+  out.f15 -= vec4f(f32(asinh(unconst_f16(-21704.3))));
+  var vf211: f32 = fma(unconst_f32(0.1397), unconst_f32(0.07337), unconst_f32(0.2475));
+  var vf212: i32 = override3;
+  break;
+  _ = override3;
+}
+  break;
+  _ = override3;
+}
+  while bool(vf204[2]) {
+  out = VertexOutput8(vec4f(tan(vec3h(unconst_f16(20801.3), unconst_f16(-6080.0), unconst_f16(36354.1))).rbbb), i32(tan(vec3h(unconst_f16(20801.3), unconst_f16(-6080.0), unconst_f16(36354.1)))[0]));
+  let vf213: vec3h = sinh(acosh(vec4h(unconst_f16(-7523.1), unconst_f16(13278.1), unconst_f16(5513.5), unconst_f16(2019.2))).zyz);
+  var vf214: vec3i = (vec3i(unconst_i32(-40), unconst_i32(-60), unconst_i32(28)) + bitcast<vec3i>(clamp(vec4f(unconst_f32(0.4943), unconst_f32(-0.2108), unconst_f32(0.5430), unconst_f32(0.2339)), vec4f(bitcast<f32>(insertBits(u32(min(unconst_f16(15484.7), unconst_f16(522.3))), unconst_u32(147), unconst_u32(306), unconst_u32(150)))), vec4f(f32(pack4xU8(vec4u(unconst_u32(80), unconst_u32(326), unconst_u32(14), unconst_u32(78)))))).wyz));
+  out.f15 -= bitcast<vec4f>((vec3i(unconst_i32(312), unconst_i32(81), unconst_i32(330)) + vec3i(unconst_i32(397), unconst_i32(22), unconst_i32(191))).yyyz);
+  return out;
+}
+  var vf215: i32 = vf204[unconst_u32(175)];
+  return out;
+  _ = override3;
+}
+
+override override3: i32;
+
+@group(0) @binding(125) var st9: texture_storage_2d_array<r32float, read_write>;
+
+struct T1 {
+  f0: atomic<i32>,
+}
+
+/* used global variables: buffer113, st9 */
+fn fn2() -> VertexOutput8 {
+  var out: VertexOutput8;
+  while bool(normalize(vec2f(unconst_f32(0.6305), unconst_f32(0.2210)))[0]) {
+  let vf224: f16 = acosh(unconst_f16(22966.2));
+  fn0();
+  fn0();
+  fn0();
+  out.f15 = vec4f((vec2i(bitcast<i32>(extractBits(unconst_u32(202), unconst_u32(725), unconst_u32(8)))) | vec2i(unconst_i32(1), unconst_i32(107))).grrg);
+  return out;
+  _ = override3;
+}
+  var vf225: f16 = floor(f16(textureDimensions(st9)[1]));
+  let vf226: vec2f = unpack2x16snorm(unconst_u32(42));
+  var vf227 = fn0();
+  if bool((*&buffer113).g) {
+  out.f16 = i32(all((vec2f(f32(dot(vec3i(unconst_i32(116), unconst_i32(191), unconst_i32(6)), vec3i(unconst_i32(37), unconst_i32(66), unconst_i32(239))))) < vec2f(unconst_f32(0.08934), unconst_f32(0.2423)))));
+  out = VertexOutput8(vec4f(radians(vec4h(f16((abs(vec3h(unconst_f16(19386.6), unconst_f16(1229.1), unconst_f16(58.51))).b <= unconst_f16(11004.7)))))), i32(radians(vec4h(f16((abs(vec3h(unconst_f16(19386.6), unconst_f16(1229.1), unconst_f16(58.51))).b <= unconst_f16(11004.7))))).r));
+  var vf228: u32 = textureNumLayers(st9);
+  for (var it8=pack4x8unorm(quantizeToF16(vec4f(unconst_f32(0.09900), unconst_f32(0.00195), unconst_f32(0.2841), unconst_f32(-0.04257)))); it8<u32(log2(vec3f(unconst_f32(0.2416), unconst_f32(0.3935), unconst_f32(0.1192)))[1]); it8++) {
+  let vf229: vec3h = fract(vec3h(unconst_f16(27198.6), unconst_f16(-1822.7), unconst_f16(27316.5)));
+  var vf230 = fn0();
+  let vf231: vec3h = fract(vec3h(unconst_f16(4847.6), unconst_f16(8488.3), unconst_f16(21258.1)));
+  _ = override3;
+}
+  textureStore(st9, vec2i(unconst_i32(194), unconst_i32(87)), unconst_i32(41), vec4f(vec4f(unconst_f32(-0.03345), unconst_f32(-0.01516), unconst_f32(0.1483), unconst_f32(0.01804))));
+  return out;
+  _ = override3;
+  _ = st9;
+}
+  return out;
+  _ = override3;
+  _ = st9;
+  _ = buffer113;
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+@group(0) @binding(166) var<uniform> buffer113: vec2h;
+
+struct S6 {
+  @builtin(num_workgroups) @size(16) f0: vec3u,
+}
+
+/* zero global variables used */
+@vertex @must_use
+fn vertex9(@builtin(vertex_index) a0: u32, @location(9) @interpolate(flat) a1: vec2i) -> VertexOutput8 {
+  var out: VertexOutput8;
+  fn1();
+  return out;
+  _ = override3;
+}
+
+/* used global variables: buffer113, st9 */
+@fragment
+fn fragment8(@builtin(position) a0: vec4f, @builtin(front_facing) a1: bool) -> @location(200) @interpolate(perspective, centroid) vec2f {
+  var out: vec2f;
+  out = (vec3f(f32((bool(textureDimensions(st9).r) || unconst_bool(false)))) / unconst_f32(0.1003)).yx;
+  fn2();
+  out = vec2f(buffer113);
+  fn2();
+  fn2();
+  out = asin(vec3f(unconst_f32(0.02056), unconst_f32(0.3598), unconst_f32(-0.07031))).rb;
+  out = bitcast<vec2f>(unpack4xI8(unconst_u32(125)).rb);
+  textureStore(st9, vec2i(unconst_i32(184), unconst_i32(255)), unconst_i32(30), vec4f(vec4f(unconst_f32(0.1224), unconst_f32(-0.00613), unconst_f32(0.2452), unconst_f32(0.00201))));
+  let vf232: vec3u = countTrailingZeros(vec3u(unconst_u32(212), unconst_u32(39), unconst_u32(143)));
+  out -= unpack2x16unorm( ~unconst_u32(20));
+  var vf233: vec3f = mix(vec3f(unconst_f32(0.04535), unconst_f32(0.00958), unconst_f32(0.4644)), saturate(vec3f(unconst_f32(0.07660), unconst_f32(0.00708), unconst_f32(0.1365))), unconst_f32(0.6175));
+  fn0();
+  for (var it9=textureNumLayers(st9); it9<bitcast<u32>((*&buffer113)); it9++) {
+  var vf234: vec3f = pow(vec3f(unconst_f32(0.02760), unconst_f32(0.1740), unconst_f32(0.05170)), vec3f(unconst_f32(0.2252), unconst_f32(0.1214), unconst_f32(0.2841)));
+  let ptr73: ptr<function, vec3f> = &vf234;
+  var vf235: f32 = a0[unconst_u32(209)];
+  break;
+}
+  textureStore(st9, vec2i(unconst_i32(125), unconst_i32(50)), unconst_i32(405), vec4f(vec4f(unconst_f32(0.07443), unconst_f32(-0.1940), unconst_f32(-0.2082), unconst_f32(0.08973))));
+  textureStore(st9, vec2i(unconst_i32(141), unconst_i32(97)), unconst_i32(65), vec4f(vec4f(unconst_f32(0.3971), unconst_f32(0.05327), unconst_f32(0.1769), unconst_f32(0.06950))));
+  return out;
+  _ = override3;
+  _ = st9;
+  _ = buffer113;
+}
+
+/* used global variables: buffer113, st9 */
+@compute @workgroup_size(5, 2, 1)
+fn compute10(@builtin(local_invocation_id) a0: vec3u, @builtin(workgroup_id) a1: vec3u) {
+  textureStore(st9, vec2i(i32(pack4xI8(vec4i(unpack4x8snorm(unconst_u32(264)))))), bitcast<i32>(textureNumLayers(st9)), vec4f(vec4f(unconst_f32(0.08884), unconst_f32(0.01925), unconst_f32(0.1500), unconst_f32(0.1810))));
+  textureStore(st9, vec2i(unconst_i32(45), unconst_i32(32)), unconst_i32(301), vec4f(vec4f(unconst_f32(0.8096), unconst_f32(0.00877), unconst_f32(0.2543), unconst_f32(0.06527))));
+  textureStore(st9, vec2i(unconst_i32(-155), unconst_i32(179)), unconst_i32(56), vec4f(vec4f(unconst_f32(0.01924), unconst_f32(0.5725), unconst_f32(0.1111), unconst_f32(0.2641))));
+  textureStore(st9, vec2i(unconst_i32(346), unconst_i32(75)), unconst_i32(170), vec4f(vec4f(unconst_f32(0.1695), unconst_f32(0.2078), unconst_f32(0.01679), unconst_f32(0.06400))));
+  let vf236: f16 = determinant(mat3x3h(unconst_f16(1052.0), unconst_f16(5095.5), unconst_f16(1719.8), unconst_f16(16437.0), unconst_f16(-8421.1), unconst_f16(-7800.8), unconst_f16(38037.9), unconst_f16(21243.1), unconst_f16(-2952.3)));
+  var vf237: u32 = textureNumLayers(st9);
+  vf237 <<= u32(buffer113[unconst_u32(20)]);
+  _ = st9;
+  _ = buffer113;
+}
+
+/* used global variables: buffer113, st9 */
+@compute @workgroup_size(1, 1, 2)
+fn compute11(a0: S6, @builtin(local_invocation_id) a1: vec3u) {
+  var vf238: bool = (unconst_bool(false) || unconst_bool(false));
+  if bool(a0.f0[2]) {
+  while bool((firstLeadingBit(vec2i(unconst_i32(63), unconst_i32(70))).xxxy | vec4i(textureDimensions(st9).grgg))[2]) {
+  textureStore(st9, vec2i(unconst_i32(344), unconst_i32(46)), unconst_i32(32), vec4f(vec4f(buffer113.gggr)));
+  var vf239: u32 = a0.f0[unconst_u32(143)];
+  _ = buffer113;
+  _ = st9;
+}
+  fn2();
+  var vf240 = fn0();
+  vf240.f15 = unpack4x8snorm(insertBits(unconst_u32(5), unconst_u32(41), unconst_u32(26), bitcast<u32>(cosh(vec2h(unconst_f16(4011.0), unconst_f16(39987.9))))));
+  _ = override3;
+  _ = buffer113;
+  _ = st9;
+}
+  var vf241: vec4i = extractBits(vec4i(unconst_i32(512), unconst_i32(227), unconst_i32(-16), unconst_i32(422)), unconst_u32(315), unconst_u32(73));
+  fn0();
+  let vf242: vec3h = pow(vec3h(unconst_f16(-6134.2), unconst_f16(13217.4), unconst_f16(-2976.8)), vec3h(unconst_f16(7059.0), unconst_f16(7933.8), unconst_f16(79.25)));
+  textureStore(st9, vec2i(unconst_i32(217), unconst_i32(185)), unconst_i32(153), vec4f(vec4f(unconst_f32(0.4748), unconst_f32(0.03500), unconst_f32(0.2293), unconst_f32(-0.07821))));
+  _ = override3;
+  _ = st9;
+  _ = buffer113;
+}`,
+});
+let commandEncoder162 = device0.createCommandEncoder({});
+try {
+computePassEncoder140.setBindGroup(2, bindGroup78, new Uint32Array(5198), 1_850, 0);
+} catch {}
+try {
+renderPassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder32.drawIndexed(310, 0, 541, 247_949_822);
+} catch {}
+try {
+renderPassEncoder32.drawIndexedIndirect(buffer70, 4);
+} catch {}
+try {
+renderPassEncoder32.drawIndirect(buffer70, 32);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(0, buffer5, 7_884, 428);
+} catch {}
+try {
+commandEncoder77.copyBufferToTexture({
+  /* bytesInLastRow: 100 widthInBlocks: 100 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2863 */
+  offset: 2863,
+  buffer: buffer86,
+}, {
+  texture: texture219,
+  mipLevel: 0,
+  origin: {x: 153, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 100, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline37 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule9, entryPoint: 'compute11', constants: {override3: 1}}});
+let buffer114 = device0.createBuffer({
+  size: 191,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder163 = device0.createCommandEncoder({});
+let textureView180 = texture7.createView({dimension: '2d'});
+let sampler90 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.54,
+  compare: 'less-equal',
+  maxAnisotropy: 11,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder137); computePassEncoder137.dispatchWorkgroups(2, 1, 2); };
+} catch {}
+try {
+computePassEncoder149.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder32.drawIndirect(buffer83, 1_348);
+} catch {}
+try {
+commandEncoder65.copyBufferToBuffer(buffer20, 9504, buffer72, 60, 1112);
+} catch {}
+try {
+commandEncoder163.resolveQuerySet(querySet9, 98, 1, buffer114, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer74, 556, new Float32Array(10426), 1198, 116);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder164 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder133); computePassEncoder133.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup60, new Uint32Array(585), 2, 0);
+} catch {}
+try {
+renderPassEncoder32.draw(176, 0, 372_044_939, 1);
+} catch {}
+document.body.prepend(img4);
+let canvas1 = document.createElement('canvas');
+let commandBuffer16 = commandEncoder77.finish();
+let externalTexture12 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'srgb'});
+try {
+renderPassEncoder32.end();
+} catch {}
+try {
+renderPassEncoder33.executeBundles([renderBundle1, renderBundle1, renderBundle0, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder164.clearBuffer(buffer108, 140, 28);
+} catch {}
+await gc();
+let computePassEncoder150 = commandEncoder65.beginComputePass({});
+try {
+computePassEncoder71.setBindGroup(1, bindGroup89, new Uint32Array(149), 13, 0);
+} catch {}
+try {
+computePassEncoder150.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(1, bindGroup22, new Uint32Array(6851), 2_816, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle4]);
+} catch {}
+try {
+buffer97.unmap();
+} catch {}
+try {
+commandEncoder164.copyTextureToTexture({
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 343, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer15]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture89,
+  mipLevel: 1,
+  origin: {x: 47, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(99).fill(19), /* required buffer size: 99 */
+{offset: 99, bytesPerRow: 649}, {width: 314, height: 7, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 185});
+let computePassEncoder151 = commandEncoder162.beginComputePass({});
+try {
+computePassEncoder119.setBindGroup(0, bindGroup12);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+let recycledExplicitBindGroupLayout13 = pipeline7.getBindGroupLayout(0);
+let buffer115 = device0.createBuffer({
+  size: 1736,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+});
+let texture257 = device0.createTexture({
+  size: [1880, 10, 1],
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView181 = texture194.createView({dimension: '2d'});
+let sampler91 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat'});
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup42, new Uint32Array(1739), 77, 0);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder45.setVertexBuffer(6, buffer40);
+} catch {}
+try {
+computePassEncoder138.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer16]);
+} catch {}
+let bindGroup91 = device0.createBindGroup({layout: veryExplicitBindGroupLayout14, entries: [{binding: 21, resource: textureView57}]});
+let commandBuffer17 = commandEncoder97.finish({});
+try {
+computePassEncoder151.setPipeline(pipeline33);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(6, buffer56, 644, 1_328);
+} catch {}
+try {
+buffer102.unmap();
+} catch {}
+let veryExplicitBindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 33,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {binding: 54, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+    {binding: 77, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 119,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+    {binding: 155, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+let commandEncoder165 = device0.createCommandEncoder({});
+let texture258 = device0.createTexture({
+  size: {width: 153, height: 3, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder47 = commandEncoder165.beginRenderPass({colorAttachments: [{view: textureView134, depthSlice: 40, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+computePassEncoder139.setBindGroup(0, bindGroup25, new Uint32Array(133), 10, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder85); computePassEncoder85.dispatchWorkgroups(2); };
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(1, buffer85, 0, 1_242);
+} catch {}
+try {
+buffer115.unmap();
+} catch {}
+try {
+commandEncoder163.clearBuffer(buffer28, 2632, 168);
+} catch {}
+try {
+externalTexture9.label = '\u{1f96e}\udcd3\uf1e8\ub9bc\u02f7\u1ae4\u067a\u{1f610}\u29cd\u9a00';
+} catch {}
+let commandEncoder166 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder46); computePassEncoder46.dispatchWorkgroupsIndirect(buffer52, 180); };
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(0, bindGroup73, new Uint32Array(699), 38, 0);
+} catch {}
+try {
+renderPassEncoder35.drawIndexedIndirect(buffer70, 4);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer92, 'uint32', 7_588, 2_047);
+} catch {}
+try {
+commandEncoder164.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1220 */
+  offset: 1220,
+  bytesPerRow: 3328,
+  buffer: buffer84,
+}, {
+  texture: texture175,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+let computePassEncoder152 = commandEncoder164.beginComputePass({});
+let sampler92 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', lodMinClamp: 74.10, lodMaxClamp: 84.67});
+try {
+{ clearResourceUsages(device0, computePassEncoder151); computePassEncoder151.dispatchWorkgroupsIndirect(buffer62, 396); };
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup82);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(1, bindGroup58, new Uint32Array(2042), 607, 0);
+} catch {}
+try {
+renderPassEncoder35.drawIndexedIndirect(buffer89, 240);
+} catch {}
+try {
+renderPassEncoder35.drawIndirect(buffer60, 792);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer108, 'uint32', 24, 359);
+} catch {}
+try {
+device0.queue.submit([commandBuffer17]);
+} catch {}
+let gpuCanvasContext4 = canvas1.getContext('webgpu');
+let bindGroup92 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout3,
+  entries: [
+    {binding: 144, resource: textureView145},
+    {binding: 323, resource: {buffer: buffer33, offset: 256, size: 1216}},
+  ],
+});
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 288});
+let texture259 = device0.createTexture({
+  size: {width: 492, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['depth24plus-stencil8'],
+});
+let textureView182 = texture21.createView({dimension: '2d-array'});
+try {
+computePassEncoder152.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup69, new Uint32Array(616), 89, 0);
+} catch {}
+try {
+renderPassEncoder41.setIndexBuffer(buffer89, 'uint32', 624, 144);
+} catch {}
+try {
+commandEncoder163.copyBufferToTexture({
+  /* bytesInLastRow: 26 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2852 */
+  offset: 2852,
+  rowsPerImage: 1127,
+  buffer: buffer80,
+}, {
+  texture: texture190,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame22 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'bt470m', transfer: 'hlg'} });
+let texture260 = device0.createTexture({size: [984], dimension: '1d', format: 'r8uint', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder153 = commandEncoder163.beginComputePass();
+try {
+renderPassEncoder35.draw(114, 326, 1_243_395_296, 61_912_001);
+} catch {}
+try {
+renderPassEncoder35.drawIndexed(28, 349, 17, 329_730_128, 356_979_686);
+} catch {}
+try {
+renderPassEncoder35.drawIndirect(buffer33, 948);
+} catch {}
+try {
+renderPassEncoder46.setIndexBuffer(buffer67, 'uint32', 36, 823);
+} catch {}
+let arrayBuffer25 = buffer26.getMappedRange(240, 0);
+try {
+device0.queue.writeTexture({
+  texture: texture203,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(119).fill(3), /* required buffer size: 119 */
+{offset: 119}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder154 = commandEncoder166.beginComputePass({});
+let sampler93 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 68.32,
+});
+try {
+renderPassEncoder44.setVertexBuffer(1, buffer5, 852, 1_184);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+await gc();
+let recycledExplicitBindGroupLayout14 = pipeline5.getBindGroupLayout(0);
+let bindGroup93 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [
+    {binding: 39, resource: {buffer: buffer81, offset: 1280, size: 5628}},
+    {binding: 41, resource: textureView53},
+  ],
+});
+let pipelineLayout18 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout5]});
+let querySet22 = device0.createQuerySet({type: 'occlusion', count: 77});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup81, new Uint32Array(2908), 8, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder139); computePassEncoder139.dispatchWorkgroupsIndirect(buffer2, 680); };
+} catch {}
+try {
+computePassEncoder124.setPipeline(pipeline19);
+} catch {}
+try {
+computePassEncoder153.setPipeline(pipeline37);
+} catch {}
+try {
+renderPassEncoder15.draw(345, 96, 156_830_206, 11_736_963);
+} catch {}
+try {
+renderPassEncoder35.drawIndexed(0, 51, 2, -2_050_116_145, 609_783_089);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer114, 12);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture225,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(92).fill(41), /* required buffer size: 92 */
+{offset: 92, bytesPerRow: 113}, {width: 8, height: 19, depthOrArrayLayers: 0});
+} catch {}
+let pipeline38 = await device0.createComputePipelineAsync({layout: pipelineLayout3, compute: {module: shaderModule8}});
+let buffer116 = device0.createBuffer({
+  size: 814,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let querySet23 = device0.createQuerySet({type: 'occlusion', count: 1892});
+try {
+computePassEncoder129.setBindGroup(0, bindGroup92);
+} catch {}
+try {
+computePassEncoder85.end();
+} catch {}
+try {
+computePassEncoder154.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder41.setBlendConstant({ r: 718.4, g: -150.3, b: 960.8, a: 871.0, });
+} catch {}
+try {
+renderPassEncoder13.setViewport(35.957043929367686, 0.3906617468418573, 527.1402194531695, 0.3079656581032337, 0.8126004257518021, 0.8542464949171331);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer97, 168);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 1120 widthInBlocks: 140 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 80 */
+  offset: 80,
+  bytesPerRow: 7168,
+  buffer: buffer42,
+}, {
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 140, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder167 = device0.createCommandEncoder({});
+let computePassEncoder155 = commandEncoder16.beginComputePass({});
+try {
+computePassEncoder57.setBindGroup(2, bindGroup44);
+} catch {}
+try {
+computePassEncoder137.setBindGroup(3, bindGroup60, new Uint32Array(3024), 122, 0);
+} catch {}
+try {
+computePassEncoder116.end();
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(11, 0, 29, 0);
+} catch {}
+try {
+renderPassEncoder38.setViewport(37.12303208180343, 41.760680288937756, 0.9437596957084109, 1.8763246990122755, 0.2801549338967556, 0.5246252165030834);
+} catch {}
+try {
+renderPassEncoder15.draw(151, 591, 120_167_919, 1_259_729_520);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(12, 292, 120, 311_091_000, 412_333_163);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer70, 8);
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(6, buffer2, 0, 250);
+} catch {}
+try {
+commandEncoder167.resolveQuerySet(querySet3, 51, 79, buffer85, 768);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture130,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 5},
+  aspect: 'all',
+}, new Uint8Array(117_013).fill(12), /* required buffer size: 117_013 */
+{offset: 55, bytesPerRow: 121, rowsPerImage: 34}, {width: 18, height: 15, depthOrArrayLayers: 29});
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+let bindGroup94 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout14,
+  entries: [
+    {binding: 144, resource: textureView5},
+    {binding: 323, resource: {buffer: buffer5, offset: 768, size: 2104}},
+  ],
+});
+let buffer117 = device0.createBuffer({
+  size: 41426,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder168 = device0.createCommandEncoder({});
+let texture261 = device0.createTexture({
+  size: [307, 7, 1],
+  mipLevelCount: 1,
+  sampleCount: 4,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler94 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat', mipmapFilter: 'nearest'});
+let externalTexture13 = device0.importExternalTexture({source: videoFrame14});
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup59);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(234, 0, 117, 484_374_354, 1_147_917_687);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(0, buffer37);
+} catch {}
+let buffer118 = device0.createBuffer({size: 6041, usage: GPUBufferUsage.MAP_READ});
+let commandBuffer18 = commandEncoder127.finish({label: '\u{1fd24}\u7399'});
+let texture262 = device0.createTexture({
+  size: [307, 7, 1],
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup71, new Uint32Array(730), 7, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder44); computePassEncoder44.dispatchWorkgroupsIndirect(buffer107, 1_948); };
+} catch {}
+try {
+computePassEncoder143.end();
+} catch {}
+try {
+computePassEncoder155.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder35.draw(131, 102, 615_966_006, 283_947_747);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer106, 'uint32', 2_420, 6_605);
+} catch {}
+let commandEncoder169 = device0.createCommandEncoder({});
+try {
+renderPassEncoder40.setBindGroup(1, bindGroup0, new Uint32Array(2543), 1_768, 0);
+} catch {}
+try {
+renderPassEncoder35.end();
+} catch {}
+try {
+renderPassEncoder41.drawIndexed(2, 71, 1, 312_747_587, 358_869_684);
+} catch {}
+try {
+renderPassEncoder41.drawIndirect(buffer13, 1_364);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder152.resolveQuerySet(querySet5, 18, 8, buffer19, 256);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 90, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame23 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'smpteSt4281', transfer: 'gamma22curve'} });
+let commandEncoder170 = device0.createCommandEncoder();
+let computePassEncoder156 = commandEncoder58.beginComputePass({});
+try {
+computePassEncoder156.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(0, bindGroup52, new Uint32Array(292), 66, 0);
+} catch {}
+try {
+renderPassEncoder41.drawIndexed(1, 221, 6, 490_443_521, 744_404_980);
+} catch {}
+try {
+renderPassEncoder41.drawIndexedIndirect(buffer86, 20);
+} catch {}
+try {
+renderPassEncoder41.drawIndirect(buffer13, 1_840);
+} catch {}
+try {
+renderPassEncoder38.setIndexBuffer(buffer76, 'uint16', 148, 14);
+} catch {}
+let textureView183 = texture67.createView({mipLevelCount: 1});
+let computePassEncoder157 = commandEncoder167.beginComputePass({});
+let sampler95 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', compare: 'less'});
+try {
+computePassEncoder157.setPipeline(pipeline30);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(2, bindGroup24, []);
+} catch {}
+try {
+renderPassEncoder41.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder169.insertDebugMarker('\u06b0');
+} catch {}
+try {
+device0.queue.submit([commandBuffer18]);
+} catch {}
+let imageData22 = new ImageData(24, 88);
+let commandEncoder171 = device0.createCommandEncoder();
+let computePassEncoder158 = commandEncoder169.beginComputePass({});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup62, []);
+} catch {}
+try {
+computePassEncoder44.end();
+} catch {}
+try {
+computePassEncoder158.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(0, bindGroup45, new Uint32Array(798), 35, 0);
+} catch {}
+try {
+renderPassEncoder45.setViewport(36.48888629986804, 41.6548890879704, 0.2162198737084153, 1.7790948216884146, 0.6768141617886493, 0.6970039296920072);
+} catch {}
+try {
+commandEncoder168.copyTextureToTexture({
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture238,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder170.resolveQuerySet(querySet15, 40, 3, buffer1, 1280);
+} catch {}
+let commandEncoder172 = device0.createCommandEncoder({});
+let computePassEncoder159 = commandEncoder170.beginComputePass({});
+let renderPassEncoder48 = commandEncoder172.beginRenderPass({
+  label: '\ud8fa\u0734\u096a\u02b9\u0cd8\u35da\u0207\u{1fd1f}\u5697\u0e3a',
+  colorAttachments: [{
+  view: textureView101,
+  clearValue: { r: -857.0, g: 703.9, b: 468.3, a: -847.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet20,
+});
+try {
+computePassEncoder141.setBindGroup(1, bindGroup48);
+} catch {}
+try {
+computePassEncoder84.setBindGroup(0, bindGroup70, new Uint32Array(1820), 8, 0);
+} catch {}
+try {
+computePassEncoder135.end();
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup91);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup73, new Uint32Array(3860), 42, 0);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline22);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer119 = device0.createBuffer({
+  size: 2489,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder173 = device0.createCommandEncoder();
+let commandBuffer19 = commandEncoder152.finish();
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: false, stencilReadOnly: true});
+let renderBundle17 = renderBundleEncoder17.finish({});
+let externalTexture14 = device0.importExternalTexture({source: videoFrame17});
+try {
+{ clearResourceUsages(device0, computePassEncoder137); computePassEncoder137.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline35);
+} catch {}
+try {
+computePassEncoder159.setPipeline(pipeline36);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup74);
+} catch {}
+try {
+  await promise15;
+} catch {}
+let buffer120 = device0.createBuffer({
+  size: 8117,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture263 = device0.createTexture({
+  size: [1880],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder160 = commandEncoder173.beginComputePass();
+try {
+computePassEncoder110.setBindGroup(3, bindGroup42, new Uint32Array(2465), 425, 0);
+} catch {}
+try {
+computePassEncoder160.setPipeline(pipeline36);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline31);
+} catch {}
+let commandBuffer20 = commandEncoder21.finish();
+let sampler96 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'not-equal',
+});
+try {
+computePassEncoder49.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroups(3); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder133); computePassEncoder133.dispatchWorkgroupsIndirect(buffer120, 2_028); };
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(4, buffer13, 0, 348);
+} catch {}
+let autogeneratedBindGroupLayout6 = pipeline4.getBindGroupLayout(0);
+let sampler97 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 96.67,
+});
+try {
+computePassEncoder146.setBindGroup(0, bindGroup8, new Uint32Array(208), 11, 0);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(0, bindGroup21, new Uint32Array(520), 11, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 123, height: 1, depthOrArrayLayers: 153}
+*/
+{
+  source: imageData16,
+  origin: { x: 5, y: 0 },
+  flipY: true,
+}, {
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 62, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer121 = device0.createBuffer({
+  size: 8186,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder41.end();
+} catch {}
+try {
+renderPassEncoder48.beginOcclusionQuery(11);
+} catch {}
+try {
+renderPassEncoder48.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer82, 'uint32', 12, 90);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(2, buffer111, 0, 697);
+} catch {}
+let commandEncoder174 = device0.createCommandEncoder({});
+let commandBuffer21 = commandEncoder134.finish();
+let sampler98 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.67,
+});
+try {
+computePassEncoder156.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder175 = device0.createCommandEncoder({});
+let texture264 = device0.createTexture({size: [1968, 1, 36], mipLevelCount: 3, format: 'rgb10a2unorm', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder161 = commandEncoder168.beginComputePass({});
+try {
+computePassEncoder161.setPipeline(pipeline33);
+} catch {}
+try {
+renderPassEncoder47.executeBundles([renderBundle2, renderBundle3, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer104, 'uint16', 9_988, 1_648);
+} catch {}
+try {
+commandEncoder175.copyBufferToBuffer(buffer65, 3872, buffer47, 3020, 1336);
+} catch {}
+try {
+commandEncoder146.copyBufferToTexture({
+  /* bytesInLastRow: 512 widthInBlocks: 64 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1504 */
+  offset: 1504,
+  bytesPerRow: 57856,
+  buffer: buffer64,
+}, {
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 31, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 64, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer48, 176, new BigUint64Array(5036), 0, 4);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let pipeline39 = await device0.createComputePipelineAsync({layout: pipelineLayout3, compute: {module: shaderModule7}});
+let pipeline40 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-dst-alpha'},
+  },
+}],
+},
+  vertex: {module: shaderModule3, constants: {}, buffers: []},
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+try {
+  await promise16;
+} catch {}
+let buffer122 = device0.createBuffer({
+  size: 6606,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup94);
+} catch {}
+try {
+renderPassEncoder44.setPipeline(pipeline21);
+} catch {}
+try {
+commandEncoder54.copyBufferToTexture({
+  /* bytesInLastRow: 1936 widthInBlocks: 242 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 120 */
+  offset: 120,
+  bytesPerRow: 8960,
+  buffer: buffer10,
+}, {
+  texture: texture169,
+  mipLevel: 0,
+  origin: {x: 156, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 242, height: 30, depthOrArrayLayers: 0});
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+let commandBuffer22 = commandEncoder54.finish();
+let computePassEncoder162 = commandEncoder175.beginComputePass({});
+try {
+computePassEncoder133.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+computePassEncoder162.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer89, 'uint32', 160, 261);
+} catch {}
+try {
+buffer119.unmap();
+} catch {}
+try {
+commandEncoder171.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1222 */
+  offset: 1222,
+  rowsPerImage: 798,
+  buffer: buffer110,
+}, {
+  texture: texture167,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder174.copyTextureToBuffer({
+  texture: texture206,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 352 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1920 */
+  offset: 1920,
+  rowsPerImage: 2439,
+  buffer: buffer57,
+}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder153.pushDebugGroup('\u0af2');
+} catch {}
+try {
+computePassEncoder153.popDebugGroup();
+} catch {}
+let textureView184 = texture170.createView({mipLevelCount: 1});
+let computePassEncoder163 = commandEncoder171.beginComputePass({label: '\u{1f61e}\u7a96\u061f'});
+let sampler99 = device0.createSampler({addressModeU: 'repeat', lodMaxClamp: 86.09});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup70);
+} catch {}
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+renderPassEncoder38.setScissorRect(5, 15, 0, 1);
+} catch {}
+try {
+renderPassEncoder25.setViewport(172.21992884766976, 0.11217052949601214, 10.519353456686556, 0.5011116839807332, 0.45070729494272765, 0.8987900066380355);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(3, buffer22, 0, 664);
+} catch {}
+try {
+commandEncoder146.resolveQuerySet(querySet3, 84, 95, buffer96, 0);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+  await promise17;
+} catch {}
+await gc();
+let recycledExplicitBindGroupLayout15 = pipeline30.getBindGroupLayout(0);
+let commandEncoder176 = device0.createCommandEncoder({});
+let commandBuffer23 = commandEncoder146.finish();
+let texture265 = device0.createTexture({
+  size: {width: 470, height: 2, depthOrArrayLayers: 54},
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView185 = texture91.createView({});
+let computePassEncoder164 = commandEncoder176.beginComputePass({});
+let renderPassEncoder49 = commandEncoder174.beginRenderPass({
+  colorAttachments: [{
+  view: textureView120,
+  depthSlice: 33,
+  clearValue: { r: -726.1, g: -707.6, b: -24.14, a: 434.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 24799625,
+});
+try {
+computePassEncoder163.setBindGroup(2, bindGroup5, new Uint32Array(5538), 403, 0);
+} catch {}
+try {
+computePassEncoder163.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup16, new Uint32Array(1566), 396, 0);
+} catch {}
+try {
+renderPassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder43.setViewport(894.9703241128443, 26.812269528463304, 12.1390674944498, 1.873168012508372, 0.8689580690217936, 0.872970916350216);
+} catch {}
+try {
+commandEncoder57.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1504 */
+  offset: 1504,
+  buffer: buffer81,
+}, {
+  texture: texture205,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer20, commandBuffer23, commandBuffer19]);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let textureView186 = texture91.createView({});
+let computePassEncoder165 = commandEncoder57.beginComputePass({});
+try {
+computePassEncoder149.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder155.setBindGroup(0, bindGroup17, new Uint32Array(1454), 33, 0);
+} catch {}
+try {
+computePassEncoder139.end();
+} catch {}
+try {
+computePassEncoder164.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup22);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup71, new Uint32Array(822), 36, 0);
+} catch {}
+try {
+commandEncoder75.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 8 */
+  offset: 8,
+  bytesPerRow: 19200,
+  buffer: buffer35,
+}, {
+  texture: texture159,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder148.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 25},
+  aspect: 'all',
+},
+{
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas1);
+let texture266 = device0.createTexture({
+  size: [1230],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView187 = texture194.createView({format: 'rg8sint', baseArrayLayer: 2, arrayLayerCount: 24});
+let computePassEncoder166 = commandEncoder75.beginComputePass({});
+let sampler100 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', magFilter: 'linear', lodMaxClamp: 98.92});
+try {
+computePassEncoder57.setBindGroup(1, bindGroup93);
+} catch {}
+try {
+computePassEncoder133.setBindGroup(0, bindGroup12, new Uint32Array(2312), 180, 0);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer76, 'uint32', 8, 0);
+} catch {}
+try {
+commandEncoder148.copyBufferToBuffer(buffer77, 2836, buffer13, 220, 536);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 90, depthOrArrayLayers: 69}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture236,
+  mipLevel: 0,
+  origin: {x: 51, y: 3, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup95 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 39, resource: {buffer: buffer10, offset: 1280}}, {binding: 41, resource: textureView53}],
+});
+let texture267 = device0.createTexture({
+  size: {width: 307},
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView188 = texture88.createView({dimension: '2d-array', baseArrayLayer: 2, arrayLayerCount: 1});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup69, new Uint32Array(271), 14, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder161); computePassEncoder161.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(3, bindGroup13, new Uint32Array(1140), 25, 0);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer76, 'uint32', 56, 159);
+} catch {}
+try {
+commandEncoder148.resolveQuerySet(querySet16, 21, 186, buffer85, 256);
+} catch {}
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55); };
+} catch {}
+let commandEncoder177 = device0.createCommandEncoder({label: '\ud8c0\u41dc\u{1fd33}\u9d15\u343c\u767b\u4111'});
+let textureView189 = texture229.createView({});
+let externalTexture15 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder165.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer90, 'uint16', 442, 216);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline10);
+} catch {}
+try {
+commandEncoder148.clearBuffer(buffer23);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 45, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 2, y: 21, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture268 = device0.createTexture({
+  size: [1230, 30, 11],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder50 = commandEncoder148.beginRenderPass({colorAttachments: [{view: textureView101, loadOp: 'clear', storeOp: 'discard'}]});
+let sampler101 = device0.createSampler({addressModeV: 'mirror-repeat', minFilter: 'linear', mipmapFilter: 'linear', lodMaxClamp: 93.00});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup70);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup49, [768]);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55); };
+} catch {}
+let buffer123 = device0.createBuffer({size: 599, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder178 = device0.createCommandEncoder({});
+let texture269 = gpuCanvasContext1.getCurrentTexture();
+try {
+{ clearResourceUsages(device0, computePassEncoder161); computePassEncoder161.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder137.end();
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup36);
+} catch {}
+try {
+renderPassEncoder16.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(0, buffer111, 3_104, 356);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer87, 20, new BigUint64Array(6710), 2705, 12);
+} catch {}
+try {
+  await promise14;
+} catch {}
+let commandEncoder179 = device0.createCommandEncoder({});
+let textureView190 = texture141.createView({arrayLayerCount: 1});
+let computePassEncoder167 = commandEncoder178.beginComputePass();
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder108.setBindGroup(2, bindGroup38);
+} catch {}
+try {
+computePassEncoder167.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder16.drawIndexedIndirect(buffer97, 2_812);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer107, 5_516);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer67, 'uint32', 424, 9);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline24);
+} catch {}
+let pipeline41 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule2, constants: {}}});
+let commandEncoder180 = device0.createCommandEncoder({});
+let renderPassEncoder51 = commandEncoder180.beginRenderPass({
+  colorAttachments: [{view: textureView55, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet15,
+});
+let renderBundle18 = renderBundleEncoder18.finish({});
+try {
+computePassEncoder167.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+computePassEncoder166.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(4, buffer38, 0, 71);
+} catch {}
+try {
+computePassEncoder57.pushDebugGroup('\ueecb');
+} catch {}
+let buffer124 = device0.createBuffer({
+  size: 5210,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let texture270 = device0.createTexture({
+  size: {width: 10, height: 11, depthOrArrayLayers: 8},
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder150); computePassEncoder150.dispatchWorkgroupsIndirect(buffer32, 1_424); };
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(0, 71, 0, 228_886_063, 478_628_956);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer47, 3_204);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(3, buffer111, 0, 7_434);
+} catch {}
+try {
+commandEncoder41.copyTextureToTexture({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture128,
+  mipLevel: 1,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise18 = device0.queue.onSubmittedWorkDone();
+try {
+adapter1.label = '\u0bdd\u95f6\u0413\u2288\u82e5\u1f71\uf91f\uca2d\u{1fcf2}\u06e5';
+} catch {}
+let commandEncoder181 = device0.createCommandEncoder({});
+let commandBuffer24 = commandEncoder41.finish();
+let textureView191 = texture166.createView({dimension: '2d', baseArrayLayer: 8});
+let renderPassEncoder52 = commandEncoder177.beginRenderPass({
+  colorAttachments: [{view: textureView118, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet9,
+});
+let sampler102 = device0.createSampler({addressModeV: 'mirror-repeat', mipmapFilter: 'nearest', compare: 'less'});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder119); computePassEncoder119.dispatchWorkgroupsIndirect(buffer13, 1_068); };
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(1, bindGroup79);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(0, 246, 0, -2_015_055_619, 1_037_585_307);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer0, 'uint16', 22, 135);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(5, buffer111, 0);
+} catch {}
+try {
+commandEncoder181.copyBufferToBuffer(buffer32, 3572, buffer19, 2116, 172);
+} catch {}
+try {
+computePassEncoder57.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer21, commandBuffer22, commandBuffer24]);
+} catch {}
+let buffer125 = device0.createBuffer({size: 25131, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandBuffer25 = commandEncoder181.finish({});
+let renderPassEncoder53 = commandEncoder179.beginRenderPass({
+  label: '\u5d60\u{1f84a}\u0f01\u0766\u0fd9\u{1ff78}\ud0ee\u{1fc8d}\u0db0\ub464\u{1fb3d}',
+  colorAttachments: [{
+  view: textureView134,
+  depthSlice: 37,
+  clearValue: { r: 499.1, g: -16.00, b: 657.1, a: 890.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder47.setBindGroup(2, bindGroup12, new Uint32Array(2680), 235, 0);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer7, 220);
+} catch {}
+try {
+device0.queue.submit([commandBuffer25]);
+} catch {}
+let imageData23 = new ImageData(72, 68);
+try {
+renderPassEncoder16.drawIndexedIndirect(buffer102, 52);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer102, 9_164);
+} catch {}
+document.body.append(img3);
+let texture271 = device0.createTexture({
+  size: [940, 5, 48],
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView192 = texture260.createView({aspect: 'all'});
+let sampler103 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 70.92,
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder142.setBindGroup(0, bindGroup75, new Uint32Array(1924), 209, 0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(2, bindGroup54, new Uint32Array(800), 30, 0);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle17]);
+} catch {}
+try {
+renderPassEncoder16.draw(195, 131, 281_136_427, 1_233_727_526);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(1, 112, 0, -1_465_743_786, 167_009_391);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer48, 1_068);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer120, 'uint16', 3_078, 100);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let veryExplicitBindGroupLayout23 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 39, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 41,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+  ],
+});
+let buffer126 = device0.createBuffer({
+  size: 24580,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let texture272 = gpuCanvasContext1.getCurrentTexture();
+try {
+computePassEncoder49.setBindGroup(1, bindGroup53);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder51.setBlendConstant({ r: 221.7, g: -217.2, b: 817.6, a: -356.9, });
+} catch {}
+try {
+renderPassEncoder50.setViewport(22.03745440019402, 31.168295800139862, 16.579327668218703, 6.738772073303138, 0.04581180130140883, 0.27051242089635197);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(0, 96, 0, 44_905_835, 888_872_692);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer83, 4_724);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer1, 'uint16', 6_684, 1_158);
+} catch {}
+try {
+renderPassEncoder52.setPipeline(pipeline12);
+} catch {}
+let recycledExplicitBindGroupLayout16 = pipeline32.getBindGroupLayout(0);
+let buffer127 = device0.createBuffer({size: 1137, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture273 = device0.createTexture({size: [153, 3, 80], dimension: '3d', format: 'rg16sint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['r8uint', 'r8sint'], stencilReadOnly: true});
+try {
+computePassEncoder163.setBindGroup(0, bindGroup46);
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline37);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(1, bindGroup44, new Uint32Array(747), 22, 0);
+} catch {}
+try {
+renderPassEncoder16.drawIndexed(0, 178, 0, 197_921_443, 1_725_499_300);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer18, 'uint32', 84, 273);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline34);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let arrayBuffer26 = buffer26.getMappedRange(248, 8);
+try {
+computePassEncoder88.pushDebugGroup('\ua576');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 470, height: 2, depthOrArrayLayers: 54}
+*/
+{
+  source: img3,
+  origin: { x: 0, y: 26 },
+  flipY: false,
+}, {
+  texture: texture265,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 19},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise18;
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+diagnostic(info, xyz);
+
+override override7: u32 = 399;
+
+override override8: u32;
+
+@id(8813) override override12: f32;
+
+override override14: f32;
+
+/* zero global variables used */
+fn fn0(a0: ptr<uniform, VertexOutput9>) {
+  var vf243: bool = override13;
+  vf243 = bool(abs(vec3u(unconst_u32(199), unconst_u32(109), unconst_u32(655))).g);
+  let vf244: vec2h = atanh(vec2h(unconst_f16(-18151.8), unconst_f16(1169.3)));
+  let vf245: f16 = override5;
+  _ = override5;
+  _ = override13;
+}
+
+@id(24264) override override15: i32;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+override override5: f16 = -28567.5;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T0 {
+  f0: f32,
+}
+
+struct VertexOutput9 {
+  @location(14) @interpolate(flat, sample) f17: u32,
+  @location(2) @interpolate(perspective, center) f18: f16,
+  @location(15) @interpolate(perspective, sample) f19: f32,
+  @builtin(position) f20: vec4f,
+}
+
+override override4: u32;
+
+override override9: bool;
+
+/* zero global variables used */
+fn fn1() -> T0 {
+  var out: T0;
+  var vf246: vec2i =  ~vec2i(unconst_i32(270), unconst_i32(-4));
+  switch bitcast<i32>(sin(vec2h(unconst_f16(3701.8), unconst_f16(38993.2)))) { 
+  default {
+  out.f0 = bitcast<f32>(pack4xU8(firstLeadingBit(vec4u(transpose(mat3x2f())[unconst_i32(0)].zzyz))));
+  let vf247: vec3f = sqrt(vec3f(unconst_f32(0.6527), unconst_f32(-0.00765), unconst_f32(0.8034)));
+  {
+  loop {
+  out.f0 = f32(pack4x8snorm(vec4f(unconst_f32(0.3167), unconst_f32(-0.04137), unconst_f32(0.02590), unconst_f32(0.2245))));
+  break;
+}
+  var vf248: vec3i = (vec3i(unconst_i32(97), unconst_i32(3), unconst_i32(29)) | vec3i(unconst_i32(40), unconst_i32(45), unconst_i32(7)));
+  var vf249: f32 = exp2(unconst_f32(0.06810));
+}
+  let vf250: bool = all(unconst_bool(false));
+  out = T0(unpack2x16unorm(unconst_u32(158)).y);
+  break;
+}
+  }
+  {
+  {
+  if bool(sin(vec4f(unconst_f32(0.1375), unconst_f32(0.06164), unconst_f32(0.03808), unconst_f32(0.01311))).b) {
+  var vf251: i32 = override15;
+  _ = override15;
+}
+  let vf252: vec3h = sin(vec3h(unconst_f16(-15435.8), unconst_f16(4132.6), unconst_f16(6976.2)));
+  let vf253: vec3h = sin(vec3h(unconst_f16(6214.3), unconst_f16(5212.4), unconst_f16(603.1)));
+  let vf254: vec3h = faceForward(vec3h(unconst_f16(8310.3), unconst_f16(10520.9), unconst_f16(7525.9)), vec3h(unconst_f16(1550.0), unconst_f16(24118.6), unconst_f16(10747.9)), vec3h(unconst_f16(4525.3), unconst_f16(7523.3), unconst_f16(1625.7)));
+  _ = override15;
+}
+  out.f0 = trunc(unconst_f32(0.00712));
+  out = T0(cross(vec3f(cross(vec3h(unconst_f16(20078.5), unconst_f16(4497.9), unconst_f16(2780.5)), vec3h(unconst_f16(19735.3), unconst_f16(3523.5), unconst_f16(10158.9)))), vec3f(unconst_f32(0.06705), unconst_f32(0.00382), unconst_f32(0.08519)))[2]);
+  out = T0(f32(override13));
+  _ = override15;
+  _ = override13;
+}
+  loop {
+  out.f0 += f32((unconst_f32(0.02281) >= bitcast<f32>(override8)));
+  let vf255: f32 = override14;
+  out.f0 = override12;
+  break;
+  _ = override8;
+  _ = override12;
+  _ = override14;
+}
+  let vf256: u32 = override10;
+  return out;
+  _ = override10;
+  _ = override15;
+  _ = override8;
+  _ = override14;
+  _ = override12;
+  _ = override13;
+}
+
+override override11: f16;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@group(0) @binding(125) var st10: texture_storage_2d_array<r32float, read_write>;
+
+@id(26056) override override10: u32;
+
+override override6: i32 = 112;
+
+override override13 = true;
+
+/* zero global variables used */
+@vertex
+fn vertex10(@location(14) a0: vec2h) -> VertexOutput9 {
+  var out: VertexOutput9;
+  out.f20 = exp(vec3f(unconst_f32(0.1847), unconst_f32(0.2205), unconst_f32(0.08515))).xzzx;
+  let vf257: i32 = override15;
+  var vf258: mat4x2h = transpose(mat2x4h(unconst_f16(11297.9), unconst_f16(-13781.2), unconst_f16(-25341.4), unconst_f16(-20941.0), unconst_f16(12830.2), unconst_f16(26015.1), unconst_f16(-5024.3), unconst_f16(2690.5)));
+  var vf259: u32 = pack4xI8Clamp(vec4i(unconst_i32(283), unconst_i32(21), unconst_i32(212), unconst_i32(61)));
+  {
+  var vf260: bool = (unconst_bool(false) || unconst_bool(true));
+}
+  let ptr74: ptr<function, mat4x2h> = &vf258;
+  var vf261 = fn1();
+  while bool(override6) {
+  out.f17 |= u32(saturate(unconst_f32(0.2327)));
+  for (var it10=bitcast<u32>(radians(vec2h(unconst_f16(5422.3), unconst_f16(891.3)))); it10<bitcast<u32>(override6); it10++) {
+  let vf262: u32 = pack4xU8(vec4u(unconst_u32(187), unconst_u32(162), unconst_u32(50), unconst_u32(1)));
+  var vf263: vec3<bool> = (vec3h(unconst_f16(1024.9), unconst_f16(4418.8), unconst_f16(8857.5)) >= vec3h(unconst_f16(530.0), unconst_f16(7382.5), unconst_f16(14663.1)));
+  out.f20 = vec4f( ~vec4i(unconst_i32(205), unconst_i32(563), unconst_i32(303), unconst_i32(67)));
+  break;
+}
+  var vf264 = fn1();
+  out.f17 = vec3u(acos(vec3h(unconst_f16(16722.0), unconst_f16(17708.4), unconst_f16(7164.3))))[0];
+  fn1();
+  out.f18 += f16(unpack2x16snorm(unconst_u32(231))[1]);
+  out.f17 ^= insertBits(vec2u(unconst_u32(82), unconst_u32(19)), vec2u(u32( !bool(override6))), unconst_u32(8), unconst_u32(120))[1];
+  break;
+  _ = override6;
+  _ = override14;
+  _ = override12;
+  _ = override8;
+  _ = override13;
+  _ = override15;
+  _ = override10;
+}
+  let vf265: u32 = pack4x8unorm(vec4f(unconst_f32(0.04122), unconst_f32(0.1252), unconst_f32(0.02908), unconst_f32(0.1504)));
+  vf258 = mat4x2h(vf258[unconst_u32(47)][unconst_u32(193)], vf258[unconst_u32(47)][unconst_u32(193)], vf258[unconst_u32(47)][unconst_u32(193)], vf258[unconst_u32(47)][unconst_u32(193)], vf258[unconst_u32(47)][unconst_u32(193)], vf258[unconst_u32(47)][unconst_u32(193)], vf258[unconst_u32(47)][unconst_u32(193)], vf258[unconst_u32(47)][unconst_u32(193)]);
+  return out;
+  _ = override12;
+  _ = override6;
+  _ = override15;
+  _ = override10;
+  _ = override13;
+  _ = override8;
+  _ = override14;
+}
+
+/* used global variables: st10 */
+@compute @workgroup_size(1, 1, 1)
+fn compute12() {
+  let vf266: f32 = override12;
+  switch i32(atan2(vec4h(faceForward(vec4f(unconst_f32(0.3925), unconst_f32(0.09009), unconst_f32(0.2680), unconst_f32(0.1600)), vec4f(unconst_f32(0.1274), unconst_f32(0.06581), unconst_f32(0.08532), unconst_f32(0.5406)), vec4f(unconst_f32(0.03829), unconst_f32(0.04538), unconst_f32(0.1204), unconst_f32(0.09037))))[3], unconst_f16(-10817.4))) { 
+  default {
+  var vf267: f32 = override12;
+  let vf268: vec4i = countOneBits(vec4i(unconst_i32(434), unconst_i32(328), unconst_i32(0), unconst_i32(174)));
+  _ = override12;
+}
+  }
+  textureStore(st10, vec2i(unconst_i32(-192), unconst_i32(23)), unconst_i32(58), vec4f(vec4f(unconst_f32(-0.07948), unconst_f32(0.2272), unconst_f32(0.04103), unconst_f32(0.5135))));
+  let vf269: f32 = ldexp(unconst_f32(0.00264), unconst_i32(233));
+  textureStore(st10, vec2i(unconst_i32(199), unconst_i32(147)), unconst_i32(251), vec4f(vec4f(unconst_f32(0.03272), unconst_f32(0.02084), unconst_f32(0.2167), unconst_f32(0.1312))));
+  var vf270: f32 = override14;
+  var vf271: vec4f = textureLoad(st10, vec2i(unconst_i32(266), unconst_i32(122)), unconst_i32(58));
+  var vf272: i32 = override15;
+  textureStore(st10, vec2i(unconst_i32(-553), unconst_i32(57)), unconst_i32(507), vec4f(vec4f(unconst_f32(0.2253), unconst_f32(0.01818), unconst_f32(0.1638), unconst_f32(0.00748))));
+  let vf273: bool = override13;
+  _ = override13;
+  _ = override12;
+  _ = override14;
+  _ = override15;
+  _ = st10;
+}`,
+});
+let bindGroup96 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout3,
+  entries: [
+    {binding: 144, resource: textureView4},
+    {binding: 323, resource: {buffer: buffer125, offset: 6400, size: 888}},
+  ],
+});
+let buffer129 = device0.createBuffer({size: 10395, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let texture274 = device0.createTexture({
+  size: [32, 32, 21],
+  mipLevelCount: 2,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder16.draw(265, 481, 82_097_211, 57_918_545);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer67, 'uint16', 1_508, 227);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(1, buffer33, 628);
+} catch {}
+try {
+renderBundleEncoder19.setIndexBuffer(buffer56, 'uint32', 1_008, 423);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(6, buffer14, 0, 2_518);
+} catch {}
+try {
+computePassEncoder128.setBindGroup(0, bindGroup60, new Uint32Array(2154), 271, 0);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder16.drawIndexedIndirect(buffer107, 7_012);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(2, bindGroup68, []);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup41, new Uint32Array(3430), 322, 0);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(2, buffer105, 0);
+} catch {}
+document.body.prepend(canvas0);
+let recycledExplicitBindGroupLayout17 = pipeline7.getBindGroupLayout(0);
+let textureView193 = texture49.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+let renderBundle19 = renderBundleEncoder19.finish({});
+try {
+computePassEncoder47.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder16.drawIndexedIndirect(buffer21, 5_172);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer7, 536);
+} catch {}
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['rg32uint'], depthStencilFormat: 'depth24plus-stencil8', depthReadOnly: true});
+try {
+renderPassEncoder44.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderPassEncoder48.setViewport(14.929800446239895, 28.383638773852304, 1.0789774788189197, 3.2135103688293065, 0.09121940413593232, 0.13150825272852693);
+} catch {}
+try {
+renderPassEncoder16.drawIndirect(buffer85, 212);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer83, 'uint32', 308, 1_583);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(canvas0);
+let buffer130 = device0.createBuffer({
+  size: 1078,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture275 = device0.createTexture({size: [984, 1, 3], mipLevelCount: 3, format: 'r8sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+{ clearResourceUsages(device0, computePassEncoder119); computePassEncoder119.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder33.setBindGroup(3, bindGroup68, new Uint32Array(1509), 513, 0);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(2, bindGroup42);
+} catch {}
+try {
+renderBundleEncoder20.setIndexBuffer(buffer37, 'uint16', 1_396, 137);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(0, buffer22, 0, 119);
+} catch {}
+try {
+buffer129.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 100, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(30).fill(15), /* required buffer size: 30 */
+{offset: 30}, {width: 115, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let videoFrame24 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'bt2020', transfer: 'log'} });
+let renderBundle20 = renderBundleEncoder20.finish({});
+let sampler104 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 73.86,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup94);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder58); computePassEncoder58.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder129); computePassEncoder129.dispatchWorkgroupsIndirect(buffer70, 8); };
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup68, new Uint32Array(198), 25, 0);
+} catch {}
+try {
+renderPassEncoder16.end();
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(6, buffer14, 0, 13_022);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 230},
+  aspect: 'all',
+},
+{
+  texture: texture228,
+  mipLevel: 0,
+  origin: {x: 711, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 55, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup97 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 54, resource: sampler79},
+    {binding: 119, resource: textureView158},
+    {binding: 77, resource: {buffer: buffer63, offset: 256, size: 396}},
+    {binding: 155, resource: externalTexture2},
+    {binding: 33, resource: {buffer: buffer124, offset: 1536, size: 540}},
+  ],
+});
+let buffer131 = device0.createBuffer({
+  size: 8641,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let computePassEncoder168 = commandEncoder23.beginComputePass({});
+let sampler105 = device0.createSampler({addressModeV: 'clamp-to-edge', addressModeW: 'mirror-repeat', mipmapFilter: 'nearest'});
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup48);
+} catch {}
+try {
+renderPassEncoder47.setIndexBuffer(buffer124, 'uint32', 1_804, 955);
+} catch {}
+try {
+renderPassEncoder37.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder48.setVertexBuffer(4, buffer100);
+} catch {}
+let bindGroup98 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout4,
+  entries: [
+    {binding: 323, resource: {buffer: buffer75, offset: 768, size: 1436}},
+    {binding: 144, resource: textureView2},
+  ],
+});
+let buffer132 = device0.createBuffer({size: 9715, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView194 = texture161.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm']});
+let sampler106 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 52.35,
+});
+let externalTexture16 = device0.importExternalTexture({source: videoFrame23});
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup21, new Uint32Array(1348), 128, 0);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([renderBundle13, renderBundle0, renderBundle11, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer56, 'uint16', 632, 500);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup39, new Uint32Array(409), 98, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer38, 'uint16', 172, 63);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer98, 1360, new Float32Array(22), 1, 0);
+} catch {}
+let pipeline42 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {module: shaderModule2, constants: {override0: 1}, targets: [{format: 'rg8unorm'}]},
+  vertex: {module: shaderModule4, entryPoint: 'vertex3', constants: {}, buffers: []},
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+  await promise13;
+} catch {}
+let buffer133 = device0.createBuffer({
+  label: '\u4895\u0354\u077e\u5521\u3e58\u4b6b\u3f57\ud3a3\u{1fb25}',
+  size: 6972,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder182 = device0.createCommandEncoder({});
+let sampler107 = device0.createSampler({addressModeW: 'mirror-repeat', minFilter: 'linear'});
+try {
+computePassEncoder39.end();
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer22, 'uint16', 438, 248);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 615, height: 15, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData20,
+  origin: { x: 9, y: 2 },
+  flipY: false,
+}, {
+  texture: texture116,
+  mipLevel: 0,
+  origin: {x: 171, y: 9, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder183 = device0.createCommandEncoder({});
+let textureView195 = texture80.createView({dimension: '2d-array', format: 'r8sint', mipLevelCount: 1});
+try {
+computePassEncoder168.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(0, bindGroup61, new Uint32Array(1087), 88, 0);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer103, 'uint16', 2_450, 291);
+} catch {}
+try {
+renderPassEncoder38.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(2, buffer117, 0);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup61);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline14);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture253,
+  mipLevel: 0,
+  origin: {x: 4, y: 2, z: 8},
+  aspect: 'all',
+}, new Uint8Array(12_594).fill(111), /* required buffer size: 12_594 */
+{offset: 425, bytesPerRow: 39, rowsPerImage: 24}, {width: 1, height: 1, depthOrArrayLayers: 14});
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+try {
+adapter1.label = '\u0e53\ubbeb\u0d4f\u3d2f\u{1f66c}\u{1fe2a}\u8a97\uc423\uaac1\u04a7';
+} catch {}
+let commandEncoder184 = device0.createCommandEncoder({});
+let texture276 = device0.createTexture({
+  size: [1968, 1, 78],
+  mipLevelCount: 5,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder169 = commandEncoder183.beginComputePass();
+try {
+computePassEncoder169.setPipeline(pipeline32);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup86, new Uint32Array(1166), 172, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer67, 'uint16', 480, 157);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(0, buffer55, 256);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer98, 12676, new DataView(new ArrayBuffer(2304)), 956, 40);
+} catch {}
+let commandEncoder185 = device0.createCommandEncoder();
+let texture277 = device0.createTexture({
+  size: {width: 984, height: 1, depthOrArrayLayers: 441},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder170 = commandEncoder24.beginComputePass();
+try {
+computePassEncoder96.setBindGroup(2, bindGroup64, [2304]);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup2, new Uint32Array(2941), 45, 0);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer122, 'uint16', 32, 1_327);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(0, buffer88, 2_304);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(1, buffer38, 12, 56);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 58, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(74).fill(130), /* required buffer size: 74 */
+{offset: 74, bytesPerRow: 99}, {width: 9, height: 19, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 246, height: 1, depthOrArrayLayers: 307}
+*/
+{
+  source: videoFrame24,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 23},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+globalThis.someLabel = textureView111.label;
+} catch {}
+let bindGroup99 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout16,
+  entries: [
+    {binding: 323, resource: {buffer: buffer119, offset: 0, size: 1472}},
+    {binding: 144, resource: textureView2},
+  ],
+});
+let commandEncoder186 = device0.createCommandEncoder({});
+let textureView196 = texture229.createView({arrayLayerCount: 1});
+let computePassEncoder171 = commandEncoder184.beginComputePass({});
+let renderPassEncoder54 = commandEncoder186.beginRenderPass({
+  colorAttachments: [{
+  view: textureView36,
+  depthSlice: 190,
+  clearValue: { r: 177.2, g: -14.85, b: -232.4, a: -121.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 14688991,
+});
+try {
+computePassEncoder148.setBindGroup(0, bindGroup53);
+} catch {}
+try {
+computePassEncoder53.setBindGroup(2, bindGroup70, new Uint32Array(507), 21, 0);
+} catch {}
+try {
+computePassEncoder170.setPipeline(pipeline33);
+} catch {}
+try {
+renderPassEncoder17.setViewport(1.7272215886332434, 0.7289382667443219, 219.12080670547584, 0.013698171926536686, 0.45635960225396377, 0.8168287812175108);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup52, new Uint32Array(1663), 57, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer92, 'uint32', 344, 3_019);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let pipeline43 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule9, entryPoint: 'compute11', constants: {override3: 1}}});
+document.body.prepend(canvas1);
+let commandEncoder187 = device0.createCommandEncoder({});
+let textureView197 = texture183.createView({mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 3});
+let computePassEncoder172 = commandEncoder187.beginComputePass({});
+try {
+computePassEncoder170.setBindGroup(0, bindGroup73, new Uint32Array(661), 175, 0);
+} catch {}
+try {
+renderPassEncoder54.setIndexBuffer(buffer67, 'uint32', 480, 564);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(2, buffer1, 0, 1_890);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer76, 'uint16', 0, 132);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline42);
+} catch {}
+let computePassEncoder173 = commandEncoder185.beginComputePass();
+try {
+computePassEncoder171.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(3, bindGroup34, new Uint32Array(3764), 90, 0);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup51, new Uint32Array(799), 105, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer104, 'uint16', 7_800, 3_697);
+} catch {}
+try {
+computePassEncoder88.popDebugGroup();
+} catch {}
+try {
+commandEncoder182.insertDebugMarker('\ub7b9');
+} catch {}
+let buffer134 = device0.createBuffer({size: 22986, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder118.setBindGroup(1, bindGroup64, [0]);
+} catch {}
+try {
+computePassEncoder172.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder53.setIndexBuffer(buffer14, 'uint16', 4_394, 11_510);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture119,
+  mipLevel: 0,
+  origin: {x: 88, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(126).fill(132), /* required buffer size: 126 */
+{offset: 126}, {width: 121, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder188 = device0.createCommandEncoder({});
+let texture278 = gpuCanvasContext1.getCurrentTexture();
+try {
+{ clearResourceUsages(device0, computePassEncoder167); computePassEncoder167.dispatchWorkgroupsIndirect(buffer89, 148); };
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer106, 'uint32', 196, 841);
+} catch {}
+try {
+renderPassEncoder20.setPipeline(pipeline31);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup26, new Uint32Array(277), 52, 0);
+} catch {}
+try {
+renderPassEncoder13.insertDebugMarker('\uab5b');
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let videoFrame25 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'film', transfer: 'iec6196624'} });
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2unorm', 'rg16sint'], depthReadOnly: true, stencilReadOnly: true});
+let sampler108 = device0.createSampler({addressModeV: 'repeat', lodMaxClamp: 58.45, compare: 'equal'});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup81, new Uint32Array(3340), 89, 0);
+} catch {}
+try {
+computePassEncoder173.setPipeline(pipeline30);
+} catch {}
+try {
+renderPassEncoder46.setVertexBuffer(6, buffer43, 0, 37);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(2, bindGroup1, new Uint32Array(524), 92, 0);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer8, 'uint16', 96, 39);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(2, buffer74, 348);
+} catch {}
+let arrayBuffer27 = buffer26.getMappedRange(184, 0);
+try {
+commandEncoder182.copyBufferToBuffer(buffer55, 28, buffer132, 68, 296);
+} catch {}
+let commandEncoder189 = device0.createCommandEncoder({});
+let computePassEncoder174 = commandEncoder189.beginComputePass({});
+try {
+computePassEncoder174.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(3, bindGroup16, new Uint32Array(1791), 236, 0);
+} catch {}
+try {
+renderPassEncoder29.setViewport(169.31747534721484, 0.1323659397013882, 73.84020701794618, 0.4272327062052206, 0.033144936012354576, 0.7978273105685754);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer107, 'uint16', 552, 6_063);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder21.drawIndexedIndirect(buffer107, 5_084);
+} catch {}
+try {
+renderBundleEncoder21.drawIndirect(buffer121, 1_880);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer60, 'uint16', 298, 1_288);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(1, buffer14, 4_008, 2_820);
+} catch {}
+try {
+commandEncoder188.copyBufferToBuffer(buffer95, 196, buffer79, 624, 60);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+  await promise19;
+} catch {}
+let bindGroup100 = device0.createBindGroup({layout: autogeneratedBindGroupLayout2, entries: [{binding: 144, resource: textureView2}]});
+let commandEncoder190 = device0.createCommandEncoder({});
+try {
+computePassEncoder147.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder21.drawIndexedIndirect(buffer13, 3_936);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline26);
+} catch {}
+let promise20 = shaderModule1.getCompilationInfo();
+let bindGroup101 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout6,
+  entries: [
+    {binding: 144, resource: textureView145},
+    {binding: 323, resource: {buffer: buffer124, offset: 0, size: 1340}},
+  ],
+});
+let buffer135 = device0.createBuffer({size: 6398, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder191 = device0.createCommandEncoder({});
+let textureView198 = texture97.createView({dimension: '2d-array'});
+try {
+computePassEncoder150.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder161); computePassEncoder161.dispatchWorkgroupsIndirect(buffer2, 16); };
+} catch {}
+try {
+renderPassEncoder33.draw(329, 51, 1_272_462_675, 1_503_186_683);
+} catch {}
+try {
+renderPassEncoder33.drawIndexedIndirect(buffer62, 408);
+} catch {}
+try {
+renderPassEncoder33.drawIndirect(buffer131, 832);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer117, 'uint16', 10_648, 584);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(5, buffer80, 0, 207);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup87, new Uint32Array(1036), 190, 0);
+} catch {}
+try {
+renderBundleEncoder21.drawIndexed(57, 55, 138, 269_657_684, 431_189_335);
+} catch {}
+try {
+renderBundleEncoder21.drawIndexedIndirect(buffer90, 72);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(7, buffer102);
+} catch {}
+try {
+commandEncoder188.copyBufferToBuffer(buffer73, 352, buffer74, 2064, 84);
+} catch {}
+try {
+renderPassEncoder47.insertDebugMarker('\u{1fbe7}');
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let buffer136 = device0.createBuffer({
+  size: 17814,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder192 = device0.createCommandEncoder({});
+let textureView199 = texture228.createView({label: '\u0375\u00d2\u2db1\u{1fd63}\uf174\u9e54\ue2ee', baseArrayLayer: 0});
+let computePassEncoder175 = commandEncoder188.beginComputePass({});
+try {
+computePassEncoder100.setBindGroup(0, bindGroup74);
+} catch {}
+try {
+renderPassEncoder29.setStencilReference(282);
+} catch {}
+try {
+renderPassEncoder53.setViewport(1045.6533740009957, 0.17955172584369627, 412.00354643342047, 0.2596693063656096, 0.8020642323537057, 0.9346435370264887);
+} catch {}
+try {
+renderPassEncoder33.drawIndexedIndirect(buffer21, 18_500);
+} catch {}
+try {
+renderPassEncoder33.drawIndirect(buffer102, 4_324);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(2, buffer85);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup101);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup96, new Uint32Array(194), 16, 0);
+} catch {}
+await gc();
+let bindGroup102 = device0.createBindGroup({layout: autogeneratedBindGroupLayout2, entries: [{binding: 144, resource: textureView97}]});
+let textureView200 = texture55.createView({label: '\ubf27\u0998\u{1f9dc}\u73bf\uc7c1\u{1fd7b}\uee2d\u078d', arrayLayerCount: 1});
+let renderPassEncoder55 = commandEncoder191.beginRenderPass({
+  colorAttachments: [{
+  view: textureView142,
+  clearValue: { r: -683.9, g: -377.8, b: -444.0, a: -978.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundle21 = renderBundleEncoder22.finish({});
+try {
+computePassEncoder175.setPipeline(pipeline30);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup13, new Uint32Array(1755), 1_701, 0);
+} catch {}
+try {
+renderPassEncoder33.draw(52, 361, 282_120_181, 311_776_933);
+} catch {}
+try {
+renderPassEncoder33.drawIndexedIndirect(buffer70, 0);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(0, buffer70, 12, 9);
+} catch {}
+try {
+buffer63.unmap();
+} catch {}
+try {
+commandEncoder190.insertDebugMarker('\ua86c');
+} catch {}
+let imageBitmap2 = await createImageBitmap(videoFrame20);
+let bindGroup103 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout6,
+  entries: [
+    {binding: 144, resource: textureView5},
+    {binding: 323, resource: {buffer: buffer136, offset: 512, size: 7028}},
+  ],
+});
+let textureView201 = texture227.createView({mipLevelCount: 1});
+let computePassEncoder176 = commandEncoder182.beginComputePass();
+let renderBundle22 = renderBundleEncoder21.finish({});
+let sampler109 = device0.createSampler({addressModeU: 'mirror-repeat', maxAnisotropy: 1});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup34);
+} catch {}
+try {
+computePassEncoder141.setBindGroup(0, bindGroup47, new Uint32Array(82), 3, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder151); computePassEncoder151.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder176.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder33.drawIndexed(0, 312, 0, 110_935_173, 280_907_715);
+} catch {}
+try {
+renderPassEncoder49.setIndexBuffer(buffer96, 'uint16', 350, 111);
+} catch {}
+let recycledExplicitBindGroupLayout18 = pipeline0.getBindGroupLayout(0);
+let bindGroup104 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 9, resource: textureView67}]});
+let texture279 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 21},
+  sampleCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder37.setBindGroup(3, bindGroup87, new Uint32Array(2247), 398, 0);
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline38);
+} catch {}
+try {
+renderPassEncoder39.setBindGroup(2, bindGroup74);
+} catch {}
+try {
+renderPassEncoder33.drawIndexed(2, 4, 4, 349_165_567, 342_311_292);
+} catch {}
+try {
+renderPassEncoder33.drawIndexedIndirect(buffer65, 2_020);
+} catch {}
+try {
+renderPassEncoder33.drawIndirect(buffer1, 2_524);
+} catch {}
+try {
+renderPassEncoder50.setIndexBuffer(buffer41, 'uint32', 4_312, 7_846);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline42);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(6, buffer111);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55); };
+} catch {}
+let imageData24 = new ImageData(24, 80);
+let texture280 = device0.createTexture({
+  size: [470, 2, 1],
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder177 = commandEncoder192.beginComputePass();
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup91, []);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup58, new Uint32Array(1599), 45, 0);
+} catch {}
+try {
+renderPassEncoder33.end();
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer96, 'uint32', 132, 207);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer57, 572, new BigUint64Array(27781), 5171, 236);
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise21;
+} catch {}
+let veryExplicitBindGroupLayout24 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 246,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let computePassEncoder178 = commandEncoder40.beginComputePass({});
+try {
+computePassEncoder146.setBindGroup(2, bindGroup59, new Uint32Array(3665), 572, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder133); computePassEncoder133.dispatchWorkgroups(3); };
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup48);
+} catch {}
+try {
+renderPassEncoder53.setVertexBuffer(0, buffer117, 0, 1_201);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder190.copyBufferToBuffer(buffer4, 156, buffer41, 3200, 388);
+} catch {}
+try {
+commandEncoder190.copyBufferToTexture({
+  /* bytesInLastRow: 127 widthInBlocks: 127 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 651 */
+  offset: 651,
+  bytesPerRow: 6400,
+  buffer: buffer52,
+}, {
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 127, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise20;
+} catch {}
+let commandEncoder193 = device0.createCommandEncoder({});
+let computePassEncoder179 = commandEncoder193.beginComputePass();
+try {
+computePassEncoder161.setBindGroup(1, bindGroup61, new Uint32Array(210), 101, 0);
+} catch {}
+try {
+computePassEncoder179.setPipeline(pipeline37);
+} catch {}
+try {
+renderPassEncoder27.executeBundles([renderBundle6, renderBundle12, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder43.setStencilReference(1590);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder190.copyBufferToBuffer(buffer97, 524, buffer2, 8, 112);
+} catch {}
+let buffer137 = device0.createBuffer({size: 4684, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet24 = device0.createQuerySet({type: 'occlusion', count: 1598});
+let computePassEncoder180 = commandEncoder190.beginComputePass();
+let sampler110 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 94.83});
+try {
+{ clearResourceUsages(device0, computePassEncoder170); computePassEncoder170.dispatchWorkgroupsIndirect(buffer86, 10_760); };
+} catch {}
+try {
+renderPassEncoder51.setIndexBuffer(buffer89, 'uint32', 1_772, 171);
+} catch {}
+let arrayBuffer28 = buffer72.getMappedRange(16, 36);
+try {
+device0.queue.writeTexture({
+  texture: texture208,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(22).fill(186), /* required buffer size: 22 */
+{offset: 22, rowsPerImage: 4}, {width: 29, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+let pipeline44 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule0, constants: {}}});
+let bindGroup105 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout14,
+  entries: [
+    {binding: 323, resource: {buffer: buffer71, offset: 6912, size: 4104}},
+    {binding: 144, resource: textureView145},
+  ],
+});
+let textureView202 = texture106.createView({dimension: '2d', baseArrayLayer: 4});
+try {
+computePassEncoder148.setBindGroup(3, bindGroup96, new Uint32Array(2573), 31, 0);
+} catch {}
+try {
+computePassEncoder177.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup19, new Uint32Array(2452), 23, 0);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer37, 'uint16', 3_334, 1_000);
+} catch {}
+try {
+renderPassEncoder37.setVertexBuffer(1, buffer73);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup106 = device0.createBindGroup({layout: autogeneratedBindGroupLayout2, entries: [{binding: 144, resource: textureView145}]});
+let buffer138 = device0.createBuffer({size: 2285, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let sampler111 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 74.57,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder167.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+computePassEncoder66.setBindGroup(3, bindGroup27, new Uint32Array(91), 4, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup46);
+} catch {}
+try {
+renderPassEncoder47.setPipeline(pipeline21);
+} catch {}
+document.body.prepend(img3);
+let commandEncoder194 = device0.createCommandEncoder({});
+let textureView203 = texture103.createView({baseArrayLayer: 0, arrayLayerCount: 9});
+let renderPassEncoder56 = commandEncoder194.beginRenderPass({
+  colorAttachments: [{
+  view: textureView142,
+  clearValue: { r: 257.7, g: 825.0, b: -293.9, a: -89.60, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({colorFormats: ['rg32uint'], depthStencilFormat: 'depth24plus-stencil8', depthReadOnly: true});
+try {
+computePassEncoder152.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder47.setBindGroup(2, bindGroup84, new Uint32Array(3092), 1_355, 0);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(5, buffer131, 1_924, 323);
+} catch {}
+let textureView204 = texture72.createView({});
+let renderBundle23 = renderBundleEncoder23.finish({});
+let sampler112 = device0.createSampler({addressModeU: 'mirror-repeat', magFilter: 'nearest', lodMinClamp: 2.358});
+try {
+renderPassEncoder24.setScissorRect(10, 0, 6, 0);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup107 = device0.createBindGroup({
+  label: '\u5c12\u832e\u0d30\u0e51\uebfb\u155e\ueb2e\uc721',
+  layout: recycledExplicitBindGroupLayout13,
+  entries: [
+    {binding: 144, resource: textureView145},
+    {binding: 323, resource: {buffer: buffer111, offset: 7936, size: 3852}},
+  ],
+});
+let commandEncoder195 = device0.createCommandEncoder({});
+let texture281 = device0.createTexture({
+  size: [3760, 20, 1],
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder181 = commandEncoder195.beginComputePass({});
+let externalTexture17 = device0.importExternalTexture({source: videoFrame7});
+try {
+{ clearResourceUsages(device0, computePassEncoder150); computePassEncoder150.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup47);
+} catch {}
+try {
+renderPassEncoder51.setBindGroup(3, bindGroup101, new Uint32Array(83), 83, 0);
+} catch {}
+try {
+renderPassEncoder42.setPipeline(pipeline42);
+} catch {}
+document.body.append(img4);
+let commandEncoder196 = device0.createCommandEncoder({});
+let querySet25 = device0.createQuerySet({type: 'occlusion', count: 1058});
+let textureView205 = texture177.createView({dimension: '2d', baseMipLevel: 0, baseArrayLayer: 0});
+let computePassEncoder182 = commandEncoder196.beginComputePass({});
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderPassEncoder45.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(2, buffer117);
+} catch {}
+let pipeline45 = device0.createRenderPipeline({
+  layout: 'auto',
+  multisample: {mask: 0x1c7617e2},
+  fragment: {
+  module: shaderModule0,
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule9,
+    constants: {override3: 1},
+    buffers: [
+      {
+        arrayStride: 360,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 20, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list'},
+});
+let commandEncoder197 = device0.createCommandEncoder();
+let textureView206 = texture178.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+try {
+computePassEncoder72.setBindGroup(1, bindGroup40, new Uint32Array(4097), 1_203, 0);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer60, 'uint16', 1_090, 1_146);
+} catch {}
+try {
+renderPassEncoder53.setPipeline(pipeline20);
+} catch {}
+let recycledExplicitBindGroupLayout19 = pipeline2.getBindGroupLayout(0);
+let textureView207 = texture84.createView({dimension: '2d-array'});
+let sampler113 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat', mipmapFilter: 'nearest'});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup68, new Uint32Array(1569), 166, 0);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(2, bindGroup96);
+} catch {}
+try {
+renderPassEncoder43.setIndexBuffer(buffer124, 'uint16', 592, 280);
+} catch {}
+try {
+commandEncoder197.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7132 */
+  offset: 7132,
+  bytesPerRow: 34816,
+  buffer: buffer83,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 27, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder168.insertDebugMarker('\u0b27');
+} catch {}
+let bindGroup108 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout9,
+  entries: [
+    {binding: 144, resource: textureView4},
+    {binding: 323, resource: {buffer: buffer125, offset: 3072, size: 4364}},
+  ],
+});
+let buffer139 = device0.createBuffer({size: 452, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder198 = device0.createCommandEncoder();
+let computePassEncoder183 = commandEncoder197.beginComputePass();
+let sampler114 = device0.createSampler({addressModeU: 'mirror-repeat', lodMaxClamp: 75.81, compare: 'greater-equal'});
+let commandEncoder199 = device0.createCommandEncoder({});
+let sampler115 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 63.86, compare: 'greater'});
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(0, buffer33, 0);
+} catch {}
+let buffer140 = device0.createBuffer({size: 8020, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let texture282 = device0.createTexture({
+  size: {width: 307, height: 7, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder48.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, undefined, 0, 45_702_030);
+} catch {}
+try {
+commandEncoder198.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 25, y: 12, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder200 = device0.createCommandEncoder({});
+try {
+computePassEncoder67.setBindGroup(2, bindGroup93, new Uint32Array(566), 169, 0);
+} catch {}
+try {
+commandEncoder199.copyBufferToTexture({
+  /* bytesInLastRow: 1488 widthInBlocks: 186 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 8888 */
+  offset: 8888,
+  buffer: buffer1,
+}, {
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 186, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 106, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(19).fill(147), /* required buffer size: 19 */
+{offset: 19, bytesPerRow: 186}, {width: 135, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer141 = device0.createBuffer({
+  size: 2480,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let texture283 = device0.createTexture({
+  size: [10, 11, 1],
+  sampleCount: 4,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder184 = commandEncoder198.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder147); computePassEncoder147.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline23);
+} catch {}
+try {
+computePassEncoder182.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup42, new Uint32Array(710), 36, 0);
+} catch {}
+let arrayBuffer29 = buffer26.getMappedRange(264, 20);
+try {
+commandEncoder200.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3036 */
+  offset: 3036,
+  bytesPerRow: 41984,
+  buffer: buffer56,
+}, {
+  texture: texture229,
+  mipLevel: 0,
+  origin: {x: 231, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer133, 92, new BigUint64Array(2651), 378, 92);
+} catch {}
+let promise23 = device0.queue.onSubmittedWorkDone();
+await gc();
+let bindGroup109 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout16,
+  entries: [
+    {binding: 430, resource: sampler87},
+    {binding: 133, resource: {buffer: buffer20, offset: 1024, size: 6480}},
+    {binding: 73, resource: sampler17},
+    {binding: 34, resource: textureView111},
+  ],
+});
+let textureView208 = texture65.createView({format: 'astc-6x6-unorm-srgb'});
+let computePassEncoder185 = commandEncoder199.beginComputePass();
+let renderPassEncoder57 = commandEncoder200.beginRenderPass({
+  colorAttachments: [{
+  view: textureView79,
+  depthSlice: 9,
+  clearValue: { r: -78.21, g: -679.5, b: -485.2, a: 514.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 105636845,
+});
+try {
+computePassEncoder34.setBindGroup(2, bindGroup72);
+} catch {}
+try {
+computePassEncoder173.setBindGroup(0, bindGroup42, new Uint32Array(1731), 4, 0);
+} catch {}
+try {
+computePassEncoder184.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup57);
+} catch {}
+try {
+renderPassEncoder44.setIndexBuffer(buffer122, 'uint16', 2_302, 801);
+} catch {}
+try {
+renderPassEncoder29.setPipeline(pipeline21);
+} catch {}
+let arrayBuffer30 = buffer26.getMappedRange(176, 0);
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let buffer142 = device0.createBuffer({size: 941, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder201 = device0.createCommandEncoder({});
+let querySet26 = device0.createQuerySet({type: 'occlusion', count: 262});
+let texture284 = device0.createTexture({
+  size: {width: 80, height: 90, depthOrArrayLayers: 69},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView209 = texture221.createView({dimension: '2d', baseArrayLayer: 9});
+let computePassEncoder186 = commandEncoder201.beginComputePass({});
+try {
+renderPassEncoder13.setIndexBuffer(buffer130, 'uint32', 132, 12);
+} catch {}
+let canvas2 = document.createElement('canvas');
+let buffer143 = device0.createBuffer({size: 1954, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let commandEncoder202 = device0.createCommandEncoder({});
+let computePassEncoder187 = commandEncoder202.beginComputePass({});
+let externalTexture18 = device0.importExternalTexture({source: videoFrame17});
+try {
+computePassEncoder153.setPipeline(pipeline43);
+} catch {}
+try {
+computePassEncoder180.setPipeline(pipeline43);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(3, bindGroup87);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(0, bindGroup25, new Uint32Array(265), 12, 0);
+} catch {}
+try {
+renderPassEncoder48.executeBundles([renderBundle2, renderBundle12, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer41, 'uint16', 1_888, 816);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(7, buffer96, 8, 14);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+});
+} catch {}
+document.body.append(canvas0);
+let bindGroup110 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout11,
+  entries: [
+    {binding: 323, resource: {buffer: buffer111, offset: 3072, size: 6540}},
+    {binding: 144, resource: textureView5},
+  ],
+});
+let sampler116 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.33,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder115.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+computePassEncoder117.setBindGroup(1, bindGroup79, new Uint32Array(270), 30, 0);
+} catch {}
+try {
+computePassEncoder133.end();
+} catch {}
+try {
+computePassEncoder181.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder44.executeBundles([renderBundle7, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder47.setStencilReference(982);
+} catch {}
+let commandEncoder203 = device0.createCommandEncoder({});
+let textureView210 = texture90.createView({baseArrayLayer: 12, arrayLayerCount: 8});
+let textureView211 = texture256.createView({mipLevelCount: 1});
+let computePassEncoder188 = commandEncoder203.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder50); computePassEncoder50.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder147); computePassEncoder147.dispatchWorkgroupsIndirect(buffer87, 36); };
+} catch {}
+try {
+computePassEncoder185.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder138.resolveQuerySet(querySet20, 22, 16, buffer103, 512);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 90, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame23,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture92,
+  mipLevel: 0,
+  origin: {x: 14, y: 47, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer26 = commandEncoder138.finish();
+let texture285 = device0.createTexture({size: [984, 1, 26], mipLevelCount: 3, format: 'rg8unorm', usage: GPUTextureUsage.TEXTURE_BINDING});
+let sampler117 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 88.00,
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder13.setVertexBuffer(1, buffer136, 536, 491);
+} catch {}
+document.body.prepend(canvas1);
+let veryExplicitBindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 44,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let recycledExplicitBindGroupLayout20 = pipeline8.getBindGroupLayout(1);
+let buffer144 = device0.createBuffer({
+  size: 17979,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let textureView212 = texture114.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 1});
+try {
+computePassEncoder102.setBindGroup(0, bindGroup98, new Uint32Array(3683), 396, 0);
+} catch {}
+try {
+renderPassEncoder57.setPipeline(pipeline31);
+} catch {}
+await gc();
+let bindGroup111 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout20,
+  entries: [
+    {binding: 80, resource: {buffer: buffer119, offset: 512, size: 216}},
+    {binding: 22, resource: {buffer: buffer40, offset: 512}},
+    {binding: 390, resource: sampler100},
+    {binding: 160, resource: textureView95},
+    {binding: 51, resource: textureView96},
+    {binding: 188, resource: textureView131},
+    {binding: 60, resource: externalTexture15},
+    {binding: 67, resource: {buffer: buffer89, offset: 512, size: 2240}},
+    {binding: 114, resource: {buffer: buffer74, offset: 0, size: 4380}},
+  ],
+});
+let commandEncoder204 = device0.createCommandEncoder({});
+try {
+computePassEncoder66.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+computePassEncoder50.end();
+} catch {}
+try {
+computePassEncoder188.setPipeline(pipeline38);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup100, new Uint32Array(522), 13, 0);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder62.copyBufferToTexture({
+  /* bytesInLastRow: 210 widthInBlocks: 105 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 360 */
+  offset: 360,
+  buffer: buffer8,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 58, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 105, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise22;
+} catch {}
+let buffer145 = device0.createBuffer({
+  size: 6594,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder205 = device0.createCommandEncoder({});
+let textureView213 = texture54.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder189 = commandEncoder62.beginComputePass({});
+try {
+computePassEncoder183.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(23, 0, 43, 0);
+} catch {}
+let querySet27 = device0.createQuerySet({type: 'occlusion', count: 624});
+let computePassEncoder190 = commandEncoder205.beginComputePass({});
+let sampler118 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.84,
+  compare: 'always',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder70.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer120, 'uint32', 1_260, 336);
+} catch {}
+try {
+device0.queue.submit([commandBuffer26]);
+} catch {}
+let promise24 = device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule7, constants: {}}});
+offscreenCanvas0.width = 749;
+let querySet28 = device0.createQuerySet({type: 'occlusion', count: 227});
+let textureView214 = texture80.createView({dimension: '2d-array', format: 'r8sint', mipLevelCount: 1});
+let computePassEncoder191 = commandEncoder204.beginComputePass({});
+try {
+computePassEncoder110.setBindGroup(1, bindGroup109, [5376]);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder92); computePassEncoder92.dispatchWorkgroupsIndirect(buffer114, 0); };
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(4, buffer56);
+} catch {}
+let commandEncoder206 = device0.createCommandEncoder();
+let textureView215 = texture81.createView({dimension: 'cube', baseMipLevel: 0, baseArrayLayer: 6});
+let textureView216 = texture0.createView({dimension: '2d-array', aspect: 'depth-only', baseMipLevel: 0});
+try {
+renderPassEncoder24.setIndexBuffer(buffer102, 'uint16', 684, 2_212);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(2, buffer56, 0, 1_242);
+} catch {}
+try {
+commandEncoder206.copyBufferToBuffer(buffer126, 96, buffer72, 340, 1428);
+} catch {}
+let buffer146 = device0.createBuffer({size: 21232, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture286 = gpuCanvasContext3.getCurrentTexture();
+let textureView217 = texture148.createView({mipLevelCount: 1});
+let computePassEncoder192 = commandEncoder206.beginComputePass({});
+try {
+computePassEncoder189.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(0, bindGroup38, []);
+} catch {}
+try {
+renderPassEncoder57.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder55.setVertexBuffer(4, buffer55, 508, 42);
+} catch {}
+let commandEncoder207 = device0.createCommandEncoder({});
+let textureView218 = texture60.createView({dimension: '2d'});
+let renderPassEncoder58 = commandEncoder207.beginRenderPass({
+  colorAttachments: [{
+  view: textureView172,
+  clearValue: { r: 408.1, g: 558.1, b: 870.9, a: 817.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder127.setBindGroup(0, bindGroup68);
+} catch {}
+try {
+computePassEncoder167.end();
+} catch {}
+try {
+renderPassEncoder19.setViewport(146.75324431553355, 0.9902287090900082, 42.43583211755888, 0.00169724000425971, 0.7578387990503729, 0.9305702144511402);
+} catch {}
+try {
+commandEncoder178.copyBufferToTexture({
+  /* bytesInLastRow: 156 widthInBlocks: 39 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 324 */
+  offset: 324,
+  bytesPerRow: 9216,
+  buffer: buffer137,
+}, {
+  texture: texture126,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 39, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder17.insertDebugMarker('\u1c94');
+} catch {}
+try {
+  await promise23;
+} catch {}
+let bindGroup112 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [
+    {binding: 323, resource: {buffer: buffer42, offset: 256, size: 2876}},
+    {binding: 144, resource: textureView145},
+  ],
+});
+let texture287 = gpuCanvasContext1.getCurrentTexture();
+let textureView219 = texture11.createView({});
+let renderPassEncoder59 = commandEncoder178.beginRenderPass({
+  colorAttachments: [{
+  view: textureView134,
+  depthSlice: 3,
+  clearValue: { r: -560.3, g: -855.5, b: 807.3, a: -227.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder187.setPipeline(pipeline37);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup45, new Uint32Array(953), 28, 0);
+} catch {}
+try {
+renderPassEncoder27.beginOcclusionQuery(41);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture251,
+  mipLevel: 0,
+  origin: {x: 307, y: 0, z: 72},
+  aspect: 'all',
+}, new Uint8Array(450_687).fill(210), /* required buffer size: 450_687 */
+{offset: 111, bytesPerRow: 894, rowsPerImage: 14}, {width: 221, height: 0, depthOrArrayLayers: 37});
+} catch {}
+let buffer147 = device0.createBuffer({size: 14661, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let texture288 = device0.createTexture({
+  size: [80, 90, 45],
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView220 = texture71.createView({dimension: '2d-array', format: 'r8uint'});
+let offscreenCanvas3 = new OffscreenCanvas(244, 280);
+let imageData25 = new ImageData(4, 32);
+let textureView221 = texture258.createView({dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1});
+let sampler119 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 69.44});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup59, new Uint32Array(1762), 370, 0);
+} catch {}
+try {
+renderPassEncoder50.setBindGroup(0, bindGroup58, new Uint32Array(176), 58, 0);
+} catch {}
+try {
+computePassEncoder70.pushDebugGroup('\u0ddb');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 1682, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(7).fill(30), /* required buffer size: 7 */
+{offset: 7}, {width: 454, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule11 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(144) var st11: texture_storage_1d<r32uint, read_write>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T0 {
+  @align(32) @size(864) f0: array<u32>,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@id(42511) override override16: i32;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct VertexOutput10 {
+  @location(6) f21: vec4h,
+  @location(14) @interpolate(flat, either) f22: vec4i,
+  @location(15) f23: vec4i,
+  @location(13) @interpolate(flat, either) f24: vec4f,
+  @location(7) @interpolate(flat) f25: vec4u,
+  @builtin(position) f26: vec4f,
+  @location(4) f27: vec4i,
+}
+
+struct VertexOutput11 {
+  @location(11) f28: f16,
+  @location(1) @interpolate(perspective, sample) f29: vec2f,
+  @location(8) @interpolate(flat, first) f30: vec2i,
+  @location(6) f31: vec2f,
+  @location(0) @interpolate(flat, sample) f32: vec4u,
+  @location(4) @interpolate(flat, either) f33: vec4i,
+  @location(3) f34: vec2h,
+  @location(10) @interpolate(flat, either) f35: vec2i,
+  @builtin(position) f36: vec4f,
+  @location(15) @interpolate(flat, first) f37: vec4i,
+  @location(2) f38: f32,
+}
+
+/* zero global variables used */
+@vertex
+fn vertex11(@location(7) a0: vec2u) -> VertexOutput10 {
+  var out: VertexOutput10;
+  let vf274: vec2f = min(vec2f(unconst_f32(-0.2147), unconst_f32(0.2707)), vec2f(f32((unconst_bool(false) && unconst_bool(false)))));
+  var vf275: u32 = dot(vec4u(unconst_u32(631), unconst_u32(94), unconst_u32(165), unconst_u32(282)), abs(vec3u(acos(vec3h(unconst_f16(9915.2), unconst_f16(5450.5), unconst_f16(12030.0))))).ggbr);
+  let vf276: f32 = sqrt(unconst_f32(0.00144));
+  let vf277: bool = (unconst_bool(false) && unconst_bool(true));
+  var vf278: f16 = smoothstep(unconst_f16(735.6), unconst_f16(6079.9), unconst_f16(40666.4));
+  switch vec3i(acos(vec3h(refract(vec4f(unconst_f32(-0.04074), unconst_f32(0.02494), unconst_f32(0.02260), unconst_f32(0.3109)), vec4f((vec4i(unconst_i32(108), unconst_i32(48), unconst_i32(276), unconst_i32(42)) != bitcast<vec4i>(radians(vec3f(unconst_f32(0.3002), unconst_f32(0.01551), unconst_f32(0.07194))).zyxz))), unconst_f32(0.06649)).ggg)))[0] { 
+  default {
+  let vf279: u32 = pack4x8snorm(vec4f(unconst_f32(0.3181), unconst_f32(-0.2238), unconst_f32(0.1228), unconst_f32(0.4140)));
+  let vf280: u32 = pack4x8snorm(vec4f(unconst_f32(-0.1071), unconst_f32(0.2351), unconst_f32(-0.06115), unconst_f32(0.1490)));
+  let vf281: vec2h = min(vec2h(unconst_f16(-9703.9), unconst_f16(15542.2)), vec2h(unconst_f16(21107.7), unconst_f16(12483.6)));
+  out.f26 -= unpack4x8snorm(pack4x8snorm(vec4f(unconst_f32(0.3051), unconst_f32(0.2004), unconst_f32(0.3439), unconst_f32(0.01155))));
+  var vf282: u32 = a0[unconst_u32(19)];
+  let vf283: i32 = override16;
+  break;
+  _ = override16;
+}
+  }
+  return out;
+  _ = override16;
+}
+
+/* zero global variables used */
+@vertex
+fn vertex12() -> VertexOutput11 {
+  var out: VertexOutput11;
+  let vf284: vec3h = atan2(vec3h(unconst_f16(19826.5), unconst_f16(3063.0), unconst_f16(9699.7)), vec3h(unconst_f16(511.1), unconst_f16(5678.7), unconst_f16(5086.6)));
+  switch vec3i(vf284)[2] { 
+  default {
+  {
+  var vf285: i32 = dot4I8Packed(unconst_u32(199), unconst_u32(185));
+  var vf286: vec4i = extractBits(vec4i(unpack2x16float(vec4u(step(vec4h(f16(countTrailingZeros(unconst_i32(114)))), vec4h(unconst_f16(5721.0), unconst_f16(7899.3), unconst_f16(7283.1), unconst_f16(38730.8)))).y).ggrr), unconst_u32(279), unconst_u32(926));
+  out.f36 = vec4f(f32(override16));
+  var vf287: i32 = countTrailingZeros(unconst_i32(-154));
+  break;
+  _ = override16;
+}
+  _ = override16;
+}
+  }
+  out.f30 = vec2i(saturate(vec3h(unconst_f16(14644.6), unconst_f16(8815.6), unconst_f16(15548.9))).bg);
+  let vf288: vec3h = cross(vec3h(unconst_f16(38964.8), unconst_f16(21554.2), unconst_f16(11928.8)), vec3h(unconst_f16(-1790.4), unconst_f16(6753.4), unconst_f16(550.6)));
+  let vf289: i32 = override16;
+  let vf290: vec3u = max(vec3u(u32(trunc(unconst_f16(2581.2)))), vec3u(unconst_u32(151), unconst_u32(52), unconst_u32(155)));
+  out = VertexOutput11(sqrt(vec3h(unconst_f16(3116.6), unconst_f16(-12296.6), unconst_f16(4410.8))).r, vec2f(sqrt(vec3h(unconst_f16(3116.6), unconst_f16(-12296.6), unconst_f16(4410.8))).gg), vec2i(sqrt(vec3h(unconst_f16(3116.6), unconst_f16(-12296.6), unconst_f16(4410.8))).zz), vec2f(sqrt(vec3h(unconst_f16(3116.6), unconst_f16(-12296.6), unconst_f16(4410.8))).zz), vec4u(sqrt(vec3h(unconst_f16(3116.6), unconst_f16(-12296.6), unconst_f16(4410.8))).xzzz), vec4i(sqrt(vec3h(unconst_f16(3116.6), unconst_f16(-12296.6), unconst_f16(4410.8))).grrr), sqrt(vec3h(unconst_f16(3116.6), unconst_f16(-12296.6), unconst_f16(4410.8))).rb, vec2i(sqrt(vec3h(unconst_f16(3116.6), unconst_f16(-12296.6), unconst_f16(4410.8))).rb), vec4f(sqrt(vec3h(unconst_f16(3116.6), unconst_f16(-12296.6), unconst_f16(4410.8))).grrr), vec4i(sqrt(vec3h(unconst_f16(3116.6), unconst_f16(-12296.6), unconst_f16(4410.8))).rgrr), vec3f(sqrt(vec3h(unconst_f16(3116.6), unconst_f16(-12296.6), unconst_f16(4410.8))))[2]);
+  let vf291: vec3u = countLeadingZeros(vec3u(u32((unconst_bool(true) || bool(inverseSqrt(vec2h(countLeadingZeros(vec3u(unconst_u32(10), unconst_u32(15), unconst_u32(57))).zx)).g)))));
+  let vf292: f16 = sin(unconst_f16(9643.1));
+  let vf293: u32 = pack4xU8(vec4u(unconst_u32(40), unconst_u32(145), unconst_u32(90), unconst_u32(102)));
+  out.f32 = vec4u(pack4x8snorm(vec4f(unconst_f32(0.00582), unconst_f32(0.1480), unconst_f32(0.2355), unconst_f32(0.3811))));
+  var vf294: vec4f = exp2(vec4f(unconst_f32(-0.00565), unconst_f32(0.1497), unconst_f32(-0.1527), unconst_f32(0.09265)));
+  out.f34 = bitcast<vec2h>(vf294[unconst_u32(83)]);
+  var vf295: vec3h = cross(vec3h(unconst_f16(16189.7), unconst_f16(9660.2), unconst_f16(2466.9)), vec3h(unconst_f16(10276.3), unconst_f16(7415.7), unconst_f16(6420.5)));
+  while bool(exp2(vec4f(unconst_f32(0.1538), unconst_f32(-0.1250), unconst_f32(0.1936), unconst_f32(0.3704)))[1]) {
+  out = VertexOutput11(f16(distance(vec2f(unconst_f32(0.2537), unconst_f32(0.09032)), vec2f(unconst_f32(-0.3492), unconst_f32(0.06305)))), vec2f(distance(vec2f(unconst_f32(0.2537), unconst_f32(0.09032)), vec2f(unconst_f32(-0.3492), unconst_f32(0.06305)))), vec2i(bitcast<i32>(distance(vec2f(unconst_f32(0.2537), unconst_f32(0.09032)), vec2f(unconst_f32(-0.3492), unconst_f32(0.06305))))), vec2f(distance(vec2f(unconst_f32(0.2537), unconst_f32(0.09032)), vec2f(unconst_f32(-0.3492), unconst_f32(0.06305)))), vec4u(bitcast<u32>(distance(vec2f(unconst_f32(0.2537), unconst_f32(0.09032)), vec2f(unconst_f32(-0.3492), unconst_f32(0.06305))))), vec4i(i32(distance(vec2f(unconst_f32(0.2537), unconst_f32(0.09032)), vec2f(unconst_f32(-0.3492), unconst_f32(0.06305))))), bitcast<vec2h>(distance(vec2f(unconst_f32(0.2537), unconst_f32(0.09032)), vec2f(unconst_f32(-0.3492), unconst_f32(0.06305)))), vec2i(i32(distance(vec2f(unconst_f32(0.2537), unconst_f32(0.09032)), vec2f(unconst_f32(-0.3492), unconst_f32(0.06305))))), vec4f(distance(vec2f(unconst_f32(0.2537), unconst_f32(0.09032)), vec2f(unconst_f32(-0.3492), unconst_f32(0.06305)))), vec4i(bitcast<i32>(distance(vec2f(unconst_f32(0.2537), unconst_f32(0.09032)), vec2f(unconst_f32(-0.3492), unconst_f32(0.06305))))), distance(vec2f(unconst_f32(0.2537), unconst_f32(0.09032)), vec2f(unconst_f32(-0.3492), unconst_f32(0.06305))));
+  let vf296: vec2i = extractBits(vec2i(unconst_i32(428), unconst_i32(93)), u32(dot4I8Packed(unconst_u32(31), unconst_u32(230))), unconst_u32(93));
+  let vf297: vec4h = faceForward(vec4h(unconst_f16(21751.5), unconst_f16(42882.0), unconst_f16(3547.0), unconst_f16(11633.5)), vec4h(unconst_f16(54392.7), unconst_f16(9420.5), unconst_f16(13908.0), unconst_f16(16691.8)), vec4h(unconst_f16(29477.4), unconst_f16(20259.9), unconst_f16(9068.5), unconst_f16(-1126.6)));
+  let vf298: vec2i = extractBits(vec2i(unconst_i32(877), unconst_i32(112)), u32(vf296[unconst_u32(49)]), unconst_u32(31));
+  out.f38 += vec3f((vec3f(unconst_f32(0.2958), unconst_f32(0.09016), unconst_f32(0.1296)) <= floor(vec2f(unconst_f32(0.1648), unconst_f32(0.01152))).xxx))[1];
+}
+  return out;
+  _ = override16;
+}
+
+/* used global variables: st11 */
+@compute @workgroup_size(1, 1, 1)
+fn compute13() {
+  let vf299: vec4h = normalize(vec4h(unconst_f16(60000.0), unconst_f16(12604.4), unconst_f16(16826.5), unconst_f16(24461.9)));
+  textureStore(st11, unconst_i32(196), vec4u(vec4u(unconst_u32(41), unconst_u32(16), unconst_u32(155), unconst_u32(121))));
+  var vf300: vec2<bool> = (vec2f(unconst_f32(0.3951), unconst_f32(0.06366)) < vec2f(unconst_f32(0.2311), unconst_f32(-0.2759)));
+  var vf301: i32 = override16;
+  vf301 += insertBits(vec2i(unconst_i32(42), unconst_i32(74)), vec2i(unconst_i32(38), unconst_i32(-41)), unconst_u32(393), unconst_u32(29))[0];
+  vf301 |= vec4i( !vec4<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false), unconst_bool(false)))[3];
+  vf301 -= vec2i(vf300)[0];
+  let ptr75: ptr<function, vec2<bool>> = &vf300;
+  vf301 = bitcast<i32>(pack4x8unorm(vec4f(unconst_f32(-0.1011), unconst_f32(0.1890), unconst_f32(0.2380), unconst_f32(0.1103))));
+  _ = override16;
+  _ = st11;
+}`,
+});
+let buffer148 = device0.createBuffer({size: 43082, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView222 = texture154.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 25});
+try {
+{ clearResourceUsages(device0, computePassEncoder92); computePassEncoder92.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder161.end();
+} catch {}
+try {
+computePassEncoder190.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder27.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline7);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 45, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 6, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let bindGroup113 = device0.createBindGroup({layout: veryExplicitBindGroupLayout14, entries: [{binding: 21, resource: textureView60}]});
+let buffer149 = device0.createBuffer({size: 3360, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let computePassEncoder193 = commandEncoder168.beginComputePass({});
+try {
+computePassEncoder146.setBindGroup(3, bindGroup62);
+} catch {}
+try {
+computePassEncoder122.setBindGroup(3, bindGroup15, new Uint32Array(4630), 394, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder127); computePassEncoder127.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder191.setPipeline(pipeline1);
+} catch {}
+try {
+computePassEncoder49.pushDebugGroup('\u04f8');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture154,
+  mipLevel: 0,
+  origin: {x: 5, y: 4, z: 17},
+  aspect: 'all',
+}, new Uint8Array(5_724).fill(151), /* required buffer size: 5_724 */
+{offset: 0, bytesPerRow: 26, rowsPerImage: 220}, {width: 2, height: 1, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 615, height: 15, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData16,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture89,
+  mipLevel: 1,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55); };
+} catch {}
+let autogeneratedBindGroupLayout7 = pipeline4.getBindGroupLayout(0);
+let commandEncoder208 = device0.createCommandEncoder({});
+let textureView223 = texture58.createView({});
+let computePassEncoder194 = commandEncoder208.beginComputePass();
+let sampler120 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 94.55});
+try {
+computePassEncoder194.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(55);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder47.setPipeline(pipeline5);
+} catch {}
+try {
+computePassEncoder70.popDebugGroup();
+} catch {}
+try {
+computePassEncoder132.insertDebugMarker('\u8927');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 984, height: 1, depthOrArrayLayers: 140}
+*/
+{
+  source: imageData21,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture120,
+  mipLevel: 1,
+  origin: {x: 195, y: 0, z: 17},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext5 = canvas2.getContext('webgpu');
+await gc();
+let bindGroup114 = device0.createBindGroup({layout: autogeneratedBindGroupLayout2, entries: [{binding: 144, resource: textureView97}]});
+let textureView224 = texture65.createView({dimension: '2d-array', baseMipLevel: 0});
+let sampler121 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 76.42,
+  compare: 'always',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder80.setBindGroup(1, bindGroup97, new Uint32Array(1834), 294, 0);
+} catch {}
+try {
+computePassEncoder192.setPipeline(pipeline41);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: 538.5, g: -167.1, b: -394.2, a: 753.8, });
+} catch {}
+let bindGroup115 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout12,
+  entries: [
+    {binding: 166, resource: {buffer: buffer65, offset: 512, size: 152}},
+    {binding: 125, resource: textureView21},
+  ],
+});
+let commandEncoder209 = device0.createCommandEncoder();
+let texture289 = device0.createTexture({
+  size: {width: 40},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder195 = commandEncoder209.beginComputePass({});
+let externalTexture19 = device0.importExternalTexture({source: videoFrame20});
+try {
+renderPassEncoder37.setBindGroup(0, bindGroup58);
+} catch {}
+try {
+renderPassEncoder24.executeBundles([renderBundle12]);
+} catch {}
+try {
+renderPassEncoder37.drawIndexed(8, 149, 11, -2_047_378_921, 569_277_789);
+} catch {}
+try {
+renderPassEncoder37.drawIndexedIndirect(buffer89, 112);
+} catch {}
+let commandEncoder210 = device0.createCommandEncoder({});
+let texture290 = gpuCanvasContext4.getCurrentTexture();
+let textureView225 = texture116.createView({dimension: '2d-array'});
+let computePassEncoder196 = commandEncoder210.beginComputePass({});
+try {
+computePassEncoder150.end();
+} catch {}
+try {
+computePassEncoder196.setPipeline(pipeline36);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup97);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(3, bindGroup43, new Uint32Array(40), 3, 0);
+} catch {}
+try {
+renderPassEncoder51.beginOcclusionQuery(459);
+} catch {}
+try {
+renderPassEncoder51.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder37.draw(0, 75, 0, 1_757_927_516);
+} catch {}
+try {
+renderPassEncoder37.drawIndexedIndirect(buffer21, 30_392);
+} catch {}
+try {
+renderPassEncoder37.drawIndirect(buffer102, 1_892);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(4, buffer37, 0, 1_583);
+} catch {}
+try {
+commandEncoder65.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 268 */
+  offset: 268,
+  bytesPerRow: 1024,
+  buffer: buffer48,
+}, {
+  texture: texture175,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder211 = device0.createCommandEncoder();
+let texture291 = device0.createTexture({
+  size: [470, 2, 1],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView226 = texture18.createView({});
+let renderPassEncoder60 = commandEncoder65.beginRenderPass({
+  colorAttachments: [{
+  view: textureView101,
+  clearValue: { r: 227.7, g: -958.8, b: -477.1, a: 278.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let sampler122 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', magFilter: 'nearest'});
+try {
+{ clearResourceUsages(device0, computePassEncoder151); computePassEncoder151.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder147.end();
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(2, bindGroup43, []);
+} catch {}
+try {
+renderPassEncoder37.drawIndexed(28, 3, 5, 49_714_539, 724_293_540);
+} catch {}
+try {
+renderPassEncoder57.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(7, buffer145, 476, 1_070);
+} catch {}
+try {
+commandEncoder211.copyTextureToTexture({
+  texture: texture247,
+  mipLevel: 0,
+  origin: {x: 6, y: 12, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture119,
+  mipLevel: 0,
+  origin: {x: 124, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder212 = device0.createCommandEncoder({});
+let computePassEncoder197 = commandEncoder212.beginComputePass({});
+let sampler123 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 74.31});
+try {
+computePassEncoder56.setBindGroup(3, bindGroup115, new Uint32Array(2204), 375, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder149); computePassEncoder149.dispatchWorkgroupsIndirect(buffer1, 3_008); };
+} catch {}
+try {
+computePassEncoder197.setPipeline(pipeline33);
+} catch {}
+try {
+renderPassEncoder52.beginOcclusionQuery(20);
+} catch {}
+try {
+renderPassEncoder52.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder37.draw(0, 115, 0, 2_092_110_602);
+} catch {}
+try {
+renderPassEncoder37.drawIndexed(2, 54, 14, 576_862_989, 2_132_989_996);
+} catch {}
+try {
+renderPassEncoder37.drawIndexedIndirect(buffer102, 3_140);
+} catch {}
+try {
+renderPassEncoder37.drawIndirect(buffer119, 276);
+} catch {}
+try {
+renderPassEncoder50.setVertexBuffer(4, buffer79);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+document.body.prepend(canvas0);
+let texture292 = device0.createTexture({
+  size: [492, 1, 31],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView227 = texture130.createView({
+  label: '\ua57a\u{1f719}\ue137\u8f33\u0190\u3e09\u{1feb1}\u06b4',
+  baseArrayLayer: 24,
+  arrayLayerCount: 29,
+});
+let computePassEncoder198 = commandEncoder156.beginComputePass({});
+try {
+renderPassEncoder56.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder37.drawIndexedIndirect(buffer117, 1_820);
+} catch {}
+try {
+renderPassEncoder37.drawIndirect(buffer31, 328);
+} catch {}
+try {
+renderPassEncoder47.setVertexBuffer(0, buffer117, 4_764, 5_151);
+} catch {}
+try {
+buffer63.unmap();
+} catch {}
+let veryExplicitBindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 78,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup20, new Uint32Array(1152), 159, 0);
+} catch {}
+try {
+computePassEncoder193.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([renderBundle12]);
+} catch {}
+try {
+commandEncoder211.copyTextureToTexture({
+  texture: texture116,
+  mipLevel: 0,
+  origin: {x: 56, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture116,
+  mipLevel: 0,
+  origin: {x: 68, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 117, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let buffer150 = device0.createBuffer({
+  size: 8929,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder213 = device0.createCommandEncoder({});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup115, new Uint32Array(702), 143, 0);
+} catch {}
+try {
+renderPassEncoder37.drawIndexed(0, 430, 11, 584_709_186, 297_190_770);
+} catch {}
+try {
+renderPassEncoder37.drawIndexedIndirect(buffer93, 108);
+} catch {}
+try {
+renderPassEncoder37.drawIndirect(buffer90, 664);
+} catch {}
+let bindGroup116 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout19,
+  entries: [{binding: 323, resource: {buffer: buffer12, offset: 4864}}, {binding: 144, resource: textureView145}],
+});
+let buffer151 = device0.createBuffer({
+  size: 21097,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture293 = device0.createTexture({
+  size: {width: 32},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView228 = texture45.createView({dimension: '2d-array'});
+try {
+computePassEncoder129.setBindGroup(3, bindGroup72, new Uint32Array(1073), 141, 0);
+} catch {}
+try {
+computePassEncoder186.setPipeline(pipeline41);
+} catch {}
+try {
+renderPassEncoder48.beginOcclusionQuery(0);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: -648.6, g: 558.2, b: -965.5, a: 173.2, });
+} catch {}
+try {
+renderPassEncoder37.drawIndexedIndirect(buffer102, 1_644);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+try {
+computePassEncoder49.popDebugGroup();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 45, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData8,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 5, y: 6, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline46 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule6, entryPoint: 'compute6', constants: {}}});
+let buffer152 = device0.createBuffer({
+  size: 9610,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder214 = device0.createCommandEncoder({});
+let computePassEncoder199 = commandEncoder214.beginComputePass({});
+try {
+computePassEncoder178.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(1, bindGroup64, new Uint32Array(68), 23, 1);
+} catch {}
+try {
+renderPassEncoder60.setScissorRect(4, 28, 12, 7);
+} catch {}
+try {
+renderPassEncoder37.drawIndirect(buffer102, 8_260);
+} catch {}
+try {
+commandEncoder211.copyBufferToBuffer(buffer149, 308, buffer121, 1288, 824);
+} catch {}
+let pipeline47 = await device0.createComputePipelineAsync({layout: pipelineLayout9, compute: {module: shaderModule2, constants: {}}});
+let recycledExplicitBindGroupLayout21 = pipeline7.getBindGroupLayout(0);
+let buffer153 = device0.createBuffer({
+  size: 1644,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder215 = device0.createCommandEncoder({});
+let textureView229 = texture178.createView({dimension: '2d-array', aspect: 'all', mipLevelCount: 1});
+let computePassEncoder200 = commandEncoder211.beginComputePass({});
+let sampler124 = device0.createSampler({addressModeU: 'repeat', lodMinClamp: 23.99});
+try {
+renderPassEncoder54.setBindGroup(3, bindGroup75);
+} catch {}
+try {
+renderPassEncoder48.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder37.drawIndexedIndirect(buffer89, 348);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer111, 'uint32', 4_792, 5_274);
+} catch {}
+try {
+renderPassEncoder54.setPipeline(pipeline10);
+} catch {}
+let querySet29 = device0.createQuerySet({type: 'occlusion', count: 635});
+try {
+computePassEncoder102.setBindGroup(1, bindGroup47, new Uint32Array(5858), 2_685, 0);
+} catch {}
+try {
+renderPassEncoder37.draw(0, 230, 0, 430_025_407);
+} catch {}
+try {
+renderPassEncoder56.setVertexBuffer(3, buffer135, 0, 181);
+} catch {}
+try {
+commandEncoder213.resolveQuerySet(querySet21, 130, 0, buffer130, 0);
+} catch {}
+try {
+commandEncoder215.insertDebugMarker('\uff0a');
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer15.detached) { new Uint8Array(arrayBuffer15).fill(0x55); };
+} catch {}
+let texture294 = device0.createTexture({
+  label: '\u5f58\u{1fc2c}\u4783\u1262\u0aaa\u72e7\u{1f94d}\u{1f80a}',
+  size: {width: 10, height: 11, depthOrArrayLayers: 8},
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView230 = texture137.createView({dimension: '2d-array'});
+let computePassEncoder201 = commandEncoder213.beginComputePass({});
+let sampler125 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'clamp-to-edge', lodMaxClamp: 64.81});
+try {
+{ clearResourceUsages(device0, computePassEncoder92); computePassEncoder92.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder59.setBindGroup(3, bindGroup91, new Uint32Array(1017), 187, 0);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([renderBundle1, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder37.draw(0, 278, 0, 1_275_364_033);
+} catch {}
+try {
+renderPassEncoder37.drawIndexedIndirect(buffer87, 0);
+} catch {}
+try {
+commandEncoder215.copyBufferToTexture({
+  /* bytesInLastRow: 305 widthInBlocks: 305 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1211 */
+  offset: 1211,
+  bytesPerRow: 4608,
+  rowsPerImage: 172,
+  buffer: buffer42,
+}, {
+  texture: texture62,
+  mipLevel: 1,
+  origin: {x: 100, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 305, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 68, new Int16Array(7014), 2936, 24);
+} catch {}
+let gpuCanvasContext6 = offscreenCanvas3.getContext('webgpu');
+let buffer154 = device0.createBuffer({size: 23853, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder216 = device0.createCommandEncoder({});
+let commandBuffer27 = commandEncoder216.finish();
+let computePassEncoder202 = commandEncoder215.beginComputePass({});
+try {
+computePassEncoder199.setPipeline(pipeline39);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer13, 'uint32', 116, 239);
+} catch {}
+let pipeline48 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule2,
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule8,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 28,
+        attributes: [{format: 'float32', offset: 0, shaderLocation: 13}, {format: 'unorm8x2', offset: 2, shaderLocation: 4}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+let bindGroup117 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 323, resource: {buffer: buffer119, offset: 512, size: 872}},
+    {binding: 144, resource: textureView145},
+  ],
+});
+try {
+computePassEncoder129.end();
+} catch {}
+try {
+computePassEncoder200.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder52.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderPassEncoder48.setBindGroup(1, bindGroup106, new Uint32Array(2310), 692, 0);
+} catch {}
+try {
+renderPassEncoder37.drawIndexed(3, 341, 23, 122_712_473, 392_719_039);
+} catch {}
+try {
+renderPassEncoder37.drawIndexedIndirect(buffer126, 4_636);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder141.copyTextureToBuffer({
+  texture: texture101,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 5 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 767 */
+  offset: 767,
+  bytesPerRow: 15616,
+  buffer: buffer106,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let commandEncoder217 = device0.createCommandEncoder({});
+let computePassEncoder203 = commandEncoder141.beginComputePass({});
+try {
+{ clearResourceUsages(device0, computePassEncoder25); computePassEncoder25.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder54.setBlendConstant({ r: -280.4, g: -869.0, b: -185.8, a: 887.0, });
+} catch {}
+try {
+renderPassEncoder37.drawIndexed(1, 212, 9, -2_031_769_071, 1_136_214_681);
+} catch {}
+try {
+renderPassEncoder37.drawIndexedIndirect(buffer12, 5_408);
+} catch {}
+try {
+renderPassEncoder37.drawIndirect(buffer87, 168);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer97, 'uint16', 58, 1_324);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(4, buffer152, 380, 5_622);
+} catch {}
+let pipeline49 = device0.createRenderPipeline({
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule6,
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.RED,
+}],
+},
+  vertex: {module: shaderModule7, buffers: []},
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'back'},
+});
+let bindGroup118 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout7,
+  entries: [
+    {binding: 144, resource: textureView5},
+    {binding: 323, resource: {buffer: buffer124, offset: 2304, size: 1240}},
+  ],
+});
+let commandEncoder218 = device0.createCommandEncoder();
+let texture295 = device0.createTexture({
+  size: [246, 1, 35],
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder204 = commandEncoder218.beginComputePass({});
+try {
+computePassEncoder196.setBindGroup(0, bindGroup80);
+} catch {}
+try {
+renderPassEncoder39.setBlendConstant({ r: -37.29, g: 293.0, b: 479.8, a: -645.0, });
+} catch {}
+try {
+renderPassEncoder37.draw(0, 29, 0, 853_033_683);
+} catch {}
+try {
+commandEncoder217.copyBufferToTexture({
+  /* bytesInLastRow: 1132 widthInBlocks: 283 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2280 */
+  offset: 2280,
+  bytesPerRow: 13056,
+  buffer: buffer69,
+}, {
+  texture: texture141,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 283, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout22 = pipeline19.getBindGroupLayout(0);
+let commandEncoder219 = device0.createCommandEncoder({});
+let texture296 = device0.createTexture({
+  size: [32, 32, 204],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView231 = texture78.createView({dimension: '3d', format: 'r8uint', baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+computePassEncoder132.setBindGroup(1, bindGroup107, new Uint32Array(2072), 234, 0);
+} catch {}
+try {
+computePassEncoder203.setPipeline(pipeline43);
+} catch {}
+try {
+renderPassEncoder57.setBindGroup(1, bindGroup110, new Uint32Array(903), 66, 0);
+} catch {}
+try {
+renderPassEncoder52.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder37.draw(0, 11, 0, 7_382_850);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer8, 'uint16', 2, 158);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer80, 188, new Float32Array(1051), 693, 132);
+} catch {}
+let pipeline50 = await promise24;
+document.body.prepend(img3);
+let imageBitmap3 = await createImageBitmap(videoFrame25);
+let imageData26 = new ImageData(104, 72);
+let commandEncoder220 = device0.createCommandEncoder();
+let textureView232 = texture295.createView({});
+let computePassEncoder205 = commandEncoder217.beginComputePass({});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle24 = renderBundleEncoder24.finish({});
+let sampler126 = device0.createSampler({addressModeU: 'clamp-to-edge', lodMaxClamp: 63.99, maxAnisotropy: 1});
+try {
+computePassEncoder103.setBindGroup(1, bindGroup47, new Uint32Array(1427), 140, 0);
+} catch {}
+try {
+computePassEncoder201.setPipeline(pipeline43);
+} catch {}
+try {
+renderPassEncoder37.end();
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder52.setIndexBuffer(buffer111, 'uint16', 7_104, 274);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder220.copyTextureToTexture({
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 0, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup119 = device0.createBindGroup({layout: autogeneratedBindGroupLayout5, entries: [{binding: 144, resource: textureView2}]});
+let commandEncoder221 = device0.createCommandEncoder({});
+let texture297 = device0.createTexture({
+  size: [153, 3, 1],
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder181.setBindGroup(3, bindGroup97, new Uint32Array(3580), 211, 0);
+} catch {}
+try {
+computePassEncoder198.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder49.executeBundles([renderBundle17, renderBundle24, renderBundle3, renderBundle17, renderBundle12]);
+} catch {}
+try {
+renderPassEncoder43.setPipeline(pipeline12);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder108.copyBufferToBuffer(buffer87, 84, buffer106, 580, 92);
+} catch {}
+try {
+commandEncoder221.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 684 */
+  offset: 684,
+  bytesPerRow: 49408,
+  buffer: buffer126,
+}, {
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let computePassEncoder206 = commandEncoder219.beginComputePass({});
+let renderPassEncoder61 = commandEncoder108.beginRenderPass({
+  colorAttachments: [{
+  view: textureView231,
+  depthSlice: 387,
+  clearValue: { r: 503.2, g: -379.6, b: 59.52, a: -924.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView138,
+  clearValue: { r: 518.6, g: 495.2, b: -672.6, a: -239.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet12,
+});
+try {
+computePassEncoder64.setBindGroup(1, bindGroup68, new Uint32Array(486), 469, 0);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(1, bindGroup110);
+} catch {}
+try {
+renderPassEncoder56.setVertexBuffer(5, buffer140, 472, 1_098);
+} catch {}
+try {
+commandEncoder220.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1448 */
+  offset: 1448,
+  bytesPerRow: 5632,
+  buffer: buffer120,
+}, {
+  texture: texture123,
+  mipLevel: 0,
+  origin: {x: 24, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 28, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder13.insertDebugMarker('\u7b77');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView233 = texture268.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder207 = commandEncoder221.beginComputePass();
+try {
+computePassEncoder121.setBindGroup(3, bindGroup50);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let commandEncoder222 = device0.createCommandEncoder({});
+let textureView234 = texture229.createView({});
+let computePassEncoder208 = commandEncoder222.beginComputePass({});
+try {
+computePassEncoder107.setBindGroup(0, bindGroup47);
+} catch {}
+try {
+computePassEncoder56.setBindGroup(1, bindGroup52, new Uint32Array(635), 17, 0);
+} catch {}
+try {
+renderPassEncoder44.setBindGroup(3, bindGroup52, new Uint32Array(2088), 87, 0);
+} catch {}
+try {
+renderPassEncoder36.setPipeline(pipeline20);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let canvas3 = document.createElement('canvas');
+let videoFrame26 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'smpte170m', transfer: 'bt1361ExtendedColourGamut'} });
+try {
+canvas3.getContext('webgl2');
+} catch {}
+let textureView235 = texture296.createView({dimension: '3d', baseArrayLayer: 0});
+let computePassEncoder209 = commandEncoder220.beginComputePass({});
+let sampler127 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.63,
+});
+try {
+computePassEncoder205.setPipeline(pipeline43);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(1, bindGroup113);
+} catch {}
+try {
+renderPassEncoder46.setBindGroup(3, bindGroup27, new Uint32Array(578), 92, 0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(0, buffer100, 0, 1_356);
+} catch {}
+document.body.prepend(img4);
+let commandEncoder223 = device0.createCommandEncoder();
+let texture298 = device0.createTexture({
+  size: {width: 940, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder62 = commandEncoder223.beginRenderPass({
+  colorAttachments: [{view: textureView231, depthSlice: 54, loadOp: 'clear', storeOp: 'discard'}, {view: textureView138, loadOp: 'load', storeOp: 'store'}],
+});
+let sampler128 = device0.createSampler({addressModeW: 'repeat', magFilter: 'nearest'});
+try {
+buffer75.unmap();
+} catch {}
+let bindGroup120 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout21,
+  entries: [
+    {binding: 34, resource: textureView96},
+    {binding: 73, resource: sampler84},
+    {binding: 133, resource: {buffer: buffer133, offset: 256}},
+    {binding: 430, resource: sampler99},
+  ],
+});
+let sampler129 = device0.createSampler({addressModeV: 'mirror-repeat', compare: 'less'});
+try {
+computePassEncoder60.setBindGroup(2, bindGroup109, new Uint32Array(442), 173, 1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder61.setPipeline(pipeline29);
+} catch {}
+let shaderModule12 = device0.createShaderModule({
+  code: `
+enable f16;
+
+diagnostic(info, xyz);
+
+requires pointer_composite_access;
+
+override override19: i32;
+
+override override26 = false;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+@id(52866) override override20: f32;
+
+struct VertexOutput12 {
+  @builtin(position) f39: vec4f,
+}
+
+@group(0) @binding(166) var<uniform> buffer155: u32;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct FragmentOutput8 {
+  @builtin(frag_depth) f0: f32,
+  @location(2) @interpolate(flat, centroid) f1: vec4f,
+  @location(0) @interpolate(flat) f2: vec4u,
+}
+
+override override22: i32;
+
+struct S9 {
+  @builtin(local_invocation_id) @size(16) f0: vec3u,
+}
+
+override override21: u32;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct S8 {
+  @location(6) f0: i32,
+}
+
+@group(0) @binding(125) var st12: texture_storage_2d_array<r32float, read_write>;
+
+var<workgroup> vw40: VertexOutput12;
+
+override override25 = 0.04430;
+
+@id(5098) override override23: f16 = 946.3;
+
+struct T0 {
+  f0: vec2h,
+}
+
+struct S7 {
+  @location(14) f0: vec2i,
+  @location(11) @interpolate(flat, centroid) f1: f16,
+  @location(8) @interpolate(perspective, sample) f2: vec2f,
+}
+
+@id(36360) override override27 = 0.4869;
+
+@id(27282) override override17: f16;
+
+@id(23879) override override24: f16 = -6598.6;
+
+@id(17693) override override18 = true;
+
+/* used global variables: buffer155, st12 */
+fn fn0(a0: ptr<storage, array<vec2<bool>>, read>, a1: array<vec2u, 1>) -> array<f16, 1> {
+  var out: array<f16, 1>;
+  let ptr76: ptr<uniform, u32> = &(*&buffer155);
+  let vf302: vec2u = a1[0];
+  textureStore(st12, extractBits(vec2i(i32(pack4xU8(vec4u(unconst_u32(67), unconst_u32(17), unconst_u32(34), unconst_u32(79))))), unconst_u32(273), unconst_u32(279)), unconst_i32(4), vec4f(textureLoad(st12, vec2i(unconst_i32(12), unconst_i32(103)), bitcast<i32>(pack2x16snorm(vec2f(unconst_f32(0.00123), unconst_f32(0.1738)))))));
+  if bool(pack2x16unorm(vec2f(unconst_f32(0.2157), unconst_f32(0.1308)))) {
+  textureStore(st12, vec2i(unconst_i32(54), unconst_i32(201)), unconst_i32(223), vec4f(vec4f(unconst_f32(-0.2313), unconst_f32(0.3949), unconst_f32(-0.1348), unconst_f32(0.3833))));
+  out[unconst_u32(15)] = vec2h((*a0)[arrayLength(&(*a0))])[0];
+  var vf303: i32 = override22;
+  out[unconst_u32(88)] = f16((vec2i(unconst_i32(7), unconst_i32(232)) - unconst_i32(-88))[0]);
+  let ptr77: ptr<uniform, u32> = &buffer155;
+  let vf304: vec4<bool> = (vec4h(unconst_f16(15957.0), unconst_f16(12889.5), unconst_f16(2308.5), unconst_f16(397.6)) != vec4h(unconst_f16(4445.3), unconst_f16(11298.6), unconst_f16(14205.0), unconst_f16(769.3)));
+  out[unconst_u32(613)] = f16(all((vec4h(unconst_f16(5468.4), unconst_f16(2945.0), unconst_f16(17599.7), unconst_f16(20365.2)) != vec4h(unconst_f16(15325.1), unconst_f16(-8317.5), unconst_f16(11385.4), unconst_f16(7276.3)))));
+  _ = override22;
+  _ = buffer155;
+  _ = st12;
+}
+  textureStore(st12, vec2i(unconst_i32(-4), unconst_i32(50)), bitcast<vec4i>(ceil(vec4f(unconst_f32(0.5666), unconst_f32(0.3783), unconst_f32(0.3281), unconst_f32(-0.2463)))).y, vec4f(vec4f(unconst_f32(0.05313), unconst_f32(0.3179), unconst_f32(0.01458), unconst_f32(0.1671))));
+  let ptr78: ptr<storage, vec2<bool>, read> = &(*a0)[unconst_u32(325)];
+  let vf305: vec2f = unpack2x16float(unconst_u32(619));
+  var vf306: u32 = vf302[unconst_u32(115)];
+  let ptr79: ptr<uniform, u32> = &(*ptr76);
+  let ptr80: ptr<function, u32> = &vf306;
+  return out;
+  _ = override22;
+  _ = st12;
+  _ = buffer155;
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+/* zero global variables used */
+@vertex @must_use
+fn vertex13(a0: S7, a1: S8, @location(4) a2: vec4i, @location(7) @interpolate(flat, either) a3: i32, @location(2) @interpolate(flat, sample) a4: vec2i, @location(9) @interpolate(flat) a5: vec2u, @location(15) a6: vec4u, @location(10) a7: vec4u, @location(0) @interpolate(flat, centroid) a8: vec4u, @location(12) a9: u32, @location(13) @interpolate(linear) a10: vec2h) -> VertexOutput12 {
+  var out: VertexOutput12;
+  var vf307: vec4f = log(vec4f(unconst_f32(0.1119), unconst_f32(-0.1158), unconst_f32(0.4750), unconst_f32(0.7946)));
+  var vf308: i32 = a4[unconst_u32(54)];
+  var vf309: bool = override18;
+  let vf310: i32 = a4[unconst_u32(62)];
+  return out;
+  _ = override18;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment9() -> FragmentOutput8 {
+  var out: FragmentOutput8;
+  out.f2 |= unpack4xU8(pack4xU8(vec4u(unconst_u32(253), unconst_u32(190), unconst_u32(83), unconst_u32(535))));
+  var vf311: mat3x4f = (mat3x4f(unconst_f32(0.06248), unconst_f32(0.2264), unconst_f32(0.00227), unconst_f32(0.1877), unconst_f32(0.3191), unconst_f32(0.1000), unconst_f32(0.4797), unconst_f32(0.3206), unconst_f32(0.07241), unconst_f32(0.2231), unconst_f32(0.2616), unconst_f32(0.1943)) + mat3x4f(vec4f(step(bitcast<vec2h>(dot4U8Packed(unconst_u32(48), unconst_u32(189))), vec2h(unconst_f16(2324.0), unconst_f16(5007.3))).rrgg), vec4f(step(bitcast<vec2h>(dot4U8Packed(unconst_u32(48), unconst_u32(189))), vec2h(unconst_f16(2324.0), unconst_f16(5007.3))).rgrr), vec4f(step(bitcast<vec2h>(dot4U8Packed(unconst_u32(48), unconst_u32(189))), vec2h(unconst_f16(2324.0), unconst_f16(5007.3))).xyxy)));
+  var vf312: vec4u = extractBits(vec4u(unconst_u32(65), unconst_u32(226), unconst_u32(71), unconst_u32(112)), unconst_u32(69), unconst_u32(355));
+  return out;
+}
+
+/* used global variables: buffer155, st12 */
+@compute @workgroup_size(3, 1, 2)
+fn compute14(a0: S9) {
+  var vf313: bool = override26;
+  vf313 = bool(vw40.f39[0]);
+  let vf314: vec4f = acos(vec4f(unconst_f32(0.01991), unconst_f32(0.4109), unconst_f32(0.01736), unconst_f32(-0.1122)));
+  var vf315: u32 = textureNumLayers(st12);
+  let vf316: f16 = override23;
+  vf313 = bool(buffer155);
+  loop {
+  textureStore(st12, vec2i(unconst_i32(173), unconst_i32(529)), unconst_i32(-313), vec4f(vec4f(unconst_f32(0.01171), unconst_f32(0.06891), unconst_f32(0.03731), unconst_f32(0.3261))));
+  let vf317: f16 = acos(f16(override20));
+  break;
+  _ = override20;
+  _ = st12;
+}
+  workgroupBarrier();
+  var vf318: u32 = pack2x16unorm(vec2f(unconst_f32(-0.04106), unconst_f32(0.2015)));
+  vf315 = bitcast<vec2u>(step(vec2f(unconst_f32(0.03479), unconst_f32(0.01126)), vec2f(unconst_f32(0.1782), unconst_f32(0.7855)))).y;
+  var vf319: vec2h = tanh(vec2h(unconst_f16(5937.2), unconst_f16(6579.3)));
+  textureBarrier();
+  let ptr81: ptr<workgroup, VertexOutput12> = &(*&vw40);
+  let vf320: f32 = override27;
+  textureStore(st12, vec2i(unconst_i32(302), unconst_i32(124)), unconst_i32(648), vec4f(vec4f(unconst_f32(0.07655), unconst_f32(0.1113), unconst_f32(0.08207), unconst_f32(0.1417))));
+  _ = override20;
+  _ = override27;
+  _ = override23;
+  _ = override26;
+  _ = buffer155;
+  _ = st12;
+}`,
+});
+let bindGroup121 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout13,
+  entries: [
+    {binding: 39, resource: {buffer: buffer98, offset: 5376, size: 4324}},
+    {binding: 41, resource: textureView53},
+  ],
+});
+let buffer156 = device0.createBuffer({size: 29128, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder224 = device0.createCommandEncoder({});
+let querySet30 = device0.createQuerySet({type: 'occlusion', count: 371});
+let computePassEncoder210 = commandEncoder224.beginComputePass({label: '\u2f0e\u2c8f\u8daf\u801f\u0764\u4889'});
+try {
+{ clearResourceUsages(device0, computePassEncoder119); computePassEncoder119.dispatchWorkgroupsIndirect(buffer131, 768); };
+} catch {}
+try {
+renderPassEncoder59.setViewport(949.2924912788644, 0.4140345197566826, 819.4688392428487, 0.4071303937020217, 0.617213433441621, 0.8030020285334046);
+} catch {}
+try {
+renderPassEncoder51.setVertexBuffer(0, buffer32, 0);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup122 = device0.createBindGroup({layout: veryExplicitBindGroupLayout19, entries: [{binding: 44, resource: textureView218}]});
+let commandEncoder225 = device0.createCommandEncoder({});
+let texture299 = device0.createTexture({
+  size: {width: 1968},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder211 = commandEncoder225.beginComputePass({});
+try {
+computePassEncoder180.setBindGroup(1, bindGroup115, new Uint32Array(48), 5, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder5); computePassEncoder5.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder209.setPipeline(pipeline44);
+} catch {}
+try {
+renderPassEncoder53.executeBundles([renderBundle12, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder58.setPipeline(pipeline8);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 470, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData9,
+  origin: { x: 2, y: 4 },
+  flipY: false,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 72, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer157 = device0.createBuffer({
+  size: 6317,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder226 = device0.createCommandEncoder({});
+try {
+computePassEncoder49.setBindGroup(0, bindGroup68);
+} catch {}
+try {
+computePassEncoder204.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(1, bindGroup102, new Uint32Array(2132), 28, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+await gc();
+let videoFrame27 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'bt470m', transfer: 'log'} });
+let buffer158 = device0.createBuffer({size: 14032, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder227 = device0.createCommandEncoder({});
+let texture300 = device0.createTexture({
+  size: [492, 1, 58],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView236 = texture147.createView({label: '\u88be\u1065\u0697\u{1fdfb}', dimension: '2d-array', baseArrayLayer: 0});
+let computePassEncoder212 = commandEncoder226.beginComputePass();
+try {
+computePassEncoder170.setBindGroup(3, bindGroup1, new Uint32Array(6853), 4_145, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer97, 708); };
+} catch {}
+try {
+computePassEncoder202.setPipeline(pipeline3);
+} catch {}
+let arrayBuffer31 = buffer72.getMappedRange(0, 0);
+await gc();
+let bindGroup123 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout21,
+  entries: [
+    {binding: 144, resource: textureView97},
+    {binding: 323, resource: {buffer: buffer152, offset: 3072, size: 2704}},
+  ],
+});
+let texture301 = device0.createTexture({
+  size: [20, 22, 1],
+  sampleCount: 1,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder213 = commandEncoder227.beginComputePass({});
+try {
+computePassEncoder110.setBindGroup(2, bindGroup119, new Uint32Array(2936), 520, 0);
+} catch {}
+try {
+computePassEncoder211.setPipeline(pipeline47);
+} catch {}
+try {
+renderPassEncoder48.setIndexBuffer(buffer56, 'uint16', 342, 562);
+} catch {}
+try {
+computePassEncoder208.setPipeline(pipeline13);
+} catch {}
+try {
+adapter1.label = '\u0b53\u0aa9\u0e3e\u0b6d';
+} catch {}
+let bindGroup124 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout16,
+  entries: [
+    {binding: 323, resource: {buffer: buffer32, offset: 2560, size: 2652}},
+    {binding: 144, resource: textureView2},
+  ],
+});
+let commandEncoder228 = device0.createCommandEncoder();
+let computePassEncoder214 = commandEncoder228.beginComputePass({});
+try {
+computePassEncoder132.setBindGroup(3, bindGroup103);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup117, new Uint32Array(2008), 117, 0);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let autogeneratedBindGroupLayout8 = pipeline4.getBindGroupLayout(0);
+let buffer159 = device0.createBuffer({
+  size: 10408,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder229 = device0.createCommandEncoder({});
+let texture302 = device0.createTexture({
+  size: {width: 153, height: 3, depthOrArrayLayers: 1},
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder189.setBindGroup(0, bindGroup82);
+} catch {}
+try {
+computePassEncoder196.setBindGroup(1, bindGroup92, new Uint32Array(1789), 249, 0);
+} catch {}
+try {
+computePassEncoder212.setPipeline(pipeline47);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup62, new Uint32Array(940), 12, 0);
+} catch {}
+try {
+renderPassEncoder61.setIndexBuffer(buffer66, 'uint16', 4_470, 3_951);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline42);
+} catch {}
+try {
+renderPassEncoder44.setVertexBuffer(0, buffer13, 0, 278);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 470, height: 2, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 106, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer160 = device0.createBuffer({size: 11414, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder230 = device0.createCommandEncoder({});
+let querySet31 = device0.createQuerySet({type: 'occlusion', count: 1288});
+let computePassEncoder215 = commandEncoder229.beginComputePass({});
+let sampler130 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 78.02,
+});
+try {
+computePassEncoder66.setBindGroup(3, bindGroup97);
+} catch {}
+try {
+computePassEncoder176.setBindGroup(0, bindGroup110, new Uint32Array(1552), 102, 0);
+} catch {}
+try {
+computePassEncoder206.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder43.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder57.setVertexBuffer(3, buffer105, 0, 815);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture295,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 11},
+  aspect: 'all',
+}, new Uint8Array(145_406).fill(242), /* required buffer size: 145_406 */
+{offset: 254, bytesPerRow: 288, rowsPerImage: 252}, {width: 58, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let veryExplicitBindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup125 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout1,
+  entries: [
+    {binding: 144, resource: textureView145},
+    {binding: 323, resource: {buffer: buffer84, offset: 3072, size: 4812}},
+  ],
+});
+let buffer161 = device0.createBuffer({
+  size: 8873,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder231 = device0.createCommandEncoder({label: '\ud9a8\u{1f743}\uedd3\u009d\u0c95\u0148\u{1f9a2}'});
+let querySet32 = device0.createQuerySet({type: 'occlusion', count: 114});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup67);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder0); computePassEncoder0.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+computePassEncoder210.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder53.setBindGroup(0, bindGroup99, new Uint32Array(3277), 341, 0);
+} catch {}
+try {
+renderPassEncoder53.drawIndirect(buffer87, 216);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline29);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer53, 32, new BigUint64Array(56002), 4107, 32);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 20, height: 22, depthOrArrayLayers: 17}
+*/
+{
+  source: img2,
+  origin: { x: 4, y: 1 },
+  flipY: true,
+}, {
+  texture: texture236,
+  mipLevel: 2,
+  origin: {x: 0, y: 1, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame28 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-ncl', primaries: 'bt470m', transfer: 'bt2020_10bit'} });
+let bindGroup126 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout8,
+  entries: [
+    {binding: 323, resource: {buffer: buffer86, offset: 4608, size: 12720}},
+    {binding: 144, resource: textureView97},
+  ],
+});
+let commandEncoder232 = device0.createCommandEncoder({});
+let texture303 = device0.createTexture({
+  size: {width: 80},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+renderPassEncoder45.executeBundles([renderBundle4, renderBundle24]);
+} catch {}
+try {
+renderPassEncoder62.setPipeline(pipeline29);
+} catch {}
+let bindGroup127 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout3,
+  entries: [
+    {binding: 323, resource: {buffer: buffer5, offset: 2304, size: 984}},
+    {binding: 144, resource: textureView4},
+  ],
+});
+let textureView237 = texture220.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder216 = commandEncoder29.beginComputePass({});
+let externalTexture20 = device0.importExternalTexture({source: videoFrame26});
+try {
+renderPassEncoder53.drawIndexed(1_161, 55, 1_181, 226_415_161, 122_959_359);
+} catch {}
+try {
+renderPassEncoder53.drawIndexedIndirect(buffer69, 256);
+} catch {}
+try {
+renderPassEncoder59.setVertexBuffer(1, undefined, 0, 215_313_450);
+} catch {}
+try {
+if (!arrayBuffer18.detached) { new Uint8Array(arrayBuffer18).fill(0x55); };
+} catch {}
+document.body.prepend(canvas0);
+let veryExplicitBindGroupLayout28 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup128 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout7,
+  entries: [{binding: 323, resource: {buffer: buffer68, offset: 1024}}, {binding: 144, resource: textureView97}],
+});
+let computePassEncoder217 = commandEncoder230.beginComputePass({});
+try {
+computePassEncoder191.setBindGroup(1, bindGroup105, new Uint32Array(8161), 102, 0);
+} catch {}
+try {
+computePassEncoder216.setPipeline(pipeline41);
+} catch {}
+try {
+renderPassEncoder53.end();
+} catch {}
+try {
+renderPassEncoder54.setViewport(18.009962214854784, 0.8440206225266744, 106.25593715203586, 0.023101474858522212, 0.4255724220607108, 0.741590832913253);
+} catch {}
+try {
+renderPassEncoder58.setIndexBuffer(buffer141, 'uint32', 220, 253);
+} catch {}
+try {
+commandEncoder179.resolveQuerySet(querySet32, 3, 7, buffer77, 2048);
+} catch {}
+let texture304 = device0.createTexture({
+  size: [940],
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView238 = texture67.createView({aspect: 'all'});
+let renderPassEncoder63 = commandEncoder231.beginRenderPass({
+  colorAttachments: [{
+  view: textureView134,
+  depthSlice: 19,
+  clearValue: { r: 367.0, g: -607.7, b: 188.1, a: 31.84, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder98.setBindGroup(0, bindGroup118, []);
+} catch {}
+try {
+computePassEncoder207.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder60.setBindGroup(2, bindGroup57);
+} catch {}
+try {
+commandEncoder179.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1228 */
+  offset: 1228,
+  bytesPerRow: 4096,
+  buffer: buffer64,
+}, {
+  texture: texture136,
+  mipLevel: 0,
+  origin: {x: 10, y: 18, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 40, height: 45, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 7, y: 0 },
+  flipY: true,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 10, y: 23, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline51 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule7,
+  targets: [{
+  format: 'r8uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8sint'}],
+},
+  vertex: {
+    module: shaderModule0,
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 160, shaderLocation: 13},
+          {format: 'uint32x4', offset: 100, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+let buffer162 = device0.createBuffer({size: 1766, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture305 = device0.createTexture({
+  size: {width: 4824, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'astc-12x10-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+});
+try {
+renderPassEncoder39.setBindGroup(1, bindGroup19, new Uint32Array(3824), 651, 0);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(2, buffer96);
+} catch {}
+try {
+commandEncoder179.copyTextureToBuffer({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 4, y: 6, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1996 */
+  offset: 1996,
+  bytesPerRow: 43520,
+  buffer: buffer66,
+}, {width: 8, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup129 = device0.createBindGroup({
+  label: '\u0ad7\u0553\u34fd\u0119\u0326\u{1fdb7}',
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 64, resource: {buffer: buffer119, offset: 256, size: 496}},
+    {binding: 45, resource: {buffer: buffer126, offset: 6656}},
+    {binding: 68, resource: {buffer: buffer37, offset: 2560, size: 1372}},
+    {binding: 97, resource: externalTexture12},
+  ],
+});
+let sampler131 = device0.createSampler({magFilter: 'linear', minFilter: 'linear', mipmapFilter: 'linear', maxAnisotropy: 10});
+try {
+device0.queue.writeBuffer(buffer116, 24, new BigUint64Array(3017), 26, 0);
+} catch {}
+let texture306 = device0.createTexture({
+  size: {width: 615, height: 15, depthOrArrayLayers: 1},
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView239 = texture225.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder218 = commandEncoder179.beginComputePass({});
+let sampler132 = device0.createSampler({addressModeU: 'clamp-to-edge', minFilter: 'linear', lodMaxClamp: 96.03});
+try {
+computePassEncoder111.setBindGroup(1, bindGroup58, []);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(1, bindGroup92);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup125, new Uint32Array(2316), 1_293, 0);
+} catch {}
+try {
+renderPassEncoder42.drawIndexedIndirect(buffer131, 2_548);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let pipeline52 = device0.createComputePipeline({layout: pipelineLayout9, compute: {module: shaderModule5, entryPoint: 'compute4'}});
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let commandEncoder233 = device0.createCommandEncoder({});
+let texture307 = device0.createTexture({
+  size: {width: 10, height: 11, depthOrArrayLayers: 4},
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView240 = texture52.createView({aspect: 'all'});
+try {
+computePassEncoder83.setBindGroup(2, bindGroup102);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup113);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup71, new Uint32Array(420), 10, 0);
+} catch {}
+try {
+renderPassEncoder42.draw(600, 44, 250_212_836, 1_908_996_446);
+} catch {}
+try {
+renderPassEncoder42.drawIndexed(35, 9, 104, 175_325_256, 86_248_662);
+} catch {}
+try {
+renderPassEncoder42.drawIndirect(buffer144, 140);
+} catch {}
+try {
+commandEncoder232.copyBufferToBuffer(buffer20, 1152, buffer65, 696, 180);
+} catch {}
+let buffer163 = device0.createBuffer({
+  label: '\u{1fac3}\ubf75\uae6b\u{1f85f}',
+  size: 5563,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder234 = device0.createCommandEncoder({});
+let texture308 = device0.createTexture({size: [153], dimension: '1d', format: 'r8sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder88.setBindGroup(2, bindGroup54, []);
+} catch {}
+try {
+renderPassEncoder42.end();
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline31);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 80, height: 90, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame23,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture128,
+  mipLevel: 0,
+  origin: {x: 3, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/CommandBuffer.mm
+++ b/Source/WebGPU/WebGPU/CommandBuffer.mm
@@ -76,8 +76,10 @@ void CommandBuffer::makeInvalidDueToCommit(NSString* lastError)
     m_cachedCommandBuffer = m_commandBuffer;
     [m_commandBuffer addCompletedHandler:[protectedThis = Ref { *this }](id<MTLCommandBuffer>) {
         protectedThis->m_commandBufferComplete.signal();
-        protectedThis->m_cachedCommandBuffer = nil;
-        protectedThis->m_commandEncoder = nullptr;
+        protectedThis->m_device->protectedQueue()->scheduleWork([protectedThis = WTFMove(protectedThis)]() mutable {
+            protectedThis->m_cachedCommandBuffer = nil;
+            protectedThis->m_commandEncoder = nullptr;
+        });
     }];
     m_lastErrorString = lastError;
     m_commandBuffer = nil;


### PR DESCRIPTION
#### acff513d2d4e37e447ca336e02f58b56f97ed639
<pre>
[WebGPU] CommandEncoder is set to nullptr on a different thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=285311">https://bugs.webkit.org/show_bug.cgi?id=285311</a>
<a href="https://rdar.apple.com/142217786">rdar://142217786</a>

Reviewed by Tadeu Zagallo.

287497@main retained the CommandEncoder until its corresponding MTLCommandBuffer
completed to avoid an apparent retain count bug in the shader validation layer,
however in doing so, the non-thread safe RefPtr was set to nullptr off the thread
it was created on. This could lead to potential races when iterating over a WeakHashSet
of the corresponding type.

Address this by setting the member variable to nullptr on the work queue&apos;s
thread.

* Source/WebGPU/WebGPU/CommandBuffer.mm:
(WebGPU::CommandBuffer::makeInvalidDueToCommit):
Set to nullptr on the appropriate thread.

* LayoutTests/fast/webgpu/nocrash/fuzz-285311-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-285311.html: Added.
Add regression test.

Canonical link: <a href="https://commits.webkit.org/288538@main">https://commits.webkit.org/288538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/593b30eb462cec3306efca2f34bba1959d482ede

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88034 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/33971 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64619 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22385 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/85973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44893 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1854 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29615 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33005 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30299 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89400 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73037 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72257 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17998 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16998 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15176 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1588 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10160 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15674 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10032 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13497 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11800 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->