### PR TITLE
[iOS] Document context requests with attributed string should include adaptive image glyphs as attributes

### DIFF
--- a/Source/WebCore/editing/cocoa/HTMLConverter.h
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.h
@@ -29,6 +29,7 @@
 namespace WebCore {
 
 enum class IgnoreUserSelectNone : bool;
+enum class TextIteratorBehavior : uint16_t;
 
 WEBCORE_EXPORT AttributedString attributedString(const SimpleRange&, IgnoreUserSelectNone);
 
@@ -45,5 +46,6 @@ enum class IncludedElement : uint8_t {
 };
 
 WEBCORE_EXPORT AttributedString editingAttributedString(const SimpleRange&, OptionSet<IncludedElement> = { IncludedElement::Images });
+WEBCORE_EXPORT AttributedString editingAttributedStringReplacingNoBreakSpace(const SimpleRange&, OptionSet<TextIteratorBehavior>, OptionSet<IncludedElement>);
 
 } // namespace WebCore

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdaptiveImageGlyph.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AdaptiveImageGlyph.mm
@@ -27,10 +27,12 @@
 
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
 
+#import "AppKitSPI.h"
 #import "DragAndDropSimulator.h"
 #import "PlatformUtilities.h"
 #import "TestInputDelegate.h"
 #import "TestWKWebView.h"
+#import "UIKitSPIForTesting.h"
 #import <CoreText/CTAdaptiveImageGlyphPriv.h>
 #import <UIFoundation/NSAdaptiveImageGlyph.h>
 #import <UIFoundation/NSAttributedString_Private.h>
@@ -39,12 +41,7 @@
 #import <WebKit/WebKitPrivate.h>
 #import <pal/spi/cocoa/NSAttributedStringSPI.h>
 #import <pal/spi/cocoa/UIFoundationSPI.h>
-
-#if PLATFORM(IOS_FAMILY)
-#import <UIKit/UITextInput_Private.h>
-#else
-#import <AppKit/NSTextInputClient_Private.h>
-#endif
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if USE(APPKIT)
 
@@ -63,6 +60,12 @@ static NSData *readRTFDataFromPasteboard()
 }
 
 #endif
+
+RetainPtr<NSAdaptiveImageGlyph> createAdaptiveImageGlyphForTesting()
+{
+    RetainPtr data = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
+    return adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:data.get()]);
+}
 
 @interface AdaptiveImageGlyphWKWebView : TestWKWebView<WKUIDelegatePrivate>
 - (void)focusElementAndEnsureEditorStateUpdate:(NSString *)element;
@@ -280,9 +283,7 @@ TEST(AdaptiveImageGlyph, InsertAdaptiveImageGlyphAsPictureElement)
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
-
-    RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
+    RetainPtr adaptiveImageGlyph = createAdaptiveImageGlyphForTesting();
 
     [webView insertAdaptiveImageGlyph:adaptiveImageGlyph.get()];
 
@@ -323,9 +324,7 @@ TEST(AdaptiveImageGlyph, InsertAdaptiveImageGlyphAtLargerFontSize)
     [webView synchronouslyLoadHTMLString:@"<body style='font-size: 64px;'></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
-
-    RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
+    RetainPtr adaptiveImageGlyph = createAdaptiveImageGlyphForTesting();
 
     [webView insertAdaptiveImageGlyph:adaptiveImageGlyph.get()];
     [webView waitForNextPresentationUpdate];
@@ -354,9 +353,7 @@ TEST(AdaptiveImageGlyph, InsertAdaptiveImageGlyphMatchStyle)
         "})();";
     [webView stringByEvaluatingJavaScript:setSelectionJavaScript];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
-
-    RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
+    RetainPtr adaptiveImageGlyph = createAdaptiveImageGlyphForTesting();
 
     [webView insertAdaptiveImageGlyph:adaptiveImageGlyph.get()];
     [webView waitForNextPresentationUpdate];
@@ -375,9 +372,7 @@ TEST(AdaptiveImageGlyph, InsertAndRemoveWKAttachments)
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
-
-    RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
+    RetainPtr adaptiveImageGlyph = createAdaptiveImageGlyphForTesting();
 
     [webView insertAdaptiveImageGlyph:adaptiveImageGlyph.get()];
     [webView waitForNextPresentationUpdate];
@@ -429,9 +424,7 @@ TEST(AdaptiveImageGlyph, InsertAndRemoveWKAttachments)
 
 TEST(AdaptiveImageGlyph, InsertWKAttachmentsOnPaste)
 {
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
-
-    RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
+    RetainPtr adaptiveImageGlyph = createAdaptiveImageGlyphForTesting();
 
     RetainPtr font = [WebCore::CocoaFont systemFontOfSize:16];
 
@@ -499,9 +492,7 @@ TEST(AdaptiveImageGlyph, InsertWKAttachmentsCopyFromWebViewPasteToWebView)
     [copyWebView synchronouslyLoadHTMLString:@"<body></body>"];
     [copyWebView focusElementAndEnsureEditorStateUpdate:@"document.body"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
-
-    RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
+    RetainPtr adaptiveImageGlyph = createAdaptiveImageGlyphForTesting();
 
     [copyWebView insertAdaptiveImageGlyph:adaptiveImageGlyph.get()];
     [copyWebView waitForNextPresentationUpdate];
@@ -566,9 +557,7 @@ TEST(AdaptiveImageGlyph, InsertWKAttachmentsMovingParagraphs)
     "})();";
     [webView stringByEvaluatingJavaScript:setSelectionJavaScript];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
-
-    RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
+    RetainPtr adaptiveImageGlyph = createAdaptiveImageGlyphForTesting();
 
     [webView insertAdaptiveImageGlyph:adaptiveImageGlyph.get()];
     [webView waitForNextPresentationUpdate];
@@ -620,9 +609,7 @@ TEST(AdaptiveImageGlyph, InsertMultiple)
     "})();";
     [webView stringByEvaluatingJavaScript:setSelectionJavaScript];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
-
-    RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
+    RetainPtr adaptiveImageGlyph = createAdaptiveImageGlyphForTesting();
 
     [webView insertAdaptiveImageGlyph:adaptiveImageGlyph.get()];
     [webView insertAdaptiveImageGlyph:adaptiveImageGlyph.get()];
@@ -682,9 +669,7 @@ TEST(AdaptiveImageGlyph, InsertTextAfterAdaptiveImageGlyph)
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
-
-    RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
+    RetainPtr adaptiveImageGlyph = createAdaptiveImageGlyphForTesting();
 
     [webView insertAdaptiveImageGlyph:adaptiveImageGlyph.get()];
 
@@ -746,9 +731,7 @@ TEST(AdaptiveImageGlyph, ContentsAsAttributedString)
     [webView synchronouslyLoadHTMLString:@"<body></body>"];
     [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
-
-    RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
+    RetainPtr adaptiveImageGlyph = createAdaptiveImageGlyphForTesting();
 
     [webView insertAdaptiveImageGlyph:adaptiveImageGlyph.get()];
     [webView waitForNextPresentationUpdate];
@@ -818,9 +801,7 @@ TEST(AdaptiveImageGlyph, DragAdaptiveImageGlyphFromContentEditable)
 
     [webView focusElementAndEnsureEditorStateUpdate:@"source"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
-
-    RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
+    RetainPtr adaptiveImageGlyph = createAdaptiveImageGlyphForTesting();
 
     [webView insertAdaptiveImageGlyph:adaptiveImageGlyph.get()];
     [webView waitForNextPresentationUpdate];
@@ -839,8 +820,7 @@ TEST(AdaptiveImageGlyph, DropAdaptiveImageGlyphAsText)
     RetainPtr webView = [simulator webView];
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width'><body style='width: 100%; height: 100%;' contenteditable>"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
-    RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
+    RetainPtr adaptiveImageGlyph = createAdaptiveImageGlyphForTesting();
 
     RetainPtr font = [WebCore::CocoaFont systemFontOfSize:36];
 
@@ -871,8 +851,7 @@ TEST(AdaptiveImageGlyph, DropAdaptiveImageGlyphAsSticker)
     RetainPtr webView = [simulator webView];
     [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width'><body style='width: 100%; height: 100%;' contenteditable>"];
 
-    RetainPtr adaptiveImageGlyphData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"adaptive-image-glyph" withExtension:@"heic"]];
-    RetainPtr adaptiveImageGlyph = adoptNS([[NSAdaptiveImageGlyph alloc] initWithImageContent:adaptiveImageGlyphData.get()]);
+    RetainPtr adaptiveImageGlyph = createAdaptiveImageGlyphForTesting();
 
     RetainPtr font = [WebCore::CocoaFont systemFontOfSize:36];
 
@@ -903,6 +882,54 @@ TEST(AdaptiveImageGlyph, DropAdaptiveImageGlyphAsSticker)
 }
 
 #endif // ENABLE(DRAG_SUPPORT) && !PLATFORM(MACCATALYST)
+
+#if HAVE(UI_WK_DOCUMENT_CONTEXT)
+
+TEST(AdaptiveImageGlyph, AttributedStringDocumentEditingContext)
+{
+    auto webView = adoptNS([[AdaptiveImageGlyphWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    [webView _setEditable:YES];
+
+    [webView synchronouslyLoadHTMLString:@"<body style='font-family: Arial; font-size: 20px;'></body>"];
+    [webView focusElementAndEnsureEditorStateUpdate:@"document.body"];
+    [[webView textInputContentView] insertText:@"Hello "];
+
+    RetainPtr adaptiveImageGlyph = createAdaptiveImageGlyphForTesting();
+    [webView insertAdaptiveImageGlyph:adaptiveImageGlyph.get()];
+    [[webView textInputContentView] insertText:@" world"];
+    [webView stringByEvaluatingJavaScript:@"getSelection().removeAllRanges();"
+        "getSelection().addRange((() => {"
+        "    const picture = document.querySelector('picture');"
+        "    const range = document.createRange();"
+        "    range.setStartBefore(picture);"
+        "    range.setEndAfter(picture);"
+        "    return range;"
+        "})());"];
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr request = adoptNS([[UIWKDocumentRequest alloc] init]);
+    [request setFlags:UIWKDocumentRequestAttributed];
+    [request setSurroundingGranularity:UITextGranularityLine];
+    [request setGranularityCount:1];
+
+    RetainPtr context = [webView synchronouslyRequestDocumentContext:request.get()];
+    RetainPtr contextBefore = dynamic_objc_cast<NSAttributedString>([context contextBefore]);
+    RetainPtr selectedText = dynamic_objc_cast<NSAttributedString>([context selectedText]);
+    RetainPtr contextAfter = dynamic_objc_cast<NSAttributedString>([context contextAfter]);
+
+    EXPECT_WK_STREQ(@"Hello ", [contextBefore string]);
+    EXPECT_WK_STREQ(@"\uFFFC", [selectedText string]);
+    __block BOOL foundAdaptiveImageGlyph = NO;
+    [selectedText enumerateAttribute:NSAdaptiveImageGlyphAttributeName inRange:NSMakeRange(0, 1) options:0 usingBlock:^(NSAdaptiveImageGlyph *glyph, NSRange, BOOL *) {
+        foundAdaptiveImageGlyph = YES;
+        EXPECT_WK_STREQ(glyph.contentIdentifier, [adaptiveImageGlyph contentIdentifier]);
+        EXPECT_WK_STREQ(glyph.contentDescription, [adaptiveImageGlyph contentDescription]);
+    }];
+    EXPECT_TRUE(foundAdaptiveImageGlyph);
+    EXPECT_WK_STREQ(@" world", [contextAfter string]);
+}
+
+#endif // HAVE(UI_WK_DOCUMENT_CONTEXT)
 
 } // namespace TestWebKitAPI
 


### PR DESCRIPTION
#### ac643ee151bc20383f2bedcec717ae457d609ee7
<pre>
[iOS] Document context requests with attributed string should include adaptive image glyphs as attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=285373">https://bugs.webkit.org/show_bug.cgi?id=285373</a>
<a href="https://rdar.apple.com/142280535">rdar://142280535</a>

Reviewed by Megan Gardner and Abrar Rahman Protyasha.

Add support for the `UIWKDocumentRequestAttributed` (`BETextDocumentOptionAttributedText`) flag when
handling document editing context requests. We currently just extract plain text in the context
range and return an `NSAttributedString` whose string is equal to that plain text, but which lacks
any attributes.

This instead uses `WebCore::editingAttributedString` to include a subset of presentational and
semantic attributes in the result, including `NSAdaptiveImageGlyphAttributeName` when the context
range includes Genmojis.

See below for more detail.

* Source/WebCore/editing/cocoa/HTMLConverter.h:
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(WebCore::editingAttributedStringInternal):

Move the existing logic in `editingAttributedString` into a separate static helper function, so that
we can share the implementation between `editingAttributedStringReplacingNoBreakSpace` and
`editingAttributedString` below.

(WebCore::editingAttributedString):
(WebCore::editingAttributedStringReplacingNoBreakSpace):

Add support for a `editingAttributedStringReplacingNoBreakSpace` method that is similar to the
extant `editingAttributedString`, except that it:

1.  Replaces non-breaking spaces with a regular space (matching `plainTextReplacingNoBreakSpace`&apos;s
    behavior).

2.  Takes in a set of `TextIteratorBehaviors` to use when iterating over the range.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::requestDocumentEditingContext):

Use `editingAttributedStringReplacingNoBreakSpace` when attributed string data is requested, instead
of always falling back on `plainTextReplacingNoBreakSpace`.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/AdaptiveImageGlyph.mm:
(createAdaptiveImageGlyphForTesting):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertAdaptiveImageGlyphAsPictureElement)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertAdaptiveImageGlyphAtLargerFontSize)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertAdaptiveImageGlyphMatchStyle)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertAndRemoveWKAttachments)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertWKAttachmentsOnPaste)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertWKAttachmentsCopyFromWebViewPasteToWebView)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertWKAttachmentsMovingParagraphs)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertMultiple)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, InsertTextAfterAdaptiveImageGlyph)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, ContentsAsAttributedString)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, DragAdaptiveImageGlyphFromContentEditable)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, DropAdaptiveImageGlyphAsText)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, DropAdaptiveImageGlyphAsSticker)):
(TestWebKitAPI::TEST(AdaptiveImageGlyph, AttributedStringDocumentEditingContext)):

Add a new API test to verify that adaptive image glyphs are surfaced when requesting attributed
strings through the document editing context API; also, remove a little code duplication in these
tests by adding a new helper method, `createAdaptiveImageGlyphForTesting()`.

Canonical link: <a href="https://commits.webkit.org/288436@main">https://commits.webkit.org/288436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ee34d43d83810b9b61e9f8756885ca2a9761b6b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88323 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34256 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85332 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10801 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64769 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22524 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45053 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2044 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29859 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33305 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73180 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89696 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73203 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72432 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17950 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16634 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15366 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1849 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10464 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15941 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10318 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13788 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->