### PR TITLE
The runSuccessCallback function should take a reference as an argument in GeoNotifier

### DIFF
--- a/Source/WebCore/Modules/geolocation/GeoNotifier.cpp
+++ b/Source/WebCore/Modules/geolocation/GeoNotifier.cpp
@@ -69,14 +69,14 @@ bool GeoNotifier::hasZeroTimeout() const
     return !m_options.timeout;
 }
 
-void GeoNotifier::runSuccessCallback(GeolocationPosition* position)
+void GeoNotifier::runSuccessCallback(GeolocationPosition& position)
 {
     // If we are here and the Geolocation permission is not approved, something has
     // gone horribly wrong.
     if (!m_geolocation->isAllowed())
         CRASH();
 
-    protectedSuccessCallback()->handleEvent(position);
+    protectedSuccessCallback()->handleEvent(&position);
 }
 
 void GeoNotifier::runErrorCallback(GeolocationPositionError& error)

--- a/Source/WebCore/Modules/geolocation/GeoNotifier.h
+++ b/Source/WebCore/Modules/geolocation/GeoNotifier.h
@@ -55,7 +55,7 @@ public:
     bool useCachedPosition() const { return m_useCachedPosition; }
     void setUseCachedPosition();
 
-    void runSuccessCallback(GeolocationPosition*); // FIXME: This should take a reference.
+    void runSuccessCallback(GeolocationPosition&);
     void runErrorCallback(GeolocationPositionError&);
 
     void startTimerIfNeeded();

--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -434,7 +434,7 @@ void Geolocation::makeCachedPositionCallbacks()
     for (auto& notifier : m_requestsAwaitingCachedPosition) {
         // FIXME: This seems wrong, since makeCachedPositionCallbacks() is called in a branch where
         // lastPosition() is known to be null in Geolocation::setIsAllowed().
-        notifier->runSuccessCallback(lastPosition());
+        notifier->runSuccessCallback(*lastPosition());
 
         // If this is a one-shot request, stop it. Otherwise, if the watch still
         // exists, start the service to get updates.
@@ -533,7 +533,7 @@ void Geolocation::sendError(GeoNotifierVector& notifiers, GeolocationPositionErr
 void Geolocation::sendPosition(GeoNotifierVector& notifiers, GeolocationPosition& position)
 {
     for (auto& notifier : notifiers)
-        notifier->runSuccessCallback(&position);
+        notifier->runSuccessCallback(position);
 }
 
 void Geolocation::stopTimer(GeoNotifierVector& notifiers)


### PR DESCRIPTION
#### 266114a34d2b1009d11fb02c77f18a015f917f3b
<pre>
The runSuccessCallback function should take a reference as an argument in GeoNotifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=285329">https://bugs.webkit.org/show_bug.cgi?id=285329</a>

Reviewed by NOBODY (OOPS!).

The runSuccessCallback function should take a reference as an argument instead of pointer in GeoNotifier

* Source/WebCore/Modules/geolocation/GeoNotifier.cpp:
(WebCore::GeoNotifier::runSuccessCallback):
* Source/WebCore/Modules/geolocation/GeoNotifier.h:
* Source/WebCore/Modules/geolocation/Geolocation.cpp:
(WebCore::Geolocation::makeCachedPositionCallbacks):
(WebCore::Geolocation::sendPosition):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/266114a34d2b1009d11fb02c77f18a015f917f3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88170 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34107 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64670 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22428 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44951 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1936 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29713 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33141 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89536 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10343 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7468 "Found 2 new test failures: imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-peerconnection.https.html svg/as-object/deep-nested-embedded-svg-size-changes-no-layout-triggers-1.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73101 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10572 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72326 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16506 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15234 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10296 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/15812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10168 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13633 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11937 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->