### PR TITLE
[SwiftUI] Support context menu configuration (macOS)

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WKUIDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WKUIDelegateAdapter.swift
@@ -26,6 +26,11 @@
 import Foundation
 internal import WebKit_Private
 
+#if os(macOS)
+internal import WebKit_Private._WKContextMenuElementInfo
+internal import WebKit_Private._WKHitTestResult
+#endif
+
 private struct DefaultDialogPresenting: DialogPresenting {
 }
 
@@ -36,6 +41,10 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegate {
     }
 
     weak var owner: WebPage_v0? = nil
+
+#if os(macOS)
+    var menuBuilder: ((WebPage_v0.ElementInfo) -> NSMenu)? = nil
+#endif
 
     private let dialogPresenter: any DialogPresenting
 
@@ -89,6 +98,20 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegate {
 
         return await owner.configuration.deviceSensorAuthorization.decisionHandler(.mediaCapture(type), .init(frame), origin)
     }
+
+    // MARK: Context menu support
+
+#if os(macOS)
+    @objc(_webView:getContextMenuFromProposedMenu:forElement:userInfo:completionHandler:)
+    func _webView(_ webView: WKWebView!, getContextMenuFromProposedMenu menu: NSMenu!, forElement element: _WKContextMenuElementInfo!, userInfo: (any NSSecureCoding)!) async -> NSMenu? {
+        guard let menuBuilder else {
+            return menu
+        }
+
+        let info = WebPage_v0.ElementInfo(linkURL: element.hitTestResult.absoluteLinkURL)
+        return menuBuilder(info)
+    }
+#endif
 }
 
 #endif

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+ElementInfo.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+ElementInfo.swift
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_SWIFTUI && compiler(>=6.0)
+
+import Foundation
+internal import WebKit_Internal
+
+extension WebPage_v0 {
+    @MainActor
+    @_spi(Private)
+    public struct ElementInfo: Sendable {
+        init(linkURL: URL?) {
+            self.linkURL = linkURL
+        }
+
+        public let linkURL: URL?
+    }
+}
+
+#endif

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -246,7 +246,7 @@ public class WebPage_v0 {
     }
 
     private let backingNavigationDelegate: WKNavigationDelegateAdapter
-    private let backingUIDelegate: WKUIDelegateAdapter
+    let backingUIDelegate: WKUIDelegateAdapter
     let backingDownloadDelegate: WKDownloadDelegateAdapter
 
     @ObservationIgnored
@@ -395,12 +395,12 @@ public class WebPage_v0 {
     // For these to work, a custom implementation of `DownloadCoordinator.destination(forDownload:response:suggestedFilename:) async -> URL?`
     // must be provided so that the downloads are not immediately cancelled.
 
-    func startDownload(using request: URLRequest) async -> WebPage_v0.DownloadID {
+    public func startDownload(using request: URLRequest) async -> WebPage_v0.DownloadID {
         let cocoaDownload = await backingWebView.startDownload(using: request)
         return WebPage_v0.DownloadID(cocoaDownload)
     }
 
-    func resumeDownload(fromResumeData resumeData: Data) async -> WebPage_v0.DownloadID {
+    public func resumeDownload(fromResumeData resumeData: Data) async -> WebPage_v0.DownloadID {
         let cocoaDownload = await backingWebView.resumeDownload(fromResumeData: resumeData)
         return WebPage_v0.DownloadID(cocoaDownload)
     }

--- a/Source/WebKit/UIProcess/API/Swift/WebView/WebViewRepresentable.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebView/WebViewRepresentable.swift
@@ -58,6 +58,10 @@ struct WebViewRepresentable {
         webView.configuration.preferences.isElementFullscreenEnabled = environment.webViewAllowsElementFullscreen
 
         context.coordinator.update(platformView, configuration: self, environment: environment)
+
+#if os(macOS)
+        owner.page.backingUIDelegate.menuBuilder = environment.webViewContextMenuContext?.menu
+#endif
     }
 
     func makeCoordinator() -> WebViewCoordinator {

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		076E884E1A13CADF005E90FC /* APIContextMenuClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 076E884D1A13CADF005E90FC /* APIContextMenuClient.h */; };
 		0772811D21234FF600C8EF2E /* UserMediaPermissionRequestManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A410F4319AF7B27002EBAB5 /* UserMediaPermissionRequestManager.h */; };
 		077FD1A02CC7569200C5D9E0 /* WKIntelligenceTextEffectCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077FD19F2CC7569200C5D9E0 /* WKIntelligenceTextEffectCoordinator.swift */; };
+		0784FFCA2D28B5800032E68C /* WebPage+ElementInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0784FFC92D28B5800032E68C /* WebPage+ElementInfo.swift */; };
 		0785E8002CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0785E7FF2CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift */; };
 		078B04442CF1149200B453A6 /* URLSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04432CF1149200B453A6 /* URLSchemeHandler.swift */; };
 		078B04462CF1154B00B453A6 /* WebPage+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */; };
@@ -3104,6 +3105,7 @@
 		076E884F1A13CBC6005E90FC /* APIInjectedBundlePageContextMenuClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIInjectedBundlePageContextMenuClient.h; sourceTree = "<group>"; };
 		077BA570260E8F630072F19F /* MediaSessionCoordinatorProxyPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaSessionCoordinatorProxyPrivate.h; sourceTree = "<group>"; };
 		077FD19F2CC7569200C5D9E0 /* WKIntelligenceTextEffectCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKIntelligenceTextEffectCoordinator.swift; sourceTree = "<group>"; };
+		0784FFC92D28B5800032E68C /* WebPage+ElementInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+ElementInfo.swift"; sourceTree = "<group>"; };
 		0785E7FF2CBCDFFD00F68126 /* PlatformIntelligenceTextEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformIntelligenceTextEffectView.swift; sourceTree = "<group>"; };
 		078B04432CF1149200B453A6 /* URLSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSchemeHandler.swift; sourceTree = "<group>"; };
 		078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+Configuration.swift"; sourceTree = "<group>"; };
@@ -8778,6 +8780,7 @@
 				078B04452CF1154B00B453A6 /* WebPage+Configuration.swift */,
 				076897ED2D07B0BE006F9FA7 /* WebPage+DialogPresenting.swift */,
 				0718F1142D1B57940060C030 /* WebPage+Download.swift */,
+				0784FFC92D28B5800032E68C /* WebPage+ElementInfo.swift */,
 				078B04B32CF1A27F00B453A6 /* WebPage+FrameInfo.swift */,
 				07FAA74A2CE947AA00128360 /* WebPage+Navigation.swift */,
 				074E87E02CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift */,
@@ -20100,6 +20103,7 @@
 				078B04462CF1154B00B453A6 /* WebPage+Configuration.swift in Sources */,
 				076897EE2D07B0BE006F9FA7 /* WebPage+DialogPresenting.swift in Sources */,
 				0718F1152D1B57940060C030 /* WebPage+Download.swift in Sources */,
+				0784FFCA2D28B5800032E68C /* WebPage+ElementInfo.swift in Sources */,
 				078B04B42CF1A27F00B453A6 /* WebPage+FrameInfo.swift in Sources */,
 				07FAA74B2CE947AA00128360 /* WebPage+Navigation.swift in Sources */,
 				074E87E12CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift in Sources */,

--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -272,6 +272,37 @@ struct ContentView: View {
                     DownloadsList(downloads: viewModel.downloadCoordinator.downloads)
                         .presentationDetents([.medium, .large])
                 }
+                .webViewContextMenu { element in
+                    if let url = element.linkURL {
+                        Button("Open Link in New Window") {
+                            let request = URLRequest(url: url)
+                            openWindow(value: CodableURLRequest(request))
+                        }
+
+                        Button("Download Linked File") {
+                            let request = URLRequest(url: url)
+                            Task {
+                                await viewModel.page.startDownload(using: request)
+                            }
+                        }
+                    } else {
+                        if let previousItem = viewModel.page.backForwardList.backList.last {
+                            Button("Back") {
+                                viewModel.page.load(backForwardItem: previousItem)
+                            }
+                        }
+
+                        if let nextItem = viewModel.page.backForwardList.forwardList.first {
+                            Button("Forward") {
+                                viewModel.page.load(backForwardItem: nextItem)
+                            }
+                        }
+
+                        Button("Reload") {
+                            viewModel.page.reload()
+                        }
+                    }
+                }
                 .toolbar {
                     ToolbarItemGroup(placement: Self.navigationToolbarItemPlacement) {
                         ToolbarBackForwardMenuView(


### PR DESCRIPTION
#### 7500dd98a00323c796512c6c7f727022ad9bcdef
<pre>
[SwiftUI] Support context menu configuration (macOS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=285371">https://bugs.webkit.org/show_bug.cgi?id=285371</a>
<a href="https://rdar.apple.com/142334574">rdar://142334574</a>

Reviewed by Aditya Keerthi.

Add support for customizing context menus on macOS using SwiftUI views.

* Source/WebKit/UIProcess/API/Swift/View+WebViewModifiers.swift:
(EnvironmentValues.webViewContextMenuContext):
* Source/WebKit/UIProcess/API/Swift/WKUIDelegateAdapter.swift:
(WKUIDelegateAdapter.menuBuilder):
(WKUIDelegateAdapter._webView(_:getContextMenuFromProposedMenu:forElement:userInfo:)):
* Source/WebKit/UIProcess/API/Swift/WebPage+ElementInfo.swift: Added.
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
* Source/WebKit/UIProcess/API/Swift/WebView/WebViewRepresentable.swift:
(WebViewRepresentable.updatePlatformView(_:context:)):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/SwiftBrowser/Source/Views/ContentView.swift:
(ContentView.body):

Canonical link: <a href="https://commits.webkit.org/288428@main">https://commits.webkit.org/288428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea99753743ac68afb50695cca0df604c472432fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37541 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/34265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10812 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/88332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/34265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86305 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/2153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/75670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/2058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/29866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/33314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/30590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/89705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10520 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/89705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10745 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/71490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/89705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/16646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/1858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12865 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/10475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/15950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/10327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/13797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/12098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->