### PR TITLE
Ensure RemoteSampleBufferDisplayLayer messages are not sent when MediaPlaybackEnabled is false

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.cpp
@@ -31,6 +31,13 @@
 
 namespace WebCore {
 
+static bool s_mediaPlaybackEnabled { false };
+
+void SampleBufferDisplayLayer::enableMediaPlayback()
+{
+    s_mediaPlaybackEnabled = true;
+}
+
 SampleBufferDisplayLayer::LayerCreator SampleBufferDisplayLayer::m_layerCreator = nullptr;
 void SampleBufferDisplayLayer::setCreator(LayerCreator creator)
 {
@@ -39,6 +46,9 @@ void SampleBufferDisplayLayer::setCreator(LayerCreator creator)
 
 RefPtr<SampleBufferDisplayLayer> SampleBufferDisplayLayer::create(SampleBufferDisplayLayerClient& client)
 {
+    if (!s_mediaPlaybackEnabled)
+        return nullptr;
+
     if (m_layerCreator)
         return m_layerCreator(client);
 

--- a/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
@@ -58,6 +58,7 @@ public:
     WEBCORE_EXPORT static RefPtr<SampleBufferDisplayLayer> create(SampleBufferDisplayLayerClient&);
     using LayerCreator = RefPtr<SampleBufferDisplayLayer> (*)(SampleBufferDisplayLayerClient&);
     WEBCORE_EXPORT static void setCreator(LayerCreator);
+    WEBCORE_EXPORT static void enableMediaPlayback();
 
     virtual ~SampleBufferDisplayLayer() = default;
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -167,6 +167,7 @@
 
 #if PLATFORM(COCOA)
 #include "UserMediaCaptureManager.h"
+#include <WebCore/SampleBufferDisplayLayer.h>
 #endif
 
 #if USE(CG)
@@ -2466,6 +2467,10 @@ void WebProcess::enableMediaPlayback()
 
 #if ENABLE(ROUTING_ARBITRATION)
     m_routingArbitrator = makeUnique<AudioSessionRoutingArbitrator>(*this);
+#endif
+
+#if PLATFORM(COCOA)
+    SampleBufferDisplayLayer::enableMediaPlayback();
 #endif
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -218,6 +218,7 @@
 #import <WebCore/ResourceLoadObserver.h>
 #import <WebCore/ResourceRequest.h>
 #import <WebCore/SQLiteFileSystem.h>
+#import <WebCore/SampleBufferDisplayLayer.h>
 #import <WebCore/ScriptController.h>
 #import <WebCore/SecurityOrigin.h>
 #import <WebCore/SecurityPolicy.h>
@@ -1493,6 +1494,7 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
 #if USE(AUDIO_SESSION)
         WebCore::AudioSession::enableMediaPlayback();
 #endif
+        WebCore::SampleBufferDisplayLayer::enableMediaPlayback();
 
 #if ENABLE(VIDEO)
         WebCore::HTMLMediaElement::setMediaCacheDirectory(FileSystem::pathByAppendingComponent(String(NSTemporaryDirectory()), "MediaCache/"_s));


### PR DESCRIPTION
#### b712a35afc811419f321d764ee1933f6c57ab5ef
<pre>
Ensure RemoteSampleBufferDisplayLayer messages are not sent when MediaPlaybackEnabled is false
<a href="https://bugs.webkit.org/show_bug.cgi?id=285314">https://bugs.webkit.org/show_bug.cgi?id=285314</a>
<a href="https://rdar.apple.com/142283690">rdar://142283690</a>

Reviewed by NOBODY (OOPS!).

RemoteSampleBufferDisplayLayer and RemoteSampleBufferDisplayLayerManager message endpoints are annotated with
MediaPlaybackEnabled, which means GPU process does not expect to receive these messages when MediaPlaybackEnabled is
false. Accordingly, we need to make sure web process does not send out these messages. This patch implements that by
ensuring the sender WebKit::SampleBufferDisplayLayer is not created when MediaPlaybackEnabled is false.

Also this patch adds the annotation to RemoteRemoteCommandListenerProxy related messages in GPUConnectionToWebProcess.

* Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.cpp:
(WebCore::SampleBufferDisplayLayer::enableMediaPlayback):
(WebCore::SampleBufferDisplayLayer::create):
* Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::enableMediaPlayback):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _commonInitializationWithFrameName:groupName:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b712a35afc811419f321d764ee1933f6c57ab5ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37253 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88073 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34010 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64632 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22395 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1970 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75444 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44908 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29637 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33044 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73087 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89439 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73060 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72280 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16440 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15186 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1625 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10199 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15711 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10071 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13536 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11839 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->