### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in Source/WebCore/platform/graphics

### DIFF
--- a/Source/WebCore/platform/graphics/mac/ColorMac.mm
+++ b/Source/WebCore/platform/graphics/mac/ColorMac.mm
@@ -36,8 +36,6 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/TinyLRUCache.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 template<> RetainPtr<NSColor> TinyLRUCachePolicy<WebCore::Color, RetainPtr<NSColor>>::createValueForKey(const WebCore::Color& color)
@@ -91,8 +89,8 @@ static std::optional<SRGBA<uint8_t>> makeSimpleColorFromNSColor(NSColor *color)
             LocalCurrentCGContext localContext { [NSGraphicsContext graphicsContextWithBitmapImageRep:offscreenRep.get()].CGContext };
             [color drawSwatchInRect:NSMakeRect(0, 0, 1, 1)];
         }
-        NSUInteger pixel[4];
-        [offscreenRep getPixel:pixel atX:0 y:0];
+        std::array<NSUInteger, 4> pixel;
+        [offscreenRep getPixel:pixel.data() atX:0 y:0];
 
         return makeFromComponentsClamping<SRGBA<uint8_t>>(pixel[0], pixel[1], pixel[2], pixel[3]);
     }
@@ -152,7 +150,5 @@ RetainPtr<NSColor> cocoaColor(const Color& color)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(APPKIT)

--- a/Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm
@@ -34,8 +34,6 @@
 #import "LocalDefaultSystemAppearance.h"
 #import <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ButtonMac);
@@ -52,11 +50,11 @@ ButtonMac::ButtonMac(ButtonPart& owningPart, ControlFactoryMac& controlFactory, 
 IntSize ButtonMac::cellSize(NSControlSize controlSize, const ControlStyle&) const
 {
     // Buttons really only constrain height. They respect width.
-    static const IntSize cellSizes[] = {
-        { 0, 20 },
-        { 0, 16 },
-        { 0, 13 },
-        { 0, 28 }
+    static constexpr std::array cellSizes {
+        IntSize { 0, 20 },
+        IntSize { 0, 16 },
+        IntSize { 0, 13 },
+        IntSize { 0, 28 }
     };
     return cellSizes[controlSize];
 }
@@ -65,12 +63,12 @@ IntOutsets ButtonMac::cellOutsets(NSControlSize controlSize, const ControlStyle&
 {
     // FIXME: Determine these values programmatically.
     // https://bugs.webkit.org/show_bug.cgi?id=251066
-    static const IntOutsets cellOutsets[] = {
+    static const std::array cellOutsets {
         // top right bottom left
-        { 5, 7, 7, 7 },
-        { 4, 6, 7, 6 },
-        { 1, 2, 2, 2 },
-        { 6, 6, 6, 6 },
+        IntOutsets { 5, 7, 7, 7 },
+        IntOutsets { 4, 6, 7, 6 },
+        IntOutsets { 1, 2, 2, 2 },
+        IntOutsets { 6, 6, 6, 6 },
     };
     return cellOutsets[controlSize];
 }
@@ -133,7 +131,5 @@ void ButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRec
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm
@@ -38,8 +38,6 @@
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(InnerSpinButtonMac);
@@ -68,20 +66,20 @@ IntSize InnerSpinButtonMac::cellSize(NSControlSize controlSize, const ControlSty
 {
 #if HAVE(NSSTEPPERCELL_INCREMENTING)
     if ([NSStepperCell instancesRespondToSelector:@selector(setIncrementing:)]) {
-        static const IntSize sizes[] = {
-            { 19, 28 },
-            { 15, 22 },
-            { 13, 18 },
-            { 19, 28 }
+        static constexpr std::array sizes {
+            IntSize { 19, 28 },
+            IntSize { 15, 22 },
+            IntSize { 13, 18 },
+            IntSize { 19, 28 }
         };
         return sizes[controlSize];
     }
 #endif
-    static const IntSize sizes[] = {
-        { 19, 27 },
-        { 15, 22 },
-        { 13, 15 },
-        { 19, 27 }
+    static constexpr std::array sizes {
+        IntSize { 19, 27 },
+        IntSize { 15, 22 },
+        IntSize { 13, 15 },
+        IntSize { 19, 27 }
     };
     return sizes[controlSize];
 }
@@ -203,7 +201,5 @@ void InnerSpinButtonMac::updateCellStates(const FloatRect& rect, const ControlSt
 #endif
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
@@ -34,8 +34,6 @@
 #import "MenuListButtonPart.h"
 #import <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MenuListButtonMac);
@@ -45,53 +43,54 @@ MenuListButtonMac::MenuListButtonMac(MenuListButtonPart& owningPart, ControlFact
 {
 }
 
-static void interpolateGradient(const CGFloat* inData, CGFloat* outData, const float* dark, const float* light)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+static void interpolateGradient(const CGFloat* inData, CGFloat* outData, std::span<const float, 4> dark, std::span<const float, 4> light)
 {
     float a = inData[0];
-    int i = 0;
-    for (i = 0; i < 4; i++)
+    for (size_t i = 0; i < 4; ++i)
         outData[i] = (1.0f - a) * dark[i] + a * light[i];
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static void topGradientInterpolate(void*, const CGFloat* inData, CGFloat* outData)
 {
-    static constexpr float dark[4] = { 1.0f, 1.0f, 1.0f, 0.4f };
-    static constexpr float light[4] = { 1.0f, 1.0f, 1.0f, 0.15f };
+    static constexpr std::array dark { 1.0f, 1.0f, 1.0f, 0.4f };
+    static constexpr std::array light { 1.0f, 1.0f, 1.0f, 0.15f };
     interpolateGradient(inData, outData, dark, light);
 }
 
 static void bottomGradientInterpolate(void*, const CGFloat* inData, CGFloat* outData)
 {
-    static constexpr float dark[4] = { 1.0f, 1.0f, 1.0f, 0.0f };
-    static constexpr float light[4] = { 1.0f, 1.0f, 1.0f, 0.3f };
+    static constexpr std::array dark { 1.0f, 1.0f, 1.0f, 0.0f };
+    static constexpr std::array light { 1.0f, 1.0f, 1.0f, 0.3f };
     interpolateGradient(inData, outData, dark, light);
 }
 
 static void mainGradientInterpolate(void*, const CGFloat* inData, CGFloat* outData)
 {
-    static constexpr float dark[4] = { 0.0f, 0.0f, 0.0f, 0.15f };
-    static constexpr float light[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    static constexpr std::array dark { 0.0f, 0.0f, 0.0f, 0.15f };
+    static constexpr std::array light { 0.0f, 0.0f, 0.0f, 0.0f };
     interpolateGradient(inData, outData, dark, light);
 }
 
 static void darkTopGradientInterpolate(void*, const CGFloat* inData, CGFloat* outData)
 {
-    static constexpr float dark[4] = { 0.0f, 0.0f, 0.0f, 0.4f };
-    static constexpr float light[4] = { 0.0f, 0.0f, 0.0f, 0.15f };
+    static constexpr std::array dark { 0.0f, 0.0f, 0.0f, 0.4f };
+    static constexpr std::array light { 0.0f, 0.0f, 0.0f, 0.15f };
     interpolateGradient(inData, outData, dark, light);
 }
 
 static void darkBottomGradientInterpolate(void*, const CGFloat* inData, CGFloat* outData)
 {
-    static constexpr float dark[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
-    static constexpr float light[4] = { 0.0f, 0.0f, 0.0f, 0.3f };
+    static constexpr std::array dark { 0.0f, 0.0f, 0.0f, 0.0f };
+    static constexpr std::array light { 0.0f, 0.0f, 0.0f, 0.3f };
     interpolateGradient(inData, outData, dark, light);
 }
 
 static void darkMainGradientInterpolate(void*, const CGFloat* inData, CGFloat* outData)
 {
-    static constexpr float dark[4] = { 1.0f, 1.0f, 1.0f, 0.15f };
-    static constexpr float light[4] = { 1.0f, 1.0f, 1.0f, 0.0f };
+    static constexpr std::array dark { 1.0f, 1.0f, 1.0f, 0.15f };
+    static constexpr std::array light { 1.0f, 1.0f, 1.0f, 0.0f };
     interpolateGradient(inData, outData, dark, light);
 }
 
@@ -225,7 +224,5 @@ void MenuListButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& b
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm
@@ -34,8 +34,6 @@
 #import "MenuListPart.h"
 #import <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MenuListMac);
@@ -49,24 +47,23 @@ MenuListMac::MenuListMac(MenuListPart& owningPart, ControlFactoryMac& controlFac
 
 IntSize MenuListMac::cellSize(NSControlSize controlSize, const ControlStyle&) const
 {
-    static const IntSize sizes[] =
-    {
-        { 0, 21 },
-        { 0, 18 },
-        { 0, 15 },
-        { 0, 24 }
+    static constexpr std::array sizes {
+        IntSize { 0, 21 },
+        IntSize { 0, 18 },
+        IntSize { 0, 15 },
+        IntSize { 0, 24 }
     };
     return sizes[controlSize];
 }
 
 IntOutsets MenuListMac::cellOutsets(NSControlSize controlSize, const ControlStyle&) const
 {
-    static const IntOutsets outsets[] = {
+    static const std::array outsets {
         // top right bottom left
-        { 0, 3, 1, 3 },
-        { 0, 3, 2, 3 },
-        { 0, 1, 0, 1 },
-        { 0, 6, 2, 6 },
+        IntOutsets { 0, 3, 1, 3 },
+        IntOutsets { 0, 3, 2, 3 },
+        IntOutsets { 0, 1, 0, 1 },
+        IntOutsets { 0, 6, 2, 6 },
     };
     return outsets[controlSize];
 }
@@ -123,7 +120,5 @@ void MenuListMac::draw(GraphicsContext& context, const FloatRoundedRect& borderR
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
@@ -35,8 +35,6 @@
 #import <pal/spi/mac/CoreUISPI.h>
 #import <pal/spi/mac/NSAppearanceSPI.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ProgressBarMac);
@@ -60,12 +58,12 @@ IntSize ProgressBarMac::cellSize(NSControlSize controlSize, const ControlStyle&)
 
 IntOutsets ProgressBarMac::cellOutsets(NSControlSize controlSize, const ControlStyle&) const
 {
-    static const IntOutsets cellOutsets[] = {
+    static const std::array cellOutsets {
         // top right bottom left
-        { 0, 0, 1, 0 },
-        { 0, 0, 1, 0 },
-        { 0, 0, 1, 0 },
-        { 0, 0, 1, 0 },
+        IntOutsets { 0, 0, 1, 0 },
+        IntOutsets { 0, 0, 1, 0 },
+        IntOutsets { 0, 0, 1, 0 },
+        IntOutsets { 0, 0, 1, 0 },
     };
     return cellOutsets[controlSize];
 }
@@ -163,7 +161,5 @@ void ProgressBarMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm
@@ -34,8 +34,6 @@
 #import "LocalDefaultSystemAppearance.h"
 #import "SearchFieldCancelButtonPart.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 SearchFieldCancelButtonMac::SearchFieldCancelButtonMac(SearchFieldCancelButtonPart& owningPart, ControlFactoryMac& controlFactory, NSSearchFieldCell *searchFieldCell)
@@ -46,11 +44,11 @@ SearchFieldCancelButtonMac::SearchFieldCancelButtonMac(SearchFieldCancelButtonPa
 
 IntSize SearchFieldCancelButtonMac::cellSize(NSControlSize controlSize, const ControlStyle&) const
 {
-    static const IntSize sizes[] = {
-        { 22, 22 },
-        { 19, 19 },
-        { 15, 15 },
-        { 22, 22 }
+    static constexpr std::array sizes {
+        IntSize { 22, 22 },
+        IntSize { 19, 19 },
+        IntSize { 15, 15 },
+        IntSize { 22, 22 }
     };
     return sizes[controlSize];
 }
@@ -100,7 +98,5 @@ void SearchFieldCancelButtonMac::draw(GraphicsContext& context, const FloatRound
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm
@@ -33,8 +33,6 @@
 #import "GraphicsContext.h"
 #import <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SliderTrackMac);
@@ -64,15 +62,16 @@ FloatRect SliderTrackMac::rectForBounds(const FloatRect& bounds, const ControlSt
     return rect;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 static void trackGradientInterpolate(void*, const CGFloat* inData, CGFloat* outData)
 {
-    static const float dark[4] = { 0.0f, 0.0f, 0.0f, 0.678f };
-    static const float light[4] = { 0.0f, 0.0f, 0.0f, 0.13f };
+    static constexpr std::array dark { 0.0f, 0.0f, 0.0f, 0.678f };
+    static constexpr std::array light { 0.0f, 0.0f, 0.0f, 0.13f };
     float a = inData[0];
-    int i = 0;
-    for (i = 0; i < 4; i++)
+    for (size_t i = 0; i < 4; ++i)
         outData[i] = (1.0f - a) * dark[i] + a * light[i];
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void SliderTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float, const ControlStyle& style)
 {
@@ -106,7 +105,5 @@ void SliderTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.mm
@@ -33,8 +33,6 @@
 #import <pal/spi/mac/CoreUISPI.h>
 #import <pal/spi/mac/NSAppearanceSPI.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore::SwitchMacUtilities {
 
 IntSize cellSize(NSControlSize controlSize)
@@ -59,13 +57,12 @@ FloatSize visualCellSize(IntSize size, const ControlStyle& style)
 
 IntOutsets cellOutsets(NSControlSize controlSize)
 {
-    static const IntOutsets margins[] =
-    {
+    static const std::array margins {
         // top right bottom left
-        { 2, 2, 1, 2 },
-        { 2, 2, 1, 2 },
-        { 1, 1, 0, 1 },
-        { 2, 2, 1, 2 },
+        IntOutsets { 2, 2, 1, 2 },
+        IntOutsets { 2, 2, 1, 2 },
+        IntOutsets { 1, 1, 0, 1 },
+        IntOutsets { 2, 2, 1, 2 },
     };
     return margins[controlSize];
 }
@@ -144,7 +141,5 @@ RefPtr<ImageBuffer> trackMaskImage(GraphicsContext& context, FloatSize trackRect
 }
 
 } // namespace WebCore::SwitchMacUtilities
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm
@@ -36,8 +36,6 @@
 #import <pal/spi/cocoa/NSButtonCellSPI.h>
 #import <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ToggleButtonMac);
@@ -83,19 +81,19 @@ IntSize ToggleButtonMac::cellSize(NSControlSize controlSize, const ControlStyle&
 
 IntOutsets ToggleButtonMac::cellOutsets(NSControlSize controlSize, const ControlStyle&) const
 {
-    static const IntOutsets checkboxOutsets[] = {
+    static const std::array checkboxOutsets {
         // top right bottom left
-        { 2, 2, 2, 2 },
-        { 2, 1, 2, 1 },
-        { 0, 0, 1, 0 },
-        { 2, 2, 2, 2 },
+        IntOutsets { 2, 2, 2, 2 },
+        IntOutsets { 2, 1, 2, 1 },
+        IntOutsets { 0, 0, 1, 0 },
+        IntOutsets { 2, 2, 2, 2 },
     };
-    static const IntOutsets radioOutsets[] = {
+    static const std::array radioOutsets {
         // top right bottom left
-        { 1, 0, 1, 2 },
-        { 1, 1, 2, 1 },
-        { 0, 0, 1, 1 },
-        { 1, 0, 1, 2 },
+        IntOutsets { 1, 0, 1, 2 },
+        IntOutsets { 1, 1, 2, 1 },
+        IntOutsets { 0, 0, 1, 1 },
+        IntOutsets { 1, 0, 1, 2 },
     };
     return (m_owningPart.type() == StyleAppearance::Checkbox ? checkboxOutsets : radioOutsets)[controlSize];
 }
@@ -139,7 +137,5 @@ void ToggleButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& bor
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeCG.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeCG.cpp
@@ -28,15 +28,18 @@
 #include "OpenTypeCG.h"
 
 #include "OpenTypeTypes.h"
+#include <wtf/StdLibExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#if USE(CF)
+#include <wtf/cf/VectorCF.h>
+#endif
 
 namespace WebCore {
 namespace OpenType {
 
-static inline short readShortFromTable(const UInt8* os2Data, CFIndex offset)
+static inline short readShortFromTable(std::span<const UInt8> os2Data, CFIndex offset)
 {
-    return *(reinterpret_cast<const OpenType::Int16*>(os2Data + offset));
+    return reinterpretCastSpanStartTo<const OpenType::Int16>(os2Data.subspan(offset));
 }
 
 bool tryGetTypoMetrics(CTFontRef font, short& ascent, short& descent, short& lineGap)
@@ -50,10 +53,10 @@ bool tryGetTypoMetrics(CTFontRef font, short& ascent, short& descent, short& lin
         const CFIndex sTypoDescenderOffset = sTypoAscenderOffset + 2;
         const CFIndex sTypoLineGapOffset = sTypoDescenderOffset + 2;
         if (CFDataGetLength(os2Table.get()) >= sTypoLineGapOffset + 2) {
-            const UInt8* os2Data = CFDataGetBytePtr(os2Table.get());
+            auto os2Data = span(os2Table.get());
             // We test the use typo bit on the least significant byte of fsSelection.
             const UInt8 useTypoMetricsMask = 1 << 7;
-            if (*(os2Data + fsSelectionOffset + 1) & useTypoMetricsMask) {
+            if (os2Data[fsSelectionOffset + 1] & useTypoMetricsMask) {
                 ascent = readShortFromTable(os2Data, sTypoAscenderOffset);
                 descent = readShortFromTable(os2Data, sTypoDescenderOffset);
                 lineGap = readShortFromTable(os2Data, sTypoLineGapOffset);
@@ -66,5 +69,3 @@ bool tryGetTypoMetrics(CTFontRef font, short& ascent, short& descent, short& lin
 
 } // namespace OpenType
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h
@@ -30,8 +30,7 @@
 #endif
 
 #include "SharedBuffer.h"
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 namespace OpenType {
@@ -75,11 +74,18 @@ typedef UInt16 GlyphID;
 typedef uint32_t Tag;
 #define OT_MAKE_TAG(ch1, ch2, ch3, ch4) ((((uint32_t)(ch4)) << 24) | (((uint32_t)(ch3)) << 16) | (((uint32_t)(ch2)) << 8) | ((uint32_t)(ch1)))
 
-template <typename T> static const T* validateTable(const RefPtr<SharedBuffer>& buffer, size_t count = 1)
+template<typename T> static const T* validateTableSingle(const RefPtr<SharedBuffer>& buffer)
 {
-    if (!buffer || buffer->size() < sizeof(T) * count)
-        return 0;
-    return reinterpret_cast<const T*>(buffer->span().data());
+    if (!buffer || buffer->size() < sizeof(T))
+        return nullptr;
+    return &reinterpretCastSpanStartTo<const T>(buffer->span());
+}
+
+template<typename T> static std::span<const T> validateTable(const RefPtr<SharedBuffer>& buffer, size_t count)
+{
+    if (!buffer || (buffer->size() / sizeof(T)) < count)
+        return { };
+    return spanReinterpretCast<const T>(buffer->span().first(sizeof(T) * count));
 }
 
 struct TableBase {
@@ -93,6 +99,7 @@ protected:
         return offset <= buffer.size(); // "<=" because end is included as valid
     }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     template <typename T> static const T* validatePtr(const SharedBuffer& buffer, const void* position)
     {
         const T* casted = reinterpret_cast<const T*>(position);
@@ -105,6 +112,7 @@ protected:
     {
         return validatePtr<T>(buffer, reinterpret_cast<const int8_t*>(this) + offset);
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 };
 
 #if ENABLE(OPENTYPE_VERTICAL) || ENABLE(OPENTYPE_MATH)
@@ -128,6 +136,7 @@ struct Coverage2Table : CoverageTable {
 #endif // ENABLE(OPENTYPE_VERTICAL) || ENABLE(OPENTYPE_MATH)
 
 #if ENABLE(OPENTYPE_MATH)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 struct TableWithCoverage : TableBase {
 protected:
     bool getCoverageIndex(const SharedBuffer& buffer, const CoverageTable* coverage, Glyph glyph, uint32_t& coverageIndex) const
@@ -186,11 +195,10 @@ protected:
         return false;
     }
 };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 
 } // namespace OpenType
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // OpenTypeTypes_h

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp
@@ -88,18 +88,14 @@ struct VheaTable {
     OpenType::UInt16 numOfLongVerMetrics;
 };
 
-struct HmtxTable {
-    struct Entry {
-        OpenType::UInt16 advanceWidth;
-        OpenType::Int16 lsb;
-    } entries[1];
+struct HmtxTableEntry {
+    OpenType::UInt16 advanceWidth;
+    OpenType::Int16 lsb;
 };
 
-struct VmtxTable {
-    struct Entry {
-        OpenType::UInt16 advanceHeight;
-        OpenType::Int16 topSideBearing;
-    } entries[1];
+struct VmtxTableEntry {
+    OpenType::UInt16 advanceHeight;
+    OpenType::Int16 topSideBearing;
 };
 
 struct VORGTable {
@@ -385,7 +381,7 @@ struct GSUBTable : TableBase {
 static bool loadHmtxTable(const FontPlatformData& platformData, Vector<uint16_t>& advanceWidths)
 {
     auto buffer = platformData.openTypeTable(OpenType::HheaTag);
-    const OpenType::HheaTable* hhea = OpenType::validateTable<OpenType::HheaTable>(buffer);
+    auto* hhea = OpenType::validateTableSingle<OpenType::HheaTable>(buffer);
     if (!hhea)
         return false;
     uint16_t countHmtxEntries = hhea->numberOfHMetrics;
@@ -395,15 +391,16 @@ static bool loadHmtxTable(const FontPlatformData& platformData, Vector<uint16_t>
     }
 
     buffer = platformData.openTypeTable(OpenType::HmtxTag);
-    const OpenType::HmtxTable* hmtx = OpenType::validateTable<OpenType::HmtxTable>(buffer, countHmtxEntries);
-    if (!hmtx) {
+    auto hmtx = OpenType::validateTable<OpenType::HmtxTableEntry>(buffer, countHmtxEntries);
+    if (hmtx.empty()) {
         LOG_ERROR("hhea exists but hmtx does not (or broken)");
         return false;
     }
 
-    advanceWidths.resize(countHmtxEntries);
-    for (uint16_t i = 0; i < countHmtxEntries; ++i)
-        advanceWidths[i] = hmtx->entries[i].advanceWidth;
+    advanceWidths = Vector<uint16_t>(countHmtxEntries, [&](size_t i) {
+        return hmtx[i].advanceWidth;
+    });
+
     return true;
 }
 
@@ -428,7 +425,7 @@ void OpenTypeVerticalData::loadMetrics(const FontPlatformData& platformData)
 {
     // Load vhea first. This table is required for fonts that support vertical flow.
     auto buffer = platformData.openTypeTable(OpenType::VheaTag);
-    const OpenType::VheaTable* vhea = OpenType::validateTable<OpenType::VheaTable>(buffer);
+    auto* vhea = OpenType::validateTableSingle<OpenType::VheaTable>(buffer);
     if (!vhea)
         return;
     uint16_t countVmtxEntries = vhea->numOfLongVerMetrics;
@@ -439,7 +436,7 @@ void OpenTypeVerticalData::loadMetrics(const FontPlatformData& platformData)
 
     // Load VORG. This table is optional.
     buffer = platformData.openTypeTable(OpenType::VORGTag);
-    const OpenType::VORGTable* vorg = OpenType::validateTable<OpenType::VORGTable>(buffer);
+    auto* vorg = OpenType::validateTableSingle<OpenType::VORGTable>(buffer);
     if (vorg && buffer->size() >= vorg->requiredSize()) {
         m_defaultVertOriginY = vorg->defaultVertOriginY;
         uint16_t countVertOriginYMetrics = vorg->numVertOriginYMetrics;
@@ -456,21 +453,21 @@ void OpenTypeVerticalData::loadMetrics(const FontPlatformData& platformData)
 
     // Load vmtx then. This table is required for fonts that support vertical flow.
     buffer = platformData.openTypeTable(OpenType::VmtxTag);
-    const OpenType::VmtxTable* vmtx = OpenType::validateTable<OpenType::VmtxTable>(buffer, countVmtxEntries);
-    if (!vmtx) {
+    auto vmtx = OpenType::validateTable<OpenType::VmtxTableEntry>(buffer, countVmtxEntries);
+    if (vmtx.empty()) {
         LOG_ERROR("vhea exists but vmtx does not (or broken)");
         return;
     }
-    m_advanceHeights.resize(countVmtxEntries);
-    for (uint16_t i = 0; i < countVmtxEntries; ++i)
-        m_advanceHeights[i] = vmtx->entries[i].advanceHeight;
+    m_advanceHeights = Vector<uint16_t>(countVmtxEntries, [&](size_t i) {
+        return vmtx[i].advanceHeight;
+    });
 
     // VORG is preferred way to calculate vertical origin than vmtx,
     // so load topSideBearing from vmtx only if VORG is missing.
     if (hasVORG())
         return;
 
-    size_t sizeExtra = buffer->size() - sizeof(OpenType::VmtxTable::Entry) * countVmtxEntries;
+    size_t sizeExtra = buffer->size() - sizeof(OpenType::VmtxTableEntry) * countVmtxEntries;
     if (sizeExtra % sizeof(OpenType::Int16)) {
         LOG_ERROR("vmtx has incorrect tsb count");
         return;
@@ -479,9 +476,9 @@ void OpenTypeVerticalData::loadMetrics(const FontPlatformData& platformData)
     m_topSideBearings.resize(countTopSideBearings);
     size_t i;
     for (i = 0; i < countVmtxEntries; ++i)
-        m_topSideBearings[i] = vmtx->entries[i].topSideBearing;
+        m_topSideBearings[i] = vmtx[i].topSideBearing;
     if (i < countTopSideBearings) {
-        const OpenType::Int16* pTopSideBearingsExtra = reinterpret_cast<const OpenType::Int16*>(&vmtx->entries[countVmtxEntries]);
+        const OpenType::Int16* pTopSideBearingsExtra = reinterpret_cast<const OpenType::Int16*>(std::to_address(vmtx.end()));
         for (; i < countTopSideBearings; ++i, ++pTopSideBearingsExtra)
             m_topSideBearings[i] = *pTopSideBearingsExtra;
     }
@@ -490,7 +487,7 @@ void OpenTypeVerticalData::loadMetrics(const FontPlatformData& platformData)
 void OpenTypeVerticalData::loadVerticalGlyphSubstitutions(const FontPlatformData& platformData)
 {
     auto buffer = platformData.openTypeTable(OpenType::GSUBTag);
-    const OpenType::GSUBTable* gsub = OpenType::validateTable<OpenType::GSUBTable>(buffer);
+    auto* gsub = OpenType::validateTableSingle<OpenType::GSUBTable>(buffer);
     if (gsub)
         gsub->getVerticalGlyphSubstitutions(&m_verticalGlyphMap, *buffer.get());
 }

--- a/Source/WebCore/platform/graphics/transforms/TransformOperation.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperation.cpp
@@ -29,8 +29,6 @@
 #include "IdentityTransformOperation.h"
 #include <wtf/text/TextStream.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 void IdentityTransformOperation::dump(TextStream& ts) const
@@ -84,10 +82,10 @@ std::optional<TransformOperation::Type> TransformOperation::sharedPrimitiveType(
     auto type = primitiveType();
     if (type == other)
         return type;
-    static constexpr Type sharedPrimitives[][2] = {
-        { Type::Rotate, Type::Rotate3D },
-        { Type::Scale, Type::Scale3D },
-        { Type::Translate, Type::Translate3D }
+    static constexpr std::array sharedPrimitives {
+        std::array { Type::Rotate, Type::Rotate3D },
+        std::array { Type::Scale, Type::Scale3D },
+        std::array { Type::Translate, Type::Translate3D }
     };
     for (auto typePair : sharedPrimitives) {
         if ((type == typePair[0] || type == typePair[1]) && (other == typePair[0] || other == typePair[1]))
@@ -110,5 +108,3 @@ std::optional<TransformOperation::Type> TransformOperation::sharedPrimitiveType(
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
@@ -44,8 +44,6 @@
 #include <emmintrin.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 //
@@ -72,8 +70,8 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TransformationMatrix);
 
-typedef double Vector4[4];
-typedef double Vector3[3];
+using Vector4 = std::array<double, 4>;
+using Vector3 = std::array<double, 3>;
 
 const TransformationMatrix TransformationMatrix::identity { };
 
@@ -243,7 +241,7 @@ static void transposeMatrix4(const TransformationMatrix::Matrix4& a, Transformat
 }
 
 // Multiply a homogeneous point by a matrix and return the transformed point
-static void v4MulPointByMatrix(const Vector4 p, const TransformationMatrix::Matrix4& m, Vector4 result)
+static void v4MulPointByMatrix(const Vector4& p, const TransformationMatrix::Matrix4& m, Vector4& result)
 {
     result[0] = (p[0] * m[0][0]) + (p[1] * m[1][0]) +
                 (p[2] * m[2][0]) + (p[3] * m[3][0]);
@@ -255,12 +253,12 @@ static void v4MulPointByMatrix(const Vector4 p, const TransformationMatrix::Matr
                 (p[2] * m[2][3]) + (p[3] * m[3][3]);
 }
 
-static double v3Length(Vector3 a)
+static double v3Length(const Vector3& a)
 {
     return std::hypot(a[0], a[1], a[2]);
 }
 
-static void v3Scale(Vector3 v, double desiredLength)
+static void v3Scale(Vector3& v, double desiredLength)
 {
     double len = v3Length(v);
     if (len != 0) {
@@ -271,14 +269,14 @@ static void v3Scale(Vector3 v, double desiredLength)
     }
 }
 
-static double v3Dot(const Vector3 a, const Vector3 b)
+static double v3Dot(const Vector3& a, const Vector3& b)
 {
     return (a[0] * b[0]) + (a[1] * b[1]) + (a[2] * b[2]);
 }
 
 // Make a linear combination of two vectors and return the result.
 // result = (a * ascl) + (b * bscl)
-static void v3Combine(const Vector3 a, const Vector3 b, Vector3 result, double ascl, double bscl)
+static void v3Combine(const Vector3& a, const Vector3& b, Vector3& result, double ascl, double bscl)
 {
     result[0] = (ascl * a[0]) + (bscl * b[0]);
     result[1] = (ascl * a[1]) + (bscl * b[1]);
@@ -286,7 +284,7 @@ static void v3Combine(const Vector3 a, const Vector3 b, Vector3 result, double a
 }
 
 // Return the cross product result = a cross b */
-static void v3Cross(const Vector3 a, const Vector3 b, Vector3 result)
+static void v3Cross(const Vector3& a, const Vector3& b, Vector3& result)
 {
     result[0] = (a[1] * b[2]) - (a[2] * b[1]);
     result[1] = (a[2] * b[0]) - (a[0] * b[2]);
@@ -426,7 +424,8 @@ static bool decompose4(const TransformationMatrix::Matrix4& mat, TransformationM
     // stored on column major order and not row major. Using the variable 'row'
     // instead of 'column' in the spec pseudocode has been the source of
     // confusion, specifically in sorting out rotations.
-    Vector3 column[3], pdum3;
+    std::array<Vector3, 3> column;
+    Vector3 pdum3;
 
     // Now get scale and shear.
     for (i = 0; i < 3; i++) {
@@ -1950,5 +1949,3 @@ TextStream& operator<<(TextStream& ts, const TransformationMatrix& transform)
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### f0f93c393abec436e0da6b4017dfd04f69f8f65f
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in Source/WebCore/platform/graphics
<a href="https://bugs.webkit.org/show_bug.cgi?id=285367">https://bugs.webkit.org/show_bug.cgi?id=285367</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/graphics/mac/ColorMac.mm:
* Source/WebCore/platform/graphics/mac/controls/ButtonMac.mm:
(WebCore::ButtonMac::cellSize const):
(WebCore::ButtonMac::cellOutsets const):
* Source/WebCore/platform/graphics/mac/controls/InnerSpinButtonMac.mm:
(WebCore::InnerSpinButtonMac::cellSize const):
* Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm:
(WebCore::interpolateGradient):
(WebCore::topGradientInterpolate):
(WebCore::bottomGradientInterpolate):
(WebCore::mainGradientInterpolate):
(WebCore::darkTopGradientInterpolate):
(WebCore::darkBottomGradientInterpolate):
(WebCore::darkMainGradientInterpolate):
* Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm:
(WebCore::MenuListMac::cellSize const):
(WebCore::MenuListMac::cellOutsets const):
* Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm:
(WebCore::ProgressBarMac::cellOutsets const):
* Source/WebCore/platform/graphics/mac/controls/SearchFieldCancelButtonMac.mm:
(WebCore::SearchFieldCancelButtonMac::cellSize const):
* Source/WebCore/platform/graphics/mac/controls/SliderTrackMac.mm:
(WebCore::trackGradientInterpolate):
* Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.mm:
(WebCore::SwitchMacUtilities::cellOutsets):
* Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm:
(WebCore::ToggleButtonMac::cellOutsets const):
* Source/WebCore/platform/graphics/opentype/OpenTypeCG.cpp:
(WebCore::OpenType::readShortFromTable):
(WebCore::OpenType::tryGetTypoMetrics):
* Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp:
(WebCore::OpenTypeMathData::OpenTypeMathData):
* Source/WebCore/platform/graphics/opentype/OpenTypeTypes.h:
(WebCore::OpenType::validateTableSingle):
(WebCore::OpenType::validateTable):
* Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp:
(WebCore::loadHmtxTable):
(WebCore::OpenTypeVerticalData::loadMetrics):
(WebCore::OpenTypeVerticalData::loadVerticalGlyphSubstitutions):
* Source/WebCore/platform/graphics/transforms/TransformOperation.cpp:
(WebCore::TransformOperation::sharedPrimitiveType const):
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
(WebCore::decompose4):

Canonical link: <a href="https://commits.webkit.org/288440@main">https://commits.webkit.org/288440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/503c242a39a03731b52959fce6dbf0c80e17976a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83345 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88424 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34356 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85436 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10910 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64839 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22585 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75746 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45123 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29947 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33407 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73238 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89798 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10612 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7640 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73267 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72497 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16710 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15447 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12870 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10567 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16039 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10417 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12190 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->