### PR TITLE
Use WTF::String for toWebExtensionError and toErrorString

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "WebExtensionUtilities.h"
+#include <wtf/text/MakeString.h>
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -96,6 +97,111 @@ RefPtr<JSON::Object> mergeJSON(RefPtr<JSON::Object> jsonA, RefPtr<JSON::Object> 
     }
 
     return mergedObject;
+}
+
+WTF_ATTRIBUTE_PRINTF(1, 0)
+static String formatString(const char* format, va_list arguments)
+{
+    va_list args;
+    va_copy(args, arguments);
+
+ALLOW_NONLITERAL_FORMAT_BEGIN
+
+#if PLATFORM(COCOA)
+    auto cfFormat = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, format, kCFStringEncodingUTF8, kCFAllocatorNull));
+    auto cfResult = adoptCF(CFStringCreateWithFormatAndArguments(0, 0, cfFormat.get(), args));
+    va_end(args);
+    return cfResult.get();
+#endif
+
+#if PLATFORM(WIN)
+    int len = _vscwprintf(format, args);
+    Vector<wchar_t> buffer(len + 1);
+    _vsnwprintf(buffer.data(), len + 1, format, args);
+    va_end(args);
+    return { buffer.data() };
+#else
+    char ch;
+    int result = vsnprintf(&ch, 1, format, args);
+
+    if (!result) {
+        va_end(args);
+        return emptyString();
+    }
+
+    if (result < 0) {
+        va_end(args);
+        return nullString();
+    }
+
+    Vector<char, 256> buffer;
+    buffer.grow(result + 1);
+
+    vsnprintf(buffer.data(), buffer.size(), format, args);
+    va_end(args);
+
+    return StringImpl::create(buffer.subspan(0, buffer.size() - 1));
+#endif
+
+ALLOW_NONLITERAL_FORMAT_END
+}
+
+WTF_ATTRIBUTE_PRINTF(1, 0)
+static String formatString(const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+ALLOW_NONLITERAL_FORMAT_BEGIN
+    auto result = formatString(format, args);
+ALLOW_NONLITERAL_FORMAT_END
+    va_end(args);
+    return result;
+}
+
+static inline String lowercaseFirst(const String& input)
+{
+    return !input.isEmpty() ? makeString(input.left(1).convertToASCIILowercase(), input.substring(1, input.length())) : input;
+}
+
+static inline String uppercaseFirst(const String& input)
+{
+    return !input.isEmpty() ? makeString(input.left(1).convertToASCIIUppercase(), input.substring(1, input.length())) : input;
+}
+
+String toErrorString(const String& callingAPIName, const String& sourceKey, String underlyingErrorString, ...)
+{
+    ASSERT(!underlyingErrorString.isEmpty());
+
+    const char* rawUnderlyingString = underlyingErrorString.utf8().data();
+
+    va_list arguments;
+    va_start(arguments, underlyingErrorString);
+
+ALLOW_NONLITERAL_FORMAT_BEGIN
+    String formattedUnderlyingErrorString = formatString(rawUnderlyingString, arguments).trim([](UChar character) -> bool {
+        return character == '.';
+    });
+ALLOW_NONLITERAL_FORMAT_END
+
+    va_end(arguments);
+
+    String source = sourceKey;
+
+    if (UNLIKELY(!callingAPIName.isEmpty() && !sourceKey.isEmpty() && formattedUnderlyingErrorString.contains("value is invalid"_s))) {
+        ASSERT_NOT_REACHED_WITH_MESSAGE("Overly nested error string, use a `nullString()` sourceKey for this call instead.");
+        source = nullString();
+    }
+
+    if (!callingAPIName.isEmpty() && !source.isEmpty())
+        return formatString("Invalid call to %s. The '%s' value is invalid, because %s.", callingAPIName.utf8().data(), source.utf8().data(), lowercaseFirst(formattedUnderlyingErrorString).utf8().data());
+
+    if (callingAPIName.isEmpty() && !source.isEmpty())
+        return formatString("The '%s' value is invalid, because %s.", source.utf8().data(), lowercaseFirst(formattedUnderlyingErrorString).utf8().data());
+
+    if (!callingAPIName.isEmpty())
+        return formatString("Invalid call to %s. %s.", callingAPIName.utf8().data(), uppercaseFirst(formattedUnderlyingErrorString).utf8().data());
+
+    return formattedUnderlyingErrorString;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
@@ -54,6 +54,16 @@ double largestDisplayScale();
 RefPtr<JSON::Object> jsonWithLowercaseKeys(RefPtr<JSON::Object>);
 RefPtr<JSON::Object> mergeJSON(RefPtr<JSON::Object>, RefPtr<JSON::Object>);
 
+/// Returns a concatenated error string that combines the provided information into a single, descriptive message.
+String toErrorString(const String& callingAPIName, const String& sourceKey, String underlyingErrorString, ...);
+
+/// Returns an error for Expected results in CompletionHandler.
+template<typename... Args>
+Unexpected<WebExtensionError> toWebExtensionError(const String& callingAPIName, const String& sourceKey, const String& underlyingErrorString, Args&&... args)
+{
+    return makeUnexpected(toErrorString(callingAPIName, sourceKey, underlyingErrorString, std::forward<Args>(args)...));
+}
+
 #ifdef __OBJC__
 
 /// Verifies that a dictionary:
@@ -75,9 +85,6 @@ bool validateDictionary(NSDictionary<NSString *, id> *, NSString *sourceKey, NSA
 ///  - The `callingAPIName` and `sourceKey` parameters are used to reference the object within a larger context. When an error occurs, this key helps identify the source of the problem in the `outExceptionString`.
 /// If the object is valid, returns `YES`. Otherwise returns `NO` and sets `outExceptionString` to a message describing what validation failed.
 bool validateObject(NSObject *, NSString *sourceKey, id valueTypes, NSString **outExceptionString);
-
-/// Returns a concatenated error string that combines the provided information into a single, descriptive message.
-NSString *toErrorString(NSString *callingAPIName, NSString *sourceKey, NSString *underlyingErrorString, ...) NS_FORMAT_ARGUMENT(3);
 
 /// Returns an error object that combines the provided information into a single, descriptive message.
 JSObjectRef toJSError(JSContextRef, NSString *callingAPIName, NSString *sourceKey, NSString *underlyingErrorString);
@@ -117,13 +124,6 @@ NSArray *toWebAPI(const Vector<T>& items)
 inline NSNumber *toWebAPI(size_t index)
 {
     return index != notFound ? @(index) : @(std::numeric_limits<double>::quiet_NaN());
-}
-
-/// Returns an error for Expected results in CompletionHandler.
-template<typename... Args>
-Unexpected<WebExtensionError> toWebExtensionError(NSString *callingAPIName, NSString *sourceKey, NSString *underlyingErrorString, Args&&... args)
-{
-    return makeUnexpected(String(toErrorString(callingAPIName, sourceKey, underlyingErrorString, std::forward<Args>(args)...)));
 }
 
 #endif // __OBJC__

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
@@ -297,7 +297,7 @@ bool validateDictionary(NSDictionary<NSString *, id> *dictionary, NSString *sour
         errorString = [NSString stringWithFormat:@"it is missing required keys: %@", formatList(remainingRequiredKeys.allObjects)];
 
     if (errorString && outExceptionString)
-        *outExceptionString = toErrorString(nil, sourceKey, errorString);
+        *outExceptionString = toErrorString(nullString(), sourceKey, errorString);
 
     return !errorString;
 }
@@ -310,54 +310,9 @@ bool validateObject(NSObject *object, NSString *sourceKey, id expectedValueType,
     validate(nil, object, expectedValueType, &errorString);
 
     if (errorString && outExceptionString)
-        *outExceptionString = toErrorString(nil, sourceKey, errorString);
+        *outExceptionString = toErrorString(nullString(), sourceKey, errorString);
 
     return !errorString;
-}
-
-static inline NSString* lowercaseFirst(NSString *input)
-{
-    return input.length ? [[input substringToIndex:1].lowercaseString stringByAppendingString:[input substringFromIndex:1]] : input;
-}
-
-static inline NSString* uppercaseFirst(NSString *input)
-{
-    return input.length ? [[input substringToIndex:1].uppercaseString stringByAppendingString:[input substringFromIndex:1]] : input;
-}
-
-inline NSString* trimTrailingPeriod(NSString *input)
-{
-    return [input hasSuffix:@"."] ? [input substringToIndex:input.length - 1] : input;
-}
-
-NSString *toErrorString(NSString *callingAPIName, NSString *sourceKey, NSString *underlyingErrorString, ...)
-{
-    ASSERT(underlyingErrorString.length);
-
-    va_list arguments;
-    va_start(arguments, underlyingErrorString);
-
-    ALLOW_NONLITERAL_FORMAT_BEGIN
-    NSString *formattedUnderlyingErrorString = trimTrailingPeriod([[NSString alloc] initWithFormat:underlyingErrorString arguments:arguments]);
-    ALLOW_NONLITERAL_FORMAT_END
-
-    va_end(arguments);
-
-    if (UNLIKELY(callingAPIName.length && sourceKey.length && [formattedUnderlyingErrorString containsString:@"value is invalid"])) {
-        ASSERT_NOT_REACHED_WITH_MESSAGE("Overly nested error string, use a `nil` sourceKey for this call instead.");
-        sourceKey = nil;
-    }
-
-    if (callingAPIName.length && sourceKey.length)
-        return [NSString stringWithFormat:@"Invalid call to %@. The '%@' value is invalid, because %@.", callingAPIName, sourceKey, lowercaseFirst(formattedUnderlyingErrorString)];
-
-    if (!callingAPIName.length && sourceKey.length)
-        return [NSString stringWithFormat:@"The '%@' value is invalid, because %@.", sourceKey, lowercaseFirst(formattedUnderlyingErrorString)];
-
-    if (callingAPIName.length)
-        return [NSString stringWithFormat:@"Invalid call to %@. %@.", callingAPIName, uppercaseFirst(formattedUnderlyingErrorString)];
-
-    return formattedUnderlyingErrorString;
 }
 
 JSObjectRef toJSError(JSContextRef context, NSString *callingAPIName, NSString *sourceKey, NSString *underlyingErrorString)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
@@ -44,7 +44,7 @@ static Expected<Ref<WebExtensionAction>, WebExtensionError> getActionWithIdentif
     if (windowIdentifier) {
         RefPtr window = context.getWindow(windowIdentifier.value());
         if (!window)
-            return toWebExtensionError(apiName, nil, @"window not found");
+            return toWebExtensionError(apiName, nullString(), @"window not found");
 
         return context.getAction(window.get());
     }
@@ -52,7 +52,7 @@ static Expected<Ref<WebExtensionAction>, WebExtensionError> getActionWithIdentif
     if (tabIdentifier) {
         RefPtr tab = context.getTab(tabIdentifier.value());
         if (!tab)
-            return toWebExtensionError(apiName, nil, @"tab not found");
+            return toWebExtensionError(apiName, nullString(), @"tab not found");
 
         return context.getAction(tab.get());
     }
@@ -65,7 +65,7 @@ static Expected<Ref<WebExtensionAction>, WebExtensionError> getOrCreateActionWit
     if (windowIdentifier) {
         RefPtr window = context.getWindow(windowIdentifier.value());
         if (!window)
-            return toWebExtensionError(apiName, nil, @"window not found");
+            return toWebExtensionError(apiName, nullString(), @"window not found");
 
         return context.getOrCreateAction(window.get());
     }
@@ -73,7 +73,7 @@ static Expected<Ref<WebExtensionAction>, WebExtensionError> getOrCreateActionWit
     if (tabIdentifier) {
         RefPtr tab = context.getTab(tabIdentifier.value());
         if (!tab)
-            return toWebExtensionError(apiName, nil, @"tab not found");
+            return toWebExtensionError(apiName, nullString(), @"tab not found");
 
         return context.getOrCreateAction(tab.get());
     }
@@ -177,12 +177,12 @@ void WebExtensionContext::actionOpenPopup(WebPageProxyIdentifier identifier, std
     static NSString * const apiName = @"action.openPopup()";
 
     if (!protectedDefaultAction()->canProgrammaticallyPresentPopup()) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
         return;
     }
 
     if (extensionController()->isShowingActionPopup()) {
-        completionHandler(toWebExtensionError(apiName, nil, @"another popup is already open"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"another popup is already open"));
         return;
     }
 
@@ -192,13 +192,13 @@ void WebExtensionContext::actionOpenPopup(WebPageProxyIdentifier identifier, std
     if (windowIdentifier) {
         window = getWindow(windowIdentifier.value());
         if (!window) {
-            completionHandler(toWebExtensionError(apiName, nil, @"window not found"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"window not found"));
             return;
         }
 
         tab = window->activeTab();
         if (!tab) {
-            completionHandler(toWebExtensionError(apiName, nil, @"active tab not found in window"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"active tab not found in window"));
             return;
         }
     }
@@ -206,7 +206,7 @@ void WebExtensionContext::actionOpenPopup(WebPageProxyIdentifier identifier, std
     if (tabIdentifier) {
         tab = getTab(tabIdentifier.value());
         if (!tab) {
-            completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"tab not found"));
             return;
         }
     }
@@ -214,13 +214,13 @@ void WebExtensionContext::actionOpenPopup(WebPageProxyIdentifier identifier, std
     if (!tab) {
         window = frontmostWindow();
         if (!window) {
-            completionHandler(toWebExtensionError(apiName, nil, @"no windows open"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"no windows open"));
             return;
         }
 
         tab = window->activeTab();
         if (!tab) {
-            completionHandler(toWebExtensionError(apiName, nil, @"active tab not found in window"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"active tab not found in window"));
             return;
         }
     }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
@@ -118,7 +118,7 @@ void WebExtensionContext::cookiesGet(std::optional<PAL::SessionID> sessionID, co
 {
     RefPtr dataStore = websiteDataStore(sessionID);
     if (!dataStore) {
-        completionHandler(toWebExtensionError(@"cookies.get()", nil, @"cookie store not found"));
+        completionHandler(toWebExtensionError(@"cookies.get()", nullString(), @"cookie store not found"));
         return;
     }
 
@@ -150,7 +150,7 @@ void WebExtensionContext::cookiesGetAll(std::optional<PAL::SessionID> sessionID,
 {
     RefPtr dataStore = websiteDataStore(sessionID);
     if (!dataStore) {
-        completionHandler(toWebExtensionError(@"cookies.getAll()", nil, @"cookie store not found"));
+        completionHandler(toWebExtensionError(@"cookies.getAll()", nullString(), @"cookie store not found"));
         return;
     }
 
@@ -163,7 +163,7 @@ void WebExtensionContext::cookiesSet(std::optional<PAL::SessionID> sessionID, co
 {
     RefPtr dataStore = websiteDataStore(sessionID);
     if (!dataStore) {
-        completionHandler(toWebExtensionError(@"cookies.set()", nil, @"cookie store not found"));
+        completionHandler(toWebExtensionError(@"cookies.set()", nullString(), @"cookie store not found"));
         return;
     }
 
@@ -171,7 +171,7 @@ void WebExtensionContext::cookiesSet(std::optional<PAL::SessionID> sessionID, co
 
     requestPermissionToAccessURLs({ url }, nullptr, [this, protectedThis = Ref { *this }, dataStore, url, cookieParameters, completionHandler = WTFMove(completionHandler)](auto&& requestedURLs, auto&& allowedURLs, auto expirationDate) mutable {
         if (!hasPermission(url)) {
-            completionHandler(toWebExtensionError(@"cookies.set()", nil, @"host permissions are missing or not granted"));
+            completionHandler(toWebExtensionError(@"cookies.set()", nullString(), @"host permissions are missing or not granted"));
             return;
         }
 
@@ -185,13 +185,13 @@ void WebExtensionContext::cookiesRemove(std::optional<PAL::SessionID> sessionID,
 {
     RefPtr dataStore = websiteDataStore(sessionID);
     if (!dataStore) {
-        completionHandler(toWebExtensionError(@"cookies.remove()", nil, @"cookie store not found"));
+        completionHandler(toWebExtensionError(@"cookies.remove()", nullString(), @"cookie store not found"));
         return;
     }
 
     requestPermissionToAccessURLs({ url }, nullptr, [this, protectedThis = Ref { *this }, dataStore, name, url, completionHandler = WTFMove(completionHandler)](auto&& requestedURLs, auto&& allowedURLs, auto expirationDate) mutable {
         if (!hasPermission(url)) {
-            completionHandler(toWebExtensionError(@"cookies.remove()", nil, @"host permissions are missing or not granted"));
+            completionHandler(toWebExtensionError(@"cookies.remove()", nullString(), @"host permissions are missing or not granted"));
             return;
         }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
@@ -113,7 +113,7 @@ WebExtensionContext::DeclarativeNetRequestValidatedRulesets WebExtensionContext:
     for (auto& identifier : rulesetIdentifiers) {
         auto ruleset = extension->declarativeNetRequestRuleset(identifier);
         if (!ruleset)
-            return toWebExtensionError(@"declarativeNetRequest.updateEnabledRulesets()", nil, @"Failed to apply rules. Invalid ruleset id: %@.", (NSString *)identifier);
+            return toWebExtensionError(@"declarativeNetRequest.updateEnabledRulesets()", nullString(), @"Failed to apply rules. Invalid ruleset id: %@.", (NSString *)identifier);
 
         validatedRulesets.append(ruleset.value());
     }
@@ -158,7 +158,7 @@ void WebExtensionContext::declarativeNetRequestUpdateEnabledRulesets(const Vecto
     }
 
     if (declarativeNetRequestEnabledRulesetCount() - rulesetIdentifiersToDisable.size() + rulesetIdentifiersToEnable.size() > webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets) {
-        completionHandler(toWebExtensionError(@"declarativeNetRequest.updateEnabledRulesets()", nil, @"The number of enabled static rulesets exceeds the limit. Only %lu rulesets can be enabled at once.", webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets));
+        completionHandler(toWebExtensionError(@"declarativeNetRequest.updateEnabledRulesets()", nullString(), @"The number of enabled static rulesets exceeds the limit. Only %lu rulesets can be enabled at once.", webExtensionDeclarativeNetRequestMaximumNumberOfEnabledRulesets));
         return;
     }
 
@@ -178,7 +178,7 @@ void WebExtensionContext::declarativeNetRequestUpdateEnabledRulesets(const Vecto
         declarativeNetRequestToggleRulesets(rulesetIdentifiersToDisable, true, rulesetIdentifiersToEnabledState.get());
         declarativeNetRequestToggleRulesets(rulesetIdentifiersToEnable, false, rulesetIdentifiersToEnabledState.get());
 
-        completionHandler(toWebExtensionError(@"declarativeNetRequest.updateEnabledRulesets()", nil, @"Failed to apply rules."));
+        completionHandler(toWebExtensionError(@"declarativeNetRequest.updateEnabledRulesets()", nullString(), @"Failed to apply rules."));
     });
 }
 
@@ -222,7 +222,7 @@ void WebExtensionContext::declarativeNetRequestIncrementActionCount(WebExtension
 {
     RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
-        completionHandler(toWebExtensionError(@"declarativeNetRequest.setExtensionActionOptions()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"declarativeNetRequest.setExtensionActionOptions()", nullString(), @"tab not found"));
         return;
     }
 
@@ -236,13 +236,13 @@ void WebExtensionContext::declarativeNetRequestGetMatchedRules(std::optional<Web
 
     static NSString * const apiName = @"declarativeNetRequest.getMatchedRules()";
     if (tabIdentifier && !tab) {
-        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"tab not found"));
         return;
     }
 
     if (!hasPermission(WKWebExtensionPermissionDeclarativeNetRequestFeedback)) {
         if (!tab->extensionHasTemporaryPermission()) {
-            completionHandler(toWebExtensionError(apiName, nil, @"the 'activeTab' permission has not been granted by the user for the tab"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"the 'activeTab' permission has not been granted by the user for the tab"));
             return;
         }
     }
@@ -296,7 +296,7 @@ void WebExtensionContext::updateDeclarativeNetRequestRulesInStorage(_WKWebExtens
             RELEASE_LOG_ERROR(Extensions, "Unable to create %{public}@ rules savepoint for extension %{private}@. Error: %{public}@", storageType, (NSString *)uniqueIdentifier(), errorMessage);
 
         if (errorMessage.length) {
-            completionHandler(toWebExtensionError(apiName, nil, errorMessage));
+            completionHandler(toWebExtensionError(apiName, nullString(), errorMessage));
             return;
         }
 
@@ -310,7 +310,7 @@ void WebExtensionContext::updateDeclarativeNetRequestRulesInStorage(_WKWebExtens
                     if (savepointErrorMessage)
                         RELEASE_LOG_ERROR(Extensions, "Unable to rollback to %{public}@ rules savepoint for extension %{private}@. Error: %{public}@", storageType, (NSString *)uniqueIdentifier(), savepointErrorMessage);
 
-                    completionHandler(toWebExtensionError(apiName, nil, errorMessage));
+                    completionHandler(toWebExtensionError(apiName, nullString(), errorMessage));
                 }).get()];
 
                 return;
@@ -327,7 +327,7 @@ void WebExtensionContext::updateDeclarativeNetRequestRulesInStorage(_WKWebExtens
                         // Load the declarativeNetRequest rules again after rolling back the dynamic update.
                         loadDeclarativeNetRequestRules([completionHandler = WTFMove(completionHandler), apiName](bool success) mutable {
                             if (!success) {
-                                completionHandler(toWebExtensionError(apiName, nil, @"unable to load declarativeNetRequest rules"));
+                                completionHandler(toWebExtensionError(apiName, nullString(), @"unable to load declarativeNetRequest rules"));
                                 return;
                             }
 
@@ -354,7 +354,7 @@ void WebExtensionContext::declarativeNetRequestGetDynamicRules(CompletionHandler
 {
     [declarativeNetRequestDynamicRulesStore() getRulesWithCompletionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSArray *rules, NSString *errorMessage) mutable {
         if (errorMessage) {
-            completionHandler(toWebExtensionError(@"declarativeNetRequest.getDynamicRules()", nil, errorMessage));
+            completionHandler(toWebExtensionError(@"declarativeNetRequest.getDynamicRules()", nullString(), errorMessage));
             return;
         }
 
@@ -381,7 +381,7 @@ void WebExtensionContext::declarativeNetRequestUpdateDynamicRules(String&& rules
 
     auto updatedDynamicRulesCount = m_dynamicRulesIDs.size() + rulesToAdd.count - ruleIDsToDelete.count;
     if (updatedDynamicRulesCount + m_sessionRulesIDs.size() > webExtensionDeclarativeNetRequestMaximumNumberOfDynamicAndSessionRules) {
-        completionHandler(toWebExtensionError(apiName, nil, @"Failed to add dynamic rules. Maximum number of dynamic and session rules exceeded."));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"Failed to add dynamic rules. Maximum number of dynamic and session rules exceeded."));
         return;
     }
 
@@ -392,7 +392,7 @@ void WebExtensionContext::declarativeNetRequestGetSessionRules(CompletionHandler
 {
     [declarativeNetRequestSessionRulesStore() getRulesWithCompletionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSArray *rules, NSString *errorMessage) mutable {
         if (errorMessage) {
-            completionHandler(toWebExtensionError(@"declarativeNetRequest.getSessionRules()", nil, errorMessage));
+            completionHandler(toWebExtensionError(@"declarativeNetRequest.getSessionRules()", nullString(), errorMessage));
             return;
         }
 
@@ -419,7 +419,7 @@ void WebExtensionContext::declarativeNetRequestUpdateSessionRules(String&& rules
 
     auto updatedSessionRulesCount = m_sessionRulesIDs.size() + rulesToAdd.count - ruleIDsToDelete.count;
     if (updatedSessionRulesCount + m_dynamicRulesIDs.size() > webExtensionDeclarativeNetRequestMaximumNumberOfDynamicAndSessionRules) {
-        completionHandler(toWebExtensionError(apiName, nil, @"Failed to add session rules. Maximum number of dynamic and session rules exceeded."));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"Failed to add session rules. Maximum number of dynamic and session rules exceeded."));
         return;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsInspectedWindow.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsInspectedWindow.mm
@@ -47,7 +47,7 @@ void WebExtensionContext::devToolsInspectedWindowEval(WebPageProxyIdentifier web
     RefPtr extension = inspectorExtension(webPageProxyIdentifier);
     if (!extension) {
         RELEASE_LOG_ERROR(Extensions, "Inspector extension not found for page %llu", webPageProxyIdentifier.toUInt64());
-        completionHandler(toWebExtensionError(apiName, nil, @"Web Inspector not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"Web Inspector not found"));
         return;
     }
 
@@ -55,20 +55,20 @@ void WebExtensionContext::devToolsInspectedWindowEval(WebPageProxyIdentifier web
 
     RefPtr tab = getTab(webPageProxyIdentifier, std::nullopt, IncludeExtensionViews::Yes);
     if (!tab) {
-        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"tab not found"));
         return;
     }
 
     requestPermissionToAccessURLs({ tab->url() }, tab, [extension, tab, scriptSource, frameURL, completionHandler = WTFMove(completionHandler)](auto&& requestedURLs, auto&& allowedURLs, auto expirationDate) mutable {
         if (!tab->extensionHasPermission()) {
-            completionHandler(toWebExtensionError(apiName, nil, @"this extension does not have access to this tab"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"this extension does not have access to this tab"));
             return;
         }
 
         extension->evaluateScript(scriptSource, frameURL, std::nullopt, std::nullopt, [completionHandler = WTFMove(completionHandler)](Inspector::ExtensionEvaluationResult&& result) mutable {
             if (!result) {
                 RELEASE_LOG_ERROR(Extensions, "Inspector could not evaluate script (%{public}@)", (NSString *)extensionErrorToString(result.error()));
-                completionHandler(toWebExtensionError(apiName, nil, @"Web Inspector could not evaluate script"));
+                completionHandler(toWebExtensionError(apiName, nullString(), @"Web Inspector could not evaluate script"));
                 return;
             }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsPanels.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsPanels.mm
@@ -45,14 +45,14 @@ void WebExtensionContext::devToolsPanelsCreate(WebPageProxyIdentifier webPagePro
     RefPtr extension = inspectorExtension(webPageProxyIdentifier);
     if (!extension) {
         RELEASE_LOG_ERROR(Extensions, "Inspector extension not found for page %llu", webPageProxyIdentifier.toUInt64());
-        completionHandler(toWebExtensionError(apiName, nil, @"Web Inspector not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"Web Inspector not found"));
         return;
     }
 
     extension->createTab(title, { baseURL(), iconPath }, { baseURL(), pagePath }, [completionHandler = WTFMove(completionHandler)](Expected<Inspector::ExtensionTabID, Inspector::ExtensionError>&& result) mutable {
         if (!result) {
             RELEASE_LOG_ERROR(Extensions, "Inspector could not create panel (%{public}@)", (NSString *)extensionErrorToString(result.error()));
-            completionHandler(toWebExtensionError(apiName, nil, @"Web Inspector could not create the panel"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"Web Inspector could not create the panel"));
             return;
         }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIMenusCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIMenusCocoa.mm
@@ -66,17 +66,17 @@ void WebExtensionContext::menusCreate(const WebExtensionMenuItemParameters& para
     static NSString * const apiName = @"menus.create()";
 
     if (m_menuItems.contains(parameters.identifier)) {
-        completionHandler(toWebExtensionError(apiName, nil, @"identifier is already used"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"identifier is already used"));
         return;
     }
 
     if (parameters.parentIdentifier && !m_menuItems.contains(parameters.parentIdentifier.value())) {
-        completionHandler(toWebExtensionError(apiName, nil, @"parent menu item not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"parent menu item not found"));
         return;
     }
 
     if (parameters.parentIdentifier && isAncestorOrSelf(*this, parameters.parentIdentifier.value(), parameters.identifier)) {
-        completionHandler(toWebExtensionError(apiName, nil, @"parent menu item cannot be another ancestor"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"parent menu item cannot be another ancestor"));
         return;
     }
 
@@ -96,7 +96,7 @@ void WebExtensionContext::menusUpdate(const String& identifier, const WebExtensi
 
     RefPtr menuItem = this->menuItem(identifier);
     if (!menuItem) {
-        completionHandler(toWebExtensionError(apiName, nil, @"menu item not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"menu item not found"));
         return;
     }
 
@@ -106,12 +106,12 @@ void WebExtensionContext::menusUpdate(const String& identifier, const WebExtensi
     }
 
     if (parameters.parentIdentifier && !m_menuItems.contains(parameters.parentIdentifier.value())) {
-        completionHandler(toWebExtensionError(apiName, nil, @"parent menu item not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"parent menu item not found"));
         return;
     }
 
     if (parameters.parentIdentifier && isAncestorOrSelf(*this, parameters.parentIdentifier.value(), !parameters.identifier.isEmpty() ? parameters.identifier : identifier)) {
-        completionHandler(toWebExtensionError(apiName, nil, @"parent menu item cannot be itself or another ancestor"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"parent menu item cannot be itself or another ancestor"));
         return;
     }
 
@@ -124,7 +124,7 @@ void WebExtensionContext::menusRemove(const String& identifier, CompletionHandle
 {
     RefPtr menuItem = this->menuItem(identifier);
     if (!menuItem) {
-        completionHandler(toWebExtensionError(@"menus.remove()", nil, @"menu item not found"));
+        completionHandler(toWebExtensionError(@"menus.remove()", nullString(), @"menu item not found"));
         return;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -59,13 +59,13 @@ void WebExtensionContext::runtimeOpenOptionsPage(CompletionHandler<void(Expected
     static NSString * const apiName = @"runtime.openOptionsPage()";
 
     if (!optionsPageURL().isValid()) {
-        completionHandler(toWebExtensionError(apiName, nil, @"no options page is specified in the manifest"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"no options page is specified in the manifest"));
         return;
     }
 
     RefPtr extensionController = this->extensionController();
     if (!extensionController) {
-        completionHandler(toWebExtensionError(apiName, nil, @"No extensionController"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"No extensionController"));
         return;
     }
 
@@ -74,7 +74,7 @@ void WebExtensionContext::runtimeOpenOptionsPage(CompletionHandler<void(Expected
     bool respondsToOpenOptionsPage = [delegate respondsToSelector:@selector(webExtensionController:openOptionsPageForExtensionContext:completionHandler:)];
     bool respondsToOpenNewTab = [delegate respondsToSelector:@selector(webExtensionController:openNewTabUsingConfiguration:forExtensionContext:completionHandler:)];
     if (!respondsToOpenOptionsPage && !respondsToOpenNewTab) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
         return;
     }
 
@@ -82,7 +82,7 @@ void WebExtensionContext::runtimeOpenOptionsPage(CompletionHandler<void(Expected
         [delegate webExtensionController:extensionController->wrapper() openOptionsPageForExtensionContext:wrapper() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
             if (error) {
                 RELEASE_LOG_ERROR(Extensions, "Error opening options page: %{public}@", privacyPreservingDescription(error));
-                completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+                completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
                 return;
             }
 
@@ -106,12 +106,12 @@ void WebExtensionContext::runtimeOpenOptionsPage(CompletionHandler<void(Expected
     [delegate webExtensionController:extensionController->wrapper() openNewTabUsingConfiguration:configuration forExtensionContext:wrapper() completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](id<WKWebExtensionTab> newTab, NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error opening options page in new tab: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
         if (!newTab) {
-            completionHandler(toWebExtensionError(apiName, nil, @"the options page cound not be opened"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"the options page cound not be opened"));
             return;
         }
 
@@ -139,7 +139,7 @@ void WebExtensionContext::runtimeSendMessage(const String& extensionID, const St
         completeSenderParameters.tabParameters = tab->parameters();
     else if (senderParameters.contentWorldType == WebExtensionContentWorldType::ContentScript) {
         RELEASE_LOG_ERROR(Extensions, "Tab not found for message for content script message");
-        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"tab not found"));
         return;
     }
 
@@ -189,7 +189,7 @@ void WebExtensionContext::runtimeConnect(const String& extensionID, WebExtension
         completeSenderParameters.tabParameters = tab->parameters();
     else if (senderParameters.contentWorldType == WebExtensionContentWorldType::ContentScript) {
         RELEASE_LOG_ERROR(Extensions, "Tab not found for message for content script port");
-        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"tab not found"));
         return;
     }
 
@@ -198,7 +198,7 @@ void WebExtensionContext::runtimeConnect(const String& extensionID, WebExtension
     wakeUpBackgroundContentIfNecessaryToFireEvents({ eventType }, [=, this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
         auto mainWorldProcesses = processes(eventType, targetContentWorldType);
         if (mainWorldProcesses.isEmpty()) {
-            completionHandler(toWebExtensionError(apiName, nil, @"no runtime.onConnect listeners found"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"no runtime.onConnect listeners found"));
             return;
         }
 
@@ -246,13 +246,13 @@ void WebExtensionContext::sendNativeMessage(const String& applicationID, id mess
 
         auto *bundle = extension().bundle();
         if (!bundle) {
-            completionHandler(toWebExtensionError(apiName, nil, @"native messaging is not supported"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"native messaging is not supported"));
             return;
         }
 
         if (activeRequestCount >= maximumActiveRequestCount) {
             RELEASE_LOG_INFO(Extensions, "Dropping native message due to too many active native messages");
-            completionHandler(toWebExtensionError(apiName, nil, @"there are too many active native message requests"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"there are too many active native message requests"));
             return;
         }
 
@@ -261,7 +261,7 @@ void WebExtensionContext::sendNativeMessage(const String& applicationID, id mess
         auto *nativeExtension = [NSExtension extensionWithIdentifier:bundle.bundleIdentifier error:&error];
         if (!nativeExtension || error) {
             RELEASE_LOG_ERROR(Extensions, "Error creating NSExtension: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, @"native messaging is not supported"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"native messaging is not supported"));
             return;
         }
 
@@ -273,7 +273,7 @@ void WebExtensionContext::sendNativeMessage(const String& applicationID, id mess
             dispatch_async(dispatch_get_main_queue(), makeBlockPtr([callbackAggregator] {
                 --activeRequestCount;
 
-                callbackAggregator.get()(toWebExtensionError(apiName, nil, @"the native extension canceled the request or encountered an error"));
+                callbackAggregator.get()(toWebExtensionError(apiName, nullString(), @"the native extension canceled the request or encountered an error"));
             }).get());
         }).get();
 
@@ -283,7 +283,7 @@ void WebExtensionContext::sendNativeMessage(const String& applicationID, id mess
             dispatch_async(dispatch_get_main_queue(), makeBlockPtr([callbackAggregator] {
                 --activeRequestCount;
 
-                callbackAggregator.get()(toWebExtensionError(apiName, nil, @"the native extension was interrupted or crashed"));
+                callbackAggregator.get()(toWebExtensionError(apiName, nullString(), @"the native extension was interrupted or crashed"));
             }).get());
 
             // NSExtension does not release the interrupted request and assertions unless we cancel it. See: rdar://80093371
@@ -314,7 +314,7 @@ void WebExtensionContext::sendNativeMessage(const String& applicationID, id mess
             dispatch_async(dispatch_get_main_queue(), makeBlockPtr([callbackAggregator, nativeExtension, requestIdentifier = RetainPtr { requestIdentifier }] {
                 --activeRequestCount;
 
-                callbackAggregator.get()(toWebExtensionError(apiName, nil, @"the native extension encountered an unknown error"));
+                callbackAggregator.get()(toWebExtensionError(apiName, nullString(), @"the native extension encountered an unknown error"));
 
                 // NSExtension does not release the failed request and assertions unless we cancel it. See: rdar://80093371
                 [nativeExtension cancelExtensionRequestWithIdentifier:requestIdentifier.get()];
@@ -328,12 +328,12 @@ void WebExtensionContext::sendNativeMessage(const String& applicationID, id mess
 
     [delegate webExtensionController:extensionController->wrapper() sendMessage:message toApplicationWithIdentifier:applicationIdentifier forExtensionContext:wrapper() replyHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](id replyMessage, NSError *error) mutable {
         if (error) {
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
         if (replyMessage && !isValidJSONObject(replyMessage, JSONOptions::FragmentsAllowed)) {
-            completionHandler(toWebExtensionError(apiName, nil, @"reply message was not JSON-serializable"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"reply message was not JSON-serializable"));
             return;
         }
 
@@ -413,7 +413,7 @@ void WebExtensionContext::runtimeConnectNative(const String& applicationID, WebE
 
     [delegate webExtensionController:extensionController->wrapper() connectUsingMessagePort:nativePort->wrapper() forExtensionContext:wrapper() completionHandler:makeBlockPtr([=, this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] (NSError *error) mutable {
         if (error) {
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
 
             nativePort->disconnect(toWebExtensionMessagePortError(error));
             clearQueuedPortMessages(targetContentWorldType, channelIdentifier);
@@ -533,7 +533,7 @@ void WebExtensionContext::runtimeWebPageConnect(const String& extensionID, WebEx
     wakeUpBackgroundContentIfNecessaryToFireEvents({ eventType }, [=, this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
         auto mainWorldProcesses = processes(eventType, targetContentWorldType);
         if (mainWorldProcesses.isEmpty()) {
-            completionHandler(toWebExtensionError(apiName, nil, @"no runtime.onConnectExternal listeners found"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"no runtime.onConnectExternal listeners found"));
             return;
         }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -68,19 +68,19 @@ void WebExtensionContext::scriptingExecuteScript(const WebExtensionScriptInjecti
 
     RefPtr tab = getTab(parameters.tabIdentifier.value());
     if (!tab) {
-        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"tab not found"));
         return;
     }
 
     requestPermissionToAccessURLs({ tab->url() }, tab, [this, protectedThis = Ref { *this }, tab, parameters, completionHandler = WTFMove(completionHandler)](auto&& requestedURLs, auto&& allowedURLs, auto expirationDate) mutable {
         if (!tab->extensionHasPermission()) {
-            completionHandler(toWebExtensionError(apiName, nil, @"this extension does not have access to this tab"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"this extension does not have access to this tab"));
             return;
         }
 
         auto *webView = tab->webView();
         if (!webView) {
-            completionHandler(toWebExtensionError(apiName, nil, @"could not execute script on this tab"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"could not execute script on this tab"));
             return;
         }
 
@@ -99,19 +99,19 @@ void WebExtensionContext::scriptingInsertCSS(const WebExtensionScriptInjectionPa
 
     RefPtr tab = getTab(parameters.tabIdentifier.value());
     if (!tab) {
-        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"tab not found"));
         return;
     }
 
     requestPermissionToAccessURLs({ tab->url() }, tab, [this, protectedThis = Ref { *this }, tab, parameters, completionHandler = WTFMove(completionHandler)](auto&& requestedURLs, auto&& allowedURLs, auto expirationDate) mutable {
         if (!tab->extensionHasPermission()) {
-            completionHandler(toWebExtensionError(apiName, nil, @"this extension does not have access to this tab"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"this extension does not have access to this tab"));
             return;
         }
 
         auto *webView = tab->webView();
         if (!webView) {
-            completionHandler(toWebExtensionError(apiName, nil, @"could not inject stylesheet on this tab"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"could not inject stylesheet on this tab"));
             return;
         }
 
@@ -136,13 +136,13 @@ void WebExtensionContext::scriptingRemoveCSS(const WebExtensionScriptInjectionPa
 
     RefPtr tab = getTab(parameters.tabIdentifier.value());
     if (!tab) {
-        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"tab not found"));
         return;
     }
 
     auto *webView = tab->webView();
     if (!webView) {
-        completionHandler(toWebExtensionError(apiName, nil, @"could not remove stylesheet from this tab"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"could not remove stylesheet from this tab"));
         return;
     }
 
@@ -165,13 +165,13 @@ void WebExtensionContext::scriptingRegisterContentScripts(const Vector<WebExtens
     DynamicInjectedContentsMap injectedContentsMap;
     NSString *errorMessage;
     if (!createInjectedContentForScripts(scripts, FirstTimeRegistration::Yes, injectedContentsMap, apiName, &errorMessage)) {
-        completionHandler(toWebExtensionError(apiName, nil, errorMessage));
+        completionHandler(toWebExtensionError(apiName, nullString(), errorMessage));
         return;
     }
 
     [registeredContentScriptsStore() addScripts:toWebAPI(scripts) completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, scripts, injectedContentsMap = WTFMove(injectedContentsMap), completionHandler = WTFMove(completionHandler)](NSString *errorMessage) mutable {
         if (errorMessage) {
-            completionHandler(toWebExtensionError(apiName, nil, errorMessage));
+            completionHandler(toWebExtensionError(apiName, nullString(), errorMessage));
             return;
         }
 
@@ -198,7 +198,7 @@ void WebExtensionContext::scriptingUpdateRegisteredScripts(const Vector<WebExten
         auto scriptID = parameters.identifier;
         RefPtr registeredScript = m_registeredScriptsMap.get(scriptID);
         if (!registeredScript) {
-            completionHandler(toWebExtensionError(apiName, nil, @"no existing script with ID '%@'", (NSString *)scriptID));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"no existing script with ID '%@'", (NSString *)scriptID));
             return;
         }
 
@@ -209,14 +209,14 @@ void WebExtensionContext::scriptingUpdateRegisteredScripts(const Vector<WebExten
     NSString *errorMessage;
     DynamicInjectedContentsMap injectedContentsMap;
     if (!createInjectedContentForScripts(updatedParameters, FirstTimeRegistration::No, injectedContentsMap, apiName, &errorMessage)) {
-        completionHandler(toWebExtensionError(apiName, nil, errorMessage));
+        completionHandler(toWebExtensionError(apiName, nullString(), errorMessage));
         return;
     }
 
     auto *scriptsArray = toWebAPI(updatedParameters);
     [registeredContentScriptsStore() updateScripts:scriptsArray completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, scripts = WTFMove(updatedParameters), injectedContentsMap = WTFMove(injectedContentsMap), completionHandler = WTFMove(completionHandler)](NSString *errorMessage) mutable {
         if (errorMessage) {
-            completionHandler(toWebExtensionError(apiName, nil, errorMessage));
+            completionHandler(toWebExtensionError(apiName, nullString(), errorMessage));
             return;
         }
 
@@ -273,14 +273,14 @@ void WebExtensionContext::scriptingUnregisterContentScripts(const Vector<String>
 
     for (auto& scriptID : ids) {
         if (!m_registeredScriptsMap.contains(scriptID)) {
-            completionHandler(toWebExtensionError(apiName, nil, @"no script with ID '%@'", (NSString *)scriptID));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"no script with ID '%@'", (NSString *)scriptID));
             return;
         }
     }
 
     [registeredContentScriptsStore() deleteScriptsWithIDs:createNSArray(ids).get() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, ids, completionHandler = WTFMove(completionHandler)](NSString *errorMessage) mutable {
         if (errorMessage) {
-            completionHandler(toWebExtensionError(apiName, nil, errorMessage));
+            completionHandler(toWebExtensionError(apiName, nullString(), errorMessage));
             return;
         }
 
@@ -349,7 +349,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         auto scriptID = parameters.identifier;
 
         if (firstTimeRegistration == FirstTimeRegistration::Yes && (m_registeredScriptsMap.contains(scriptID) || idsToAdd.contains(scriptID))) {
-            *errorMessage = toErrorString(callingAPIName, nil, @"duplicate ID '%@'", (NSString *)scriptID);
+            *errorMessage = toErrorString(callingAPIName, nullString(), @"duplicate ID '%@'", (NSString *)scriptID);
             return false;
         }
 
@@ -369,7 +369,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
             RefPtr<API::Error> error;
             if (!extension->resourceStringForPath(scriptPath, error)) {
                 recordError(::WebKit::wrapper(*error));
-                *errorMessage = toErrorString(callingAPIName, nil, @"invalid resource '%@'", scriptPath);
+                *errorMessage = toErrorString(callingAPIName, nullString(), @"invalid resource '%@'", scriptPath);
                 return false;
             }
         }
@@ -384,7 +384,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
             RefPtr<API::Error> error;
             if (!extension->resourceStringForPath(styleSheetPath, error)) {
                 recordError(::WebKit::wrapper(*error));
-                *errorMessage = toErrorString(callingAPIName, nil, @"invalid resource '%@'", styleSheetPath);
+                *errorMessage = toErrorString(callingAPIName, nullString(), @"invalid resource '%@'", styleSheetPath);
                 return false;
             }
         }
@@ -393,13 +393,13 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         auto *matchesArray = parameters.matchPatterns ? createNSArray(parameters.matchPatterns.value()).get() : @[ ];
         for (NSString *matchPatternString in matchesArray) {
             if (!matchPatternString.length) {
-                *errorMessage = toErrorString(callingAPIName, nil, @"script with ID '%@' contains an empty match pattern", (NSString *)scriptID);
+                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' contains an empty match pattern", (NSString *)scriptID);
                 return false;
             }
 
             RefPtr matchPattern = WebExtensionMatchPattern::getOrCreate(matchPatternString);
             if (!matchPattern || !matchPattern->isSupported()) {
-                *errorMessage = toErrorString(callingAPIName, nil, @"script with ID '%@' has an invalid match pattern '%@'", (NSString *)scriptID, matchPatternString);
+                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' has an invalid match pattern '%@'", (NSString *)scriptID, matchPatternString);
                 return false;
             }
 
@@ -410,13 +410,13 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         auto *excludeMatchesArray = parameters.excludeMatchPatterns ? createNSArray(parameters.excludeMatchPatterns.value()).get() : @[ ];
         for (NSString *matchPatternString in excludeMatchesArray) {
             if (!matchPatternString.length) {
-                *errorMessage = toErrorString(callingAPIName, nil, @"script with ID '%@' contains an empty exclude match pattern", (NSString *)scriptID);
+                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' contains an empty exclude match pattern", (NSString *)scriptID);
                 return false;
             }
 
             RefPtr matchPattern = WebExtensionMatchPattern::getOrCreate(matchPatternString);
             if (!matchPattern || !matchPattern->isSupported()) {
-                *errorMessage = toErrorString(callingAPIName, nil, @"script with ID '%@' has an invalid exclude match pattern '%@'", (NSString *)scriptID, matchPatternString);
+                *errorMessage = toErrorString(callingAPIName, nullString(), @"script with ID '%@' has an invalid exclude match pattern '%@'", (NSString *)scriptID, matchPatternString);
                 return false;
             }
         }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm
@@ -183,7 +183,7 @@ void WebExtensionContext::sidebarOpen(const std::optional<WebExtensionWindowIden
     static NSString * const apiName = @"open()";
 
     if (!canProgrammaticallyOpenSidebar()) {
-        completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nullString(), @"it is not implemented"));
         return;
     }
 
@@ -194,7 +194,7 @@ void WebExtensionContext::sidebarOpen(const std::optional<WebExtensionWindowIden
         if (RefPtr window = frontmostWindow())
             tab = window->activeTab();
         else {
-            completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nil, @"no windows are open"));
+            completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nullString(), @"no windows are open"));
             return;
         }
     } else {
@@ -216,24 +216,24 @@ void WebExtensionContext::sidebarOpen(const std::optional<WebExtensionWindowIden
         else if (auto window = frontmostWindow())
             tab = window->activeTab();
         else {
-            completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nil, unknownErrorString));
+            completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nullString(), unknownErrorString));
             return;
         }
     }
 
     if (!tab) {
-        completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nil, unknownErrorString));
+        completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nullString(), unknownErrorString));
         return;
     }
 
     std::optional<Ref<WebExtensionSidebar>> sidebar = getOrCreateSidebar(*tab);
     if (!sidebar) {
-        completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nil, unknownErrorString));
+        completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nullString(), unknownErrorString));
         return;
     }
 
     if (!sidebar.value()->isEnabled()) {
-        completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nil, @"the sidebar is not enabled"));
+        completionHandler(toWebExtensionError(scopedAPINameFor(apiName, *this), nullString(), @"the sidebar is not enabled"));
         return;
     }
 
@@ -248,25 +248,25 @@ void WebExtensionContext::sidebarClose(CompletionHandler<void(Expected<void, Web
     static NSString * const apiName = @"sidebarAction.close()";
 
     if (!canProgrammaticallyCloseSidebar()) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
         return;
     }
 
     auto window = frontmostWindow();
     if (!window) {
-        completionHandler(toWebExtensionError(apiName, nil, @"no windows are open"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"no windows are open"));
         return;
     }
 
     auto tab = window->activeTab();
     if (!tab) {
-        completionHandler(toWebExtensionError(apiName, nil, unknownErrorString));
+        completionHandler(toWebExtensionError(apiName, nullString(), unknownErrorString));
         return;
     }
 
     auto maybeSidebar = getOrCreateSidebar(*tab);
     if (!maybeSidebar) {
-        completionHandler(toWebExtensionError(apiName, nil, unknownErrorString));
+        completionHandler(toWebExtensionError(apiName, nullString(), unknownErrorString));
         return;
     }
 
@@ -306,25 +306,25 @@ void WebExtensionContext::sidebarToggle(CompletionHandler<void(Expected<void, We
     static NSString * const apiName = @"sidebarAction.toggle()";
 
     if (!canProgrammaticallyCloseSidebar() || !canProgrammaticallyOpenSidebar()) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
         return;
     }
 
     auto window = frontmostWindow();
     if (!window) {
-        completionHandler(toWebExtensionError(apiName, nil, @"no windows are open"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"no windows are open"));
         return;
     }
 
     auto tab = window->activeTab();
     if (!tab) {
-        completionHandler(toWebExtensionError(apiName, nil, unknownErrorString));
+        completionHandler(toWebExtensionError(apiName, nullString(), unknownErrorString));
         return;
     }
 
     auto maybeSidebar = getOrCreateSidebar(*tab);
     if (!maybeSidebar) {
-        completionHandler(toWebExtensionError(apiName, nil, unknownErrorString));
+        completionHandler(toWebExtensionError(apiName, nullString(), unknownErrorString));
         return;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm
@@ -58,7 +58,7 @@ void WebExtensionContext::storageGet(WebPageProxyIdentifier webPageProxyIdentifi
     auto *storage = storageForType(dataType);
     [storage getValuesForKeys:createNSArray(keys).get() completionHandler:makeBlockPtr([callingAPIName, completionHandler = WTFMove(completionHandler)](NSDictionary<NSString *, NSString *> *values, NSString *errorMessage) mutable {
         if (errorMessage)
-            completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
+            completionHandler(toWebExtensionError(callingAPIName, nullString(), errorMessage));
         else
             completionHandler(String(encodeJSONString(values)));
     }).get()];
@@ -71,7 +71,7 @@ void WebExtensionContext::storageGetKeys(WebPageProxyIdentifier webPageProxyIden
     auto *storage = storageForType(dataType);
     [storage getAllKeys:makeBlockPtr([callingAPIName, completionHandler = WTFMove(completionHandler)](NSArray<NSString *> *keys, NSString *errorMessage) mutable {
         if (errorMessage)
-            completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
+            completionHandler(toWebExtensionError(callingAPIName, nullString(), errorMessage));
         else
             completionHandler(makeVector<String>(keys));
     }).get()];
@@ -84,7 +84,7 @@ void WebExtensionContext::storageGetBytesInUse(WebPageProxyIdentifier webPagePro
     auto *storage = storageForType(dataType);
     [storage getStorageSizeForKeys:createNSArray(keys).get() completionHandler:makeBlockPtr([callingAPIName, completionHandler = WTFMove(completionHandler)](size_t size, NSString *errorMessage) mutable {
         if (errorMessage)
-            completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
+            completionHandler(toWebExtensionError(callingAPIName, nullString(), errorMessage));
         else
             completionHandler(size);
     }).get()];
@@ -98,23 +98,23 @@ void WebExtensionContext::storageSet(WebPageProxyIdentifier webPageProxyIdentifi
 
     [storageForType(dataType) getStorageSizeForAllKeysIncludingKeyedData:data withCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callingAPIName, dataType, retainData = RetainPtr { data }, completionHandler = WTFMove(completionHandler)](size_t size, NSUInteger numberOfKeys, NSDictionary<NSString *, NSString *> *existingKeysAndValues, NSString *errorMessage) mutable {
         if (errorMessage) {
-            completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
+            completionHandler(toWebExtensionError(callingAPIName, nullString(), errorMessage));
             return;
         }
 
         if (size > quotaForStorageType(dataType)) {
-            completionHandler(toWebExtensionError(callingAPIName, nil, @"exceeded storage quota"));
+            completionHandler(toWebExtensionError(callingAPIName, nullString(), @"exceeded storage quota"));
             return;
         }
 
         if (dataType == WebExtensionDataType::Sync && numberOfKeys > webExtensionStorageAreaSyncMaximumItems) {
-            completionHandler(toWebExtensionError(callingAPIName, nil, @"exceeded maximum number of items"));
+            completionHandler(toWebExtensionError(callingAPIName, nullString(), @"exceeded maximum number of items"));
             return;
         }
 
         [storageForType(dataType) setKeyedData:retainData.get() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callingAPIName, retainData, dataType, existingKeysAndValues = RetainPtr { existingKeysAndValues }, completionHandler = WTFMove(completionHandler)](NSArray *keysSuccessfullySet, NSString *errorMessage) mutable {
             if (errorMessage)
-                completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
+                completionHandler(toWebExtensionError(callingAPIName, nullString(), errorMessage));
             else
                 completionHandler({ });
 
@@ -137,13 +137,13 @@ void WebExtensionContext::storageRemove(WebPageProxyIdentifier webPageProxyIdent
 
     [storageForType(dataType) getValuesForKeys:createNSArray(keys).get() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callingAPIName, keys, dataType, completionHandler = WTFMove(completionHandler)](NSDictionary<NSString *, NSString *> *oldValuesAndKeys, NSString *errorMessage) mutable {
         if (errorMessage) {
-            completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
+            completionHandler(toWebExtensionError(callingAPIName, nullString(), errorMessage));
             return;
         }
 
         [storageForType(dataType) deleteValuesForKeys:createNSArray(keys).get() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callingAPIName, dataType, oldValuesAndKeys = RetainPtr { oldValuesAndKeys }, completionHandler = WTFMove(completionHandler)](NSString *errorMessage) mutable {
             if (errorMessage) {
-                completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
+                completionHandler(toWebExtensionError(callingAPIName, nullString(), errorMessage));
                 return;
             }
 
@@ -160,13 +160,13 @@ void WebExtensionContext::storageClear(WebPageProxyIdentifier webPageProxyIdenti
 
     [storageForType(dataType) getValuesForKeys:@[ ] completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callingAPIName, dataType, completionHandler = WTFMove(completionHandler)](NSDictionary<NSString *, NSString *> *oldValuesAndKeys, NSString *errorMessage) mutable {
         if (errorMessage) {
-            completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
+            completionHandler(toWebExtensionError(callingAPIName, nullString(), errorMessage));
             return;
         }
 
         [storageForType(dataType) deleteDatabaseWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callingAPIName, oldValuesAndKeys = RetainPtr { oldValuesAndKeys }, dataType, completionHandler = WTFMove(completionHandler)](NSString *errorMessage) mutable {
             if (errorMessage) {
-                completionHandler(toWebExtensionError(callingAPIName, nil, errorMessage));
+                completionHandler(toWebExtensionError(callingAPIName, nullString(), errorMessage));
                 return;
             }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -65,13 +65,13 @@ void WebExtensionContext::tabsCreate(std::optional<WebPageProxyIdentifier> webPa
 
     RefPtr extensionController = this->extensionController();
     if (!extensionController) {
-        completionHandler(toWebExtensionError(apiName, nil, @"No extensionController"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"No extensionController"));
         return;
     }
 
     auto delegate = extensionController->delegate();
     if (![delegate respondsToSelector:@selector(webExtensionController:openNewTabUsingConfiguration:forExtensionContext:completionHandler:)]) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
         return;
     }
 
@@ -84,7 +84,7 @@ void WebExtensionContext::tabsCreate(std::optional<WebPageProxyIdentifier> webPa
 
     RefPtr window = getWindow(parameters.windowIdentifier.value_or(WebExtensionWindowConstants::CurrentIdentifier), webPageProxyIdentifier);
     if (parameters.windowIdentifier && !window) {
-        completionHandler(toWebExtensionError(apiName, nil, @"window not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"window not found"));
         return;
     }
 
@@ -94,7 +94,7 @@ void WebExtensionContext::tabsCreate(std::optional<WebPageProxyIdentifier> webPa
     if (parameters.parentTabIdentifier) {
         RefPtr tab = getTab(parameters.parentTabIdentifier.value());
         if (!tab) {
-            completionHandler(toWebExtensionError(apiName, nil, @"parent tab not found"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"parent tab not found"));
             return;
         }
 
@@ -107,7 +107,7 @@ void WebExtensionContext::tabsCreate(std::optional<WebPageProxyIdentifier> webPa
     [delegate webExtensionController:extensionController->wrapper() openNewTabUsingConfiguration:configuration forExtensionContext:wrapper() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](id<WKWebExtensionTab> newTab, NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for open new tab: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -134,7 +134,7 @@ void WebExtensionContext::tabsUpdate(WebPageProxyIdentifier webPageProxyIdentifi
 
     RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier, IncludeExtensionViews::Yes);
     if (!tab) {
-        completionHandler(toWebExtensionError(@"tabs.update()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"tabs.update()", nullString(), @"tab not found"));
         return;
     }
 
@@ -254,7 +254,7 @@ void WebExtensionContext::tabsDuplicate(WebExtensionTabIdentifier tabIdentifier,
 {
     RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
-        completionHandler(toWebExtensionError(@"tabs.duplicate()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"tabs.duplicate()", nullString(), @"tab not found"));
         return;
     }
 
@@ -278,7 +278,7 @@ void WebExtensionContext::tabsGet(WebExtensionTabIdentifier tabIdentifier, Compl
 {
     RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
-        completionHandler(toWebExtensionError(@"tabs.get()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"tabs.get()", nullString(), @"tab not found"));
         return;
     }
 
@@ -332,7 +332,7 @@ void WebExtensionContext::tabsReload(WebPageProxyIdentifier webPageProxyIdentifi
 {
     RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier, IncludeExtensionViews::Yes);
     if (!tab) {
-        completionHandler(toWebExtensionError(@"tabs.reload()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"tabs.reload()", nullString(), @"tab not found"));
         return;
     }
 
@@ -343,7 +343,7 @@ void WebExtensionContext::tabsGoBack(WebPageProxyIdentifier webPageProxyIdentifi
 {
     RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier, IncludeExtensionViews::Yes);
     if (!tab) {
-        completionHandler(toWebExtensionError(@"tabs.goBack()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"tabs.goBack()", nullString(), @"tab not found"));
         return;
     }
 
@@ -354,7 +354,7 @@ void WebExtensionContext::tabsGoForward(WebPageProxyIdentifier webPageProxyIdent
 {
     RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier, IncludeExtensionViews::Yes);
     if (!tab) {
-        completionHandler(toWebExtensionError(@"tabs.goForward()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"tabs.goForward()", nullString(), @"tab not found"));
         return;
     }
 
@@ -367,13 +367,13 @@ void WebExtensionContext::tabsDetectLanguage(WebPageProxyIdentifier webPageProxy
 
     RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier, IncludeExtensionViews::Yes);
     if (!tab) {
-        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"tab not found"));
         return;
     }
 
     requestPermissionToAccessURLs({ tab->url() }, tab, [tab, completionHandler = WTFMove(completionHandler)](auto&& requestedURLs, auto&& allowedURLs, auto expirationDate) mutable {
         if (!tab->extensionHasPermission()) {
-            completionHandler(toWebExtensionError(apiName, nil, @"this extension does not have access to this tab"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"this extension does not have access to this tab"));
             return;
         }
 
@@ -404,19 +404,19 @@ void WebExtensionContext::tabsCaptureVisibleTab(WebPageProxyIdentifier webPagePr
 
     RefPtr window = getWindow(windowIdentifier.value_or(WebExtensionWindowConstants::CurrentIdentifier), webPageProxyIdentifier);
     if (!window) {
-        completionHandler(toWebExtensionError(apiName, nil, @"window not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"window not found"));
         return;
     }
 
     RefPtr activeTab = window->activeTab();
     if (!activeTab) {
-        completionHandler(toWebExtensionError(apiName, nil, @"active tab not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"active tab not found"));
         return;
     }
 
     requestPermissionToAccessURLs({ activeTab->url() }, activeTab, [activeTab, imageFormat, imageQuality, completionHandler = WTFMove(completionHandler)](auto&& requestedURLs, auto&& allowedURLs, auto expirationDate) mutable {
         if (!activeTab->extensionHasPermission()) {
-            completionHandler(toWebExtensionError(apiName, nil, @"either the 'activeTab' permission or granted host permissions for the current website are required"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"either the 'activeTab' permission or granted host permissions for the current website are required"));
             return;
         }
 
@@ -451,7 +451,7 @@ void WebExtensionContext::tabsToggleReaderMode(WebPageProxyIdentifier webPagePro
 {
     RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier, IncludeExtensionViews::Yes);
     if (!tab) {
-        completionHandler(toWebExtensionError(@"tabs.toggleReaderMode()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"tabs.toggleReaderMode()", nullString(), @"tab not found"));
         return;
     }
 
@@ -464,7 +464,7 @@ void WebExtensionContext::tabsSendMessage(WebExtensionTabIdentifier tabIdentifie
 
     RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
-        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"tab not found"));
         return;
     }
 
@@ -490,7 +490,7 @@ void WebExtensionContext::tabsConnect(WebExtensionTabIdentifier tabIdentifier, W
 
     RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
-        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"tab not found"));
         return;
     }
 
@@ -502,7 +502,7 @@ void WebExtensionContext::tabsConnect(WebExtensionTabIdentifier tabIdentifier, W
 
     auto processes = tab->processes(WebExtensionEventListenerType::RuntimeOnConnect, targetContentWorldType);
     if (processes.isEmpty()) {
-        completionHandler(toWebExtensionError(apiName, nil, @"no runtime.onConnect listeners found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"no runtime.onConnect listeners found"));
         return;
     }
 
@@ -529,7 +529,7 @@ void WebExtensionContext::tabsGetZoom(WebPageProxyIdentifier webPageProxyIdentif
 {
     RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier, IncludeExtensionViews::Yes);
     if (!tab) {
-        completionHandler(toWebExtensionError(@"tabs.getZoom()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"tabs.getZoom()", nullString(), @"tab not found"));
         return;
     }
 
@@ -540,7 +540,7 @@ void WebExtensionContext::tabsSetZoom(WebPageProxyIdentifier webPageProxyIdentif
 {
     RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier, IncludeExtensionViews::Yes);
     if (!tab) {
-        completionHandler(toWebExtensionError(@"tabs.setZoom()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"tabs.setZoom()", nullString(), @"tab not found"));
         return;
     }
 
@@ -552,7 +552,7 @@ void WebExtensionContext::tabsRemove(Vector<WebExtensionTabIdentifier> tabIdenti
     auto tabs = tabIdentifiers.map([&](auto& tabIdentifier) -> RefPtr<WebExtensionTab> {
         RefPtr tab = getTab(tabIdentifier);
         if (!tab) {
-            completionHandler(toWebExtensionError(@"tabs.remove()", nil, @"tab '%llu' was not found", tabIdentifier.toUInt64()));
+            completionHandler(toWebExtensionError(@"tabs.remove()", nullString(), @"tab '%llu' was not found", tabIdentifier.toUInt64()));
             return nullptr;
         }
 
@@ -580,19 +580,19 @@ void WebExtensionContext::tabsExecuteScript(WebPageProxyIdentifier webPageProxyI
 
     RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier, IncludeExtensionViews::Yes);
     if (!tab) {
-        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"tab not found"));
         return;
     }
 
     requestPermissionToAccessURLs({ tab->url() }, tab, [this, protectedThis = Ref { *this }, tab, parameters, completionHandler = WTFMove(completionHandler)](auto&& requestedURLs, auto&& allowedURLs, auto expirationDate) mutable {
         if (!tab->extensionHasPermission()) {
-            completionHandler(toWebExtensionError(apiName, nil, @"this extension does not have access to this tab"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"this extension does not have access to this tab"));
             return;
         }
 
         auto *webView = tab->webView();
         if (!webView) {
-            completionHandler(toWebExtensionError(apiName, nil, @"could not execute script in tab"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"could not execute script in tab"));
             return;
         }
 
@@ -603,7 +603,7 @@ void WebExtensionContext::tabsExecuteScript(WebPageProxyIdentifier webPageProxyI
             NSString *filePath = parameters.files.value().first();
             scriptData = sourcePairForResource(filePath, *this);
             if (!scriptData) {
-                completionHandler(toWebExtensionError(apiName, nil, @"Invalid resource: %@", filePath));
+                completionHandler(toWebExtensionError(apiName, nullString(), @"Invalid resource: %@", filePath));
                 return;
             }
         }
@@ -621,19 +621,19 @@ void WebExtensionContext::tabsInsertCSS(WebPageProxyIdentifier webPageProxyIdent
 
     RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier, IncludeExtensionViews::Yes);
     if (!tab) {
-        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"tab not found"));
         return;
     }
 
     requestPermissionToAccessURLs({ tab->url() }, tab, [this, protectedThis = Ref { *this }, tab, parameters, completionHandler = WTFMove(completionHandler)](auto&& requestedURLs, auto&& allowedURLs, auto expirationDate) mutable {
         if (!tab->extensionHasPermission()) {
-            completionHandler(toWebExtensionError(apiName, nil, @"this extension does not have access to this tab"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"this extension does not have access to this tab"));
             return;
         }
 
         auto *webView = tab->webView();
         if (!webView) {
-            completionHandler(toWebExtensionError(apiName, nil, @"could not inject stylesheet on this tab"));
+            completionHandler(toWebExtensionError(apiName, nullString(), @"could not inject stylesheet on this tab"));
             return;
         }
 
@@ -653,13 +653,13 @@ void WebExtensionContext::tabsRemoveCSS(WebPageProxyIdentifier webPageProxyIdent
 
     RefPtr tab = getTab(webPageProxyIdentifier, tabIdentifier, IncludeExtensionViews::Yes);
     if (!tab) {
-        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"tab not found"));
         return;
     }
 
     auto *webView = tab->webView();
     if (!webView) {
-        completionHandler(toWebExtensionError(apiName, nil, @"could not remove stylesheet on this tab"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"could not remove stylesheet on this tab"));
         return;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm
@@ -88,27 +88,27 @@ void WebExtensionContext::webNavigationGetFrame(WebExtensionTabIdentifier tabIde
 {
     RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
-        completionHandler(toWebExtensionError(@"webNavigation.getFrame()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"webNavigation.getFrame()", nullString(), @"tab not found"));
         return;
     }
 
     auto *webView = tab->webView();
     if (!webView) {
-        completionHandler(toWebExtensionError(@"webNavigation.getFrame()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"webNavigation.getFrame()", nullString(), @"tab not found"));
         return;
     }
 
     [webView _frames:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), tab, frameIdentifier](_WKFrameTreeNode *mainFrame) mutable {
         if (!mainFrame.info.isMainFrame) {
             RELEASE_LOG_INFO(Extensions, "Skipping frame traversal because the mainFrame is nil");
-            completionHandler(toWebExtensionError(@"webNavigation.getFrame()", nil, @"main frame not found"));
+            completionHandler(toWebExtensionError(@"webNavigation.getFrame()", nullString(), @"main frame not found"));
             return;
         }
 
         if (auto frameParameters = webNavigationFindFrameIdentifierInFrameTree(mainFrame, nil, tab.get(), frameIdentifier))
             completionHandler(WTFMove(frameParameters));
         else
-            completionHandler(toWebExtensionError(@"webNavigation.getFrame()", nil, @"frame not found"));
+            completionHandler(toWebExtensionError(@"webNavigation.getFrame()", nullString(), @"frame not found"));
     }).get()];
 }
 
@@ -116,20 +116,20 @@ void WebExtensionContext::webNavigationGetAllFrames(WebExtensionTabIdentifier ta
 {
     RefPtr tab = getTab(tabIdentifier);
     if (!tab) {
-        completionHandler(toWebExtensionError(@"webNavigation.getAllFrames()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"webNavigation.getAllFrames()", nullString(), @"tab not found"));
         return;
     }
 
     auto *webView = tab->webView();
     if (!webView) {
-        completionHandler(toWebExtensionError(@"webNavigation.getAllFrames()", nil, @"tab not found"));
+        completionHandler(toWebExtensionError(@"webNavigation.getAllFrames()", nullString(), @"tab not found"));
         return;
     }
 
     [webView _frames:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), tab](_WKFrameTreeNode *mainFrame) mutable {
         if (!mainFrame.info.isMainFrame) {
             RELEASE_LOG_INFO(Extensions, "Skipping frame traversal because the mainFrame is nil");
-            completionHandler(toWebExtensionError(@"webNavigation.getAllFrames()", nil, @"main frame not found"));
+            completionHandler(toWebExtensionError(@"webNavigation.getAllFrames()", nullString(), @"main frame not found"));
             return;
         }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
@@ -48,7 +48,7 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
     static NSString * const apiName = @"windows.create()";
 
     if (!canOpenNewWindow()) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
         return;
     }
 
@@ -87,7 +87,7 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
             if (tabParameters.identifier) {
                 RefPtr tab = getTab(tabParameters.identifier.value());
                 if (!tab) {
-                    completionHandler(toWebExtensionError(apiName, nil, @"tab '%llu' was not found", tabParameters.identifier.value().toUInt64()));
+                    completionHandler(toWebExtensionError(apiName, nullString(), @"tab '%llu' was not found", tabParameters.identifier.value().toUInt64()));
                     return;
                 }
 
@@ -102,13 +102,13 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
 
     RefPtr extensionController = this->extensionController();
     if (!extensionController) {
-        completionHandler(toWebExtensionError(apiName, nil, @"No extensionController"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"No extensionController"));
         return;
     }
     [extensionController->delegate() webExtensionController:extensionController->wrapper() openNewWindowUsingConfiguration:configuration forExtensionContext:wrapper() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](id<WKWebExtensionWindow> newWindow, NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for open new window: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -128,12 +128,12 @@ void WebExtensionContext::windowsGet(WebPageProxyIdentifier, WebExtensionWindowI
 
     RefPtr window = getWindow(windowIdentifier);
     if (!window) {
-        completionHandler(toWebExtensionError(apiName, nil, @"window not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"window not found"));
         return;
     }
 
     if (!window->matches(filter)) {
-        completionHandler(toWebExtensionError(apiName, nil, @"window does not match requested 'windowTypes'"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"window does not match requested 'windowTypes'"));
         return;
     }
 
@@ -154,12 +154,12 @@ void WebExtensionContext::windowsGetLastFocused(OptionSet<WindowTypeFilter> filt
 
     RefPtr window = frontmostWindow();
     if (!window) {
-        completionHandler(toWebExtensionError(apiName, nil, @"window not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"window not found"));
         return;
     }
 
     if (!window->matches(filter)) {
-        completionHandler(toWebExtensionError(apiName, nil, @"window does not match requested 'windowTypes'"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"window does not match requested 'windowTypes'"));
         return;
     }
 
@@ -207,7 +207,7 @@ void WebExtensionContext::windowsUpdate(WebExtensionWindowIdentifier windowIdent
 
     RefPtr window = getWindow(windowIdentifier);
     if (!window) {
-        completionHandler(toWebExtensionError(apiName, nil, @"window not found"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"window not found"));
         return;
     }
 
@@ -237,7 +237,7 @@ void WebExtensionContext::windowsUpdate(WebExtensionWindowIdentifier windowIdent
 
         CGRect currentFrame = window.frame();
         if (CGRectIsNull(currentFrame)) {
-            stepCompletionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'top', 'left', 'width', and 'height'"));
+            stepCompletionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented for 'top', 'left', 'width', and 'height'"));
             return;
         }
 
@@ -255,7 +255,7 @@ void WebExtensionContext::windowsUpdate(WebExtensionWindowIdentifier windowIdent
         // coordinates with the origin in the top-left corner.
         CGRect screenFrame = window.screenFrame();
         if (CGRectIsEmpty(screenFrame)) {
-            stepCompletionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'top', 'left', 'width', and 'height'"));
+            stepCompletionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented for 'top', 'left', 'width', and 'height'"));
             return;
         }
 
@@ -321,7 +321,7 @@ void WebExtensionContext::windowsRemove(WebExtensionWindowIdentifier windowIdent
 {
     RefPtr window = getWindow(windowIdentifier);
     if (!window) {
-        completionHandler(toWebExtensionError(@"windows.remove()", nil, @"window not found"));
+        completionHandler(toWebExtensionError(@"windows.remove()", nullString(), @"window not found"));
         return;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -321,14 +321,14 @@ void WebExtensionTab::setParentTab(RefPtr<WebExtensionTab> parentTab, Completion
     static NSString * const apiName = @"tabs.update()";
 
     if (!isValid() || !m_respondsToSetParentTab) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'openerTabId'"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented for 'openerTabId'"));
         return;
     }
 
     [m_delegate setParentTab:(parentTab ? parentTab->delegate() : nil) forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for setParentTab: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -397,14 +397,14 @@ void WebExtensionTab::setPinned(bool pinned, CompletionHandler<void(Expected<voi
     static NSString * const apiName = @"tabs.update()";
 
     if (!isValid() || !m_respondsToSetPinned) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'pinned' set to `true`"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented for 'pinned' set to `true`"));
         return;
     }
 
     [m_delegate setPinned:pinned forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for pin: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -444,14 +444,14 @@ void WebExtensionTab::setReaderModeActive(bool showReaderMode, CompletionHandler
     static NSString * const apiName = @"tabs.toggleReaderMode()";
 
     if (!isValid() || !m_respondsToSetReaderModeActive) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
         return;
     }
 
     [m_delegate setReaderModeActive:showReaderMode forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for toggleReaderMode: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -480,14 +480,14 @@ void WebExtensionTab::setMuted(bool muted, CompletionHandler<void(Expected<void,
     static NSString * const apiName = @"tabs.update()";
 
     if (!isValid() || !m_respondsToSetMuted) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'muted' set to `true`"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented for 'muted' set to `true`"));
         return;
     }
 
     [m_delegate setMuted:muted forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for mute: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -540,7 +540,7 @@ void WebExtensionTab::setZoomFactor(double zoomFactor, CompletionHandler<void(Ex
     [m_delegate setZoomFactor:zoomFactor forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for setZoomFactor: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -583,14 +583,14 @@ void WebExtensionTab::detectWebpageLocale(CompletionHandler<void(Expected<NSLoca
     static NSString * const apiName = @"tabs.detectLanguage()";
 
     if (!isValid() || !m_respondsToDetectWebpageLocale) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
         return;
     }
 
     [m_delegate detectWebpageLocaleForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSLocale *locale, NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for detectWebpageLocale: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -607,14 +607,14 @@ void WebExtensionTab::captureVisibleWebpage(CompletionHandler<void(Expected<Coco
     WKWebView *webView = delegateIsUnavailable ? this->webView() : nil;
 
     if (delegateIsUnavailable && !webView) {
-        completionHandler(toWebExtensionError(apiName, nil, @"capture is unavailable for this tab"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"capture is unavailable for this tab"));
         return;
     }
 
     auto internalCompletionHandler = makeBlockPtr([completionHandler = WTFMove(completionHandler)](CocoaImage *image, NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for captureVisibleWebpage: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -651,7 +651,7 @@ void WebExtensionTab::loadURL(URL url, CompletionHandler<void(Expected<void, Web
     [m_delegate loadURL:url forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for loadURL: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -672,7 +672,7 @@ void WebExtensionTab::reload(ReloadFromOrigin fromOrigin, CompletionHandler<void
     [m_delegate reloadFromOrigin:(fromOrigin == ReloadFromOrigin::Yes) forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for reload: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -693,7 +693,7 @@ void WebExtensionTab::goBack(CompletionHandler<void(Expected<void, WebExtensionE
     [m_delegate goBackForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for goBack: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -714,7 +714,7 @@ void WebExtensionTab::goForward(CompletionHandler<void(Expected<void, WebExtensi
     [m_delegate goForwardForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for goForward: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -727,14 +727,14 @@ void WebExtensionTab::activate(CompletionHandler<void(Expected<void, WebExtensio
     static NSString * const apiName = @"tabs.update()";
 
     if (!isValid() || !m_respondsToActivate) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'active' set to `true`"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented for 'active' set to `true`"));
         return;
     }
 
     [m_delegate activateForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for activate: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -747,14 +747,14 @@ void WebExtensionTab::setSelected(bool selected, CompletionHandler<void(Expected
     static NSString * const apiName = @"tabs.update()";
 
     if (!isValid() || !m_respondsToSetSelected) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'highlighted' or 'selected' set to `true`"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented for 'highlighted' or 'selected' set to `true`"));
         return;
     }
 
     [m_delegate setSelected:selected forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for select: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -779,13 +779,13 @@ void WebExtensionTab::duplicate(const WebExtensionTabParameters& parameters, Com
     static NSString * const apiName = @"tabs.duplicate()";
 
     if (!isValid() || !m_respondsToDuplicate) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
         return;
     }
 
     RefPtr extensionContext = m_extensionContext.get();
     if (!extensionContext) {
-        completionHandler(toWebExtensionError(apiName, nil, @"No extensionContext"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"No extensionContext"));
         return;
     }
 
@@ -806,7 +806,7 @@ void WebExtensionTab::duplicate(const WebExtensionTabParameters& parameters, Com
     [m_delegate duplicateUsingConfiguration:configuration forWebExtensionContext:extensionContext->wrapper() completionHandler:makeBlockPtr([extensionContext, completionHandler = WTFMove(completionHandler)](id<WKWebExtensionTab> duplicatedTab, NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for duplicate: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -824,14 +824,14 @@ void WebExtensionTab::close(CompletionHandler<void(Expected<void, WebExtensionEr
     static NSString * const apiName = @"tabs.remove()";
 
     if (!isValid() || !m_respondsToClose) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
         return;
     }
 
     [m_delegate closeForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for tab close: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
@@ -307,14 +307,14 @@ void WebExtensionWindow::setState(WebExtensionWindow::State state, CompletionHan
     static NSString * const apiName = @"windows.update()";
 
     if (!isValid() || !m_respondsToSetWindowState || !m_respondsToWindowState) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'state'"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented for 'state'"));
         return;
     }
 
     [m_delegate setWindowState:toAPI(state) forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for setWindowState: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -356,14 +356,14 @@ void WebExtensionWindow::focus(CompletionHandler<void(Expected<void, WebExtensio
     static NSString * const apiName = @"windows.update()";
 
     if (!isValid() || !m_respondsToFocus) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'focused'"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented for 'focused'"));
         return;
     }
 
     [m_delegate focusForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for window focus: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -419,7 +419,7 @@ void WebExtensionWindow::setFrame(CGRect frame, CompletionHandler<void(Expected<
     if (!isValid() || !m_respondsToSetFrame || !m_respondsToFrame)
 #endif
     {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented for 'top', 'left', 'width', and 'height'"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented for 'top', 'left', 'width', and 'height'"));
         return;
     }
 
@@ -430,7 +430,7 @@ void WebExtensionWindow::setFrame(CGRect frame, CompletionHandler<void(Expected<
     [m_delegate setFrame:frame forWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for setFrame: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 
@@ -453,14 +453,14 @@ void WebExtensionWindow::close(CompletionHandler<void(Expected<void, WebExtensio
     static NSString * const apiName = @"windows.remove()";
 
     if (!isValid() || !m_respondsToClose) {
-        completionHandler(toWebExtensionError(apiName, nil, @"it is not implemented"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
         return;
     }
 
     [m_delegate closeForWebExtensionContext:m_extensionContext->wrapper() completionHandler:makeBlockPtr([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for window close: %{public}@", privacyPreservingDescription(error));
-            completionHandler(toWebExtensionError(apiName, nil, error.localizedDescription));
+            completionHandler(toWebExtensionError(apiName, nullString(), error.localizedDescription));
             return;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
@@ -79,7 +79,7 @@ bool WebExtensionAPIAction::parseActionDetails(NSDictionary *details, std::optio
         return false;
 
     if (details[tabIdKey] && details[windowIdKey]) {
-        *outExceptionString = toErrorString(nil, @"details", @"it cannot specify both 'tabId' and 'windowID'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'tabId' and 'windowID'");
         return false;
     }
 
@@ -292,13 +292,13 @@ static NSString *dataURLFromImageData(JSValue *imageData, size_t *outWidth, NSSt
 
     auto *imageDataConstructor = imageData.context[@"ImageData"];
     if (![imageData isInstanceOf:imageDataConstructor]) {
-        *outExceptionString = toErrorString(nil, sourceKey, notImageDataError);
+        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError);
         return nil;
     }
 
     auto *dataObject = imageData[@"data"];
     if (!dataObject.isObject) {
-        *outExceptionString = toErrorString(nil, sourceKey, notImageDataError);
+        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError);
         return nil;
     }
 
@@ -307,7 +307,7 @@ static NSString *dataURLFromImageData(JSValue *imageData, size_t *outWidth, NSSt
 
     auto dataArrayType = JSValueGetTypedArrayType(context, dataObjectRef, nullptr);
     if (dataArrayType != kJSTypedArrayTypeUint8ClampedArray) {
-        *outExceptionString = toErrorString(nil, sourceKey, notImageDataError);
+        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError);
         return nil;
     }
 
@@ -338,7 +338,7 @@ static NSString *dataURLFromImageData(JSValue *imageData, size_t *outWidth, NSSt
     CGColorSpaceRelease(colorSpace);
 
     if (!cgImage) {
-        *outExceptionString = toErrorString(nil, sourceKey, notImageDataError);
+        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError);
         return nil;
     }
 
@@ -355,13 +355,13 @@ static NSString *dataURLFromImageData(JSValue *imageData, size_t *outWidth, NSSt
 #endif
 
     if (!pngData.length) {
-        *outExceptionString = toErrorString(nil, sourceKey, notImageDataError);
+        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError);
         return nil;
     }
 
     auto *base64String = [pngData base64EncodedStringWithOptions:0];
     if (!base64String.length) {
-        *outExceptionString = toErrorString(nil, sourceKey, notImageDataError);
+        *outExceptionString = toErrorString(nullString(), sourceKey, notImageDataError);
         return nil;
     }
 
@@ -414,7 +414,7 @@ NSMutableDictionary *WebExtensionAPIAction::parseIconPathsDictionary(NSDictionar
 
         if (!isValidDimensionKey(key)) {
             if (outExceptionString)
-                *outExceptionString = toErrorString(nullptr, inputKey, @"'%@' is not a valid dimension", key);
+                *outExceptionString = toErrorString(nullString(), inputKey, @"'%@' is not a valid dimension", key);
             return nil;
         }
 
@@ -440,7 +440,7 @@ NSMutableDictionary *WebExtensionAPIAction::parseIconImageDataDictionary(NSDicti
 
         if (!isValidDimensionKey(key)) {
             if (outExceptionString)
-                *outExceptionString = toErrorString(nullptr, inputKey, @"'%@' is not a valid dimension", key);
+                *outExceptionString = toErrorString(nullString(), inputKey, @"'%@' is not a valid dimension", key);
             return nil;
         }
 
@@ -488,7 +488,7 @@ NSArray *WebExtensionAPIAction::parseIconVariants(NSArray *input, const URL& bas
 
             if (![colorSchemes containsObject:lightKey] && ![colorSchemes containsObject:darkKey]) {
                 if (!firstExceptionString)
-                    firstExceptionString = toErrorString(nil, colorSchemesCompositeKey, @"it must specify either 'light' or 'dark'");
+                    firstExceptionString = toErrorString(nullString(), colorSchemesCompositeKey, @"it must specify either 'light' or 'dark'");
                 continue;
             }
 
@@ -503,7 +503,7 @@ NSArray *WebExtensionAPIAction::parseIconVariants(NSArray *input, const URL& bas
         // An exception is only set if no valid icon variants were found,
         // maintaining flexibility for future support of different inputs.
         if (!firstExceptionString)
-            firstExceptionString = toErrorString(nil, inputKey, @"it didn't contain any valid icon variants");
+            firstExceptionString = toErrorString(nullString(), inputKey, @"it didn't contain any valid icon variants");
         if (outExceptionString)
             *outExceptionString = firstExceptionString;
         return nil;
@@ -535,7 +535,7 @@ void WebExtensionAPIAction::setIcon(WebFrame& frame, NSDictionary *details, Ref<
         return;
 
     if (details[pathKey] && details[imageDataKey]) {
-        *outExceptionString = toErrorString(nil, @"details", @"it cannot specify both 'path' and 'imageData'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'path' and 'imageData'");
         return;
     }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
@@ -85,7 +85,7 @@ void WebExtensionAPIAlarms::createAlarm(NSString *name, NSDictionary *alarmInfo,
     auto *periodNumber = objectForKey<NSNumber>(alarmInfo, periodInMinutesKey);
 
     if (whenNumber && delayNumber) {
-        *outExceptionString = toErrorString(nil, @"info", @"it cannot specify both 'delayInMinutes' and 'when'");
+        *outExceptionString = toErrorString(nullString(), @"info", @"it cannot specify both 'delayInMinutes' and 'when'");
         return;
     }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
@@ -165,20 +165,20 @@ std::optional<WebExtensionAPICookies::ParsedDetails> WebExtensionAPICookies::par
 
     String name = details[nameKey];
     if (!name.isNull() && name.isEmpty()) {
-        *outExceptionString = toErrorString(nil, nameKey, @"it must not be empty");
+        *outExceptionString = toErrorString(nullString(), nameKey, @"it must not be empty");
         return std::nullopt;
     }
 
     URL url;
     if (NSString *urlString = details[urlKey]) {
         if (!urlString.length) {
-            *outExceptionString = toErrorString(nil, urlKey, @"it must not be empty");
+            *outExceptionString = toErrorString(nullString(), urlKey, @"it must not be empty");
             return std::nullopt;
         }
 
         url = URL { urlString };
         if (!url.isValid()) {
-            *outExceptionString = toErrorString(nil, urlKey, @"'%@' is not a valid URL", urlString);
+            *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid URL", urlString);
             return std::nullopt;
         }
     }
@@ -186,13 +186,13 @@ std::optional<WebExtensionAPICookies::ParsedDetails> WebExtensionAPICookies::par
     std::optional<PAL::SessionID> sessionID;
     if (NSString *storeID = details[storeIdKey]) {
         if (!storeID.length) {
-            *outExceptionString = toErrorString(nil, storeIdKey, @"it must not be empty");
+            *outExceptionString = toErrorString(nullString(), storeIdKey, @"it must not be empty");
             return std::nullopt;
         }
 
         sessionID = toImpl(storeID);
         if (!sessionID) {
-            *outExceptionString = toErrorString(nil, storeIdKey, @"'%@' is not a valid cookie store identifier", storeID);
+            *outExceptionString = toErrorString(nullString(), storeIdKey, @"'%@' is not a valid cookie store identifier", storeID);
             return std::nullopt;
         }
     }
@@ -329,7 +329,7 @@ void WebExtensionAPICookies::set(NSDictionary *details, Ref<WebExtensionCallback
         else if ([sameSiteString isEqualToString:strictKey])
             cookie.sameSite = WebCore::Cookie::SameSitePolicy::Strict;
         else {
-            *outExceptionString = toErrorString(nil, sameSiteKey, @"it must specify either 'no_restriction', 'lax', or 'strict'");
+            *outExceptionString = toErrorString(nullString(), sameSiteKey, @"it must specify either 'no_restriction', 'lax', or 'strict'");
             return;
         }
     }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
@@ -111,7 +111,7 @@ void WebExtensionAPIDeclarativeNetRequest::updateDynamicRules(NSDictionary *opti
     for (NSDictionary *ruleDictionary in rulesToAdd) {
         if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary errorString:&ruleErrorString]) {
             ASSERT(ruleErrorString);
-            *outExceptionString = toErrorString(nil, addRulesKey, @"an error with rule at index %lu: %@", index, ruleErrorString);
+            *outExceptionString = toErrorString(nullString(), addRulesKey, @"an error with rule at index %lu: %@", index, ruleErrorString);
             return;
         }
 
@@ -167,7 +167,7 @@ void WebExtensionAPIDeclarativeNetRequest::updateSessionRules(NSDictionary *opti
     for (NSDictionary *ruleDictionary in rulesToAdd) {
         if (![[_WKWebExtensionDeclarativeNetRequestRule  alloc] initWithDictionary:ruleDictionary errorString:&ruleErrorString]) {
             ASSERT(ruleErrorString);
-            *outExceptionString = toErrorString(nil, addRulesKey, @"an error with rule at index %lu: %@", index, ruleErrorString);
+            *outExceptionString = toErrorString(nullString(), addRulesKey, @"an error with rule at index %lu: %@", index, ruleErrorString);
             return;
         }
 
@@ -227,7 +227,7 @@ void WebExtensionAPIDeclarativeNetRequest::getMatchedRules(NSDictionary *filter,
     bool hasActiveTabPermission = extensionContext().hasPermission("activeTab"_s);
 
     if (!hasFeedbackPermission && !hasActiveTabPermission) {
-        *outExceptionString = toErrorString(nil, nil, @"either the 'declarativeNetRequestFeedback' or 'activeTab' permission is required");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"either the 'declarativeNetRequestFeedback' or 'activeTab' permission is required");
         return;
     }
 
@@ -247,7 +247,7 @@ void WebExtensionAPIDeclarativeNetRequest::getMatchedRules(NSDictionary *filter,
     NSNumber *tabID = objectForKey<NSNumber>(filter, getMatchedRulesTabIDKey);
     auto optionalTabIdentifier = tabID ? toWebExtensionTabIdentifier(tabID.doubleValue) : std::nullopt;
     if (tabID && !isValid(optionalTabIdentifier)) {
-        *outExceptionString = toErrorString(nil, getMatchedRulesTabIDKey, @"%@ is not a valid tab identifier", tabID);
+        *outExceptionString = toErrorString(nullString(), getMatchedRulesTabIDKey, @"%@ is not a valid tab identifier", tabID);
         return;
     }
 
@@ -306,7 +306,7 @@ void WebExtensionAPIDeclarativeNetRequest::setExtensionActionOptions(NSDictionar
         NSNumber *tabID = objectForKey<NSNumber>(tabUpdateDictionary, actionCountTabIDKey);
         auto tabIdentifier = toWebExtensionTabIdentifier(tabID.doubleValue);
         if (!isValid(tabIdentifier)) {
-            *outExceptionString = toErrorString(nil, actionCountTabIDKey, @"%@ is not a valid tab identifier", tabID);
+            *outExceptionString = toErrorString(nullString(), actionCountTabIDKey, @"%@ is not a valid tab identifier", tabID);
             return;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
@@ -67,7 +67,7 @@ void WebExtensionAPIDevToolsInspectedWindow::eval(WebPageProxyIdentifier webPage
         frameURL = URL { url };
 
         if (!frameURL.value().isValid()) {
-            *outExceptionString = toErrorString(nil, frameURLKey, @"'%@' is not a valid URL", url);
+            *outExceptionString = toErrorString(nullString(), frameURLKey, @"'%@' is not a valid URL", url);
             return;
         }
     }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
@@ -66,7 +66,7 @@ bool WebExtensionAPIExtension::parseViewFilters(NSDictionary *filter, std::optio
         else if ([typeString isEqualToString:tabKey])
             viewType = ViewType::Tab;
         else {
-            *outExceptionString = toErrorString(nil, typeKey, @"it must specify either 'popup' or 'tab'");
+            *outExceptionString = toErrorString(nullString(), typeKey, @"it must specify either 'popup' or 'tab'");
             return false;
         }
     }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -143,7 +143,7 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
         else if ([type isEqualToString:separatorKey])
             parameters.type = WebExtensionMenuItemType::Separator;
         else {
-            *outExceptionString = toErrorString(nil, typeKey, @"it must specify either 'normal', 'checkbox', 'radio', or 'separator'");
+            *outExceptionString = toErrorString(nullString(), typeKey, @"it must specify either 'normal', 'checkbox', 'radio', or 'separator'");
             return false;
         }
     }
@@ -178,12 +178,12 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
             }
 
             if ([context isEqualToString:@"action"] && !extensionContext().supportsManifestVersion(3)) {
-                *outExceptionString = toErrorString(nil, contextsKey, @"'%@' is not a valid context", context);
+                *outExceptionString = toErrorString(nullString(), contextsKey, @"'%@' is not a valid context", context);
                 return false;
             }
 
             if (([context isEqualToString:@"browser_action"] || [context isEqualToString:@"page_action"]) && extensionContext().supportsManifestVersion(3)) {
-                *outExceptionString = toErrorString(nil, contextsKey, @"'%@' is not a valid context", context);
+                *outExceptionString = toErrorString(nullString(), contextsKey, @"'%@' is not a valid context", context);
                 return false;
             }
 
@@ -195,7 +195,7 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
         for (NSString *patternString in documentPatterns) {
             auto pattern = WebExtensionMatchPattern::getOrCreate(patternString);
             if (!pattern || !pattern->isSupported()) {
-                *outExceptionString = toErrorString(nil, documentURLPatternsKey, @"'%@' is not a valid pattern", patternString);
+                *outExceptionString = toErrorString(nullString(), documentURLPatternsKey, @"'%@' is not a valid pattern", patternString);
                 return false;
             }
         }
@@ -209,7 +209,7 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
 
             // Any valid pattern is allowed, not just supported schemes.
             if (!pattern || !pattern->isValid()) {
-                *outExceptionString = toErrorString(nil, targetURLPatternsKey, @"'%@' is not a valid pattern", patternString);
+                *outExceptionString = toErrorString(nullString(), targetURLPatternsKey, @"'%@' is not a valid pattern", patternString);
                 return false;
             }
         }
@@ -219,7 +219,7 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
 
     if (NSString *identifier = objectForKey<NSString>(properties, idKey, false)) {
         if (!identifier.length) {
-            *outExceptionString = toErrorString(nil, idKey, @"it must not be empty");
+            *outExceptionString = toErrorString(nullString(), idKey, @"it must not be empty");
             return false;
         }
 
@@ -229,7 +229,7 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
 
     if (NSString *parentIdentifier = objectForKey<NSString>(properties, parentIdKey, false)) {
         if (!parentIdentifier.length) {
-            *outExceptionString = toErrorString(nil, parentIdKey, @"it must not be empty");
+            *outExceptionString = toErrorString(nullString(), parentIdKey, @"it must not be empty");
             return false;
         }
 
@@ -239,7 +239,7 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
 
     if (NSString *title = properties[titleKey]) {
         if (!title.length && parameters.type != WebExtensionMenuItemType::Separator) {
-            *outExceptionString = toErrorString(nil, titleKey, @"it must not be empty");
+            *outExceptionString = toErrorString(nullString(), titleKey, @"it must not be empty");
             return false;
         }
 
@@ -248,7 +248,7 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
 
     if (JSValue *clickCallback = properties[onclickKey]) {
         if (!clickCallback._isFunction) {
-            *outExceptionString = toErrorString(nil, onclickKey, @"it must be a function");
+            *outExceptionString = toErrorString(nullString(), onclickKey, @"it must be a function");
             return false;
         }
 
@@ -293,7 +293,7 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
 
     if (NSString *command = properties[commandKey]) {
         if (!command.length) {
-            *outExceptionString = toErrorString(nil, commandKey, @"it must not be empty");
+            *outExceptionString = toErrorString(nullString(), commandKey, @"it must not be empty");
             return false;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -93,20 +93,20 @@ void WebExtensionAPIPermissions::request(NSDictionary *details, Ref<WebExtension
 
     if (!validatePermissionsDetails(permissions, origins, matchPatterns, apiName, &errorMessage)) {
         // Chrome reports this error as callback error and not an exception, so do the same.
-        callback->reportError(toErrorString(apiName, nil, errorMessage));
+        callback->reportError(toErrorString(apiName, nullString(), errorMessage));
         return;
     }
 
     if (!WebCore::UserGestureIndicator::processingUserGesture()) {
         // Chrome reports this error as callback error and not an exception, so do the same.
-        callback->reportError(toErrorString(apiName, nil, @"must be called during a user gesture"));
+        callback->reportError(toErrorString(apiName, nullString(), @"must be called during a user gesture"));
         return;
     }
 
     if (!verifyRequestedPermissions(permissions, matchPatterns, apiName, &errorMessage)) {
         // Chrome reports these errors as callback errors and not exceptions, so do the same. Instead of round tripping
         // to the UI process, we can answer this here and report the error right away.
-        callback->reportError(toErrorString(apiName, nil, errorMessage));
+        callback->reportError(toErrorString(apiName, nullString(), errorMessage));
         return;
     }
 
@@ -129,13 +129,13 @@ void WebExtensionAPIPermissions::remove(NSDictionary *details, Ref<WebExtensionC
     WebExtension::MatchPatternSet matchPatterns;
     if (!validatePermissionsDetails(permissions, origins, matchPatterns, apiName, &errorMessage)) {
         // Chrome reports this error as callback error and not an exception, so do the same.
-        callback->reportError(toErrorString(apiName, nil, errorMessage));
+        callback->reportError(toErrorString(apiName, nullString(), errorMessage));
         return;
     }
 
     if (!verifyRequestedPermissions(permissions, matchPatterns, apiName, &errorMessage)) {
         // Chrome reports this error as callback error and not an exception, so do the same.
-        callback->reportError(toErrorString(apiName, nil, errorMessage));
+        callback->reportError(toErrorString(apiName, nullString(), errorMessage));
         return;
     }
 
@@ -171,14 +171,14 @@ bool WebExtensionAPIPermissions::verifyRequestedPermissions(HashSet<String>& per
 
     if ([callingAPIName isEqualToString:@"permissions.remove()"]) {
         if (bool requestingToRemoveFunctionalPermissions = permissions.size() && permissions.intersectionWith(allowedPermissions).size()) {
-            *outExceptionString = toErrorString(nil, permissionsKey, @"required permissions cannot be removed");
+            *outExceptionString = toErrorString(nullString(), permissionsKey, @"required permissions cannot be removed");
             return false;
         }
 
         for (auto& requestedPattern : matchPatterns) {
             for (auto& allowedPattern : allowedHostPermissions) {
                 if (allowedPattern->matchesPattern(requestedPattern, { WebExtensionMatchPattern::Options::IgnorePaths })) {
-                    *outExceptionString = toErrorString(nil, originsKey, @"required permissions cannot be removed");
+                    *outExceptionString = toErrorString(nullString(), originsKey, @"required permissions cannot be removed");
                     return false;
                 }
             }
@@ -191,9 +191,9 @@ bool WebExtensionAPIPermissions::verifyRequestedPermissions(HashSet<String>& per
     bool requestingPermissionsNotDeclaredInManifest = (permissions.size() && !permissions.isSubset(allowedPermissions)) || (matchPatterns.size() && !allowedHostPermissions.size());
     if (requestingPermissionsNotDeclaredInManifest) {
         if ([callingAPIName isEqualToString:@"permissions.remove()"])
-            *outExceptionString = toErrorString(nil, permissionsKey, @"only permissions specified in the manifest may be removed");
+            *outExceptionString = toErrorString(nullString(), permissionsKey, @"only permissions specified in the manifest may be removed");
         else
-            *outExceptionString = toErrorString(nil, permissionsKey, @"only permissions specified in the manifest may be requested");
+            *outExceptionString = toErrorString(nullString(), permissionsKey, @"only permissions specified in the manifest may be requested");
         return false;
     }
 
@@ -208,9 +208,9 @@ bool WebExtensionAPIPermissions::verifyRequestedPermissions(HashSet<String>& per
 
         if (!matchFound) {
             if ([callingAPIName isEqualToString:@"permissions.remove()"])
-                *outExceptionString = toErrorString(nil, originsKey, @"only permissions specified in the manifest may be removed");
+                *outExceptionString = toErrorString(nullString(), originsKey, @"only permissions specified in the manifest may be removed");
             else
-                *outExceptionString = toErrorString(nil, originsKey, @"only permissions specified in the manifest may be requested");
+                *outExceptionString = toErrorString(nullString(), originsKey, @"only permissions specified in the manifest may be requested");
             return false;
         }
     }
@@ -222,7 +222,7 @@ bool WebExtensionAPIPermissions::validatePermissionsDetails(HashSet<String>& per
 {
     for (auto& permission : permissions) {
         if (!WebExtension::supportedPermissions().contains(permission)) {
-            *outExceptionString = toErrorString(nil, permissionsKey, @"'%@' is not a valid permission", (NSString *)permission);
+            *outExceptionString = toErrorString(nullString(), permissionsKey, @"'%@' is not a valid permission", (NSString *)permission);
             return false;
         }
     }
@@ -230,7 +230,7 @@ bool WebExtensionAPIPermissions::validatePermissionsDetails(HashSet<String>& per
     for (auto& origin : origins) {
         auto pattern = WebExtensionMatchPattern::getOrCreate(origin);
         if (!pattern || !pattern->isSupported()) {
-            *outExceptionString = toErrorString(nil, originsKey, @"'%@' is not a valid pattern", (NSString *)origin);
+            *outExceptionString = toErrorString(nullString(), originsKey, @"'%@' is not a valid pattern", (NSString *)origin);
             return false;
         }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
@@ -126,12 +126,12 @@ void WebExtensionAPIPort::postMessage(WebFrame& frame, NSString *message, NSStri
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port#postmessage
 
     if (isDisconnected()) {
-        *outExceptionString = toErrorString(nil, nil, @"the port is disconnected");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"the port is disconnected");
         return;
     }
 
     if (message.length > webExtensionMaxMessageLength) {
-        *outExceptionString = toErrorString(nil, @"message", @"it exceeded the maximum allowed length");
+        *outExceptionString = toErrorString(nullString(), @"message", @"it exceeded the maximum allowed length");
         return;
     }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -304,13 +304,13 @@ void WebExtensionAPIRuntime::sendMessage(WebPageProxyIdentifier webPageProxyIden
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage
 
     if (messageJSON.length > webExtensionMaxMessageLength) {
-        *outExceptionString = toErrorString(nil, @"message", @"it exceeded the maximum allowed length");
+        *outExceptionString = toErrorString(nullString(), @"message", @"it exceeded the maximum allowed length");
         return;
     }
 
     auto documentIdentifier = toDocumentIdentifier(frame);
     if (!documentIdentifier) {
-        *outExceptionString = toErrorString(nil, nil, @"an unexpected error occured");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"an unexpected error occured");
         return;
     }
 
@@ -342,7 +342,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPIRuntime::connect(WebPageProxyIdentifi
 
     auto documentIdentifier = toDocumentIdentifier(frame);
     if (!documentIdentifier) {
-        *outExceptionString = toErrorString(nil, nil, @"an unexpected error occured");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"an unexpected error occured");
         return nullptr;
     }
 
@@ -411,13 +411,13 @@ void WebExtensionAPIWebPageRuntime::sendMessage(WebPage& page, WebFrame& frame, 
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage
 
     if (messageJSON.length > webExtensionMaxMessageLength) {
-        *outExceptionString = toErrorString(nil, @"message", @"it exceeded the maximum allowed length");
+        *outExceptionString = toErrorString(nullString(), @"message", @"it exceeded the maximum allowed length");
         return;
     }
 
     auto documentIdentifier = toDocumentIdentifier(frame);
     if (!documentIdentifier) {
-        *outExceptionString = toErrorString(nil, nil, @"an unexpected error occured");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"an unexpected error occured");
         return;
     }
 
@@ -461,7 +461,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPIWebPageRuntime::connect(WebPage& page
 
     auto documentIdentifier = toDocumentIdentifier(frame);
     if (!documentIdentifier) {
-        *outExceptionString = toErrorString(nil, nil, @"an unexpected error occured");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"an unexpected error occured");
         return nullptr;
     }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
@@ -305,7 +305,7 @@ bool WebExtensionAPIScripting::parseStyleLevel(NSDictionary *script, NSString *k
 {
     if (NSString *cssOrigin = objectForKey<NSString>(script, key).lowercaseString) {
         if (![cssOrigin isEqualToString:userValue] && ![cssOrigin isEqualToString:authorValue]) {
-            *outExceptionString = toErrorString(nil, key, @"it must specify either 'author' or 'user'");
+            *outExceptionString = toErrorString(nullString(), key, @"it must specify either 'author' or 'user'");
             return false;
         }
 
@@ -320,7 +320,7 @@ bool WebExtensionAPIScripting::parseExecutionWorld(NSDictionary *script, std::op
 {
     if (NSString *world = objectForKey<NSString>(script, worldKey).lowercaseString) {
         if (![world isEqualToString:isolatedWorld] && ![world isEqualToString:mainWorld]) {
-            *outExceptionString = toErrorString(nil, worldKey, @"it must specify either 'isolated' or 'main'");
+            *outExceptionString = toErrorString(nullString(), worldKey, @"it must specify either 'isolated' or 'main'");
             return false;
         }
 
@@ -352,24 +352,24 @@ bool WebExtensionAPIScripting::parseTargetInjectionOptions(NSDictionary *targetI
 
     bool allFrames = boolForKey(targetInfo, allFramesKey, false);
     if (allFrames && targetInfo[frameIDsKey]) {
-        *outExceptionString = toErrorString(nil, targetKey, @"it cannot specify both 'allFrames' and 'frameIds'");
+        *outExceptionString = toErrorString(nullString(), targetKey, @"it cannot specify both 'allFrames' and 'frameIds'");
         return false;
     }
 
     if (targetInfo[frameIDsKey] && targetInfo[documentIDsKey]) {
-        *outExceptionString = toErrorString(nil, targetKey, @"it cannot specify both 'frameIds' and 'documentIds'");
+        *outExceptionString = toErrorString(nullString(), targetKey, @"it cannot specify both 'frameIds' and 'documentIds'");
         return false;
     }
 
     if (allFrames && targetInfo[documentIDsKey]) {
-        *outExceptionString = toErrorString(nil, targetKey, @"it cannot specify both 'allFrames' and 'documentIds'");
+        *outExceptionString = toErrorString(nullString(), targetKey, @"it cannot specify both 'allFrames' and 'documentIds'");
         return false;
     }
 
     NSNumber *tabID = targetInfo[tabIDKey];
     auto tabIdentifier = toWebExtensionTabIdentifier(tabID.doubleValue);
     if (!tabIdentifier) {
-        *outExceptionString = toErrorString(nil, tabIDKey, @"'%@' is not a tab identifier", tabID);
+        *outExceptionString = toErrorString(nullString(), tabIDKey, @"'%@' is not a tab identifier", tabID);
         return false;
     }
 
@@ -380,7 +380,7 @@ bool WebExtensionAPIScripting::parseTargetInjectionOptions(NSDictionary *targetI
         for (NSString *documentIdentifier in documentIdentifiers) {
             auto parsedUUID = WTF::UUID::parse(String(documentIdentifier));
             if (!parsedUUID) {
-                *outExceptionString = toErrorString(nil, documentIDsKey, @"'%@' is not a document identifier", documentIdentifier);
+                *outExceptionString = toErrorString(nullString(), documentIDsKey, @"'%@' is not a document identifier", documentIdentifier);
                 return false;
             }
 
@@ -395,7 +395,7 @@ bool WebExtensionAPIScripting::parseTargetInjectionOptions(NSDictionary *targetI
         for (NSNumber *frameID in frameIDs) {
             auto frameIdentifier = toWebExtensionFrameIdentifier(frameID.doubleValue);
             if (!isValid(frameIdentifier)) {
-                *outExceptionString = toErrorString(nil, frameIDsKey, @"'%@' is not a frame identifier", frameID);
+                *outExceptionString = toErrorString(nullString(), frameIDsKey, @"'%@' is not a frame identifier", frameID);
                 return false;
             }
 
@@ -432,37 +432,37 @@ bool WebExtensionAPIScripting::parseScriptInjectionOptions(NSDictionary *script,
         return false;
 
     if (script[functionKey] && script[funcKey]) {
-        *outExceptionString = toErrorString(nil, @"details", @"it cannot specify both 'func' and 'function'. Please use 'func'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'func' and 'function'. Please use 'func'");
         return false;
     }
 
     if (script[argumentsKey] && script[argsKey]) {
-        *outExceptionString = toErrorString(nil, @"details", @"it cannot specify both 'args' and 'arguments'. Please use 'args'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'args' and 'arguments'. Please use 'args'");
         return false;
     }
 
     auto *usedFunctionKey = script[funcKey] ? funcKey : functionKey;
     bool functionWasPassed = script[usedFunctionKey];
     if (script[filesKey] && functionWasPassed) {
-        *outExceptionString = toErrorString(nil, @"details", @"it cannot specify both 'files' and 'func'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'files' and 'func'");
         return false;
     }
 
     if (!functionWasPassed && !script[filesKey]) {
-        *outExceptionString = toErrorString(nil, @"details", @"it must specify either 'func' or 'files''");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it must specify either 'func' or 'files''");
         return false;
     }
 
     auto *usedArgumentKey = script[argsKey] ? argsKey : argumentsKey;
     bool scriptContainsArguments = script[usedArgumentKey];
     if (scriptContainsArguments && !functionWasPassed) {
-        *outExceptionString = toErrorString(nil, @"details", @"it must specify both 'func' and 'args'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it must specify both 'func' and 'args'");
         return false;
     }
 
     if (NSArray *files = script[filesKey]) {
         if (!files.count) {
-            *outExceptionString = toErrorString(nil, filesKey, @"at least one file must be specified");
+            *outExceptionString = toErrorString(nullString(), filesKey, @"at least one file must be specified");
             return false;
         }
 
@@ -478,7 +478,7 @@ bool WebExtensionAPIScripting::parseScriptInjectionOptions(NSDictionary *script,
 
     if (JSValue *function = script[usedFunctionKey]) {
         if (!function._isFunction) {
-            *outExceptionString = toErrorString(nil, usedFunctionKey, @"it is not a function");
+            *outExceptionString = toErrorString(nullString(), usedFunctionKey, @"it is not a function");
             return false;
         }
 
@@ -488,7 +488,7 @@ bool WebExtensionAPIScripting::parseScriptInjectionOptions(NSDictionary *script,
 
     if (NSArray *arguments = script[usedArgumentKey]) {
         if (!isValidJSONObject(arguments, JSONOptions::FragmentsAllowed)) {
-            *outExceptionString = toErrorString(nil, usedArgumentKey, @"it is not JSON-serializable");
+            *outExceptionString = toErrorString(nullString(), usedArgumentKey, @"it is not JSON-serializable");
             return false;
         }
 
@@ -519,12 +519,12 @@ bool WebExtensionAPIScripting::parseCSSInjectionOptions(NSDictionary *cssInfo, W
         return false;
 
     if (cssInfo[cssKey] && cssInfo[filesKey]) {
-        *outExceptionString = toErrorString(nil, @"details", @"it cannot specify both 'css' and 'files'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'css' and 'files'");
         return false;
     }
 
     if (!cssInfo[filesKey] && !cssInfo[cssKey]) {
-        *outExceptionString = toErrorString(nil, @"details", @"it must specify either 'css' or 'files'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it must specify either 'css' or 'files'");
         return false;
     }
 
@@ -571,12 +571,12 @@ bool WebExtensionAPIScripting::parseRegisteredContentScripts(NSArray *scripts, F
 
         NSString *scriptID = script[idKey];
         if (!scriptID.length) {
-            *outExceptionString = toErrorString(nil, idKey, @"it must not be empty");
+            *outExceptionString = toErrorString(nullString(), idKey, @"it must not be empty");
             return false;
         }
 
         if ([scriptID characterAtIndex:0] == '_') {
-            *outExceptionString = toErrorString(nil, idKey, @"it must not start with '_'");
+            *outExceptionString = toErrorString(nullString(), idKey, @"it must not start with '_'");
             return false;
         }
 
@@ -584,25 +584,25 @@ bool WebExtensionAPIScripting::parseRegisteredContentScripts(NSArray *scripts, F
 
         NSArray *matchPatterns = script[matchesKey];
         if (firstTimeRegistration == FirstTimeRegistration::Yes && !matchPatterns.count) {
-            *outExceptionString = toErrorString(nil, matchesKey, @"it must specify at least one match pattern for script with ID '%@'", script[idKey]);
+            *outExceptionString = toErrorString(nullString(), matchesKey, @"it must specify at least one match pattern for script with ID '%@'", script[idKey]);
             return false;
         }
 
         if (matchPatterns && !matchPatterns.count) {
-            *outExceptionString = toErrorString(nil, matchesKey, @"it must not be empty");
+            *outExceptionString = toErrorString(nullString(), matchesKey, @"it must not be empty");
             return false;
         }
 
         NSArray *jsFiles = script[jsKey];
         NSArray *cssFiles = script[cssKey];
         if (firstTimeRegistration == FirstTimeRegistration::Yes && !jsFiles.count && !cssFiles.count) {
-            *outExceptionString = toErrorString(nil, @"details", @"it must specify at least one 'css' or 'js' file");
+            *outExceptionString = toErrorString(nullString(), @"details", @"it must specify at least one 'css' or 'js' file");
             return false;
         }
 
         if (NSString *injectionTime = script[runAtKey]) {
             if (![injectionTime isEqualToString:documentIdle] && ![injectionTime isEqualToString:documentStart] && ![injectionTime isEqualToString:documentEnd]) {
-                *outExceptionString = toErrorString(nil, runAtKey, @"it must specify either 'document_start', 'document_end', or 'document_idle'");
+                *outExceptionString = toErrorString(nullString(), runAtKey, @"it must specify either 'document_start', 'document_end', or 'document_idle'");
                 return false;
             }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm
@@ -54,10 +54,10 @@ static ParseResult parseTabIdentifier(NSDictionary *options)
 
     if ([maybeTabId isKindOfClass:NSNumber.class]) {
         auto tabId = toWebExtensionTabIdentifier(((NSNumber *) maybeTabId).doubleValue);
-        return isValid(tabId) ? ParseResult(tabId.value()) : ParseResult(toErrorString(nil, @"options", @"'tabId' is invalid"));
+        return isValid(tabId) ? ParseResult(tabId.value()) : ParseResult(toErrorString(nullString(), @"options", @"'tabId' is invalid"));
     }
 
-    return toErrorString(nil, @"options", @"'tabId' must be a number");
+    return toErrorString(nullString(), @"options", @"'tabId' must be a number");
 }
 
 static ParseResult parseWindowIdentifier(NSDictionary *options)
@@ -69,10 +69,10 @@ static ParseResult parseWindowIdentifier(NSDictionary *options)
 
     if ([maybeWindowId isKindOfClass:NSNumber.class]) {
         auto windowId = toWebExtensionWindowIdentifier(((NSNumber *) maybeWindowId).doubleValue);
-        return isValid(windowId) ? ParseResult(windowId.value()) : ParseResult(toErrorString(nil, @"options", @"'windowId' is invalid"));
+        return isValid(windowId) ? ParseResult(windowId.value()) : ParseResult(toErrorString(nullString(), @"options", @"'windowId' is invalid"));
     }
 
-    return toErrorString(nil, @"options", @"'windowId' must be a number");
+    return toErrorString(nullString(), @"options", @"'windowId' must be a number");
 }
 
 static std::variant<WebExtensionActionClickBehavior, SidebarError> parseActionClickBehavior(NSDictionary *behavior)
@@ -215,7 +215,7 @@ void WebExtensionAPISidePanel::open(NSDictionary *options, Ref<WebExtensionCallb
     auto windowId = toOptional<WebExtensionWindowIdentifier>(windowResult);
 
     if (!windowId && !tabId) {
-        *outExceptionString = toErrorString(nil, @"details", @"it must specify at least one of 'tabId' or 'windowId'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it must specify at least one of 'tabId' or 'windowId'");
         return;
     }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
@@ -52,22 +52,22 @@ static ParseResult parseSidebarActionDetails(NSDictionary *details)
     id maybeWindowId = [details objectForKey:windowIdKey];
 
     if (maybeTabId && maybeWindowId)
-        return toErrorString(nil, @"details", @"it cannot specify both 'tabId' and 'windowId'");
+        return toErrorString(nullString(), @"details", @"it cannot specify both 'tabId' and 'windowId'");
 
     if (maybeTabId && ![maybeTabId isKindOfClass:NSNumber.class])
-        return toErrorString(nil, @"details", @"'tabId' must be a number");
+        return toErrorString(nullString(), @"details", @"'tabId' must be a number");
 
     if (maybeWindowId && ![maybeWindowId isKindOfClass:NSNumber.class])
-        return toErrorString(nil, @"details", @"'windowId' must be a number");
+        return toErrorString(nullString(), @"details", @"'windowId' must be a number");
 
     if (maybeTabId) {
         auto tabId = toWebExtensionTabIdentifier(((NSNumber *) maybeTabId).doubleValue);
-        return isValid(tabId) ? ParseResult(tabId.value()) : ParseResult(toErrorString(nil, @"details", @"'tabId' is invalid"));
+        return isValid(tabId) ? ParseResult(tabId.value()) : ParseResult(toErrorString(nullString(), @"details", @"'tabId' is invalid"));
     }
 
     if (maybeWindowId) {
         auto windowId = toWebExtensionWindowIdentifier(((NSNumber *) maybeWindowId).doubleValue);
-        return isValid(windowId) ? ParseResult(windowId.value()) : ParseResult(toErrorString(nil, @"details", @"'windowId' is invalid"));
+        return isValid(windowId) ? ParseResult(windowId.value()) : ParseResult(toErrorString(nullString(), @"details", @"'windowId' is invalid"));
     }
 
     return std::monostate();
@@ -77,18 +77,18 @@ static std::variant<std::monostate, String, SidebarError> parseDetailsStringFrom
 {
     id maybeValue = [dict objectForKey:key];
     if (!maybeValue && required)
-        return SidebarError { toErrorString(nil, @"details", [NSString stringWithFormat:@"'%@' is required", key]) };
+        return SidebarError { toErrorString(nullString(), @"details", [NSString stringWithFormat:@"'%@' is required", key]) };
 
     if ([maybeValue isKindOfClass:NSNull.class]) {
         if (required)
-            return SidebarError { toErrorString(nil, @"details", [NSString stringWithFormat:@"'%@' is required", key]) };
+            return SidebarError { toErrorString(nullString(), @"details", [NSString stringWithFormat:@"'%@' is required", key]) };
         return std::monostate();
     }
 
     if (![maybeValue isKindOfClass:NSString.class]) {
         if (required)
-            return SidebarError { toErrorString(nil, @"details", [NSString stringWithFormat:@"'%@' must be of type 'string'", key]) };
-        return SidebarError { toErrorString(nil, @"details", [NSString stringWithFormat:@"'%@' must be of type 'string' or 'null'", key]) };
+            return SidebarError { toErrorString(nullString(), @"details", [NSString stringWithFormat:@"'%@' must be of type 'string'", key]) };
+        return SidebarError { toErrorString(nullString(), @"details", [NSString stringWithFormat:@"'%@' must be of type 'string' or 'null'", key]) };
     }
 
     return String((NSString *)maybeValue);
@@ -106,7 +106,7 @@ static std::tuple<std::optional<WebExtensionWindowIdentifier>, std::optional<Web
 void WebExtensionAPISidebarAction::open(Ref<WebExtensionCallbackHandler>&& callback , NSString **outExceptionString)
 {
     if (!WebCore::UserGestureIndicator::processingUserGesture()) {
-        *outExceptionString = toErrorString(nil, nil, @"it must be called during a user gesture");
+        *outExceptionString = toErrorString(nullString(), nil, @"it must be called during a user gesture");
         return;
     }
 
@@ -123,7 +123,7 @@ void WebExtensionAPISidebarAction::open(Ref<WebExtensionCallbackHandler>&& callb
 void WebExtensionAPISidebarAction::close(Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     if (!WebCore::UserGestureIndicator::processingUserGesture()) {
-        *outExceptionString = toErrorString(nil, nil, @"it must be called during a user gesture");
+        *outExceptionString = toErrorString(nullString(), nil, @"it must be called during a user gesture");
         return;
     }
 
@@ -140,7 +140,7 @@ void WebExtensionAPISidebarAction::close(Ref<WebExtensionCallbackHandler>&& call
 void WebExtensionAPISidebarAction::toggle(Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     if (!WebCore::UserGestureIndicator::processingUserGesture()) {
-        *outExceptionString = toErrorString(nil, nil, @"it must be called during a user gesture");
+        *outExceptionString = toErrorString(nullString(), nil, @"it must be called during a user gesture");
         return;
     }
 
@@ -159,13 +159,13 @@ void WebExtensionAPISidebarAction::isOpen(NSDictionary *details, Ref<WebExtensio
     // we don't use parseSidebarActionDetails here because we only need windowId for isOpen
     id maybeWindowId = details[windowIdKey];
     if (maybeWindowId && ![maybeWindowId isKindOfClass:NSNumber.class]) {
-        *outExceptionString = toErrorString(nil, @"details", @"'windowId' must be a number");
+        *outExceptionString = toErrorString(nullString(), @"details", @"'windowId' must be a number");
         return;
     }
 
     std::optional<WebExtensionWindowIdentifier> windowId = maybeWindowId ? toWebExtensionWindowIdentifier(((NSNumber *) maybeWindowId).doubleValue) : std::nullopt;
     if (windowId && !isValid(windowId)) {
-        *outExceptionString = toErrorString(nil, @"details", @"'windowId' is invalid");
+        *outExceptionString = toErrorString(nullString(), @"details", @"'windowId' is invalid");
         return;
     }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -182,12 +182,12 @@ void WebExtensionAPIStorageArea::set(WebPageProxyIdentifier webPageProxyIdentifi
     });
 
     if (keyWithError) {
-        *outExceptionString = toErrorString(nil, [NSString stringWithFormat:@"items[`%@`]", keyWithError], @"it is not JSON-serializable");
+        *outExceptionString = toErrorString(nullString(), [NSString stringWithFormat:@"items[`%@`]", keyWithError], @"it is not JSON-serializable");
         return;
     }
 
     if (m_type == WebExtensionDataType::Sync && anyItemsExceedQuota(serializedData, webExtensionStorageAreaSyncQuotaBytesPerItem, &keyWithError)) {
-        *outExceptionString = toErrorString(nil, [NSString stringWithFormat:@"items[`%@`]", keyWithError], @"it exceeded maximum size for a single item");
+        *outExceptionString = toErrorString(nullString(), [NSString stringWithFormat:@"items[`%@`]", keyWithError], @"it exceeded maximum size for a single item");
         return;
     }
 
@@ -241,7 +241,7 @@ void WebExtensionAPIStorageArea::setAccessLevel(WebPageProxyIdentifier webPagePr
 
     NSString *accessLevelString = accessOptions[accessLevelKey];
     if (![accessLevelString isEqualToString:accessLevelTrustedContexts] && ![accessLevelString isEqualToString:accessLevelTrustedAndUntrustedContexts]) {
-        *outExceptionString = toErrorString(nil, @"accessLevel", @"it must specify either 'TRUSTED_CONTEXTS' or 'TRUSTED_AND_UNTRUSTED_CONTEXTS'");
+        *outExceptionString = toErrorString(nullString(), @"accessLevel", @"it must specify either 'TRUSTED_CONTEXTS' or 'TRUSTED_AND_UNTRUSTED_CONTEXTS'");
         return;
     }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -212,7 +212,7 @@ bool WebExtensionAPITabs::parseTabCreateOptions(NSDictionary *options, WebExtens
         parameters.windowIdentifier = toWebExtensionWindowIdentifier(windowId.doubleValue);
 
         if (!parameters.windowIdentifier || !isValid(parameters.windowIdentifier.value())) {
-            *outExceptionString = toErrorString(nil, windowIdKey, @"'%@' is not a window identifier", windowId);
+            *outExceptionString = toErrorString(nullString(), windowIdKey, @"'%@' is not a window identifier", windowId);
             return false;
         }
     }
@@ -248,7 +248,7 @@ bool WebExtensionAPITabs::parseTabUpdateOptions(NSDictionary *options, WebExtens
         parameters.url = URL { extensionContext().baseURL(), url };
 
         if (!parameters.url.value().isValid()) {
-            *outExceptionString = toErrorString(nil, urlKey, @"'%@' is not a valid URL", url);
+            *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid URL", url);
             return false;
         }
     }
@@ -257,7 +257,7 @@ bool WebExtensionAPITabs::parseTabUpdateOptions(NSDictionary *options, WebExtens
         parameters.parentTabIdentifier = toWebExtensionTabIdentifier(openerTabId.doubleValue);
 
         if (!parameters.parentTabIdentifier || !isValid(parameters.parentTabIdentifier.value())) {
-            *outExceptionString = toErrorString(nil, openerTabIdKey, @"'%@' is not a tab identifier", openerTabId);
+            *outExceptionString = toErrorString(nullString(), openerTabIdKey, @"'%@' is not a tab identifier", openerTabId);
             return false;
         }
     }
@@ -326,7 +326,7 @@ bool WebExtensionAPITabs::parseTabQueryOptions(NSDictionary *options, WebExtensi
         parameters.windowIdentifier = toWebExtensionWindowIdentifier(windowId.doubleValue);
 
         if (!parameters.windowIdentifier || !isValid(parameters.windowIdentifier.value())) {
-            *outExceptionString = toErrorString(nil, windowIdKey, @"'%@' is not a window identifier", windowId);
+            *outExceptionString = toErrorString(nullString(), windowIdKey, @"'%@' is not a window identifier", windowId);
             return false;
         }
 
@@ -350,7 +350,7 @@ bool WebExtensionAPITabs::parseTabQueryOptions(NSDictionary *options, WebExtensi
         else if ([status isEqualToString:completeKey])
             parameters.loading = false;
         else {
-            *outExceptionString = toErrorString(nil, statusKey, @"it must specify either 'loading' or 'complete'");
+            *outExceptionString = toErrorString(nullString(), statusKey, @"it must specify either 'loading' or 'complete'");
             return false;
         }
     }
@@ -364,7 +364,7 @@ bool WebExtensionAPITabs::parseTabQueryOptions(NSDictionary *options, WebExtensi
         for (auto& patternString : parameters.urlPatterns.value()) {
             auto pattern = WebExtensionMatchPattern::getOrCreate(patternString);
             if (!pattern || !pattern->isSupported()) {
-                *outExceptionString = toErrorString(nil, urlKey, @"'%@' is not a valid pattern", (NSString *)patternString);
+                *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid pattern", (NSString *)patternString);
                 return false;
             }
         }
@@ -430,14 +430,14 @@ bool WebExtensionAPITabs::parseCaptureVisibleTabOptions(NSDictionary *options, W
         else if ([format isEqualToString:jpegValue])
             imageFormat = WebExtensionTab::ImageFormat::JPEG;
         else {
-            *outExceptionString = toErrorString(nil, formatKey, @"it must specify either 'png' or 'jpeg'");
+            *outExceptionString = toErrorString(nullString(), formatKey, @"it must specify either 'png' or 'jpeg'");
             return false;
         }
     }
 
     if (NSNumber *quality = objectForKey<NSNumber>(options, qualityKey)) {
         if (quality.integerValue < 0 || quality.integerValue > 100) {
-            *outExceptionString = toErrorString(nil, qualityKey, @"it must specify a value between 0 and 100");
+            *outExceptionString = toErrorString(nullString(), qualityKey, @"it must specify a value between 0 and 100");
             return false;
         }
 
@@ -458,14 +458,14 @@ bool WebExtensionAPITabs::parseSendMessageOptions(NSDictionary *options, WebExte
         return false;
 
     if (options[frameIdKey] && options[documentIdKey]) {
-        *outExceptionString = toErrorString(nil, sourceKey, @"it cannot specify both 'frameId' and 'documentId'");
+        *outExceptionString = toErrorString(nullString(), sourceKey, @"it cannot specify both 'frameId' and 'documentId'");
         return false;
     }
 
     if (NSNumber *frameIdentifier = options[frameIdKey]) {
         auto identifier = toWebExtensionFrameIdentifier(frameIdentifier.doubleValue);
         if (!isValid(identifier)) {
-            *outExceptionString = toErrorString(nil, frameIdKey, @"'%@' is not a frame identifier", frameIdentifier);
+            *outExceptionString = toErrorString(nullString(), frameIdKey, @"'%@' is not a frame identifier", frameIdentifier);
             return false;
         }
 
@@ -475,7 +475,7 @@ bool WebExtensionAPITabs::parseSendMessageOptions(NSDictionary *options, WebExte
     if (NSString *documentIdentifier = options[documentIdKey]) {
         auto parsedUUID = WTF::UUID::parse(String(documentIdentifier));
         if (!parsedUUID) {
-            *outExceptionString = toErrorString(nil, documentIdKey, @"'%@' is not a document identifier", documentIdentifier);
+            *outExceptionString = toErrorString(nullString(), documentIdKey, @"'%@' is not a document identifier", documentIdentifier);
             return false;
         }
 
@@ -518,28 +518,28 @@ bool WebExtensionAPITabs::parseScriptOptions(NSDictionary *options, WebExtension
         return false;
 
     if (options[fileKey] && options[codeKey]) {
-        *outExceptionString = toErrorString(nil, @"details", @"it cannot specify both 'file' and 'code'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'file' and 'code'");
         return false;
     }
 
     if (!options[fileKey] && !options[codeKey]) {
-        *outExceptionString = toErrorString(nil, @"details", @"it must specify either 'file' or 'code'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it must specify either 'file' or 'code'");
         return false;
     }
 
     bool allFrames = boolForKey(options, allFramesKey, false);
     if (allFrames && options[frameIdKey]) {
-        *outExceptionString = toErrorString(nil, @"details", @"it cannot specify both 'allFrames' and 'frameId'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'allFrames' and 'frameId'");
         return false;
     }
 
     if (options[frameIdKey] && options[documentIdKey]) {
-        *outExceptionString = toErrorString(nil, @"details", @"it cannot specify both 'frameId' and 'documentId'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'frameId' and 'documentId'");
         return false;
     }
 
     if (allFrames && options[documentIdKey]) {
-        *outExceptionString = toErrorString(nil, @"details", @"it cannot specify both 'allFrames' and 'documentId'");
+        *outExceptionString = toErrorString(nullString(), @"details", @"it cannot specify both 'allFrames' and 'documentId'");
         return false;
     }
 
@@ -552,7 +552,7 @@ bool WebExtensionAPITabs::parseScriptOptions(NSDictionary *options, WebExtension
     if (NSString *documentIdentifer = options[documentIdKey]) {
         auto parsedUUID = WTF::UUID::parse(String(documentIdentifer));
         if (!parsedUUID) {
-            *outExceptionString = toErrorString(nil, documentIdKey, @"'%@' is not a valid document identifier", documentIdentifer);
+            *outExceptionString = toErrorString(nullString(), documentIdKey, @"'%@' is not a valid document identifier", documentIdentifer);
             return false;
         }
 
@@ -562,7 +562,7 @@ bool WebExtensionAPITabs::parseScriptOptions(NSDictionary *options, WebExtension
     if (NSNumber *frameID = options[frameIdKey]) {
         auto frameIdentifier = toWebExtensionFrameIdentifier(frameID.doubleValue);
         if (!isValid(frameIdentifier)) {
-            *outExceptionString = toErrorString(nil, frameIdKey, @"'%@' is not a frame identifier", frameID);
+            *outExceptionString = toErrorString(nullString(), frameIdKey, @"'%@' is not a frame identifier", frameID);
             return false;
         }
 
@@ -576,7 +576,7 @@ bool WebExtensionAPITabs::parseScriptOptions(NSDictionary *options, WebExtension
         else if ([origin isEqualToString:authorValue])
             parameters.styleLevel = WebCore::UserStyleLevel::Author;
         else {
-            *outExceptionString = toErrorString(nil, cssOriginKey, @"it must specify either 'author' or 'user'");
+            *outExceptionString = toErrorString(nullString(), cssOriginKey, @"it must specify either 'author' or 'user'");
             return false;
         }
     }
@@ -588,11 +588,11 @@ bool isValid(std::optional<WebExtensionTabIdentifier> identifier, NSString **out
 {
     if (UNLIKELY(!isValid(identifier))) {
         if (isNone(identifier))
-            *outExceptionString = toErrorString(nil, @"tabId", @"'tabs.TAB_ID_NONE' is not allowed");
+            *outExceptionString = toErrorString(nullString(), @"tabId", @"'tabs.TAB_ID_NONE' is not allowed");
         else if (identifier)
-            *outExceptionString = toErrorString(nil, @"tabId", @"'%llu' is not a tab identifier", identifier.value().toUInt64());
+            *outExceptionString = toErrorString(nullString(), @"tabId", @"'%llu' is not a tab identifier", identifier.value().toUInt64());
         else
-            *outExceptionString = toErrorString(nil, @"tabId", @"it is not a tab identifier");
+            *outExceptionString = toErrorString(nullString(), @"tabId", @"it is not a tab identifier");
         return false;
     }
 
@@ -766,7 +766,7 @@ void WebExtensionAPITabs::remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandl
     if (NSNumber *tabID = dynamic_objc_cast<NSNumber>(tabIDs)) {
         auto tabIdentifer = toWebExtensionTabIdentifier(tabID.doubleValue);
         if (!isValid(tabIdentifer)) {
-            *outExceptionString = toErrorString(nil, @"tabIDs", @"'%@' is not a tab identifier", tabID);
+            *outExceptionString = toErrorString(nullString(), @"tabIDs", @"'%@' is not a tab identifier", tabID);
             return;
         }
 
@@ -777,7 +777,7 @@ void WebExtensionAPITabs::remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandl
         for (NSNumber *tabID in tabIDArray) {
             auto tabIdentifer = toWebExtensionTabIdentifier(tabID.doubleValue);
             if (!isValid(tabIdentifer)) {
-                *outExceptionString = toErrorString(nil, @"tabIDs", @"'%@' is not a tab identifier", tabID);
+                *outExceptionString = toErrorString(nullString(), @"tabIDs", @"'%@' is not a tab identifier", tabID);
                 return;
             }
 
@@ -976,13 +976,13 @@ void WebExtensionAPITabs::sendMessage(WebFrame& frame, double tabID, NSString *m
         return;
 
     if (messageJSON.length > webExtensionMaxMessageLength) {
-        *outExceptionString = toErrorString(nil, @"message", @"it exceeded the maximum allowed length");
+        *outExceptionString = toErrorString(nullString(), @"message", @"it exceeded the maximum allowed length");
         return;
     }
 
     auto documentIdentifier = toDocumentIdentifier(frame);
     if (!documentIdentifier) {
-        *outExceptionString = toErrorString(@"runtime.sendMessage()", nil, @"an unexpected error occured");
+        *outExceptionString = toErrorString(@"runtime.sendMessage()", nullString(), @"an unexpected error occured");
         return;
     }
 
@@ -1020,7 +1020,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPITabs::connect(WebFrame& frame, JSCont
 
     auto documentIdentifier = toDocumentIdentifier(frame);
     if (!documentIdentifier) {
-        *outExceptionString = toErrorString(nil, nil, @"an unexpected error occured");
+        *outExceptionString = toErrorString(nullString(), nullString(), @"an unexpected error occured");
         return nullptr;
     }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
@@ -125,7 +125,7 @@ void WebExtensionAPIWebNavigation::getFrame(NSDictionary *details, Ref<WebExtens
     NSNumber *frameId = details[frameIdKey];
     auto frameIdentifier = toWebExtensionFrameIdentifier(frameId.doubleValue);
     if (!isValid(frameIdentifier)) {
-        *outExceptionString = toErrorString(nil, frameIdKey, @"it is not a frame identifier");
+        *outExceptionString = toErrorString(nullString(), frameIdKey, @"it is not a frame identifier");
         return;
     }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -216,7 +216,7 @@ bool WebExtensionAPIWindows::parseWindowTypesFilter(NSDictionary *options, Optio
         windowTypeFilter.remove(WindowTypeFilter::Popup);
 
     if (!windowTypeFilter) {
-        *outExceptionString = toErrorString(nil, windowTypesKey, @"it must specify either 'normal', 'popup', or both.");
+        *outExceptionString = toErrorString(nullString(), windowTypesKey, @"it must specify either 'normal', 'popup', or both.");
         return false;
     }
 
@@ -231,7 +231,7 @@ bool WebExtensionAPIWindows::parseWindowTypeFilter(NSString *windowType, OptionS
         windowTypeFilter.add(WindowTypeFilter::Popup);
 
     if (!windowTypeFilter) {
-        *outExceptionString = toErrorString(nil, sourceKey, @"it must specify either 'normal' or 'popup'");
+        *outExceptionString = toErrorString(nullString(), sourceKey, @"it must specify either 'normal' or 'popup'");
         return false;
     }
 
@@ -275,7 +275,7 @@ bool WebExtensionAPIWindows::parseWindowCreateOptions(NSDictionary *options, Web
         tabParameters.url = URL { extensionContext().baseURL(), url };
 
         if (!tabParameters.url.value().isValid()) {
-            *outExceptionString = toErrorString(nil, urlKey, @"'%@' is not a valid URL", url);
+            *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid URL", url);
             return false;
         }
 
@@ -289,7 +289,7 @@ bool WebExtensionAPIWindows::parseWindowCreateOptions(NSDictionary *options, Web
             tabParameters.url = URL { extensionContext().baseURL(), url };
 
             if (!tabParameters.url.value().isValid()) {
-                *outExceptionString = toErrorString(nil, urlKey, @"'%@' is not a valid URL", url);
+                *outExceptionString = toErrorString(nullString(), urlKey, @"'%@' is not a valid URL", url);
                 return false;
             }
 
@@ -329,7 +329,7 @@ bool WebExtensionAPIWindows::parseWindowUpdateOptions(NSDictionary *options, Web
         parameters.state = toStateImpl(state);
 
         if (!parameters.state) {
-            *outExceptionString = toErrorString(nil, stateKey, @"it must specify 'normal', 'minimized', 'maximized', or 'fullscreen'");
+            *outExceptionString = toErrorString(nullString(), stateKey, @"it must specify 'normal', 'minimized', 'maximized', or 'fullscreen'");
             return false;
         }
     }
@@ -344,7 +344,7 @@ bool WebExtensionAPIWindows::parseWindowUpdateOptions(NSDictionary *options, Web
 
     if (left || top || width || height) {
         if (parameters.state && parameters.state.value() != WebExtensionWindow::State::Normal) {
-            *outExceptionString = toErrorString(nil, sourceKey, @"when 'top', 'left', 'width', or 'height' are specified, 'state' must specify 'normal'.");
+            *outExceptionString = toErrorString(nullString(), sourceKey, @"when 'top', 'left', 'width', or 'height' are specified, 'state' must specify 'normal'.");
             return false;
         }
 
@@ -365,11 +365,11 @@ bool isValid(std::optional<WebExtensionWindowIdentifier> identifier, NSString **
 {
     if (UNLIKELY(!isValid(identifier))) {
         if (isNone(identifier))
-            *outExceptionString = toErrorString(nil, @"windowId", @"'windows.WINDOW_ID_NONE' is not allowed");
+            *outExceptionString = toErrorString(nullString(), @"windowId", @"'windows.WINDOW_ID_NONE' is not allowed");
         else if (identifier)
-            *outExceptionString = toErrorString(nil, @"windowId", @"'%llu' is not a window identifier", identifier.value().toUInt64());
+            *outExceptionString = toErrorString(nullString(), @"windowId", @"'%llu' is not a window identifier", identifier.value().toUInt64());
         else
-            *outExceptionString = toErrorString(nil, @"windowId", @"it is not a window identifier");
+            *outExceptionString = toErrorString(nullString(), @"windowId", @"it is not a window identifier");
         return false;
     }
 

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm
@@ -153,7 +153,7 @@ static NSString * const portsKey = @"ports";
         ASSERT([rawValue isKindOfClass:NSString.class]);
 
         if (!(_value = [NSRegularExpression regularExpressionWithPattern:rawValue options:0 error:nil])) {
-            *outErrorMessage = toErrorString(nil, originAndPathMatchesKey, @"'%@' is not a valid regular expression", rawValue);
+            *outErrorMessage = toErrorString(nullString(), originAndPathMatchesKey, @"'%@' is not a valid regular expression", rawValue);
             return nil;
         }
 
@@ -181,21 +181,21 @@ static NSString * const portsKey = @"ports";
             if (NSNumber *number = dynamic_objc_cast<NSNumber>(portOrRange)) {
                 NSInteger integerValue = number.integerValue;
                 if (integerValue < 0 || integerValue > maximumPortNumber) {
-                    *outErrorMessage = toErrorString(nil, portsKey, @"'%zd' is not a valid port", integerValue);
+                    *outErrorMessage = toErrorString(nullString(), portsKey, @"'%zd' is not a valid port", integerValue);
                     return nil;
                 }
 
                 [ports addIndex:(NSUInteger)integerValue];
             } else if (NSArray<NSNumber *> *rangeArray = dynamic_objc_cast<NSArray>(portOrRange)) {
                 if (rangeArray.count != 2) {
-                    *outErrorMessage = toErrorString(nil, portsKey, @"a port range must specify 2 numbers");
+                    *outErrorMessage = toErrorString(nullString(), portsKey, @"a port range must specify 2 numbers");
                     return nil;
                 }
 
                 for (NSNumber *number in rangeArray) {
                     NSInteger integerValue = number.integerValue;
                     if (integerValue < 0 || integerValue > maximumPortNumber) {
-                        *outErrorMessage = toErrorString(nil, portsKey, @"'%zd' is not a valid port", integerValue);
+                        *outErrorMessage = toErrorString(nullString(), portsKey, @"'%zd' is not a valid port", integerValue);
                         return nil;
                     }
                 }
@@ -203,7 +203,7 @@ static NSString * const portsKey = @"ports";
                 NSUInteger firstPort = rangeArray[0].unsignedIntegerValue;
                 NSUInteger lastPort = rangeArray[1].unsignedIntegerValue;
                 if (firstPort >= lastPort) {
-                    *outErrorMessage = toErrorString(nil, portsKey, @"'%zd-%zd' is not a valid port range", firstPort, lastPort);
+                    *outErrorMessage = toErrorString(nullString(), portsKey, @"'%zd-%zd' is not a valid port range", firstPort, lastPort);
                     return nil;
                 }
 

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm
@@ -132,7 +132,7 @@ static NSArray<WKWebExtensionMatchPattern *> *toMatchPatterns(NSArray<NSString *
         WKWebExtensionMatchPattern *pattern = [[WKWebExtensionMatchPattern alloc] initWithString:rawPattern error:&error];
         if (!pattern) {
             if (outErrorMessage)
-                *outErrorMessage = toErrorString(nil, urlsKey, @"'%@' is an invalid match pattern. %@", rawPattern, error.localizedDescription);
+                *outErrorMessage = toErrorString(nullString(), urlsKey, @"'%@' is an invalid match pattern. %@", rawPattern, error.localizedDescription);
             return nil;
         }
 
@@ -165,7 +165,7 @@ static NSNumber *toResourceType(NSString *typeString, NSString **outErrorMessage
 
     NSNumber *typeAsNumber = validTypes[typeString];
     if (!typeAsNumber) {
-        *outErrorMessage = toErrorString(nil, typesKey, @"'%@' is an unknown resource type", typeString);
+        *outErrorMessage = toErrorString(nullString(), typesKey, @"'%@' is an unknown resource type", typeString);
         return nil;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -124,7 +124,7 @@ TEST(WKWebExtensionAPITabs, Errors)
         @"browser.test.assertThrows(() => browser.tabs.update(1, 'bad'), /'properties' value is invalid, because an object is expected/i)",
 
         @"browser.test.assertThrows(() => browser.tabs.update(1, { 'openerTabId': true }), /'openerTabId' is expected to be a number, but a boolean was provided/i)",
-        @"browser.test.assertThrows(() => browser.tabs.update(1, { 'openerTabId': 4.2 }), /'openerTabId' value is invalid, because '4.2' is not a tab identifier/i)",
+        @"browser.test.assertThrows(() => browser.tabs.update(1, { 'openerTabId': 4.5 }), /'openerTabId' value is invalid, because '4.5' is not a tab identifier/i)",
 
         @"browser.test.assertThrows(() => browser.tabs.create({ 'url': 1234 }), /'url' is expected to be a string/i)",
 


### PR DESCRIPTION
#### e08116f49166892e34c78ed95e2a14d054042226
<pre>
Use WTF::String for toWebExtensionError and toErrorString
<a href="https://webkit.org/b/285374">https://webkit.org/b/285374</a>

Reviewed by Timothy Hatcher.

In order to port Context APIs to C++, the error string functions must use
WTF::String. This creates a new variadic string formatter in WebExtensionUtilities,
removes the Obj-C specific error string functions, and fixes the usage throughout the Context APIs
to use nullString() instead of nil.

* Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp:
(WebKit::formatString):
(WebKit::lowercaseFirst):
(WebKit::uppercaseFirst):
(WebKit::toErrorString):
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.h:
(WebKit::toWebExtensionError):
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm:
(WebKit::validateDictionary):
(WebKit::validateObject):
(WebKit::lowercaseFirst): Deleted.
(WebKit::uppercaseFirst): Deleted.
(WebKit::trimTrailingPeriod): Deleted.
(WebKit::toErrorString): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm:
(WebKit::getActionWithIdentifiers):
(WebKit::getOrCreateActionWithIdentifiers):
(WebKit::WebExtensionContext::actionOpenPopup):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm:
(WebKit::WebExtensionContext::cookiesGet):
(WebKit::WebExtensionContext::cookiesGetAll):
(WebKit::WebExtensionContext::cookiesSet):
(WebKit::WebExtensionContext::cookiesRemove):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::declarativeNetRequestValidateRulesetIdentifiers):
(WebKit::WebExtensionContext::declarativeNetRequestUpdateEnabledRulesets):
(WebKit::WebExtensionContext::declarativeNetRequestIncrementActionCount):
(WebKit::WebExtensionContext::declarativeNetRequestGetMatchedRules):
(WebKit::WebExtensionContext::updateDeclarativeNetRequestRulesInStorage):
(WebKit::WebExtensionContext::declarativeNetRequestGetDynamicRules):
(WebKit::WebExtensionContext::declarativeNetRequestUpdateDynamicRules):
(WebKit::WebExtensionContext::declarativeNetRequestGetSessionRules):
(WebKit::WebExtensionContext::declarativeNetRequestUpdateSessionRules):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsInspectedWindow.mm:
(WebKit::WebExtensionContext::devToolsInspectedWindowEval):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsPanels.mm:
(WebKit::WebExtensionContext::devToolsPanelsCreate):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIMenusCocoa.mm:
(WebKit::WebExtensionContext::menusCreate):
(WebKit::WebExtensionContext::menusUpdate):
(WebKit::WebExtensionContext::menusRemove):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeOpenOptionsPage):
(WebKit::WebExtensionContext::runtimeSendMessage):
(WebKit::WebExtensionContext::runtimeConnect):
(WebKit::WebExtensionContext::sendNativeMessage):
(WebKit::WebExtensionContext::runtimeConnectNative):
(WebKit::WebExtensionContext::runtimeWebPageConnect):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::scriptingExecuteScript):
(WebKit::WebExtensionContext::scriptingInsertCSS):
(WebKit::WebExtensionContext::scriptingRemoveCSS):
(WebKit::WebExtensionContext::scriptingRegisterContentScripts):
(WebKit::WebExtensionContext::scriptingUpdateRegisteredScripts):
(WebKit::WebExtensionContext::scriptingUnregisterContentScripts):
(WebKit::WebExtensionContext::createInjectedContentForScripts):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPISidebarCocoa.mm:
(WebKit::WebExtensionContext::sidebarOpen):
(WebKit::WebExtensionContext::sidebarClose):
(WebKit::WebExtensionContext::sidebarToggle):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm:
(WebKit::WebExtensionContext::storageGet):
(WebKit::WebExtensionContext::storageGetKeys):
(WebKit::WebExtensionContext::storageGetBytesInUse):
(WebKit::WebExtensionContext::storageSet):
(WebKit::WebExtensionContext::storageRemove):
(WebKit::WebExtensionContext::storageClear):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsCreate):
(WebKit::WebExtensionContext::tabsUpdate):
(WebKit::WebExtensionContext::tabsDuplicate):
(WebKit::WebExtensionContext::tabsGet):
(WebKit::WebExtensionContext::tabsReload):
(WebKit::WebExtensionContext::tabsGoBack):
(WebKit::WebExtensionContext::tabsGoForward):
(WebKit::WebExtensionContext::tabsDetectLanguage):
(WebKit::WebExtensionContext::tabsCaptureVisibleTab):
(WebKit::WebExtensionContext::tabsToggleReaderMode):
(WebKit::WebExtensionContext::tabsSendMessage):
(WebKit::WebExtensionContext::tabsConnect):
(WebKit::WebExtensionContext::tabsGetZoom):
(WebKit::WebExtensionContext::tabsSetZoom):
(WebKit::WebExtensionContext::tabsRemove):
(WebKit::WebExtensionContext::tabsExecuteScript):
(WebKit::WebExtensionContext::tabsInsertCSS):
(WebKit::WebExtensionContext::tabsRemoveCSS):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm:
(WebKit::WebExtensionContext::webNavigationGetFrame):
(WebKit::WebExtensionContext::webNavigationGetAllFrames):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm:
(WebKit::WebExtensionContext::windowsCreate):
(WebKit::WebExtensionContext::windowsGet):
(WebKit::WebExtensionContext::windowsGetLastFocused):
(WebKit::WebExtensionContext::windowsUpdate):
(WebKit::WebExtensionContext::windowsRemove):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::setParentTab):
(WebKit::WebExtensionTab::setPinned):
(WebKit::WebExtensionTab::setReaderModeActive):
(WebKit::WebExtensionTab::setMuted):
(WebKit::WebExtensionTab::setZoomFactor):
(WebKit::WebExtensionTab::detectWebpageLocale):
(WebKit::WebExtensionTab::captureVisibleWebpage):
(WebKit::WebExtensionTab::loadURL):
(WebKit::WebExtensionTab::reload):
(WebKit::WebExtensionTab::goBack):
(WebKit::WebExtensionTab::goForward):
(WebKit::WebExtensionTab::activate):
(WebKit::WebExtensionTab::setSelected):
(WebKit::WebExtensionTab::duplicate):
(WebKit::WebExtensionTab::close):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm:
(WebKit::WebExtensionWindow::setState):
(WebKit::WebExtensionWindow::focus):
(WebKit::WebExtensionWindow::setFrame):
(WebKit::WebExtensionWindow::close):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm:
(WebKit::WebExtensionAPIAction::parseActionDetails):
(WebKit::dataURLFromImageData):
(WebKit::WebExtensionAPIAction::parseIconPathsDictionary):
(WebKit::WebExtensionAPIAction::parseIconImageDataDictionary):
(WebKit::WebExtensionAPIAction::parseIconVariants):
(WebKit::WebExtensionAPIAction::setIcon):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm:
(WebKit::WebExtensionAPIAlarms::createAlarm):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm:
(WebKit::WebExtensionAPICookies::parseCookieDetails):
(WebKit::WebExtensionAPICookies::set):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateDynamicRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::updateSessionRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::getMatchedRules):
(WebKit::WebExtensionAPIDeclarativeNetRequest::setExtensionActionOptions):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm:
(WebKit::WebExtensionAPIDevToolsInspectedWindow::eval):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm:
(WebKit::WebExtensionAPIExtension::parseViewFilters):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::WebExtensionAPIMenus::parseCreateAndUpdateProperties):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm:
(WebKit::WebExtensionAPIPermissions::request):
(WebKit::WebExtensionAPIPermissions::remove):
(WebKit::WebExtensionAPIPermissions::verifyRequestedPermissions):
(WebKit::WebExtensionAPIPermissions::validatePermissionsDetails):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm:
(WebKit::WebExtensionAPIPort::postMessage):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::sendMessage):
(WebKit::WebExtensionAPIRuntime::connect):
(WebKit::WebExtensionAPIWebPageRuntime::sendMessage):
(WebKit::WebExtensionAPIWebPageRuntime::connect):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
(WebKit::WebExtensionAPIScripting::parseStyleLevel):
(WebKit::WebExtensionAPIScripting::parseExecutionWorld):
(WebKit::WebExtensionAPIScripting::parseTargetInjectionOptions):
(WebKit::WebExtensionAPIScripting::parseScriptInjectionOptions):
(WebKit::WebExtensionAPIScripting::parseCSSInjectionOptions):
(WebKit::WebExtensionAPIScripting::parseRegisteredContentScripts):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm:
(WebKit::parseTabIdentifier):
(WebKit::parseWindowIdentifier):
(WebKit::WebExtensionAPISidePanel::open):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm:
(WebKit::parseSidebarActionDetails):
(WebKit::parseDetailsStringFromKey):
(WebKit::WebExtensionAPISidebarAction::open):
(WebKit::WebExtensionAPISidebarAction::close):
(WebKit::WebExtensionAPISidebarAction::toggle):
(WebKit::WebExtensionAPISidebarAction::isOpen):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::set):
(WebKit::WebExtensionAPIStorageArea::setAccessLevel):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::parseTabCreateOptions):
(WebKit::WebExtensionAPITabs::parseTabUpdateOptions):
(WebKit::WebExtensionAPITabs::parseTabQueryOptions):
(WebKit::WebExtensionAPITabs::parseCaptureVisibleTabOptions):
(WebKit::WebExtensionAPITabs::parseSendMessageOptions):
(WebKit::WebExtensionAPITabs::parseScriptOptions):
(WebKit::isValid):
(WebKit::WebExtensionAPITabs::remove):
(WebKit::WebExtensionAPITabs::sendMessage):
(WebKit::WebExtensionAPITabs::connect):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm:
(WebKit::WebExtensionAPIWebNavigation::getFrame):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::WebExtensionAPIWindows::parseWindowTypesFilter):
(WebKit::WebExtensionAPIWindows::parseWindowTypeFilter):
(WebKit::WebExtensionAPIWindows::parseWindowCreateOptions):
(WebKit::WebExtensionAPIWindows::parseWindowUpdateOptions):
(WebKit::isValid):
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm:
(-[_WKWebExtensionWebNavigationURLPredicate initWithTypeString:value:outErrorMessage:]):
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm:
(toResourceType):

Canonical link: <a href="https://commits.webkit.org/288537@main">https://commits.webkit.org/288537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f4f0995571330c864b6e218bb3c8d743e754713

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88645 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34582 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85659 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65015 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22757 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45302 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30147 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33630 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73394 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90022 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7826 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73447 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11062 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72670 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16913 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15623 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2163 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12921 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10791 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16263 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10639 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14114 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12411 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->