### PR TITLE
Haptic feedback for <input type=checkbox switch> should require user activation

### DIFF
--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -51,6 +51,7 @@
 #include "ScriptDisallowedScope.h"
 #include "ShadowRoot.h"
 #include "UserAgentParts.h"
+#include "UserGestureIndicator.h"
 #include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(IOS_TOUCH_EVENTS)
@@ -389,8 +390,13 @@ void CheckboxInputType::performSwitchAnimation(SwitchAnimationType type)
 void CheckboxInputType::performSwitchVisuallyOnAnimation(SwitchTrigger trigger)
 {
     performSwitchAnimation(SwitchAnimationType::VisuallyOn);
+
     if (!RenderTheme::singleton().hasSwitchHapticFeedback(trigger))
         return;
+
+    if (trigger == SwitchTrigger::Click && !UserGestureIndicator::processingUserGesture())
+        return;
+
     if (RefPtr page = element()->document().page())
         page->chrome().client().performSwitchHapticFeedback();
 }

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -257,6 +257,7 @@ Tests/WebKitCocoa/SpeechRecognition.mm
 Tests/WebKitCocoa/StopSuspendResumeAllMedia.mm
 Tests/WebKitCocoa/StorageQuota.mm
 Tests/WebKitCocoa/StoreBlobThenDelete.mm
+Tests/WebKitCocoa/SwitchInputTests.mm
 Tests/WebKitCocoa/SystemColors.mm
 Tests/WebKitCocoa/SystemPreview.mm
 Tests/WebKitCocoa/TextPlaceholderTests.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3645,6 +3645,7 @@
 		E4C9ABC71B3DB1710040A987 /* RunLoop.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RunLoop.cpp; sourceTree = "<group>"; };
 		E5036F77211BC22800BFDBE2 /* color-drop.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "color-drop.html"; sourceTree = "<group>"; };
 		E5194E512D1882CF0006B52F /* UseSystemAppearance.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UseSystemAppearance.mm; sourceTree = "<group>"; };
+		E5194E5F2D1C67AA0006B52F /* SwitchInputTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SwitchInputTests.mm; sourceTree = "<group>"; };
 		E51A740D2B0442180047FEB1 /* ColorInputTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ColorInputTests.mm; sourceTree = "<group>"; };
 		E520A36A25AFB76C00526CB9 /* WKWebViewTitlebarSeparatorTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewTitlebarSeparatorTests.mm; sourceTree = "<group>"; };
 		E532A15E2BDA271F00E79810 /* DataListTextSuggestionTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DataListTextSuggestionTests.mm; sourceTree = "<group>"; };
@@ -4493,6 +4494,7 @@
 				CDC0932D21C993440030C4B0 /* StopSuspendResumeAllMedia.mm */,
 				414AD6852285D1B000777F2D /* StorageQuota.mm */,
 				515BE1701D428BD100DD7C68 /* StoreBlobThenDelete.mm */,
+				E5194E5F2D1C67AA0006B52F /* SwitchInputTests.mm */,
 				1C734B5220788C4800F430EA /* SystemColors.mm */,
 				31B76E4223298E2B007FED2C /* SystemPreview.mm */,
 				2D70059521EDA0C6003463CB /* TabOutOfWebView.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SwitchInputTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SwitchInputTests.mm
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if PLATFORM(COCOA)
+
+#import "InstanceMethodSwizzler.h"
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestWKWebView.h"
+#import <WebKit/_WKTouchEventGenerator.h>
+#import <wtf/RetainPtr.h>
+
+#if PLATFORM(MAC)
+
+TEST(SwitchInputTests, HapticFeedbackOnDrag)
+{
+    __block bool done = false;
+
+    InstanceMethodSwizzler swizzler {
+        NSHapticFeedbackManager.defaultPerformer.class,
+        @selector(performFeedbackPattern:performanceTime:),
+        imp_implementationWithBlock(^{
+            done = true;
+        })
+    };
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 300)]);
+    [webView synchronouslyLoadHTMLString:@"<input type='checkbox' switch>"];
+
+    [webView mouseMoveToPoint:NSMakePoint(15, 290) withFlags:0];
+    [webView mouseDownAtPoint:NSMakePoint(15, 290) simulatePressure:NO];
+    [webView waitForPendingMouseEvents];
+
+    [webView mouseDragToPoint:NSMakePoint(30, 290)];
+    [webView waitForPendingMouseEvents];
+
+    TestWebKitAPI::Util::run(&done);
+}
+
+#endif // PLATFORM(MAC)
+
+#if HAVE(UI_IMPACT_FEEDBACK_GENERATOR) || PLATFORM(MAC)
+
+TEST(SwitchInputTests, HapticFeedbackRequiresUserGesture)
+{
+    InstanceMethodSwizzler swizzler {
+#if PLATFORM(MAC)
+        NSHapticFeedbackManager.defaultPerformer.class,
+        @selector(performFeedbackPattern:performanceTime:),
+#else
+        UIImpactFeedbackGenerator.class,
+        @selector(impactOccurred),
+#endif
+        imp_implementationWithBlock(^{
+            FAIL();
+        })
+    };
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 300)]);
+    [webView synchronouslyLoadHTMLString:@"<label><input type='checkbox' switch></label>"];
+
+    [webView stringByEvaluatingJavaScript:@"document.querySelector('label').click()"];
+    [webView waitForNextPresentationUpdate];
+}
+
+#endif // HAVE(UI_IMPACT_FEEDBACK_GENERATOR) || PLATFORM(MAC)
+
+#endif // PLATFORM(COCOA)


### PR DESCRIPTION
#### dfb3971bb0d9ef84f41784e277404aa10a5ad5f3
<pre>
Haptic feedback for &lt;input type=checkbox switch&gt; should require user activation
<a href="https://bugs.webkit.org/show_bug.cgi?id=285120">https://bugs.webkit.org/show_bug.cgi?id=285120</a>
<a href="https://rdar.apple.com/142190653">rdar://142190653</a>

Reviewed by Wenson Hsieh.

It should not be possible to generate haptic feedback from script alone.

Check that a user gesture is being processed if the haptic feedback is triggered
due to a click.

* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::performSwitchVisuallyOnAnimation):

`SwitchTrigger::PointerTracking` is not checked since it is only generated by
trusted mouse move events, and `processingUserGesture` is not true for mouse
moves.

* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SwitchInputTests.mm: Added.
(TEST(SwitchInputTests, HapticFeedbackOnDrag)):

This test is macOS only since there is no way to simulate a drag on iOS in API
tests, until a real UIApplication is available.

(TEST(SwitchInputTests, HapticFeedbackRequiresUserGesture)):

Canonical link: <a href="https://commits.webkit.org/288403@main">https://commits.webkit.org/288403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a93daf468c82ffcd7a22a8caa895c8d0fa653e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/82987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88098 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34035 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64639 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22401 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/1984 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44917 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1891 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29661 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33069 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73094 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89464 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73063 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72284 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16453 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15197 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1650 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12844 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10224 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15736 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10096 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13561 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11864 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->