### PR TITLE
Convert (bidi) inline content coordinates for writing-mode: sideways-lr

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-004-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-004-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>Reference for Sideways Inline Layout: Bidi</title>
+<meta charset=utf-8>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body > div {
+    float: left;
+  }
+  p {
+    height: max-content;
+    border: solid silver 1px;
+    text-align: right;
+  }
+  span {
+    border-inline-start: solid;
+  }
+  .s2 { border-width: 1px;  margin-inline-start: 1px; }
+  .s1 { border-width: 5px;  margin-inline-start: 5px; }
+  .s3 { border-width: 10px; margin-inline-start: 10px; }
+  em {
+    border: 3px orange solid;
+    border-inline-end-width: 7px;
+    margin: 2px;
+    font-style: normal;
+  }
+
+  .lr { writing-mode: sideways-lr; }
+  .rl { writing-mode: sideways-rl; }
+</style>
+
+<div class="lr">
+  <p dir=ltr>789—<em><span class=s2>456</span>—<span class=s1>123</span></em><br>الفبا—<span class=s3>ABC</span>
+</div>
+
+<div class="rl">
+  <p dir=ltr>789—<em><span class=s2>456</span>—<span class=s1>123</span></em><br>الفبا—<span class=s3>ABC</span>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-004-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-004-ref.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>Reference for Sideways Inline Layout: Bidi</title>
+<meta charset=utf-8>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body > div {
+    float: left;
+  }
+  p {
+    height: max-content;
+    border: solid silver 1px;
+    text-align: right;
+  }
+  span {
+    border-inline-start: solid;
+  }
+  .s2 { border-width: 1px;  margin-inline-start: 1px; }
+  .s1 { border-width: 5px;  margin-inline-start: 5px; }
+  .s3 { border-width: 10px; margin-inline-start: 10px; }
+  em {
+    border: 3px orange solid;
+    border-inline-end-width: 7px;
+    margin: 2px;
+    font-style: normal;
+  }
+
+  .lr { writing-mode: sideways-lr; }
+  .rl { writing-mode: sideways-rl; }
+</style>
+
+<div class="lr">
+  <p dir=ltr>789—<em><span class=s2>456</span>—<span class=s1>123</span></em><br>الفبا—<span class=s3>ABC</span>
+</div>
+
+<div class="rl">
+  <p dir=ltr>789—<em><span class=s2>456</span>—<span class=s1>123</span></em><br>الفبا—<span class=s3>ABC</span>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-004.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<title>Sideways Inline Layout: Bidi</title>
+<meta charset=utf-8>
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-4/#block-flow">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#text-direction">
+
+<link rel="match" href="sideways-inline-004-ref.html">
+<style>
+  body > div {
+    float: left;
+  }
+  p {
+    height: max-content;
+    border: solid silver 1px;
+  }
+  span {
+    border-inline-end: solid;
+  }
+  .s2 { border-width: 1px;  margin-inline-end: 1px; }
+  .s1 { border-width: 5px;  margin-inline-end: 5px; }
+  .s3 { border-width: 10px; margin-inline-end: 10px; }
+  em {
+    border: 3px orange solid;
+    border-inline-start-width: 7px;
+    margin: 2px;
+    font-style: normal;
+  }
+
+  .lr { writing-mode: sideways-lr; }
+  .rl { writing-mode: sideways-rl; }
+</style>
+
+<div class="lr">
+  <p dir=rtl><em><span class=s1>123</span>—<span class=s2>456</span></em>—<span class=s3>789<br>ABC</span>—الفبا
+</div>
+
+<div class="rl">
+  <p dir=rtl><em><span class=s1>123</span>—<span class=s2>456</span></em>—<span class=s3>789<br>ABC</span>—الفبا
+</div>


### PR DESCRIPTION
#### 48afbcffb5ec154c0a413ec70279247b1c16d29c
<pre>
Convert (bidi) inline content coordinates for writing-mode: sideways-lr
<a href="https://bugs.webkit.org/show_bug.cgi?id=285351">https://bugs.webkit.org/show_bug.cgi?id=285351</a>
<a href="https://rdar.apple.com/142324115">rdar://142324115</a>

Reviewed by Alan Baradlay.

Updates the bidi codepath in inline layout to also support sideways-lr output.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-004-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-004-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/sideways-inline-004.html: Added.
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::adjustVisualGeometryForDisplayBox):
(WebCore::Layout::InlineDisplayContentBuilder::processBidiContent):

Canonical link: <a href="https://commits.webkit.org/288447@main">https://commits.webkit.org/288447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/565710eb6f30b591e67739e34bc3fc8b6b8cda3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88249 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34186 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10713 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64730 "Found 1 new test failure: fast/ruby/bopomofo-rl.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22486 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2093 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45009 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/1999 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29850 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33221 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73153 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89617 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10428 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7523 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73165 "Found 1 new test failure: fast/ruby/bopomofo-rl.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72385 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16573 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15309 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1786 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12874 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10382 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15878 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10248 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13714 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->