### PR TITLE
[view-transitions] animation-name set from user agent dynamic stylesheet has extra quotes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dynamic-stylesheet-animations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dynamic-stylesheet-animations-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Both old and new snapshots
+PASS Only old snapshot
+PASS Only new snapshot
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dynamic-stylesheet-animations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dynamic-stylesheet-animations.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: Dynamic stylesheet sets correct animations</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions/#setup-transition-pseudo-elements-algorithm">
+
+<style>
+:root { view-transition-name: none; }
+#target {
+    view-transition-name: target;
+    background: red;
+    width: 100px;
+    height: 100px;
+}
+html::view-transition-group(*) {
+    animation-timing-function: steps(2, start);
+    animation-play-state: paused;
+}
+html::view-transition-old(*),
+html::view-transition-new(*) {
+    animation-play-state: paused;
+}
+</style>
+
+<div id="target"></div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async () => {
+    let vt = document.startViewTransition(() => {
+        target.style.backgroundColor = "green";
+    });
+
+    await vt.ready;
+
+    assert_equals(
+        getComputedStyle(document.documentElement, "::view-transition-group(target)").animationName,
+        "-ua-view-transition-group-anim-target",
+        "Animation on group when there are 2 snapshots"
+    );
+
+    assert_equals(
+        getComputedStyle(document.documentElement, "::view-transition-old(target)").animationName,
+        "-ua-view-transition-fade-out, -ua-mix-blend-mode-plus-lighter",
+        "Two animations when there are 2 snapshots"
+    );
+
+    assert_equals(
+        getComputedStyle(document.documentElement, "::view-transition-new(target)").animationName,
+        "-ua-view-transition-fade-in, -ua-mix-blend-mode-plus-lighter",
+        "Two animations when there are 2 snapshots"
+    );
+    await vt.skipTransition();
+}, "Both old and new snapshots");
+
+promise_test(async () => {
+    let vt = await document.startViewTransition(() => {
+        target.remove();
+    });
+
+    await vt.ready;
+
+    assert_equals(
+        getComputedStyle(document.documentElement, "::view-transition-group(target)").animationName,
+        "none",
+        "No animation on group when one snapshot is missing"
+    );
+
+    assert_equals(
+        getComputedStyle(document.documentElement, "::view-transition-old(target)").animationName,
+        "-ua-view-transition-fade-out",
+        "Only one animation for old snapshot when new snapshot is missing"
+    );
+
+    assert_equals(
+        getComputedStyle(document.documentElement, "::view-transition-new(target)").animationName,
+        "none",
+        "No animation since the snapshot is not generated"
+    );
+
+    await vt.skipTransition();
+}, "Only old snapshot");
+
+promise_test(async () => {
+    let vt = await document.startViewTransition(() => {
+        const div = document.createElement("div");
+        div.id = "target";
+        document.body.append(div);
+    });
+
+    await vt.ready;
+
+    assert_equals(
+        getComputedStyle(document.documentElement, "::view-transition-group(target)").animationName,
+        "none",
+        "No animation on group when one snapshot is missing"
+    );
+
+    assert_equals(
+        getComputedStyle(document.documentElement, "::view-transition-old(target)").animationName,
+        "none",
+        "No animation since the snapshot is not generated"
+    );
+
+    assert_equals(
+        getComputedStyle(document.documentElement, "::view-transition-new(target)").animationName,
+        "-ua-view-transition-fade-in",
+        "Only one animation for new snapshot when old snapshot is missing"
+    );
+    await vt.skipTransition();
+}, "Only new snapshot");
+</script>
+
+</body>
+</html>

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -606,11 +606,11 @@ void ViewTransition::setupDynamicStyleSheet(const AtomString& name, const Captur
     Ref resolver = protectedDocument()->styleScope().resolver();
 
     // image animation name rule
-    {
+    if (capturedElement.oldImage) {
         CSSValueListBuilder list;
-        list.append(CSSPrimitiveValue::create("-ua-view-transition-fade-out"_s));
+        list.append(CSSPrimitiveValue::createCustomIdent("-ua-view-transition-fade-out"_s));
         if (capturedElement.newElement)
-            list.append(CSSPrimitiveValue::create("-ua-mix-blend-mode-plus-lighter"_s));
+            list.append(CSSPrimitiveValue::createCustomIdent("-ua-mix-blend-mode-plus-lighter"_s));
         Ref valueList = CSSValueList::createCommaSeparated(WTFMove(list));
         Ref props = MutableStyleProperties::create();
         props->setProperty(CSSPropertyAnimationName, WTFMove(valueList));
@@ -618,11 +618,11 @@ void ViewTransition::setupDynamicStyleSheet(const AtomString& name, const Captur
         resolver->setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionOld, name, props);
     }
 
-    {
+    if (capturedElement.newElement) {
         CSSValueListBuilder list;
-        list.append(CSSPrimitiveValue::create("-ua-view-transition-fade-in"_s));
+        list.append(CSSPrimitiveValue::createCustomIdent("-ua-view-transition-fade-in"_s));
         if (capturedElement.oldImage)
-            list.append(CSSPrimitiveValue::create("-ua-mix-blend-mode-plus-lighter"_s));
+            list.append(CSSPrimitiveValue::createCustomIdent("-ua-mix-blend-mode-plus-lighter"_s));
         Ref valueList = CSSValueList::createCommaSeparated(WTFMove(list));
         Ref props = MutableStyleProperties::create();
         props->setProperty(CSSPropertyAnimationName, WTFMove(valueList));
@@ -635,7 +635,7 @@ void ViewTransition::setupDynamicStyleSheet(const AtomString& name, const Captur
 
     // group animation name rule
     {
-        Ref list = CSSValueList::createCommaSeparated(CSSPrimitiveValue::create(makeString("-ua-view-transition-group-anim-"_s, name)));
+        Ref list = CSSValueList::createCommaSeparated(CSSPrimitiveValue::createCustomIdent(makeString("-ua-view-transition-group-anim-"_s, name)));
         Ref props = MutableStyleProperties::create();
         props->setProperty(CSSPropertyAnimationName, WTFMove(list));
 


### PR DESCRIPTION
#### f0baf504e518ad2af424e9ea20c6fbf0defebdfc
<pre>
[view-transitions] animation-name set from user agent dynamic stylesheet has extra quotes
<a href="https://bugs.webkit.org/show_bug.cgi?id=285295">https://bugs.webkit.org/show_bug.cgi?id=285295</a>
<a href="https://rdar.apple.com/142298840">rdar://142298840</a>

Reviewed by Darin Adler.

- Use `createCustomIdent` to avoid showing quotes around animation names.
- Stop setting animation names on pseudo-elements when the pseudo-element is not generated (not really user observable, aside from getComputedStyle)
- Add a WPT to test all of these

Spec: <a href="https://drafts.csswg.org/css-view-transitions/#setup-transition-pseudo-elements-algorithm">https://drafts.csswg.org/css-view-transitions/#setup-transition-pseudo-elements-algorithm</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dynamic-stylesheet-animations-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dynamic-stylesheet-animations.html: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::setupDynamicStyleSheet):

Canonical link: <a href="https://commits.webkit.org/288417@main">https://commits.webkit.org/288417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eba15314af0ee9dd4d0e7ce253539c350be064ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88236 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34173 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85227 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64720 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22479 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75595 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45003 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1996 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29795 "Found 1 new test failure: fast/editing/recursive-reapply-edit-command-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33208 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73151 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89604 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7517 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73154 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72380 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/17942 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16565 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15310 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12856 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10369 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/15866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10235 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12004 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->