### PR TITLE
[GTK][WPE] Generalize DMABufRendererBufferMode naming

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -73,8 +73,8 @@ endif ()
 
 list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/glib/DMABufRendererBufferFormat.serialization.in
-    Shared/glib/DMABufRendererBufferMode.serialization.in
     Shared/glib/InputMethodState.serialization.in
+    Shared/glib/RendererBufferTransportMode.serialization.in
     Shared/glib/SystemSettings.serialization.in
     Shared/glib/UserMessage.serialization.in
 

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -111,8 +111,8 @@ if (USE_GBM)
 endif ()
 
 list(APPEND WebKit_SERIALIZATION_IN_FILES
-    Shared/glib/DMABufRendererBufferMode.serialization.in
     Shared/glib/InputMethodState.serialization.in
+    Shared/glib/RendererBufferTransportMode.serialization.in
     Shared/glib/SystemSettings.serialization.in
     Shared/glib/UserMessage.serialization.in
 

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -59,7 +59,7 @@
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
-#include "DMABufRendererBufferMode.h"
+#include "RendererBufferTransportMode.h"
 #include <WebCore/SystemSettings.h>
 #include <wtf/MemoryPressureHandler.h>
 #endif
@@ -231,7 +231,7 @@ struct WebProcessCreationParameters {
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
-    OptionSet<DMABufRendererBufferMode> dmaBufRendererBufferMode;
+    OptionSet<RendererBufferTransportMode> rendererBufferTransportMode;
     WebCore::SystemSettings::State systemSettings;
 #endif
 

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -180,7 +180,7 @@
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
-    OptionSet<WebKit::DMABufRendererBufferMode> dmaBufRendererBufferMode;
+    OptionSet<WebKit::RendererBufferTransportMode> rendererBufferTransportMode;
     WebCore::SystemSettings::State systemSettings;
 #endif
 

--- a/Source/WebKit/Shared/glib/RendererBufferTransportMode.h
+++ b/Source/WebKit/Shared/glib/RendererBufferTransportMode.h
@@ -27,7 +27,7 @@
 
 namespace WebKit {
 
-enum class DMABufRendererBufferMode : uint8_t {
+enum class RendererBufferTransportMode : uint8_t {
     Hardware = 1 << 0,
     SharedMemory = 1 << 1
 };

--- a/Source/WebKit/Shared/glib/RendererBufferTransportMode.serialization.in
+++ b/Source/WebKit/Shared/glib/RendererBufferTransportMode.serialization.in
@@ -22,7 +22,7 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-[Nested, OptionSet] enum class WebKit::DMABufRendererBufferMode : uint8_t {
+[Nested, OptionSet] enum class WebKit::RendererBufferTransportMode : uint8_t {
     Hardware,
     SharedMemory,
 };

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -22,9 +22,9 @@
 
 #include "APIPageConfiguration.h"
 #include "BuildRevision.h"
-#include "DMABufRendererBufferMode.h"
 #include "DRMDevice.h"
 #include "DisplayVBlankMonitor.h"
+#include "RendererBufferTransportMode.h"
 #include "WebKitError.h"
 #include "WebKitURISchemeRequestPrivate.h"
 #include "WebKitVersion.h"
@@ -188,18 +188,18 @@ static String dmabufRendererWithSupportedBuffers()
     buffers.append("DMABuf (Supported buffers: "_s);
 
 #if PLATFORM(GTK)
-    auto mode = AcceleratedBackingStoreDMABuf::rendererBufferMode();
+    auto mode = AcceleratedBackingStoreDMABuf::rendererBufferTransportMode();
 #else
-    OptionSet<DMABufRendererBufferMode> mode;
+    OptionSet<RendererBufferTransportMode> mode;
     if (wpe_display_get_drm_render_node(wpe_display_get_primary()))
-        mode.add(DMABufRendererBufferMode::Hardware);
-    mode.add(DMABufRendererBufferMode::SharedMemory);
+        mode.add(RendererBufferTransportMode::Hardware);
+    mode.add(RendererBufferTransportMode::SharedMemory);
 #endif
 
-    if (mode.contains(DMABufRendererBufferMode::Hardware))
+    if (mode.contains(RendererBufferTransportMode::Hardware))
         buffers.append("Hardware"_s);
-    if (mode.contains(DMABufRendererBufferMode::SharedMemory)) {
-        if (mode.contains(DMABufRendererBufferMode::Hardware))
+    if (mode.contains(RendererBufferTransportMode::SharedMemory)) {
+        if (mode.contains(RendererBufferTransportMode::Hardware))
             buffers.append(", "_s);
         buffers.append("Shared Memory"_s);
     }

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -115,21 +115,21 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 #endif
 
 #if PLATFORM(GTK)
-    parameters.dmaBufRendererBufferMode = AcceleratedBackingStoreDMABuf::rendererBufferMode();
+    parameters.rendererBufferTransportMode = AcceleratedBackingStoreDMABuf::rendererBufferTransportMode();
 #elif PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
     if (usingWPEPlatformAPI) {
 #if USE(GBM)
         if (!parameters.renderDeviceFile.isEmpty())
-            parameters.dmaBufRendererBufferMode.add(DMABufRendererBufferMode::Hardware);
+            parameters.rendererBufferTransportMode.add(RendererBufferTransportMode::Hardware);
 #endif
-        parameters.dmaBufRendererBufferMode.add(DMABufRendererBufferMode::SharedMemory);
+        parameters.rendererBufferTransportMode.add(RendererBufferTransportMode::SharedMemory);
     }
 #endif
 
 #if PLATFORM(WPE)
     parameters.isServiceWorkerProcess = process.isRunningServiceWorkers();
 
-    if (!parameters.isServiceWorkerProcess && parameters.dmaBufRendererBufferMode.isEmpty()) {
+    if (!parameters.isServiceWorkerProcess && parameters.rendererBufferTransportMode.isEmpty()) {
         parameters.hostClientFileDescriptor = UnixFileDescriptor { wpe_renderer_host_create_client(), UnixFileDescriptor::Adopt };
         parameters.implementationLibraryName = FileSystem::fileSystemRepresentation(String::fromLatin1(wpe_loader_get_loaded_implementation_library_name()));
     }

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -28,10 +28,10 @@
 
 #include "AcceleratedBackingStoreDMABufMessages.h"
 #include "AcceleratedSurfaceDMABufMessages.h"
-#include "DMABufRendererBufferMode.h"
 #include "DRMDevice.h"
 #include "Display.h"
 #include "LayerTreeContext.h"
+#include "RendererBufferTransportMode.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 #include <WebCore/GLContext.h>
@@ -77,9 +77,9 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedBackingStoreDMABuf);
 
-OptionSet<DMABufRendererBufferMode> AcceleratedBackingStoreDMABuf::rendererBufferMode()
+OptionSet<RendererBufferTransportMode> AcceleratedBackingStoreDMABuf::rendererBufferTransportMode()
 {
-    static OptionSet<DMABufRendererBufferMode> mode;
+    static OptionSet<RendererBufferTransportMode> mode;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         const char* disableDMABuf = getenv("WEBKIT_DISABLE_DMABUF_RENDERER");
@@ -92,7 +92,7 @@ OptionSet<DMABufRendererBufferMode> AcceleratedBackingStoreDMABuf::rendererBuffe
             return;
         }
 
-        mode.add(DMABufRendererBufferMode::SharedMemory);
+        mode.add(RendererBufferTransportMode::SharedMemory);
 
         const char* forceSHM = getenv("WEBKIT_DMABUF_RENDERER_FORCE_SHM");
         if (forceSHM && strcmp(forceSHM, "0"))
@@ -106,21 +106,21 @@ OptionSet<DMABufRendererBufferMode> AcceleratedBackingStoreDMABuf::rendererBuffe
         if (auto* glDisplay = Display::singleton().glDisplay()) {
             const auto& eglExtensions = glDisplay->extensions();
             if (eglExtensions.KHR_image_base && eglExtensions.EXT_image_dma_buf_import)
-                mode.add(DMABufRendererBufferMode::Hardware);
+                mode.add(RendererBufferTransportMode::Hardware);
         }
     });
     return mode;
 }
 bool AcceleratedBackingStoreDMABuf::checkRequirements()
 {
-    return !rendererBufferMode().isEmpty();
+    return !rendererBufferTransportMode().isEmpty();
 }
 
 #if USE(GBM)
 Vector<DMABufRendererBufferFormat> AcceleratedBackingStoreDMABuf::preferredBufferFormats()
 {
-    auto mode = rendererBufferMode();
-    if (!mode.contains(DMABufRendererBufferMode::Hardware))
+    auto mode = rendererBufferTransportMode();
+    if (!mode.contains(RendererBufferTransportMode::Hardware))
         return { };
 
     auto& display = Display::singleton();

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -62,13 +62,13 @@ namespace WebKit {
 
 class WebPageProxy;
 class WebProcessProxy;
-enum class DMABufRendererBufferMode : uint8_t;
+enum class RendererBufferTransportMode : uint8_t;
 
 class AcceleratedBackingStoreDMABuf final : public AcceleratedBackingStore, public IPC::MessageReceiver, public RefCounted<AcceleratedBackingStoreDMABuf> {
     WTF_MAKE_TZONE_ALLOCATED(AcceleratedBackingStoreDMABuf);
     WTF_MAKE_NONCOPYABLE(AcceleratedBackingStoreDMABuf);
 public:
-    static OptionSet<DMABufRendererBufferMode> rendererBufferMode();
+    static OptionSet<RendererBufferTransportMode> rendererBufferTransportMode();
     static bool checkRequirements();
 #if USE(GBM)
     static Vector<DMABufRendererBufferFormat> preferredBufferFormats();

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -403,7 +403,7 @@ AcceleratedSurfaceDMABuf::SwapChain::SwapChain(uint64_t surfaceID)
     auto& display = WebCore::PlatformDisplay::sharedDisplay();
     switch (display.type()) {
     case WebCore::PlatformDisplay::Type::Surfaceless:
-        if (display.eglExtensions().MESA_image_dma_buf_export && WebProcess::singleton().dmaBufRendererBufferMode().contains(DMABufRendererBufferMode::Hardware))
+        if (display.eglExtensions().MESA_image_dma_buf_export && WebProcess::singleton().rendererBufferTransportMode().contains(RendererBufferTransportMode::Hardware))
             m_type = Type::Texture;
         else
             m_type = Type::SharedMemory;

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -74,7 +74,7 @@ OBJC_CLASS NSMutableDictionary;
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
-#include "DMABufRendererBufferMode.h"
+#include "RendererBufferTransportMode.h"
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -471,7 +471,7 @@ public:
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
-    const OptionSet<DMABufRendererBufferMode>& dmaBufRendererBufferMode() const { return m_dmaBufRendererBufferMode; }
+    const OptionSet<RendererBufferTransportMode>& rendererBufferTransportMode() const { return m_rendererBufferTransportMode; }
     void initializePlatformDisplayIfNeeded() const;
 #endif
 
@@ -837,7 +837,7 @@ private:
     WeakHashMap<WebCore::UserGestureToken, WebCore::UserGestureTokenIdentifier> m_userGestureTokens;
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
-    OptionSet<DMABufRendererBufferMode> m_dmaBufRendererBufferMode;
+    OptionSet<RendererBufferTransportMode> m_rendererBufferTransportMode;
 #endif
 
     bool m_hasSuspendedPageProxy { false };

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -138,7 +138,7 @@ void WebProcess::initializePlatformDisplayIfNeeded() const
         return;
 
 #if USE(GBM)
-    if (m_dmaBufRendererBufferMode.contains(DMABufRendererBufferMode::Hardware)) {
+    if (m_rendererBufferTransportMode.contains(RendererBufferTransportMode::Hardware)) {
         bool disabled = false;
 #if PLATFORM(GTK)
         const char* disableGBM = getenv("WEBKIT_DMABUF_RENDERER_DISABLE_GBM");
@@ -185,10 +185,10 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     DRMDeviceManager::singleton().initializeMainDevice(parameters.renderDeviceFile);
 #endif
 
-    m_dmaBufRendererBufferMode = parameters.dmaBufRendererBufferMode;
+    m_rendererBufferTransportMode = parameters.rendererBufferTransportMode;
 #if PLATFORM(WPE)
     if (!parameters.isServiceWorkerProcess) {
-        if (m_dmaBufRendererBufferMode.isEmpty()) {
+        if (m_rendererBufferTransportMode.isEmpty()) {
             auto& implementationLibraryName = parameters.implementationLibraryName;
             if (!implementationLibraryName.isNull() && implementationLibraryName.data()[0] != '\0')
                 wpe_loader_init(parameters.implementationLibraryName.data());
@@ -232,7 +232,7 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 #endif
 
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
-    if (!m_dmaBufRendererBufferMode.isEmpty())
+    if (!m_rendererBufferTransportMode.isEmpty())
         WebCore::setScreenProperties(parameters.screenProperties);
 #endif
 }


### PR DESCRIPTION
#### c1f406cb1524a05ace5eb7530eecf8c688d4c504
<pre>
[GTK][WPE] Generalize DMABufRendererBufferMode naming
<a href="https://bugs.webkit.org/show_bug.cgi?id=285333">https://bugs.webkit.org/show_bug.cgi?id=285333</a>

Reviewed by Carlos Garcia Campos.

Rename DMABufRendererBufferMode to RendererBufferTransportMode
to accommodate additional transport methods such as AHardwareBuffer.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/Shared/glib/RendererBufferTransportMode.h: Renamed from Source/WebKit/Shared/glib/DMABufRendererBufferMode.h.
* Source/WebKit/Shared/glib/RendererBufferTransportMode.serialization.in: Renamed from Source/WebKit/Shared/glib/DMABufRendererBufferMode.serialization.in.
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::dmabufRendererWithSupportedBuffers):
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::rendererBufferTransportMode):
(WebKit::AcceleratedBackingStoreDMABuf::checkRequirements):
(WebKit::AcceleratedBackingStoreDMABuf::preferredBufferFormats):
(WebKit::AcceleratedBackingStoreDMABuf::rendererBufferMode): Deleted.
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::SwapChain::SwapChain):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::initializePlatformDisplayIfNeeded const):
(WebKit::WebProcess::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/289008@main">https://commits.webkit.org/289008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2790e7a15b76eec8cc6ea6f738d87214c57d4017

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35733 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65911 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23746 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76966 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3303 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34808 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74167 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91197 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8784 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74387 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73512 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17884 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16329 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/3469 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13252 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11973 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17413 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11807 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15301 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13553 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->