### PR TITLE
[css-anchor-position-1] `position-try-fallbacks` should work with `transition: all`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/property-interpolations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/property-interpolations-expected.txt
@@ -300,9 +300,9 @@ PASS CSS Transitions with transition-behavior:allow-discrete: property <position
 PASS CSS Transitions with transition-behavior:allow-discrete: property <position-try-fallbacks> from [none] to [flip-block] at (0.6) should be [flip-block]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <position-try-fallbacks> from [none] to [flip-block] at (1) should be [flip-block]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <position-try-fallbacks> from [none] to [flip-block] at (1.5) should be [flip-block]
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [none] to [flip-block] at (-0.3) should be [none] assert_equals: expected "none " but got "flip - block "
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [none] to [flip-block] at (0) should be [none] assert_equals: expected "none " but got "flip - block "
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [none] to [flip-block] at (0.3) should be [none] assert_equals: expected "none " but got "flip - block "
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [none] to [flip-block] at (-0.3) should be [none]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [none] to [flip-block] at (0) should be [none]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [none] to [flip-block] at (0.3) should be [none]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [none] to [flip-block] at (0.5) should be [flip-block]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [none] to [flip-block] at (0.6) should be [flip-block]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [none] to [flip-block] at (1) should be [flip-block]
@@ -342,9 +342,9 @@ PASS CSS Transitions with transition-behavior:allow-discrete: property <position
 PASS CSS Transitions with transition-behavior:allow-discrete: property <position-try-fallbacks> from [flip-inline] to [flip-block] at (0.6) should be [flip-block]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <position-try-fallbacks> from [flip-inline] to [flip-block] at (1) should be [flip-block]
 PASS CSS Transitions with transition-behavior:allow-discrete: property <position-try-fallbacks> from [flip-inline] to [flip-block] at (1.5) should be [flip-block]
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [flip-inline] to [flip-block] at (-0.3) should be [flip-inline] assert_equals: expected "flip - inline " but got "flip - block "
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [flip-inline] to [flip-block] at (0) should be [flip-inline] assert_equals: expected "flip - inline " but got "flip - block "
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [flip-inline] to [flip-block] at (0.3) should be [flip-inline] assert_equals: expected "flip - inline " but got "flip - block "
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [flip-inline] to [flip-block] at (-0.3) should be [flip-inline]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [flip-inline] to [flip-block] at (0) should be [flip-inline]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [flip-inline] to [flip-block] at (0.3) should be [flip-inline]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [flip-inline] to [flip-block] at (0.5) should be [flip-block]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [flip-inline] to [flip-block] at (0.6) should be [flip-block]
 PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-try-fallbacks> from [flip-inline] to [flip-block] at (1) should be [flip-block]

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1522,7 +1522,7 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
         if (first.pointerEvents != second.pointerEvents)
             changingProperties.m_properties.set(CSSPropertyPointerEvents);
 
-        // Writing mode changes conversion of logical -> pysical properties.
+        // Writing mode changes conversion of logical -> physical properties.
         // Thus we need to list up all physical properties.
         if (first.writingMode != second.writingMode) {
             changingProperties.m_properties.merge(CSSProperty::physicalProperties);
@@ -1944,6 +1944,8 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyAnchorName);
         if (first.positionAnchor != second.positionAnchor)
             changingProperties.m_properties.set(CSSPropertyPositionAnchor);
+        if (first.positionTryFallbacks != second.positionTryFallbacks)
+            changingProperties.m_properties.set(CSSPropertyPositionTryFallbacks);
         if (first.positionTryOrder != second.positionTryOrder)
             changingProperties.m_properties.set(CSSPropertyPositionTryOrder);
         if (first.scrollSnapAlign != second.scrollSnapAlign)


### PR DESCRIPTION
#### 13f0566bb335d09e10352b3d12f5eaeb97201eef
<pre>
[css-anchor-position-1] `position-try-fallbacks` should work with `transition: all`
<a href="https://bugs.webkit.org/show_bug.cgi?id=285339">https://bugs.webkit.org/show_bug.cgi?id=285339</a>
<a href="https://rdar.apple.com/142313982">rdar://142313982</a>

Reviewed by Alan Baradlay.

Add missing check in `RenderStyle::conservativelyCollectChangedAnimatableProperties`.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/property-interpolations-expected.txt:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):

Canonical link: <a href="https://commits.webkit.org/288402@main">https://commits.webkit.org/288402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c198438a8f2265e947137d895000ff4fda44b332

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88210 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10664 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/64704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22461 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86156 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/2067 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44984 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1973 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29763 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33181 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73137 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89576 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10383 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7502 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10613 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71375 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72360 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17938 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16540 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15279 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10336 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/15842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10208 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13674 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->