### PR TITLE
Internal clients unable to set context menu images

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2112,6 +2112,21 @@ ContentDispositionAttachmentSandboxEnabled:
     WebCore:
       default: false
 
+ContextMenuImagesForInternalClientsEnabled:
+  type: bool
+  status: internal
+  humanReadableName: "Context Menu Images Allowed for Internal Clients"
+  humanReadableDescription: "Allow internal clients to enable images for context menu items"
+  condition: PLATFORM(MAC)
+  defaultValue:
+    WebKit:
+      "ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)" : true
+      default: false
+    WebKitLegacy:
+      default: false
+    WebCore:
+      default: false
+
 ContextMenuQRCodeDetectionEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/PAL/pal/spi/mac/NSMenuSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSMenuSPI.h
@@ -79,6 +79,16 @@ enum {
 - (BOOL)_containsItemMatchingEvent:(NSEvent *)event includingDisabledItems:(BOOL)includingDisabledItems;
 @end
 
+#if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
+@interface NSMenuItem (Staging_138651669)
+
++ (NSString *)_systemImageNameForAction:(SEL)action;
+@property (strong, setter=_setActionImage:) NSImage *_actionImage;
+@property (setter=_setHasActionImage:) BOOL _hasActionImage;
+
+@end
+#endif
+
 typedef NSUInteger NSPopUpMenuFlags;
 
 WTF_EXTERN_C_BEGIN

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -153,19 +153,19 @@ namespace WebCore {
     String contextMenuItemTagCopyVideoLinkToClipboard();
     String contextMenuItemTagCopyAudioLinkToClipboard();
     String contextMenuItemTagToggleMediaControls();
-    String contextMenuItemTagShowMediaControls();
+    WEBCORE_EXPORT String contextMenuItemTagShowMediaControls();
     String contextMenuItemTagHideMediaControls();
     String contextMenuItemTagToggleMediaLoop();
     String contextMenuItemTagEnterVideoFullscreen();
-    String contextMenuItemTagExitVideoFullscreen();
+    WEBCORE_EXPORT String contextMenuItemTagExitVideoFullscreen();
 #if PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE)
     String contextMenuItemTagEnterVideoEnhancedFullscreen();
-    String contextMenuItemTagExitVideoEnhancedFullscreen();
+    WEBCORE_EXPORT String contextMenuItemTagExitVideoEnhancedFullscreen();
     String contextMenuItemTagEnterVideoViewer();
-    String contextMenuItemTagExitVideoViewer();
+    WEBCORE_EXPORT String contextMenuItemTagExitVideoViewer();
 #endif
     String contextMenuItemTagMediaPlay();
-    String contextMenuItemTagMediaPause();
+    WEBCORE_EXPORT String contextMenuItemTagMediaPause();
     String contextMenuItemTagMediaMute();
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     String contextMenuItemTagPlayAllAnimations();

--- a/Source/WebKit/Platform/mac/MenuUtilities.h
+++ b/Source/WebKit/Platform/mac/MenuUtilities.h
@@ -26,15 +26,24 @@
 #ifndef MenuUtilities_h
 #define MenuUtilities_h
 
+#import <WebCore/ContextMenuItem.h>
 #import <WebCore/IntRect.h>
 #import <wtf/text/WTFString.h>
 
 namespace WebKit {
 
-#if ENABLE(TELEPHONE_NUMBER_DETECTION) && PLATFORM(MAC)
+#if PLATFORM(MAC)
+
+#if ENABLE(TELEPHONE_NUMBER_DETECTION)
 NSMenuItem *menuItemForTelephoneNumber(const String& telephoneNumber);
 RetainPtr<NSMenu> menuForTelephoneNumber(const String& telephoneNumber, NSView *webView, const WebCore::IntRect&);
 NSString *menuItemTitleForTelephoneNumberGroup();
+#endif
+
+#if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
+NSString *symbolNameForAction(const WebCore::ContextMenuAction, bool);
+#endif
+
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -32,6 +32,10 @@
 #import <WebCore/LocalizedStrings.h>
 #import <WebCore/RevealUtilities.h>
 
+#if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
+#import <pal/spi/mac/NSMenuSPI.h>
+#endif
+
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
 #import <pal/spi/mac/TelephonyUtilitiesSPI.h>
 #import <wtf/SoftLinking.h>
@@ -149,6 +153,200 @@ RetainPtr<NSMenu> menuForTelephoneNumber(const String& telephoneNumber, NSView *
     [menu setItemArray:proposedMenuItems];
 
     return menu;
+}
+
+#endif
+
+#if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
+
+NSString *symbolNameForAction(const WebCore::ContextMenuAction action, bool useAlternateImage)
+{
+    // FIXME: <rdar://142002509> The chosen images need to be reviewed.
+    if (![NSMenuItem respondsToSelector:@selector(_systemImageNameForAction:)])
+        return nil;
+
+    switch (action) {
+    case WebCore::ContextMenuItemBaseApplicationTag:
+    case WebCore::ContextMenuItemBaseCustomTag:
+    case WebCore::ContextMenuItemLastCustomTag:
+    case WebCore::ContextMenuItemTagDictationAlternative:
+    case WebCore::ContextMenuItemTagFontMenu:
+    case WebCore::ContextMenuItemTagNoAction:
+    case WebCore::ContextMenuItemTagOther:
+    case WebCore::ContextMenuItemTagSpellingGuess:
+    case WebCore::ContextMenuItemTagSpeechMenu:
+    case WebCore::ContextMenuItemTagSpellingMenu:
+    case WebCore::ContextMenuItemTagSubstitutionsMenu:
+    case WebCore::ContextMenuItemTagTextDirectionMenu:
+    case WebCore::ContextMenuItemTagTransformationsMenu:
+    case WebCore::ContextMenuItemTagWritingDirectionMenu:
+    case WebCore::ContextMenuItemTagWritingTools:
+        return nil;
+    case WebCore::ContextMenuItemPDFAutoSize:
+        return @"sparkle.magnifyingglass";
+    case WebCore::ContextMenuItemPDFActualSize:
+        return @"text.magnifyingglass";
+    case WebCore::ContextMenuItemPDFContinuous:
+    case WebCore::ContextMenuItemPDFSinglePageContinuous:
+    case WebCore::ContextMenuItemTagPDFSinglePageScrolling:
+        return @"rectangle.stack";
+    case WebCore::ContextMenuItemPDFFacingPages:
+    case WebCore::ContextMenuItemPDFTwoPages:
+        return @"rectangle.split.2x1";
+    case WebCore::ContextMenuItemPDFNextPage:
+        return @"chevron.right";
+    case WebCore::ContextMenuItemPDFPreviousPage:
+        return @"chevron.left";
+    case WebCore::ContextMenuItemPDFSinglePage:
+        return @"rectangle.portrait";
+    case WebCore::ContextMenuItemPDFTwoPagesContinuous:
+    case WebCore::ContextMenuItemTagPDFFacingPagesScrolling:
+        return @"rectangle.stack.fill";
+    case WebCore::ContextMenuItemPDFZoomIn:
+        return @"plus.magnifyingglass";
+    case WebCore::ContextMenuItemPDFZoomOut:
+        return @"minus.magnifyingglass";
+    case WebCore::ContextMenuItemTagAddHighlightToCurrentQuickNote:
+    case WebCore::ContextMenuItemTagAddHighlightToNewQuickNote:
+        return @"append.page";
+    case WebCore::ContextMenuItemTagBold:
+        return @"bold";
+    case WebCore::ContextMenuItemTagCapitalize:
+        return @"textformat.characters";
+    case WebCore::ContextMenuItemTagChangeBack:
+        return @"arrow.uturn.backward.circle";
+    case WebCore::ContextMenuItemTagCheckGrammarWithSpelling:
+        return @"character.magnify";
+    case WebCore::ContextMenuItemTagCheckSpelling:
+        return @"text.page.badge.magnifyingglass";
+    case WebCore::ContextMenuItemTagCheckSpellingWhileTyping:
+        return @"character.cursor.ibeam";
+    case WebCore::ContextMenuItemTagCopy:
+    case WebCore::ContextMenuItemTagCopyImageToClipboard:
+    case WebCore::ContextMenuItemTagCopyLinkToClipboard:
+    case WebCore::ContextMenuItemTagCopyMediaLinkToClipboard:
+        return [NSMenuItem _systemImageNameForAction:@selector(copy:)];
+    case WebCore::ContextMenuItemTagCopyLinkWithHighlight:
+        return @"text.quote";
+    case WebCore::ContextMenuItemTagCopySubject:
+        return @"person.fill.viewfinder";
+    case WebCore::ContextMenuItemTagCorrectSpellingAutomatically:
+        return @"keyboard.badge.eye";
+    case WebCore::ContextMenuItemTagCut:
+        return [NSMenuItem _systemImageNameForAction:@selector(cut:)];
+    case WebCore::ContextMenuItemTagDefaultDirection:
+    case WebCore::ContextMenuItemTagTextDirectionDefault:
+        return @"arrow.left.arrow.right";
+    case WebCore::ContextMenuItemTagDownloadImageToDisk:
+    case WebCore::ContextMenuItemTagDownloadLinkToDisk:
+    case WebCore::ContextMenuItemTagDownloadMediaToDisk:
+        return @"square.and.arrow.down";
+    case WebCore::ContextMenuItemTagEnterVideoFullscreen:
+        return @"arrow.up.left.and.arrow.down.right";
+    case WebCore::ContextMenuItemTagGoBack:
+        return @"chevron.backward";
+    case WebCore::ContextMenuItemTagGoForward:
+        return @"chevron.forward";
+    case WebCore::ContextMenuItemTagIgnoreGrammar:
+    case WebCore::ContextMenuItemTagIgnoreSpelling:
+        return @"checkmark.circle";
+    case WebCore::ContextMenuItemTagInspectElement:
+        return @"doc.badge.gearshape";
+    case WebCore::ContextMenuItemTagItalic:
+        return @"italic";
+    case WebCore::ContextMenuItemTagLearnSpelling:
+        return @"text.book.closed";
+    case WebCore::ContextMenuItemTagLeftToRight:
+        return [NSMenuItem _systemImageNameForAction:@selector(makeTextWritingDirectionLeftToRight:)];
+    case WebCore::ContextMenuItemTagLookUpImage:
+    case WebCore::ContextMenuItemTagSearchWeb:
+        return @"magnifyingglass";
+    case WebCore::ContextMenuItemTagLookUpInDictionary:
+        return @"character.book.closed";
+    case WebCore::ContextMenuItemTagMakeLowerCase:
+        return @"characters.lowercase";
+    case WebCore::ContextMenuItemTagMakeUpperCase:
+        return @"characters.uppercase";
+    case WebCore::ContextMenuItemTagMediaMute:
+        return @"speaker.slash";
+    case WebCore::ContextMenuItemTagMediaPlayPause:
+        return useAlternateImage ? @"pause" : @"play";
+    case WebCore::ContextMenuItemTagNoGuessesFound:
+        return @"x.circle";
+    case WebCore::ContextMenuItemTagOpenFrameInNewWindow:
+    case WebCore::ContextMenuItemTagOpenImageInNewWindow:
+    case WebCore::ContextMenuItemTagOpenLinkInNewWindow:
+    case WebCore::ContextMenuItemTagOpenMediaInNewWindow:
+        return @"macwindow.badge.plus";
+    case WebCore::ContextMenuItemTagOpenLink:
+        return @"arrow.up.to.line";
+    case WebCore::ContextMenuItemTagOpenWithDefaultApplication:
+        return @"arrow.up.forward.app";
+    case WebCore::ContextMenuItemTagOutline:
+        return @"character.circle";
+    case WebCore::ContextMenuItemTagPaste:
+        return [NSMenuItem _systemImageNameForAction:@selector(paste:)];
+    case WebCore::ContextMenuItemTagPauseAllAnimations:
+        return @"rectangle.stack.badge.minus";
+    case WebCore::ContextMenuItemTagPauseAnimation:
+        return @"pause.rectangle";
+    case WebCore::ContextMenuItemTagPlayAllAnimations:
+        return @"rectangle.stack.badge.play.fill";
+    case WebCore::ContextMenuItemTagPlayAnimation:
+        return @"play.rectangle";
+    case WebCore::ContextMenuItemTagReload:
+        return @"arrow.clockwise.circle";
+    case WebCore::ContextMenuItemTagRightToLeft:
+        return [NSMenuItem _systemImageNameForAction:@selector(makeTextWritingDirectionRightToLeft:)];
+    case WebCore::ContextMenuItemTagShareMenu:
+        return @"square.and.arrow.up";
+    case WebCore::ContextMenuItemTagShowColors:
+        return @"paintpalette";
+    case WebCore::ContextMenuItemTagShowFonts:
+        return @"text.and.command.macwindow";
+    case WebCore::ContextMenuItemTagShowMediaStats:
+        return @"info";
+    case WebCore::ContextMenuItemTagShowSpellingPanel:
+    case WebCore::ContextMenuItemTagShowSubstitutions:
+        return useAlternateImage ? @"eye.slash" : @"text.and.command.macwindow";
+    case WebCore::ContextMenuItemTagSmartCopyPaste:
+        return @"list.clipboard";
+    case WebCore::ContextMenuItemTagSmartDashes:
+        return @"arrowtriangle.right.and.line.vertical.and.arrowtriangle.left";
+    case WebCore::ContextMenuItemTagSmartLinks:
+        return @"link";
+    case WebCore::ContextMenuItemTagSmartQuotes:
+        return @"quote.closing";
+    case WebCore::ContextMenuItemTagStartSpeaking:
+        return @"play";
+    case WebCore::ContextMenuItemTagStop:
+    case WebCore::ContextMenuItemTagStopSpeaking:
+        return @"stop";
+    case WebCore::ContextMenuItemTagStyles:
+        return @"bold.italic.underline";
+    case WebCore::ContextMenuItemTagTextDirectionLeftToRight:
+        return @"arrow.left.to.line";
+    case WebCore::ContextMenuItemTagTextDirectionRightToLeft:
+        return @"arrow.right.to.line";
+    case WebCore::ContextMenuItemTagTextReplacement:
+        return @"text.page.badge.magnifyingglass";
+    case WebCore::ContextMenuItemTagToggleMediaControls:
+        return useAlternateImage ? @"eye" : @"eye.slash";
+    case WebCore::ContextMenuItemTagToggleMediaLoop:
+        return @"arrow.2.squarepath";
+    case WebCore::ContextMenuItemTagToggleVideoEnhancedFullscreen:
+        return useAlternateImage ? @"pip.exit" : @"pip.enter";
+    case WebCore::ContextMenuItemTagToggleVideoFullscreen:
+        return useAlternateImage ? @"arrow.down.right.and.arrow.up.left" : @"arrow.up.backward.and.arrow.down.forward";
+    case WebCore::ContextMenuItemTagToggleVideoViewer:
+        return useAlternateImage ? @"rectangle.slash" : @"rectangle.expand.diagonal";
+    case WebCore::ContextMenuItemTagTranslate:
+        return @"translate";
+    case WebCore::ContextMenuItemTagUnderline:
+        return @"underline";
+    }
+
+    return nil;
 }
 
 #endif

--- a/Source/WebKit/Shared/mac/PDFContextMenu.h
+++ b/Source/WebKit/Shared/mac/PDFContextMenu.h
@@ -27,6 +27,8 @@
 
 #if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
 
+#include <WebCore/ContextMenuItem.h>
+
 namespace WebKit {
 enum class ContextMenuItemEnablement : bool { Disabled, Enabled };
 
@@ -37,6 +39,7 @@ struct PDFContextMenuItem {
     String title;
     int state;
     int tag;
+    WebCore::ContextMenuAction action;
     ContextMenuItemEnablement enabled;
     ContextMenuItemHasAction hasAction;
     ContextMenuItemIsSeparator separator;

--- a/Source/WebKit/Shared/mac/PDFContextMenuItem.serialization.in
+++ b/Source/WebKit/Shared/mac/PDFContextMenuItem.serialization.in
@@ -31,6 +31,7 @@ enum class WebKit::ContextMenuItemIsSeparator : bool;
     String title;
     int state;
     int tag;
+    WebCore::ContextMenuAction action;
     WebKit::ContextMenuItemEnablement enabled;
     WebKit::ContextMenuItemHasAction hasAction;
     WebKit::ContextMenuItemIsSeparator separator;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -506,7 +506,7 @@ public:
     WebExtensionMenuItem* menuItem(const String& identifier) const;
     void performMenuItem(WebExtensionMenuItem&, const WebExtensionMenuItemContextParameters&, UserTriggered = UserTriggered::No);
 
-    CocoaMenuItem *singleMenuItemOrExtensionItemWithSubmenu(const WebExtensionMenuItemContextParameters&) const;
+    CocoaMenuItem *singleMenuItemOrExtensionItemWithSubmenu(const WebExtensionMenuItemContextParameters&, const bool allowTopLevelImages) const;
 
 #if PLATFORM(MAC)
     void addItemsToContextMenu(WebPageProxy&, const ContextMenuContextData&, NSMenu *);

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -431,6 +431,45 @@ void WebContextMenuProxyMac::removeBackgroundFromControlledImage()
 #endif // ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
 }
 
+#if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
+static void updateMenuItemImage(NSMenuItem *menuItem, const WebContextMenuItemData& webMenuItem)
+{
+    if (![menuItem respondsToSelector:@selector(_setActionImage:)])
+        return;
+
+    bool useAlternateImage;
+
+    switch (webMenuItem.action()) {
+    case ContextMenuItemTagMediaPlayPause:
+        useAlternateImage = webMenuItem.title() == contextMenuItemTagMediaPause();
+        break;
+    case ContextMenuItemTagShowSpellingPanel:
+        useAlternateImage = webMenuItem.title() == contextMenuItemTagShowSpellingPanel(false);
+        break;
+    case ContextMenuItemTagShowSubstitutions:
+        useAlternateImage = webMenuItem.title() == contextMenuItemTagShowSubstitutions(false);
+        break;
+    case ContextMenuItemTagToggleMediaControls:
+        useAlternateImage = webMenuItem.title() == contextMenuItemTagShowMediaControls();
+        break;
+    case ContextMenuItemTagToggleVideoEnhancedFullscreen:
+        useAlternateImage = webMenuItem.title() == contextMenuItemTagExitVideoEnhancedFullscreen();
+        break;
+    case ContextMenuItemTagToggleVideoFullscreen:
+        useAlternateImage = webMenuItem.title() == contextMenuItemTagExitVideoFullscreen();
+        break;
+    case ContextMenuItemTagToggleVideoViewer:
+        useAlternateImage = webMenuItem.title() == contextMenuItemTagExitVideoViewer();
+        break;
+    default:
+        useAlternateImage = false;
+        break;
+    }
+
+    [menuItem _setActionImage:[NSImage imageWithSystemSymbolName:symbolNameForAction(webMenuItem.action(), useAlternateImage) accessibilityDescription:nil]];
+}
+#endif
+
 RetainPtr<NSMenuItem> WebContextMenuProxyMac::createShareMenuItem(ShareMenuItemType type)
 {
     ASSERT(m_context.webHitTestResultData());
@@ -473,8 +512,19 @@ RetainPtr<NSMenuItem> WebContextMenuProxyMac::createShareMenuItem(ShareMenuItemT
     RetainPtr sharingServicePicker = adoptNS([[NSSharingServicePicker alloc] initWithItems:items.get()]);
     RetainPtr shareMenuItem = [sharingServicePicker standardShareMenuItem];
 
+#if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
+    RetainPtr<NSImage> actionImage;
+    bool shouldSetMenuItemImage = page()->preferences().contextMenuImagesForInternalClientsEnabled() && [shareMenuItem respondsToSelector:@selector(_setActionImage:)];
+    if (shouldSetMenuItemImage)
+        actionImage = [shareMenuItem _actionImage];
+#endif
+
     if (usePlaceholder) {
         shareMenuItem = adoptNS([[NSMenuItem alloc] initWithTitle:[shareMenuItem title] action:@selector(performShare:) keyEquivalent:@""]);
+#if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
+        if (shouldSetMenuItemImage)
+            [shareMenuItem _setActionImage:actionImage.get()];
+#endif
         [shareMenuItem setTarget:[WKMenuTarget sharedMenuTarget]];
     } else
         [shareMenuItem setRepresentedObject:sharingServicePicker.get()];
@@ -884,9 +934,15 @@ void WebContextMenuProxyMac::getContextMenuItem(const WebContextMenuItemData& it
 
     switch (item.type()) {
     case WebCore::ContextMenuItemType::Action:
-    case WebCore::ContextMenuItemType::CheckableAction:
-        completionHandler(createMenuActionItem(item).get());
+    case WebCore::ContextMenuItemType::CheckableAction: {
+        RetainPtr menuItem = createMenuActionItem(item);
+#if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
+        if (page()->preferences().contextMenuImagesForInternalClientsEnabled())
+            updateMenuItemImage(menuItem.get(), item);
+#endif
+        completionHandler(menuItem.get());
         return;
+    }
 
     case WebCore::ContextMenuItemType::Separator:
         completionHandler(NSMenuItem.separatorItem);

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -598,6 +598,10 @@ void WebPageProxy::showPDFContextMenu(const WebKit::PDFContextMenu& contextMenu,
         [nsItem setTitle:item.title];
         [nsItem setEnabled:item.enabled == ContextMenuItemEnablement::Enabled];
         [nsItem setState:item.state];
+#if ENABLE(CONTEXT_MENU_IMAGES_FOR_INTERNAL_CLIENTS)
+        if (m_preferences->contextMenuImagesForInternalClientsEnabled() && [nsItem respondsToSelector:@selector(_setActionImage:)])
+            [nsItem _setActionImage:[NSImage imageWithSystemSymbolName:symbolNameForAction(item.action, false) accessibilityDescription:nil]];
+#endif
         if (item.hasAction == ContextMenuItemHasAction::Yes) {
             [nsItem setTarget:menuTarget.get()];
             [nsItem setAction:@selector(contextMenuAction:)];

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1128,7 +1128,7 @@ bool PDFPlugin::handleContextMenuEvent(const WebMouseEvent& event)
             continue;
         if ([NSStringFromSelector(item.action) isEqualToString:@"openWithPreview"])
             openInPreviewTag = i;
-        PDFContextMenuItem menuItem { String([item title]), static_cast<int>([item state]), i,
+        PDFContextMenuItem menuItem { String([item title]), static_cast<int>([item state]), i, ContextMenuItemTagNoAction,
             [item isEnabled] ? ContextMenuItemEnablement::Enabled : ContextMenuItemEnablement::Disabled,
             [item action] ? ContextMenuItemHasAction::Yes : ContextMenuItemHasAction::No,
             [item isSeparatorItem] ? ContextMenuItemIsSeparator::Yes : ContextMenuItemIsSeparator::No

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -30,6 +30,7 @@
 #include "PDFDocumentLayout.h"
 #include "PDFPageCoverage.h"
 #include "PDFPluginBase.h"
+#include <WebCore/ContextMenuItem.h>
 #include <WebCore/ElementIdentifier.h>
 #include <WebCore/GraphicsLayer.h>
 #include <WebCore/GraphicsLayerClient.h>
@@ -359,6 +360,7 @@ private:
     Vector<PDFContextMenuItem> displayModeContextMenuItems() const;
     Vector<PDFContextMenuItem> scaleContextMenuItems() const;
     Vector<PDFContextMenuItem> navigationContextMenuItemsForPageAtIndex(PDFDocumentLayout::PageIndex) const;
+    WebCore::ContextMenuAction contextMenuActionFromTag(ContextMenuItemTag) const;
     ContextMenuItemTag toContextMenuItemTag(int tagValue) const;
     void performContextMenuAction(ContextMenuItemTag, const WebCore::IntPoint& contextMenuEventRootViewPoint);
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -2253,6 +2253,47 @@ PDFDocumentLayout::DisplayMode UnifiedPDFPlugin::displayModeFromContextMenuItemT
     }
 }
 
+ContextMenuAction UnifiedPDFPlugin::contextMenuActionFromTag(ContextMenuItemTag tag) const
+{
+    switch (tag) {
+    case ContextMenuItemTag::ActualSize:
+        return ContextMenuItemPDFActualSize;
+    case ContextMenuItemTag::AutoSize:
+        return ContextMenuItemPDFAutoSize;
+    case ContextMenuItemTag::Copy:
+        return ContextMenuItemTagCopy;
+    case ContextMenuItemTag::CopyLink:
+        return ContextMenuItemTagCopyLinkToClipboard;
+    case ContextMenuItemTag::DictionaryLookup:
+        return ContextMenuItemTagLookUpInDictionary;
+    case ContextMenuItemTag::Invalid:
+    case ContextMenuItemTag::Unknown:
+        return ContextMenuItemTagNoAction;
+    case ContextMenuItemTag::NextPage:
+        return ContextMenuItemPDFNextPage;
+    case ContextMenuItemTag::OpenWithPreview:
+        return ContextMenuItemTagOpenWithDefaultApplication;
+    case ContextMenuItemTag::PreviousPage:
+        return ContextMenuItemPDFPreviousPage;
+    case ContextMenuItemTag::SinglePage:
+        return ContextMenuItemPDFSinglePage;
+    case ContextMenuItemTag::SinglePageContinuous:
+        return ContextMenuItemPDFSinglePageContinuous;
+    case ContextMenuItemTag::TwoPages:
+        return ContextMenuItemPDFTwoPages;
+    case ContextMenuItemTag::TwoPagesContinuous:
+        return ContextMenuItemPDFTwoPagesContinuous;
+    case ContextMenuItemTag::WebSearch:
+        return ContextMenuItemTagSearchWeb;
+    case ContextMenuItemTag::ZoomIn:
+        return ContextMenuItemPDFZoomIn;
+    case ContextMenuItemTag::ZoomOut:
+        return ContextMenuItemPDFZoomOut;
+    }
+
+    return ContextMenuItemTagNoAction;
+}
+
 auto UnifiedPDFPlugin::toContextMenuItemTag(int tagValue) const -> ContextMenuItemTag
 {
     static constexpr std::array regularContextMenuItemTags {
@@ -2389,14 +2430,14 @@ PDFContextMenuItem UnifiedPDFPlugin::contextMenuItem(ContextMenuItemTag tag, boo
         auto itemEnabled = disableItemDueToLockedDocument ? ContextMenuItemEnablement::Disabled : ContextMenuItemEnablement::Enabled;
         auto itemHasAction = hasAction && !disableItemDueToLockedDocument ? ContextMenuItemHasAction::Yes : ContextMenuItemHasAction::No;
 
-        return { titleForContextMenuItemTag(tag), state, enumToUnderlyingType(tag), itemEnabled, itemHasAction, ContextMenuItemIsSeparator::No };
+        return { titleForContextMenuItemTag(tag), state, enumToUnderlyingType(tag), contextMenuActionFromTag(tag), itemEnabled, itemHasAction, ContextMenuItemIsSeparator::No };
     }
     }
 }
 
 PDFContextMenuItem UnifiedPDFPlugin::separatorContextMenuItem() const
 {
-    return { { }, 0, enumToUnderlyingType(ContextMenuItemTag::Invalid), ContextMenuItemEnablement::Disabled, ContextMenuItemHasAction::No, ContextMenuItemIsSeparator::Yes };
+    return { { }, 0, enumToUnderlyingType(ContextMenuItemTag::Invalid), ContextMenuItemTagNoAction, ContextMenuItemEnablement::Disabled, ContextMenuItemHasAction::No, ContextMenuItemIsSeparator::Yes };
 }
 
 Vector<PDFContextMenuItem> UnifiedPDFPlugin::selectionContextMenuItems(const IntPoint& contextMenuEventRootViewPoint) const


### PR DESCRIPTION
#### c6bfe500c5dc35b74d322616cb4da3807aedad7a
<pre>
Internal clients unable to set context menu images
<a href="https://bugs.webkit.org/show_bug.cgi?id=285317">https://bugs.webkit.org/show_bug.cgi?id=285317</a>
<a href="https://rdar.apple.com/139537720">rdar://139537720</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

Allow internal WebKit clients to enable context menu images.
When enabled, the ContextMenuAction of menu items is used
to determine which image to use, if available.

PDFContextMenuItems now store a ContextMenuAction so that
the image can be determined in the same manner. Each item&apos;s
ContextMenuAction is determined from its ContextMenuItemTag.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/PAL/pal/spi/mac/NSMenuSPI.h:
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebKit/Platform/mac/MenuUtilities.h:
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::symbolNameForAction):
* Source/WebKit/Shared/mac/PDFContextMenu.h:
* Source/WebKit/Shared/mac/PDFContextMenuItem.serialization.in:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::platformMenuItems const):
(WebKit::WebExtensionContext::singleMenuItemOrExtensionItemWithSubmenu const):
(WebKit::WebExtensionContext::addItemsToContextMenu):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::updateMenuItemImage):
(WebKit::WebContextMenuProxyMac::getContextMenuItem):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::showPDFContextMenu):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::handleContextMenuEvent):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::contextMenuActionFromTag const):
(WebKit::UnifiedPDFPlugin::contextMenuItem const):
(WebKit::UnifiedPDFPlugin::separatorContextMenuItem const):

Canonical link: <a href="https://commits.webkit.org/288471@main">https://commits.webkit.org/288471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c17a19b0e6895ce4c9caa8fde3ff578a8ae8d15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88539 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34473 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11038 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64931 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22673 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75841 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45222 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2219 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30047 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33523 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76426 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73313 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89915 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/82482 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10728 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7735 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73356 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72585 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17964 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16819 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15537 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2061 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10683 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16152 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/104902 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10534 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25361 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14005 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12305 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->