### PR TITLE
[git-webkit] add option to update list of changed files

### DIFF
--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -5,12 +5,13 @@ import re
 import subprocess
 import sys
 
-TOPLEVEL = subprocess.check_output(['git', 'rev-parse', '--show-toplevel'], encoding='utf-8').strip()
+TOPLEVEL = subprocess.run(['git', 'rev-parse', '--show-toplevel'], encoding='utf-8', capture_output=True, check=True).stdout.strip()
 
 LOCATION = os.path.join(TOPLEVEL, r'{{ location }}')
 SPACING = 8
 IDENT = 4
 SCRIPTS = os.path.dirname(os.path.dirname(LOCATION))
+PREPARE_CHANGELOG_CMD = [{{ perl }}, os.path.join(SCRIPTS, 'prepare-ChangeLog'), '--no-write', '--only-files', '--delimiters', '--git-index']
 CHERRY_PICKING_RE = re.compile(r'^# You are currently cherry-picking commit (?P<hash>[a-f0-9A-F]+)\.$')
 CHERRY_PICK_COMMIT_RE = re.compile(r'^(?P<a>\S+)( \((?P<b>\S+)\))?$')
 REFNAME_RE = re.compile(r'^refs/remotes/(?P<remote>[^/ ]+)/(?P<branch>\S+)$')
@@ -35,8 +36,9 @@ sys.path.append(SCRIPTS)
 from webkitpy.common.checkout.diff_parser import DiffParser
 from webkitbugspy import radar
 
+
 def set_env_variables_from_branch_config():
-    BRANCH = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], encoding='utf-8').strip()
+    BRANCH = subprocess.run(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], encoding='utf-8', capture_output=True, check=True).stdout.strip()
     for name, data in dict(
         title=('COMMIT_MESSAGE_TITLE', 1),
         bug=('COMMIT_MESSAGE_BUG', re.compile(r'^(\D+)\d+$')),
@@ -48,11 +50,12 @@ def set_env_variables_from_branch_config():
         try:
             value = ''
             count = 0
-            for line in reversed(subprocess.check_output(
+            for line in reversed(subprocess.run(
                 ['git', 'config', '--get-all', 'branch.{}.{}'.format(BRANCH, name)],
-                stderr=subprocess.PIPE,
+                capture_output=True,
                 encoding='utf-8',
-            ).strip().splitlines()):
+                check=True
+            ).stdout.strip().splitlines()):
                 if isinstance(mode, int) and count >= mode:
                     break
                 elif isinstance(mode, re.Pattern):
@@ -93,12 +96,15 @@ def get_bugs_string():
 
 def parseChanges(command, commit_message):
     dirname = None
+    changes = []
 
     try:
-        for line in subprocess.check_output(
+        for line in subprocess.run(
             command,
             encoding='utf-8',
-        ).splitlines():
+            capture_output=True,
+            check=True
+        ).stdout.splitlines():
             if line == '~':
                 dirname = None
                 continue
@@ -106,6 +112,7 @@ def parseChanges(command, commit_message):
                 if dirname:
                     line = line.replace('* ', '* {}/'.format(dirname))
                 commit_message.append(line[SPACING:])
+                changes.append(line[SPACING:])
                 continue
             if line.endswith(':'):
                 dirname = line.split(':')[0]
@@ -113,21 +120,22 @@ def parseChanges(command, commit_message):
     except subprocess.CalledProcessError:
         commit_message.append('')
         return
+    return changes
 
 def message(source=None, sha=None):
     commit_message = []
-    command = [{{ perl }}, os.path.join(SCRIPTS, 'prepare-ChangeLog'), '--no-write', '--only-files', '--delimiters', '--git-index']
+    amend_changes = None
+    command = PREPARE_CHANGELOG_CMD
 
     if sha:
         commit_message.append('Amend changes:')
-        parseChanges(command, commit_message)
+        amend_changes = parseChanges(command, commit_message)
         commit_message.append('')
 
         commit_message.append('Combined changes:')
-        command.append('--git-commit')
-        command.append('HEAD')
+        command += ['--git-commit', 'HEAD']
 
-    parseChanges(command, commit_message)
+    combined_changes = parseChanges(command, commit_message)
 
     revert_msg = os.environ.get('COMMIT_MESSAGE_REVERT', '')
     if revert_msg:
@@ -149,7 +157,7 @@ Explanation of why this fixes the bug (OOPS!).
         title=os.environ.get('COMMIT_MESSAGE_TITLE', '') or 'Need a short description (OOPS!).',
         bugs=bugs_string,
         content='\n'.join(commit_message) + os.environ.get('COMMIT_MESSAGE_CONTENT', ''),
-    )
+    ), combined_changes, amend_changes
 
 def source_branches():
     proc = None
@@ -163,10 +171,12 @@ def source_branches():
         outer_line = proc.stdout.readline()
         while outer_line:
             branches = set()
-            for inner_line in subprocess.check_output(
+            for inner_line in subprocess.run(
                 ['git', 'branch', '--contains', outer_line.strip(), '-a', '--format', '%(refname)'],
                 encoding='utf-8',
-            ).splitlines():
+                capture_output=True,
+                check=True
+            ).stdout.splitlines():
                 if not inner_line.startswith('refs/remotes'):
                     continue
                 _, _, remote, branch = inner_line.split('/', 3)
@@ -244,16 +254,18 @@ def cherry_pick(content):
 
     if production_hash:
         try:
-            subprocess.check_output(
+            subprocess.run(
                 ['git', 'merge-base', '--is-ancestor', production_hash, DEFAULT_BRANCH],
-                encoding='utf-8',
+                encoding='utf-8', check=True
             )
         except subprocess.CalledProcessError:
             remotes = set()
-            for line in subprocess.check_output(
+            for line in subprocess.run(
                 ['git', 'branch', '--contains', production_hash, '-a', '--format', '%(refname)'],
                 encoding='utf-8',
-            ).splitlines():
+                capture_output=True,
+                check=True
+            ).stdout.splitlines():
                 match = REFNAME_RE.match(line.strip())
                 if not match:
                     continue
@@ -304,6 +316,52 @@ def cherry_pick(content):
             result.append(line)
     return '\n'.join(result)
 
+def annotate_deleted_lines(amend_changes, combined_changes):
+    annotated_lines = []
+    for line in amend_changes:
+        if line not in combined_changes:
+            if line.startswith('*'):
+                if not line.endswith('Removed.'):
+                    line += ' Removed.'
+            elif not line.endswith('Deleted.'):
+                line += ' Deleted.'
+        annotated_lines.append(line)
+    return annotated_lines
+
+def amended_message(full_message, combined_changes, amend_changes, update_changelog):
+    if amend_changes and update_changelog:
+        try:
+            from webkitscmpy.commit_parser import CommitMessageParser
+        except ImportError as e:
+            sys.stderr.write(f'{e}: Could not update changelog automatically. Falling back to the default template.\n')
+        else:
+            commit_message_parser = CommitMessageParser()
+        commit_message_parser.parse_message(full_message)
+        updated_changelog_lines = commit_message_parser.apply_comments_to_modified_files_lines(combined_changes)
+        reviewed_by_lines = (commit_message_parser.reviewed_by_lines or ['Reviewed by NOBODY (OOPS!).'])
+        description_lines = (commit_message_parser.description_lines or ['Explanation of why this fixes the bug (OOPS!).'])
+        tests_lines = [commit_message_parser.tests_lines, ''] if commit_message_parser.tests_lines else []
+        amended_message = commit_message_parser.title_lines + [''] + reviewed_by_lines + [''] + description_lines + [''] + tests_lines + updated_changelog_lines
+        removed_changelog_lines = commit_message_parser.apply_comments_to_modified_files_lines(annotate_deleted_lines(amend_changes, combined_changes), return_deleted=True)
+        return '''{message_body}
+
+# Your changelog has been updated with the following files/functions:
+{changed_lines}
+# The following lines have been removed from the changelog:
+{removed_lines}
+# To temporarily disable this feature, run `git-webkit commit --amend --no-update`.
+'''.format(message_body='\n'.join(amended_message),
+        changed_lines='\n'.join([f'#    {file}' for file in amend_changes]),
+        removed_lines='\n'.join([f'#    {file}' for file in removed_changelog_lines]))
+
+    commit_message = full_message
+    if not update_changelog:
+        commit_message += '''
+# To automatically update your changelog when amending, run `git-webkit setup`
+# or `git-webkit commit --amend --update` for one-time use.
+'''
+    return commit_message
+
 def main(file_name=None, source=None, sha=None):
     with open(file_name, 'r') as commit_message_file:
         content = commit_message_file.read()
@@ -332,14 +390,36 @@ def main(file_name=None, source=None, sha=None):
         # When there's no editor being launched, do nothing.
         return 0
 
+    update_changelog = False
+    # Allow for overrides with git-webkit commit --amend [--update/--no-update]
+    if os.environ.get('WKSCMPY_UPDATE_CHANGELOG', '') == 'True':
+        update_changelog = True
+    elif os.environ.get('WKSCMPY_UPDATE_CHANGELOG', '') == 'False':
+        update_changelog = False
+    else:
+        try:
+            update_changelog = subprocess.run(
+                ['git', 'config', '--get', '--type', 'bool', 'webkitscmpy.auto-update-changelog'],
+                encoding='utf-8',
+                capture_output=True,
+                check=True
+            ).stdout.strip()
+        except subprocess.CalledProcessError as error:
+            if error.returncode != 1:
+                sys.stderr.write(error.stderr)
+
     with open(file_name, 'w') as commit_message_file:
+        generated_msg, combined_changes, amend_changes = message(source=source, sha=sha)
         if sha:
-            commit_message_file.write(subprocess.check_output(
+            git_log_msg = subprocess.run(
                 ['git', 'log', sha, '-1', '--pretty=format:%B'],
                 encoding='utf-8',
-            ))
+                capture_output=True,
+                check=True
+            ).stdout
+            commit_message_file.write(amended_message(git_log_msg, combined_changes, amend_changes, update_changelog))
         else:
-            commit_message_file.write(message(source=source, sha=sha))
+            commit_message_file.write(generated_msg)
 
         commit_message_file.write('''
 # Please populate the above commit message. Lines starting with '#'
@@ -348,13 +428,15 @@ def main(file_name=None, source=None, sha=None):
 
 ''')
         if sha:
-            for line in message(source=source, sha=sha).splitlines():
+            for line in generated_msg.splitlines():
                 commit_message_file.write('# {}\n'.format(line))
             commit_message_file.write('\n')
-        for line in subprocess.check_output(
+        for line in subprocess.run(
             ['git', 'status'],
             encoding='utf-8',
-        ).splitlines():
+            capture_output=True,
+            check=True
+        ).stdout.splitlines():
             commit_message_file.write('# {}\n'.format(line))
 
     return 0

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/commit.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/commit.py
@@ -26,7 +26,7 @@ import sys
 from .command import Command
 
 from webkitbugspy import Tracker
-from webkitcorepy import run, string_utils
+from webkitcorepy import run, string_utils, arguments
 from webkitscmpy import local
 
 
@@ -57,6 +57,11 @@ class Commit(Command):
             '--amend',
             dest='amend', action='store_true', default=False,
             help='Replace the tip of the current branch by creating a new commit',
+        )
+        parser.add_argument(
+            '--update', '--no-update',
+            dest='update', action=arguments.NoAction, default=None,
+            help='Update the commit message with the most recent changes.'
         )
 
     @classmethod
@@ -99,6 +104,9 @@ class Commit(Command):
         if issue:
             env['COMMIT_MESSAGE_TITLE'] = issue.title
             env['COMMIT_MESSAGE_BUG'] = '\n'.join(cls.bug_urls(issue))
+        if args.update is not None:
+            env['WKSCMPY_UPDATE_CHANGELOG'] = str(bool(args.update))
+
         return run(
             [repository.executable(), 'commit', '--date=now'] + additional_args + args.args,
             cwd=repository.root_path,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
@@ -379,6 +379,15 @@ class Setup(Command):
             sys.stderr.write('Failed to use {} as the merge strategy for this repository\n'.format('merge commits' if args.merge else 'rebase'))
             result += 1
 
+        if not local_config.get('webkitscmpy.auto-update-changelog'):
+            log.info('Setting auto-updates for commit message changelogs when amending...')
+            if run(
+                [local.Git.executable(), 'config', 'webkitscmpy.auto-update-changelog', 'true'],
+                cwd=repository.root_path,
+            ).returncode:
+                sys.stderr.write('Failed to set auto-updates for commit message changelog\n')
+                result += 1
+
         need_prompt_auto_update = args.all or not local_config.get('webkitscmpy.auto-rebase-branch')
         if not args.merge and not args.defaults and need_prompt_auto_update:
             log.info('Setting auto update on PR creation...')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_parser_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_parser_unittest.py
@@ -1,0 +1,169 @@
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from webkitscmpy.commit_parser import CommitMessageParser
+
+COMMIT_MSG_BASE = '''Commit Message Title
+https://bugs.example.com
+rdar://1234567
+
+Reviewed by NOBODY (OOPS!).
+
+Commit description.
+'''
+
+
+class TestCommitParser(unittest.TestCase):
+
+    def test_basic_commit(self):
+        commit_message_parser = CommitMessageParser()
+        commit_message_parser.parse_message(
+            COMMIT_MSG_BASE + '''
+* Change.py:
+''')
+        self.assertEqual(['Commit Message Title', 'https://bugs.example.com', 'rdar://1234567'], commit_message_parser.title_lines)
+        self.assertEqual(['Reviewed by NOBODY (OOPS!).'], commit_message_parser.reviewed_by_lines)
+        self.assertEqual(['Commit description.'], commit_message_parser.description_lines)
+        self.assertEqual(['* Change.py:'], commit_message_parser.modified_files_lines)
+
+    def test_changelog_comments(self):
+        commit_message_parser = CommitMessageParser()
+        commit_message_parser.parse_message(
+            COMMIT_MSG_BASE + '''
+* Change.py: Comment on the file.
+* File.py: Added. Comment 2.
+''')
+        self.assertEqual(
+            [
+                '* Change.py: Comment on the file.',
+                '* File.py: Added. Comment 2.',
+            ],
+            commit_message_parser.modified_files_lines,
+        )
+        self.assertEqual(
+            [
+                '* Change.py: Comment on the file.',
+                '* File.py: Added. Comment 2.',
+                '* new_file.cpp: Added.',
+            ],
+            commit_message_parser.apply_comments_to_modified_files_lines(
+                [
+                    '* Change.py:',
+                    '* File.py: Added.',
+                    '* new_file.cpp: Added.',
+                ],
+            ),
+        )
+
+    def test_removed_changes(self):
+        commit_message_parser = CommitMessageParser()
+        commit_message_parser.parse_message(
+            COMMIT_MSG_BASE + '''
+* Change.py: Comment on the file.
+* File.py: Added. Comment 2.
+(Class.function):
+''')
+        self.assertEqual(
+            [
+                '* Change.py: Comment on the file.',
+                '* File.py: Added. Comment 2.',
+                '(Class.function):',
+            ],
+            commit_message_parser.modified_files_lines,
+        )
+        self.assertEqual(['* Change.py: Comment on the file.'], commit_message_parser.apply_comments_to_modified_files_lines(['* Change.py:']))
+
+    def test_return_deleted_simple(self):
+        commit_message_parser = CommitMessageParser()
+        commit_message_parser.parse_message(
+            COMMIT_MSG_BASE + '''
+* file1.py: Comment.
+* file2.py:
+* file3.py:
+   - A newline comment.
+(Class.function): Another comment.
+''')
+        self.assertEqual(
+            [
+                '* file1.py: Comment.',
+                '* file2.py:',
+                '* file3.py:',
+                '   - A newline comment.',
+                '(Class.function): Another comment.',
+            ],
+            commit_message_parser.modified_files_lines,
+        )
+        self.assertEqual(
+            [
+                '* file1.py: Comment.',
+                '* file3.py:',
+                '   - A newline comment.',
+                '(Class.function): Another comment.'
+            ],
+            commit_message_parser.apply_comments_to_modified_files_lines(
+                [
+                    '* file1.py: Removed.',
+                    '* file2.py: Added.',
+                    '* file3.py: Removed.',
+                    '(Class.function): Deleted.'
+                ],
+                return_deleted=True),
+        )
+
+    def test_return_deleted_additions(self):
+        self.maxDiff = None
+        commit_message_parser = CommitMessageParser()
+        commit_message_parser.parse_message(
+            COMMIT_MSG_BASE + '''
+* file1.py: Comment.
+* file2.py: Added.
+* file3.py: Added.
+   - A newline comment.
+(Class.function): Another comment.
+''')
+        self.assertEqual(
+            [
+                '* file1.py: Comment.',
+                '* file2.py: Added.',
+                '* file3.py: Added.',
+                '   - A newline comment.',
+                '(Class.function): Another comment.',
+            ],
+            commit_message_parser.modified_files_lines,
+        )
+        self.assertEqual(
+            [
+                '* file1.py: Comment.', '* file3.py: Added.',
+                '   - A newline comment.',
+                '(Class.function): Another comment.',
+            ],
+            commit_message_parser.apply_comments_to_modified_files_lines(
+                [
+                    '* file1.py: Removed.',
+                    '* file2.py: Added.',
+                    '* file3.py: Removed.',
+                    '(Class.function): Deleted.',
+                ],
+                return_deleted=True),
+        )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py
@@ -116,6 +116,7 @@ No project git config found, continuing
 Setting better Objective-C diffing behavior for this repository...
 Set better Objective-C diffing behavior for this repository!
 Using a rebase merge strategy for this repository
+Setting auto-updates for commit message changelogs when amending...
 Setting git editor for {repository}...
 Setting contents of 'SVN_LOG_EDITOR' as editor
 Set git editor to 'SVN_LOG_EDITOR' for this repository
@@ -128,7 +129,7 @@ Fetched 1 remote!
     def test_github_checkout(self):
         self.maxDiff = None
         with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, \
-            MockTerminal.input('n', 'n', 'committer@webkit.org', 'n', 'Committer', 's', 'overwrite', 'y', 'disabled', '1', 'y'), \
+            MockTerminal.input('n', 'n', 'committer@webkit.org', 'n', 'Committer', 's', 'overwrite', 'n', 'y', 'disabled', '1', 'y'), \
             mocks.local.Git(self.path, remote='https://{}.git'.format(remote.remote)) as repo, \
             wkmocks.Environment(EMAIL_ADDRESS='', SVN_LOG_EDITOR=''):
 
@@ -186,6 +187,7 @@ No project git config found, continuing
 Setting better Objective-C diffing behavior for this repository...
 Set better Objective-C diffing behavior for this repository!
 Using a rebase merge strategy for this repository
+Setting auto-updates for commit message changelogs when amending...
 Setting auto update on PR creation...
 Disabled auto update on PR creation
 Setting git editor for {repository}...
@@ -206,7 +208,7 @@ Fetched 2 remotes!
         )
 
     def test_commit_message(self):
-        with OutputCapture(level=logging.INFO), mocks.local.Git(self.path) as git, mocks.local.Svn():
+        with OutputCapture(level=logging.INFO), MockTerminal.input('n'), mocks.local.Git(self.path) as git, mocks.local.Svn():
             self.assertEqual(0, program.main(
                 args=('setup', '--defaults', '-v'),
                 path=self.path,


### PR DESCRIPTION
#### d68e12aac8d992e36259542a6ed9677b0a60cef3
<pre>
[git-webkit] add option to update list of changed files
<a href="https://bugs.webkit.org/show_bug.cgi?id=285368">https://bugs.webkit.org/show_bug.cgi?id=285368</a>
<a href="https://rdar.apple.com/140809288">rdar://140809288</a>

Reviewed by Jonathan Bedard.

Add a feature that automatically updates the changelog in your
commit message with the most recent changes.

This feature will be enabled by default. It can be disabled by:
    1) Set webkitscmpy.auto-update-changelog in .git/config to false
    2) Run git-webkit commit --amend --no-update

* Tools/Scripts/hooks/prepare-commit-msg:
    - When amending a commit with changes, parse the message and update
      the changelog with the modified lines. Then, reconstruct the message.
    - Add the relevant instructions/logging when the changelog is or is not
      updated.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_parser.py:
    - Change regex const names to match the expression (removed &lt;-&gt; deleted)
(CommitMessageParser._parse_modified_files_lines):
(CommitMessageParser.apply_comments_to_modified_files_lines):
    - Add return_deleted arg which will only return the lines that end with &quot;Deleted&quot; or &quot;Removed&quot;.
    - Catch the case in which a comment is made after &quot;Filename: [Added/Removed/Deleted].&quot;
(CommitMessageParser.delete_trailing_blank_lines):
    - Fix class method arguments

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/commit.py:
(Commit.parser): Add --update/--no-update flags
(Commit.main): Set WKSCMPY_UPDATE_CHANGELOG env variable

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
(Setup.git): Set webkitscmpy.auto-update-changelog.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_parser_unittest.py: Added.
(TestCommitParser):
(TestCommitParser.test_basic_commit):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py:

Canonical link: <a href="https://commits.webkit.org/295625@main">https://commits.webkit.org/295625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45b9c2058f61bebb30268d65698a0d6f6b43bf0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101333 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46785 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24313 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73381 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30611 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53718 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/95753 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11889 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4723 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46112 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103361 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16990 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82420 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/95837 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82981 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81795 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26424 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3862 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16707 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17140 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23296 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22955 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26435 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24696 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->