### PR TITLE
Stop using NSKeyedUnarchiver for IPC on platforms that have the needed ObjC support

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -452,9 +452,9 @@ class ConditionalHeader(object):
 
 
 class UsingStatement(object):
-    def __init__(self, name, alias, condition):
+    def __init__(self, name, alias_lines, condition):
         self.name = name
-        self.alias = alias
+        self.alias_lines = alias_lines
         self.condition = condition
 
 
@@ -1366,7 +1366,13 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers, u
     for using_statement in using_statements:
         if using_statement.condition is not None:
             result.append(f'#if {using_statement.condition}')
-        result.append(f'static_assert(std::is_same_v<{using_statement.name}, {using_statement.alias}>);')
+        result.append(f'static_assert(std::is_same_v<{using_statement.name},')
+        for alias_line in using_statement.alias_lines:
+            if '#' in alias_line:
+                result.append(f'{alias_line.strip()}')
+            else:
+                result.append(f'    {alias_line}')
+        result.append('>);')
         if using_statement.condition is not None:
             result.append('#endif')
 
@@ -1398,7 +1404,16 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers, u
         if using_statement.condition is not None:
             result.append(f'#if {using_statement.condition}')
         result.append(f'        {{ "{using_statement.name}"_s, {{')
-        result.append(f'            {{ "{using_statement.alias}"_s, "alias"_s }}')
+        result.append(f'        {{')
+        for line_number in range(len(using_statement.alias_lines)):
+            alias_line = using_statement.alias_lines[line_number]
+            if '#' in alias_line:
+                result.append(f'{alias_line.strip()}')
+            else:
+                underscore_s_after_last_line = '_s' if line_number is len(using_statement.alias_lines) - 1 else ''
+                extra_space_after_comma = ' ' if ',' in alias_line else ''
+                result.append(f'            "{alias_line.strip()}{extra_space_after_comma}"{underscore_s_after_last_line}')
+        result.append(f'            , "alias"_s }}')
         result.append('        } },')
         if using_statement.condition is not None:
             result.append('#endif')
@@ -1483,8 +1498,12 @@ def parse_serialized_types(file):
     metadata = None
     templates = []
 
+    file_lines = []
     for line in file:
-        line = line.strip()
+        file_lines.append(line.strip())
+
+    for line_number in range(len(file_lines)):
+        line = file_lines[line_number]
         if line.startswith('#'):
             if line == '#else':
                 if name is None:
@@ -1630,9 +1649,19 @@ def parse_serialized_types(file):
             declaration = match.groups()[0]
             additional_forward_declarations.append(ConditionalForwardDeclaration(declaration, type_condition))
             continue
+        match = re.search(r'using (.*) = std::variant<$', line)
+        if match:
+            line_number = line_number + 1
+            alias_lines = ['std::variant<']
+            while not file_lines[line_number].startswith('>'):
+                alias_lines.append('    ' + file_lines[line_number])
+                line_number = line_number + 1
+            alias_lines.append('>')
+            using_statements.append(UsingStatement(match.groups()[0], alias_lines, type_condition))
+            continue
         match = re.search(r'using (.*) = ([^;]*)', line)
         if match:
-            using_statements.append(UsingStatement(match.groups()[0], match.groups()[1], type_condition))
+            using_statements.append(UsingStatement(match.groups()[0], [match.groups()[1]], type_condition))
             continue
         if underlying_type is not None:
             members.append(EnumMember(line.strip(' ,'), member_condition))
@@ -1707,7 +1736,7 @@ def generate_webkit_secure_coding_impl(serialized_types, headers):
     result.append('')
     result.append('static RetainPtr<NSDictionary> dictionaryForWebKitSecureCodingType(id object)')
     result.append('{')
-    result.append('    if (WebKit::CoreIPCSecureCoding::conformsToWebKitSecureCoding(object))')
+    result.append('    if (WebKit::conformsToWebKitSecureCoding(object))')
     result.append('        return [object _webKitPropertyListData];')
     result.append('')
     result.append('    return dictionaryForWebKitSecureCodingTypeFromWKKeyedCoder(object);')

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp
@@ -44,7 +44,7 @@ static RetainPtr<NSDictionary> dictionaryForWebKitSecureCodingTypeFromWKKeyedCod
 
 static RetainPtr<NSDictionary> dictionaryForWebKitSecureCodingType(id object)
 {
-    if (WebKit::CoreIPCSecureCoding::conformsToWebKitSecureCoding(object))
+    if (WebKit::conformsToWebKitSecureCoding(object))
         return [object _webKitPropertyListData];
 
     return dictionaryForWebKitSecureCodingTypeFromWKKeyedCoder(object);

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -80,14 +80,34 @@
 #include <wtf/CreateUsingClass.h>
 #include <wtf/Seconds.h>
 
-static_assert(std::is_same_v<WebCore::SharedStringHash, uint32_t>);
-static_assert(std::is_same_v<WebCore::UsingWithSemicolon, uint32_t>);
+static_assert(std::is_same_v<WebCore::SharedStringHash,
+    uint32_t
+>);
+static_assert(std::is_same_v<WebCore::UsingWithSemicolon,
+    uint32_t
+>);
 #if OS(WINDOWS)
-static_assert(std::is_same_v<WTF::ProcessID, int>);
+static_assert(std::is_same_v<WTF::ProcessID,
+    int
+>);
 #endif
 #if !(OS(WINDOWS))
-static_assert(std::is_same_v<WTF::ProcessID, pid_t>);
+static_assert(std::is_same_v<WTF::ProcessID,
+    pid_t
+>);
 #endif
+static_assert(std::is_same_v<WebCore::ConditionalVariant,
+    std::variant<
+        int,
+#if USE(CHAR)
+        char,
+#endif
+        double
+    >
+>);
+static_assert(std::is_same_v<WebCore::NonConditionalVariant,
+    std::variant<int, double>
+>);
 
 #if ENABLE(IPC_TESTING_API)
 
@@ -534,21 +554,45 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             { "WebKit::CoreIPCNull"_s, "wrapper"_s }
         } },
         { "WebCore::SharedStringHash"_s, {
-            { "uint32_t"_s, "alias"_s }
+        {
+            "uint32_t"_s
+            , "alias"_s }
         } },
         { "WebCore::UsingWithSemicolon"_s, {
-            { "uint32_t"_s, "alias"_s }
+        {
+            "uint32_t"_s
+            , "alias"_s }
         } },
 #if OS(WINDOWS)
         { "WTF::ProcessID"_s, {
-            { "int"_s, "alias"_s }
+        {
+            "int"_s
+            , "alias"_s }
         } },
 #endif
 #if !(OS(WINDOWS))
         { "WTF::ProcessID"_s, {
-            { "pid_t"_s, "alias"_s }
+        {
+            "pid_t"_s
+            , "alias"_s }
         } },
 #endif
+        { "WebCore::ConditionalVariant"_s, {
+        {
+            "std::variant<"
+            "int, "
+#if USE(CHAR)
+            "char, "
+#endif
+            "double"
+            ">"_s
+            , "alias"_s }
+        } },
+        { "WebCore::NonConditionalVariant"_s, {
+        {
+            "std::variant<int, double> "_s
+            , "alias"_s }
+        } },
     };
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -353,3 +353,13 @@ NSNull wrapped by CoreIPCNull
     bool bottom();
     bool left();
 }
+
+using WebCore::ConditionalVariant = std::variant<
+    int,
+#if USE(CHAR)
+    char,
+#endif
+    double
+>;
+
+using WebCore::NonConditionalVariant = std::variant<int, double>

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -74,6 +74,26 @@ namespace IPC {
 enum class NSType : uint8_t {
     Array,
     Color,
+#if USE(PASSKIT)
+    PKPaymentMethod,
+    PKPaymentMerchantSession,
+    PKContact,
+    PKSecureElementPass,
+    PKPayment,
+    PKPaymentToken,
+    PKShippingMethod,
+    PKDateComponentsRange,
+    CNContact,
+    CNPhoneNumber,
+    CNPostalAddress,
+#endif
+#if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
+    DDScannerResult,
+#if PLATFORM(MAC)
+    WKDDActionContext,
+#endif
+#endif
+    NSDateComponents,
     Data,
     Date,
     Error,
@@ -82,7 +102,9 @@ enum class NSType : uint8_t {
     Locale,
     Number,
     Null,
+#if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
     SecureCoding,
+#endif
     String,
     URL,
     NSValue,
@@ -193,6 +215,7 @@ template<typename T> struct ArgumentCoder<T *> {
     }
 };
 
+#if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
 template<typename T> struct ArgumentCoder<CoreIPCRetainPtr<T>> {
     template<typename U = T>
     static void encode(Encoder& encoder, const CoreIPCRetainPtr<U>& object)
@@ -212,6 +235,7 @@ template<typename T> struct ArgumentCoder<CoreIPCRetainPtr<T>> {
         return decodeObjectDirectlyRequiringAllowedClasses<U>(decoder);
     }
 };
+#endif // !HAVE(WK_SECURE_CODING_NSURLREQUEST)
 
 template<typename T> struct ArgumentCoder<RetainPtr<T>> {
     template<typename U = T, typename = IsObjCObject<U>>

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -36,6 +36,25 @@ namespace WebKit {
 class CoreIPCArray;
 class CoreIPCCFType;
 class CoreIPCColor;
+#if USE(PASSKIT)
+class CoreIPCPKPaymentMethod;
+class CoreIPCPKPaymentMerchantSession;
+class CoreIPCPKContact;
+class CoreIPCPKSecureElementPass;
+class CoreIPCPKPayment;
+class CoreIPCPKPaymentToken;
+class CoreIPCPKShippingMethod;
+class CoreIPCPKDateComponentsRange;
+class CoreIPCCNContact;
+class CoreIPCCNPhoneNumber;
+class CoreIPCCNPostalAddress;
+#endif
+#if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
+class CoreIPCDDScannerResult;
+#if PLATFORM(MAC)
+class CoreIPCDDSecureActionContext;
+#endif
+#endif
 class CoreIPCData;
 class CoreIPCDate;
 class CoreIPCDateComponents;
@@ -47,7 +66,9 @@ class CoreIPCNSShadow;
 class CoreIPCNSValue;
 class CoreIPCNumber;
 class CoreIPCNull;
+#if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
 class CoreIPCSecureCoding;
+#endif
 class CoreIPCString;
 class CoreIPCURL;
 
@@ -66,12 +87,35 @@ using ObjectValue = std::variant<
     CoreIPCNSValue,
     CoreIPCNumber,
     CoreIPCNull,
+#if USE(PASSKIT)
+    CoreIPCPKPaymentMethod,
+    CoreIPCPKPaymentMerchantSession,
+    CoreIPCPKContact,
+    CoreIPCPKSecureElementPass,
+    CoreIPCPKPayment,
+    CoreIPCPKPaymentToken,
+    CoreIPCPKShippingMethod,
+    CoreIPCPKDateComponentsRange,
+    CoreIPCCNContact,
+    CoreIPCCNPhoneNumber,
+    CoreIPCCNPostalAddress,
+#endif
+#if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
+    CoreIPCDDScannerResult,
+#if PLATFORM(MAC)
+    CoreIPCDDSecureActionContext,
+#endif
+#endif
+    CoreIPCDateComponents,
+#if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
     CoreIPCSecureCoding,
+#endif // HAVE(WK_SECURE_CODING_NSURLREQUEST)
     CoreIPCString,
     CoreIPCURL
 >;
 
 class CoreIPCNSCFObject {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     CoreIPCNSCFObject(id);
     CoreIPCNSCFObject(UniqueRef<ObjectValue>&&);

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
@@ -28,6 +28,46 @@ webkit_platform_headers: "ArgumentCodersCocoa.h" "CoreIPCNSCFObject.h"
     [Validator='WebKit::CoreIPCNSCFObject::valueIsAllowed(decoder, *value)'] UniqueRef<WebKit::ObjectValue> value();
 }
 
-using WebKit::ObjectValue = std::variant<std::nullptr_t, WebKit::CoreIPCArray, WebKit::CoreIPCCFType, WebKit::CoreIPCColor, WebKit::CoreIPCData, WebKit::CoreIPCDate, WebKit::CoreIPCDictionary, WebKit::CoreIPCError, WebKit::CoreIPCFont, WebKit::CoreIPCLocale, WebKit::CoreIPCNSShadow, WebKit::CoreIPCNSValue, WebKit::CoreIPCNumber, WebKit::CoreIPCNull, WebKit::CoreIPCSecureCoding, WebKit::CoreIPCString, WebKit::CoreIPCURL>
+using WebKit::ObjectValue = std::variant<
+    std::nullptr_t,
+    WebKit::CoreIPCArray,
+    WebKit::CoreIPCCFType,
+    WebKit::CoreIPCColor,
+    WebKit::CoreIPCData,
+    WebKit::CoreIPCDate,
+    WebKit::CoreIPCDictionary,
+    WebKit::CoreIPCError,
+    WebKit::CoreIPCFont,
+    WebKit::CoreIPCLocale,
+    WebKit::CoreIPCNSShadow,
+    WebKit::CoreIPCNSValue,
+    WebKit::CoreIPCNumber,
+    WebKit::CoreIPCNull,
+#if USE(PASSKIT)
+    WebKit::CoreIPCPKPaymentMethod,
+    WebKit::CoreIPCPKPaymentMerchantSession,
+    WebKit::CoreIPCPKContact,
+    WebKit::CoreIPCPKSecureElementPass,
+    WebKit::CoreIPCPKPayment,
+    WebKit::CoreIPCPKPaymentToken,
+    WebKit::CoreIPCPKShippingMethod,
+    WebKit::CoreIPCPKDateComponentsRange,
+    WebKit::CoreIPCCNContact,
+    WebKit::CoreIPCCNPhoneNumber,
+    WebKit::CoreIPCCNPostalAddress,
+#endif
+#if ENABLE(DATA_DETECTION) && HAVE(WK_SECURE_CODING_DATA_DETECTORS)
+    WebKit::CoreIPCDDScannerResult,
+#if PLATFORM(MAC)
+    WebKit::CoreIPCDDSecureActionContext,
+#endif
+#endif
+    WebKit::CoreIPCDateComponents,
+#if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
+    WebKit::CoreIPCSecureCoding,
+#endif
+    WebKit::CoreIPCString,
+    WebKit::CoreIPCURL
+>
 
 #endif // USE(CF)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSShadow.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSShadow.h
@@ -28,15 +28,12 @@
 #if PLATFORM(COCOA)
 
 #include "ArgumentCodersCocoa.h"
-#include "CoreIPCSecureCoding.h"
 #include <WebCore/ColorCocoa.h>
 #include <wtf/RetainPtr.h>
 
 OBJC_CLASS NSShadow;
 
 namespace WebKit {
-
-class CoreIPCSecureCoding;
 
 class CoreIPCNSShadow {
 public:

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.h
@@ -28,43 +28,35 @@
 #if PLATFORM(COCOA)
 
 #include "ArgumentCodersCocoa.h"
-#include "CoreIPCSecureCoding.h"
+#include <CoreGraphics/CGGeometry.h>
 #include <wtf/RetainPtr.h>
 
 OBJC_CLASS NSValue;
 
 namespace WebKit {
 
-class CoreIPCSecureCoding;
+class CoreIPCNSCFObject;
 
 class CoreIPCNSValue {
 public:
     CoreIPCNSValue(NSValue *);
     CoreIPCNSValue(const RetainPtr<NSValue>& value)
-        : CoreIPCNSValue(value.get())
-    {
-    }
+        : CoreIPCNSValue(value.get()) { }
+    CoreIPCNSValue(CoreIPCNSValue&&);
+    ~CoreIPCNSValue();
 
     RetainPtr<id> toID() const;
 
     static bool shouldWrapValue(NSValue *);
 
-#if PLATFORM(MAC)
-    using WrappedNSValue = std::variant<NSRange, NSRect>;
-#else
-    using WrappedNSValue = std::variant<NSRange>;
-#endif
-    using Value = std::variant<WrappedNSValue, CoreIPCSecureCoding>;
+    using Value = std::variant<NSRange, CGRect, UniqueRef<CoreIPCNSCFObject>>;
 
 private:
     friend struct IPC::ArgumentCoder<CoreIPCNSValue, void>;
 
     static Value valueFromNSValue(NSValue *);
 
-    CoreIPCNSValue(Value&& value)
-        : m_value(WTFMove(value))
-    {
-    }
+    CoreIPCNSValue(Value&&);
 
     Value m_value;
 };

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSValue.serialization.in
@@ -31,14 +31,7 @@ webkit_platform_headers: "CoreIPCNSValue.h" <Foundation/NSRange.h>
 using NSRange = _NSRange
 
 [WebKitPlatform] class WebKit::CoreIPCNSValue {
-    WebKit::CoreIPCNSValue::Value m_value
+    std::variant<NSRange, CGRect, UniqueRef<WebKit::CoreIPCNSCFObject>> m_value
 }
-
-#if PLATFORM(MAC)
-using WebKit::CoreIPCNSValue::WrappedNSValue = std::variant<NSRange, NSRect>;
-#else
-using WebKit::CoreIPCNSValue::WrappedNSValue = std::variant<NSRange>;
-#endif
-using WebKit::CoreIPCNSValue::Value = std::variant<WebKit::CoreIPCNSValue::WrappedNSValue, WebKit::CoreIPCSecureCoding>;
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKSecureElementPass.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKSecureElementPass.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,39 +23,30 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
-#import "CoreIPCNSShadow.h"
+#pragma once
 
-#if PLATFORM(COCOA)
+#if USE(PASSKIT)
 
-#import <WebCore/AttributedString.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/Vector.h>
 
-#if USE(APPKIT)
-#import <AppKit/NSShadow.h>
-#endif
-#if PLATFORM(IOS_FAMILY)
-#import <UIKit/NSShadow.h>
-#import <pal/ios/UIKitSoftLink.h>
-#endif
+OBJC_CLASS PKSecureElementPass;
 
 namespace WebKit {
 
-CoreIPCNSShadow::CoreIPCNSShadow(NSShadow *shadow)
-    : m_shadowOffset(shadow.shadowOffset)
-    , m_shadowBlurRadius(shadow.shadowBlurRadius)
-    , m_shadowColor(shadow.shadowColor)
-{
-}
+class CoreIPCPKSecureElementPass {
+public:
+    CoreIPCPKSecureElementPass(PKSecureElementPass *);
+    CoreIPCPKSecureElementPass(Vector<uint8_t>&& data)
+        : m_data(WTFMove(data)) { }
 
-RetainPtr<id> CoreIPCNSShadow::toID() const
-{
-    RetainPtr<NSShadow> result = adoptNS([PlatformNSShadow new]);
-    [result setShadowOffset:m_shadowOffset];
-    [result setShadowBlurRadius:m_shadowBlurRadius];
-    [result setShadowColor:m_shadowColor.get()];
-    return result;
-}
+    RetainPtr<id> toID() const;
+    const Vector<uint8_t>& ipcData() const { return m_data; }
+
+private:
+    Vector<uint8_t> m_data;
+};
 
 } // namespace WebKit
 
-#endif // PLATFORM(COCOA)
+#endif // USE(PASSKIT)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
@@ -33,6 +33,11 @@ secure_coding_header: <pal/cocoa/PassKitSoftLink.h>
     String m_supplementarySublocality;
 }
 
+webkit_platform_headers: "CoreIPCPKSecureElementPass.h"
+[WebKitPlatform] class WebKit::CoreIPCPKSecureElementPass {
+    Vector<uint8_t> ipcData()
+}
+
 [WebKitSecureCodingClass=PAL::getPKPaymentMerchantSessionClass(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKPaymentMerchantSession {
     merchantIdentifier: String
     merchantSessionIdentifier: String

--- a/Source/WebKit/Shared/Cocoa/CoreIPCRetainPtr.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCRetainPtr.h
@@ -27,6 +27,7 @@
 
 #include <wtf/RetainPtr.h>
 
+#if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
 namespace IPC {
 
 template<typename T>
@@ -40,3 +41,4 @@ public:
 };
 
 }
+#endif // !HAVE(WK_SECURE_CODING_NSURLREQUEST)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h
@@ -51,6 +51,7 @@ void applyProcessCreationParameters(const AuxiliaryProcessCreationParameters&);
 
 #ifdef __OBJC__
 
+#if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
 class CoreIPCSecureCoding {
 WTF_MAKE_TZONE_ALLOCATED(CoreIPCSecureCoding);
 public:
@@ -64,14 +65,14 @@ public:
 
     Class objectClass() { return m_secureCoding.get().class; }
 
-    static bool conformsToWebKitSecureCoding(id);
-    static bool conformsToSecureCoding(id);
-
 private:
     friend struct IPC::ArgumentCoder<CoreIPCSecureCoding, void>;
 
     IPC::CoreIPCRetainPtr<NSObject<NSSecureCoding>> m_secureCoding;
 };
+#endif // !HAVE(WK_SECURE_CODING_NSURLREQUEST)
+
+bool conformsToWebKitSecureCoding(id);
 
 #endif // __OBJC__
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm
@@ -23,10 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if PLATFORM(COCOA)
-
 #import "config.h"
 #import "CoreIPCSecureCoding.h"
+
+#if PLATFORM(COCOA)
 
 #import "ArgumentCodersCocoa.h"
 #import "AuxiliaryProcessCreationParameters.h"
@@ -84,19 +84,17 @@ void applyProcessCreationParameters(const AuxiliaryProcessCreationParameters& pa
 
 } // namespace SecureCoding
 
+#if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CoreIPCSecureCoding);
+#endif
 
-bool CoreIPCSecureCoding::conformsToWebKitSecureCoding(id object)
+bool conformsToWebKitSecureCoding(id object)
 {
     return [object respondsToSelector:@selector(_webKitPropertyListData)]
         && [object respondsToSelector:@selector(_initWithWebKitPropertyListData:)];
 }
 
-bool CoreIPCSecureCoding::conformsToSecureCoding(id object)
-{
-    return [object conformsToProtocol:@protocol(NSSecureCoding)];
-}
-
+#if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
 NO_RETURN static void crashWithClassName(Class objectClass)
 {
     WebKit::logAndSetCrashLogMessage("NSSecureCoding path used for unexpected object"_s);
@@ -120,6 +118,7 @@ CoreIPCSecureCoding::CoreIPCSecureCoding(id object)
 
     crashWithClassName([object class]);
 }
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.serialization.in
@@ -20,12 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#if PLATFORM(COCOA)
-
 webkit_platform_headers: "CoreIPCSecureCoding.h"
 
+#if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
 [WebKitPlatform] class WebKit::CoreIPCSecureCoding {
     IPC::CoreIPCRetainPtr<NSObject<NSSecureCoding>> m_secureCoding;
 }
-
-#endif // PLATFORM(COCOA)
+#endif

--- a/Source/WebKit/Shared/Cocoa/CoreIPCTypes.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCTypes.h
@@ -40,6 +40,7 @@
 #import "CoreIPCNSValue.h"
 #import "CoreIPCNull.h"
 #import "CoreIPCNumber.h"
+#import "CoreIPCPKSecureElementPass.h"
 #import "CoreIPCPassKit.h"
 #import "CoreIPCPersonNameComponents.h"
 #import "CoreIPCPresentationIntent.h"

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -470,6 +470,7 @@ AVOutputContext wrapped by CoreIPCAVOutputContext
 PKPaymentMethod wrapped by CoreIPCPKPaymentMethod
 PKPaymentMerchantSession wrapped by CoreIPCPKPaymentMerchantSession
 PKContact wrapped by CoreIPCPKContact
+PKSecureElementPass wrapped by CoreIPCPKSecureElementPass
 PKPayment wrapped by CoreIPCPKPayment
 PKPaymentToken wrapped by CoreIPCPKPaymentToken
 PKShippingMethod wrapped by CoreIPCPKShippingMethod

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2520,6 +2520,7 @@
 		FAE61CEA2D0A5608000D238D /* UnifiedSource137.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAE61CE32D0A5607000D238D /* UnifiedSource137.cpp */; };
 		FAE61CEB2D0A5608000D238D /* UnifiedSource135.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAE61CE42D0A5607000D238D /* UnifiedSource135.cpp */; };
 		FAE61CEC2D0A5608000D238D /* UnifiedSource131.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAE61CE52D0A5607000D238D /* UnifiedSource131.cpp */; };
+		FAF27D302D2851EB00F1F0BB /* CoreIPCPKSecureElementPass.mm in Sources */ = {isa = PBXBuildFile; fileRef = FAF27D2F2D2850D400F1F0BB /* CoreIPCPKSecureElementPass.mm */; };
 		FEDBDCD71E68D20500A59F8F /* WebInspectorInterruptDispatcherMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = FEDBDCD51E68D19C00A59F8F /* WebInspectorInterruptDispatcherMessages.h */; };
 		FEE43FD31E67B0180077D6D1 /* WebInspectorInterruptDispatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = FEE43FD11E67AFC60077D6D1 /* WebInspectorInterruptDispatcher.h */; };
 /* End PBXBuildFile section */
@@ -8350,6 +8351,8 @@
 		FAE61CE32D0A5607000D238D /* UnifiedSource137.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource137.cpp; sourceTree = "<group>"; };
 		FAE61CE42D0A5607000D238D /* UnifiedSource135.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource135.cpp; sourceTree = "<group>"; };
 		FAE61CE52D0A5607000D238D /* UnifiedSource131.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource131.cpp; sourceTree = "<group>"; };
+		FAF27D2E2D2850D400F1F0BB /* CoreIPCPKSecureElementPass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCPKSecureElementPass.h; sourceTree = "<group>"; };
+		FAF27D2F2D2850D400F1F0BB /* CoreIPCPKSecureElementPass.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCPKSecureElementPass.mm; sourceTree = "<group>"; };
 		FED3C1DA1B447AE800E0EB7F /* APISerializedScriptValueCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = APISerializedScriptValueCocoa.mm; sourceTree = "<group>"; };
 		FEDBDCD41E68D19C00A59F8F /* WebInspectorInterruptDispatcherMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebInspectorInterruptDispatcherMessageReceiver.cpp; sourceTree = "<group>"; };
 		FEDBDCD51E68D19C00A59F8F /* WebInspectorInterruptDispatcherMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebInspectorInterruptDispatcherMessages.h; sourceTree = "<group>"; };
@@ -12005,6 +12008,8 @@
 				51AD568D2B1C46EF001A0ECB /* CoreIPCPersonNameComponents.h */,
 				51AD568E2B1C46EF001A0ECB /* CoreIPCPersonNameComponents.mm */,
 				51AD568F2B1C46F0001A0ECB /* CoreIPCPersonNameComponents.serialization.in */,
+				FAF27D2E2D2850D400F1F0BB /* CoreIPCPKSecureElementPass.h */,
+				FAF27D2F2D2850D400F1F0BB /* CoreIPCPKSecureElementPass.mm */,
 				F4B63E162C49586700BC59EF /* CoreIPCPlist.serialization.in */,
 				F4F12CB12C48B8BB00BC1254 /* CoreIPCPlistArray.h */,
 				F4F12CB22C48B8BB00BC1254 /* CoreIPCPlistArray.mm */,
@@ -19667,6 +19672,7 @@
 				FA4FE2662B75EB290016E671 /* CoreIPCNull.mm in Sources */,
 				5157AE0B2B23E97400C0E095 /* CoreIPCPassKit.mm in Sources */,
 				51AD56902B1C46FE001A0ECB /* CoreIPCPersonNameComponents.mm in Sources */,
+				FAF27D302D2851EB00F1F0BB /* CoreIPCPKSecureElementPass.mm in Sources */,
 				F4F12CB32C48B8C100BC1254 /* CoreIPCPlistArray.mm in Sources */,
 				F4F12CB02C48B2C800BC1254 /* CoreIPCPlistDictionary.mm in Sources */,
 				F4F12CAD2C485BE200BC1254 /* CoreIPCPlistObject.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -549,8 +549,10 @@ static NSMutableSet<NSString *> *extractTypesFromContainers(NSSet<NSString *> *i
             @"KeyValuePair",
             @"Markable",
             @"RetainPtr",
-            @"HashCountedSet",
-            @"IPC::CoreIPCRetainPtr"
+            @"HashCountedSet"
+#if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
+            , @"IPC::CoreIPCRetainPtr"
+#endif
         ];
         for (NSString *container in containerTypes) {
             if ([input hasPrefix:[container stringByAppendingString:@"<"]]
@@ -683,9 +685,8 @@ TEST(IPCTestingAPI, SerializedTypeInfo)
     // add IPC metadata in a *.serialization.in file instead.
     NSSet<NSString *> *expectedTypesNeedingDescriptions = [NSSet setWithArray:@[
         @"CTFontDescriptorOptions",
-        @"NSObject<NSSecureCoding>",
-        @"PKSecureElementPass",
 #if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
+        @"NSObject<NSSecureCoding>",
         @"NSURLRequest",
 #endif
         @"MachSendRight",
@@ -707,6 +708,7 @@ TEST(IPCTestingAPI, SerializedTypeInfo)
 
 #endif
 
+#if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
 TEST(IPCTestingAPI, CGColorInNSSecureCoding)
 {
     auto archiver = adoptNS([[NSKeyedArchiver alloc] initRequiringSecureCoding:YES]);
@@ -792,3 +794,4 @@ TEST(IPCTestingAPI, NSURLWithBaseURLInNSSecureCoding)
     [unarchiver finishDecoding];
     unarchiver.get().delegate = nil;
 }
+#endif // !HAVE(WK_SECURE_CODING_NSURLREQUEST)


### PR DESCRIPTION
#### 57052761f12cac99419741ade11be63a170f01b3
<pre>
Stop using NSKeyedUnarchiver for IPC on platforms that have the needed ObjC support
<a href="https://bugs.webkit.org/show_bug.cgi?id=285356">https://bugs.webkit.org/show_bug.cgi?id=285356</a>
<a href="https://rdar.apple.com/142327308">rdar://142327308</a>

Reviewed by Brady Eidson.

To do this I needed to do a few things:
1. I needed to make CoreIPCPKSecureElementPass which continues to use NSKU under
the hood, but with a runtime verification that it is only used to send a
PKSecureElementPass into the web content process, so it can&apos;t be use to escape
the web content process.
2. I added a few more types to the NSType enumeration to replace SecureCoding.
3. I use a CoreIPCNSCFObject instead of a CoreIPCSecureCoding to store and serialize
the non-NSRange and non-NSRect possibilities in a CoreIPCNSValue.  This can probably
be tightened later, but for now it is not expanding the IPC possibilities that
are reachable by serializing an NSValue.
Now our IPC surface area has no ObjC types as primitive types on new platforms!

* Source/WebKit/Scripts/generate-serializers.py:
(generate_webkit_secure_coding_impl):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::typeFromObject):
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::valueFromID):
(WebKit::CoreIPCNSCFObject::valueIsAllowed):
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCNSShadow.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSShadow.mm:
* Source/WebKit/Shared/Cocoa/CoreIPCNSValue.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSValue.mm:
(WebKit::CoreIPCNSValue::valueFromNSValue):
(WebKit::CoreIPCNSValue::toID const):
(WebKit::CoreIPCNSValue::shouldWrapValue): Deleted.
* Source/WebKit/Shared/Cocoa/CoreIPCNSValue.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCPKSecureElementPass.h: Copied from Source/WebKit/Shared/Cocoa/CoreIPCRetainPtr.h.
(WebKit::CoreIPCPKSecureElementPass::CoreIPCPKSecureElementPass):
(WebKit::CoreIPCPKSecureElementPass::ipcData const):
* Source/WebKit/Shared/Cocoa/CoreIPCPKSecureElementPass.mm: Copied from Source/WebKit/Shared/Cocoa/CoreIPCNSShadow.mm.
(WebKit::CoreIPCPKSecureElementPass::CoreIPCPKSecureElementPass):
(WebKit::CoreIPCPKSecureElementPass::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCRetainPtr.h:
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.h:
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.mm:
(WebKit::conformsToWebKitSecureCoding):
(WebKit::CoreIPCSecureCoding::conformsToWebKitSecureCoding): Deleted.
(WebKit::CoreIPCSecureCoding::conformsToSecureCoding): Deleted.
* Source/WebKit/Shared/Cocoa/CoreIPCSecureCoding.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCTypes.h:
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:
(SerializedTypeInfo)):

Canonical link: <a href="https://commits.webkit.org/288484@main">https://commits.webkit.org/288484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/808fbd69a28226f8ef2e5a59f7f91919b5dc8894

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88614 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34551 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64995 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22737 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45282 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/82951 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2289 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30124 "Found 1 new test failure: fast/editing/recursive-reapply-edit-command-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33599 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89991 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10808 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7797 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73428 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71730 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72653 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16887 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15600 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2132 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12890 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10760 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16232 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10607 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14082 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->