### PR TITLE
[SwiftUI] Command+Click should open link in a new window in SwiftBrowser

### DIFF
--- a/Tools/SwiftBrowser/Source/SwiftBrowser.swift
+++ b/Tools/SwiftBrowser/Source/SwiftBrowser.swift
@@ -28,11 +28,16 @@ import SwiftUI
 struct SwiftBrowserApp: App {
     @FocusedValue(BrowserViewModel.self) var focusedBrowserViewModel
 
+    @AppStorage(AppStorageKeys.homepage) private var homepage = "https://www.webkit.org"
+
     @State private var mostRecentURL: URL? = nil
 
     var body: some Scene {
-        WindowGroup {
-            BrowserView(url: $mostRecentURL)
+        WindowGroup(for: CodableURLRequest.self) { $request in
+            BrowserView(url: $mostRecentURL, initialRequest: request.value)
+        } defaultValue: {
+            let url = URL(string: homepage)!
+            return CodableURLRequest(.init(url: url))
         }
         .commands {
             CommandGroup(after: .sidebar) {

--- a/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
@@ -39,6 +39,10 @@ extension PDF: Transferable {
     }
 }
 
+struct OpenRequest: Equatable {
+    let request: URLRequest
+}
+
 @Observable
 @MainActor
 final class BrowserViewModel {
@@ -64,7 +68,7 @@ final class BrowserViewModel {
 
         self.page = WebPage(configuration: configuration, navigationDecider: self.navigationDecider, dialogPresenter: self.dialogPresenter, downloadCoordinator: self.downloadCoordinator)
 
-        
+        self.navigationDecider.owner = self
         self.dialogPresenter.owner = self
     }
 
@@ -75,6 +79,8 @@ final class BrowserViewModel {
     private let navigationDecider = NavigationDecider()
 
     var displayedURL: String = ""
+
+    var currentOpenRequest: OpenRequest? = nil
 
     // MARK: PDF properties
 

--- a/Tools/SwiftBrowser/Source/Views/BrowserView.swift
+++ b/Tools/SwiftBrowser/Source/Views/BrowserView.swift
@@ -26,10 +26,12 @@ import SwiftUI
 struct BrowserView: View {
     @Binding var url: URL?
 
+    let initialRequest: URLRequest
+
     @State private var viewModel = BrowserViewModel()
 
     var body: some View {
-        ContentView(url: $url)
+        ContentView(url: $url, initialRequest: initialRequest)
             .environment(viewModel)
     }
 }
@@ -39,6 +41,11 @@ struct BrowserView: View {
 
     @Previewable @State var url: URL? = nil
 
-    BrowserView(url: $url)
+    let request = {
+        let url = URL(string: "https://www.apple.com")!
+        return URLRequest(url: url)
+    }()
+
+    BrowserView(url: $url, initialRequest: request)
         .environment(viewModel)
 }

--- a/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj
+++ b/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		07259B362D1F969A00B45C4E /* NavigationDecider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07259B352D1F969A00B45C4E /* NavigationDecider.swift */; };
 		07259B392D1F97A500B45C4E /* URLResponse+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07259B382D1F97A500B45C4E /* URLResponse+Extras.swift */; };
 		072823132D1D315D00A0658F /* DownloadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072823122D1D315D00A0658F /* DownloadsView.swift */; };
+		078F11852D288FAC00B3582D /* URLRequest+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078F11842D288FAC00B3582D /* URLRequest+Codable.swift */; };
 		07A4CE9F2D08C06400764F5E /* Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A4CE9E2D08C06400764F5E /* Empty.swift */; };
 		07A58BED2D04013100CAB4ED /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 07A58BE82D04013100CAB4ED /* Assets.xcassets */; };
 		07A58BEE2D04013100CAB4ED /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A58BE92D04013100CAB4ED /* ContentView.swift */; };
@@ -31,6 +32,7 @@
 		07259B352D1F969A00B45C4E /* NavigationDecider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDecider.swift; sourceTree = "<group>"; };
 		07259B382D1F97A500B45C4E /* URLResponse+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLResponse+Extras.swift"; sourceTree = "<group>"; };
 		072823122D1D315D00A0658F /* DownloadsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsView.swift; sourceTree = "<group>"; };
+		078F11842D288FAC00B3582D /* URLRequest+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Codable.swift"; sourceTree = "<group>"; };
 		07A4CE9E2D08C06400764F5E /* Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Empty.swift; sourceTree = "<group>"; };
 		07A58BD42D0400B300CAB4ED /* SwiftBrowser.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftBrowser.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		07A58BE82D04013100CAB4ED /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -88,6 +90,7 @@
 		07259B372D1F978200B45C4E /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				078F11842D288FAC00B3582D /* URLRequest+Codable.swift */,
 				07259B382D1F97A500B45C4E /* URLResponse+Extras.swift */,
 			);
 			path = Extensions;
@@ -253,6 +256,7 @@
 				07259B362D1F969A00B45C4E /* NavigationDecider.swift in Sources */,
 				07A58C4A2D0567A100CAB4ED /* SettingsView.swift in Sources */,
 				07A58BEF2D04013100CAB4ED /* SwiftBrowser.swift in Sources */,
+				078F11852D288FAC00B3582D /* URLRequest+Codable.swift in Sources */,
 				07259B392D1F97A500B45C4E /* URLResponse+Extras.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
#### 0d60ee41d0e851595e89a856a3b99a0e86fc0df7
<pre>
[SwiftUI] Command+Click should open link in a new window in SwiftBrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=285361">https://bugs.webkit.org/show_bug.cgi?id=285361</a>
<a href="https://rdar.apple.com/142330693">rdar://142330693</a>

Reviewed by Megan Gardner and Abrar Rahman Protyasha.

Use the SwiftUI WindowGroup mechanism in conjunction with the navigation decider to create a new window
from a new URL request when a user command+click&apos;s on a link.

* Tools/SwiftBrowser/Source/Extensions/URLRequest+Codable.swift: Copied from Tools/SwiftBrowser/Source/ViewModel/NavigationDecider.swift.
(encode(to:)):
* Tools/SwiftBrowser/Source/SwiftBrowser.swift:
(SwiftBrowserApp.body):
* Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift:
(BrowserViewModel.currentOpenRequest):
* Tools/SwiftBrowser/Source/ViewModel/NavigationDecider.swift:
(NavigationDecider.owner):
(NavigationDecider.decidePolicy(for:preferences:)):
* Tools/SwiftBrowser/Source/Views/BrowserView.swift:
(BrowserView.body):
* Tools/SwiftBrowser/Source/Views/ContentView.swift:
(ContentView.body):
* Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/288421@main">https://commits.webkit.org/288421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da0038235398e38f31407efe119a9a3aa2b7e97e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83208 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/2833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37496 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/34233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10768 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/88298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/34233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86262 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/2126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/75633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/2030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/29831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/33275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30544 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/89668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/10481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/89668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/10708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71446 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/89668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12860 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10435 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/10295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/13763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/12064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->