### PR TITLE
[Flex] Computing inner cross size of a flexbox with a definite cross size should consider box-sizing.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-single-line-definite-cross-size-with-box-sizing-border-box-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-single-line-definite-cross-size-with-box-sizing-border-box-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This test passes if you see a green <strong>square</strong> and no red.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-single-line-definite-cross-size-with-box-sizing-border-box-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-single-line-definite-cross-size-with-box-sizing-border-box-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This test passes if you see a 200x200 green <strong>square</strong>.</p>
+<div style="width: 200px; height: 200px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-single-line-definite-cross-size-with-box-sizing-border-box-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-single-line-definite-cross-size-with-box-sizing-border-box-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Reftest Reference</title>
+</head>
+<body>
+<p>This test passes if you see a 200x200 green <strong>square</strong>.</p>
+<div style="width: 200px; height: 200px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-single-line-definite-cross-size-with-box-sizing-border-box.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-single-line-definite-cross-size-with-box-sizing-border-box.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#algo-main-item">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#definite-sizes">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Definite cross size of a single line flex container it the container's content box cross size which is used to size flex item with a preferred aspect ratio.">
+<style>
+.flexbox {
+  display: flex;
+  width: min-content;
+  height: 10px;
+  border: 50px solid green; 
+  box-sizing: border-box;
+}
+.item {
+  aspect-ratio: 1;
+  background-color: red;
+}
+</style>
+</head>
+<body>
+<p>This test passes if you see a green <strong>square</strong> and no red.</p>
+<div class="flexbox">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-single-line-definite-cross-size-with-box-sizing-border-box.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-single-line-definite-cross-size-with-box-sizing-border-box.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#algo-main-item">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#definite-sizes">
+<link rel="match" href="flexbox-single-line-definite-cross-size-with-box-sizing-border-box-ref.html">
+<meta name="assert" content="Definite cross size of a single line flex container is the container's content box cross size which is used to size a flex item with a preferred aspect ratio.">
+<style>
+.flexbox {
+  display: flex;
+  width: min-content;
+  height: 200px;
+  border: 50px solid green;
+  box-sizing: border-box;
+}
+.item {
+  aspect-ratio: 1;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<p>This test passes if you see a 200x200 green <strong>square</strong>.</p>
+<div class="flexbox">
+  <div class="item"></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1976,6 +1976,7 @@ LayoutUnit RenderFlexibleBox::computeCrossSizeForFlexItemUsingContainerCrossSize
         return contentWidth();
 
     // Keep this sync'ed with flexItemCrossSizeShouldUseContainerCrossSize().
+    ASSERT(flexItemCrossSizeShouldUseContainerCrossSize(flexItem));
     auto definiteSizeValue = [&] {
         // Let's compute the definite size value for the flex item (value that we can resolve without running layout).
         auto isHorizontal = isHorizontalFlow();
@@ -1993,7 +1994,7 @@ LayoutUnit RenderFlexibleBox::computeCrossSizeForFlexItemUsingContainerCrossSize
         if (minimumSize.isFixed())
             definiteValue = std::max(definiteValue, LayoutUnit { minimumSize.value() });
 
-        return definiteValue;
+        return adjustContentBoxLogicalWidthForBoxSizing(definiteValue, LengthType::Fixed);
     };
     return std::max(0_lu, definiteSizeValue() - crossAxisMarginExtentForFlexItem(flexItem));
 }

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -2328,6 +2328,7 @@ LayoutUnit RenderFlexibleBox::computeCrossSizeForFlexItemUsingContainerCrossSize
         return contentBoxLogicalWidth();
 
     // Keep this sync'ed with hasDefiniteCrossSizeForFlexItem().
+    ASSERT(hasDefiniteCrossSizeForFlexItem(flexItem));
     auto definiteSizeValue = [&] {
         // Let's compute the definite size value for the flex item (value that we can resolve without running layout).
         auto isHorizontal = isHorizontalFlow();
@@ -2347,6 +2348,10 @@ LayoutUnit RenderFlexibleBox::computeCrossSizeForFlexItemUsingContainerCrossSize
         if (auto fixedMinimumSize = minimumSize.tryFixed())
             definiteValue = std::max(definiteValue, LayoutUnit { fixedMinimumSize->resolveZoom(style().usedZoomForLength()) });
 
+        if (style().boxSizing() == BoxSizing::BorderBox) {
+            auto crossAxisBorderAndPadding = isHorizontal ? borderAndPaddingLogicalHeight() : borderAndPaddingLogicalWidth();
+            return std::max({ }, definiteValue - crossAxisBorderAndPadding);
+        }
         return definiteValue;
     };
     return std::max(0_lu, definiteSizeValue() - crossAxisMarginExtentForFlexItem(flexItem));


### PR DESCRIPTION
#### 165eecce7ce55dcc7eab59c76dd4992088944b85
<pre>
[Flex] Computing inner cross size of a flexbox with a definite cross size should consider box-sizing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244697">https://bugs.webkit.org/show_bug.cgi?id=244697</a>
<a href="https://rdar.apple.com/99475341">rdar://99475341</a>

Reviewed by NOBODY (OOPS!).

The flexbox spec states &quot;If a single-line flex container has a
definite cross size, the automatic preferred outer cross size of
any stretched flex items is the flex container’s inner cross
size (clamped to the flex item’s min and max cross size) and is considered
definite.&quot;

We compute this cross size in computeCrossSizeForFlexItemUsingContainerCrossSize,
but we fail to take into consideration the box-sizing property. If the
flexbox has box-sizing: border-box specified on it then this will change
how we compute the inner cross size as we will need to take away any
border and padding from this fixed value.

* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-single-line-definite-cross-size-with-box-sizing-border-box-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-single-line-definite-cross-size-with-box-sizing-border-box.html: Added.
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::computeCrossSizeForFlexItemUsingContainerCrossSize const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/165eecce7ce55dcc7eab59c76dd4992088944b85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/34716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/27817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170146 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117614 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4bb017d-08e7-4715-9e45-84bcf373ab7a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163112 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/34817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/34717 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125073 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-sizing/stretch/flexbox-auto-minimum-002.html imported/w3c/web-platform-tests/css/css-sizing/stretch/flexbox-flex-base-size-002.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88159 "1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/18833481-5b47-419b-854b-0939a073e310) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/144845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105670 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2b4ad57-c9c6-4193-80a0-137d5d34ccc5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26421 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24907 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/17866 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136115 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172629 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19650 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24246 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133349 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-sizing/stretch/flexbox-auto-minimum-002.html imported/w3c/web-platform-tests/css/css-sizing/stretch/flexbox-flex-base-size-002.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34390 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29000 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-sizing/stretch/flexbox-auto-minimum-002.html imported/w3c/web-platform-tests/css/css-sizing/stretch/flexbox-flex-base-size-002.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133358 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144400 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96240 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27906 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21218 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/33885 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101310 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33384 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33628 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33533 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->