### PR TITLE
Remove unused code from `FloatPolygon.cpp|h`

### DIFF
--- a/Source/WebCore/platform/graphics/FloatPolygon.cpp
+++ b/Source/WebCore/platform/graphics/FloatPolygon.cpp
@@ -52,13 +52,6 @@ static inline bool areCoincidentPoints(const FloatPoint& p0, const FloatPoint& p
     return p0.x() == p1.x() && p0.y() == p1.y();
 }
 
-static inline bool isPointOnLineSegment(const FloatPoint& vertex1, const FloatPoint& vertex2, const FloatPoint& point)
-{
-    return point.x() >= std::min(vertex1.x(), vertex2.x())
-        && point.x() <= std::max(vertex1.x(), vertex2.x())
-        && areCollinearPoints(vertex1, vertex2, point);
-}
-
 static inline unsigned nextVertexIndex(unsigned vertexIndex, unsigned nVertices, bool clockwise)
 {
     return ((clockwise) ? vertexIndex + 1 : vertexIndex - 1 + nVertices) % nVertices;
@@ -82,9 +75,8 @@ static unsigned findNextEdgeVertexIndex(const FloatPolygon& polygon, unsigned ve
     return vertexIndex2;
 }
 
-FloatPolygon::FloatPolygon(Vector<FloatPoint>&& vertices, WindRule fillRule)
+FloatPolygon::FloatPolygon(Vector<FloatPoint>&& vertices)
     : m_vertices(WTFMove(vertices))
-    , m_fillRule(fillRule)
     , m_empty(m_vertices.size() < 3)
     , m_edges(m_vertices.size())
 {
@@ -143,54 +135,6 @@ Vector<std::reference_wrapper<const FloatPolygonEdge>> FloatPolygon::overlapping
     return overlappingEdgeIntervals.map([](auto& interval) -> std::reference_wrapper<const FloatPolygonEdge> {
         return *interval.data();
     });
-}
-
-static inline float leftSide(const FloatPoint& vertex1, const FloatPoint& vertex2, const FloatPoint& point)
-{
-    return ((point.x() - vertex1.x()) * (vertex2.y() - vertex1.y())) - ((vertex2.x() - vertex1.x()) * (point.y() - vertex1.y()));
-}
-
-bool FloatPolygon::containsEvenOdd(const FloatPoint& point) const
-{
-    unsigned crossingCount = 0;
-    for (unsigned i = 0; i < numberOfEdges(); ++i) {
-        const FloatPoint& vertex1 = edgeAt(i).vertex1();
-        const FloatPoint& vertex2 = edgeAt(i).vertex2();
-        if (isPointOnLineSegment(vertex1, vertex2, point))
-            return true;
-        if ((vertex1.y() <= point.y() && vertex2.y() > point.y()) || (vertex1.y() > point.y() && vertex2.y() <= point.y())) {
-            float vt = (point.y()  - vertex1.y()) / (vertex2.y() - vertex1.y());
-            if (point.x() < vertex1.x() + vt * (vertex2.x() - vertex1.x()))
-                ++crossingCount;
-        }
-    }
-    return crossingCount & 1;
-}
-
-bool FloatPolygon::containsNonZero(const FloatPoint& point) const
-{
-    int windingNumber = 0;
-    for (unsigned i = 0; i < numberOfEdges(); ++i) {
-        const FloatPoint& vertex1 = edgeAt(i).vertex1();
-        const FloatPoint& vertex2 = edgeAt(i).vertex2();
-        if (isPointOnLineSegment(vertex1, vertex2, point))
-            return true;
-        if (vertex2.y() < point.y()) {
-            if ((vertex1.y() > point.y()) && (leftSide(vertex1, vertex2, point) > 0))
-                ++windingNumber;
-        } else if (vertex2.y() > point.y()) {
-            if ((vertex1.y() <= point.y()) && (leftSide(vertex1, vertex2, point) < 0))
-                --windingNumber;
-        }
-    }
-    return windingNumber;
-}
-
-bool FloatPolygon::contains(const FloatPoint& point) const
-{
-    if (!m_boundingBox.contains(point))
-        return false;
-    return fillRule() == WindRule::NonZero ? containsNonZero(point) : containsEvenOdd(point);
 }
 
 bool VertexPair::intersection(const VertexPair& other, FloatPoint& point) const

--- a/Source/WebCore/platform/graphics/FloatPolygon.h
+++ b/Source/WebCore/platform/graphics/FloatPolygon.h
@@ -44,12 +44,10 @@ typedef PODIntervalTree<float, FloatPolygonEdge*> EdgeIntervalTree;
 
 class FloatPolygon {
 public:
-    FloatPolygon(Vector<FloatPoint>&& vertices, WindRule fillRule);
+    FloatPolygon(Vector<FloatPoint>&& vertices);
 
     const FloatPoint& vertexAt(unsigned index) const { return m_vertices[index]; }
     unsigned numberOfVertices() const { return m_vertices.size(); }
-
-    WindRule fillRule() const { return m_fillRule; }
 
     const FloatPolygonEdge& edgeAt(unsigned index) const { return m_edges[index]; }
     unsigned numberOfEdges() const { return m_edges.size(); }
@@ -60,11 +58,7 @@ public:
     bool isEmpty() const { return m_empty; }
 
 private:
-    bool containsNonZero(const FloatPoint&) const;
-    bool containsEvenOdd(const FloatPoint&) const;
-
     Vector<FloatPoint> m_vertices;
-    WindRule m_fillRule;
     FloatRect m_boundingBox;
     bool m_empty;
     Vector<FloatPolygonEdge> m_edges;

--- a/Source/WebCore/rendering/shapes/LayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/LayoutShape.cpp
@@ -62,9 +62,9 @@ static Ref<LayoutShape> createEllipseShape(const FloatPoint& center, const Float
     return adoptRef(*new RectangleLayoutShape(FloatRect(center.x() - radii.width(), center.y() - radii.height(), radii.width()*2, radii.height()*2), radii, boxLogicalWidth));
 }
 
-static Ref<LayoutShape> createPolygonShape(Vector<FloatPoint>&& vertices, WindRule fillRule, float boxLogicalWidth)
+static Ref<LayoutShape> createPolygonShape(Vector<FloatPoint>&& vertices, float boxLogicalWidth)
 {
-    return adoptRef(*new PolygonLayoutShape(WTFMove(vertices), fillRule, boxLogicalWidth));
+    return adoptRef(*new PolygonLayoutShape(WTFMove(vertices), boxLogicalWidth));
 }
 
 static inline FloatRect physicalRectToLogical(const FloatRect& rect, float logicalBoxHeight, WritingMode writingMode)
@@ -155,7 +155,7 @@ Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicSh
                 return physicalPointToLogical(Style::evaluate(vertex, boxSize) + borderBoxOffset, logicalBoxSize.height(), writingMode);
             });
 
-            return createPolygonShape(WTFMove(vertices), Style::windRule(*polygon), logicalBoxSize.width());
+            return createPolygonShape(WTFMove(vertices), logicalBoxSize.width());
         },
         [&](const Style::PathFunction&) -> Ref<LayoutShape> {
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/rendering/shapes/PolygonLayoutShape.h
+++ b/Source/WebCore/rendering/shapes/PolygonLayoutShape.h
@@ -59,8 +59,8 @@ private:
 class PolygonLayoutShape : public LayoutShape {
     WTF_MAKE_NONCOPYABLE(PolygonLayoutShape);
 public:
-    PolygonLayoutShape(Vector<FloatPoint>&& vertices, WindRule fillRule, float boxLogicalWidth)
-        : m_polygon(WTFMove(vertices), fillRule)
+    PolygonLayoutShape(Vector<FloatPoint>&& vertices, float boxLogicalWidth)
+        : m_polygon(WTFMove(vertices))
         , m_boxLogicalWidth(boxLogicalWidth)
     {
     }


### PR DESCRIPTION
#### f34362289cfc420ab1d8201c88a79c2d6d26128c
<pre>
Remove unused code from `FloatPolygon.cpp|h`

<a href="https://bugs.webkit.org/show_bug.cgi?id=285376">https://bugs.webkit.org/show_bug.cgi?id=285376</a>
<a href="https://rdar.apple.com/142341006">rdar://142341006</a>

Reviewed by Simon Fraser.

This patch is just to clean-up code without any call sites.

* Source/WebCore/platform/graphics/FloatPolygon.cpp:
(WebCore::FloatPolygon::FloatPolygon):
(WebCore::isPointOnLineSegment): Deleted.
(WebCore::leftSide): Deleted.
(WebCore::FloatPolygon::containsEvenOdd const): Deleted.
(WebCore::FloatPolygon::containsNonZero const): Deleted.
(WebCore::FloatPolygon::contains const): Deleted.
* Source/WebCore/platform/graphics/FloatPolygon.h:
(WebCore::FloatPolygon::fillRule const): Deleted.
* Source/WebCore/rendering/shapes/PolygonLayoutShape.h:
* Source/WebCore/rendering/shapes/LayoutShape.cpp:
(createPolygonShape):
(createShape):

Canonical link: <a href="https://commits.webkit.org/288535@main">https://commits.webkit.org/288535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae14c6d30e51fe60b25e955cd3a098898e648714

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2874 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88336 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34269 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85347 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64774 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22525 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45058 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29973 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33318 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73186 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89709 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10524 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73212 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72441 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17996 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16644 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15374 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1862 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10479 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15954 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10331 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13801 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12102 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->