### PR TITLE
Remove `RenderBlock::offsetFromLogicalTopOfFirstPage` by consolidating in `RenderBox`

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2859,27 +2859,6 @@ RenderPtr<RenderBlock> RenderBlock::createAnonymousBlockWithStyleAndDisplay(Docu
     return newBox;
 }
 
-LayoutUnit RenderBlock::offsetFromLogicalTopOfFirstPage() const
-{
-    auto* layoutState = view().frameView().layoutContext().layoutState();
-    if (layoutState && !layoutState->isPaginated())
-        return 0;
-
-    RenderFragmentedFlow* fragmentedFlow = enclosingFragmentedFlow();
-    if (fragmentedFlow)
-        return fragmentedFlow->offsetFromLogicalTopOfFirstFragment(this);
-
-    if (layoutState) {
-        ASSERT(layoutState->renderer() == this);
-
-        LayoutSize offsetDelta = layoutState->layoutOffset() - layoutState->pageOffset();
-        return isHorizontalWritingMode() ? offsetDelta.height() : offsetDelta.width();
-    }
-    
-    ASSERT_NOT_REACHED();
-    return 0;
-}
-
 RenderFragmentContainer* RenderBlock::fragmentAtBlockOffset(LayoutUnit blockOffset) const
 {
     RenderFragmentedFlow* fragmentedFlow = enclosingFragmentedFlow();

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -433,7 +433,6 @@ protected:
     bool recomputeLogicalWidth();
     
 public:
-    LayoutUnit offsetFromLogicalTopOfFirstPage() const override;
     RenderFragmentContainer* fragmentAtBlockOffset(LayoutUnit) const;
 
     // FIXME: This is temporary to allow us to move code from RenderBlock into RenderBlockFlow that accesses member variables that we haven't moved out of

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5778,10 +5778,22 @@ bool RenderBox::hasRelativeLogicalWidth() const
 LayoutUnit RenderBox::offsetFromLogicalTopOfFirstPage() const
 {
     auto* layoutState = view().frameView().layoutContext().layoutState();
-    if ((layoutState && !layoutState->isPaginated()) || (!layoutState && !enclosingFragmentedFlow()))
-        return 0;
+    if (!layoutState || !layoutState->isPaginated())
+        return { };
 
+    if (layoutState) {
+        ASSERT(layoutState->renderer() == this);
+        LayoutSize offsetDelta = layoutState->layoutOffset() - layoutState->pageOffset();
+        return isHorizontalWritingMode() ? offsetDelta.height() : offsetDelta.width();
+    }
+
+    // A RenderBlock always establishes a layout state, and this method is only meant to be called
+    // on the object currently being laid out.
+    ASSERT(!isRenderBlock());
+
+    // In case this box doesn't establish a layout state, try the containing block.
     RenderBlock* containerBlock = containingBlock();
+    ASSERT(layoutState->renderer() == containerBlock);
     return containerBlock->offsetFromLogicalTopOfFirstPage() + logicalTop();
 }
 

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -342,7 +342,7 @@ public:
 
     RenderFragmentContainer* clampToStartAndEndFragments(RenderFragmentContainer*) const;
     bool hasFragmentRangeInFragmentedFlow() const;
-    virtual LayoutUnit offsetFromLogicalTopOfFirstPage() const;
+    LayoutUnit offsetFromLogicalTopOfFirstPage() const;
 
     RepaintRects localRectsForRepaint(RepaintOutlineBounds) const override;
     std::optional<RepaintRects> computeVisibleRectsInContainer(const RepaintRects&, const RenderLayerModelObject* container, VisibleRectContext) const override;


### PR DESCRIPTION
#### 17a744796c5677f4ec358a554124655dc6816d6b
<pre>
Remove `RenderBlock::offsetFromLogicalTopOfFirstPage` by consolidating in `RenderBox`
<a href="https://bugs.webkit.org/show_bug.cgi?id=285327">https://bugs.webkit.org/show_bug.cgi?id=285327</a>
<a href="https://rdar.apple.com/142298308">rdar://142298308</a>

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/107910589e9522b4df8313b7dd6957acfce0b029">https://chromium.googlesource.com/chromium/src.git/+/107910589e9522b4df8313b7dd6957acfce0b029</a>

WIP - still in draft (since I tried to remove Multicolumn code as well)

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::offsetFromLogicalTopOfFirstPage const): Deleted.
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::offsetFromLogicalTopOfFirstPage const):
* Source/WebCore/rendering/RenderBox.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17a744796c5677f4ec358a554124655dc6816d6b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2668 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88136 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34073 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10588 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64657 "Failure limit exceed. At least found 453 new test failures: compositing/columns/ancestor-clipped-in-paginated.html compositing/columns/clipped-in-paginated.html compositing/columns/composited-columns-vertical-rl.html compositing/columns/composited-columns.html compositing/columns/composited-in-paginated-rl.html compositing/columns/composited-in-paginated-writing-mode-rl.html compositing/columns/composited-in-paginated.html compositing/columns/composited-lr-paginated-repaint.html compositing/columns/composited-nested-columns.html compositing/columns/composited-rl-paginated-repaint.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22414 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86082 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2012 "Found 1 new test failure: fast/multicol/client-rects-spanners-complex.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44938 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1920 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29695 "Found 1 new test failure: fast/multicol/client-rects-spanners-complex.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33107 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73108 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30391 "Found 1 new test failure: fast/multicol/client-rects-spanners-complex.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89502 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10309 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7455 "Found 60 new test failures: compositing/backing/backing-store-columns-inside-position-fixed.html compositing/columns/ancestor-clipped-in-paginated.html compositing/columns/clipped-in-paginated.html compositing/columns/composited-columns-vertical-rl.html compositing/columns/composited-columns.html compositing/columns/composited-in-paginated-rl.html compositing/columns/composited-in-paginated-writing-mode-rl.html compositing/tiling/crash-when-unapplying-mask-border.html css3/unicode-bidi-isolate-basic.html fast/block/block-remove-child-delete-line-box-crash.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73089 "Found 1 new test failure: fast/multicol/client-rects-spanners-complex.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10538 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71312 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72311 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16483 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15222 "Found 1 new test failure: fast/multicol/client-rects-spanners-complex.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1688 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10262 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15774 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10134 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13599 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11903 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->