### PR TITLE
Use `LayoutUnit::fromRawValue` more in `LayoutUnit.h` and other fixes

### DIFF
--- a/Source/WebCore/platform/LayoutUnit.h
+++ b/Source/WebCore/platform/LayoutUnit.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2012-2017, Google Inc. All rights reserved.
- * Copyright (c) 2012-2024, Apple Inc. All rights reserved.
+ * Copyright (c) 2012-2024, Google Inc. All rights reserved.
+ * Copyright (c) 2012-2025, Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -59,10 +59,10 @@ while (0)
 
 #endif
 
-static const int kLayoutUnitFractionalBits = 6;
-static constexpr int kFixedPointDenominator = 1 << kLayoutUnitFractionalBits;
-const int intMaxForLayoutUnit = INT_MAX / kFixedPointDenominator;
-const int intMinForLayoutUnit = INT_MIN / kFixedPointDenominator;
+inline constexpr int kLayoutUnitFractionalBits = 6;
+inline constexpr int kFixedPointDenominator = 1 << kLayoutUnitFractionalBits;
+inline constexpr int intMaxForLayoutUnit = INT_MAX / kFixedPointDenominator;
+inline constexpr int intMinForLayoutUnit = INT_MIN / kFixedPointDenominator;
 
 class LayoutUnit {
 public:
@@ -91,16 +91,12 @@ public:
 
     static LayoutUnit fromFloatCeil(float value)
     {
-        LayoutUnit v;
-        v.m_value = clampToInteger(ceilf(value * kFixedPointDenominator));
-        return v;
+        return fromRawValue(clampToInteger(ceilf(value * kFixedPointDenominator)));
     }
 
     static LayoutUnit fromFloatFloor(float value)
     {
-        LayoutUnit v;
-        v.m_value = clampToInteger(floorf(value * kFixedPointDenominator));
-        return v;
+        return fromRawValue(clampToInteger(floorf(value * kFixedPointDenominator)));
     }
 
     static LayoutUnit fromFloatRound(float value)
@@ -110,7 +106,7 @@ public:
         return clamp(value - epsilon() / 2.0f);
     }
 
-    static LayoutUnit fromRawValue(int value)
+    static constexpr LayoutUnit fromRawValue(int value)
     {
         LayoutUnit v;
         v.m_value = value;
@@ -143,9 +139,7 @@ public:
 
     LayoutUnit abs() const
     {
-        LayoutUnit returnValue;
-        returnValue.setRawValue(::abs(m_value));
-        return returnValue;
+        return fromRawValue(::abs(m_value));
     }
 
     int ceil() const
@@ -183,9 +177,7 @@ public:
     {   
         // Add the fraction to the size (as opposed to the full location) to avoid overflows.
         // Compute fraction using the mod operator to preserve the sign of the value as it may affect rounding.
-        LayoutUnit fraction;
-        fraction.setRawValue(rawValue() % kFixedPointDenominator);
-        return fraction;
+        return fromRawValue(rawValue() % kFixedPointDenominator);
     }
 
     bool mightBeSaturated() const
@@ -194,33 +186,25 @@ public:
             || rawValue() == std::numeric_limits<int>::min();
     }
 
-    static float epsilon() { return 1.0f / kFixedPointDenominator; }
+    static constexpr float epsilon() { return 1.0f / kFixedPointDenominator; }
 
-    static const LayoutUnit max()
+    static constexpr LayoutUnit max()
     {
-        LayoutUnit m;
-        m.m_value = std::numeric_limits<int>::max();
-        return m;
+        return fromRawValue(std::numeric_limits<int>::max());
     }
-    static const LayoutUnit min()
+    static constexpr LayoutUnit min()
     {
-        LayoutUnit m;
-        m.m_value = std::numeric_limits<int>::min();
-        return m;
+        return fromRawValue(std::numeric_limits<int>::min());
     }
 
     // Versions of max/min that are slightly smaller/larger than max/min() to allow for roinding without overflowing.
-    static const LayoutUnit nearlyMax()
+    static constexpr LayoutUnit nearlyMax()
     {
-        LayoutUnit m;
-        m.m_value = std::numeric_limits<int>::max() - kFixedPointDenominator / 2;
-        return m;
+        return fromRawValue(std::numeric_limits<int>::max() - kFixedPointDenominator / 2);
     }
-    static const LayoutUnit nearlyMin()
+    static constexpr LayoutUnit nearlyMin()
     {
-        LayoutUnit m;
-        m.m_value = std::numeric_limits<int>::min() + kFixedPointDenominator / 2;
-        return m;
+        return fromRawValue(std::numeric_limits<int>::min() + kFixedPointDenominator / 2);
     }
     
     static LayoutUnit clamp(double value)
@@ -408,9 +392,7 @@ inline LayoutUnit boundedMultiply(const LayoutUnit& a, const LayoutUnit& b)
     if (high != low >> 31)
         result = saturated;
 
-    LayoutUnit returnVal;
-    returnVal.setRawValue(static_cast<int>(result));
-    return returnVal;
+    return LayoutUnit::fromRawValue(static_cast<int>(result));
 }
 
 inline LayoutUnit operator*(const LayoutUnit& a, const LayoutUnit& b)
@@ -490,10 +472,8 @@ inline double operator*(const double a, const LayoutUnit& b)
 
 inline LayoutUnit operator/(const LayoutUnit& a, const LayoutUnit& b)
 {
-    LayoutUnit returnVal;
     long long rawVal = static_cast<long long>(kFixedPointDenominator) * a.rawValue() / b.rawValue();
-    returnVal.setRawValue(clampTo<int>(rawVal));
-    return returnVal;
+    return LayoutUnit::fromRawValue(clampTo<int>(rawVal));
 }
 
 inline float operator/(const LayoutUnit& a, float b)
@@ -568,9 +548,7 @@ inline LayoutUnit operator/(unsigned long long a, const LayoutUnit& b)
 
 inline LayoutUnit operator+(const LayoutUnit& a, const LayoutUnit& b)
 {
-    LayoutUnit returnVal;
-    returnVal.setRawValue(saturatedSum<int>(a.rawValue(), b.rawValue()));
-    return returnVal;
+    return LayoutUnit::fromRawValue(saturatedSum<int>(a.rawValue(), b.rawValue()));
 }
 
 inline LayoutUnit operator+(const LayoutUnit& a, int b)
@@ -605,9 +583,7 @@ inline double operator+(const double a, const LayoutUnit& b)
 
 inline LayoutUnit operator-(const LayoutUnit& a, const LayoutUnit& b)
 {
-    LayoutUnit returnVal;
-    returnVal.setRawValue(saturatedDifference<int>(a.rawValue(), b.rawValue()));
-    return returnVal;
+    return LayoutUnit::fromRawValue(saturatedDifference<int>(a.rawValue(), b.rawValue()));
 }
 
 inline LayoutUnit operator-(const LayoutUnit& a, int b)
@@ -641,27 +617,21 @@ inline LayoutUnit operator-(const LayoutUnit& a)
     if (a == LayoutUnit::min())
         return LayoutUnit::max();
 
-    LayoutUnit returnVal;
-    returnVal.setRawValue(-a.rawValue());
-    return returnVal;
+    return LayoutUnit::fromRawValue(-a.rawValue());
 }
 
 // For returning the remainder after a division with integer results.
 inline LayoutUnit intMod(const LayoutUnit& a, const LayoutUnit& b)
 {
     // This calculates the modulo so that: a = static_cast<int>(a / b) * b + intMod(a, b).
-    LayoutUnit returnVal;
-    returnVal.setRawValue(a.rawValue() % b.rawValue());
-    return returnVal;
+    return LayoutUnit::fromRawValue(a.rawValue() % b.rawValue());
 }
 
 inline LayoutUnit operator%(const LayoutUnit& a, const LayoutUnit& b)
 {
     // This calculates the modulo so that: a = (a / b) * b + a % b.
-    LayoutUnit returnVal;
     long long rawVal = (static_cast<long long>(kFixedPointDenominator) * a.rawValue()) % b.rawValue();
-    returnVal.setRawValue(rawVal / kFixedPointDenominator);
-    return returnVal;
+    return LayoutUnit::fromRawValue(rawVal / kFixedPointDenominator);
 }
 
 inline LayoutUnit operator%(const LayoutUnit& a, int b)
@@ -829,7 +799,7 @@ namespace WTF {
 template<> struct DefaultHash<WebCore::LayoutUnit> {
     static unsigned hash(const WebCore::LayoutUnit& p) { return DefaultHash<int>::hash(p.rawValue()); }
     static bool equal(const WebCore::LayoutUnit& a, const WebCore::LayoutUnit& b) { return a == b; }
-    static const bool safeToCompareToEmptyOrDeleted = true;
+    static constexpr bool safeToCompareToEmptyOrDeleted = true;
 };
 
 // The empty value is INT_MIN, the deleted value is INT_MAX. During the course of layout
@@ -839,9 +809,7 @@ template<> struct HashTraits<WebCore::LayoutUnit> : GenericHashTraits<WebCore::L
     static constexpr bool emptyValueIsZero = false;
     static WebCore::LayoutUnit emptyValue()
     {
-        WebCore::LayoutUnit value;
-        value.setRawValue(std::numeric_limits<int>::min());
-        return value;
+        return WebCore::LayoutUnit::fromRawValue(std::numeric_limits<int>::min());
     }
     static void constructDeletedValue(WebCore::LayoutUnit& slot) { slot.setRawValue(std::numeric_limits<int>::max()); }
     static bool isDeletedValue(WebCore::LayoutUnit value) { return value.rawValue() == std::numeric_limits<int>::max(); }


### PR DESCRIPTION
#### 778c00cc651d4811b2137f2bade7849ca04017e1
<pre>
Use `LayoutUnit::fromRawValue` more in `LayoutUnit.h` and other fixes

<a href="https://bugs.webkit.org/show_bug.cgi?id=285362">https://bugs.webkit.org/show_bug.cgi?id=285362</a>
<a href="https://rdar.apple.com/142330759">rdar://142330759</a>

Reviewed by Antti Koivisto.

Inspired by: <a href="https://source.chromium.org/chromium/chromium/src/+/6477aa568ab9445ef2c5cb1314e237c8c8faeb4c">https://source.chromium.org/chromium/chromium/src/+/6477aa568ab9445ef2c5cb1314e237c8c8faeb4c</a>,
<a href="https://source.chromium.org/chromium/chromium/src/+/54c3bf5d8173d5e11a32cfcb088cf85c818e992a">https://source.chromium.org/chromium/chromium/src/+/54c3bf5d8173d5e11a32cfcb088cf85c818e992a</a> and
<a href="https://source.chromium.org/chromium/chromium/src/+/e22d0d6c01c78bfa7362f9bc57eb4a46256c69ff">https://source.chromium.org/chromium/chromium/src/+/e22d0d6c01c78bfa7362f9bc57eb4a46256c69ff</a>

This patch leverages `fromRawValue` throughout code to reduce duplicate pattern
and it also brings consistency of `static constexpr` throughout code.

Only two function which are made `constexpr` are `epsilon` and `fromRawValue`.

Additionally, it makes four global variables `inline constexpr` as well to take single
copy by using C++17 inline variables.

* Source/WebCore/platform/LayoutUnit.h:
(WebCore::LayoutUnit::fromFloatCeil):
(WebCore::LayoutUnit::fromFloatFloor):
(WebCore::LayoutUnit::fromRawValue):
(WebCore::LayoutUnit::abs const):
(WebCore::LayoutUnit::fraction const):
(WebCore::LayoutUnit::epsilon):
(WebCore::LayoutUnit::max):
(WebCore::LayoutUnit::min):
(WebCore::LayoutUnit::nearlyMax):
(WebCore::LayoutUnit::nearlyMin):
(WebCore::boundedMultiply):
(WebCore::operator/):
(WebCore::operator+):
(WebCore::operator-):
(WebCore::intMod):
(WebCore::operator%):
(WTF::HashTraits&lt;WebCore::LayoutUnit&gt;::emptyValue):

Canonical link: <a href="https://commits.webkit.org/289048@main">https://commits.webkit.org/289048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73d7747e6305cde5ac895d77681384dc36b6d7f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89234 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35167 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86243 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65458 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23292 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45751 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30705 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34215 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73773 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90614 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11425 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73909 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73113 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18282 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17422 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2770 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11377 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16853 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11226 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14702 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12999 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->