### PR TITLE
Use more const and strong references on stack in WebResourceLoader

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -97,7 +97,6 @@ WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
 WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
 WebProcess/Network/NetworkProcessConnection.cpp
 WebProcess/Network/WebLoaderStrategy.cpp
-WebProcess/Network/WebResourceLoader.cpp
 WebProcess/Network/WebSocketChannel.cpp
 WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
 WebProcess/Network/webrtc/LibWebRTCProvider.cpp

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -98,11 +98,11 @@ void WebResourceLoader::detachFromCoreLoader()
 
 MainFrameMainResource WebResourceLoader::mainFrameMainResource() const
 {
-    auto* frame = m_coreLoader->frame();
+    RefPtr frame = m_coreLoader->frame();
     if (!frame || !frame->isMainFrame())
         return MainFrameMainResource::No;
 
-    auto* frameLoader = m_coreLoader->frameLoader();
+    RefPtr frameLoader = m_coreLoader->frameLoader();
     if (!frameLoader)
         return MainFrameMainResource::No;
 
@@ -122,8 +122,8 @@ void WebResourceLoader::willSendRequest(ResourceRequest&& proposedRequest, IPC::
     LOG(Network, "(WebProcess) WebResourceLoader::willSendRequest to '%s'", proposedRequest.url().string().latin1().data());
     WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_WILLSENDREQUEST);
     
-    if (auto* frame = m_coreLoader->frame()) {
-        if (auto* page = frame->page()) {
+    if (RefPtr frame = m_coreLoader->frame()) {
+        if (RefPtr page = frame->page()) {
             if (!page->allowsLoadFromURL(proposedRequest.url(), mainFrameMainResource()))
                 proposedRequest = { };
         }
@@ -320,8 +320,8 @@ void WebResourceLoader::didReceiveResource(ShareableResource::Handle&& handle)
     if (!buffer) {
         LOG_ERROR("Unable to create buffer from ShareableResource sent from the network process.");
         WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDRECEIVERESOURCE_UNABLE_TO_CREATE_FRAGMENTEDSHAREDBUFFER);
-        if (auto* frame = m_coreLoader->frame()) {
-            if (auto* page = frame->page())
+        if (RefPtr frame = m_coreLoader->frame()) {
+            if (RefPtr page = frame->page())
                 page->diagnosticLoggingClient().logDiagnosticMessage(WebCore::DiagnosticLoggingKeys::internalErrorKey(), WebCore::DiagnosticLoggingKeys::createSharedBufferFailedKey(), WebCore::ShouldSample::No);
         }
         m_coreLoader->didFail(internalError(m_coreLoader->request().url()));

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.h
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.h
@@ -107,7 +107,7 @@ private:
 #endif
     
     RefPtr<WebCore::ResourceLoader> m_coreLoader;
-    TrackingParameters m_trackingParameters;
+    const TrackingParameters m_trackingParameters;
     WebResourceInterceptController m_interceptController;
     size_t m_numBytesReceived { 0 };
 
@@ -117,7 +117,7 @@ private:
 
     Seconds timeSinceLoadStart() const { return MonotonicTime::now() - m_loadStart; }
 
-    MonotonicTime m_loadStart;
+    const MonotonicTime m_loadStart;
     MonotonicTime m_workerStart;
 };
 


### PR DESCRIPTION
#### 24a214b27c99a122f194c92c8a01b82964d4de66
<pre>
Use more const and strong references on stack in WebResourceLoader
<a href="https://bugs.webkit.org/show_bug.cgi?id=285321">https://bugs.webkit.org/show_bug.cgi?id=285321</a>
<a href="https://rdar.apple.com/142290548">rdar://142290548</a>

Reviewed by Tim Nguyen.

Keeping a RefPtr on the stack instead of just a raw pointer will ensure
the Page or Frame is not destroyed before the function returns.

* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::mainFrameMainResource const):
(WebKit::WebResourceLoader::willSendRequest):
(WebKit::WebResourceLoader::didReceiveResource):
* Source/WebKit/WebProcess/Network/WebResourceLoader.h:

Canonical link: <a href="https://commits.webkit.org/288410@main">https://commits.webkit.org/288410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0137740931ddbdb94b6c040b6a2a8c52be82ae93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88218 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34155 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64710 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22467 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44990 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1982 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33189 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89584 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10393 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7508 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73142 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10622 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72366 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16547 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15285 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12851 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10346 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/15850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10216 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13682 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->