### PR TITLE
Use the enum class in ErrorType at XMLErrors

### DIFF
--- a/Source/WebCore/xml/XMLErrors.cpp
+++ b/Source/WebCore/xml/XMLErrors.cpp
@@ -56,20 +56,20 @@ XMLErrors::XMLErrors(Document& document)
 {
 }
 
-void XMLErrors::handleError(ErrorType type, const char* message, int lineNumber, int columnNumber)
+void XMLErrors::handleError(Type type, const char* message, int lineNumber, int columnNumber)
 {
     handleError(type, message, TextPosition(OrdinalNumber::fromOneBasedInt(lineNumber), OrdinalNumber::fromOneBasedInt(columnNumber)));
 }
 
-void XMLErrors::handleError(ErrorType type, const char* message, TextPosition position)
+void XMLErrors::handleError(Type type, const char* message, TextPosition position)
 {
-    if (type == fatal || (m_errorCount < maxErrors && (!m_lastErrorPosition || (m_lastErrorPosition->m_line != position.m_line && m_lastErrorPosition->m_column != position.m_column)))) {
+    if (type == Type::Fatal || (m_errorCount < maxErrors && (!m_lastErrorPosition || (m_lastErrorPosition->m_line != position.m_line && m_lastErrorPosition->m_column != position.m_column)))) {
         switch (type) {
-        case warning:
+        case Type::Warning:
             appendErrorMessage("warning"_s, position, message);
             break;
-        case fatal:
-        case nonFatal:
+        case Type::Fatal:
+        case Type::NonFatal:
             appendErrorMessage("error"_s, position, message);
         }
 

--- a/Source/WebCore/xml/XMLErrors.h
+++ b/Source/WebCore/xml/XMLErrors.h
@@ -43,9 +43,9 @@ class XMLErrors {
 public:
     explicit XMLErrors(Document&);
 
-    enum ErrorType { warning, nonFatal, fatal };
-    void handleError(ErrorType, const char* message, int lineNumber, int columnNumber);
-    void handleError(ErrorType, const char* message, TextPosition);
+    enum class Type : uint8_t { Warning, NonFatal, Fatal };
+    void handleError(Type, const char* message, int lineNumber, int columnNumber);
+    void handleError(Type, const char* message, TextPosition);
 
     void insertErrorMessageBlock();
 

--- a/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -75,7 +75,7 @@ void XMLDocumentParser::pushCurrentNode(ContainerNode* n)
         n->ref();
     m_currentNodeStack.append(std::exchange(m_currentNode, n));
     if (m_currentNodeStack.size() > maxXMLTreeDepth)
-        handleError(XMLErrors::fatal, "Excessive node nesting.", textPosition());
+        handleError(XMLErrors::Type::Fatal, "Excessive node nesting.", textPosition());
 }
 
 void XMLDocumentParser::popCurrentNode()
@@ -129,14 +129,14 @@ void XMLDocumentParser::append(RefPtr<StringImpl>&& inputSource)
     doWrite(source);
 }
 
-void XMLDocumentParser::handleError(XMLErrors::ErrorType type, const char* m, TextPosition position)
+void XMLDocumentParser::handleError(XMLErrors::Type type, const char* m, TextPosition position)
 {
     if (!m_xmlErrors)
         m_xmlErrors = makeUnique<XMLErrors>(*document());
     m_xmlErrors->handleError(type, m, position);
-    if (type != XMLErrors::warning)
+    if (type != XMLErrors::Type::Warning)
         m_sawError = true;
-    if (type == XMLErrors::fatal)
+    if (type == XMLErrors::Type::Fatal)
         stopParsing();
 }
 

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -81,7 +81,7 @@ public:
     ~XMLDocumentParser();
 
     // Exposed for callbacks:
-    void handleError(XMLErrors::ErrorType, const char* message, TextPosition);
+    void handleError(XMLErrors::Type, const char* message, TextPosition);
 
     void setIsXHTMLDocument(bool isXHTML) { m_isXHTMLDocument = isXHTML; }
     bool isXHTMLDocument() const { return m_isXHTMLDocument; }
@@ -125,7 +125,7 @@ public:
     // Callbacks from parser SAX, and other functions needed inside
     // the parser implementation, but outside this class.
 
-    void error(XMLErrors::ErrorType, const char* message, va_list args) WTF_ATTRIBUTE_PRINTF(3, 0);
+    void error(XMLErrors::Type, const char* message, va_list args) WTF_ATTRIBUTE_PRINTF(3, 0);
     void startElementNs(const xmlChar* xmlLocalName, const xmlChar* xmlPrefix, const xmlChar* xmlURI,
         int numNamespaces, const xmlChar** namespaces,
         int numAttributes, int numDefaulted, const xmlChar** libxmlAttributes);

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -197,7 +197,7 @@ public:
         m_callbacks.append(WTFMove(callback));
     }
 
-    void appendErrorCallback(XMLErrors::ErrorType type, const xmlChar* message, OrdinalNumber lineNumber, OrdinalNumber columnNumber)
+    void appendErrorCallback(XMLErrors::Type type, const xmlChar* message, OrdinalNumber lineNumber, OrdinalNumber columnNumber)
     {
         auto callback = makeUnique<PendingErrorCallback>();
 
@@ -351,7 +351,7 @@ private:
             parser->handleError(type, reinterpret_cast<char*>(message), TextPosition(lineNumber, columnNumber));
         }
 
-        XMLErrors::ErrorType type;
+        XMLErrors::Type type;
         xmlChar* message;
         OrdinalNumber lineNumber;
         OrdinalNumber columnNumber;
@@ -697,7 +697,7 @@ void XMLDocumentParser::doWrite(const String& parseString)
     if (document()->decoder() && document()->decoder()->sawError()) {
         // If the decoder saw an error, report it as fatal (stops parsing)
         TextPosition position(OrdinalNumber::fromOneBasedInt(context->context()->input->line), OrdinalNumber::fromOneBasedInt(context->context()->input->col));
-        handleError(XMLErrors::fatal, "Encoding error", position);
+        handleError(XMLErrors::Type::Fatal, "Encoding error", position);
     }
 }
 
@@ -949,7 +949,7 @@ void XMLDocumentParser::characters(std::span<const xmlChar> characters)
     m_bufferedText.append(characters);
 }
 
-void XMLDocumentParser::error(XMLErrors::ErrorType type, const char* message, va_list args)
+void XMLDocumentParser::error(XMLErrors::Type type, const char* message, va_list args)
 {
     if (isStopped())
         return;
@@ -1119,7 +1119,7 @@ static void warningHandler(void* closure, const char* message, ...)
 {
     va_list args;
     va_start(args, message);
-    getParser(closure)->error(XMLErrors::warning, message, args);
+    getParser(closure)->error(XMLErrors::Type::Warning, message, args);
     va_end(args);
 }
 
@@ -1128,7 +1128,7 @@ static void fatalErrorHandler(void* closure, const char* message, ...)
 {
     va_list args;
     va_start(args, message);
-    getParser(closure)->error(XMLErrors::fatal, message, args);
+    getParser(closure)->error(XMLErrors::Type::Fatal, message, args);
     va_end(args);
 }
 
@@ -1137,7 +1137,7 @@ static void normalErrorHandler(void* closure, const char* message, ...)
 {
     va_list args;
     va_start(args, message);
-    getParser(closure)->error(XMLErrors::nonFatal, message, args);
+    getParser(closure)->error(XMLErrors::Type::NonFatal, message, args);
     va_end(args);
 }
 


### PR DESCRIPTION
#### e734aaf3a805927c3e9676e2ecdb3aebdf1319b4
<pre>
Use the enum class in ErrorType at XMLErrors
<a href="https://bugs.webkit.org/show_bug.cgi?id=285331">https://bugs.webkit.org/show_bug.cgi?id=285331</a>

Reviewed by Charlie Wolfe.

Use the enum class in ErrorType at XMLErrors

* Source/WebCore/xml/XMLErrors.cpp:
(WebCore::XMLErrors::handleError):
* Source/WebCore/xml/XMLErrors.h:
* Source/WebCore/xml/parser/XMLDocumentParser.cpp:
(WebCore::XMLDocumentParser::pushCurrentNode):
(WebCore::XMLDocumentParser::handleError):
* Source/WebCore/xml/parser/XMLDocumentParser.h:
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::doWrite):
(WebCore::warningHandler):
(WebCore::fatalErrorHandler):
(WebCore::normalErrorHandler):

Canonical link: <a href="https://commits.webkit.org/289106@main">https://commits.webkit.org/289106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0d68ab67848df5d6581c3cba0e4d7c50ac5dd7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88345 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34278 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85356 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2967 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64781 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22533 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2161 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45065 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30210 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33327 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89718 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10533 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7573 "Found 1 new test failure: http/wpt/mediarecorder/record-96KHz-sources.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73217 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10758 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72447 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18331 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16652 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15381 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1871 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/13058 "The change is no longer eligible for processing.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10488 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15963 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10340 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12111 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->