### PR TITLE
Regression(288156@main): http/tests/security/contentSecurityPolicy/connect-src-star-websocket-allowed.html is flakily crashing

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -76,7 +76,6 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
 
     SetCaptureExtraNetworkLoadMetricsEnabled(bool enabled)
 
-    [EnabledBy=WebSocketEnabled]
     CreateSocketChannel(WebCore::ResourceRequest request, String protocol, WebCore::WebSocketIdentifier identifier, WebKit::WebPageProxyIdentifier webPageProxyID, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID, struct WebCore::ClientOrigin clientOrigin, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections> protections, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, enum:uint8_t WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
 
     ClearPageSpecificData(WebCore::PageIdentifier pageID);

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
@@ -178,12 +178,4 @@ CheckedPtr<WebSocketTask> NetworkSocketChannel::checkedSocket()
     return m_socket.get();
 }
 
-std::optional<SharedPreferencesForWebProcess> NetworkSocketChannel::sharedPreferencesForWebProcess()
-{
-    if (RefPtr networkConnectionToWebProcess = protectedConnectionToWebProcess())
-        return networkConnectionToWebProcess->sharedPreferencesForWebProcess();
-
-    return std::nullopt;
-}
-
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
@@ -57,7 +57,6 @@ class WebSocketTask;
 class NetworkConnectionToWebProcess;
 class NetworkProcess;
 class NetworkSession;
-struct SharedPreferencesForWebProcess;
 
 class NetworkSocketChannel : public IPC::MessageSender, public IPC::MessageReceiver, public RefCounted<NetworkSocketChannel> {
     WTF_MAKE_TZONE_ALLOCATED(NetworkSocketChannel);
@@ -69,7 +68,6 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess();
 
     friend class WebSocketTask;
 

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.messages.in
@@ -21,9 +21,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [
+    ExceptionForEnabledBy,
     DispatchedFrom=WebContent,
-    DispatchedTo=Networking,
-    EnabledBy=WebSocketEnabled
+    DispatchedTo=Networking
 ]
 messages -> NetworkSocketChannel {
     SendString(std::span<const uint8_t> message) -> ()


### PR DESCRIPTION
#### 0ee21124e6f2f761479cf2a5e3d9b09ae014e61e
<pre>
Regression(288156@main): http/tests/security/contentSecurityPolicy/connect-src-star-websocket-allowed.html is flakily crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=285348">https://bugs.webkit.org/show_bug.cgi?id=285348</a>
<a href="https://rdar.apple.com/142320806">rdar://142320806</a>

Reviewed by Charlie Wolfe.

According to crash log on bots, network process kills web process for sending NetworkSocketChannel message when
WebSocketEnabled is false. However, WebSocketEnabled should always be true during test run, so there could be other
issues in implementation. To avoid slowing down bots during investigation, revert 288156@main. Also, to investigate the
root cause, add debug assertion and loggings to help understand how WebSocketEnabled becomes false.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::m_ipcTester):
(WebKit::NetworkConnectionToWebProcess::dispatchMessage):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp:
(WebKit::NetworkSocketChannel::sharedPreferencesForWebProcess): Deleted.
* Source/WebKit/NetworkProcess/NetworkSocketChannel.h:
* Source/WebKit/NetworkProcess/NetworkSocketChannel.messages.in:

Canonical link: <a href="https://commits.webkit.org/288420@main">https://commits.webkit.org/288420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/307e6352b59f6701ef956c812a864749687a91ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88243 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34180 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64723 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22483 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45006 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2001 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33215 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89611 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10422 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73155 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72381 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17943 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16567 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15313 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10376 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/15872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10242 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13708 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12011 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->