### PR TITLE
Make HashSet validate its key by default in release builds

### DIFF
--- a/Source/JavaScriptCore/API/JSValue.mm
+++ b/Source/JavaScriptCore/API/JSValue.mm
@@ -1315,7 +1315,7 @@ static StructHandlers* createStructHandlerMap()
     });
 
     // Step 3: clean up - remove entries where we found prospective valueWith<Foo>:inContext: conversions, but no matching to<Foo> methods.
-    typedef HashSet<String> RemoveSet;
+    typedef UncheckedKeyHashSet<String> RemoveSet;
     RemoveSet removeSet;
     for (StructHandlers::iterator iter = structHandlers->begin(); iter != structHandlers->end(); ++iter) {
         StructTagHandler& handler = iter->value;

--- a/Source/JavaScriptCore/API/ObjcRuntimeExtras.h
+++ b/Source/JavaScriptCore/API/ObjcRuntimeExtras.h
@@ -56,7 +56,7 @@ inline void forEachProtocolImplementingProtocol(Class cls, Protocol *target, voi
     ASSERT(target);
 
     Vector<Protocol*> worklist;
-    HashSet<void*> visited;
+    UncheckedKeyHashSet<void*> visited;
 
     // Initially fill the worklist with the Class's protocols.
     {

--- a/Source/JavaScriptCore/b3/B3CanonicalizePrePostIncrements.cpp
+++ b/Source/JavaScriptCore/b3/B3CanonicalizePrePostIncrements.cpp
@@ -63,7 +63,7 @@ bool canonicalizePrePostIncrements(Procedure& proc)
     UncheckedKeyHashMap<MemoryValue*, Vector<Value*>> preIndexCandidates;
 
     UncheckedKeyHashMap<Value*, unsigned> memoryToIndex;
-    UncheckedKeyHashMap<BasicBlock*, HashSet<MemoryValue*>> blockToPrePostIndexCandidates;
+    UncheckedKeyHashMap<BasicBlock*, UncheckedKeyHashSet<MemoryValue*>> blockToPrePostIndexCandidates;
 
     auto tryFindCandidates = [&](Value* value, unsigned index) ALWAYS_INLINE_LAMBDA {
         switch (value->opcode()) {
@@ -96,7 +96,7 @@ bool canonicalizePrePostIncrements(Procedure& proc)
                     if (uses != addressUses.end() && uses->value.size() > 0)
                         continue;
                     preIndexCandidates.add(memory, Vector<Value*>()).iterator->value.append(address);
-                    blockToPrePostIndexCandidates.add(memory->owner, HashSet<MemoryValue*>()).iterator->value.add(memory);
+                    blockToPrePostIndexCandidates.add(memory->owner, UncheckedKeyHashSet<MemoryValue*>()).iterator->value.add(memory);
                 }
             } else
                 baseToMemories.add(base, Vector<MemoryValue*>()).iterator->value.append(memory);
@@ -129,7 +129,7 @@ bool canonicalizePrePostIncrements(Procedure& proc)
                 break;
             for (MemoryValue* memory : memories->value) {
                 postIndexCandidates.add(memory, Vector<Value*>()).iterator->value.append(address);
-                blockToPrePostIndexCandidates.add(memory->owner, HashSet<MemoryValue*>()).iterator->value.add(memory);
+                blockToPrePostIndexCandidates.add(memory->owner, UncheckedKeyHashSet<MemoryValue*>()).iterator->value.add(memory);
             }
             break;
         }

--- a/Source/JavaScriptCore/b3/B3LowerInt64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerInt64.cpp
@@ -1287,7 +1287,7 @@ private:
     bool m_changed;
     UncheckedKeyHashMap<Value*, Value*> m_rewrittenTupleResults;
     UncheckedKeyHashMap<Value*, std::pair<Value*, Value*>> m_mapping;
-    HashSet<Value*> m_syntheticValues;
+    UncheckedKeyHashSet<Value*> m_syntheticValues;
     UncheckedKeyHashMap<Variable*, std::pair<Variable*, Variable*>> m_variableMapping;
 };
 

--- a/Source/JavaScriptCore/b3/B3OptimizeAssociativeExpressionTrees.cpp
+++ b/Source/JavaScriptCore/b3/B3OptimizeAssociativeExpressionTrees.cpp
@@ -252,8 +252,8 @@ bool OptimizeAssociativeExpressionTrees::run()
     m_proc.resetValueOwners();
 
     Vector<unsigned> useCounts(m_proc.values().size(), 0); // Mapping from Value::m_index to use counts.
-    HashSet<Value*> expressionTreeRoots;
-    HashSet<BasicBlock*> rootOwners;
+    UncheckedKeyHashSet<Value*> expressionTreeRoots;
+    UncheckedKeyHashSet<BasicBlock*> rootOwners;
 
     for (BasicBlock* block : m_proc) {
         for (Value* value : *block) {

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -316,7 +316,7 @@ private:
     std::unique_ptr<NaturalLoops> m_naturalLoops;
     std::unique_ptr<BackwardsCFG> m_backwardsCFG;
     std::unique_ptr<BackwardsDominators> m_backwardsDominators;
-    HashSet<ValueKey> m_fastConstants;
+    UncheckedKeyHashSet<ValueKey> m_fastConstants;
     const char* m_lastPhaseName;
     std::unique_ptr<OpaqueByproducts> m_byproducts;
     std::unique_ptr<Air::Code> m_code;

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -67,8 +67,8 @@ public:
 
     void run()
     {
-        HashSet<BasicBlock*> blocks;
-        HashSet<Value*> valueInProc;
+        UncheckedKeyHashSet<BasicBlock*> blocks;
+        UncheckedKeyHashSet<Value*> valueInProc;
         UncheckedKeyHashMap<Value*, unsigned> valueInBlock;
         UncheckedKeyHashMap<Value*, BasicBlock*> valueOwner;
         UncheckedKeyHashMap<Value*, unsigned> valueIndex;
@@ -114,7 +114,7 @@ public:
             }
         }
 
-        UncheckedKeyHashMap<BasicBlock*, HashSet<BasicBlock*>> allPredecessors;
+        UncheckedKeyHashMap<BasicBlock*, UncheckedKeyHashSet<BasicBlock*>> allPredecessors;
         for (BasicBlock* block : blocks) {
             VALIDATE(block->size() >= 1, ("At ", *block));
             for (unsigned i = 0; i < block->size() - 1; ++i)
@@ -122,7 +122,7 @@ public:
             VALIDATE(block->last()->effects().terminal, ("At ", *block->last()));
             
             for (BasicBlock* successor : block->successorBlocks()) {
-                allPredecessors.add(successor, HashSet<BasicBlock*>()).iterator->value.add(block);
+                allPredecessors.add(successor, UncheckedKeyHashSet<BasicBlock*>()).iterator->value.add(block);
                 VALIDATE(
                     blocks.contains(successor), ("At ", *block, "->", pointerDump(successor)));
             }
@@ -131,7 +131,7 @@ public:
         // Note that this totally allows dead code.
         for (auto& entry : allPredecessors) {
             BasicBlock* successor = entry.key;
-            HashSet<BasicBlock*>& predecessors = entry.value;
+            UncheckedKeyHashSet<BasicBlock*>& predecessors = entry.value;
             VALIDATE(predecessors == successor->predecessors(), ("At ", *successor));
         }
 
@@ -870,7 +870,7 @@ public:
 
         for (BasicBlock* block : m_procedure) {
             // We expect the predecessor list to be de-duplicated.
-            HashSet<BasicBlock*> predecessors;
+            UncheckedKeyHashSet<BasicBlock*> predecessors;
             for (BasicBlock* predecessor : block->predecessors())
                 predecessors.add(predecessor);
             VALIDATE(block->numPredecessors() == predecessors.size(), ("At ", *block));
@@ -969,7 +969,7 @@ private:
     {
         bool changed = true;
         BitVector blocksToVisit;
-        IndexMap<BasicBlock*, HashSet<Value*>> undominatedPhisAtTail(m_procedure.size());
+        IndexMap<BasicBlock*, UncheckedKeyHashSet<Value*>> undominatedPhisAtTail(m_procedure.size());
         for (BasicBlock* block : m_procedure)
             blocksToVisit.set(block->index());
         while (changed) {
@@ -977,7 +977,7 @@ private:
             for (BasicBlock* block : m_procedure.blocksInPostOrder()) {
                 if (!blocksToVisit.quickClear(block->index()))
                     continue;
-                HashSet<Value*> undominatedPhis = undominatedPhisAtTail[block];
+                UncheckedKeyHashSet<Value*> undominatedPhis = undominatedPhisAtTail[block];
                 for (unsigned index = block->size()-1; index--;) {
                     Value* value = block->at(index);
                     switch (value->opcode()) {

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
@@ -507,8 +507,8 @@ void GenerateAndAllocateRegisters::prepareForGeneration()
         UnifiedTmpLiveness liveness(m_code);
         for (BasicBlock* block : m_code) {
             auto assertLivenessAreEqual = [&] (auto a, auto b) {
-                HashSet<Tmp> livenessA;
-                HashSet<Tmp> livenessB;
+                UncheckedKeyHashSet<Tmp> livenessA;
+                UncheckedKeyHashSet<Tmp> livenessB;
                 for (Tmp tmp : a) {
                     if (tmp.isReg() && isDisallowedRegister(tmp.reg()))
                         continue;

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
@@ -456,7 +456,7 @@ protected:
     {
         out.print("graph InterferenceGraph { \n");
 
-        HashSet<Tmp> tmpsWithInterferences;
+        UncheckedKeyHashSet<Tmp> tmpsWithInterferences;
 
         m_interferenceEdges.forEach([&tmpsWithInterferences] (std::pair<IndexType, IndexType> edge) {
             tmpsWithInterferences.add(TmpMapper::tmpFromAbsoluteIndex(edge.first));
@@ -1330,7 +1330,7 @@ protected:
 
     // Work lists.
     // Low-degree, Move related.
-    HashSet<IndexType> m_freezeWorklist;
+    UncheckedKeyHashSet<IndexType> m_freezeWorklist;
     // Set of "move" enabled for possible coalescing.
     OrderedMoveSet m_worklistMoves;
     // Set of "move" not yet ready for coalescing.

--- a/Source/JavaScriptCore/b3/air/AirCustom.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCustom.cpp
@@ -148,7 +148,7 @@ bool ShuffleCustom::isValidForm(Inst& inst)
     // - Closed loops. These loops consist of nodes that have one successor and one predecessor, so
     //   there is no way to "get into" the loop from outside of it. These can be executed using swaps
     //   or by saving one of the Args to a scratch register and executing it as a shift.
-    HashSet<Arg> dsts;
+    UncheckedKeyHashSet<Arg> dsts;
 
     for (unsigned i = 0; i < inst.args.size(); ++i) {
         Arg arg = inst.args[i];

--- a/Source/JavaScriptCore/b3/air/AirValidate.cpp
+++ b/Source/JavaScriptCore/b3/air/AirValidate.cpp
@@ -53,9 +53,9 @@ public:
     
     void run()
     {
-        HashSet<StackSlot*> validSlots;
-        HashSet<BasicBlock*> validBlocks;
-        HashSet<Special*> validSpecials;
+        UncheckedKeyHashSet<StackSlot*> validSlots;
+        UncheckedKeyHashSet<BasicBlock*> validBlocks;
+        UncheckedKeyHashSet<Special*> validSpecials;
         
         for (BasicBlock* block : m_code)
             validBlocks.add(block);
@@ -134,7 +134,7 @@ public:
 
         for (BasicBlock* block : m_code) {
             // We expect the predecessor list to be de-duplicated.
-            HashSet<BasicBlock*> predecessors;
+            UncheckedKeyHashSet<BasicBlock*> predecessors;
             for (BasicBlock* predecessor : block->predecessors())
                 predecessors.add(predecessor);
             VALIDATE(block->numPredecessors() == predecessors.size(), ("At ", *block));

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -436,7 +436,7 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
     }
 
     // Bookkeep the strongly referenced module environments.
-    HashSet<JSModuleEnvironment*> stronglyReferencedModuleEnvironments;
+    UncheckedKeyHashSet<JSModuleEnvironment*> stronglyReferencedModuleEnvironments;
 
     auto link_objectAllocationProfile = [&](const auto& /*instruction*/, auto bytecode, auto& metadata) {
         metadata.m_objectAllocationProfile.initializeProfile(vm, m_globalObject.get(), this, m_globalObject->objectPrototype(), bytecode.m_inlineCapacity);
@@ -2766,7 +2766,7 @@ bool CodeBlock::hasIdentifier(UniquedStringImpl* uid)
         if (m_cachedIdentifierUids.size() != numberOfIdentifiers) {
             Locker locker(m_cachedIdentifierUidsLock);
             createRareDataIfNecessary();
-            HashSet<UniquedStringImpl*> cachedIdentifierUids;
+            UncheckedKeyHashSet<UniquedStringImpl*> cachedIdentifierUids;
             cachedIdentifierUids.reserveInitialCapacity(numberOfIdentifiers);
             for (unsigned index = 0; index < unlinkedIdentifiers; ++index) {
                 const Identifier& identifier = unlinkedCode->identifier(index);

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -980,7 +980,7 @@ private:
 
 #if ASSERT_ENABLED
     Lock m_cachedIdentifierUidsLock;
-    HashSet<UniquedStringImpl*> m_cachedIdentifierUids;
+    UncheckedKeyHashSet<UniquedStringImpl*> m_cachedIdentifierUids;
     uint32_t m_magic;
 #endif
 };

--- a/Source/JavaScriptCore/bytecode/DFGExitProfile.h
+++ b/Source/JavaScriptCore/bytecode/DFGExitProfile.h
@@ -237,7 +237,7 @@ private:
         return m_frequentExitSites.find(site) != m_frequentExitSites.end();
     }
     
-    HashSet<FrequentExitSite> m_frequentExitSites;
+    UncheckedKeyHashSet<FrequentExitSite> m_frequentExitSites;
 };
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/bytecode/SharedJITStubSet.h
+++ b/Source/JavaScriptCore/bytecode/SharedJITStubSet.h
@@ -160,7 +160,7 @@ public:
     void setSlowPathHandler(AccessType, Ref<InlineCacheHandler>);
 
 private:
-    HashSet<Hash::Key, Hash, Hash::KeyTraits> m_stubs;
+    UncheckedKeyHashSet<Hash::Key, Hash, Hash::KeyTraits> m_stubs;
     UncheckedKeyHashMap<StatelessCacheKey, Ref<PolymorphicAccessJITStubRoutine>> m_statelessStubs;
     UncheckedKeyHashMap<DOMJITCacheKey, MacroAssemblerCodeRef<JITStubRoutinePtrTag>> m_domJITCodes;
     std::array<RefPtr<InlineCacheHandler>, numberOfAccessTypes> m_fallbackHandlers { };

--- a/Source/JavaScriptCore/bytecode/TrackedReferences.h
+++ b/Source/JavaScriptCore/bytecode/TrackedReferences.h
@@ -46,7 +46,7 @@ public:
     void dump(PrintStream&) const;
     
 private:
-    HashSet<JSCell*> m_references;
+    UncheckedKeyHashSet<JSCell*> m_references;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
@@ -282,7 +282,7 @@ bool UnlinkedCodeBlock::hasIdentifier(UniquedStringImpl* uid)
     if (numberOfIdentifiers() > 100) {
         if (numberOfIdentifiers() != m_cachedIdentifierUids.size()) {
             Locker locker(m_cachedIdentifierUidsLock);
-            HashSet<UniquedStringImpl*> cachedIdentifierUids;
+            UncheckedKeyHashSet<UniquedStringImpl*> cachedIdentifierUids;
             for (unsigned i = 0; i < numberOfIdentifiers(); ++i) {
                 const Identifier& identifier = this->identifier(i);
                 cachedIdentifierUids.add(identifier.impl());

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -511,7 +511,7 @@ private:
 
 #if ASSERT_ENABLED
     Lock m_cachedIdentifierUidsLock;
-    HashSet<UniquedStringImpl*> m_cachedIdentifierUids;
+    UncheckedKeyHashSet<UniquedStringImpl*> m_cachedIdentifierUids;
 #endif
 
 protected:

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -3255,7 +3255,7 @@ Vector<Identifier> BytecodeGenerator::getParameterNames() const
 std::optional<PrivateNameEnvironment> BytecodeGenerator::getAvailablePrivateAccessNames()
 {
     PrivateNameEnvironment result;
-    HashSet<UniquedStringImpl*> excludedNames;
+    UncheckedKeyHashSet<UniquedStringImpl*> excludedNames;
     for (unsigned i = m_privateNamesStack.size(); i--; ) {
         auto& map = m_privateNamesStack[i];
         for (auto& entry : map)  {

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -1148,7 +1148,7 @@ namespace JSC {
         using NumberMap = UncheckedKeyHashMap<double, JSValue>;
         using IdentifierStringMap = UncheckedKeyHashMap<UniquedStringImpl*, JSString*, IdentifierRepHash>;
         using IdentifierBigIntMap = UncheckedKeyHashMap<BigIntMapEntry, JSValue>;
-        using TemplateObjectDescriptorSet = HashSet<Ref<TemplateObjectDescriptor>>;
+        using TemplateObjectDescriptorSet = UncheckedKeyHashSet<Ref<TemplateObjectDescriptor>>;
         using TemplateDescriptorMap = UncheckedKeyHashMap<uint64_t, JSTemplateObjectDescriptor*, WTF::IntHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
 
         // Helper for emitCall() and emitConstruct(). This works because the set of
@@ -1316,7 +1316,7 @@ namespace JSC {
 
         // Some of these objects keep pointers to one another. They are arranged
         // to ensure a sane destruction order that avoids references to freed memory.
-        HashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash> m_functions;
+        UncheckedKeyHashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash> m_functions;
         RegisterID m_ignoredResultRegister;
         RegisterID m_thisRegister;
         RegisterID m_calleeRegister;

--- a/Source/JavaScriptCore/bytecompiler/StaticPropertyAnalysis.h
+++ b/Source/JavaScriptCore/bytecompiler/StaticPropertyAnalysis.h
@@ -51,7 +51,7 @@ private:
     }
 
     JSInstructionStream::MutableRef m_instructionRef;
-    typedef HashSet<unsigned, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> PropertyIndexSet;
+    typedef UncheckedKeyHashSet<unsigned, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> PropertyIndexSet;
     PropertyIndexSet m_propertyIndexes;
 };
 

--- a/Source/JavaScriptCore/debugger/Debugger.cpp
+++ b/Source/JavaScriptCore/debugger/Debugger.cpp
@@ -137,9 +137,8 @@ Debugger::~Debugger()
 {
     m_vm.removeDebugger(*this);
 
-    HashSet<JSGlobalObject*>::iterator end = m_globalObjects.end();
-    for (HashSet<JSGlobalObject*>::iterator it = m_globalObjects.begin(); it != end; ++it)
-        (*it)->setDebugger(nullptr);
+    for (auto* globalObject : m_globalObjects)
+        globalObject->setDebugger(nullptr);
 }
 
 void Debugger::attach(JSGlobalObject* globalObject)
@@ -151,7 +150,7 @@ void Debugger::attach(JSGlobalObject* globalObject)
     m_vm.setShouldBuildPCToCodeOriginMapping();
 
     // Call `sourceParsed` after iterating because it will execute JavaScript in Web Inspector.
-    HashSet<RefPtr<SourceProvider>> sourceProviders;
+    UncheckedKeyHashSet<RefPtr<SourceProvider>> sourceProviders;
     {
         JSLockHolder locker(m_vm);
         HeapIterationScope iterationScope(m_vm.heap);

--- a/Source/JavaScriptCore/debugger/Debugger.h
+++ b/Source/JavaScriptCore/debugger/Debugger.h
@@ -326,7 +326,7 @@ private:
     void dispatchFunctionToObservers(Function<void(Observer&)>);
 
     VM& m_vm;
-    HashSet<JSGlobalObject*> m_globalObjects;
+    UncheckedKeyHashSet<JSGlobalObject*> m_globalObjects;
     UncheckedKeyHashMap<SourceID, DebuggerParseData, WTF::IntHash<SourceID>, WTF::UnsignedWithZeroKeyHashTraits<SourceID>> m_parseDataMap;
     UncheckedKeyHashMap<SourceID, BlackboxConfiguration, WTF::IntHash<SourceID>, WTF::UnsignedWithZeroKeyHashTraits<SourceID>> m_blackboxConfigurations;
     bool m_blackboxBreakpointEvaluations : 1;
@@ -351,7 +351,7 @@ private:
 
     using LineToBreakpointsMap = UncheckedKeyHashMap<unsigned, BreakpointsVector, WTF::IntHash<int>, WTF::UnsignedWithZeroKeyHashTraits<int>>;
     UncheckedKeyHashMap<SourceID, LineToBreakpointsMap, WTF::IntHash<SourceID>, WTF::UnsignedWithZeroKeyHashTraits<SourceID>> m_breakpointsForSourceID;
-    HashSet<Ref<Breakpoint>> m_breakpoints;
+    UncheckedKeyHashSet<Ref<Breakpoint>> m_breakpoints;
     RefPtr<Breakpoint> m_specialBreakpoint;
     ListHashSet<Ref<Breakpoint>> m_deferredBreakpoints;
     BreakpointID m_pausingBreakpointID;
@@ -365,7 +365,7 @@ private:
 
     RefPtr<JSC::DebuggerCallFrame> m_currentDebuggerCallFrame;
 
-    HashSet<Observer*> m_observers;
+    UncheckedKeyHashSet<Observer*> m_observers;
 
     Client* m_client { nullptr };
     ProfilingClient* m_profilingClient { nullptr };

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -5696,7 +5696,7 @@ template<typename AbstractStateType>
 void AbstractInterpreter<AbstractStateType>::dump(PrintStream& out)
 {
     CommaPrinter comma(" "_s);
-    HashSet<NodeFlowProjection> seen;
+    UncheckedKeyHashSet<NodeFlowProjection> seen;
     if (m_graph.m_form == SSA) {
         for (NodeFlowProjection node : m_state.block()->ssa->liveAtHead) {
             seen.add(node);

--- a/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
@@ -548,7 +548,7 @@ private:
             return IterationStatus::Continue;
         });
 
-        using InlineCallFrames = HashSet<InlineCallFrame*, WTF::DefaultHash<InlineCallFrame*>, WTF::NullableHashTraits<InlineCallFrame*>>;
+        using InlineCallFrames = UncheckedKeyHashSet<InlineCallFrame*, WTF::DefaultHash<InlineCallFrame*>, WTF::NullableHashTraits<InlineCallFrame*>>;
         using InlineCallFramesForCanditates = UncheckedKeyHashMap<Node*, InlineCallFrames>;
         InlineCallFramesForCanditates inlineCallFramesForCandidate;
         for (auto& [candidate, availability] : m_candidates) {

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -8351,7 +8351,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
 
             Vector<SpeculatedType> argumentPredictions(m_numArguments);
             Vector<SpeculatedType> localPredictions;
-            HashSet<unsigned, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> seenArguments;
+            UncheckedKeyHashSet<unsigned, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> seenArguments;
 
             {
                 ConcurrentJSLocker locker(m_inlineStackTop->m_profiledBlock->valueProfileLock());

--- a/Source/JavaScriptCore/dfg/DFGCSEPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCSEPhase.cpp
@@ -219,7 +219,7 @@ public:
     }
 
 private:
-    typedef HashSet<std::unique_ptr<ImpureDataSlot>, ImpureDataSlotHash> Map;
+    typedef UncheckedKeyHashSet<std::unique_ptr<ImpureDataSlot>, ImpureDataSlotHash> Map;
 
     const ImpureDataSlot* addImpl(const HeapLocation& location, const LazyNode& node)
     {

--- a/Source/JavaScriptCore/dfg/DFGClobberSet.cpp
+++ b/Source/JavaScriptCore/dfg/DFGClobberSet.cpp
@@ -111,12 +111,12 @@ void ClobberSet::clear()
     m_clobbers.clear();
 }
 
-HashSet<AbstractHeap> ClobberSet::direct() const
+UncheckedKeyHashSet<AbstractHeap> ClobberSet::direct() const
 {
     return setOf(true);
 }
 
-HashSet<AbstractHeap> ClobberSet::super() const
+UncheckedKeyHashSet<AbstractHeap> ClobberSet::super() const
 {
     return setOf(false);
 }
@@ -126,9 +126,9 @@ void ClobberSet::dump(PrintStream& out) const
     out.print("(Direct:[", sortedListDump(direct()), "], Super:[", sortedListDump(super()), "])");
 }
 
-HashSet<AbstractHeap> ClobberSet::setOf(bool direct) const
+UncheckedKeyHashSet<AbstractHeap> ClobberSet::setOf(bool direct) const
 {
-    HashSet<AbstractHeap> result;
+    UncheckedKeyHashSet<AbstractHeap> result;
     for (auto& clobber : m_clobbers) {
         if (clobber.value == direct)
             result.add(clobber.key);

--- a/Source/JavaScriptCore/dfg/DFGClobberSet.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberSet.h
@@ -58,15 +58,15 @@ public:
     // Calls useful for debugging the ClobberSet.
     // Do not call for non debugging purpose. Otherwise, you must handle DOMState hierarchy carefully.
     
-    HashSet<AbstractHeap> direct() const;
-    HashSet<AbstractHeap> super() const;
+    UncheckedKeyHashSet<AbstractHeap> direct() const;
+    UncheckedKeyHashSet<AbstractHeap> super() const;
     
     void dump(PrintStream&) const;
     
 private:
     bool contains(AbstractHeap) const;
 
-    HashSet<AbstractHeap> setOf(bool direct) const;
+    UncheckedKeyHashSet<AbstractHeap> setOf(bool direct) const;
     
     // Maps heap to:
     // true --> it's a direct clobber

--- a/Source/JavaScriptCore/dfg/DFGCommonData.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCommonData.cpp
@@ -104,7 +104,7 @@ void CommonData::installVMTrapBreakpoints(CodeBlock* owner)
 #if !defined(NDEBUG)
     // We need to be able to handle more than one invalidation point at the same pc
     // but we want to make sure we don't forget to remove a pc from the map.
-    HashSet<void*> newReplacements;
+    UncheckedKeyHashSet<void*> newReplacements;
 #endif
     for (auto& jumpReplacement : m_jumpReplacements) {
         jumpReplacement.installVMTrapBreakpoint();

--- a/Source/JavaScriptCore/dfg/DFGDesiredGlobalProperties.h
+++ b/Source/JavaScriptCore/dfg/DFGDesiredGlobalProperties.h
@@ -53,7 +53,7 @@ public:
     bool reallyAdd(CodeBlock*, DesiredIdentifiers&, WatchpointCollector&);
 
 private:
-    HashSet<DesiredGlobalProperty> m_set;
+    UncheckedKeyHashSet<DesiredGlobalProperty> m_set;
 };
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.h
+++ b/Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.h
@@ -236,7 +236,7 @@ public:
     }
 
 private:
-    HashSet<WatchpointSetType> m_sets;
+    UncheckedKeyHashSet<WatchpointSetType> m_sets;
     bool m_reallyAdded;
 };
 

--- a/Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.h
+++ b/Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.h
@@ -61,8 +61,8 @@ public:
 
 private:
     CodeBlock* m_codeBlock;
-    HashSet<JSCell*> m_cells;
-    HashSet<StructureID> m_structures;
+    UncheckedKeyHashSet<JSCell*> m_cells;
+    UncheckedKeyHashSet<StructureID> m_structures;
     FixedVector<WriteBarrier<JSCell>> m_finalizedCells;
     FixedVector<StructureID> m_finalizedStructures;
 };

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -1286,7 +1286,7 @@ public:
     Bag<BitVector> m_bitVectors;
     Vector<InlineVariableData, 4> m_inlineVariableData;
     UncheckedKeyHashMap<CodeBlock*, std::unique_ptr<FullBytecodeLiveness>> m_bytecodeLiveness;
-    HashSet<std::pair<JSObject*, PropertyOffset>> m_safeToLoad;
+    UncheckedKeyHashSet<std::pair<JSObject*, PropertyOffset>> m_safeToLoad;
     Vector<Ref<Snippet>> m_domJITSnippets;
     std::unique_ptr<CPSDominators> m_cpsDominators;
     std::unique_ptr<SSADominators> m_ssaDominators;
@@ -1313,8 +1313,8 @@ public:
     UncheckedKeyHashMap<unsigned, BytecodeIndex> m_entrypointIndexToCatchBytecodeIndex;
     Vector<CatchEntrypointData> m_catchEntrypoints;
 
-    HashSet<String> m_localStrings;
-    HashSet<String> m_copiedStrings;
+    UncheckedKeyHashSet<String> m_localStrings;
+    UncheckedKeyHashSet<String> m_copiedStrings;
 
 #if USE(JSVALUE32_64)
     UncheckedKeyHashMap<GenericHashKey<int64_t>, double*> m_doubleConstantsMap;
@@ -1342,8 +1342,8 @@ public:
     RegisteredStructure stringStructure;
     RegisteredStructure symbolStructure;
 
-    HashSet<Node*> m_slowGetByVal;
-    HashSet<Node*> m_slowPutByVal;
+    UncheckedKeyHashSet<Node*> m_slowGetByVal;
+    UncheckedKeyHashSet<Node*> m_slowPutByVal;
 
 private:
     template<typename Visitor> void visitChildrenImpl(Visitor&);

--- a/Source/JavaScriptCore/dfg/DFGLivenessAnalysisPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLivenessAnalysisPhase.cpp
@@ -44,7 +44,7 @@ namespace {
 // static const char templateString[] = "unsigned, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>";
 // typedef LoggingHashSet<templateString, unsigned, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> LiveSet;
 
-typedef HashSet<unsigned, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> LiveSet;
+typedef UncheckedKeyHashSet<unsigned, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> LiveSet;
 
 typedef IndexSparseSet<unsigned, DefaultIndexSparseSetTraits<unsigned>, UnsafeVectorOverflow> Workset;
 

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -3817,7 +3817,7 @@ public:
 
 // Uncomment this to log NodeSet operations.
 // typedef LoggingHashSet<Node::HashSetTemplateInstantiationString, Node*> NodeSet;
-typedef HashSet<Node*> NodeSet;
+typedef UncheckedKeyHashSet<Node*> NodeSet;
 
 struct NodeComparator {
     template<typename NodePtrType>

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -1759,7 +1759,7 @@ private:
     {
         // Collect the set of heap locations that we will be operating
         // over.
-        HashSet<PromotedHeapLocation> locations;
+        UncheckedKeyHashSet<PromotedHeapLocation> locations;
         for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
             m_heap = m_heapAtHead[block];
 
@@ -1819,7 +1819,7 @@ private:
         if (!m_bottom)
             m_bottom = m_insertionSet.insertConstant(0, m_graph.block(0)->at(0)->origin, jsNumber(1927));
 
-        Vector<HashSet<PromotedHeapLocation>> hintsForPhi(m_sinkCandidates.size());
+        Vector<UncheckedKeyHashSet<PromotedHeapLocation>> hintsForPhi(m_sinkCandidates.size());
 
         for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
             m_heap = m_heapAtHead[block];

--- a/Source/JavaScriptCore/dfg/DFGPhiChildren.h
+++ b/Source/JavaScriptCore/dfg/DFGPhiChildren.h
@@ -63,7 +63,7 @@ public:
             functor(node);
             return;
         }
-        HashSet<Node*> seen;
+        UncheckedKeyHashSet<Node*> seen;
         Vector<Node*> worklist;
         seen.add(node);
         worklist.append(node);

--- a/Source/JavaScriptCore/dfg/DFGPutStackSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPutStackSinkingPhase.cpp
@@ -361,7 +361,7 @@ public:
             indexToOperand.append(operand);
         }
         
-        HashSet<Node*> putStacksToSink;
+        UncheckedKeyHashSet<Node*> putStacksToSink;
         
         for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
             for (Node* node : *block) {

--- a/Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp
@@ -482,7 +482,7 @@ private:
     InsertionSet m_insertionSet;
     UncheckedKeyHashMap<VariableAccessData*, SSACalculator::Variable*> m_ssaVariableForVariable;
     UncheckedKeyHashMap<Node*, Node*> m_argumentMapping;
-    HashSet<Node*> m_argumentGetters;
+    UncheckedKeyHashSet<Node*> m_argumentGetters;
     Vector<VariableAccessData*> m_variableForSSAIndex;
 };
 

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
@@ -109,8 +109,8 @@ public:
             // towards believing that all nodes need barriers. "Needing a barrier" is like
             // saying that the node is in a past epoch. "Not needing a barrier" is like saying
             // that the node is in the current epoch.
-            m_stateAtHead = makeUnique<BlockMap<HashSet<Node*>>>(m_graph);
-            m_stateAtTail = makeUnique<BlockMap<HashSet<Node*>>>(m_graph);
+            m_stateAtHead = makeUnique<BlockMap<UncheckedKeyHashSet<Node*>>>(m_graph);
+            m_stateAtTail = makeUnique<BlockMap<UncheckedKeyHashSet<Node*>>>(m_graph);
             
             BlockList postOrder = m_graph.blocksInPostOrder();
             
@@ -665,8 +665,8 @@ private:
     // Things we only use in Global mode.
     std::unique_ptr<InPlaceAbstractState> m_state;
     std::unique_ptr<AbstractInterpreter<InPlaceAbstractState>> m_interpreter;
-    std::unique_ptr<BlockMap<HashSet<Node*>>> m_stateAtHead;
-    std::unique_ptr<BlockMap<HashSet<Node*>>> m_stateAtTail;
+    std::unique_ptr<BlockMap<UncheckedKeyHashSet<Node*>>> m_stateAtHead;
+    std::unique_ptr<BlockMap<UncheckedKeyHashSet<Node*>>> m_stateAtTail;
     bool m_isConverged;
 };
 

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -496,7 +496,7 @@ public:
 
         for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
             // We expect the predecessor list to be de-duplicated.
-            HashSet<BasicBlock*> predecessors;
+            UncheckedKeyHashSet<BasicBlock*> predecessors;
             for (BasicBlock* predecessor : block->predecessors)
                 predecessors.add(predecessor);
             VALIDATE((block), predecessors.size() == block->predecessors.size());
@@ -516,8 +516,8 @@ private:
             if (!block)
                 continue;
             
-            HashSet<Node*> phisInThisBlock;
-            HashSet<Node*> nodesInThisBlock;
+            UncheckedKeyHashSet<Node*> phisInThisBlock;
+            UncheckedKeyHashSet<Node*> nodesInThisBlock;
             
             for (size_t i = 0; i < block->numNodes(); ++i) {
                 Node* node = block->node(i);
@@ -533,7 +533,7 @@ private:
             }
 
             {
-                HashSet<Node*> seenNodes;
+                UncheckedKeyHashSet<Node*> seenNodes;
                 for (size_t i = 0; i < block->size(); ++i) {
                     Node* node = block->at(i);
                     m_graph.doToChildren(node, [&] (const Edge& edge) {
@@ -797,7 +797,7 @@ private:
 
         if (m_graph.m_form == ThreadedCPS) {
             Vector<Node*> worklist;
-            HashSet<Node*> seen;
+            UncheckedKeyHashSet<Node*> seen;
             for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
                 for (Node* node : *block) {
                     if (node->op() == GetLocal || node->op() == PhantomLocal) {
@@ -867,7 +867,7 @@ private:
 
             bool isOSRExited = false;
             
-            HashSet<Node*> nodesInThisBlock;
+            UncheckedKeyHashSet<Node*> nodesInThisBlock;
 
             for (auto* node : *block) {
                 switch (node->op()) {
@@ -1102,7 +1102,7 @@ private:
 
     UncheckedKeyHashMap<Node*, unsigned> m_myRefCounts;
     Vector<uint32_t> m_myTupleRefCounts;
-    HashSet<Node*> m_acceptableNodes;
+    UncheckedKeyHashSet<Node*> m_acceptableNodes;
 };
 
 } // End anonymous namespace.

--- a/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
@@ -55,7 +55,7 @@ public:
 private:
     bool convertValueRepsToDouble()
     {
-        HashSet<Node*> candidates;
+        UncheckedKeyHashSet<Node*> candidates;
         for (BasicBlock* block : m_graph.blocksInNaturalOrder()) {
             for (Node* node : *block) {
                 switch (node->op()) {
@@ -153,7 +153,7 @@ private:
         // - Any Phi-1 that forwards into another Phi-2, where Phi-2 is a candidate,
         //   makes Phi-1 a candidate too.
         do {
-            HashSet<Node*> eligiblePhis;
+            UncheckedKeyHashSet<Node*> eligiblePhis;
             for (Node* candidate : candidates) {
                 if (candidate->op() == Phi) {
                     phiChildren.forAllIncomingValues(candidate, [&] (Node* incoming) {
@@ -177,7 +177,7 @@ private:
         } while (true);
 
         do {
-            HashSet<Node*> toRemove;
+            UncheckedKeyHashSet<Node*> toRemove;
 
             auto isEscaped = [&] (Node* node) {
                 return !candidates.contains(node) || toRemove.contains(node);
@@ -317,7 +317,7 @@ private:
             return false;
 
         NodeOrigin originForConstant = m_graph.block(0)->at(0)->origin;
-        HashSet<Node*> doubleRepRealCheckLocations;
+        UncheckedKeyHashSet<Node*> doubleRepRealCheckLocations;
 
         for (Node* candidate : candidates) {
             dataLogLnIf(verbose, "Optimized: ", candidate);

--- a/Source/JavaScriptCore/dfg/DFGVarargsForwardingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGVarargsForwardingPhase.cpp
@@ -257,7 +257,7 @@ private:
             dataLog("Selected lastUserIndex = ", lastUserIndex, ", ", block->at(lastUserIndex), "\n");
 
         InlineCallFrame* startingInlineCallFrame = block->at(candidateNodeIndex)->origin.forExit.inlineCallFrame();
-        HashSet<InlineCallFrame*, WTF::DefaultHash<InlineCallFrame*>, WTF::NullableHashTraits<InlineCallFrame*>> seenInlineCallFrames;
+        UncheckedKeyHashSet<InlineCallFrame*, WTF::DefaultHash<InlineCallFrame*>, WTF::NullableHashTraits<InlineCallFrame*>> seenInlineCallFrames;
         
         // We're still in business. Determine if between the candidate and the last user there is any
         // effect that could interfere with sinking.

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -20326,7 +20326,7 @@ IGNORE_CLANG_WARNINGS_END
 
         Vector<SwitchCase> cases;
         // These may be negative, or zero, or probably other stuff, too. We don't want to mess with HashSet's corner cases and we don't really care about throughput here.
-        HashSet<GenericHashKey<int32_t>> alreadyHandled;
+        UncheckedKeyHashSet<GenericHashKey<int32_t>> alreadyHandled;
         for (unsigned i = 0; i < data->cases.size(); ++i) {
             // FIXME: The fact that we're using the bytecode's switch table means that the
             // following DFG IR transformation would be invalid.

--- a/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
@@ -295,7 +295,7 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
     // needing another object if the later is needed for the
     // allocation of the former.
 
-    HashSet<ExitTimeObjectMaterialization*> toMaterialize;
+    UncheckedKeyHashSet<ExitTimeObjectMaterialization*> toMaterialize;
     for (ExitTimeObjectMaterialization* materialization : exit.m_descriptor->m_materializations)
         toMaterialize.add(materialization);
 

--- a/Source/JavaScriptCore/ftl/FTLState.cpp
+++ b/Source/JavaScriptCore/ftl/FTLState.cpp
@@ -89,8 +89,8 @@ void State::dumpDisassembly(PrintStream& out, LinkBuffer& linkBuffer, const Scop
     B3::Value* currentB3Value = nullptr;
     Node* currentDFGNode = nullptr;
 
-    HashSet<B3::Value*> printedValues;
-    HashSet<Node*> printedNodes;
+    UncheckedKeyHashSet<B3::Value*> printedValues;
+    UncheckedKeyHashSet<Node*> printedNodes;
     const char* dfgPrefix = "DFG " "    ";
     const char* b3Prefix  = "b3  " "          ";
     const char* airPrefix = "Air " "              ";
@@ -106,7 +106,7 @@ void State::dumpDisassembly(PrintStream& out, LinkBuffer& linkBuffer, const Scop
 
         perDFGNodeCallback(node);
 
-        HashSet<Node*> localPrintedNodes;
+        UncheckedKeyHashSet<Node*> localPrintedNodes;
         WTF::Function<void(Node*)> printNodeRecursive = [&] (Node* node) {
             if (printedNodes.contains(node) || localPrintedNodes.contains(node))
                 return;
@@ -131,7 +131,7 @@ void State::dumpDisassembly(PrintStream& out, LinkBuffer& linkBuffer, const Scop
 
         printDFGNode(std::bit_cast<Node*>(value->origin().data()));
 
-        HashSet<B3::Value*> localPrintedValues;
+        UncheckedKeyHashSet<B3::Value*> localPrintedValues;
         auto printValueRecursive = recursableLambda([&] (auto self, B3::Value* value) -> void {
             if (printedValues.contains(value) || localPrintedValues.contains(value))
                 return;

--- a/Source/JavaScriptCore/heap/CodeBlockSet.cpp
+++ b/Source/JavaScriptCore/heap/CodeBlockSet.cpp
@@ -43,7 +43,7 @@ bool CodeBlockSet::contains(const AbstractLocker&, void* candidateCodeBlock)
 {
     RELEASE_ASSERT(m_lock.isLocked());
     CodeBlock* codeBlock = static_cast<CodeBlock*>(candidateCodeBlock);
-    if (!HashSet<CodeBlock*>::isValidValue(codeBlock))
+    if (!UncheckedKeyHashSet<CodeBlock*>::isValidValue(codeBlock))
         return false;
     return m_codeBlocks.contains(codeBlock);
 }

--- a/Source/JavaScriptCore/heap/CodeBlockSet.h
+++ b/Source/JavaScriptCore/heap/CodeBlockSet.h
@@ -75,8 +75,8 @@ public:
     void remove(CodeBlock*);
 
 private:
-    HashSet<CodeBlock*> m_codeBlocks;
-    HashSet<CodeBlock*> m_currentlyExecuting;
+    UncheckedKeyHashSet<CodeBlock*> m_codeBlocks;
+    UncheckedKeyHashSet<CodeBlock*> m_currentlyExecuting;
     Lock m_lock;
 };
 

--- a/Source/JavaScriptCore/heap/ConservativeRoots.cpp
+++ b/Source/JavaScriptCore/heap/ConservativeRoots.cpp
@@ -113,7 +113,7 @@ inline void ConservativeRoots::genericAddPointer(char* pointer, HeapVersion mark
         m_roots[m_size++] = std::bit_cast<HeapCell*>(p);
     };
 
-    const HashSet<MarkedBlock*>& set = m_heap.objectSpace().blocks().set();
+    const UncheckedKeyHashSet<MarkedBlock*>& set = m_heap.objectSpace().blocks().set();
 
     ASSERT(m_heap.objectSpace().isMarking());
     static constexpr bool isMarking = true;

--- a/Source/JavaScriptCore/heap/ConservativeRoots.h
+++ b/Source/JavaScriptCore/heap/ConservativeRoots.h
@@ -61,8 +61,8 @@ private:
     // 2) tier up finishes for foo and is added to Heap::m_wasmCalleesPendingDestruction
     // 3) foo isn't added to m_wasmCalleesDiscovered
     // 4) foo gets derefed and destroyed.
-    HashSet<const Wasm::Callee*> m_wasmCalleesPendingDestructionCopy;
-    HashSet<const Wasm::Callee*> m_wasmCalleesDiscovered;
+    UncheckedKeyHashSet<const Wasm::Callee*> m_wasmCalleesPendingDestructionCopy;
+    UncheckedKeyHashSet<const Wasm::Callee*> m_wasmCalleesDiscovered;
     TinyBloomFilter<uintptr_t> m_boxedWasmCalleeFilter;
     HeapCell** m_roots;
     size_t m_size;

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -436,7 +436,7 @@ public:
     JS_EXPORT_PRIVATE std::unique_ptr<TypeCountSet> protectedObjectTypeCounts();
     JS_EXPORT_PRIVATE std::unique_ptr<TypeCountSet> objectTypeCounts();
 
-    HashSet<MarkedVectorBase*>& markListSet();
+    UncheckedKeyHashSet<MarkedVectorBase*>& markListSet();
     void addMarkedJSValueRefArray(MarkedJSValueRefArray*);
     
     template<typename Functor> void forEachProtectedCell(const Functor&);
@@ -832,7 +832,7 @@ private:
     size_t m_deprecatedExtraMemorySize { 0 };
 
     ProtectCountSet m_protectedValues;
-    HashSet<MarkedVectorBase*> m_markListSet;
+    UncheckedKeyHashSet<MarkedVectorBase*> m_markListSet;
     SentinelLinkedList<MarkedJSValueRefArray, BasicRawSentinelNode<MarkedJSValueRefArray>> m_markedJSValueRefArrays;
 
     std::unique_ptr<MachineThreads> m_machineThreads;
@@ -896,10 +896,10 @@ private:
 #endif
     unsigned m_deferralDepth { 0 };
 
-    HashSet<WeakGCHashTable*> m_weakGCHashTables;
+    UncheckedKeyHashSet<WeakGCHashTable*> m_weakGCHashTables;
     
 #if ENABLE(WEBASSEMBLY)
-    HashSet<Ref<Wasm::Callee>> m_wasmCalleesPendingDestruction WTF_GUARDED_BY_LOCK(m_wasmCalleesPendingDestructionLock);
+    UncheckedKeyHashSet<Ref<Wasm::Callee>> m_wasmCalleesPendingDestruction WTF_GUARDED_BY_LOCK(m_wasmCalleesPendingDestructionLock);
 #endif
 
     std::unique_ptr<MarkStackArray> m_sharedCollectorMarkStack;

--- a/Source/JavaScriptCore/heap/HeapInlines.h
+++ b/Source/JavaScriptCore/heap/HeapInlines.h
@@ -205,7 +205,7 @@ inline void Heap::decrementDeferralDepthAndGCIfNeeded()
     }
 }
 
-inline HashSet<MarkedVectorBase*>& Heap::markListSet()
+inline UncheckedKeyHashSet<MarkedVectorBase*>& Heap::markListSet()
 {
     return m_markListSet;
 }

--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.h
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.h
@@ -162,7 +162,7 @@ private:
     UncheckedKeyHashMap<JSCell*, RootData> m_rootData;
     UncheckedKeyHashMap<JSCell*, void*> m_wrappedObjectPointers;
     UncheckedKeyHashMap<JSCell*, String> m_cellLabels;
-    HashSet<JSCell*> m_appendedCells;
+    UncheckedKeyHashSet<JSCell*> m_appendedCells;
     SnapshotType m_snapshotType;
 };
 

--- a/Source/JavaScriptCore/heap/HeapUtil.h
+++ b/Source/JavaScriptCore/heap/HeapUtil.h
@@ -59,7 +59,7 @@ public:
             return set->contains(pointer);
         }
     
-        const HashSet<MarkedBlock*>& set = heap.objectSpace().blocks().set();
+        const UncheckedKeyHashSet<MarkedBlock*>& set = heap.objectSpace().blocks().set();
         
         MarkedBlock* candidate = MarkedBlock::blockFor(pointer);
         if (filter.ruleOut(std::bit_cast<uintptr_t>(candidate))) {

--- a/Source/JavaScriptCore/heap/MarkedBlockSet.h
+++ b/Source/JavaScriptCore/heap/MarkedBlockSet.h
@@ -39,13 +39,13 @@ public:
     void remove(MarkedBlock*);
 
     TinyBloomFilter<uintptr_t> filter() const;
-    const HashSet<MarkedBlock*>& set() const;
+    const UncheckedKeyHashSet<MarkedBlock*>& set() const;
 
 private:
     void recomputeFilter();
 
     TinyBloomFilter<uintptr_t> m_filter;
-    HashSet<MarkedBlock*> m_set;
+    UncheckedKeyHashSet<MarkedBlock*> m_set;
 };
 
 inline void MarkedBlockSet::add(MarkedBlock* block)
@@ -65,8 +65,8 @@ inline void MarkedBlockSet::remove(MarkedBlock* block)
 inline void MarkedBlockSet::recomputeFilter()
 {
     TinyBloomFilter<uintptr_t> filter;
-    for (HashSet<MarkedBlock*>::iterator it = m_set.begin(); it != m_set.end(); ++it)
-        filter.add(reinterpret_cast<uintptr_t>(*it));
+    for (auto* block : m_set)
+        filter.add(reinterpret_cast<uintptr_t>(block));
     m_filter = filter;
 }
 
@@ -75,7 +75,7 @@ inline TinyBloomFilter<uintptr_t> MarkedBlockSet::filter() const
     return m_filter;
 }
 
-inline const HashSet<MarkedBlock*>& MarkedBlockSet::set() const
+inline const UncheckedKeyHashSet<MarkedBlock*>& MarkedBlockSet::set() const
 {
     return m_set;
 }

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -270,7 +270,7 @@ void MarkedSpace::prepareForAllocation()
 
 void MarkedSpace::enablePreciseAllocationTracking()
 {
-    m_preciseAllocationSet = makeUnique<HashSet<HeapCell*>>();
+    m_preciseAllocationSet = makeUnique<UncheckedKeyHashSet<HeapCell*>>();
     for (auto* allocation : m_preciseAllocations)
         m_preciseAllocationSet->add(allocation->cell());
 }

--- a/Source/JavaScriptCore/heap/MarkedSpace.h
+++ b/Source/JavaScriptCore/heap/MarkedSpace.h
@@ -124,7 +124,7 @@ public:
     
     void prepareForConservativeScan();
 
-    typedef HashSet<MarkedBlock*>::iterator BlockIterator;
+    typedef UncheckedKeyHashSet<MarkedBlock*>::iterator BlockIterator;
 
     template<typename Functor> void forEachLiveCell(HeapIterationScope&, const Functor&);
     template<typename Functor> void forEachDeadCell(HeapIterationScope&, const Functor&);
@@ -162,7 +162,7 @@ public:
     const Vector<PreciseAllocation*>& preciseAllocations() const { return m_preciseAllocations; }
     unsigned preciseAllocationsNurseryOffset() const { return m_preciseAllocationsNurseryOffset; }
     unsigned preciseAllocationsOffsetForThisCollection() const { return m_preciseAllocationsOffsetForThisCollection; }
-    HashSet<HeapCell*>* preciseAllocationSet() const { return m_preciseAllocationSet.get(); }
+    UncheckedKeyHashSet<HeapCell*>* preciseAllocationSet() const { return m_preciseAllocationSet.get(); }
 
     void enablePreciseAllocationTracking();
     
@@ -206,7 +206,7 @@ private:
 
     Vector<Subspace*> m_subspaces;
 
-    std::unique_ptr<HashSet<HeapCell*>> m_preciseAllocationSet;
+    std::unique_ptr<UncheckedKeyHashSet<HeapCell*>> m_preciseAllocationSet;
     Vector<PreciseAllocation*> m_preciseAllocations;
     unsigned m_preciseAllocationsNurseryOffset { 0 };
     unsigned m_preciseAllocationsOffsetForThisCollection { 0 };

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -863,10 +863,10 @@ public:
         profiler.vm().heap.collectNow(Sync, CollectionScope::Full);
         profiler.setActiveHeapAnalyzer(nullptr);
 
-        HashSet<JSCell*> queue;
+        UncheckedKeyHashSet<JSCell*> queue;
 
         // Filter `m_holders` based on whether they're reachable from a non-Debugger root.
-        HashSet<JSCell*> visited;
+        UncheckedKeyHashSet<JSCell*> visited;
         for (auto* root : m_rootsToInclude)
             queue.add(root);
         while (auto* from = queue.takeAny()) {
@@ -898,7 +898,7 @@ public:
         });
     }
 
-    HashSet<JSCell*>& holders() { return m_holders; }
+    UncheckedKeyHashSet<JSCell*>& holders() { return m_holders; }
 
     void analyzeEdge(JSCell* from, JSCell* to, RootMarkReason reason) final
     {
@@ -909,11 +909,11 @@ public:
 
         if (from && from != to) {
             m_successors.ensure(from, [] {
-                return HashSet<JSCell*>();
+                return UncheckedKeyHashSet<JSCell*>();
             }).iterator->value.add(to);
 
             m_predecessors.ensure(to, [] {
-                return HashSet<JSCell*>();
+                return UncheckedKeyHashSet<JSCell*>();
             }).iterator->value.add(from);
 
             if (to == m_target)
@@ -939,7 +939,7 @@ public:
     {
         Indentation<4> indent;
 
-        HashSet<JSCell*> visited;
+        UncheckedKeyHashSet<JSCell*> visited;
 
         Function<void(JSCell*)> visit = [&] (auto* from) {
             auto isFirstVisit = visited.add(from).isNewEntry;
@@ -977,11 +977,11 @@ public:
 
 private:
     Lock m_mutex;
-    UncheckedKeyHashMap<JSCell*, HashSet<JSCell*>> m_predecessors;
-    UncheckedKeyHashMap<JSCell*, HashSet<JSCell*>> m_successors;
-    HashSet<JSCell*> m_rootsToInclude;
-    HashSet<JSCell*> m_rootsToIgnore;
-    HashSet<JSCell*> m_holders;
+    UncheckedKeyHashMap<JSCell*, UncheckedKeyHashSet<JSCell*>> m_predecessors;
+    UncheckedKeyHashMap<JSCell*, UncheckedKeyHashSet<JSCell*>> m_successors;
+    UncheckedKeyHashSet<JSCell*> m_rootsToInclude;
+    UncheckedKeyHashSet<JSCell*> m_rootsToIgnore;
+    UncheckedKeyHashSet<JSCell*> m_holders;
     const JSCell* m_target;
 };
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -1309,7 +1309,7 @@ Protocol::ErrorStringOr<void> InspectorDebuggerAgent::setShouldBlackboxURL(const
         return makeUnexpected("Blackboxing of internal scripts is controlled by 'Debugger.setPauseForInternalScripts'"_s);
 
     if (shouldBlackbox) {
-        HashSet<JSC::Debugger::BlackboxRange> blackboxRanges;
+        UncheckedKeyHashSet<JSC::Debugger::BlackboxRange> blackboxRanges;
         if (protocolSourceRanges) {
             if (protocolSourceRanges->length() % 4)
                 return makeUnexpected("Unexpected format for given sourceRanges"_s);

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
@@ -253,9 +253,9 @@ private:
     UncheckedKeyHashMap<JSC::SourceID, JSC::Debugger::Script> m_scripts;
 
     using BlackboxParameters = std::tuple<String /* url */, bool /* caseSensitive */, bool /* isRegex */>;
-    UncheckedKeyHashMap<BlackboxParameters, HashSet<JSC::Debugger::BlackboxRange>> m_blackboxedURLs;
+    UncheckedKeyHashMap<BlackboxParameters, UncheckedKeyHashSet<JSC::Debugger::BlackboxRange>> m_blackboxedURLs;
 
-    HashSet<Listener*> m_listeners;
+    UncheckedKeyHashSet<Listener*> m_listeners;
 
     JSC::JSGlobalObject* m_pausedGlobalObject { nullptr };
     JSC::Strong<JSC::Unknown> m_currentCallStack;
@@ -290,7 +290,7 @@ private:
         RefPtr<JSC::Breakpoint> specialBreakpoint;
 
         // Avoid having to (re)match the regex each time a function as called.
-        HashSet<String> knownMatchingSymbols;
+        UncheckedKeyHashSet<String> knownMatchingSymbols;
 
         inline bool operator==(const SymbolicBreakpoint& other) const
         {

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
@@ -318,7 +318,7 @@ private:
 #endif
     bool m_shouldSendParentProcessInformation { false };
     bool m_automaticInspectionEnabled WTF_GUARDED_BY_LOCK(m_mutex) { false };
-    HashSet<TargetID, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_pausedAutomaticInspectionCandidates WTF_GUARDED_BY_LOCK(m_mutex);
+    UncheckedKeyHashSet<TargetID, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_pausedAutomaticInspectionCandidates WTF_GUARDED_BY_LOCK(m_mutex);
 };
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.h
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.h
@@ -64,13 +64,13 @@ private:
 
     GRefPtr<GSocketService> m_service;
     uint16_t m_port { 0 };
-    HashSet<RefPtr<SocketConnection>> m_connections;
+    UncheckedKeyHashSet<RefPtr<SocketConnection>> m_connections;
     UncheckedKeyHashMap<SocketConnection*, uint64_t> m_remoteInspectorConnectionToIDMap;
     UncheckedKeyHashMap<uint64_t, SocketConnection*> m_idToRemoteInspectorConnectionMap;
     SocketConnection* m_clientConnection { nullptr };
     SocketConnection* m_automationConnection { nullptr };
-    HashSet<std::pair<uint64_t, uint64_t>> m_inspectionTargets;
-    HashSet<std::pair<uint64_t, uint64_t>> m_automationTargets;
+    UncheckedKeyHashSet<std::pair<uint64_t, uint64_t>> m_inspectionTargets;
+    UncheckedKeyHashSet<std::pair<uint64_t, uint64_t>> m_automationTargets;
 };
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -225,7 +225,7 @@ private:
     struct HostKeySearcher;
     struct NativeExecutableTranslator;
 
-    using WeakNativeExecutableSet = HashSet<Weak<NativeExecutable>, WeakNativeExecutableHash>;
+    using WeakNativeExecutableSet = UncheckedKeyHashSet<Weak<NativeExecutable>, WeakNativeExecutableHash>;
 
     MacroAssemblerCodeRef<JITThunkPtrTag> m_commonThunks[numberOfCommonThunkIDs] { };
     CTIStubMap m_ctiStubMap;

--- a/Source/JavaScriptCore/jit/JITWorklist.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklist.cpp
@@ -349,7 +349,7 @@ template<typename MatchFunction>
 void JITWorklist::removeMatchingPlansForVM(VM& vm, const MatchFunction& matches)
 {
     Locker locker { *m_lock };
-    HashSet<JITCompilationKey> deadPlanKeys;
+    UncheckedKeyHashSet<JITCompilationKey> deadPlanKeys;
     for (auto& entry : m_plans) {
         JITPlan* plan = entry.value.get();
         if (plan->vm() != &vm)

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -594,11 +594,11 @@ private:
         }
 
         bool contains(UniquedStringImpl* name) const { return m_names.contains(name); }
-        const HashSet<UniquedStringImpl*>& names() const { return m_names; }
+        const UncheckedKeyHashSet<UniquedStringImpl*>& names() const { return m_names; }
 
     private:
         Vector<AtomString> m_strings; // To keep the UniqueStringImpls alive.
-        HashSet<UniquedStringImpl*> m_names;
+        UncheckedKeyHashSet<UniquedStringImpl*> m_names;
     };
 
     void finishCreation(VM& vm, const Vector<String>& arguments)

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -338,7 +338,7 @@ Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>
 #if ASSERT_ENABLED
     if (m_parsingBuiltin && isProgramParseMode(parseMode)) {
         VariableEnvironment& lexicalVariables = scope->lexicalVariables();
-        const HashSet<UniquedStringImpl*>& closedVariableCandidates = scope->closedVariableCandidates();
+        auto& closedVariableCandidates = scope->closedVariableCandidates();
         for (UniquedStringImpl* candidate : closedVariableCandidates) {
             // FIXME: We allow async to leak because it appearing as a closed variable is a side effect of trying to parse async arrow functions.
             if (!lexicalVariables.contains(candidate) && !varDeclarations.contains(candidate) && !candidate->isSymbol() && candidate != m_vm.propertyNames->async.impl()) {
@@ -3646,7 +3646,7 @@ template <class TreeBuilder> typename TreeBuilder::ImportSpecifier Parser<LexerT
 template <typename LexerType>
 template <class TreeBuilder> typename TreeBuilder::ImportAttributesList Parser<LexerType>::parseImportAttributes(TreeBuilder& context)
 {
-    HashSet<UniquedStringImpl*> keys;
+    UncheckedKeyHashSet<UniquedStringImpl*> keys;
     auto attributesList = context.createImportAttributesList();
     consumeOrFail(OPENBRACE, "Expected opening '{' at the start of import attribute");
     while (!match(CLOSEBRACE)) {

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -320,7 +320,7 @@ public:
     bool usesEval() const { return m_usesEval; }
     bool usesImportMeta() const { return m_usesImportMeta; }
 
-    const HashSet<UniquedStringImpl*>& closedVariableCandidates() const { return m_closedVariableCandidates; }
+    const UncheckedKeyHashSet<UniquedStringImpl*>& closedVariableCandidates() const { return m_closedVariableCandidates; }
     VariableEnvironment& declaredVariables() { return m_declaredVariables; }
     VariableEnvironment& lexicalVariables() { return m_lexicalVariables; }
     void finalizeLexicalEnvironment()
@@ -999,7 +999,7 @@ private:
     Vector<UniquedStringImplPtrSet, 6> m_usedVariables;
     UniquedStringImplPtrSet m_variablesBeingHoisted;
     UncheckedKeyHashMap<FunctionMetadataNode*, NeedsDuplicateDeclarationCheck> m_sloppyModeFunctionHoistingCandidates;
-    HashSet<UniquedStringImpl*> m_closedVariableCandidates;
+    UncheckedKeyHashSet<UniquedStringImpl*> m_closedVariableCandidates;
     DeclarationStacks::FunctionStack m_functionDeclarations;
 };
 

--- a/Source/JavaScriptCore/parser/VariableEnvironment.h
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.h
@@ -331,7 +331,7 @@ private:
     std::unique_ptr<VariableEnvironment::RareData> m_rareData;
 };
 
-using TDZEnvironment = HashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash>;
+using TDZEnvironment = UncheckedKeyHashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash>;
 
 class CompactTDZEnvironment {
     WTF_MAKE_TZONE_ALLOCATED(CompactTDZEnvironment);

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
@@ -497,7 +497,7 @@ auto AbstractModuleRecord::resolveExportImpl(JSGlobalObject* globalObject, const
     //  4. Once we follow star links, we should not retrieve the result from the cache and should not cache the result.
     //  5. Once we see star links, even if we have not yet traversed that star link path, we should disable caching.
 
-    using ResolveSet = WTF::HashSet<ResolveQuery, ResolveQuery::Hash, ResolveQuery::HashTraits>;
+    using ResolveSet = WTF::UncheckedKeyHashSet<ResolveQuery, ResolveQuery::Hash, ResolveQuery::HashTraits>;
     enum class Type { Query, IndirectFallback, GatherStars };
     struct Task {
         ResolveQuery query;
@@ -720,7 +720,7 @@ static void getExportedNames(JSGlobalObject* globalObject, AbstractModuleRecord*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    HashSet<AbstractModuleRecord*> exportStarSet;
+    UncheckedKeyHashSet<AbstractModuleRecord*> exportStarSet;
     Vector<AbstractModuleRecord*, 8> pendingModules;
 
     pendingModules.append(root);

--- a/Source/JavaScriptCore/runtime/ArgList.h
+++ b/Source/JavaScriptCore/runtime/ArgList.h
@@ -42,7 +42,7 @@ class alignas(alignof(EncodedJSValue)) MarkedVectorBase {
 protected:
     enum class Status { Success, Overflowed };
 public:
-    typedef HashSet<MarkedVectorBase*> ListSet;
+    typedef UncheckedKeyHashSet<MarkedVectorBase*> ListSet;
 
     ~MarkedVectorBase()
     {

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -955,9 +955,9 @@ private:
 };
 
 template<typename T, typename HashArg = DefaultHash<T>>
-class CachedHashSet : public CachedObject<HashSet<SourceType<T>, HashArg>> {
+class CachedHashSet : public CachedObject<UncheckedKeyHashSet<SourceType<T>, HashArg>> {
 public:
-    void encode(Encoder& encoder, const HashSet<SourceType<T>, HashArg>& set)
+    void encode(Encoder& encoder, const UncheckedKeyHashSet<SourceType<T>, HashArg>& set)
     {
         SourceType<decltype(m_entries)> entriesVector(set.size());
         unsigned i = 0;
@@ -966,7 +966,7 @@ public:
         m_entries.encode(encoder, entriesVector);
     }
 
-    void decode(Decoder& decoder, HashSet<SourceType<T>, HashArg>& set) const
+    void decode(Decoder& decoder, UncheckedKeyHashSet<SourceType<T>, HashArg>& set) const
     {
         SourceType<decltype(m_entries)> entriesVector;
         m_entries.decode(decoder, entriesVector);

--- a/Source/JavaScriptCore/runtime/CodeCache.h
+++ b/Source/JavaScriptCore/runtime/CodeCache.h
@@ -54,7 +54,7 @@ class ProgramExecutable;
 class SourceCode;
 class VM;
 
-using TDZEnvironment = HashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash>;
+using TDZEnvironment = UncheckedKeyHashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash>;
 
 namespace CodeCacheInternal {
 static constexpr bool verbose = false;

--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
@@ -114,7 +114,7 @@ private:
     bool m_shouldStopRunLoopWhenAllTicketsFinish { false };
     bool m_currentlyRunningTask { false };
     Deque<std::tuple<Ticket, Task>> m_tasks WTF_GUARDED_BY_LOCK(m_taskLock);
-    HashSet<Ref<TicketData>> m_pendingTickets;
+    UncheckedKeyHashSet<Ref<TicketData>> m_pendingTickets;
 };
 
 inline JSObject* DeferredWorkTimer::TicketData::target()

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -283,7 +283,7 @@ struct IdentifierMapIndexHashTraits : HashTraits<int> {
     static constexpr bool emptyValueIsZero = false;
 };
 
-typedef HashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash> IdentifierSet;
+typedef UncheckedKeyHashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash> IdentifierSet;
 typedef UncheckedKeyHashMap<RefPtr<UniquedStringImpl>, int, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>, IdentifierMapIndexHashTraits> IdentifierMap;
 typedef UncheckedKeyHashMap<UniquedStringImpl*, int, IdentifierRepHash, HashTraits<UniquedStringImpl*>, IdentifierMapIndexHashTraits> BorrowedIdentifierMap;
 

--- a/Source/JavaScriptCore/runtime/ImportMap.cpp
+++ b/Source/JavaScriptCore/runtime/ImportMap.cpp
@@ -450,11 +450,11 @@ void ImportMap::addModuleToResolvedModuleSet(String referringScriptURL, AtomStri
     Vector<AtomString> referringScriptPrefixes = findURLPrefixes(referringScriptURL);
     for (AtomString& referringScriptPrefix : referringScriptPrefixes) {
         const auto& currentSetIt = m_scopedResolvedModuleMap.find(referringScriptPrefix);
-        HashSet<AtomString>* currentSet = nullptr;
+        UncheckedKeyHashSet<AtomString>* currentSet = nullptr;
         if (currentSetIt != m_scopedResolvedModuleMap.end())
             currentSet = &currentSetIt->value;
         else
-            currentSet = &(m_scopedResolvedModuleMap.set(referringScriptPrefix, HashSet<AtomString>()).iterator->value);
+            currentSet = &(m_scopedResolvedModuleMap.set(referringScriptPrefix, UncheckedKeyHashSet<AtomString>()).iterator->value);
 
         currentSet->add(specifier);
         for (AtomString& specifierPrefix : specifierPrefixes)

--- a/Source/JavaScriptCore/runtime/ImportMap.h
+++ b/Source/JavaScriptCore/runtime/ImportMap.h
@@ -83,8 +83,8 @@ private:
     // of prefixes resolved in them. That permits us to reduce the cost of merging
     // a new map, by performing more work at addModuleToResolvedModuleSet time,
     // and by keeping more prefixes in memory.
-    HashSet<AtomString> m_toplevelResolvedModuleSet;
-    UncheckedKeyHashMap<AtomString, HashSet<AtomString>> m_scopedResolvedModuleMap;
+    UncheckedKeyHashSet<AtomString> m_toplevelResolvedModuleSet;
+    UncheckedKeyHashMap<AtomString, UncheckedKeyHashSet<AtomString>> m_scopedResolvedModuleMap;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -767,7 +767,7 @@ Vector<String> canonicalizeLocaleList(JSGlobalObject* globalObject, JSValue loca
     uint64_t length = lengthProperty.toLength(globalObject);
     RETURN_IF_EXCEPTION(scope, Vector<String>());
 
-    HashSet<String> seenSet;
+    UncheckedKeyHashSet<String> seenSet;
     for (uint64_t k = 0; k < length; ++k) {
         bool kPresent = localesObject->hasProperty(globalObject, k);
         RETURN_IF_EXCEPTION(scope, Vector<String>());
@@ -1295,7 +1295,7 @@ bool LanguageTagParser::parseUnicodeLanguageId()
             return true;
     }
 
-    HashSet<VariantCode> variantCodes;
+    UncheckedKeyHashSet<VariantCode> variantCodes;
     while (true) {
         if (!isUnicodeVariantSubtag(m_current))
             return true;

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
@@ -187,7 +187,7 @@ JSObject* IntlPluralRules::resolvedOptions(JSGlobalObject* globalObject) const
     int32_t resultLength;
 
     // Category names are always ASCII, so use char[].
-    HashSet<String> categoriesSet;
+    UncheckedKeyHashSet<String> categoriesSet;
     unsigned index = 0;
     while (const char* result = uenum_next(keywords.get(), &resultLength, &status)) {
         ASSERT(U_SUCCESS(status));

--- a/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
+++ b/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
@@ -110,7 +110,7 @@ private:
 
     void timerDidFire();
 
-    HashSet<TimerNotificationCallback> m_timerSetCallbacks;
+    UncheckedKeyHashSet<TimerNotificationCallback> m_timerSetCallbacks;
     Lock m_timerCallbacksLock;
 
     Lock m_lock;

--- a/Source/JavaScriptCore/runtime/JSScope.h
+++ b/Source/JavaScriptCore/runtime/JSScope.h
@@ -35,7 +35,7 @@ class ScopeChainIterator;
 class SymbolTable;
 class WatchpointSet;
 
-using TDZEnvironment = HashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash>;
+using TDZEnvironment = UncheckedKeyHashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash>;
 
 class JSScope : public JSNonFinalObject {
 public:

--- a/Source/JavaScriptCore/runtime/LiteralParser.h
+++ b/Source/JavaScriptCore/runtime/LiteralParser.h
@@ -289,7 +289,7 @@ private:
     Lexer m_lexer;
     const ParserMode m_mode;
     String m_parseErrorMessage;
-    HashSet<JSObject*> m_visitedUnderscoreProto;
+    UncheckedKeyHashSet<JSObject*> m_visitedUnderscoreProto;
     MarkedArgumentBuffer m_objectStack;
     Vector<ParserState, 16, UnsafeVectorOverflow> m_stateStack;
     Vector<Identifier, 16, UnsafeVectorOverflow> m_identifierStack;

--- a/Source/JavaScriptCore/runtime/NativeCalleeRegistry.h
+++ b/Source/JavaScriptCore/runtime/NativeCalleeRegistry.h
@@ -60,14 +60,14 @@ public:
 #endif
     }
 
-    const HashSet<NativeCallee*>& allCallees() WTF_REQUIRES_LOCK(m_lock)
+    const UncheckedKeyHashSet<NativeCallee*>& allCallees() WTF_REQUIRES_LOCK(m_lock)
     {
         return m_calleeSet;
     }
 
     bool isValidCallee(NativeCallee* callee)  WTF_REQUIRES_LOCK(m_lock)
     {
-        if (!HashSet<NativeCallee*>::isValidValue(callee))
+        if (!UncheckedKeyHashSet<NativeCallee*>::isValidValue(callee))
             return false;
         return m_calleeSet.contains(callee);
     }
@@ -95,7 +95,7 @@ public:
 
 private:
     Lock m_lock;
-    HashSet<NativeCallee*> m_calleeSet WTF_GUARDED_BY_LOCK(m_lock);
+    UncheckedKeyHashSet<NativeCallee*> m_calleeSet WTF_GUARDED_BY_LOCK(m_lock);
 #if ENABLE(JIT)
     UncheckedKeyHashMap<NativeCallee*, Box<PCToCodeOriginMap>> m_pcToCodeOriginMaps WTF_GUARDED_BY_LOCK(m_lock);
 #endif

--- a/Source/JavaScriptCore/runtime/PropertyNameArray.h
+++ b/Source/JavaScriptCore/runtime/PropertyNameArray.h
@@ -89,7 +89,7 @@ private:
     bool isUidMatchedToTypeMode(UniquedStringImpl* identifier);
 
     RefPtr<PropertyNameArrayData> m_data;
-    HashSet<UniquedStringImpl*> m_set;
+    UncheckedKeyHashSet<UniquedStringImpl*> m_set;
     VM& m_vm;
     PropertyNameMode m_propertyNameMode;
     PrivateSymbolMode m_privateSymbolMode;

--- a/Source/JavaScriptCore/runtime/ProxyObject.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyObject.cpp
@@ -1062,7 +1062,7 @@ void ProxyObject::performGetOwnPropertyNames(JSGlobalObject* globalObject, Prope
         return;
     }
 
-    HashSet<UniquedStringImpl*> uncheckedResultKeys;
+    UncheckedKeyHashSet<UniquedStringImpl*> uncheckedResultKeys;
     forEachInArrayLike(globalObject, asObject(trapResult), [&] (JSValue value) -> bool {
         if (!value.isString() && !value.isSymbol()) {
             throwTypeError(globalObject, scope, "Proxy handler's 'ownKeys' method must return an array-like object containing only Strings and Symbols"_s);
@@ -1091,8 +1091,8 @@ void ProxyObject::performGetOwnPropertyNames(JSGlobalObject* globalObject, Prope
     PropertyNameArray targetKeys(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
     target->methodTable()->getOwnPropertyNames(target, globalObject, targetKeys, DontEnumPropertiesMode::Include);
     RETURN_IF_EXCEPTION(scope, void());
-    HashSet<UniquedStringImpl*> targetNonConfigurableKeys;
-    HashSet<UniquedStringImpl*> targetConfigurableKeys;
+    UncheckedKeyHashSet<UniquedStringImpl*> targetNonConfigurableKeys;
+    UncheckedKeyHashSet<UniquedStringImpl*> targetConfigurableKeys;
     for (const Identifier& ident : targetKeys) {
         PropertyDescriptor descriptor;
         bool isPropertyDefined = target->getOwnPropertyDescriptor(globalObject, ident.impl(), descriptor); 

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -1173,12 +1173,12 @@ Ref<JSON::Value> SamplingProfiler::stackTracesAsJSON()
 void SamplingProfiler::registerForReportAtExit()
 {
     static Lock registrationLock;
-    static HashSet<RefPtr<SamplingProfiler>>* profilesToReport;
+    static UncheckedKeyHashSet<RefPtr<SamplingProfiler>>* profilesToReport;
 
     Locker locker { registrationLock };
 
     if (!profilesToReport) {
-        profilesToReport = new HashSet<RefPtr<SamplingProfiler>>();
+        profilesToReport = new UncheckedKeyHashSet<RefPtr<SamplingProfiler>>();
         atexit([]() {
             for (const auto& profile : *profilesToReport)
                 profile->reportDataToOptionFile();

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.h
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.h
@@ -225,7 +225,7 @@ private:
     Seconds m_timingInterval;
     RefPtr<Thread> m_thread;
     RefPtr<Thread> m_jscExecutionThread WTF_GUARDED_BY_LOCK(m_lock);
-    HashSet<JSCell*> m_liveCellPointers WTF_GUARDED_BY_LOCK(m_lock);
+    UncheckedKeyHashSet<JSCell*> m_liveCellPointers WTF_GUARDED_BY_LOCK(m_lock);
     Vector<UnprocessedStackFrame> m_currentFrames WTF_GUARDED_BY_LOCK(m_lock);
 };
 

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -44,7 +44,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 namespace JSC {
 
 #if DUMP_STRUCTURE_ID_STATISTICS
-static HashSet<Structure*>& liveStructureSet = *(new HashSet<Structure*>);
+static UncheckedKeyHashSet<Structure*>& liveStructureSet = *(new UncheckedKeyHashSet<Structure*>);
 #endif
 
 inline void StructureTransitionTable::setSingleTransition(VM& vm, JSCell* owner, Structure* structure)
@@ -93,10 +93,7 @@ void Structure::dumpStatistics()
     unsigned numberWithPropertyTables = 0;
     unsigned totalPropertyTablesSize = 0;
 
-    HashSet<Structure*>::const_iterator end = liveStructureSet.end();
-    for (HashSet<Structure*>::const_iterator it = liveStructureSet.begin(); it != end; ++it) {
-        Structure* structure = *it;
-
+    for (auto* structure : liveStructureSet) {
         switch (structure->m_transitionTable.size()) {
             case 0:
                 ++numberLeaf;

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -195,7 +195,7 @@ void Structure::forEachPropertyConcurrently(const Functor& functor)
     
     bool didFindStructure = findStructuresAndMapForMaterialization(structures, tableStructure, table);
 
-    HashSet<UniquedStringImpl*> seenProperties;
+    UncheckedKeyHashSet<UniquedStringImpl*> seenProperties;
 
     for (auto* structure : structures) {
         if (!structure->m_transitionPropertyName || seenProperties.contains(structure->m_transitionPropertyName.get()))

--- a/Source/JavaScriptCore/runtime/TypeSet.h
+++ b/Source/JavaScriptCore/runtime/TypeSet.h
@@ -73,8 +73,8 @@ private:
 
     bool m_final;
     bool m_isInDictionaryMode;
-    HashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash> m_fields;
-    HashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash> m_optionalFields;
+    UncheckedKeyHashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash> m_fields;
+    UncheckedKeyHashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash> m_optionalFields;
     RefPtr<StructureShape> m_proto;
     std::unique_ptr<String> m_propertyHash;
     String m_constructorName;

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -815,7 +815,7 @@ public:
     VMEntryScope* entryScope { nullptr };
 
     JSObject* stringRecursionCheckFirstObject { nullptr };
-    HashSet<JSObject*> stringRecursionCheckVisitedObjects;
+    UncheckedKeyHashSet<JSObject*> stringRecursionCheckVisitedObjects;
 
     DateCache dateCache;
 

--- a/Source/JavaScriptCore/runtime/WeakGCSet.h
+++ b/Source/JavaScriptCore/runtime/WeakGCSet.h
@@ -61,7 +61,7 @@ template<typename ValueArg, typename HashArg = WeakGCSetHash<ValueArg>, typename
 class WeakGCSet final : public WeakGCHashTable {
     WTF_MAKE_TZONE_NON_HEAP_ALLOCATABLE(WeakGCSet);
     using ValueType = Weak<ValueArg>;
-    using HashSetType = HashSet<ValueType, HashArg, TraitsArg>;
+    using HashSetType = UncheckedKeyHashSet<ValueType, HashArg, TraitsArg>;
 
 public:
     using AddResult = typename HashSetType::AddResult;

--- a/Source/JavaScriptCore/tools/FunctionAllowlist.h
+++ b/Source/JavaScriptCore/tools/FunctionAllowlist.h
@@ -41,7 +41,7 @@ public:
     bool containsWasmFunction(uint32_t) const;
 
 private:
-    HashSet<String> m_entries;
+    UncheckedKeyHashSet<String> m_entries;
     bool m_hasActiveAllowlist { false };
 };
 

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -249,7 +249,7 @@ private:
     // Note, this can grow over time since OMG inlining can add to the set of callers and we'll tranisition from
     // a sparse adjacency matrix to a bit vector based one if that's more space efficient.
     // FIXME: This should be a WTF class and we should use it in the JIT Plans.
-    using SparseCallers = HashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+    using SparseCallers = UncheckedKeyHashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
     using DenseCallers = BitVector;
     FixedVector<std::variant<SparseCallers, DenseCallers>> m_callers WTF_GUARDED_BY_LOCK(m_lock);
     FixedVector<CodePtr<WasmEntryPtrTag>> m_wasmIndirectCallEntryPoints;

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.h
@@ -138,7 +138,7 @@ protected:
     Vector<uint8_t> m_source;
     Vector<MacroAssemblerCodeRef<WasmEntryPtrTag>> m_wasmToWasmExitStubs;
     Vector<MacroAssemblerCodeRef<WasmEntryPtrTag>> m_wasmToJSExitStubs;
-    HashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_exportedFunctionIndices;
+    UncheckedKeyHashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_exportedFunctionIndices;
 
     Vector<Vector<UnlinkedWasmToWasmCall>> m_unlinkedWasmToWasmCalls;
     StreamingParser m_streamingParser;

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -269,7 +269,7 @@ void IPIntPlan::addTailCallEdge(uint32_t callerIndex, uint32_t calleeIndex)
 void IPIntPlan::computeTransitiveTailCalls() const
 {
     // FIXME: Use FunctionCodeIndex -> FunctionSpaceIndex by adding the right HashTraits.
-    GraphNodeWorklist<uint32_t, HashSet<uint32_t, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>> worklist;
+    GraphNodeWorklist<uint32_t, UncheckedKeyHashSet<uint32_t, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>> worklist;
 
     for (auto clobberingTailCall : m_moduleInformation->clobberingTailCalls())
         worklist.push(clobberingTailCall);

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
@@ -40,7 +40,7 @@ class IPIntCallee;
 
 using JSEntrypointCalleeMap = UncheckedKeyHashMap<uint32_t, RefPtr<JSEntrypointCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
-using TailCallGraph = UncheckedKeyHashMap<uint32_t, HashSet<uint32_t, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+using TailCallGraph = UncheckedKeyHashMap<uint32_t, UncheckedKeyHashSet<uint32_t, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
 
 class IPIntPlan final : public EntryPlan {

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -272,7 +272,7 @@ void LLIntPlan::addTailCallEdge(uint32_t callerIndex, uint32_t calleeIndex)
 void LLIntPlan::computeTransitiveTailCalls() const
 {
     // FIXME: Use FunctionCodeIndex -> FunctionSpaceIndex by adding the right HashTraits.
-    GraphNodeWorklist<uint32_t, HashSet<uint32_t, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>> worklist;
+    GraphNodeWorklist<uint32_t, UncheckedKeyHashSet<uint32_t, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>> worklist;
 
     for (auto clobberingTailCall : m_moduleInformation->clobberingTailCalls())
         worklist.push(clobberingTailCall);

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.h
@@ -43,7 +43,7 @@ class StreamingCompiler;
 
 using JSEntrypointCalleeMap = UncheckedKeyHashMap<uint32_t, RefPtr<JSEntrypointCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
-using TailCallGraph = UncheckedKeyHashMap<uint32_t, HashSet<uint32_t, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+using TailCallGraph = UncheckedKeyHashMap<uint32_t, UncheckedKeyHashSet<uint32_t, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
 class LLIntPlan final : public EntryPlan {
     using Base = EntryPlan;

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -80,7 +80,7 @@ void OMGPlan::dumpDisassembly(CompilationContext& context, LinkBuffer& linkBuffe
     dataLogLnIf(context.procedure->shouldDumpIR() || shouldDumpDisassemblyFor(CompilationMode::OMGMode), "Generated OMG code for WebAssembly OMG function[", functionIndex, "] ", signature.toString().ascii().data(), " name ", makeString(IndexOrName(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace))).ascii().data());
     if (UNLIKELY(shouldDumpDisassemblyFor(CompilationMode::OMGMode))) {
         ScopedPrintStream out;
-        HashSet<B3::Value*> printedValues;
+        UncheckedKeyHashSet<B3::Value*> printedValues;
         auto* disassembler = context.procedure->code().disassembler();
 
         const char* b3Prefix = "b3    ";

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -451,7 +451,7 @@ auto SectionParser::parseExport() -> PartialResult
     RELEASE_ASSERT(!m_info->exports.capacity());
     WASM_PARSER_FAIL_IF(!m_info->exports.tryReserveInitialCapacity(exportCount), "can't allocate enough memory for "_s, exportCount, " exports"_s);
 
-    HashSet<String> exportNames;
+    UncheckedKeyHashSet<String> exportNames;
     for (uint32_t exportNumber = 0; exportNumber < exportCount; ++exportNumber) {
         uint32_t fieldLen;
         Name fieldString;

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -962,10 +962,10 @@ public:
 
     static void tryCleanup();
 private:
-    HashSet<Wasm::TypeHash> m_typeSet;
+    UncheckedKeyHashSet<Wasm::TypeHash> m_typeSet;
     UncheckedKeyHashMap<TypeIndex, RefPtr<const TypeDefinition>> m_unrollingCache;
     UncheckedKeyHashMap<TypeIndex, RefPtr<RTT>> m_rttMap;
-    HashSet<RefPtr<TypeDefinition>> m_placeholders;
+    UncheckedKeyHashSet<RefPtr<TypeDefinition>> m_placeholders;
     const FunctionSignature* thunkTypes[numTypes];
     RefPtr<TypeDefinition> m_I64_Void;
     RefPtr<TypeDefinition> m_Void_I32;

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -69,7 +69,7 @@ private:
     };
 
     class NamedCaptureGroups {
-        typedef HashSet<String> GroupNameHashSet;
+        typedef UncheckedKeyHashSet<String> GroupNameHashSet;
 
     public:
         NamedCaptureGroups()
@@ -2100,7 +2100,7 @@ private:
     bool m_kIdentityEscapeSeen { false };
     Vector<ParenthesesType, 16> m_parenthesesStack;
     NamedCaptureGroups m_namedCaptureGroups;
-    HashSet<String> m_forwardReferenceNames;
+    UncheckedKeyHashSet<String> m_forwardReferenceNames;
 
     // Derived by empirical testing of compile time in PCRE and WREC.
     static constexpr unsigned MAX_PATTERN_SIZE = 1024 * 1024;

--- a/Source/WTF/wtf/AggregateLogger.h
+++ b/Source/WTF/wtf/AggregateLogger.h
@@ -117,7 +117,7 @@ private:
         }
     }
 
-    HashSet<RefPtr<const Logger>> m_loggers;
+    UncheckedKeyHashSet<RefPtr<const Logger>> m_loggers;
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -140,7 +140,9 @@ template<typename Value, typename = DefaultHash<Value>, typename = HashTraits<Va
 template<typename KeyArg, typename MappedArg, typename = DefaultHash<KeyArg>, typename = HashTraits<KeyArg>, typename = HashTraits<MappedArg>, typename = HashTableTraits, ShouldValidateKey = ShouldValidateKey::Yes> class HashMap;
 template<typename KeyArg, typename MappedArg, typename KeyHash = DefaultHash<KeyArg>, typename KeyTraits = HashTraits<KeyArg>, typename MappedTraits = HashTraits<MappedArg>, typename HashTraits = HashTableTraits>
 using UncheckedKeyHashMap = HashMap<KeyArg, MappedArg, KeyHash, KeyTraits, MappedTraits, HashTraits, ShouldValidateKey::No>;
-template<typename ValueArg, typename = DefaultHash<ValueArg>, typename = HashTraits<ValueArg>, typename = HashTableTraits> class HashSet;
+template<typename ValueArg, typename = DefaultHash<ValueArg>, typename = HashTraits<ValueArg>, typename = HashTableTraits, ShouldValidateKey = ShouldValidateKey::Yes> class HashSet;
+template<typename ValueArg, typename HashArg = DefaultHash<ValueArg>, typename TraitsArg = HashTraits<ValueArg>, typename TableTraitsArg = HashTableTraits>
+using UncheckedKeyHashSet = HashSet<ValueArg, HashArg, TraitsArg, TableTraitsArg, ShouldValidateKey::No>;
 template<typename ResolveValueT, typename RejectValueT, unsigned options = 0> class NativePromise;
 using GenericPromise = NativePromise<void, void>;
 using GenericNonExclusivePromise = NativePromise<void, void, 1>;
@@ -213,6 +215,7 @@ using WTF::TextPosition;
 using WTF::TextStream;
 using WTF::URL;
 using WTF::UncheckedKeyHashMap;
+using WTF::UncheckedKeyHashSet;
 using WTF::UniqueRef;
 using WTF::Vector;
 using WTF::WeakPtr;

--- a/Source/WTF/wtf/GraphNodeWorklist.h
+++ b/Source/WTF/wtf/GraphNodeWorklist.h
@@ -29,7 +29,7 @@
 
 namespace WTF {
 
-template<typename Node, typename Set = HashSet<Node>>
+template<typename Node, typename Set = UncheckedKeyHashSet<Node>>
 class GraphNodeWorklist {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -93,7 +93,7 @@ struct GraphNodeWith {
     T data;
 };
 
-template<typename Node, typename T, typename Set = HashSet<Node>>
+template<typename Node, typename T, typename Set = UncheckedKeyHashSet<Node>>
 class ExtendedGraphNodeWorklist {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -165,7 +165,7 @@ struct GraphNodeWithOrder {
     GraphVisitOrder order;
 };
 
-template<typename Node, typename Set = HashSet<Node>>
+template<typename Node, typename Set = UncheckedKeyHashSet<Node>>
 class PostOrderGraphNodeWorklist {
     WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -31,7 +31,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF {
 
-template<typename ValueArg, typename HashArg, typename TraitsArg, typename TableTraitsArg>
+template<typename ValueArg, typename HashArg, typename TraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
 class HashSet final {
     WTF_MAKE_FAST_ALLOCATED;
 private:
@@ -43,7 +43,7 @@ public:
     using ValueType = typename ValueTraits::TraitType;
 
 private:
-    using HashTableType = typename TableTraitsArg::template TableType<ValueType, ValueType, IdentityExtractor, HashFunctions, ValueTraits, ValueTraits, ShouldValidateKey::No>;
+    using HashTableType = typename TableTraitsArg::template TableType<ValueType, ValueType, IdentityExtractor, HashFunctions, ValueTraits, ValueTraits, shouldValidateKey>;
 
 public:
     // HashSet iterators have the following structure:
@@ -246,115 +246,115 @@ struct HashSetEnsureTranslatorAdaptor {
     }
 };
 
-template<typename T, typename U, typename V, typename W>
-inline void HashSet<T, U, V, W>::swap(HashSet& other)
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline void HashSet<T, U, V, W, shouldValidateKey>::swap(HashSet& other)
 {
     m_impl.swap(other.m_impl); 
 }
 
-template<typename T, typename U, typename V, typename W>
-inline unsigned HashSet<T, U, V, W>::size() const
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline unsigned HashSet<T, U, V, W, shouldValidateKey>::size() const
 {
     return m_impl.size(); 
 }
 
-template<typename T, typename U, typename V, typename W>
-inline unsigned HashSet<T, U, V, W>::capacity() const
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline unsigned HashSet<T, U, V, W, shouldValidateKey>::capacity() const
 {
     return m_impl.capacity(); 
 }
 
-template<typename T, typename U, typename V, typename W>
-inline unsigned HashSet<T, U, V, W>::memoryUse() const
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline unsigned HashSet<T, U, V, W, shouldValidateKey>::memoryUse() const
 {
     return capacity() * sizeof(T);
 }
 
-template<typename T, typename U, typename V, typename W>
-inline bool HashSet<T, U, V, W>::isEmpty() const
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline bool HashSet<T, U, V, W, shouldValidateKey>::isEmpty() const
 {
     return m_impl.isEmpty(); 
 }
 
-template<typename T, typename U, typename V, typename W>
-inline auto HashSet<T, U, V, W>::begin() const -> iterator
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline auto HashSet<T, U, V, W, shouldValidateKey>::begin() const -> iterator
 {
     return m_impl.begin(); 
 }
 
-template<typename T, typename U, typename V, typename W>
-inline auto HashSet<T, U, V, W>::end() const -> iterator
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline auto HashSet<T, U, V, W, shouldValidateKey>::end() const -> iterator
 {
     return m_impl.end(); 
 }
 
-template<typename T, typename U, typename V, typename W>
-inline auto HashSet<T, U, V, W>::find(const ValueType& value) const -> iterator
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline auto HashSet<T, U, V, W, shouldValidateKey>::find(const ValueType& value) const -> iterator
 {
     return m_impl.find(value); 
 }
 
-template<typename T, typename U, typename V, typename W>
-inline bool HashSet<T, U, V, W>::contains(const ValueType& value) const
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline bool HashSet<T, U, V, W, shouldValidateKey>::contains(const ValueType& value) const
 {
     return m_impl.contains(value); 
 }
 
-template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
+template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
 template<typename HashTranslator, typename T>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::find(const T& value) const -> iterator
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::find(const T& value) const -> iterator
 {
     return m_impl.template find<HashSetTranslatorAdapter<HashTranslator>>(value);
 }
 
-template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
+template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
 template<typename HashTranslator, typename T>
-inline bool HashSet<Value, HashFunctions, Traits, TableTraits>::contains(const T& value) const
+inline bool HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::contains(const T& value) const
 {
     return m_impl.template contains<HashSetTranslatorAdapter<HashTranslator>>(value);
 }
 
-template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
+template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
 template<typename HashTranslator, typename T>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::ensure(T&& key, NOESCAPE const Invocable<ValueType()> auto& functor) -> AddResult
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::ensure(T&& key, NOESCAPE const Invocable<ValueType()> auto& functor) -> AddResult
 {
     return m_impl.template add<HashSetEnsureTranslatorAdaptor<Traits, HashTranslator>>(std::forward<T>(key), functor);
 }
 
-template<typename T, typename U, typename V, typename W>
-inline auto HashSet<T, U, V, W>::add(const ValueType& value) -> AddResult
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline auto HashSet<T, U, V, W, shouldValidateKey>::add(const ValueType& value) -> AddResult
 {
     return m_impl.add(value);
 }
 
-template<typename T, typename U, typename V, typename W>
-inline auto HashSet<T, U, V, W>::add(ValueType&& value) -> AddResult
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline auto HashSet<T, U, V, W, shouldValidateKey>::add(ValueType&& value) -> AddResult
 {
     return m_impl.add(WTFMove(value));
 }
 
-template<typename T, typename U, typename V, typename W>
-inline void HashSet<T, U, V, W>::addVoid(const ValueType& value)
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline void HashSet<T, U, V, W, shouldValidateKey>::addVoid(const ValueType& value)
 {
     m_impl.add(value);
 }
 
-template<typename T, typename U, typename V, typename W>
-inline void HashSet<T, U, V, W>::addVoid(ValueType&& value)
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline void HashSet<T, U, V, W, shouldValidateKey>::addVoid(ValueType&& value)
 {
     m_impl.add(WTFMove(value));
 }
 
-template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
+template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
 template<typename HashTranslator>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::add(const auto& value) -> AddResult
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::add(const auto& value) -> AddResult
 {
     return m_impl.template addPassingHashCode<HashSetTranslatorAdapter<HashTranslator>>(value, [&]() ALWAYS_INLINE_LAMBDA { return value; });
 }
 
-template<typename T, typename U, typename V, typename W>
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 template<typename IteratorType>
-inline bool HashSet<T, U, V, W>::add(IteratorType begin, IteratorType end)
+inline bool HashSet<T, U, V, W, shouldValidateKey>::add(IteratorType begin, IteratorType end)
 {
     bool changed = false;
     for (IteratorType iter = begin; iter != end; ++iter)
@@ -362,9 +362,9 @@ inline bool HashSet<T, U, V, W>::add(IteratorType begin, IteratorType end)
     return changed;
 }
 
-template<typename T, typename U, typename V, typename W>
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 template<typename IteratorType>
-inline bool HashSet<T, U, V, W>::remove(IteratorType begin, IteratorType end)
+inline bool HashSet<T, U, V, W, shouldValidateKey>::remove(IteratorType begin, IteratorType end)
 {
     bool changed = false;
     for (IteratorType iter = begin; iter != end; ++iter)
@@ -372,8 +372,8 @@ inline bool HashSet<T, U, V, W>::remove(IteratorType begin, IteratorType end)
     return changed;
 }
 
-template<typename T, typename U, typename V, typename W>
-inline bool HashSet<T, U, V, W>::remove(iterator it)
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline bool HashSet<T, U, V, W, shouldValidateKey>::remove(iterator it)
 {
     if (it.m_impl == m_impl.end())
         return false;
@@ -382,26 +382,26 @@ inline bool HashSet<T, U, V, W>::remove(iterator it)
     return true;
 }
 
-template<typename T, typename U, typename V, typename W>
-inline bool HashSet<T, U, V, W>::remove(const ValueType& value)
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline bool HashSet<T, U, V, W, shouldValidateKey>::remove(const ValueType& value)
 {
     return remove(find(value));
 }
 
-template<typename T, typename U, typename V, typename W>
-inline bool HashSet<T, U, V, W>::removeIf(NOESCAPE const Invocable<bool(const ValueType&)> auto& functor)
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline bool HashSet<T, U, V, W, shouldValidateKey>::removeIf(NOESCAPE const Invocable<bool(const ValueType&)> auto& functor)
 {
     return m_impl.removeIf(functor);
 }
 
-template<typename T, typename U, typename V, typename W>
-inline void HashSet<T, U, V, W>::clear()
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline void HashSet<T, U, V, W, shouldValidateKey>::clear()
 {
     m_impl.clear(); 
 }
 
-template<typename T, typename U, typename V, typename W>
-inline auto HashSet<T, U, V, W>::take(iterator it) -> TakeType
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline auto HashSet<T, U, V, W, shouldValidateKey>::take(iterator it) -> TakeType
 {
     if (it == end())
         return ValueTraits::take(ValueTraits::emptyValue());
@@ -411,30 +411,30 @@ inline auto HashSet<T, U, V, W>::take(iterator it) -> TakeType
     return result;
 }
 
-template<typename T, typename U, typename V, typename W>
-inline auto HashSet<T, U, V, W>::take(const ValueType& value) -> TakeType
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline auto HashSet<T, U, V, W, shouldValidateKey>::take(const ValueType& value) -> TakeType
 {
     return take(find(value));
 }
 
-template<typename T, typename U, typename V, typename W>
-inline auto HashSet<T, U, V, W>::takeAny() -> TakeType
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline auto HashSet<T, U, V, W, shouldValidateKey>::takeAny() -> TakeType
 {
     return take(begin());
 }
 
-template<typename T, typename U, typename V, typename W>
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 template<typename OtherCollection>
-inline auto HashSet<T, U, V, W>::unionWith(const OtherCollection& other) const -> HashSet<T, U, V, W>
+inline auto HashSet<T, U, V, W, shouldValidateKey>::unionWith(const OtherCollection& other) const -> HashSet<T, U, V, W, shouldValidateKey>
 {
     auto copy = *this;
     copy.add(other.begin(), other.end());
     return copy;
 }
 
-template<typename T, typename U, typename V, typename W>
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 template<typename OtherCollection>
-inline auto HashSet<T, U, V, W>::intersectionWith(const OtherCollection& other) const -> HashSet<T, U, V, W>
+inline auto HashSet<T, U, V, W, shouldValidateKey>::intersectionWith(const OtherCollection& other) const -> HashSet<T, U, V, W, shouldValidateKey>
 {
     HashSet result;
     for (auto& value : *this) {
@@ -444,9 +444,9 @@ inline auto HashSet<T, U, V, W>::intersectionWith(const OtherCollection& other) 
     return result;
 }
 
-template<typename T, typename U, typename V, typename W>
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 template<typename OtherCollection>
-inline auto HashSet<T, U, V, W>::differenceWith(const OtherCollection& other) const -> HashSet<T, U, V, W>
+inline auto HashSet<T, U, V, W, shouldValidateKey>::differenceWith(const OtherCollection& other) const -> HashSet<T, U, V, W, shouldValidateKey>
 {
     HashSet result;
     for (const auto& value : *this) {
@@ -456,39 +456,39 @@ inline auto HashSet<T, U, V, W>::differenceWith(const OtherCollection& other) co
     return result;
 }
 
-template<typename T, typename U, typename V, typename W>
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 template<typename OtherCollection>
-inline auto HashSet<T, U, V, W>::symmetricDifferenceWith(const OtherCollection& other) const -> HashSet<T, U, V, W>
+inline auto HashSet<T, U, V, W, shouldValidateKey>::symmetricDifferenceWith(const OtherCollection& other) const -> HashSet<T, U, V, W, shouldValidateKey>
 {
     auto copy = *this;
     copy.formSymmetricDifference(other);
     return copy;
 }
 
-template<typename T, typename U, typename V, typename W>
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 template<typename OtherCollection>
-inline void HashSet<T, U, V, W>::formUnion(const OtherCollection& other)
+inline void HashSet<T, U, V, W, shouldValidateKey>::formUnion(const OtherCollection& other)
 {
     add(other.begin(), other.end());
 }
 
-template<typename T, typename U, typename V, typename W>
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 template<typename OtherCollection>
-inline void HashSet<T, U, V, W>::formIntersection(const OtherCollection& other)
+inline void HashSet<T, U, V, W, shouldValidateKey>::formIntersection(const OtherCollection& other)
 {
     *this = intersectionWith(other);
 }
 
-template<typename T, typename U, typename V, typename W>
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 template<typename OtherCollection>
-inline void HashSet<T, U, V, W>::formDifference(const OtherCollection& other)
+inline void HashSet<T, U, V, W, shouldValidateKey>::formDifference(const OtherCollection& other)
 {
     *this = differenceWith(other);
 }
 
-template<typename T, typename U, typename V, typename W>
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 template<typename OtherCollection>
-inline void HashSet<T, U, V, W>::formSymmetricDifference(const OtherCollection& other)
+inline void HashSet<T, U, V, W, shouldValidateKey>::formSymmetricDifference(const OtherCollection& other)
 {
     for (auto& value : other) {
         if (!remove(value))
@@ -496,71 +496,71 @@ inline void HashSet<T, U, V, W>::formSymmetricDifference(const OtherCollection& 
     }
 }
 
-template<typename T, typename U, typename V, typename W>
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 template<typename OtherCollection>
-inline bool HashSet<T, U, V, W>::isSubset(const OtherCollection& other)
+inline bool HashSet<T, U, V, W, shouldValidateKey>::isSubset(const OtherCollection& other)
 {
     return intersectionWith(other).size() == size();
 }
 
-template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
+template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
 template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> typename std::enable_if<IsSmartPtr<V>::value, iterator>::type
 {
     return m_impl.template find<HashSetTranslator<Traits, HashFunctions>>(value);
 }
 
-template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
+template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
 template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) const -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
 {
     return m_impl.template contains<HashSetTranslator<Traits, HashFunctions>>(value);
 }
 
-template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
+template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
 template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> typename std::enable_if<IsSmartPtr<V>::value, bool>::type
 {
     return remove(find(value));
 }
 
-template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
+template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
 template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> typename std::enable_if<IsSmartPtr<V>::value, TakeType>::type
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>* value) -> typename std::enable_if<IsSmartPtr<V>::value, TakeType>::type
 {
     return take(find(value));
 }
 
-template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
+template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
 template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, iterator>::type
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::find(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, iterator>::type
 {
     return find(&value);
 }
 
-template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
+template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
 template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::contains(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) const -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type
 {
     return contains(&value);
 }
 
-template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
+template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
 template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type
 {
     return remove(&value);
 }
 
-template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
+template<typename Value, typename HashFunctions, typename Traits, typename TableTraits, ShouldValidateKey shouldValidateKey>
 template<typename V>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, TakeType>::type
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits, shouldValidateKey>::take(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>& value) -> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, TakeType>::type
 {
     return take(&value);
 }
 
-template<typename T, typename U, typename V, typename W>
-inline bool HashSet<T, U, V, W>::isValidValue(const ValueType& value)
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline bool HashSet<T, U, V, W, shouldValidateKey>::isValidValue(const ValueType& value)
 {
     if (ValueTraits::isDeletedValue(value))
         return false;
@@ -576,9 +576,9 @@ inline bool HashSet<T, U, V, W>::isValidValue(const ValueType& value)
     return true;
 }
 
-template<typename T, typename U, typename V, typename W>
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
 template<typename OtherCollection>
-inline bool HashSet<T, U, V, W>::operator==(const OtherCollection& otherCollection) const
+inline bool HashSet<T, U, V, W, shouldValidateKey>::operator==(const OtherCollection& otherCollection) const
 {
     if (size() != otherCollection.size())
         return false;
@@ -589,15 +589,15 @@ inline bool HashSet<T, U, V, W>::operator==(const OtherCollection& otherCollecti
     return true;
 }
 
-template<typename T, typename U, typename V, typename W>
-void HashSet<T, U, V, W>::add(std::initializer_list<std::reference_wrapper<const ValueType>> list)
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+void HashSet<T, U, V, W, shouldValidateKey>::add(std::initializer_list<std::reference_wrapper<const ValueType>> list)
 {
     for (auto& value : list)
         add(value);
 }
 
-template<typename T, typename U, typename V, typename W>
-inline void HashSet<T, U, V, W>::checkConsistency() const
+template<typename T, typename U, typename V, typename W, ShouldValidateKey shouldValidateKey>
+inline void HashSet<T, U, V, W, shouldValidateKey>::checkConsistency() const
 {
     m_impl.checkTableConsistency();
 }

--- a/Source/WTF/wtf/InterferenceGraph.h
+++ b/Source/WTF/wtf/InterferenceGraph.h
@@ -380,7 +380,7 @@ public:
     void dumpMemoryUseInKB() const { dataLog(memoryUse() / 1024); }
 
 private:
-    HashSet<InterferenceEdge> m_set;
+    UncheckedKeyHashSet<InterferenceEdge> m_set;
 };
 
 template <typename T, typename U>
@@ -505,8 +505,8 @@ using SmallInterferenceGraph = InstrumentedInterferenceGraph<ReferenceInterferen
 using LargeInterferenceGraph = InstrumentedInterferenceGraph<ReferenceInterferenceGraph, DefaultLargeInterferenceGraph>;
 using HugeInterferenceGraph = InstrumentedInterferenceGraph<HugeReferenceInterferenceGraph, DefaultHugeInterferenceGraph>;
 
-using ReferenceIterableInterferenceGraph = UndirectedEdgesDuplicatingAdapter<InterferenceVector<HashSet<uint16_t, IntHash<uint16_t>, UnsignedWithZeroKeyHashTraits<uint16_t>>, uint16_t>>;
-using HugeReferenceIterableInterferenceGraph = UndirectedEdgesDuplicatingAdapter<InterferenceVector<HashSet<uint32_t, IntHash<uint32_t>, UnsignedWithZeroKeyHashTraits<uint32_t>>, uint32_t>>;
+using ReferenceIterableInterferenceGraph = UndirectedEdgesDuplicatingAdapter<InterferenceVector<UncheckedKeyHashSet<uint16_t, IntHash<uint16_t>, UnsignedWithZeroKeyHashTraits<uint16_t>>, uint16_t>>;
+using HugeReferenceIterableInterferenceGraph = UndirectedEdgesDuplicatingAdapter<InterferenceVector<UncheckedKeyHashSet<uint32_t, IntHash<uint32_t>, UnsignedWithZeroKeyHashTraits<uint32_t>>, uint32_t>>;
 
 using SmallIterableInterferenceGraph = InstrumentedIterableInterferenceGraph<ReferenceIterableInterferenceGraph, DefaultSmallIterableInterferenceGraph>;
 using LargeIterableInterferenceGraph = InstrumentedIterableInterferenceGraph<ReferenceIterableInterferenceGraph, DefaultLargeIterableInterferenceGraph>;

--- a/Source/WTF/wtf/LikelyDenseUnsignedIntegerSet.h
+++ b/Source/WTF/wtf/LikelyDenseUnsignedIntegerSet.h
@@ -48,7 +48,7 @@ class LikelyDenseUnsignedIntegerSet {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(LikelyDenseUnsignedIntegerSet);
     static_assert(std::is_unsigned<IndexType>::value);
-    using Set = HashSet<IndexType, WTF::IntHash<IndexType>, WTF::UnsignedWithZeroKeyHashTraits<IndexType> >;
+    using Set = UncheckedKeyHashSet<IndexType, WTF::IntHash<IndexType>, WTF::UnsignedWithZeroKeyHashTraits<IndexType> >;
 public:
     LikelyDenseUnsignedIntegerSet()
         : m_size(0)

--- a/Source/WTF/wtf/LoggingHashSet.h
+++ b/Source/WTF/wtf/LoggingHashSet.h
@@ -44,7 +44,7 @@ class LoggingHashSet final {
     typedef typename ValueTraits::TakeType TakeType;
     
 public:
-    typedef WTF::HashSet<ValueArg, HashArg, TraitsArg> HashSet;
+    typedef WTF::UncheckedKeyHashSet<ValueArg, HashArg, TraitsArg> HashSet;
     
     typedef typename HashSet::ValueType ValueType;
     typedef typename HashSet::iterator iterator;

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -63,7 +63,7 @@ namespace WTF {
 #if USE(COCOA_EVENT_LOOP)
 class SchedulePair;
 struct SchedulePairHash;
-using SchedulePairHashSet = HashSet<RefPtr<SchedulePair>, SchedulePairHash>;
+using SchedulePairHashSet = UncheckedKeyHashSet<RefPtr<SchedulePair>, SchedulePairHash>;
 #endif
 
 #if USE(CF)
@@ -265,7 +265,7 @@ private:
     static LRESULT CALLBACK RunLoopWndProc(HWND, UINT, WPARAM, LPARAM);
     LRESULT wndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
     HWND m_runLoopMessageWindow;
-    HashSet<UINT_PTR> m_liveTimers;
+    UncheckedKeyHashSet<UINT_PTR> m_liveTimers;
 
     Lock m_loopLock;
 #elif USE(COCOA_EVENT_LOOP)

--- a/Source/WTF/wtf/SchedulePair.h
+++ b/Source/WTF/wtf/SchedulePair.h
@@ -95,7 +95,7 @@ struct SchedulePairHash {
     static constexpr bool safeToCompareToEmptyOrDeleted = true;
 };
 
-typedef HashSet<RefPtr<SchedulePair>, SchedulePairHash> SchedulePairHashSet;
+typedef UncheckedKeyHashSet<RefPtr<SchedulePair>, SchedulePairHash> SchedulePairHashSet;
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/ThreadSafeWeakHashSet.h
+++ b/Source/WTF/wtf/ThreadSafeWeakHashSet.h
@@ -234,7 +234,7 @@ private:
         }
     }
 
-    mutable HashSet<std::pair<ControlBlockRefPtr, const T*>> m_set WTF_GUARDED_BY_LOCK(m_lock);
+    mutable UncheckedKeyHashSet<std::pair<ControlBlockRefPtr, const T*>> m_set WTF_GUARDED_BY_LOCK(m_lock);
     mutable unsigned m_operationCountSinceLastCleanup WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     mutable unsigned m_maxOperationCountWithoutCleanup WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     mutable Lock m_lock;

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -173,9 +173,9 @@ public:
 #endif
 };
 
-HashSet<Thread*>& Thread::allThreads()
+UncheckedKeyHashSet<Thread*>& Thread::allThreads()
 {
-    static LazyNeverDestroyed<HashSet<Thread*>> allThreads;
+    static LazyNeverDestroyed<UncheckedKeyHashSet<Thread*>> allThreads;
     static std::once_flag onceKey;
     std::call_once(onceKey, [&] {
         allThreads.construct();

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -144,7 +144,7 @@ public:
     static Thread& current();
 
     // Set of all WTF::Thread created threads.
-    WTF_EXPORT_PRIVATE static HashSet<Thread*>& allThreads() WTF_REQUIRES_LOCK(allThreadsLock());
+    WTF_EXPORT_PRIVATE static UncheckedKeyHashSet<Thread*>& allThreads() WTF_REQUIRES_LOCK(allThreadsLock());
     WTF_EXPORT_PRIVATE static Lock& allThreadsLock() WTF_RETURNS_LOCK(s_allThreadsLock);
 
     WTF_EXPORT_PRIVATE unsigned numberOfThreadGroups();

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -1348,7 +1348,7 @@ bool isEqualIgnoringQueryAndFragments(const URL& a, const URL& b)
     return substringIgnoringQueryAndFragments(a) == substringIgnoringQueryAndFragments(b);
 }
 
-Vector<String> removeQueryParameters(URL& url, const HashSet<String>& keysToRemove)
+Vector<String> removeQueryParameters(URL& url, const UncheckedKeyHashSet<String>& keysToRemove)
 {
     if (keysToRemove.isEmpty())
         return { };

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -304,7 +304,7 @@ WTF_EXPORT_PRIVATE Vector<KeyValuePair<String, String>> queryParameters(const UR
 WTF_EXPORT_PRIVATE bool isEqualIgnoringQueryAndFragments(const URL&, const URL&);
 
 // Returns the parameters that were removed (including duplicates), in the order that they appear in the URL.
-WTF_EXPORT_PRIVATE Vector<String> removeQueryParameters(URL&, const HashSet<String>&);
+WTF_EXPORT_PRIVATE Vector<String> removeQueryParameters(URL&, const UncheckedKeyHashSet<String>&);
 WTF_EXPORT_PRIVATE Vector<String> removeQueryParameters(URL&, Function<bool(const String&)>&&);
 
 WTF_EXPORT_PRIVATE const URL& aboutBlankURL();

--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -35,7 +35,7 @@ template<typename T, typename WeakPtrImpl, EnableWeakPtrThreadingAssertions asse
 class WeakHashSet final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    using WeakPtrImplSet = HashSet<Ref<WeakPtrImpl>>;
+    using WeakPtrImplSet = UncheckedKeyHashSet<Ref<WeakPtrImpl>>;
     using AddResult = typename WeakPtrImplSet::AddResult;
 
     class WeakHashSetConstIterator {

--- a/Source/WTF/wtf/text/AtomStringTable.h
+++ b/Source/WTF/wtf/text/AtomStringTable.h
@@ -38,7 +38,7 @@ public:
     // If CompactPtr is 32bit, it is more efficient than PackedPtr (6 bytes).
     // We select underlying implementation based on CompactPtr's efficacy.
     using StringEntry = std::conditional_t<CompactPtrTraits<StringImpl>::is32Bit, CompactPtr<StringImpl>, PackedPtr<StringImpl>>;
-    using StringTableImpl = HashSet<StringEntry>;
+    using StringTableImpl = UncheckedKeyHashSet<StringEntry>;
 
     WTF_EXPORT_PRIVATE ~AtomStringTable();
 

--- a/Source/WTF/wtf/text/SymbolRegistry.h
+++ b/Source/WTF/wtf/text/SymbolRegistry.h
@@ -46,7 +46,7 @@ public:
     void remove(RegisteredSymbolImpl&);
 
 private:
-    HashSet<RefPtr<StringImpl>> m_table;
+    UncheckedKeyHashSet<RefPtr<StringImpl>> m_table;
     Type m_symbolType;
 };
 

--- a/Source/WTF/wtf/text/TextStream.h
+++ b/Source/WTF/wtf/text/TextStream.h
@@ -275,8 +275,8 @@ TextStream& operator<<(TextStream& ts, const FixedVector<ItemType>& vector)
     return streamSizedContainer(ts, vector);
 }
 
-template<typename ValueArg, typename HashArg, typename TraitsArg>
-TextStream& operator<<(TextStream& ts, const HashSet<ValueArg, HashArg, TraitsArg>& set)
+template<typename ValueArg, typename HashArg, typename TraitsArg, typename TableTraitsArg, ShouldValidateKey shouldValidateKey>
+TextStream& operator<<(TextStream& ts, const HashSet<ValueArg, HashArg, TraitsArg, TableTraitsArg, shouldValidateKey>& set)
 {
     return streamSizedContainer(ts, set);
 }

--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
@@ -117,8 +117,8 @@ static Lock encodingRegistryLock;
 static TextEncodingNameMap* textEncodingNameMap WTF_GUARDED_BY_LOCK(encodingRegistryLock);
 static TextCodecMap* textCodecMap WTF_GUARDED_BY_LOCK(encodingRegistryLock);
 static bool didExtendTextCodecMaps;
-static HashSet<ASCIILiteral>* japaneseEncodings;
-static HashSet<ASCIILiteral>* nonBackslashEncodings;
+static UncheckedKeyHashSet<ASCIILiteral>* japaneseEncodings;
+static UncheckedKeyHashSet<ASCIILiteral>* nonBackslashEncodings;
 
 static constexpr ASCIILiteral textEncodingNameBlocklist[] = { "UTF-7"_s, "BOCU-1"_s, "SCSU"_s };
 
@@ -197,7 +197,7 @@ static void buildBaseTextCodecMaps() WTF_REQUIRES_LOCK(encodingRegistryLock)
     TextCodecUserDefined::registerCodecs(addToTextCodecMap);
 }
 
-static void addEncodingName(HashSet<ASCIILiteral>& set, ASCIILiteral name) WTF_REQUIRES_LOCK(encodingRegistryLock)
+static void addEncodingName(UncheckedKeyHashSet<ASCIILiteral>& set, ASCIILiteral name) WTF_REQUIRES_LOCK(encodingRegistryLock)
 {
     // We must not use atomCanonicalTextEncodingName() because this function is called in it.
     ASCIILiteral atomName = textEncodingNameMap->get(name);
@@ -213,7 +213,7 @@ static void buildQuirksSets() WTF_REQUIRES_LOCK(encodingRegistryLock)
     ASSERT(!japaneseEncodings);
     ASSERT(!nonBackslashEncodings);
 
-    japaneseEncodings = new HashSet<ASCIILiteral>;
+    japaneseEncodings = new UncheckedKeyHashSet<ASCIILiteral>;
     addEncodingName(*japaneseEncodings, "EUC-JP"_s);
     addEncodingName(*japaneseEncodings, "ISO-2022-JP"_s);
     addEncodingName(*japaneseEncodings, "ISO-2022-JP-1"_s);
@@ -229,7 +229,7 @@ static void buildQuirksSets() WTF_REQUIRES_LOCK(encodingRegistryLock)
     addEncodingName(*japaneseEncodings, "cp932"_s);
     addEncodingName(*japaneseEncodings, "x-mac-japanese"_s);
 
-    nonBackslashEncodings = new HashSet<ASCIILiteral>;
+    nonBackslashEncodings = new UncheckedKeyHashSet<ASCIILiteral>;
     // The text encodings below treat backslash as a currency symbol for IE compatibility.
     // See http://blogs.msdn.com/michkap/archive/2005/09/17/469941.aspx for more information.
     addEncodingName(*nonBackslashEncodings, "x-mac-japanese"_s);

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -577,7 +577,7 @@ bool AnimationTimelinesController::isPendingTimelineAttachment(const WebAnimatio
 
 void AnimationTimelinesController::unregisterNamedTimelinesAssociatedWithElement(const Element& element)
 {
-    HashSet<AtomString> namesToClear;
+    UncheckedKeyHashSet<AtomString> namesToClear;
 
     for (auto& entry : m_nameToTimelineMap) {
         auto& timelines = entry.value;

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -194,7 +194,7 @@ void BlendingKeyframes::fillImplicitKeyframes(const KeyframeEffect& effect, cons
         }
     }
 
-    auto addImplicitKeyframe = [&](double key, const HashSet<AnimatableCSSProperty>& implicitProperties, const StyleRuleKeyframe& keyframeRule, BlendingKeyframe* existingImplicitBlendingKeyframe) {
+    auto addImplicitKeyframe = [&](double key, const UncheckedKeyHashSet<AnimatableCSSProperty>& implicitProperties, const StyleRuleKeyframe& keyframeRule, BlendingKeyframe* existingImplicitBlendingKeyframe) {
         // If we're provided an existing implicit keyframe, we need to add all the styles for the implicit properties.
         if (existingImplicitBlendingKeyframe) {
             ASSERT(existingImplicitBlendingKeyframe->style());
@@ -293,7 +293,7 @@ bool BlendingKeyframes::hasPropertySetToCurrentColor() const
     return !m_propertiesSetToCurrentColor.isEmpty();
 }
 
-const HashSet<AnimatableCSSProperty>& BlendingKeyframes::propertiesSetToInherit() const
+const UncheckedKeyHashSet<AnimatableCSSProperty>& BlendingKeyframes::propertiesSetToInherit() const
 {
     return m_propertiesSetToInherit;
 }

--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -58,7 +58,7 @@ public:
     bool isBlendingKeyframe() const final { return true; }
 
     void addProperty(const AnimatableCSSProperty&);
-    const HashSet<AnimatableCSSProperty>& properties() const { return m_properties; }
+    const UncheckedKeyHashSet<AnimatableCSSProperty>& properties() const { return m_properties; }
 
     void setOffset(double offset) { m_offset = offset; }
 
@@ -75,7 +75,7 @@ public:
 
 private:
     double m_offset;
-    HashSet<AnimatableCSSProperty> m_properties; // The properties specified in this keyframe.
+    UncheckedKeyHashSet<AnimatableCSSProperty> m_properties; // The properties specified in this keyframe.
     std::unique_ptr<RenderStyle> m_style;
     RefPtr<TimingFunction> m_timingFunction;
     std::optional<CompositeOperation> m_compositeOperation;
@@ -99,7 +99,7 @@ public:
 
     void addProperty(const AnimatableCSSProperty&);
     bool containsProperty(const AnimatableCSSProperty&) const;
-    const HashSet<AnimatableCSSProperty>& properties() const { return m_properties; }
+    const UncheckedKeyHashSet<AnimatableCSSProperty>& properties() const { return m_properties; }
 
     bool containsAnimatableCSSProperty() const;
     bool containsDirectionAwareProperty() const;
@@ -122,7 +122,7 @@ public:
     bool hasCSSVariableReferences() const;
     bool hasColorSetToCurrentColor() const;
     bool hasPropertySetToCurrentColor() const;
-    const HashSet<AnimatableCSSProperty>& propertiesSetToInherit() const;
+    const UncheckedKeyHashSet<AnimatableCSSProperty>& propertiesSetToInherit() const;
 
     void updatePropertiesMetadata(const StyleProperties&);
 
@@ -137,11 +137,11 @@ private:
 
     AtomString m_animationName;
     Vector<BlendingKeyframe> m_keyframes; // Kept sorted by key.
-    HashSet<AnimatableCSSProperty> m_properties; // The properties being animated.
-    HashSet<AnimatableCSSProperty> m_explicitToProperties; // The properties with an explicit value for the 100% keyframe.
-    HashSet<AnimatableCSSProperty> m_explicitFromProperties; // The properties with an explicit value for the 0% keyframe.
-    HashSet<AnimatableCSSProperty> m_propertiesSetToInherit;
-    HashSet<AnimatableCSSProperty> m_propertiesSetToCurrentColor;
+    UncheckedKeyHashSet<AnimatableCSSProperty> m_properties; // The properties being animated.
+    UncheckedKeyHashSet<AnimatableCSSProperty> m_explicitToProperties; // The properties with an explicit value for the 100% keyframe.
+    UncheckedKeyHashSet<AnimatableCSSProperty> m_explicitFromProperties; // The properties with an explicit value for the 0% keyframe.
+    UncheckedKeyHashSet<AnimatableCSSProperty> m_propertiesSetToInherit;
+    UncheckedKeyHashSet<AnimatableCSSProperty> m_propertiesSetToCurrentColor;
     bool m_usesRelativeFontWeight { false };
     bool m_containsCSSVariableReferences { false };
     bool m_usesAnchorFunctions { false };

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -245,7 +245,7 @@ IGNORE_GCC_WARNINGS_END
         return property;
     };
 
-    HashSet<AnimatableCSSProperty> propertiesToMatch;
+    UncheckedKeyHashSet<AnimatableCSSProperty> propertiesToMatch;
     for (auto property : keyframeEffect->animatedProperties())
         propertiesToMatch.add(resolvedProperty(property));
 
@@ -422,7 +422,7 @@ void DocumentTimeline::applyPendingAcceleratedAnimations()
 
     auto acceleratedAnimationsPendingRunningStateChange = std::exchange(m_acceleratedAnimationsPendingRunningStateChange, { });
 
-    HashSet<KeyframeEffectStack*> keyframeEffectStacksToUpdate;
+    UncheckedKeyHashSet<KeyframeEffectStack*> keyframeEffectStacksToUpdate;
 
     bool hasForcedLayout = false;
     for (auto& animation : acceleratedAnimationsPendingRunningStateChange) {

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -104,7 +104,7 @@ private:
     bool shouldRunUpdateAnimationsAndSendEventsIgnoringSuspensionState() const;
 
     Timer m_tickScheduleTimer;
-    HashSet<RefPtr<WebAnimation>> m_acceleratedAnimationsPendingRunningStateChange;
+    UncheckedKeyHashSet<RefPtr<WebAnimation>> m_acceleratedAnimationsPendingRunningStateChange;
     AnimationEvents m_pendingAnimationEvents;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     Seconds m_originTime;

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -993,7 +993,7 @@ void KeyframeEffect::updateBlendingKeyframes(RenderStyle& elementStyle, const St
     setBlendingKeyframes(WTFMove(blendingKeyframes));
 }
 
-const HashSet<AnimatableCSSProperty>& KeyframeEffect::animatedProperties()
+const UncheckedKeyHashSet<AnimatableCSSProperty>& KeyframeEffect::animatedProperties()
 {
     if (!m_blendingKeyframes.isEmpty())
         return m_blendingKeyframes.properties();
@@ -1428,7 +1428,7 @@ bool KeyframeEffect::isRunningAcceleratedAnimationForProperty(CSSPropertyID prop
     return CSSPropertyAnimation::animationOfPropertyIsAccelerated(property, document()->settings()) && m_blendingKeyframes.properties().contains(property);
 }
 
-static bool propertiesContainTransformRelatedProperty(const HashSet<AnimatableCSSProperty>& properties)
+static bool propertiesContainTransformRelatedProperty(const UncheckedKeyHashSet<AnimatableCSSProperty>& properties)
 {
     return properties.contains(CSSPropertyTranslate)
         || properties.contains(CSSPropertyScale)
@@ -2506,9 +2506,9 @@ void KeyframeEffect::computeHasImplicitKeyframeForAcceleratedProperty()
             // We keep three property lists, one which contains all properties seen across keyframes
             // which will be filtered eventually to only contain implicit properties, one containing
             // properties seen on the 0% keyframe and one containing properties seen on the 100% keyframe.
-            HashSet<CSSPropertyID> implicitProperties;
-            HashSet<CSSPropertyID> explicitZeroProperties;
-            HashSet<CSSPropertyID> explicitOneProperties;
+            UncheckedKeyHashSet<CSSPropertyID> implicitProperties;
+            UncheckedKeyHashSet<CSSPropertyID> explicitZeroProperties;
+            UncheckedKeyHashSet<CSSPropertyID> explicitOneProperties;
             auto styleProperties = keyframe.style;
             for (auto propertyReference : styleProperties.get()) {
                 auto property = propertyReference.id();

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -156,10 +156,10 @@ public:
 
     void computeStyleOriginatedAnimationBlendingKeyframes(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
     const BlendingKeyframes& blendingKeyframes() const { return m_blendingKeyframes; }
-    const HashSet<AnimatableCSSProperty>& animatedProperties();
+    const UncheckedKeyHashSet<AnimatableCSSProperty>& animatedProperties();
     bool animatesProperty(const AnimatableCSSProperty&) const;
-    const HashSet<AnimatableCSSProperty>& acceleratedProperties() const { return m_acceleratedProperties; }
-    const HashSet<AnimatableCSSProperty>& acceleratedPropertiesWithImplicitKeyframe() const { return m_acceleratedPropertiesWithImplicitKeyframe; }
+    const UncheckedKeyHashSet<AnimatableCSSProperty>& acceleratedProperties() const { return m_acceleratedProperties; }
+    const UncheckedKeyHashSet<AnimatableCSSProperty>& acceleratedPropertiesWithImplicitKeyframe() const { return m_acceleratedPropertiesWithImplicitKeyframe; }
 
     bool computeExtentOfTransformAnimation(LayoutRect&) const;
     bool computeTransformedExtentViaTransformList(const FloatRect&, const RenderStyle&, LayoutRect&) const;
@@ -293,9 +293,9 @@ private:
 
     AtomString m_keyframesName;
     BlendingKeyframes m_blendingKeyframes { emptyAtom() };
-    HashSet<AnimatableCSSProperty> m_animatedProperties;
-    HashSet<AnimatableCSSProperty> m_acceleratedProperties;
-    HashSet<AnimatableCSSProperty> m_acceleratedPropertiesWithImplicitKeyframe;
+    UncheckedKeyHashSet<AnimatableCSSProperty> m_animatedProperties;
+    UncheckedKeyHashSet<AnimatableCSSProperty> m_acceleratedProperties;
+    UncheckedKeyHashSet<AnimatableCSSProperty> m_acceleratedPropertiesWithImplicitKeyframe;
     Vector<ParsedKeyframe> m_parsedKeyframes;
     Vector<AcceleratedAction> m_pendingAcceleratedActions;
     RefPtr<Element> m_target;

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -151,7 +151,7 @@ void KeyframeEffectStack::setCSSAnimationList(RefPtr<const AnimationList>&& cssA
     m_isSorted = false;
 }
 
-OptionSet<AnimationImpact> KeyframeEffectStack::applyKeyframeEffects(RenderStyle& targetStyle, HashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext& resolutionContext)
+OptionSet<AnimationImpact> KeyframeEffectStack::applyKeyframeEffects(RenderStyle& targetStyle, UncheckedKeyHashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext& resolutionContext)
 {
     OptionSet<AnimationImpact> impact;
 
@@ -234,7 +234,7 @@ bool KeyframeEffectStack::allowsAcceleration() const
     // stack is unable to be accelerated, or if we have more than one effect animating
     // an accelerated property with an implicit keyframe.
 
-    HashSet<AnimatableCSSProperty> allAcceleratedProperties;
+    UncheckedKeyHashSet<AnimatableCSSProperty> allAcceleratedProperties;
 
     for (auto& effect : m_effects) {
         if (effect->preventsAcceleration())
@@ -274,9 +274,9 @@ void KeyframeEffectStack::lastStyleChangeEventStyleDidChange(const RenderStyle* 
         effect->lastStyleChangeEventStyleDidChange(previousStyle, currentStyle);
 }
 
-void KeyframeEffectStack::cascadeDidOverrideProperties(const HashSet<AnimatableCSSProperty>& overriddenProperties, const Document& document)
+void KeyframeEffectStack::cascadeDidOverrideProperties(const UncheckedKeyHashSet<AnimatableCSSProperty>& overriddenProperties, const Document& document)
 {
-    HashSet<AnimatableCSSProperty> acceleratedPropertiesOverriddenByCascade;
+    UncheckedKeyHashSet<AnimatableCSSProperty> acceleratedPropertiesOverriddenByCascade;
     for (auto animatedProperty : overriddenProperties) {
         if (CSSPropertyAnimation::animationOfPropertyIsAccelerated(animatedProperty, document.settings()))
             acceleratedPropertiesOverriddenByCascade.add(animatedProperty);

--- a/Source/WebCore/animation/KeyframeEffectStack.h
+++ b/Source/WebCore/animation/KeyframeEffectStack.h
@@ -66,7 +66,7 @@ public:
     bool containsProperty(CSSPropertyID) const;
     bool isCurrentlyAffectingProperty(CSSPropertyID) const;
     bool requiresPseudoElement() const;
-    OptionSet<AnimationImpact> applyKeyframeEffects(RenderStyle& targetStyle, HashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext&);
+    OptionSet<AnimationImpact> applyKeyframeEffects(RenderStyle& targetStyle, UncheckedKeyHashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext&);
     bool hasEffectWithImplicitKeyframes() const;
 
     void effectAbilityToBeAcceleratedDidChange(const KeyframeEffect&);
@@ -78,9 +78,9 @@ public:
     void addInvalidCSSAnimationName(const String&);
 
     void lastStyleChangeEventStyleDidChange(const RenderStyle* previousStyle, const RenderStyle* currentStyle);
-    void cascadeDidOverrideProperties(const HashSet<AnimatableCSSProperty>&, const Document&);
+    void cascadeDidOverrideProperties(const UncheckedKeyHashSet<AnimatableCSSProperty>&, const Document&);
 
-    const HashSet<AnimatableCSSProperty>& acceleratedPropertiesOverriddenByCascade() const { return m_acceleratedPropertiesOverriddenByCascade; }
+    const UncheckedKeyHashSet<AnimatableCSSProperty>& acceleratedPropertiesOverriddenByCascade() const { return m_acceleratedPropertiesOverriddenByCascade; }
 
     void applyPendingAcceleratedActions() const;
 
@@ -99,8 +99,8 @@ private:
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     WeakListHashSet<AcceleratedEffect> m_acceleratedEffects;
 #endif
-    HashSet<String> m_invalidCSSAnimationNames;
-    HashSet<AnimatableCSSProperty> m_acceleratedPropertiesOverriddenByCascade;
+    UncheckedKeyHashSet<String> m_invalidCSSAnimationNames;
+    UncheckedKeyHashSet<AnimatableCSSProperty> m_acceleratedPropertiesOverriddenByCascade;
     RefPtr<const AnimationList> m_cssAnimationList;
     bool m_isSorted { true };
 };

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -65,9 +65,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(WebAnimation);
 
-HashSet<WebAnimation*>& WebAnimation::instances()
+UncheckedKeyHashSet<WebAnimation*>& WebAnimation::instances()
 {
-    static NeverDestroyed<HashSet<WebAnimation*>> instances;
+    static NeverDestroyed<UncheckedKeyHashSet<WebAnimation*>> instances;
     return instances;
 }
 
@@ -1783,7 +1783,7 @@ ExceptionOr<void> WebAnimation::commitStyles()
 
     // 2.4 Let targeted properties be the set of physical longhand properties that are a target property for at least one
     // animation effect associated with animation whose effect target is target.
-    HashSet<AnimatableCSSProperty> targetedProperties;
+    UncheckedKeyHashSet<AnimatableCSSProperty> targetedProperties;
     for (auto property : effect->animatedProperties()) {
         if (std::holds_alternative<CSSPropertyID>(property)) {
             for (auto longhand : shorthandForProperty(std::get<CSSPropertyID>(property)))

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -67,7 +67,7 @@ public:
     static Ref<WebAnimation> create(Document&, AnimationEffect*, AnimationTimeline*);
     ~WebAnimation();
 
-    WEBCORE_EXPORT static HashSet<WebAnimation*>& instances();
+    WEBCORE_EXPORT static UncheckedKeyHashSet<WebAnimation*>& instances();
 
     virtual bool isStyleOriginatedAnimation() const { return false; }
     virtual bool isCSSAnimation() const { return false; }

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -79,7 +79,7 @@ protected:
 
 private:
     JSC::VM& m_vm;
-    HashSet<WindowProxy*> m_jsWindowProxies;
+    UncheckedKeyHashSet<WindowProxy*> m_jsWindowProxies;
     DOMObjectWrapperMap m_wrappers;
 
     String m_name;

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -47,7 +47,7 @@ class DOMWrapperWorld;
 class ScriptExecutionContext;
 
 using JSDOMStructureMap = UncheckedKeyHashMap<const JSC::ClassInfo*, JSC::WriteBarrier<JSC::Structure>>;
-using DOMGuardedObjectSet = HashSet<DOMGuardedObject*>;
+using DOMGuardedObjectSet = UncheckedKeyHashSet<DOMGuardedObject*>;
 
 class WEBCORE_EXPORT JSDOMGlobalObject : public JSC::JSGlobalObject {
 public:

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.h
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.h
@@ -77,7 +77,7 @@ private:
 
     WeakPtr<ScriptExecutionContext> m_context;
     MemoryCompactRobinHoodHashMap<String, URL> m_requestURLToResponseURLMap;
-    HashSet<Ref<ModuleScriptLoader>> m_loaders;
+    UncheckedKeyHashSet<Ref<ModuleScriptLoader>> m_loaders;
     OwnerType m_ownerType;
     JSC::JSGlobalObject* m_shadowRealmGlobal { nullptr };
 };

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -5901,7 +5901,7 @@ static ExceptionOr<std::unique_ptr<ArrayBufferContentsArray>> transferArrayBuffe
 
     auto contents = makeUnique<ArrayBufferContentsArray>(arrayBuffers.size());
 
-    HashSet<JSC::ArrayBuffer*> visited;
+    UncheckedKeyHashSet<JSC::ArrayBuffer*> visited;
     for (size_t arrayBufferIndex = 0; arrayBufferIndex < arrayBuffers.size(); arrayBufferIndex++) {
         if (visited.contains(arrayBuffers[arrayBufferIndex].get()))
             continue;
@@ -5966,7 +5966,7 @@ static Exception exceptionForSerializationFailure(SerializationReturnCode code)
 
 static bool containsDuplicates(const Vector<RefPtr<ImageBitmap>>& imageBitmaps)
 {
-    HashSet<ImageBitmap*> visited;
+    UncheckedKeyHashSet<ImageBitmap*> visited;
     for (auto& imageBitmap : imageBitmaps) {
         if (!visited.add(imageBitmap.get()))
             return true;
@@ -5977,7 +5977,7 @@ static bool containsDuplicates(const Vector<RefPtr<ImageBitmap>>& imageBitmaps)
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
 static bool canOffscreenCanvasesDetach(const Vector<RefPtr<OffscreenCanvas>>& offscreenCanvases)
 {
-    HashSet<OffscreenCanvas*> visited;
+    UncheckedKeyHashSet<OffscreenCanvas*> visited;
     for (auto& offscreenCanvas : offscreenCanvases) {
         if (!offscreenCanvas->canDetach())
             return false;
@@ -5992,7 +5992,7 @@ static bool canOffscreenCanvasesDetach(const Vector<RefPtr<OffscreenCanvas>>& of
 #if ENABLE(WEB_RTC)
 static bool canDetachRTCDataChannels(const Vector<Ref<RTCDataChannel>>& channels)
 {
-    HashSet<RTCDataChannel*> visited;
+    UncheckedKeyHashSet<RTCDataChannel*> visited;
     for (auto& channel : channels) {
         if (!channel->canDetach())
             return false;
@@ -6007,7 +6007,7 @@ static bool canDetachRTCDataChannels(const Vector<Ref<RTCDataChannel>>& channels
 #if ENABLE(MEDIA_STREAM)
 static bool canDetachMediaStreamTracks(const Vector<Ref<MediaStreamTrack>>& tracks)
 {
-    HashSet<MediaStreamTrack*> visited;
+    UncheckedKeyHashSet<MediaStreamTrack*> visited;
     for (auto& track : tracks) {
         if (!visited.add(track.ptr()))
             return false;
@@ -6019,7 +6019,7 @@ static bool canDetachMediaStreamTracks(const Vector<Ref<MediaStreamTrack>>& trac
 #if ENABLE(MEDIA_SOURCE_IN_WORKERS)
 static bool canDetachMediaSourceHandles(const Vector<Ref<MediaSourceHandle>>& handles)
 {
-    HashSet<MediaSourceHandle*> visited;
+    UncheckedKeyHashSet<MediaSourceHandle*> visited;
     for (auto& handle : handles) {
         if (!handle->canDetach())
             return false;
@@ -6067,7 +6067,7 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     Vector<Ref<MediaStreamTrack>> transferredMediaStreamTracks;
 #endif
 
-    HashSet<JSC::JSObject*> uniqueTransferables;
+    UncheckedKeyHashSet<JSC::JSObject*> uniqueTransferables;
     for (auto& transferable : transferList) {
         if (!uniqueTransferables.add(transferable.get()).isNewEntry)
             return Exception { ExceptionCode::DataCloneError, "Duplicate transferable for structured clone"_s };

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.h
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.h
@@ -165,7 +165,7 @@ public:
     void addClient(JSVMClientDataClient& client) { m_clients.add(client); }
 
 private:
-    HashSet<DOMWrapperWorld*> m_worldSet;
+    UncheckedKeyHashSet<DOMWrapperWorld*> m_worldSet;
     RefPtr<DOMWrapperWorld> m_normalWorld;
 
     JSBuiltinFunctions m_builtinFunctions;

--- a/Source/WebCore/bridge/IdentifierRep.cpp
+++ b/Source/WebCore/bridge/IdentifierRep.cpp
@@ -40,7 +40,7 @@ using namespace JSC;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IdentifierRep);
 
-typedef HashSet<IdentifierRep*> IdentifierSet;
+typedef UncheckedKeyHashSet<IdentifierRep*> IdentifierSet;
 
 static IdentifierSet& identifierSet()
 {

--- a/Source/WebCore/bridge/runtime_root.cpp
+++ b/Source/WebCore/bridge/runtime_root.cpp
@@ -44,7 +44,7 @@ namespace JSC { namespace Bindings {
 // comments in this file claimed that problem #1 was an issue in Java, in particular, 
 // because Java, allegedly, didn't always call finalize when collecting an object.
 
-typedef HashSet<RootObject*> RootObjectSet;
+typedef UncheckedKeyHashSet<RootObject*> RootObjectSet;
 
 static RootObjectSet& rootObjectSet()
 {
@@ -117,8 +117,8 @@ void RootObject::invalidate()
     m_globalObject.clear();
 
     {
-        HashSet<InvalidationCallback*>::iterator end = m_invalidationCallbacks.end();
-        for (HashSet<InvalidationCallback*>::iterator iter = m_invalidationCallbacks.begin(); iter != end; ++iter)
+        UncheckedKeyHashSet<InvalidationCallback*>::iterator end = m_invalidationCallbacks.end();
+        for (UncheckedKeyHashSet<InvalidationCallback*>::iterator iter = m_invalidationCallbacks.begin(); iter != end; ++iter)
             (**iter)(this);
 
         m_invalidationCallbacks.clear();

--- a/Source/WebCore/bridge/runtime_root.h
+++ b/Source/WebCore/bridge/runtime_root.h
@@ -92,7 +92,7 @@ private:
     ProtectCountSet m_protectCountSet;
     HashMap<RuntimeObject*, JSC::Weak<RuntimeObject>> m_runtimeObjects; // We use a map to implement a set.
 
-    HashSet<InvalidationCallback*> m_invalidationCallbacks;
+    UncheckedKeyHashSet<InvalidationCallback*> m_invalidationCallbacks;
 };
 
 } // namespace Bindings

--- a/Source/WebCore/contentextensions/CombinedFiltersAlphabet.h
+++ b/Source/WebCore/contentextensions/CombinedFiltersAlphabet.h
@@ -53,7 +53,7 @@ private:
         static const bool safeToCompareToEmptyOrDeleted = false;
     };
 
-    HashSet<const Term*, TermPointerHash> m_uniqueTerms;
+    UncheckedKeyHashSet<const Term*, TermPointerHash> m_uniqueTerms;
     Vector<std::unique_ptr<Term>> m_internedTermsStorage;
 };
 

--- a/Source/WebCore/contentextensions/ContentExtensionActions.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.cpp
@@ -740,7 +740,7 @@ void RedirectAction::URLTransformAction::QueryTransform::applyToURL(URL& url) co
     if (!url.hasQuery())
         return;
 
-    HashSet<String> keysToRemove;
+    UncheckedKeyHashSet<String> keysToRemove;
     for (auto& key : removeParams)
         keysToRemove.add(key);
 

--- a/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp
@@ -171,7 +171,7 @@ static Vector<unsigned> serializeActions(const Vector<ContentExtensionRule>& rul
     return actionLocations;
 }
 
-using UniversalActionSet = HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
+using UniversalActionSet = UncheckedKeyHashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
 
 static void addUniversalActionsToDFA(DFA& dfa, UniversalActionSet&& universalActions)
 {

--- a/Source/WebCore/contentextensions/ContentExtensionStyleSheet.h
+++ b/Source/WebCore/contentextensions/ContentExtensionStyleSheet.h
@@ -55,7 +55,7 @@ private:
     ContentExtensionStyleSheet(Document&);
 
     Ref<CSSStyleSheet> m_styleSheet;
-    HashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_addedSelectorIDs;
+    UncheckedKeyHashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_addedSelectorIDs;
 };
 
 } // namespace ContentExtensions

--- a/Source/WebCore/contentextensions/DFABytecodeInterpreter.h
+++ b/Source/WebCore/contentextensions/DFABytecodeInterpreter.h
@@ -40,7 +40,7 @@ public:
     DFABytecodeInterpreter(std::span<const uint8_t> bytecode)
         : m_bytecode(bytecode) { }
 
-    using Actions = HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
+    using Actions = UncheckedKeyHashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
 
     WEBCORE_EXPORT Actions interpret(const String&, ResourceFlags);
     Actions actionsMatchingEverything();

--- a/Source/WebCore/contentextensions/DFACombiner.cpp
+++ b/Source/WebCore/contentextensions/DFACombiner.cpp
@@ -151,7 +151,7 @@ private:
         uint32_t indexA = extractIndexA(newNodeSignature);
         uint32_t indexB = extractIndexB(newNodeSignature);
 
-        HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> actions;
+        UncheckedKeyHashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> actions;
         if (indexA != invalidNodeIndex) {
             const DFANode& node = m_dfaA.nodes[indexA];
             uint32_t actionsStart = node.actionsStart();

--- a/Source/WebCore/contentextensions/ImmutableNFANodeBuilder.h
+++ b/Source/WebCore/contentextensions/ImmutableNFANodeBuilder.h
@@ -41,7 +41,7 @@ namespace ContentExtensions {
 template <typename CharacterType, typename ActionType>
 class ImmutableNFANodeBuilder {
     typedef ImmutableNFA<CharacterType, ActionType> TypedImmutableNFA;
-    typedef HashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> TargetSet;
+    typedef UncheckedKeyHashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> TargetSet;
 public:
     ImmutableNFANodeBuilder() { }
 
@@ -217,7 +217,7 @@ private:
     TypedImmutableNFA* m_immutableNFA { nullptr };
     MutableRangeList<CharacterType, TargetSet> m_ranges;
     TargetSet m_epsilonTransitionTargets;
-    HashSet<ActionType, IntHash<ActionType>, WTF::UnsignedWithZeroKeyHashTraits<ActionType>> m_actions;
+    UncheckedKeyHashSet<ActionType, IntHash<ActionType>, WTF::UnsignedWithZeroKeyHashTraits<ActionType>> m_actions;
     uint32_t m_nodeId;
     bool m_finalized { true };
 };

--- a/Source/WebCore/contentextensions/NFANode.h
+++ b/Source/WebCore/contentextensions/NFANode.h
@@ -39,7 +39,7 @@ namespace ContentExtensions {
 // A NFANode abstract the transition table out of a NFA state.
 
 typedef Vector<uint64_t, 0, CrashOnOverflow, 1> ActionList;
-typedef HashSet<unsigned, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> NFANodeIndexSet;
+typedef UncheckedKeyHashSet<unsigned, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> NFANodeIndexSet;
 typedef UncheckedKeyHashMap<uint16_t, NFANodeIndexSet, DefaultHash<uint16_t>, WTF::UnsignedWithZeroKeyHashTraits<uint16_t>> NFANodeTransitions;
 
 class NFANode {

--- a/Source/WebCore/contentextensions/NFAToDFA.cpp
+++ b/Source/WebCore/contentextensions/NFAToDFA.cpp
@@ -206,7 +206,7 @@ struct UniqueNodeIdSetHashHashTraits : public WTF::CustomHashTraits<UniqueNodeId
     static const int minimumTableSize = 128;
 };
 
-typedef HashSet<std::unique_ptr<UniqueNodeIdSet>, UniqueNodeIdSetHash, UniqueNodeIdSetHashHashTraits> UniqueNodeIdSetTable;
+typedef UncheckedKeyHashSet<std::unique_ptr<UniqueNodeIdSet>, UniqueNodeIdSetHash, UniqueNodeIdSetHashHashTraits> UniqueNodeIdSetTable;
 
 struct NodeIdSetToUniqueNodeIdSetSource {
     NodeIdSetToUniqueNodeIdSetSource(DFA& dfa, const SerializedNFA& nfa, const NodeIdSet& nodeIdSet)
@@ -241,7 +241,7 @@ struct NodeIdSetToUniqueNodeIdSetTranslator {
     {
         DFANode newDFANode;
 
-        HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> actions;
+        UncheckedKeyHashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> actions;
 
         for (unsigned nfaNodeId : source.nodeIdSet) {
             const auto* nfaNode = source.nfa.nodes().pointerAt(nfaNodeId);

--- a/Source/WebCore/css/CSSCounterStyleRegistry.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.cpp
@@ -64,11 +64,11 @@ void CSSCounterStyleRegistry::resolveReferencesIfNeeded()
 
 void CSSCounterStyleRegistry::resolveExtendsReference(CSSCounterStyle& counterStyle, CounterStyleMap* map)
 {
-    HashSet<CSSCounterStyle*> countersInChain;
+    UncheckedKeyHashSet<CSSCounterStyle*> countersInChain;
     resolveExtendsReference(counterStyle, countersInChain, map);
 }
 
-void CSSCounterStyleRegistry::resolveExtendsReference(CSSCounterStyle& counter, HashSet<CSSCounterStyle*>& countersInChain, CounterStyleMap* map)
+void CSSCounterStyleRegistry::resolveExtendsReference(CSSCounterStyle& counter, UncheckedKeyHashSet<CSSCounterStyle*>& countersInChain, CounterStyleMap* map)
 {
     ASSERT(counter.isExtendsSystem() && counter.isExtendsUnresolved());
     if (!(counter.isExtendsSystem() && counter.isExtendsUnresolved()))

--- a/Source/WebCore/css/CSSCounterStyleRegistry.h
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.h
@@ -57,7 +57,7 @@ private:
     // If no map is passed on, user-agent counter styles map will be used
     static void resolveFallbackReference(CSSCounterStyle&, CounterStyleMap* = nullptr);
     static void resolveExtendsReference(CSSCounterStyle&, CounterStyleMap* = nullptr);
-    static void resolveExtendsReference(CSSCounterStyle&, HashSet<CSSCounterStyle*>&, CounterStyleMap* = nullptr);
+    static void resolveExtendsReference(CSSCounterStyle&, UncheckedKeyHashSet<CSSCounterStyle*>&, CounterStyleMap* = nullptr);
     static RefPtr<CSSCounterStyle> counterStyle(const AtomString&, CounterStyleMap* = nullptr);
     void invalidate();
 

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -384,7 +384,7 @@ static FontSelectionRequest computeFontSelectionRequest(CSSPropertyParserHelpers
     return { weightSelectionValue, widthSelectionValue, styleSelectionValue };
 }
 
-using CodePointsMap = HashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+using CodePointsMap = UncheckedKeyHashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 static CodePointsMap codePointsFromString(StringView stringView)
 {
     CodePointsMap result;
@@ -409,7 +409,7 @@ ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> CSSFontFaceSet::matchin
     if (!font)
         return Exception { ExceptionCode::SyntaxError };
 
-    HashSet<AtomString> uniqueFamilies;
+    UncheckedKeyHashSet<AtomString> uniqueFamilies;
     Vector<AtomString> familyOrder;
     for (auto& familyRaw : font->family) {
         AtomString familyAtom;
@@ -428,7 +428,7 @@ ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> CSSFontFaceSet::matchin
             familyOrder.append(familyAtom);
     }
 
-    HashSet<CSSFontFace*> resultConstituents;
+    UncheckedKeyHashSet<CSSFontFace*> resultConstituents;
     auto request = computeFontSelectionRequest(*font);
     for (auto codePoint : codePointsFromString(string)) {
         bool found = false;

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -126,7 +126,7 @@ private:
     WeakPtr<ScriptExecutionContext> m_context;
     RefPtr<FontFaceSet> m_fontFaceSet;
     Ref<CSSFontFaceSet> m_cssFontFaceSet;
-    HashSet<FontSelectorClient*> m_clients;
+    UncheckedKeyHashSet<FontSelectorClient*> m_clients;
 
     struct PaletteMapHash : DefaultHash<std::pair<AtomString, AtomString>> {
         static unsigned hash(const std::pair<AtomString, AtomString>& key)
@@ -142,8 +142,8 @@ private:
     UncheckedKeyHashMap<std::pair<AtomString, AtomString>, FontPaletteValues, PaletteMapHash> m_paletteMap;
     UncheckedKeyHashMap<String, Ref<FontFeatureValues>> m_featureValues;
 
-    HashSet<RefPtr<CSSFontFace>> m_cssConnectionsPossiblyToRemove;
-    HashSet<RefPtr<StyleRuleFontFace>> m_cssConnectionsEncounteredDuringBuild;
+    UncheckedKeyHashSet<RefPtr<CSSFontFace>> m_cssConnectionsPossiblyToRemove;
+    UncheckedKeyHashSet<RefPtr<StyleRuleFontFace>> m_cssConnectionsEncounteredDuringBuild;
 
     CSSFontFaceSet::FontModifiedObserver m_fontModifiedObserver;
 

--- a/Source/WebCore/css/CSSGridTemplateAreasValue.cpp
+++ b/Source/WebCore/css/CSSGridTemplateAreasValue.cpp
@@ -57,7 +57,7 @@ Ref<CSSGridTemplateAreasValue> CSSGridTemplateAreasValue::create(NamedGridAreaMa
 
 static String stringForPosition(const NamedGridAreaMap& gridAreaMap, size_t row, size_t column)
 {
-    HashSet<String> candidates;
+    UncheckedKeyHashSet<String> candidates;
     for (auto& it : gridAreaMap.map) {
         auto& area = it.value;
         if (row >= area.rows.startLine() && row < area.rows.endLine())

--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -146,7 +146,7 @@ void CSSImportRule::setMediaQueries(MQ::MediaQueryList&& queries)
     m_importRule->setMediaQueries(WTFMove(queries));
 }
 
-void CSSImportRule::getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>& childStyleSheets)
+void CSSImportRule::getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>& childStyleSheets)
 {
     RefPtr sheet = styleSheet();
     if (!sheet)

--- a/Source/WebCore/css/CSSImportRule.h
+++ b/Source/WebCore/css/CSSImportRule.h
@@ -55,7 +55,7 @@ private:
     String cssText() const final;
     String cssTextWithReplacementURLs(const UncheckedKeyHashMap<String, String>&, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&) const final;
     void reattach(StyleRuleBase&) final;
-    void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&) final;
+    void getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>&) final;
 
     String cssTextInternal(const String& urlString) const;
     const MQ::MediaQueryList& mediaQueries() const;

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -55,7 +55,7 @@ public:
     bool hasStyleRuleAncestor() const;
     CSSParserEnum::NestedContext nestedContext() const;
     virtual RefPtr<StyleRuleWithNesting> prepareChildStyleRuleForNesting(StyleRule&);
-    virtual void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&) { }
+    virtual void getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>&) { }
 
     WEBCORE_EXPORT ExceptionOr<void> setCssText(const String&);
 

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -317,7 +317,7 @@ CSSRuleList& CSSStyleRule::cssRules() const
     return *m_ruleListCSSOMWrapper;
 }
 
-void CSSStyleRule::getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>& childStyleSheets)
+void CSSStyleRule::getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>& childStyleSheets)
 {
     for (unsigned index = 0; index < length(); ++index)
         item(index)->getChildStyleSheets(childStyleSheets);

--- a/Source/WebCore/css/CSSStyleRule.h
+++ b/Source/WebCore/css/CSSStyleRule.h
@@ -67,7 +67,7 @@ private:
     String cssTextWithReplacementURLs(const UncheckedKeyHashMap<String, String>&, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&) const final;
     String cssTextInternal(StringBuilder& declarations, StringBuilder& rules) const;
     void reattach(StyleRuleBase&) final;
-    void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&) final;
+    void getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>&) final;
 
     String generateSelectorText() const;
     Vector<Ref<StyleRuleBase>> nestedRules() const;

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -581,7 +581,7 @@ Ref<StyleSheetContents> CSSStyleSheet::protectedContents()
     return m_contents;
 }
 
-void CSSStyleSheet::getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>& childStyleSheets)
+void CSSStyleSheet::getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>& childStyleSheets)
 {
     RefPtr ruleList = cssRules();
     if (!ruleList)

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -161,7 +161,7 @@ public:
 
     String debugDescription() const final;
     String cssTextWithReplacementURLs(const UncheckedKeyHashMap<String, String>&, const UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String>&);
-    void getChildStyleSheets(HashSet<RefPtr<CSSStyleSheet>>&);
+    void getChildStyleSheets(UncheckedKeyHashSet<RefPtr<CSSStyleSheet>>&);
 
     bool isDetached() const;
 

--- a/Source/WebCore/css/MutableStyleProperties.cpp
+++ b/Source/WebCore/css/MutableStyleProperties.cpp
@@ -289,7 +289,7 @@ bool MutableStyleProperties::removeProperties(std::span<const CSSPropertyID> pro
         return false;
 
     // FIXME: This is always used with static sets and in that case constructing the hash repeatedly is pretty pointless.
-    HashSet<CSSPropertyID> toRemove;
+    UncheckedKeyHashSet<CSSPropertyID> toRemove;
     toRemove.add(properties.begin(), properties.end());
 
     return m_propertyVector.removeAllMatching([&toRemove](const CSSProperty& property) {

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -127,7 +127,7 @@ CSSParser::ParseResult CSSParserImpl::parseCustomPropertyValue(MutableStylePrope
     return declaration.addParsedProperties(parser.topContext().m_parsedProperties) ? CSSParser::ParseResult::Changed : CSSParser::ParseResult::Unchanged;
 }
 
-static inline void filterProperties(IsImportant important, const ParsedPropertyVector& input, ParsedPropertyVector& output, size_t& unusedEntries, std::bitset<numCSSProperties>& seenProperties, HashSet<AtomString>& seenCustomProperties)
+static inline void filterProperties(IsImportant important, const ParsedPropertyVector& input, ParsedPropertyVector& output, size_t& unusedEntries, std::bitset<numCSSProperties>& seenProperties, UncheckedKeyHashSet<AtomString>& seenCustomProperties)
 {
     // Add properties in reverse order so that highest priority definitions are reached first. Duplicate definitions can then be ignored when found.
     for (size_t i = input.size(); i--;) {
@@ -158,7 +158,7 @@ static Ref<ImmutableStyleProperties> createStyleProperties(ParsedPropertyVector&
     std::bitset<numCSSProperties> seenProperties;
     size_t unusedEntries = parsedProperties.size();
     ParsedPropertyVector results(unusedEntries);
-    HashSet<AtomString> seenCustomProperties;
+    UncheckedKeyHashSet<AtomString> seenCustomProperties;
 
     filterProperties(IsImportant::Yes, parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
     filterProperties(IsImportant::No, parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
@@ -189,7 +189,7 @@ bool CSSParserImpl::parseDeclarationList(MutableStyleProperties* declaration, co
     std::bitset<numCSSProperties> seenProperties;
     size_t unusedEntries = parser.topContext().m_parsedProperties.size();
     ParsedPropertyVector results(unusedEntries);
-    HashSet<AtomString> seenCustomProperties;
+    UncheckedKeyHashSet<AtomString> seenCustomProperties;
     filterProperties(IsImportant::Yes, parser.topContext().m_parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
     filterProperties(IsImportant::No, parser.topContext().m_parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
     if (unusedEntries)

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -80,7 +80,7 @@
 namespace WebCore {
 namespace SelectorCompiler {
 
-using PseudoClassesSet = HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>>;
+using PseudoClassesSet = UncheckedKeyHashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>>;
 
 #if ENABLE(SELECTOR_OPERATION_STATS)
 

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -433,7 +433,7 @@ struct PasteboardFileTypeReader final : PasteboardFileReader {
         types.add(type);
     }
 
-    HashSet<String, ASCIICaseInsensitiveHash> types;
+    UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash> types;
 };
 
 bool DataTransfer::hasFileOfType(const String& type)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5275,7 +5275,7 @@ void Document::runScrollSteps()
     if (RefPtr frameView = view()) {
         MonotonicTime now = MonotonicTime::now();
         bool scrollAnimationsInProgress = serviceScrollAnimationForScrollableArea(frameView.get(), now);
-        HashSet<CheckedPtr<ScrollableArea>> scrollableAreasToUpdate;
+        UncheckedKeyHashSet<CheckedPtr<ScrollableArea>> scrollableAreasToUpdate;
         if (auto userScrollableAreas = frameView->scrollableAreas()) {
             for (auto& area : *userScrollableAreas)
                 scrollableAreasToUpdate.add(CheckedPtr<ScrollableArea>(area));
@@ -5439,7 +5439,7 @@ void Document::visibilityAdjustmentStateDidChange()
 }
 
 #if ENABLE(MEDIA_STREAM) && ENABLE(MEDIA_SESSION)
-static bool hasRealtimeMediaSource(const HashSet<Ref<RealtimeMediaSource>>& sources, const Function<bool(const RealtimeMediaSource&)>& filterSource)
+static bool hasRealtimeMediaSource(const UncheckedKeyHashSet<Ref<RealtimeMediaSource>>& sources, const Function<bool(const RealtimeMediaSource&)>& filterSource)
 {
     for (Ref source : sources) {
         if (!source->isEnded() && filterSource(source.get()))
@@ -9012,7 +9012,7 @@ static Element* findNearestCommonComposedAncestor(Element* elementA, Element* el
     if (elementA == elementB)
         return elementA;
 
-    HashSet<Ref<Element>> ancestorChain;
+    UncheckedKeyHashSet<Ref<Element>> ancestorChain;
     for (auto* element = elementA; element; element = element->parentElementInComposedTree())
         ancestorChain.add(*element);
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2195,7 +2195,7 @@ private:
     mutable String m_uniqueIdentifier;
 
     WeakHashSet<NodeIterator> m_nodeIterators;
-    HashSet<SingleThreadWeakRef<Range>> m_ranges;
+    UncheckedKeyHashSet<SingleThreadWeakRef<Range>> m_ranges;
 
     UniqueRef<Style::Scope> m_styleScope;
     const std::unique_ptr<ExtensionStyleSheets> m_extensionStyleSheets;
@@ -2257,8 +2257,8 @@ private:
 
     RefPtr<TextResourceDecoder> m_decoder;
 
-    HashSet<LiveNodeList*> m_listsInvalidatedAtDocument;
-    HashSet<HTMLCollection*> m_collectionsInvalidatedAtDocument;
+    UncheckedKeyHashSet<LiveNodeList*> m_listsInvalidatedAtDocument;
+    UncheckedKeyHashSet<HTMLCollection*> m_collectionsInvalidatedAtDocument;
     std::array<unsigned, numNodeListInvalidationTypes> m_nodeListAndCollectionCounts = { };
 
     RefPtr<XPathEvaluator> m_xpathEvaluator;
@@ -2284,7 +2284,7 @@ private:
 #endif
 
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_mainArticleElement;
-    HashSet<WeakRef<Element, WeakPtrImplWithEventTargetData>> m_articleElements;
+    UncheckedKeyHashSet<WeakRef<Element, WeakPtrImplWithEventTargetData>> m_articleElements;
 
     WeakHashSet<VisibilityChangeClient> m_visibilityStateCallbackClients;
 
@@ -2479,7 +2479,7 @@ private:
 #if ENABLE(MEDIA_STREAM)
     String m_idHashSalt;
     size_t m_activeMediaElementsWithMediaStreamCount { 0 };
-    HashSet<Ref<RealtimeMediaSource>> m_captureSources;
+    UncheckedKeyHashSet<Ref<RealtimeMediaSource>> m_captureSources;
     bool m_isUpdatingCaptureAccordingToMutedState { false };
     bool m_shouldListenToVoiceActivity { false };
 #endif

--- a/Source/WebCore/dom/DocumentSharedObjectPool.h
+++ b/Source/WebCore/dom/DocumentSharedObjectPool.h
@@ -44,7 +44,7 @@ public:
 
 private:
     struct ShareableElementDataHash;
-    using ShareableElementDataCache = HashSet<Ref<ShareableElementData>, ShareableElementDataHash>;
+    using ShareableElementDataCache = UncheckedKeyHashSet<Ref<ShareableElementData>, ShareableElementDataHash>;
     ShareableElementDataCache m_shareableElementDataCache;
 };
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1368,9 +1368,9 @@ static int adjustOffsetForZoomAndSubpixelLayout(RenderBoxModelObject& renderer, 
     return convertToNonSubpixelValue(offsetLeft / zoomFactor, Round);
 }
 
-static HashSet<TreeScope*> collectAncestorTreeScopeAsHashSet(Node& node)
+static UncheckedKeyHashSet<TreeScope*> collectAncestorTreeScopeAsHashSet(Node& node)
 {
-    HashSet<TreeScope*> ancestors;
+    UncheckedKeyHashSet<TreeScope*> ancestors;
     for (auto* currentScope = &node.treeScope(); currentScope; currentScope = currentScope->parentTreeScope())
         ancestors.add(currentScope);
     return ancestors;

--- a/Source/WebCore/dom/IdTargetObserverRegistry.h
+++ b/Source/WebCore/dom/IdTargetObserverRegistry.h
@@ -59,7 +59,7 @@ private:
 
         ObserverSet();
         ~ObserverSet();
-        HashSet<CheckedRef<IdTargetObserver>> observers;
+        UncheckedKeyHashSet<CheckedRef<IdTargetObserver>> observers;
     };
 
     using IdToObserverSetMap = UncheckedKeyHashMap<AtomString, std::unique_ptr<ObserverSet>>;

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -327,7 +327,7 @@ ExceptionOr<Vector<TransferredMessagePort>> MessagePort::disentanglePorts(Vector
         return Vector<TransferredMessagePort> { };
 
     // Walk the incoming array - if there are any duplicate ports, or null ports or cloned ports, throw an error (per section 8.3.3 of the HTML5 spec).
-    HashSet<Ref<MessagePort>> portSet;
+    UncheckedKeyHashSet<Ref<MessagePort>> portSet;
     for (auto& port : ports) {
         if (!port->m_entangled || !portSet.add(port).isNewEntry)
             return Exception { ExceptionCode::DataCloneError };

--- a/Source/WebCore/dom/MutationObserver.cpp
+++ b/Source/WebCore/dom/MutationObserver.cpp
@@ -193,8 +193,8 @@ void MutationObserver::deliver()
     // Calling takeTransientRegistrations() can modify m_registrations, so it's necessary
     // to make a copy of the transient registrations before operating on them.
     Vector<WeakPtr<MutationObserverRegistration>, 1> transientRegistrations;
-    Vector<HashSet<GCReachableRef<Node>>, 1> nodesToKeepAlive;
-    HashSet<GCReachableRef<Node>> pendingTargets;
+    Vector<UncheckedKeyHashSet<GCReachableRef<Node>>, 1> nodesToKeepAlive;
+    UncheckedKeyHashSet<GCReachableRef<Node>> pendingTargets;
     pendingTargets.swap(m_pendingTargets);
     for (auto& registration : m_registrations) {
         if (registration.hasTransientRegistrations())

--- a/Source/WebCore/dom/MutationObserver.h
+++ b/Source/WebCore/dom/MutationObserver.h
@@ -93,7 +93,7 @@ public:
     
     struct TakenRecords {
         Vector<Ref<MutationRecord>> records;
-        HashSet<GCReachableRef<Node>> pendingTargets;
+        UncheckedKeyHashSet<GCReachableRef<Node>> pendingTargets;
     };
     TakenRecords takeRecords();
     void disconnect();
@@ -126,7 +126,7 @@ private:
 
     Ref<MutationCallback> m_callback;
     Vector<Ref<MutationRecord>> m_records;
-    HashSet<GCReachableRef<Node>> m_pendingTargets;
+    UncheckedKeyHashSet<GCReachableRef<Node>> m_pendingTargets;
     WeakHashSet<MutationObserverRegistration> m_registrations;
     unsigned m_priority;
 };

--- a/Source/WebCore/dom/MutationObserverRegistration.cpp
+++ b/Source/WebCore/dom/MutationObserverRegistration.cpp
@@ -79,7 +79,7 @@ void MutationObserverRegistration::observedSubtreeNodeWillDetach(Node& node)
     m_transientRegistrationNodes.add(node);
 }
 
-HashSet<GCReachableRef<Node>> MutationObserverRegistration::takeTransientRegistrations()
+UncheckedKeyHashSet<GCReachableRef<Node>> MutationObserverRegistration::takeTransientRegistrations()
 {
     if (m_transientRegistrationNodes.isEmpty()) {
         ASSERT(!m_nodeKeptAlive);

--- a/Source/WebCore/dom/MutationObserverRegistration.h
+++ b/Source/WebCore/dom/MutationObserverRegistration.h
@@ -64,7 +64,7 @@ public:
 
     void resetObservation(MutationObserverOptions, const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& attributeFilter);
     void observedSubtreeNodeWillDetach(Node&);
-    HashSet<GCReachableRef<Node>> takeTransientRegistrations();
+    UncheckedKeyHashSet<GCReachableRef<Node>> takeTransientRegistrations();
     bool hasTransientRegistrations() const { return !m_transientRegistrationNodes.isEmpty(); }
 
     bool shouldReceiveMutationFrom(Node&, MutationObserverOptionType, const QualifiedName* attributeName) const;
@@ -82,7 +82,7 @@ private:
     Ref<MutationObserver> m_observer;
     WeakRef<Node, WeakPtrImplWithEventTargetData> m_node;
     RefPtr<Node> m_nodeKeptAlive;
-    HashSet<GCReachableRef<Node>> m_transientRegistrationNodes;
+    UncheckedKeyHashSet<GCReachableRef<Node>> m_transientRegistrationNodes;
     MutationObserverOptions m_options;
     MemoryCompactLookupOnlyRobinHoodHashSet<AtomString> m_attributeFilter;
 };

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -577,9 +577,9 @@ ExceptionOr<void> Node::appendChild(Node& newChild)
     return Exception { ExceptionCode::HierarchyRequestError };
 }
 
-static HashSet<RefPtr<Node>> nodeSetPreTransformedFromNodeOrStringVector(const FixedVector<NodeOrString>& vector)
+static UncheckedKeyHashSet<RefPtr<Node>> nodeSetPreTransformedFromNodeOrStringVector(const FixedVector<NodeOrString>& vector)
 {
-    HashSet<RefPtr<Node>> nodeSet;
+    UncheckedKeyHashSet<RefPtr<Node>> nodeSet;
     for (const auto& variant : vector) {
         WTF::switchOn(variant,
             [&] (const RefPtr<Node>& node) { nodeSet.add(const_cast<Node*>(node.get())); },
@@ -589,7 +589,7 @@ static HashSet<RefPtr<Node>> nodeSetPreTransformedFromNodeOrStringVector(const F
     return nodeSet;
 }
 
-static RefPtr<Node> firstPrecedingSiblingNotInNodeSet(Node& context, const HashSet<RefPtr<Node>>& nodeSet)
+static RefPtr<Node> firstPrecedingSiblingNotInNodeSet(Node& context, const UncheckedKeyHashSet<RefPtr<Node>>& nodeSet)
 {
     for (auto* sibling = context.previousSibling(); sibling; sibling = sibling->previousSibling()) {
         if (!nodeSet.contains(sibling))
@@ -598,7 +598,7 @@ static RefPtr<Node> firstPrecedingSiblingNotInNodeSet(Node& context, const HashS
     return nullptr;
 }
 
-static RefPtr<Node> firstFollowingSiblingNotInNodeSet(Node& context, const HashSet<RefPtr<Node>>& nodeSet)
+static RefPtr<Node> firstFollowingSiblingNotInNodeSet(Node& context, const UncheckedKeyHashSet<RefPtr<Node>>& nodeSet)
 {
     for (auto* sibling = context.nextSibling(); sibling; sibling = sibling->nextSibling()) {
         if (!nodeSet.contains(sibling))

--- a/Source/WebCore/dom/QualifiedNameCache.h
+++ b/Source/WebCore/dom/QualifiedNameCache.h
@@ -68,7 +68,7 @@ private:
         static const int minimumTableSize = WTF::HashTableCapacityForSize<staticQualifiedNamesCount>::value;
     };
 
-    using QNameSet = HashSet<QualifiedName::QualifiedNameImpl*, QualifiedNameHash, QualifiedNameHashTraits>;
+    using QNameSet = UncheckedKeyHashSet<QualifiedName::QualifiedNameImpl*, QualifiedNameHash, QualifiedNameHashTraits>;
     QNameSet m_cache;
 };
 

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -448,7 +448,7 @@ ExceptionOr<RefPtr<DocumentFragment>> Range::processContents(ActionType action)
                 return result.releaseException();
         }
 
-        HashSet<Ref<Element>> elementSet;
+        UncheckedKeyHashSet<Ref<Element>> elementSet;
         for (Ref element : customElementsReactionHoldingTank.takeElements())
             elementSet.add(element.get());
         if (!elementSet.isEmpty()) {

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -430,9 +430,9 @@ private:
     void checkConsistency() const;
     WEBCORE_EXPORT GuaranteedSerialFunctionDispatcher& nativePromiseDispatcher();
 
-    HashSet<MessagePort*> m_messagePorts;
-    HashSet<ContextDestructionObserver*> m_destructionObservers;
-    HashSet<ActiveDOMObject*> m_activeDOMObjects;
+    UncheckedKeyHashSet<MessagePort*> m_messagePorts;
+    UncheckedKeyHashSet<ContextDestructionObserver*> m_destructionObservers;
+    UncheckedKeyHashSet<ActiveDOMObject*> m_activeDOMObjects;
 
     UncheckedKeyHashMap<int, RefPtr<DOMTimer>> m_timeouts;
 

--- a/Source/WebCore/dom/ScriptRunner.h
+++ b/Source/WebCore/dom/ScriptRunner.h
@@ -80,7 +80,7 @@ private:
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     Vector<Ref<PendingScript>> m_scriptsToExecuteInOrder;
     Vector<RefPtr<PendingScript>> m_scriptsToExecuteSoon; // http://www.whatwg.org/specs/web-apps/current-work/#set-of-scripts-that-will-execute-as-soon-as-possible
-    HashSet<Ref<PendingScript>> m_pendingAsyncScripts;
+    UncheckedKeyHashSet<Ref<PendingScript>> m_pendingAsyncScripts;
     Timer m_timer;
 };
 

--- a/Source/WebCore/dom/SimulatedClick.cpp
+++ b/Source/WebCore/dom/SimulatedClick.cpp
@@ -136,7 +136,7 @@ bool simulateClick(Element& element, Event* underlyingEvent, SimulatedClickMouse
     if (element.isDisabledFormControl())
         return false;
 
-    static MainThreadNeverDestroyed<HashSet<Ref<Element>>> elementsDispatchingSimulatedClicks;
+    static MainThreadNeverDestroyed<UncheckedKeyHashSet<Ref<Element>>> elementsDispatchingSimulatedClicks;
     if (!elementsDispatchingSimulatedClicks.get().add(element).isNewEntry)
         return false;
 

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -505,7 +505,7 @@ void ManualSlotAssignment::removeSlotElementByName(const AtomString&, HTMLSlotEl
 void ManualSlotAssignment::slotManualAssignmentDidChange(HTMLSlotElement& slot, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& previous, Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>& current, ShadowRoot& shadowRoot)
 {
     auto effectivePrevious = effectiveAssignedNodes(shadowRoot, previous);
-    HashSet<Ref<HTMLSlotElement>> affectedSlots;
+    UncheckedKeyHashSet<Ref<HTMLSlotElement>> affectedSlots;
     for (auto& node : current) {
         RefPtr protectedNode = node.get();
         if (RefPtr previousSlot = protectedNode->manuallyAssignedSlot()) {

--- a/Source/WebCore/dom/TreeScopeOrderedMap.h
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.h
@@ -86,7 +86,7 @@ private:
         unsigned count { 0 };
         Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>> orderedList;
 #if ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)
-        HashSet<WeakRef<Element, WeakPtrImplWithEventTargetData>> registeredElements;
+        UncheckedKeyHashSet<WeakRef<Element, WeakPtrImplWithEventTargetData>> registeredElements;
 #endif
     };
 

--- a/Source/WebCore/dom/VisitedLinkState.h
+++ b/Source/WebCore/dom/VisitedLinkState.h
@@ -54,7 +54,7 @@ private:
     InsideLink determineLinkStateSlowCase(const Element&);
 
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
-    HashSet<SharedStringHash, SharedStringHashHash> m_linksCheckedForVisitedState;
+    UncheckedKeyHashSet<SharedStringHash, SharedStringHashHash> m_linksCheckedForVisitedState;
 };
 
 inline InsideLink VisitedLinkState::determineLinkState(const Element& element)

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -50,8 +50,8 @@ public:
 
     void queueMutationObserverCompoundMicrotask();
     Vector<GCReachableRef<HTMLSlotElement>>& signalSlotList() { return m_signalSlotList; }
-    HashSet<RefPtr<MutationObserver>>& activeMutationObservers() { return m_activeObservers; }
-    HashSet<RefPtr<MutationObserver>>& suspendedMutationObservers() { return m_suspendedObservers; }
+    UncheckedKeyHashSet<RefPtr<MutationObserver>>& activeMutationObservers() { return m_activeObservers; }
+    UncheckedKeyHashSet<RefPtr<MutationObserver>>& suspendedMutationObservers() { return m_suspendedObservers; }
 
     CustomElementQueue& backupElementQueue();
 
@@ -91,8 +91,8 @@ private:
     bool m_mutationObserverCompoundMicrotaskQueuedFlag { false };
     bool m_deliveringMutationRecords { false }; // FIXME: This flag doesn't exist in the spec.
     Vector<GCReachableRef<HTMLSlotElement>> m_signalSlotList; // https://dom.spec.whatwg.org/#signal-slot-list
-    HashSet<RefPtr<MutationObserver>> m_activeObservers;
-    HashSet<RefPtr<MutationObserver>> m_suspendedObservers;
+    UncheckedKeyHashSet<RefPtr<MutationObserver>> m_activeObservers;
+    UncheckedKeyHashSet<RefPtr<MutationObserver>> m_suspendedObservers;
 
     std::unique_ptr<CustomElementQueue> m_customElementQueue;
     bool m_processingBackupElementQueue { false };

--- a/Source/WebCore/dom/messageports/MessagePortChannel.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.h
@@ -75,7 +75,7 @@ private:
     std::array<std::optional<ProcessIdentifier>, 2> m_processes;
     std::array<RefPtr<MessagePortChannel>, 2> m_entangledToProcessProtectors;
     std::array<Vector<MessageWithMessagePorts>, 2> m_pendingMessages;
-    std::array<HashSet<RefPtr<MessagePortChannel>>, 2> m_pendingMessagePortTransfers;
+    std::array<UncheckedKeyHashSet<RefPtr<MessagePortChannel>>, 2> m_pendingMessagePortTransfers;
     std::array<RefPtr<MessagePortChannel>, 2> m_pendingMessageProtectors;
     uint64_t m_messageBatchesInFlight { 0 };
 

--- a/Source/WebCore/editing/AppendNodeCommand.cpp
+++ b/Source/WebCore/editing/AppendNodeCommand.cpp
@@ -61,7 +61,7 @@ void AppendNodeCommand::doUnapply()
 }
 
 #ifndef NDEBUG
-void AppendNodeCommand::getNodesInCommand(HashSet<Ref<Node>>& nodes)
+void AppendNodeCommand::getNodesInCommand(NodeSet& nodes)
 {
     addNodeAndDescendants(m_parent.ptr(), nodes);
     addNodeAndDescendants(m_node.ptr(), nodes);

--- a/Source/WebCore/editing/AppendNodeCommand.h
+++ b/Source/WebCore/editing/AppendNodeCommand.h
@@ -43,7 +43,7 @@ private:
     void doUnapply() override;
 
 #ifndef NDEBUG
-    void getNodesInCommand(HashSet<Ref<Node>>&) override;
+    void getNodesInCommand(NodeSet&) override;
 #endif
 
     Ref<ContainerNode> protectedParent() const { return m_parent; }

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -337,7 +337,7 @@ void EditCommandComposition::setRangeDeletedByUnapply(const VisiblePositionIndex
 }
 
 #ifndef NDEBUG
-void EditCommandComposition::getNodesInCommand(HashSet<Ref<Node>>& nodes)
+void EditCommandComposition::getNodesInCommand(NodeSet& nodes)
 {
     for (size_t i = 0; i < m_commands.size(); ++i) {
         RefPtr command = m_commands[i].get();

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -91,7 +91,7 @@ public:
     void setRangeDeletedByUnapply(const VisiblePositionIndexRange&);
 
 #ifndef NDEBUG
-    virtual void getNodesInCommand(HashSet<Ref<Node>>&);
+    virtual void getNodesInCommand(NodeSet&);
 #endif
 
 private:

--- a/Source/WebCore/editing/DeleteFromTextNodeCommand.cpp
+++ b/Source/WebCore/editing/DeleteFromTextNodeCommand.cpp
@@ -66,7 +66,7 @@ void DeleteFromTextNodeCommand::doUnapply()
 }
 
 #ifndef NDEBUG
-void DeleteFromTextNodeCommand::getNodesInCommand(HashSet<Ref<Node>>& nodes)
+void DeleteFromTextNodeCommand::getNodesInCommand(NodeSet& nodes)
 {
     addNodeAndDescendants(protectedNode().ptr(), nodes);
 }

--- a/Source/WebCore/editing/DeleteFromTextNodeCommand.h
+++ b/Source/WebCore/editing/DeleteFromTextNodeCommand.h
@@ -46,7 +46,7 @@ private:
     void doUnapply() override;
     
 #ifndef NDEBUG
-    void getNodesInCommand(HashSet<Ref<Node>>&) override;
+    void getNodesInCommand(NodeSet&) override;
 #endif
 
     Ref<Text> protectedNode() const;

--- a/Source/WebCore/editing/EditCommand.cpp
+++ b/Source/WebCore/editing/EditCommand.cpp
@@ -230,7 +230,7 @@ void SimpleEditCommand::doReapply()
 }
 
 #ifndef NDEBUG
-void SimpleEditCommand::addNodeAndDescendants(Node* startNode, HashSet<Ref<Node>>& nodes)
+void SimpleEditCommand::addNodeAndDescendants(Node* startNode, NodeSet& nodes)
 {
     for (RefPtr node = startNode; node; node = NodeTraversal::next(*node, startNode))
         nodes.add(*node);

--- a/Source/WebCore/editing/EditCommand.h
+++ b/Source/WebCore/editing/EditCommand.h
@@ -43,6 +43,8 @@ class Element;
 ASCIILiteral inputTypeNameForEditingAction(EditAction);
 bool isInputMethodComposingForEditingAction(EditAction);
 
+using NodeSet = UncheckedKeyHashSet<Ref<Node>>;
+
 class EditCommand : public RefCounted<EditCommand> {
 public:
     virtual ~EditCommand();
@@ -96,14 +98,14 @@ public:
     virtual void doReapply(); // calls doApply()
 
 #ifndef NDEBUG
-    virtual void getNodesInCommand(HashSet<Ref<Node>>&) = 0;
+    virtual void getNodesInCommand(NodeSet&) = 0;
 #endif
 
 protected:
     explicit SimpleEditCommand(Ref<Document>&&, EditAction = EditAction::Unspecified);
 
 #ifndef NDEBUG
-    void addNodeAndDescendants(Node*, HashSet<Ref<Node>>&);
+    void addNodeAndDescendants(Node*, NodeSet&);
 #endif
 
 private:

--- a/Source/WebCore/editing/InsertIntoTextNodeCommand.cpp
+++ b/Source/WebCore/editing/InsertIntoTextNodeCommand.cpp
@@ -90,7 +90,7 @@ void InsertIntoTextNodeCommand::doUnapply()
 
 #ifndef NDEBUG
 
-void InsertIntoTextNodeCommand::getNodesInCommand(HashSet<Ref<Node>>& nodes)
+void InsertIntoTextNodeCommand::getNodesInCommand(NodeSet& nodes)
 {
     auto node = protectedNode();
     addNodeAndDescendants(node.ptr(), nodes);

--- a/Source/WebCore/editing/InsertIntoTextNodeCommand.h
+++ b/Source/WebCore/editing/InsertIntoTextNodeCommand.h
@@ -51,7 +51,7 @@ private:
     Ref<Text> protectedNode() const { return m_node.get(); }
     
 #ifndef NDEBUG
-    void getNodesInCommand(HashSet<Ref<Node>>&) override;
+    void getNodesInCommand(NodeSet&) override;
 #endif
     
     Ref<Text> m_node;

--- a/Source/WebCore/editing/InsertNodeBeforeCommand.cpp
+++ b/Source/WebCore/editing/InsertNodeBeforeCommand.cpp
@@ -66,7 +66,7 @@ void InsertNodeBeforeCommand::doUnapply()
 }
 
 #ifndef NDEBUG
-void InsertNodeBeforeCommand::getNodesInCommand(HashSet<Ref<Node>>& nodes)
+void InsertNodeBeforeCommand::getNodesInCommand(NodeSet& nodes)
 {
     addNodeAndDescendants(m_insertChild.ptr(), nodes);
     addNodeAndDescendants(m_refChild.ptr(), nodes);

--- a/Source/WebCore/editing/InsertNodeBeforeCommand.h
+++ b/Source/WebCore/editing/InsertNodeBeforeCommand.h
@@ -45,7 +45,7 @@ private:
     void doUnapply() override;
 
 #ifndef NDEBUG
-    void getNodesInCommand(HashSet<Ref<Node>>&) override;
+    void getNodesInCommand(NodeSet&) override;
 #endif
 
     Ref<Node> protectedInsertChild() const { return m_insertChild; }

--- a/Source/WebCore/editing/MergeIdenticalElementsCommand.cpp
+++ b/Source/WebCore/editing/MergeIdenticalElementsCommand.cpp
@@ -79,7 +79,7 @@ void MergeIdenticalElementsCommand::doUnapply()
 }
 
 #ifndef NDEBUG
-void MergeIdenticalElementsCommand::getNodesInCommand(HashSet<Ref<Node>>& nodes)
+void MergeIdenticalElementsCommand::getNodesInCommand(NodeSet& nodes)
 {
     addNodeAndDescendants(m_element1.ptr(), nodes);
     addNodeAndDescendants(m_element2.ptr(), nodes);

--- a/Source/WebCore/editing/MergeIdenticalElementsCommand.h
+++ b/Source/WebCore/editing/MergeIdenticalElementsCommand.h
@@ -43,7 +43,7 @@ private:
     void doUnapply() override;
     
 #ifndef NDEBUG
-    void getNodesInCommand(HashSet<Ref<Node>>&) override;
+    void getNodesInCommand(NodeSet&) override;
 #endif
 
     Ref<Element> protectedElement1() const { return m_element1; }

--- a/Source/WebCore/editing/RemoveNodeCommand.cpp
+++ b/Source/WebCore/editing/RemoveNodeCommand.cpp
@@ -67,7 +67,7 @@ void RemoveNodeCommand::doUnapply()
 }
 
 #ifndef NDEBUG
-void RemoveNodeCommand::getNodesInCommand(HashSet<Ref<Node>>& nodes)
+void RemoveNodeCommand::getNodesInCommand(NodeSet& nodes)
 {
     addNodeAndDescendants(m_parent.get(), nodes);
     addNodeAndDescendants(m_refChild.get(), nodes);

--- a/Source/WebCore/editing/RemoveNodeCommand.h
+++ b/Source/WebCore/editing/RemoveNodeCommand.h
@@ -43,7 +43,7 @@ private:
     void doUnapply() override;
 
 #ifndef NDEBUG
-    void getNodesInCommand(HashSet<Ref<Node>>&) override;
+    void getNodesInCommand(NodeSet&) override;
 #endif
 
     Ref<Node> protectedNode() const { return m_node; }

--- a/Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp
+++ b/Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp
@@ -76,7 +76,7 @@ void ReplaceNodeWithSpanCommand::doUnapply()
 }
 
 #ifndef NDEBUG
-void ReplaceNodeWithSpanCommand::getNodesInCommand(HashSet<Ref<Node>>& nodes)
+void ReplaceNodeWithSpanCommand::getNodesInCommand(NodeSet& nodes)
 {
     addNodeAndDescendants(m_elementToReplace.ptr(), nodes);
     addNodeAndDescendants(m_spanElement.get(), nodes);

--- a/Source/WebCore/editing/ReplaceNodeWithSpanCommand.h
+++ b/Source/WebCore/editing/ReplaceNodeWithSpanCommand.h
@@ -56,7 +56,7 @@ private:
     Ref<HTMLElement> protectedElementToReplace() const { return m_elementToReplace; }
     
 #ifndef NDEBUG
-    void getNodesInCommand(HashSet<Ref<Node>>&) override;
+    void getNodesInCommand(NodeSet&) override;
 #endif
 
     Ref<HTMLElement> m_elementToReplace;

--- a/Source/WebCore/editing/SetNodeAttributeCommand.cpp
+++ b/Source/WebCore/editing/SetNodeAttributeCommand.cpp
@@ -54,7 +54,7 @@ void SetNodeAttributeCommand::doUnapply()
 }
 
 #ifndef NDEBUG
-void SetNodeAttributeCommand::getNodesInCommand(HashSet<Ref<Node>>& nodes)
+void SetNodeAttributeCommand::getNodesInCommand(NodeSet& nodes)
 {
     addNodeAndDescendants(protectedElement().ptr(), nodes);
 }

--- a/Source/WebCore/editing/SetNodeAttributeCommand.h
+++ b/Source/WebCore/editing/SetNodeAttributeCommand.h
@@ -44,7 +44,7 @@ private:
     void doUnapply() override;
 
 #ifndef NDEBUG
-    void getNodesInCommand(HashSet<Ref<Node>>&) override;
+    void getNodesInCommand(NodeSet&) override;
 #endif
 
     Ref<Element> protectedElement() const { return m_element; }

--- a/Source/WebCore/editing/SetSelectionCommand.h
+++ b/Source/WebCore/editing/SetSelectionCommand.h
@@ -44,7 +44,7 @@ private:
     void doUnapply() override;
 
 #ifndef NDEBUG
-    void getNodesInCommand(HashSet<Ref<Node>>&) override { }
+    void getNodesInCommand(NodeSet&) override { }
 #endif
 
     OptionSet<FrameSelection::SetSelectionOption> m_options;

--- a/Source/WebCore/editing/SpellingCorrectionCommand.cpp
+++ b/Source/WebCore/editing/SpellingCorrectionCommand.cpp
@@ -72,7 +72,7 @@ private:
     }
 
 #ifndef NDEBUG
-    void getNodesInCommand(HashSet<Ref<Node>>&) override
+    void getNodesInCommand(NodeSet&) override
     {
     }
 #endif

--- a/Source/WebCore/editing/SplitElementCommand.cpp
+++ b/Source/WebCore/editing/SplitElementCommand.cpp
@@ -106,7 +106,7 @@ void SplitElementCommand::doReapply()
 }
 
 #ifndef NDEBUG
-void SplitElementCommand::getNodesInCommand(HashSet<Ref<Node>>& nodes)
+void SplitElementCommand::getNodesInCommand(NodeSet& nodes)
 {
     addNodeAndDescendants(protectedElement1().get(), nodes);
     addNodeAndDescendants(protectedElement2().ptr(), nodes);

--- a/Source/WebCore/editing/SplitElementCommand.h
+++ b/Source/WebCore/editing/SplitElementCommand.h
@@ -45,7 +45,7 @@ private:
     void executeApply();
 
 #ifndef NDEBUG
-    void getNodesInCommand(HashSet<Ref<Node>>&) override;
+    void getNodesInCommand(NodeSet&) override;
 #endif
 
     RefPtr<Element> protectedElement1() const { return m_element1; }

--- a/Source/WebCore/editing/SplitTextNodeCommand.cpp
+++ b/Source/WebCore/editing/SplitTextNodeCommand.cpp
@@ -110,7 +110,7 @@ void SplitTextNodeCommand::insertText1AndTrimText2()
 
 #ifndef NDEBUG
 
-void SplitTextNodeCommand::getNodesInCommand(HashSet<Ref<Node>>& nodes)
+void SplitTextNodeCommand::getNodesInCommand(NodeSet& nodes)
 {
     addNodeAndDescendants(protectedText1().get(), nodes);
     addNodeAndDescendants(protectedText2().ptr(), nodes);

--- a/Source/WebCore/editing/SplitTextNodeCommand.h
+++ b/Source/WebCore/editing/SplitTextNodeCommand.h
@@ -47,7 +47,7 @@ private:
     void insertText1AndTrimText2();
     
 #ifndef NDEBUG
-    void getNodesInCommand(HashSet<Ref<Node>>&) override;
+    void getNodesInCommand(NodeSet&) override;
 #endif
 
     RefPtr<Text> protectedText1() const { return m_text1; }

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -600,7 +600,7 @@ void TextManipulationController::scheduleObservationUpdate()
 
         controller->m_didScheduleObservationUpdate = false;
 
-        HashSet<Ref<Node>> nodesToObserve;
+        NodeSet nodesToObserve;
         for (auto& text : controller->m_manipulatedNodesWithNewContent) {
             if (!controller->m_manipulatedNodes.contains(text))
                 continue;
@@ -689,7 +689,7 @@ void TextManipulationController::flushPendingItemsForCallback()
 auto TextManipulationController::completeManipulation(const Vector<WebCore::TextManipulationItem>& completionItems) -> Vector<ManipulationFailure>
 {
     Vector<ManipulationFailure> failures;
-    HashSet<Ref<Node>> containersWithoutVisualOverflowBeforeReplacement;
+    NodeSet containersWithoutVisualOverflowBeforeReplacement;
     for (unsigned i = 0; i < completionItems.size(); ++i) {
         auto& itemToComplete = completionItems[i];
         auto frameID = itemToComplete.frameID;
@@ -768,7 +768,7 @@ Vector<Ref<Node>> TextManipulationController::getPath(Node* ancestor, Node* node
     return path;
 }
 
-void TextManipulationController::updateInsertions(Vector<NodeEntry>& lastTopDownPath, const Vector<Ref<Node>>& currentTopDownPath, Node* currentNode, HashSet<Ref<Node>>& insertedNodes, Vector<NodeInsertion>& insertions)
+void TextManipulationController::updateInsertions(Vector<NodeEntry>& lastTopDownPath, const Vector<Ref<Node>>& currentTopDownPath, Node* currentNode, NodeSet& insertedNodes, Vector<NodeInsertion>& insertions)
 {
     size_t i = 0;
     while (i < lastTopDownPath.size() && i < currentTopDownPath.size() && lastTopDownPath[i].first.ptr() == currentTopDownPath[i].ptr())
@@ -795,7 +795,7 @@ void TextManipulationController::updateInsertions(Vector<NodeEntry>& lastTopDown
         insertions.append(NodeInsertion { lastTopDownPath.size() ? lastTopDownPath.last().second.ptr() : nullptr, *currentNode });
 }
 
-auto TextManipulationController::replace(const ManipulationItemData& item, const Vector<TextManipulationToken>& replacementTokens, HashSet<Ref<Node>>& containersWithoutVisualOverflowBeforeReplacement) -> std::optional<ManipulationFailure::Type>
+auto TextManipulationController::replace(const ManipulationItemData& item, const Vector<TextManipulationToken>& replacementTokens, NodeSet& containersWithoutVisualOverflowBeforeReplacement) -> std::optional<ManipulationFailure::Type>
 {
     if (item.start.isOrphan() || item.end.isOrphan())
         return ManipulationFailure::Type::ContentChanged;
@@ -835,7 +835,7 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
     RefPtr<Node> commonAncestor;
     RefPtr<Node> firstContentNode;
     RefPtr<Node> lastChildOfCommonAncestorInRange;
-    HashSet<Ref<Node>> nodesToRemove;
+    NodeSet nodesToRemove;
     
     for (ParagraphContentIterator iterator { item.start, item.end }; !iterator.atEnd(); iterator.advance()) {
         auto content = iterator.currentContent();
@@ -901,7 +901,7 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
     for (RefPtr node = commonAncestor; node; node = node->parentNode())
         nodesToRemove.remove(*node);
 
-    HashSet<Ref<Node>> reusedOriginalNodes;
+    NodeSet reusedOriginalNodes;
     Vector<NodeInsertion> insertions;
     auto startTopDownPath = getPath(commonAncestor.get(), firstContentNode.get());
     while (!startTopDownPath.isEmpty()) {

--- a/Source/WebCore/editing/TextManipulationController.h
+++ b/Source/WebCore/editing/TextManipulationController.h
@@ -44,6 +44,8 @@ class Document;
 class Element;
 class VisiblePosition;
 
+using NodeSet = UncheckedKeyHashSet<Ref<Node>>;
+
 class TextManipulationController final : public CanMakeWeakPtr<TextManipulationController>, public CanMakeCheckedPtr<TextManipulationController> {
     WTF_MAKE_TZONE_ALLOCATED(TextManipulationController);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextManipulationController);
@@ -100,8 +102,8 @@ private:
     };
     using NodeEntry = std::pair<Ref<Node>, Ref<Node>>;
     Vector<Ref<Node>> getPath(Node*, Node*);
-    void updateInsertions(Vector<NodeEntry>&, const Vector<Ref<Node>>&, Node*, HashSet<Ref<Node>>&, Vector<NodeInsertion>&);
-    std::optional<ManipulationFailure::Type> replace(const ManipulationItemData&, const Vector<TextManipulationToken>&, HashSet<Ref<Node>>& containersWithoutVisualOverflowBeforeReplacement);
+    void updateInsertions(Vector<NodeEntry>&, const Vector<Ref<Node>>&, Node*, NodeSet&, Vector<NodeInsertion>&);
+    std::optional<ManipulationFailure::Type> replace(const ManipulationItemData&, const Vector<TextManipulationToken>&, NodeSet& containersWithoutVisualOverflowBeforeReplacement);
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     WeakHashSet<Node, WeakPtrImplWithEventTargetData> m_manipulatedNodes;

--- a/Source/WebCore/editing/WrapContentsInDummySpanCommand.cpp
+++ b/Source/WebCore/editing/WrapContentsInDummySpanCommand.cpp
@@ -86,7 +86,7 @@ void WrapContentsInDummySpanCommand::doReapply()
 }
 
 #ifndef NDEBUG
-void WrapContentsInDummySpanCommand::getNodesInCommand(HashSet<Ref<Node>>& nodes)
+void WrapContentsInDummySpanCommand::getNodesInCommand(NodeSet& nodes)
 {
     addNodeAndDescendants(protectedElement().ptr(), nodes);
     addNodeAndDescendants(protectedDummySpan().get(), nodes);

--- a/Source/WebCore/editing/WrapContentsInDummySpanCommand.h
+++ b/Source/WebCore/editing/WrapContentsInDummySpanCommand.h
@@ -50,7 +50,7 @@ private:
     Ref<Element> protectedElement() const { return m_element; }
 
 #ifndef NDEBUG
-    void getNodesInCommand(HashSet<Ref<Node>>&) override;
+    void getNodesInCommand(NodeSet&) override;
 #endif
 
     Ref<Element> m_element;

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -133,6 +133,8 @@ const unichar WebNextLineCharacter = 0x0085;
 static const CGFloat defaultFontSize = 12;
 static const CGFloat minimumFontSize = 1;
 
+using NodeSet = UncheckedKeyHashSet<Ref<Node>>;
+
 class HTMLConverterCaches {
     WTF_MAKE_TZONE_ALLOCATED(HTMLConverterCaches);
 public:
@@ -151,7 +153,7 @@ public:
 
 private:
     UncheckedKeyHashMap<Element*, std::unique_ptr<ComputedStyleExtractor>> m_computedStyles;
-    HashSet<Ref<Node>> m_ancestorsUnderCommonAncestor;
+    NodeSet m_ancestorsUnderCommonAncestor;
 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLConverterCaches);

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -67,7 +67,7 @@ public:
     static URLRegistry& registry();
 
     Lock m_urlsPerContextLock;
-    HashMap<ScriptExecutionContextIdentifier, HashSet<URL>> m_urlsPerContext WTF_GUARDED_BY_LOCK(m_urlsPerContextLock);
+    HashMap<ScriptExecutionContextIdentifier, UncheckedKeyHashSet<URL>> m_urlsPerContext WTF_GUARDED_BY_LOCK(m_urlsPerContextLock);
 };
 
 void BlobURLRegistry::registerURL(const ScriptExecutionContext& context, const URL& publicURL, URLRegistrable& blob)
@@ -75,7 +75,7 @@ void BlobURLRegistry::registerURL(const ScriptExecutionContext& context, const U
     ASSERT(&blob.registry() == this);
     {
         Locker locker { m_urlsPerContextLock };
-        m_urlsPerContext.add(context.identifier(), HashSet<URL>()).iterator->value.add(publicURL.isolatedCopy());
+        m_urlsPerContext.add(context.identifier(), UncheckedKeyHashSet<URL>()).iterator->value.add(publicURL.isolatedCopy());
     }
     ThreadableBlobRegistry::registerBlobURL(context.securityOrigin(), context.policyContainer(), publicURL, downcast<Blob>(blob).url(), context.topOrigin().data());
 }
@@ -102,7 +102,7 @@ void BlobURLRegistry::unregisterURL(const URL& url, const SecurityOriginData& to
 
 void BlobURLRegistry::unregisterURLsForContext(const ScriptExecutionContext& context)
 {
-    HashSet<URL> urlsForContext;
+    UncheckedKeyHashSet<URL> urlsForContext;
     {
         Locker locker { m_urlsPerContextLock };
         urlsForContext = m_urlsPerContext.take(context.identifier());

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -163,7 +163,7 @@ private:
     // into an HTML or for FileRead'ing, public blob URLs must be used for those purposes.
     URL m_internalURL;
 
-    HashSet<std::unique_ptr<BlobLoader>> m_blobLoaders;
+    UncheckedKeyHashSet<std::unique_ptr<BlobLoader>> m_blobLoaders;
 };
 
 WebCoreOpaqueRoot root(Blob*);

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -626,7 +626,7 @@ void BackForwardCache::prune(PruningReason pruningReason)
     }
 }
 
-void BackForwardCache::clearEntriesForOrigins(const HashSet<RefPtr<SecurityOrigin>>& origins)
+void BackForwardCache::clearEntriesForOrigins(const UncheckedKeyHashSet<RefPtr<SecurityOrigin>>& origins)
 {
     m_cachedPageMap.removeIf([&](auto& pair) -> bool {
         if (auto* cachedPage = std::get_if<UniqueRef<CachedPage>>(&pair.value)) {

--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -63,7 +63,7 @@ public:
 
     void removeAllItemsForPage(Page&);
 
-    WEBCORE_EXPORT void clearEntriesForOrigins(const HashSet<RefPtr<SecurityOrigin>>&);
+    WEBCORE_EXPORT void clearEntriesForOrigins(const UncheckedKeyHashSet<RefPtr<SecurityOrigin>>&);
 
     unsigned pageCount() const { return m_items.size(); }
     WEBCORE_EXPORT unsigned frameCount() const;

--- a/Source/WebCore/html/Allowlist.h
+++ b/Source/WebCore/html/Allowlist.h
@@ -39,15 +39,15 @@ public:
     {
     }
     explicit Allowlist(const SecurityOriginData& origin)
-        : m_origins(HashSet<SecurityOriginData> { origin })
+        : m_origins(UncheckedKeyHashSet<SecurityOriginData> { origin })
     {
     }
-    explicit Allowlist(HashSet<SecurityOriginData>&& origins)
+    explicit Allowlist(UncheckedKeyHashSet<SecurityOriginData>&& origins)
         : m_origins(WTFMove(origins))
     {
     }
 
-    using OriginsVariant = std::variant<HashSet<SecurityOriginData>, AllowAllOrigins>;
+    using OriginsVariant = std::variant<UncheckedKeyHashSet<SecurityOriginData>, AllowAllOrigins>;
     explicit Allowlist(OriginsVariant&& origins)
         : m_origins(WTFMove(origins))
     {
@@ -57,7 +57,7 @@ public:
     // This is simplified version of https://w3c.github.io/webappsec-permissions-policy/#matches.
     bool matches(const SecurityOriginData& origin) const
     {
-        return std::visit(WTF::makeVisitor([&origin](const HashSet<SecurityOriginData>& origins) -> bool {
+        return std::visit(WTF::makeVisitor([&origin](const UncheckedKeyHashSet<SecurityOriginData>& origins) -> bool {
             return origins.contains(origin);
         }, [&] (const auto&) {
             return true;

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -211,9 +211,9 @@ void CanvasBase::notifyObserversCanvasDisplayBufferPrepared()
         observer.canvasDisplayBufferPrepared(*this);
 }
 
-HashSet<Element*> CanvasBase::cssCanvasClients() const
+UncheckedKeyHashSet<Element*> CanvasBase::cssCanvasClients() const
 {
-    HashSet<Element*> cssCanvasClients;
+    UncheckedKeyHashSet<Element*> cssCanvasClients;
     for (auto& observer : m_observers) {
         auto* image = dynamicDowncast<StyleCanvasImage>(observer);
         if (!image)

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -122,7 +122,7 @@ public:
     void notifyObserversCanvasDisplayBufferPrepared();
     bool hasDisplayBufferObservers() const { return !m_displayBufferObservers.isEmptyIgnoringNullReferences(); }
 
-    HashSet<Element*> cssCanvasClients() const;
+    UncheckedKeyHashSet<Element*> cssCanvasClients() const;
 
     // !rect means caller knows the full canvas is invalidated previously.
     void didDraw(const std::optional<FloatRect>& rect) { return didDraw(rect, ShouldApplyPostProcessingToDirtyRect::Yes); }

--- a/Source/WebCore/html/DOMTokenList.cpp
+++ b/Source/WebCore/html/DOMTokenList.cpp
@@ -227,7 +227,7 @@ void DOMTokenList::updateTokensFromAttributeValue(const AtomString& value)
     // Clear tokens but not capacity.
     m_tokens.shrink(0);
 
-    HashSet<AtomString> addedTokens;
+    UncheckedKeyHashSet<AtomString> addedTokens;
     // https://dom.spec.whatwg.org/#ordered%20sets
     for (unsigned start = 0; ; ) {
         while (start < value.length() && isASCIIWhitespace(value[start]))

--- a/Source/WebCore/html/HTMLFormControlsCollection.cpp
+++ b/Source/WebCore/html/HTMLFormControlsCollection.cpp
@@ -115,7 +115,7 @@ void HTMLFormControlsCollection::updateNamedElementCache() const
 
     auto cache = makeUnique<CollectionNamedElementCache>();
 
-    HashSet<AtomString> foundInputElements;
+    UncheckedKeyHashSet<AtomString> foundInputElements;
 
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
     for (auto& weakElement : ownerNode().unsafeListedElements()) {

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -180,7 +180,7 @@ void HTMLSlotElement::assign(FixedVector<ElementOrText>&& nodes)
     }
 
     auto previous = std::exchange(m_manuallyAssignedNodes, { });
-    HashSet<RefPtr<Node>> seenNodes;
+    UncheckedKeyHashSet<RefPtr<Node>> seenNodes;
     m_manuallyAssignedNodes = WTF::compactMap(nodes, [&seenNodes](ElementOrText& node) -> std::optional<WeakPtr<Node, WeakPtrImplWithEventTargetData>> {
         auto mapper = [&seenNodes]<typename T>(RefPtr<T>& node) -> std::optional<WeakPtr<Node, WeakPtrImplWithEventTargetData>> {
             if (seenNodes.contains(node))

--- a/Source/WebCore/html/PermissionsPolicy.cpp
+++ b/Source/WebCore/html/PermissionsPolicy.cpp
@@ -315,7 +315,7 @@ static Allowlist parseAllowlist(StringView value, const SecurityOriginData& cont
     if (value.isEmpty())
         return Allowlist { targetOrigin };
 
-    HashSet<SecurityOriginData> allowedOrigins;
+    UncheckedKeyHashSet<SecurityOriginData> allowedOrigins;
     while (!value.isEmpty()) {
         auto [token, remainingValue] = splitOnAsciiWhiteSpace(value);
         if (!token.isEmpty()) {

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -56,9 +56,9 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(CanvasRenderingContext);
 
 Lock CanvasRenderingContext::s_instancesLock;
 
-HashSet<CanvasRenderingContext*>& CanvasRenderingContext::instances()
+UncheckedKeyHashSet<CanvasRenderingContext*>& CanvasRenderingContext::instances()
 {
-    static NeverDestroyed<HashSet<CanvasRenderingContext*>> instances;
+    static NeverDestroyed<UncheckedKeyHashSet<CanvasRenderingContext*>> instances;
     return instances;
 }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -57,7 +57,7 @@ class CanvasRenderingContext : public ScriptWrappable, public CanMakeWeakPtr<Can
 public:
     virtual ~CanvasRenderingContext();
 
-    static HashSet<CanvasRenderingContext*>& instances() WTF_REQUIRES_LOCK(instancesLock());
+    static UncheckedKeyHashSet<CanvasRenderingContext*>& instances() WTF_REQUIRES_LOCK(instancesLock());
     static Lock& instancesLock() WTF_RETURNS_LOCK(s_instancesLock);
 
     WEBCORE_EXPORT void ref() const;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -309,7 +309,7 @@ static const GCGLenum supportedTypesOESTextureHalfFloat[] = {
 // Counter for determining which context has the earliest active ordinal number.
 static std::atomic<uint64_t> s_lastActiveOrdinal;
 
-using WebGLRenderingContextBaseSet = HashSet<WebGLRenderingContextBase*>;
+using WebGLRenderingContextBaseSet = UncheckedKeyHashSet<WebGLRenderingContextBase*>;
 
 static WebGLRenderingContextBaseSet& activeContexts()
 {

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -781,9 +781,9 @@ protected:
     bool m_areOESTextureHalfFloatFormatsAndTypesAdded { false };
     bool m_areEXTsRGBFormatsAndTypesAdded { false };
 
-    HashSet<GCGLenum> m_supportedTexImageSourceInternalFormats;
-    HashSet<GCGLenum> m_supportedTexImageSourceFormats;
-    HashSet<GCGLenum> m_supportedTexImageSourceTypes;
+    UncheckedKeyHashSet<GCGLenum> m_supportedTexImageSourceInternalFormats;
+    UncheckedKeyHashSet<GCGLenum> m_supportedTexImageSourceFormats;
+    UncheckedKeyHashSet<GCGLenum> m_supportedTexImageSourceTypes;
 
     // Helpers for getParameter and other similar functions.
     bool getBooleanParameter(GCGLenum);

--- a/Source/WebCore/html/parser/AtomHTMLToken.h
+++ b/Source/WebCore/html/parser/AtomHTMLToken.h
@@ -228,7 +228,7 @@ inline void AtomHTMLToken::initializeAttributes(const HTMLToken::AttributeList& 
     if (!size)
         return;
 
-    HashSet<AtomString> addedAttributes;
+    UncheckedKeyHashSet<AtomString> addedAttributes;
     addedAttributes.reserveInitialCapacity(size);
     m_attributes = WTF::compactMap(attributes, [&](auto& attribute) -> std::optional<Attribute> {
         if (attribute.name.isEmpty())

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -149,7 +149,7 @@ JSC::JSValue InspectorCanvas::resolveContext(JSC::JSGlobalObject* exec)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-HashSet<Element*> InspectorCanvas::clientNodes() const
+UncheckedKeyHashSet<Element*> InspectorCanvas::clientNodes() const
 {
     return m_context->canvasBase().cssCanvasClients();
 }

--- a/Source/WebCore/inspector/InspectorCanvas.h
+++ b/Source/WebCore/inspector/InspectorCanvas.h
@@ -61,7 +61,7 @@ public:
 
     JSC::JSValue resolveContext(JSC::JSGlobalObject*);
 
-    HashSet<Element*> clientNodes() const;
+    UncheckedKeyHashSet<Element*> clientNodes() const;
 
     void canvasChanged();
 

--- a/Source/WebCore/layout/LayoutState.h
+++ b/Source/WebCore/layout/LayoutState.h
@@ -128,7 +128,7 @@ private:
     UncheckedKeyHashMap<const ElementBox*, std::unique_ptr<TableFormattingState>> m_tableFormattingStates;
 
 #ifndef NDEBUG
-    HashSet<const FormattingContext*> m_formattingContextList;
+    UncheckedKeyHashSet<const FormattingContext*> m_formattingContextList;
 #endif
     UncheckedKeyHashMap<const Box*, std::unique_ptr<BoxGeometry>> m_layoutBoxToBoxGeometry;
     QuirksMode m_quirksMode { QuirksMode::No };

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingState.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingState.h
@@ -63,7 +63,7 @@ private:
     PlacedFloats m_placedFloats;
     OutOfFlowBoxList m_outOfFlowBoxes;
     UncheckedKeyHashMap<CheckedRef<const Box>, UsedVerticalMargin> m_usedVerticalMargins;
-    HashSet<CheckedRef<const Box>> m_clearanceSet;
+    UncheckedKeyHashSet<CheckedRef<const Box>> m_clearanceSet;
 };
 
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -381,7 +381,7 @@ static inline const ElementBox& nearestCommonAncestor(const Box& first, const Bo
     if (&firstParent != &rootBox && &secondParent != &rootBox && &firstParent.parent() == &secondParent.parent())
         return firstParent.parent();
 
-    HashSet<const ElementBox*> descendantsSet;
+    UncheckedKeyHashSet<const ElementBox*> descendantsSet;
     for (auto* descendant = &firstParent; descendant != &rootBox; descendant = &descendant->parent())
         descendantsSet.add(descendant);
     for (auto* descendant = &secondParent; descendant != &rootBox; descendant = &descendant->parent()) {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -118,7 +118,7 @@ void InlineItemsBuilder::build(InlineItemPosition startPosition)
     // Check if we've got matching inline box start/end pairs and unique inline level items (non-text, non-inline box items).
     size_t inlineBoxStart = 0;
     size_t inlineBoxEnd = 0;
-    auto inlineLevelItems = HashSet<const Box*> { };
+    auto inlineLevelItems = UncheckedKeyHashSet<const Box*> { };
     for (auto& inlineItem : inlineContentCache().inlineItems().content()) {
         if (inlineItem.isInlineBoxStart())
             ++inlineBoxStart;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -670,7 +670,7 @@ void LineBuilder::candidateContentForLine(LineCandidate& lineCandidate, size_t c
     auto firstInlineTextItemIndex = std::optional<size_t> { };
     auto lastInlineTextItemIndex = std::optional<size_t> { };
     auto trailingSoftHyphenInlineTextItemIndex = std::optional<size_t> { };
-    HashSet<const Box*> inlineBoxListWithClonedDecorationEnd;
+    UncheckedKeyHashSet<const Box*> inlineBoxListWithClonedDecorationEnd;
     auto accumulatedDecorationEndWidth = InlineLayoutUnit { 0.f };
     InlineLayoutUnit textSpacingAdjustment = 0.f;
     for (auto index = currentInlineItemIndex; index < softWrapOpportunityIndex; ++index) {

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -1156,7 +1156,7 @@ void InlineDisplayContentBuilder::processRubyContent(InlineDisplay::Boxes& displ
     if (!m_hasSeenRubyBase)
         return;
 
-    HashSet<CheckedPtr<const Box>> lineSpanningRubyBaseList;
+    UncheckedKeyHashSet<CheckedPtr<const Box>> lineSpanningRubyBaseList;
     for (auto& lineRun : lineLayoutResult.inlineContent) {
         if (lineRun.isLineSpanningInlineBoxStart() && lineRun.layoutBox().isRubyBase())
             lineSpanningRubyBaseList.add(&lineRun.layoutBox());

--- a/Source/WebCore/loader/CanvasActivityRecord.h
+++ b/Source/WebCore/loader/CanvasActivityRecord.h
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 struct CanvasActivityRecord {
-    HashSet<String> textWritten;
+    UncheckedKeyHashSet<String> textWritten;
     bool wasDataRead { false };
     
     WEBCORE_EXPORT bool recordWrittenOrMeasuredText(const String&);

--- a/Source/WebCore/loader/CrossOriginPreflightResultCache.h
+++ b/Source/WebCore/loader/CrossOriginPreflightResultCache.h
@@ -47,7 +47,7 @@ class CrossOriginPreflightResultCacheItem {
 public:
     static Expected<UniqueRef<CrossOriginPreflightResultCacheItem>, String> create(StoredCredentialsPolicy, const ResourceResponse&);
 
-    CrossOriginPreflightResultCacheItem(MonotonicTime, StoredCredentialsPolicy, HashSet<String>&&, HashSet<String, ASCIICaseInsensitiveHash>&&);
+    CrossOriginPreflightResultCacheItem(MonotonicTime, StoredCredentialsPolicy, UncheckedKeyHashSet<String>&&, UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash>&&);
 
     std::optional<String> validateMethodAndHeaders(const String& method, const HTTPHeaderMap&) const;
     bool allowsRequest(StoredCredentialsPolicy, const String& method, const HTTPHeaderMap&) const;
@@ -61,8 +61,8 @@ private:
     // it fires.
     MonotonicTime m_absoluteExpiryTime;
     StoredCredentialsPolicy m_storedCredentialsPolicy;
-    HashSet<String> m_methods;
-    HashSet<String, ASCIICaseInsensitiveHash> m_headers;
+    UncheckedKeyHashSet<String> m_methods;
+    UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash> m_headers;
 };
 
 class CrossOriginPreflightResultCache {
@@ -80,7 +80,7 @@ private:
     HashMap<std::tuple<PAL::SessionID, ClientOrigin, URL>, std::unique_ptr<CrossOriginPreflightResultCacheItem>> m_preflightHashMap;
 };
 
-inline CrossOriginPreflightResultCacheItem::CrossOriginPreflightResultCacheItem(MonotonicTime absoluteExpiryTime, StoredCredentialsPolicy  storedCredentialsPolicy, HashSet<String>&& methods, HashSet<String, ASCIICaseInsensitiveHash>&& headers)
+inline CrossOriginPreflightResultCacheItem::CrossOriginPreflightResultCacheItem(MonotonicTime absoluteExpiryTime, StoredCredentialsPolicy  storedCredentialsPolicy, UncheckedKeyHashSet<String>&& methods, UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash>&& headers)
     : m_absoluteExpiryTime(absoluteExpiryTime)
     , m_storedCredentialsPolicy(storedCredentialsPolicy)
     , m_methods(WTFMove(methods))

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -179,7 +179,7 @@ enum class PushAndNotificationsEnabledPolicy: uint8_t {
 };
 
 enum class ContentExtensionDefaultEnablement : bool { Disabled, Enabled };
-using ContentExtensionEnablement = std::pair<ContentExtensionDefaultEnablement, HashSet<String>>;
+using ContentExtensionEnablement = std::pair<ContentExtensionDefaultEnablement, UncheckedKeyHashSet<String>>;
 
 class DataLoadToken : public CanMakeWeakPtr<DataLoadToken> {
 public:

--- a/Source/WebCore/loader/ResourceLoadStatistics.cpp
+++ b/Source/WebCore/loader/ResourceLoadStatistics.cpp
@@ -365,7 +365,8 @@ static void appendHashSet(StringBuilder& builder, const String& label, const Has
 }
 
 #if ENABLE(WEB_API_STATISTICS)
-static void appendHashSet(StringBuilder& builder, const String& label, const HashSet<String>& hashSet)
+template<typename HashSetType>
+static void appendHashSet(StringBuilder& builder, const String& label, const HashSetType& hashSet)
 {
     if (hashSet.isEmpty())
         return;

--- a/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
@@ -754,7 +754,7 @@ void ApplicationCacheGroup::manifestNotFound()
     m_manifestResource = nullptr;
 
     while (!m_pendingMasterResourceLoaders.isEmpty()) {
-        HashSet<DocumentLoader*>::iterator it = m_pendingMasterResourceLoaders.begin();
+        auto it = m_pendingMasterResourceLoaders.begin();
         
         ASSERT((*it)->applicationCacheHost().candidateApplicationCacheGroup() == this);
         ASSERT(!(*it)->applicationCacheHost().applicationCache());
@@ -1025,7 +1025,7 @@ void ApplicationCacheGroup::scheduleReachedMaxAppCacheSizeCallback()
     // The timer will delete itself once it fires.
 }
 
-void ApplicationCacheGroup::postListenerTask(const AtomString& eventType, int progressTotal, int progressDone, const HashSet<DocumentLoader*>& loaderSet)
+void ApplicationCacheGroup::postListenerTask(const AtomString& eventType, int progressTotal, int progressDone, const UncheckedKeyHashSet<DocumentLoader*>& loaderSet)
 {
     for (auto& loader : loaderSet)
         postListenerTask(eventType, progressTotal, progressDone, *loader);

--- a/Source/WebCore/loader/appcache/ApplicationCacheGroup.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheGroup.h
@@ -104,9 +104,9 @@ public:
     void disassociateDocumentLoader(DocumentLoader&);
 
 private:
-    static void postListenerTask(const AtomString& eventType, const HashSet<DocumentLoader*>& set) { postListenerTask(eventType, 0, 0, set); }
+    static void postListenerTask(const AtomString& eventType, const UncheckedKeyHashSet<DocumentLoader*>& set) { postListenerTask(eventType, 0, 0, set); }
     static void postListenerTask(const AtomString& eventType, DocumentLoader& loader)  { postListenerTask(eventType, 0, 0, loader); }
-    static void postListenerTask(const AtomString& eventType, int progressTotal, int progressDone, const HashSet<DocumentLoader*>&);
+    static void postListenerTask(const AtomString& eventType, int progressTotal, int progressDone, const UncheckedKeyHashSet<DocumentLoader*>&);
     static void postListenerTask(const AtomString& eventType, int progressTotal, int progressDone, DocumentLoader&);
 
     void scheduleReachedMaxAppCacheSizeCallback();
@@ -145,19 +145,19 @@ private:
     RefPtr<ApplicationCache> m_newestCache;
     
     // All complete caches in this cache group.
-    HashSet<ApplicationCache*> m_caches;
+    UncheckedKeyHashSet<ApplicationCache*> m_caches;
     
     // The cache being updated (if any). Note that cache updating does not immediately create a new
     // ApplicationCache object, so this may be null even when update status is not Idle.
     RefPtr<ApplicationCache> m_cacheBeingUpdated;
 
     // List of pending master entries, used during the update process to ensure that new master entries are cached.
-    HashSet<DocumentLoader*> m_pendingMasterResourceLoaders;
+    UncheckedKeyHashSet<DocumentLoader*> m_pendingMasterResourceLoaders;
     // How many of the above pending master entries have not yet finished downloading.
     int m_downloadingPendingMasterResourceLoadersCount { 0 };
     
     // These are all the document loaders that are associated with a cache in this group.
-    HashSet<DocumentLoader*> m_associatedDocumentLoaders;
+    UncheckedKeyHashSet<DocumentLoader*> m_associatedDocumentLoaders;
 
     // The URLs and types of pending cache entries.
     HashMap<String, unsigned> m_pendingEntries;

--- a/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.h
@@ -36,7 +36,7 @@ using FallbackURLVector = Vector<std::pair<URL, URL>>;
 
 struct ApplicationCacheManifest {
     Vector<URL> onlineAllowedURLs;
-    HashSet<String> explicitURLs;
+    UncheckedKeyHashSet<String> explicitURLs;
     FallbackURLVector fallbackURLs;
     bool allowAllNetworkRequests { false }; // Wildcard found in NETWORK section.
 };

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
@@ -1457,7 +1457,7 @@ long long ApplicationCacheStorage::flatFileAreaSize()
     return totalSize;
 }
 
-HashSet<SecurityOriginData> ApplicationCacheStorage::originsWithCache()
+UncheckedKeyHashSet<SecurityOriginData> ApplicationCacheStorage::originsWithCache()
 {
     auto urls = manifestURLs();
     if (!urls)
@@ -1465,7 +1465,7 @@ HashSet<SecurityOriginData> ApplicationCacheStorage::originsWithCache()
 
     // Multiple manifest URLs might share the same SecurityOrigin, so we might be creating extra, wasted origins here.
     // The current schema doesn't allow for a more efficient way of building this list.
-    HashSet<SecurityOriginData> origins;
+    UncheckedKeyHashSet<SecurityOriginData> origins;
     for (auto& url : *urls)
         origins.add(SecurityOriginData::fromURL(url));
     return origins;

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.h
@@ -87,7 +87,7 @@ public:
 
     WEBCORE_EXPORT void empty();
 
-    WEBCORE_EXPORT HashSet<SecurityOriginData> originsWithCache();
+    WEBCORE_EXPORT UncheckedKeyHashSet<SecurityOriginData> originsWithCache();
     WEBCORE_EXPORT void deleteAllEntries();
 
     // FIXME: This should be consolidated with deleteAllEntries().

--- a/Source/WebCore/loader/archive/Archive.cpp
+++ b/Source/WebCore/loader/archive/Archive.cpp
@@ -38,12 +38,12 @@ Archive::~Archive() = default;
 
 void Archive::clearAllSubframeArchives()
 {
-    HashSet<Archive*> clearedArchives;
+    UncheckedKeyHashSet<Archive*> clearedArchives;
     clearedArchives.add(this);
     clearAllSubframeArchives(clearedArchives);
 }
 
-void Archive::clearAllSubframeArchives(HashSet<Archive*>& clearedArchives)
+void Archive::clearAllSubframeArchives(UncheckedKeyHashSet<Archive*>& clearedArchives)
 {
     ASSERT(clearedArchives.contains(this));
     for (auto& archive : m_subframeArchives) {

--- a/Source/WebCore/loader/archive/Archive.h
+++ b/Source/WebCore/loader/archive/Archive.h
@@ -57,7 +57,7 @@ protected:
     void clearAllSubframeArchives();
 
 private:
-    void clearAllSubframeArchives(HashSet<Archive*>&);
+    void clearAllSubframeArchives(UncheckedKeyHashSet<Archive*>&);
 
     RefPtr<ArchiveResource> m_mainResource;
     Vector<Ref<ArchiveResource>> m_subresources;

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -110,7 +110,7 @@ static String getFileNameFromURIComponent(StringView input)
     return result.toString();
 }
 
-static String generateValidFileName(const URL& url, const HashSet<String>& existingFileNames, const String& extension = { })
+static String generateValidFileName(const URL& url, const UncheckedKeyHashSet<String>& existingFileNames, const String& extension = { })
 {
     String suffix = extension.isEmpty() ? emptyString() : makeString('.', extension);
     auto extractedFileName = getFileNameFromURIComponent(url.lastPathComponent());
@@ -584,7 +584,7 @@ static void addSubresourcesForAttachmentElementsIfNecessary(LocalFrame& frame, c
 
 #endif
 
-static UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String> addSubresourcesForCSSStyleSheetsIfNecessary(LocalFrame& frame, const String& subresourcesDirectoryName, HashSet<String>& uniqueFileNames, UncheckedKeyHashMap<String, String>& uniqueSubresources, Vector<Ref<ArchiveResource>>& subresources)
+static UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String> addSubresourcesForCSSStyleSheetsIfNecessary(LocalFrame& frame, const String& subresourcesDirectoryName, UncheckedKeyHashSet<String>& uniqueFileNames, UncheckedKeyHashMap<String, String>& uniqueSubresources, Vector<Ref<ArchiveResource>>& subresources)
 {
     if (subresourcesDirectoryName.isEmpty())
         return { };
@@ -604,7 +604,7 @@ static UncheckedKeyHashMap<RefPtr<CSSStyleSheet>, String> addSubresourcesForCSSS
         if (uniqueCSSStyleSheets.contains(cssStyleSheet.get()))
             continue;
 
-        HashSet<RefPtr<CSSStyleSheet>> cssStyleSheets;
+        UncheckedKeyHashSet<RefPtr<CSSStyleSheet>> cssStyleSheets;
         cssStyleSheets.add(cssStyleSheet.get());
         cssStyleSheet->getChildStyleSheets(cssStyleSheets);
         for (auto& currentCSSStyleSheet : cssStyleSheets) {
@@ -672,7 +672,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(const String& markupString, Lo
     Vector<Ref<LegacyWebArchive>> subframeArchives;
     Vector<Ref<ArchiveResource>> subresources;
     UncheckedKeyHashMap<String, String> uniqueSubresources;
-    HashSet<String> uniqueFileNames;
+    UncheckedKeyHashSet<String> uniqueFileNames;
     String subresourcesDirectoryName = mainFrameFilePath.isNull() ? String { } : makeString(mainFrameFilePath, "_files"_s);
 
     for (auto& node : nodes) {

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -398,7 +398,7 @@ private:
 
     // These handles will need to be updated to point to the m_resourceToRevalidate in case we get 304 response.
     // FIXME: This should use a smart pointer.
-    HashSet<CachedResourceHandleBase*> m_handlesToRevalidate;
+    UncheckedKeyHashSet<CachedResourceHandleBase*> m_handlesToRevalidate;
 
     Vector<std::pair<String, String>> m_varyingHeaderValues;
 

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -576,14 +576,14 @@ void MemoryCache::removeResourcesWithOrigin(const ClientOrigin& origin)
     removeResourcesWithOrigin(origin.clientOrigin.securityOrigin(), cachePartition);
 }
 
-void MemoryCache::removeResourcesWithOrigins(PAL::SessionID sessionID, const HashSet<RefPtr<SecurityOrigin>>& origins)
+void MemoryCache::removeResourcesWithOrigins(PAL::SessionID sessionID, const UncheckedKeyHashSet<RefPtr<SecurityOrigin>>& origins)
 {
     RELEASE_ASSERT(isMainThread());
     auto* resourceMap = sessionResourceMap(sessionID);
     if (!resourceMap)
         return;
 
-    HashSet<String> originPartitions;
+    UncheckedKeyHashSet<String> originPartitions;
 
     for (auto& origin : origins)
         originPartitions.add(ResourceRequest::partitionName(origin->host()));
@@ -621,11 +621,11 @@ void MemoryCache::getOriginsWithCache(SecurityOriginSet& origins)
     }
 }
 
-HashSet<RefPtr<SecurityOrigin>> MemoryCache::originsWithCache(PAL::SessionID sessionID) const
+UncheckedKeyHashSet<RefPtr<SecurityOrigin>> MemoryCache::originsWithCache(PAL::SessionID sessionID) const
 {
     RELEASE_ASSERT(isMainThread());
 
-    HashSet<RefPtr<SecurityOrigin>> origins;
+    UncheckedKeyHashSet<RefPtr<SecurityOrigin>> origins;
 
     auto it = m_sessionResources.find(sessionID);
     if (it != m_sessionResources.end()) {

--- a/Source/WebCore/loader/cache/MemoryCache.h
+++ b/Source/WebCore/loader/cache/MemoryCache.h
@@ -157,13 +157,13 @@ public:
     void resourceAccessed(CachedResource&);
     bool inLiveDecodedResourcesList(CachedResource&) const;
 
-    typedef HashSet<RefPtr<SecurityOrigin>> SecurityOriginSet;
+    typedef UncheckedKeyHashSet<RefPtr<SecurityOrigin>> SecurityOriginSet;
     WEBCORE_EXPORT void removeResourcesWithOrigin(const SecurityOrigin&);
     void removeResourcesWithOrigin(const SecurityOrigin&, const String& cachePartition);
     WEBCORE_EXPORT void removeResourcesWithOrigin(const ClientOrigin&);
-    WEBCORE_EXPORT void removeResourcesWithOrigins(PAL::SessionID, const HashSet<RefPtr<SecurityOrigin>>&);
+    WEBCORE_EXPORT void removeResourcesWithOrigins(PAL::SessionID, const UncheckedKeyHashSet<RefPtr<SecurityOrigin>>&);
     WEBCORE_EXPORT void getOriginsWithCache(SecurityOriginSet& origins);
-    WEBCORE_EXPORT HashSet<RefPtr<SecurityOrigin>> originsWithCache(PAL::SessionID) const;
+    WEBCORE_EXPORT UncheckedKeyHashSet<RefPtr<SecurityOrigin>> originsWithCache(PAL::SessionID) const;
 
     // pruneDead*() - Flush decoded and encoded data from resources not referenced by Web pages.
     // pruneLive*() - Flush decoded data from resources still referenced by Web pages.

--- a/Source/WebCore/page/CaptionUserPreferences.cpp
+++ b/Source/WebCore/page/CaptionUserPreferences.cpp
@@ -258,7 +258,7 @@ MediaSelectionOption CaptionUserPreferences::mediaSelectionOptionForTrack(TextTr
     return { mediaType, displayNameForTrack(track), legibleType };
 }
     
-Vector<RefPtr<TextTrack>> CaptionUserPreferences::sortedTrackListForMenu(TextTrackList* trackList, HashSet<TextTrack::Kind> kinds)
+Vector<RefPtr<TextTrack>> CaptionUserPreferences::sortedTrackListForMenu(TextTrackList* trackList, UncheckedKeyHashSet<TextTrack::Kind> kinds)
 {
     ASSERT(trackList);
 

--- a/Source/WebCore/page/CaptionUserPreferences.h
+++ b/Source/WebCore/page/CaptionUserPreferences.h
@@ -95,7 +95,7 @@ public:
 
     virtual String displayNameForTrack(TextTrack*) const;
     MediaSelectionOption mediaSelectionOptionForTrack(TextTrack*) const;
-    virtual Vector<RefPtr<TextTrack>> sortedTrackListForMenu(TextTrackList*, HashSet<TextTrack::Kind>);
+    virtual Vector<RefPtr<TextTrack>> sortedTrackListForMenu(TextTrackList*, UncheckedKeyHashSet<TextTrack::Kind>);
 
     virtual String displayNameForTrack(AudioTrack*) const;
     MediaSelectionOption mediaSelectionOptionForTrack(AudioTrack*) const;

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -854,12 +854,12 @@ Vector<RefPtr<AudioTrack>> CaptionUserPreferencesMediaAF::sortedTrackListForMenu
     return tracksForMenu;
 }
 
-Vector<RefPtr<TextTrack>> CaptionUserPreferencesMediaAF::sortedTrackListForMenu(TextTrackList* trackList, HashSet<TextTrack::Kind> kinds)
+Vector<RefPtr<TextTrack>> CaptionUserPreferencesMediaAF::sortedTrackListForMenu(TextTrackList* trackList, UncheckedKeyHashSet<TextTrack::Kind> kinds)
 {
     ASSERT(trackList);
 
     Vector<RefPtr<TextTrack>> tracksForMenu;
-    HashSet<String> languagesIncluded;
+    UncheckedKeyHashSet<String> languagesIncluded;
     CaptionDisplayMode displayMode = captionDisplayMode();
     bool prefersAccessibilityTracks = userPrefersCaptions();
     bool filterTrackList = shouldFilterTrackMenu();

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
@@ -87,7 +87,7 @@ public:
 
     String captionsStyleSheetOverride() const override;
     Vector<RefPtr<AudioTrack>> sortedTrackListForMenu(AudioTrackList*) override;
-    Vector<RefPtr<TextTrack>> sortedTrackListForMenu(TextTrackList*, HashSet<TextTrack::Kind>) override;
+    Vector<RefPtr<TextTrack>> sortedTrackListForMenu(TextTrackList*, UncheckedKeyHashSet<TextTrack::Kind>) override;
     String displayNameForTrack(AudioTrack*) const override;
     String displayNameForTrack(TextTrack*) const override;
 

--- a/Source/WebCore/page/DOMSelection.cpp
+++ b/Source/WebCore/page/DOMSelection.cpp
@@ -469,7 +469,7 @@ Vector<Ref<StaticRange>> DOMSelection::getComposedRanges(FixedVector<std::refere
     if (!range)
         return { };
 
-    HashSet<Ref<ShadowRoot>> shadowRootSet;
+    UncheckedKeyHashSet<Ref<ShadowRoot>> shadowRootSet;
     shadowRootSet.reserveInitialCapacity(shadowRoots.size());
     for (auto& root : shadowRoots)
         shadowRootSet.add(root.get());

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -667,7 +667,7 @@ static URL urlForElement(const Element& element)
     return { };
 }
 
-static void collectMediaAndLinkURLsRecursive(const Element& element, HashSet<URL>& urls)
+static void collectMediaAndLinkURLsRecursive(const Element& element, UncheckedKeyHashSet<URL>& urls)
 {
     auto addURLForElement = [&urls](const Element& element) {
         if (auto url = urlForElement(element); !url.isEmpty() && !url.protocolIsData() && !url.protocolIsBlob())
@@ -695,9 +695,9 @@ static void collectMediaAndLinkURLsRecursive(const Element& element, HashSet<URL
     }
 }
 
-static HashSet<URL> collectMediaAndLinkURLs(const Element& element)
+static UncheckedKeyHashSet<URL> collectMediaAndLinkURLs(const Element& element)
 {
-    HashSet<URL> urls;
+    UncheckedKeyHashSet<URL> urls;
     collectMediaAndLinkURLsRecursive(element, urls);
     return urls;
 }
@@ -874,7 +874,7 @@ Vector<TargetedElementInfo> ElementTargetingController::findTargets(TargetedElem
     return extractTargets(WTFMove(nodes), WTFMove(innerElement), checkViewportAreaRatio, includeNearbyElements);
 }
 
-void ElementTargetingController::topologicallySortElementsHelper(ElementIdentifier currentElementID, Vector<ElementIdentifier>& depthSortedIDs, HashSet<ElementIdentifier>& processingIDs, HashSet<ElementIdentifier>& unprocessedIDs, const UncheckedKeyHashMap<ElementIdentifier, HashSet<ElementIdentifier>>& elementIDToOccludedElementIDs)
+void ElementTargetingController::topologicallySortElementsHelper(ElementIdentifier currentElementID, Vector<ElementIdentifier>& depthSortedIDs, UncheckedKeyHashSet<ElementIdentifier>& processingIDs, UncheckedKeyHashSet<ElementIdentifier>& unprocessedIDs, const UncheckedKeyHashMap<ElementIdentifier, UncheckedKeyHashSet<ElementIdentifier>>& elementIDToOccludedElementIDs)
 {
     if (processingIDs.contains(currentElementID)) {
         ASSERT_NOT_REACHED();
@@ -894,11 +894,11 @@ void ElementTargetingController::topologicallySortElementsHelper(ElementIdentifi
     depthSortedIDs.append(currentElementID);
 }
 
-Vector<ElementIdentifier> ElementTargetingController::topologicallySortElements(const UncheckedKeyHashMap<ElementIdentifier, HashSet<ElementIdentifier>>& elementIDToOccludedElementIDs)
+Vector<ElementIdentifier> ElementTargetingController::topologicallySortElements(const UncheckedKeyHashMap<ElementIdentifier, UncheckedKeyHashSet<ElementIdentifier>>& elementIDToOccludedElementIDs)
 {
     Vector<ElementIdentifier> depthSortedIDs;
-    HashSet<ElementIdentifier> processingIDs;
-    HashSet<ElementIdentifier> unprocessedIDs;
+    UncheckedKeyHashSet<ElementIdentifier> processingIDs;
+    UncheckedKeyHashSet<ElementIdentifier> unprocessedIDs;
 
     const auto elementIDs = elementIDToOccludedElementIDs.keys();
     unprocessedIDs.add(elementIDs.begin(), elementIDs.end());
@@ -950,14 +950,14 @@ Vector<Vector<TargetedElementInfo>> ElementTargetingController::findAllTargets(f
         }
     }
 
-    UncheckedKeyHashMap<ElementIdentifier, HashSet<ElementIdentifier>> elementIDToOccludedElementIDs;
+    UncheckedKeyHashMap<ElementIdentifier, UncheckedKeyHashSet<ElementIdentifier>> elementIDToOccludedElementIDs;
     UncheckedKeyHashMap<ElementIdentifier, Vector<TargetedElementInfo>> elementIDToTargets;
     for (auto& targets : targetsList) {
         if (targets.isEmpty())
             continue;
 
         const auto topElementID = targets.first().elementIdentifier;
-        HashSet<ElementIdentifier> occludedElementIDsToInsert;
+        UncheckedKeyHashSet<ElementIdentifier> occludedElementIDsToInsert;
         for (unsigned index = 1; index < targets.size(); ++index)
             occludedElementIDsToInsert.add(targets[index].elementIdentifier);
 
@@ -1091,7 +1091,7 @@ std::pair<Vector<Ref<Node>>, RefPtr<Element>> ElementTargetingController::findNo
     return { { *foundElement }, foundElement };
 }
 
-static Vector<Ref<Element>> filterRedundantNearbyTargets(HashSet<Ref<Element>>&& unfilteredNearbyTargets)
+static Vector<Ref<Element>> filterRedundantNearbyTargets(UncheckedKeyHashSet<Ref<Element>>&& unfilteredNearbyTargets)
 {
     UncheckedKeyHashMap<Ref<Element>, bool> shouldKeepCache;
     Vector<Ref<Element>> filteredResults;
@@ -1344,7 +1344,7 @@ Vector<TargetedElementInfo> ElementTargetingController::extractTargets(Vector<Re
         return results;
 
     auto nearbyTargets = [&]() -> Vector<Ref<Element>> {
-        HashSet<Ref<Element>> results;
+        UncheckedKeyHashSet<Ref<Element>> results;
         CheckedPtr bodyRenderer = bodyElement->renderer();
         if (!bodyRenderer)
             return { };
@@ -1826,7 +1826,7 @@ bool ElementTargetingController::resetVisibilityAdjustments(const Vector<Targete
 
     document->updateLayoutIgnorePendingStylesheets();
 
-    HashSet<Ref<Element>> elementsToReset;
+    UncheckedKeyHashSet<Ref<Element>> elementsToReset;
     if (identifiers.isEmpty()) {
         elementsToReset.reserveInitialCapacity(m_adjustedElements.computeSize());
         for (auto& element : m_adjustedElements)

--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -95,8 +95,8 @@ private:
 
     void recomputeAdjustedElementsIfNeeded();
 
-    void topologicallySortElementsHelper(ElementIdentifier currentElementID, Vector<ElementIdentifier>& depthSortedIDs, HashSet<ElementIdentifier>& processingIDs, HashSet<ElementIdentifier>& unprocessedIDs, const UncheckedKeyHashMap<ElementIdentifier, HashSet<ElementIdentifier>>& elementIDToOccludedElementIDs);
-    Vector<ElementIdentifier> topologicallySortElements(const UncheckedKeyHashMap<ElementIdentifier, HashSet<ElementIdentifier>>& elementIDToOccludedElementIDs);
+    void topologicallySortElementsHelper(ElementIdentifier currentElementID, Vector<ElementIdentifier>& depthSortedIDs, UncheckedKeyHashSet<ElementIdentifier>& processingIDs, UncheckedKeyHashSet<ElementIdentifier>& unprocessedIDs, const UncheckedKeyHashMap<ElementIdentifier, UncheckedKeyHashSet<ElementIdentifier>>& elementIDToOccludedElementIDs);
+    Vector<ElementIdentifier> topologicallySortElements(const UncheckedKeyHashMap<ElementIdentifier, UncheckedKeyHashSet<ElementIdentifier>>& elementIDToOccludedElementIDs);
 
     WeakPtr<Page> m_page;
     DeferrableOneShotTimer m_recentAdjustmentClientRectsCleanUpTimer;

--- a/Source/WebCore/page/ElementTargetingTypes.h
+++ b/Source/WebCore/page/ElementTargetingTypes.h
@@ -38,7 +38,7 @@
 
 namespace WebCore {
 
-using TargetedElementSelectors = Vector<HashSet<String>>;
+using TargetedElementSelectors = Vector<UncheckedKeyHashSet<String>>;
 using TargetedElementIdentifiers = std::pair<ElementIdentifier, ScriptExecutionContextIdentifier>;
 
 struct TargetedElementAdjustment {
@@ -64,7 +64,7 @@ struct TargetedElementInfo {
     FloatRect boundsInClientCoordinates;
     PositionType positionType { PositionType::Static };
     Vector<FrameIdentifier> childFrameIdentifiers;
-    HashSet<URL> mediaAndLinkURLs;
+    UncheckedKeyHashSet<URL> mediaAndLinkURLs;
     bool isNearbyTarget { true };
     bool isPseudoElement { false };
     bool isInShadowTree { false };

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -5057,7 +5057,7 @@ HandleUserInputEventResult EventHandler::handleTouchEvent(const PlatformTouchEve
     TargetTouchesMap touchesByTarget;
 
     // Array of touches per state, used to assemble the 'changedTouches' list in the JS event.
-    typedef HashSet<RefPtr<EventTarget>> EventTargetSet;
+    typedef UncheckedKeyHashSet<RefPtr<EventTarget>> EventTargetSet;
     struct Touches {
         // The touches corresponding to the particular change state this struct instance represents.
         RefPtr<TouchList> m_touches;

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -230,7 +230,7 @@ public:
 #endif
 
 #if ENABLE(IOS_TOUCH_EVENTS) || ENABLE(IOS_GESTURE_EVENTS) || ENABLE(MAC_GESTURE_EVENTS)
-    using EventTargetSet = HashSet<RefPtr<EventTarget>>;
+    using EventTargetSet = UncheckedKeyHashSet<RefPtr<EventTarget>>;
 #endif
 
 #if ENABLE(IOS_TOUCH_EVENTS)

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -405,7 +405,7 @@ private:
     const WeakRef<LocalFrame> m_rootFrame;
     SandboxFlags m_sandboxFlags;
     UniqueRef<EventHandler> m_eventHandler;
-    HashSet<RegistrableDomain> m_storageAccessExceptionDomains;
+    UncheckedKeyHashSet<RegistrableDomain> m_storageAccessExceptionDomains;
 };
 
 inline LocalFrameView* LocalFrame::view() const

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5706,7 +5706,7 @@ void LocalFrameView::willRemoveWidgetFromRenderTree(Widget& widget)
     m_widgetsInRenderTree.remove(widget);
 }
 
-static Vector<Ref<Widget>> collectAndProtectWidgets(const HashSet<SingleThreadWeakRef<Widget>>& set)
+static Vector<Ref<Widget>> collectAndProtectWidgets(const UncheckedKeyHashSet<SingleThreadWeakRef<Widget>>& set)
 {
     return WTF::map(set, [](auto& widget) -> Ref<Widget> {
         return widget.get();

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -652,7 +652,7 @@ public:
     void didAddWidgetToRenderTree(Widget&);
     void willRemoveWidgetFromRenderTree(Widget&);
 
-    const HashSet<SingleThreadWeakRef<Widget>>& widgetsInRenderTree() const { return m_widgetsInRenderTree; }
+    const UncheckedKeyHashSet<SingleThreadWeakRef<Widget>>& widgetsInRenderTree() const { return m_widgetsInRenderTree; }
 
     void notifyAllFramesThatContentAreaWillPaint() const;
 
@@ -955,7 +955,7 @@ private:
     const Ref<LocalFrame> m_frame;
     LocalFrameViewLayoutContext m_layoutContext;
 
-    HashSet<SingleThreadWeakRef<Widget>> m_widgetsInRenderTree;
+    UncheckedKeyHashSet<SingleThreadWeakRef<Widget>> m_widgetsInRenderTree;
     std::unique_ptr<ListHashSet<SingleThreadWeakRef<RenderEmbeddedObject>>> m_embeddedObjectsToUpdate;
     std::unique_ptr<SingleThreadWeakHashSet<RenderElement>> m_slowRepaintObjects;
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -242,9 +242,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Page);
 
-static HashSet<WeakRef<Page>>& allPages()
+static UncheckedKeyHashSet<WeakRef<Page>>& allPages()
 {
-    static NeverDestroyed<HashSet<WeakRef<Page>>> set;
+    static NeverDestroyed<UncheckedKeyHashSet<WeakRef<Page>>> set;
     return set;
 }
 
@@ -4333,7 +4333,7 @@ void Page::forEachLocalFrame(const Function<void(LocalFrame&)>& functor)
 
 void Page::forEachWindowEventLoop(const Function<void(WindowEventLoop&)>& functor)
 {
-    HashSet<Ref<WindowEventLoop>> windowEventLoops;
+    UncheckedKeyHashSet<Ref<WindowEventLoop>> windowEventLoops;
     WindowEventLoop* lastEventLoop = nullptr;
     for (RefPtr frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -90,7 +90,7 @@ namespace WTF {
 class SchedulePair;
 class TextStream;
 struct SchedulePairHash;
-using SchedulePairHashSet = HashSet<RefPtr<SchedulePair>, SchedulePairHash>;
+using SchedulePairHashSet = UncheckedKeyHashSet<RefPtr<SchedulePair>, SchedulePairHash>;
 }
 
 namespace WebCore {
@@ -1175,7 +1175,7 @@ public:
     void willBeginScrolling();
     void didFinishScrolling();
 
-    const HashSet<WeakRef<LocalFrame>>& rootFrames() const { return m_rootFrames; }
+    const UncheckedKeyHashSet<WeakRef<LocalFrame>>& rootFrames() const { return m_rootFrames; }
     WEBCORE_EXPORT void addRootFrame(LocalFrame&);
     WEBCORE_EXPORT void removeRootFrame(LocalFrame&);
 
@@ -1377,7 +1377,7 @@ private:
     UniqueRef<ProcessSyncClient> m_processSyncClient;
 
     UniqueRef<BackForwardController> m_backForwardController;
-    HashSet<WeakRef<LocalFrame>> m_rootFrames;
+    UncheckedKeyHashSet<WeakRef<LocalFrame>> m_rootFrames;
     UniqueRef<EditorClient> m_editorClient;
     Ref<Frame> m_mainFrame;
     String m_mainFrameURLFragment;
@@ -1702,7 +1702,7 @@ private:
     UniqueRef<WritingToolsController> m_writingToolsController;
 #endif
 
-    HashSet<std::pair<URL, ScriptTelemetryCategory>> m_reportedScriptsWithTelemetry;
+    UncheckedKeyHashSet<std::pair<URL, ScriptTelemetryCategory>> m_reportedScriptsWithTelemetry;
 
     bool m_hasActiveNowPlayingSession { false };
     Timer m_activeNowPlayingSessionUpdateTimer;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1021,8 +1021,8 @@ Quirks::StorageAccessResult Quirks::triggerOptionalStorageAccessQuirk(Element& e
 
     RegistrableDomain domain { m_document->url() };
 
-    static NeverDestroyed<HashSet<RegistrableDomain>> kinjaQuirks = [] {
-        HashSet<RegistrableDomain> set;
+    static NeverDestroyed<UncheckedKeyHashSet<RegistrableDomain>> kinjaQuirks = [] {
+        UncheckedKeyHashSet<RegistrableDomain> set;
         set.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString("jalopnik.com"_s));
         set.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString("kotaku.com"_s));
         set.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString("theroot.com"_s));

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -109,7 +109,7 @@ public:
 
     WEBCORE_EXPORT static bool needsPartitionedCookies(const ResourceRequest&);
 
-    WEBCORE_EXPORT static std::optional<Vector<HashSet<String>>> defaultVisibilityAdjustmentSelectors(const URL&);
+    WEBCORE_EXPORT static std::optional<Vector<UncheckedKeyHashSet<String>>> defaultVisibilityAdjustmentSelectors(const URL&);
 
     bool needsGMailOverflowScrollQuirk() const;
     bool needsIPadSkypeOverflowScrollQuirk() const;

--- a/Source/WebCore/page/TextIndicator.cpp
+++ b/Source/WebCore/page/TextIndicator.cpp
@@ -204,9 +204,9 @@ static bool takeSnapshots(TextIndicatorData& data, LocalFrame& frame, IntRect sn
     return true;
 }
 
-static HashSet<Color> estimatedTextColorsForRange(const SimpleRange& range)
+static UncheckedKeyHashSet<Color> estimatedTextColorsForRange(const SimpleRange& range)
 {
-    HashSet<Color> colors;
+    UncheckedKeyHashSet<Color> colors;
     for (TextIterator iterator(range); !iterator.atEnd(); iterator.advance()) {
         auto node = iterator.node();
         if (!node)
@@ -227,7 +227,7 @@ static FloatRect absoluteBoundingRectForRange(const SimpleRange& range)
     }));
 }
 
-static bool hasAnyIllegibleColors(TextIndicatorData& data, const Color& backgroundColor, HashSet<Color>&& textColors)
+static bool hasAnyIllegibleColors(TextIndicatorData& data, const Color& backgroundColor, UncheckedKeyHashSet<Color>&& textColors)
 {
     if (data.options.contains(TextIndicatorOption::PaintAllContent))
         return false;

--- a/Source/WebCore/page/UndoManager.h
+++ b/Source/WebCore/page/UndoManager.h
@@ -56,7 +56,7 @@ private:
     UndoManager(Document&);
 
     Document& m_document;
-    HashSet<RefPtr<UndoItem>> m_items;
+    UncheckedKeyHashSet<RefPtr<UndoItem>> m_items;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm
@@ -166,7 +166,7 @@ void ResourceUsageThread::platformCollectCPUData(JSC::VM*, ResourceUsageData& da
     mach_port_t resourceUsageMachThread = mach_thread_self();
     mach_port_t mainThreadMachThread = threads[0].sendRight.sendRight();
 
-    HashSet<mach_port_t> knownWebKitThreads;
+    UncheckedKeyHashSet<mach_port_t> knownWebKitThreads;
     {
         Locker locker { Thread::allThreadsLock() };
         for (auto* thread : Thread::allThreads()) {

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -1179,12 +1179,12 @@ void ContentSecurityPolicy::inheritInsecureNavigationRequestsToUpgradeFromOpener
     m_insecureNavigationRequestsToUpgrade.add(other.m_insecureNavigationRequestsToUpgrade.begin(), other.m_insecureNavigationRequestsToUpgrade.end());
 }
 
-HashSet<SecurityOriginData> ContentSecurityPolicy::takeNavigationRequestsToUpgrade()
+UncheckedKeyHashSet<SecurityOriginData> ContentSecurityPolicy::takeNavigationRequestsToUpgrade()
 {
     return WTFMove(m_insecureNavigationRequestsToUpgrade);
 }
 
-void ContentSecurityPolicy::setInsecureNavigationRequestsToUpgrade(HashSet<SecurityOriginData>&& insecureNavigationRequests)
+void ContentSecurityPolicy::setInsecureNavigationRequestsToUpgrade(UncheckedKeyHashSet<SecurityOriginData>&& insecureNavigationRequests)
 {
     m_insecureNavigationRequestsToUpgrade = WTFMove(insecureNavigationRequests);
 }

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -213,9 +213,9 @@ public:
     WEBCORE_EXPORT void upgradeInsecureRequestIfNeeded(ResourceRequest&, InsecureRequestType, AlwaysUpgradeRequest = AlwaysUpgradeRequest::No) const;
     WEBCORE_EXPORT void upgradeInsecureRequestIfNeeded(URL&, InsecureRequestType, AlwaysUpgradeRequest = AlwaysUpgradeRequest::No) const;
 
-    HashSet<SecurityOriginData> takeNavigationRequestsToUpgrade();
+    UncheckedKeyHashSet<SecurityOriginData> takeNavigationRequestsToUpgrade();
     void inheritInsecureNavigationRequestsToUpgradeFromOpener(const ContentSecurityPolicy&);
-    void setInsecureNavigationRequestsToUpgrade(HashSet<SecurityOriginData>&&);
+    void setInsecureNavigationRequestsToUpgrade(UncheckedKeyHashSet<SecurityOriginData>&&);
 
     void setClient(ContentSecurityPolicyClient* client) { m_client = client; }
     void updateSourceSelf(const SecurityOrigin&);
@@ -286,7 +286,7 @@ private:
     int m_httpStatusCode { 0 };
     OptionSet<ContentSecurityPolicyHashAlgorithm> m_hashAlgorithmsForInlineScripts;
     OptionSet<ContentSecurityPolicyHashAlgorithm> m_hashAlgorithmsForInlineStylesheets;
-    HashSet<SecurityOriginData> m_insecureNavigationRequestsToUpgrade;
+    UncheckedKeyHashSet<SecurityOriginData> m_insecureNavigationRequestsToUpgrade;
     mutable std::optional<ContentSecurityPolicyResponseHeaders> m_cachedResponseHeaders;
     bool m_isHeaderDelivered { false };
     ContentSecurityPolicyModeForExtension m_contentSecurityPolicyModeForExtension { ContentSecurityPolicyModeForExtension::None };

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.h
@@ -90,7 +90,7 @@ private:
     const ContentSecurityPolicy& m_policy;
     Vector<ContentSecurityPolicySource> m_list;
     MemoryCompactLookupOnlyRobinHoodHashSet<String> m_nonces;
-    HashSet<ContentSecurityPolicyHash> m_hashes;
+    UncheckedKeyHashSet<ContentSecurityPolicyHash> m_hashes;
     OptionSet<ContentSecurityPolicyHashAlgorithm> m_hashAlgorithmsUsed;
     String m_directiveName;
     ContentSecurityPolicyModeForExtension m_contentSecurityPolicyModeForExtension { ContentSecurityPolicyModeForExtension::None };

--- a/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.h
@@ -47,7 +47,7 @@ private:
 
     bool m_allowDuplicates { false };
     bool m_allowAny { false };
-    HashSet<String> m_list;
+    UncheckedKeyHashSet<String> m_list;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
@@ -209,7 +209,7 @@ static void collectCPUUsage(float period)
         return;
     }
 
-    HashSet<pid_t> previousTasks;
+    UncheckedKeyHashSet<pid_t> previousTasks;
     for (const auto& key : threadInfoMap().keys())
         previousTasks.add(key);
 
@@ -245,7 +245,7 @@ void ResourceUsageThread::platformCollectCPUData(JSC::VM*, ResourceUsageData& da
 
     pid_t resourceUsageThreadID = Thread::currentID();
 
-    HashSet<pid_t> knownWebKitThreads;
+    UncheckedKeyHashSet<pid_t> knownWebKitThreads;
     {
         Locker locker { Thread::allThreadsLock() };
         for (auto* thread : Thread::allThreads()) {

--- a/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
+++ b/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
@@ -70,7 +70,7 @@ void ImageOverlayController::updateDataDetectorHighlights(const HTMLElement& ove
             dataDetectorResultElements.append(child);
     }
 
-    HashSet<Ref<HTMLElement>> dataDetectorResultElementsWithHighlights;
+    UncheckedKeyHashSet<Ref<HTMLElement>> dataDetectorResultElementsWithHighlights;
     for (auto& containerAndHighlight : m_dataDetectorContainersAndHighlights) {
         if (containerAndHighlight.first)
             dataDetectorResultElementsWithHighlights.add(*containerAndHighlight.first);

--- a/Source/WebCore/page/mac/ServicesOverlayController.h
+++ b/Source/WebCore/page/mac/ServicesOverlayController.h
@@ -74,7 +74,7 @@ private:
     void invalidateHighlightsOfType(DataDetectorHighlight::Type);
     void buildPotentialHighlightsIfNeeded();
 
-    void replaceHighlightsOfTypePreservingEquivalentHighlights(HashSet<RefPtr<DataDetectorHighlight>>&, DataDetectorHighlight::Type);
+    void replaceHighlightsOfTypePreservingEquivalentHighlights(UncheckedKeyHashSet<RefPtr<DataDetectorHighlight>>&, DataDetectorHighlight::Type);
     void removeAllPotentialHighlightsOfType(DataDetectorHighlight::Type);
     void buildPhoneNumberHighlights();
     void buildSelectionHighlight();
@@ -108,8 +108,8 @@ private:
 
     RefPtr<DataDetectorHighlight> m_activeHighlight;
     RefPtr<DataDetectorHighlight> m_nextActiveHighlight;
-    HashSet<RefPtr<DataDetectorHighlight>> m_potentialHighlights;
-    HashSet<RefPtr<DataDetectorHighlight>> m_animatingHighlights;
+    UncheckedKeyHashSet<RefPtr<DataDetectorHighlight>> m_potentialHighlights;
+    UncheckedKeyHashSet<RefPtr<DataDetectorHighlight>> m_animatingHighlights;
     WeakHashSet<DataDetectorHighlight> m_highlights;
 
     Vector<LayoutRect> m_currentSelectionRects;

--- a/Source/WebCore/page/mac/ServicesOverlayController.mm
+++ b/Source/WebCore/page/mac/ServicesOverlayController.mm
@@ -372,7 +372,7 @@ void ServicesOverlayController::buildPhoneNumberHighlights()
     if (!PAL::isDataDetectorsFrameworkAvailable())
         return;
 
-    HashSet<RefPtr<DataDetectorHighlight>> newPotentialHighlights;
+    UncheckedKeyHashSet<RefPtr<DataDetectorHighlight>> newPotentialHighlights;
 
     auto& mainFrameView = *localMainFrame->view();
 
@@ -410,7 +410,7 @@ void ServicesOverlayController::buildSelectionHighlight()
     if (!PAL::isDataDetectorsFrameworkAvailable())
         return;
 
-    HashSet<RefPtr<DataDetectorHighlight>> newPotentialHighlights;
+    UncheckedKeyHashSet<RefPtr<DataDetectorHighlight>> newPotentialHighlights;
 
     Ref page = m_page.get();
     if (auto selectionRange = page->selection().firstRange()) {
@@ -440,11 +440,11 @@ void ServicesOverlayController::buildSelectionHighlight()
     replaceHighlightsOfTypePreservingEquivalentHighlights(newPotentialHighlights, DataDetectorHighlight::Type::Selection);
 }
 
-void ServicesOverlayController::replaceHighlightsOfTypePreservingEquivalentHighlights(HashSet<RefPtr<DataDetectorHighlight>>& newPotentialHighlights, DataDetectorHighlight::Type type)
+void ServicesOverlayController::replaceHighlightsOfTypePreservingEquivalentHighlights(UncheckedKeyHashSet<RefPtr<DataDetectorHighlight>>& newPotentialHighlights, DataDetectorHighlight::Type type)
 {
     // If any old Highlights are equivalent (by Range) to a new Highlight, reuse the old
     // one so that any metadata is retained.
-    HashSet<RefPtr<DataDetectorHighlight>> reusedPotentialHighlights;
+    UncheckedKeyHashSet<RefPtr<DataDetectorHighlight>> reusedPotentialHighlights;
 
     for (auto& oldHighlight : m_potentialHighlights) {
         if (oldHighlight->type() != type)

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -55,15 +55,15 @@ using OrphanScrollingNodeMap = UncheckedKeyHashMap<ScrollingNodeID, RefPtr<Scrol
 struct CommitTreeState {
     // unvisitedNodes starts with all nodes in the map; we remove nodes as we visit them. At the end, it's the unvisited nodes.
     // We can't use orphanNodes for this, because orphanNodes won't contain descendants of removed nodes.
-    HashSet<ScrollingNodeID> unvisitedNodes { };
+    UncheckedKeyHashSet<ScrollingNodeID> unvisitedNodes { };
     // Nodes with non-empty synchronousScrollingReasons.
-    HashSet<ScrollingNodeID> synchronousScrollingNodes { };
+    UncheckedKeyHashSet<ScrollingNodeID> synchronousScrollingNodes { };
     // orphanNodes keeps child nodes alive while we rebuild child lists.
     OrphanScrollingNodeMap orphanNodes { };
     // Hosted subtrees needing attaching to scrolling tree after main commit has finished
     Vector<std::pair<LayerHostingContextIdentifier, Vector<std::unique_ptr<ScrollingStateTree>>>> pendingSubtreesNeedingCommit { };
     // Nodes that are descendants of a frame hosting node.
-    HashSet<ScrollingNodeID> hostedScrollingNodes { };
+    UncheckedKeyHashSet<ScrollingNodeID> hostedScrollingNodes { };
     // This has a value when doing a commit for a hosted subtree.
     RefPtr<ScrollingTreeFrameHostingNode> frameHostingNode { };
     // Identifier for the frame associated with this commit.
@@ -489,7 +489,7 @@ bool ScrollingTree::updateTreeFromStateNodeRecursive(const ScrollingStateNode* s
         m_nodeMap.set(nodeID, node.get());
         {
             Locker locker { m_frameIDMapLock };
-            m_nodeMapPerFrame.ensure(state.frameId, [] { return HashSet<ScrollingNodeID> { }; }).iterator->value.add(node->scrollingNodeID());
+            m_nodeMapPerFrame.ensure(state.frameId, [] { return UncheckedKeyHashSet<ScrollingNodeID> { }; }).iterator->value.add(node->scrollingNodeID());
         }
         node->setFrameIdentifier(state.frameId);
     }
@@ -867,7 +867,7 @@ bool ScrollingTree::hasNodeWithActiveScrollAnimations()
     return !m_treeState.nodesWithActiveScrollAnimations.isEmpty();
 }
 
-HashSet<ScrollingNodeID> ScrollingTree::nodesWithActiveScrollAnimations()
+UncheckedKeyHashSet<ScrollingNodeID> ScrollingTree::nodesWithActiveScrollAnimations()
 {
     Locker locker { m_treeStateLock };
     return m_treeState.nodesWithActiveScrollAnimations;

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -195,8 +195,8 @@ public:
     using RelatedNodesMap = UncheckedKeyHashMap<ScrollingNodeID, Vector<ScrollingNodeID>>;
     RelatedNodesMap& overflowRelatedNodes() { return m_overflowRelatedNodesMap; }
 
-    HashSet<Ref<ScrollingTreeOverflowScrollProxyNode>>& activeOverflowScrollProxyNodes() { return m_activeOverflowScrollProxyNodes; }
-    HashSet<Ref<ScrollingTreePositionedNode>>& activePositionedNodes() { return m_activePositionedNodes; }
+    UncheckedKeyHashSet<Ref<ScrollingTreeOverflowScrollProxyNode>>& activeOverflowScrollProxyNodes() { return m_activeOverflowScrollProxyNodes; }
+    UncheckedKeyHashSet<Ref<ScrollingTreePositionedNode>>& activePositionedNodes() { return m_activePositionedNodes; }
 
     WEBCORE_EXPORT String scrollingTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior> = { });
 
@@ -276,14 +276,14 @@ protected:
 
     bool hasProcessedWheelEventsRecently();
 
-    HashSet<ScrollingNodeID> nodesWithActiveScrollAnimations();
+    UncheckedKeyHashSet<ScrollingNodeID> nodesWithActiveScrollAnimations();
     WEBCORE_EXPORT void serviceScrollAnimations(MonotonicTime) WTF_REQUIRES_LOCK(m_treeLock);
 
     mutable Lock m_treeLock; // Protects the scrolling tree.
 
 private:
     bool updateTreeFromStateNodeRecursive(const ScrollingStateNode*, struct CommitTreeState&) WTF_REQUIRES_LOCK(m_treeLock);
-    virtual void propagateSynchronousScrollingReasons(const HashSet<ScrollingNodeID>&) WTF_REQUIRES_LOCK(m_treeLock) { }
+    virtual void propagateSynchronousScrollingReasons(const UncheckedKeyHashSet<ScrollingNodeID>&) WTF_REQUIRES_LOCK(m_treeLock) { }
 
     void applyLayerPositionsRecursive(ScrollingTreeNode&) WTF_REQUIRES_LOCK(m_treeLock);
     void notifyRelatedNodesRecursive(ScrollingTreeNode&);
@@ -306,15 +306,15 @@ private:
     ScrollingTreeNodeMap m_nodeMap;
 
     Lock m_frameIDMapLock;
-    UncheckedKeyHashMap<FrameIdentifier, HashSet<ScrollingNodeID>> m_nodeMapPerFrame WTF_GUARDED_BY_LOCK(m_frameIDMapLock);
+    UncheckedKeyHashMap<FrameIdentifier, UncheckedKeyHashSet<ScrollingNodeID>> m_nodeMapPerFrame WTF_GUARDED_BY_LOCK(m_frameIDMapLock);
 
     ScrollingTreeLatchingController m_latchingController;
     ScrollingTreeGestureState m_gestureState;
 
     RelatedNodesMap m_overflowRelatedNodesMap;
 
-    HashSet<Ref<ScrollingTreeOverflowScrollProxyNode>> m_activeOverflowScrollProxyNodes;
-    HashSet<Ref<ScrollingTreePositionedNode>> m_activePositionedNodes;
+    UncheckedKeyHashSet<Ref<ScrollingTreeOverflowScrollProxyNode>> m_activeOverflowScrollProxyNodes;
+    UncheckedKeyHashSet<Ref<ScrollingTreePositionedNode>> m_activePositionedNodes;
 
     struct TreeState {
         EventTrackingRegions eventTrackingRegions;
@@ -322,10 +322,10 @@ private:
         PlatformDisplayID displayID { 0 };
         std::optional<FramesPerSecond> nominalFramesPerSecond;
         std::optional<WheelScrollGestureState> gestureState;
-        HashSet<ScrollingNodeID> nodesWithActiveRubberBanding;
-        HashSet<ScrollingNodeID> nodesWithActiveScrollSnap;
-        HashSet<ScrollingNodeID> nodesWithActiveUserScrolls;
-        HashSet<ScrollingNodeID> nodesWithActiveScrollAnimations;
+        UncheckedKeyHashSet<ScrollingNodeID> nodesWithActiveRubberBanding;
+        UncheckedKeyHashSet<ScrollingNodeID> nodesWithActiveScrollSnap;
+        UncheckedKeyHashSet<ScrollingNodeID> nodesWithActiveUserScrolls;
+        UncheckedKeyHashSet<ScrollingNodeID> nodesWithActiveScrollAnimations;
     };
     
     mutable Lock m_treeStateLock;

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h
@@ -58,7 +58,7 @@ private:
     WEBCORE_EXPORT void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 
     std::optional<LayerHostingContextIdentifier> m_hostingContext;
-    HashSet<RefPtr<ScrollingTreeNode>> m_hostedChildren;
+    UncheckedKeyHashSet<RefPtr<ScrollingTreeNode>> m_hostedChildren;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
@@ -200,7 +200,7 @@ bool ThreadedScrollingTree::scrollingTreeNodeRequestsKeyboardScroll(ScrollingNod
     return true;
 }
 
-void ThreadedScrollingTree::propagateSynchronousScrollingReasons(const HashSet<ScrollingNodeID>& synchronousScrollingNodes)
+void ThreadedScrollingTree::propagateSynchronousScrollingReasons(const UncheckedKeyHashSet<ScrollingNodeID>& synchronousScrollingNodes)
 {
     auto propagateStateToAncestors = [&](ScrollingTreeNode& node) {
         ASSERT(is<ScrollingTreeScrollingNode>(node) && !downcast<ScrollingTreeScrollingNode>(node).synchronousScrollingReasons().isEmpty());

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
@@ -100,7 +100,7 @@ protected:
 
 private:
     bool isThreadedScrollingTree() const override { return true; }
-    void propagateSynchronousScrollingReasons(const HashSet<ScrollingNodeID>&) WTF_REQUIRES_LOCK(m_treeLock) override;
+    void propagateSynchronousScrollingReasons(const UncheckedKeyHashSet<ScrollingNodeID>&) WTF_REQUIRES_LOCK(m_treeLock) override;
 
     void didCommitTree() final;
     void didCommitTreeOnScrollingThread() WTF_REQUIRES_LOCK(m_treeLock);

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -307,7 +307,7 @@ void WritingToolsController::proofreadingSessionDidReceiveSuggestions(const Writ
 
     auto adjustedProcessedRangeBeforeReplacement = resolveCharacterRange(sessionRange, { adjustedProcessedRangeLocation, processedRange.length });
 
-    HashSet<WTF::UUID> transparentContentMarkerIdentifiers;
+    UncheckedKeyHashSet<WTF::UUID> transparentContentMarkerIdentifiers;
 
     document->markers().forEach(adjustedProcessedRangeBeforeReplacement, { DocumentMarkerType::TransparentContent }, [&](auto&, auto marker) {
         auto& data = std::get<DocumentMarker::TransparentContentData>(marker.data());

--- a/Source/WebCore/platform/LegacySchemeRegistry.h
+++ b/Source/WebCore/platform/LegacySchemeRegistry.h
@@ -32,8 +32,8 @@
 
 namespace WebCore {
 
-// FIXME: Make HashSet<String>::contains(StringView) work and use StringViews here.
-using URLSchemesMap = HashSet<String, ASCIICaseInsensitiveHash>;
+// FIXME: Make UncheckedKeyHashSet<String>::contains(StringView) work and use StringViews here.
+using URLSchemesMap = UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash>;
 
 class LegacySchemeRegistry {
 public:

--- a/Source/WebCore/platform/PreviewConverter.cpp
+++ b/Source/WebCore/platform/PreviewConverter.cpp
@@ -48,7 +48,7 @@ bool PreviewConverter::supportsMIMEType(const String& mimeType)
     if (equalLettersIgnoringASCIICase(mimeType, "text/html"_s) || equalLettersIgnoringASCIICase(mimeType, "text/plain"_s))
         return false;
 
-    static NeverDestroyed<HashSet<String, ASCIICaseInsensitiveHash>> supportedMIMETypes = platformSupportedMIMETypes();
+    static NeverDestroyed<UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash>> supportedMIMETypes = platformSupportedMIMETypes();
     return supportedMIMETypes->contains(mimeType);
 }
 

--- a/Source/WebCore/platform/PreviewConverter.h
+++ b/Source/WebCore/platform/PreviewConverter.h
@@ -95,7 +95,7 @@ public:
     WEBCORE_EXPORT static void setPasswordForTesting(const String&);
 
 private:
-    static HashSet<String, ASCIICaseInsensitiveHash> platformSupportedMIMETypes();
+    static UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash> platformSupportedMIMETypes();
 
     PreviewConverter(const ResourceResponse&, PreviewConverterProvider&);
 

--- a/Source/WebCore/platform/PublicSuffixStore.h
+++ b/Source/WebCore/platform/PublicSuffixStore.h
@@ -61,7 +61,7 @@ private:
     mutable UncheckedKeyHashMap<String, String, ASCIICaseInsensitiveHash> m_hostTopPrivatelyControlledDomainCache WTF_GUARDED_BY_LOCK(m_HostTopPrivatelyControlledDomainCacheLock);
 #if PLATFORM(COCOA)
     mutable Lock m_publicSuffixCacheLock;
-    std::optional<HashSet<PublicSuffix>> m_publicSuffixCache WTF_GUARDED_BY_LOCK(m_publicSuffixCacheLock);
+    std::optional<UncheckedKeyHashSet<PublicSuffix>> m_publicSuffixCache WTF_GUARDED_BY_LOCK(m_publicSuffixCacheLock);
 #endif
 };
 

--- a/Source/WebCore/platform/RemoteCommandListener.h
+++ b/Source/WebCore/platform/RemoteCommandListener.h
@@ -50,7 +50,7 @@ public:
     void addSupportedCommand(PlatformMediaSession::RemoteControlCommandType);
     void removeSupportedCommand(PlatformMediaSession::RemoteControlCommandType);
 
-    using RemoteCommandsSet = HashSet<PlatformMediaSession::RemoteControlCommandType, IntHash<PlatformMediaSession::RemoteControlCommandType>, WTF::StrongEnumHashTraits<PlatformMediaSession::RemoteControlCommandType>>;
+    using RemoteCommandsSet = UncheckedKeyHashSet<PlatformMediaSession::RemoteControlCommandType, IntHash<PlatformMediaSession::RemoteControlCommandType>, WTF::StrongEnumHashTraits<PlatformMediaSession::RemoteControlCommandType>>;
     void setSupportedCommands(const RemoteCommandsSet&);
     const RemoteCommandsSet& supportedCommands() const;
 

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
@@ -126,9 +126,9 @@ Vector<SnapOffset<LayoutUnit>> ScrollSnapAnimatorState::currentlySnappedOffsetsF
     return currentlySnappedOffsets;
 }
 
-HashSet<ElementIdentifier> ScrollSnapAnimatorState::currentlySnappedBoxes(const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets) const
+UncheckedKeyHashSet<ElementIdentifier> ScrollSnapAnimatorState::currentlySnappedBoxes(const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets) const
 {
-    HashSet<ElementIdentifier> snappedBoxIDs;
+    UncheckedKeyHashSet<ElementIdentifier> snappedBoxIDs;
         
     for (auto offset : horizontalOffsets) {
         if (!offset.snapTargetID)
@@ -162,7 +162,7 @@ void ScrollSnapAnimatorState::updateCurrentlySnappedBoxes()
     m_currentlySnappedBoxes = currentlySnappedBoxes(horizontalOffsets, verticalOffsets);
 }
 
-static ElementIdentifier chooseBoxToResnapTo(const HashSet<ElementIdentifier>& snappedBoxes, const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets)
+static ElementIdentifier chooseBoxToResnapTo(const UncheckedKeyHashSet<ElementIdentifier>& snappedBoxes, const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets)
 {
     ASSERT(snappedBoxes.size());
 

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.h
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.h
@@ -101,7 +101,7 @@ private:
     bool preserveCurrentTargetForAxis(ScrollEventAxis, ElementIdentifier);
 
     Vector<SnapOffset<LayoutUnit>> currentlySnappedOffsetsForAxis(ScrollEventAxis) const;
-    HashSet<ElementIdentifier> currentlySnappedBoxes(const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets) const;
+    UncheckedKeyHashSet<ElementIdentifier> currentlySnappedBoxes(const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets) const;
 
     bool setNearestScrollSnapIndexForAxisAndOffsetInternal(ScrollEventAxis, ScrollOffset, const ScrollExtents&, float pageScale);
     void updateCurrentlySnappedBoxes();
@@ -122,7 +122,7 @@ private:
     
     std::optional<unsigned> m_activeSnapIndexX;
     std::optional<unsigned> m_activeSnapIndexY;
-    HashSet<ElementIdentifier> m_currentlySnappedBoxes;
+    UncheckedKeyHashSet<ElementIdentifier> m_currentlySnappedBoxes;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ScrollSnapAnimatorState&);

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -102,7 +102,7 @@ public:
     virtual IntRect windowClipRect() const = 0;
 
     // Functions for child manipulation and inspection.
-    const HashSet<Ref<Widget>>& children() const { return m_children; }
+    const UncheckedKeyHashSet<Ref<Widget>>& children() const { return m_children; }
     WEBCORE_EXPORT virtual void addChild(Widget&);
     WEBCORE_EXPORT virtual void removeChild(Widget&);
 
@@ -518,7 +518,7 @@ private:
             didFinishProhibitingScrollingWhenChangingContentSize();
     }
 
-    HashSet<Ref<Widget>> m_children;
+    UncheckedKeyHashSet<Ref<Widget>> m_children;
 
     RefPtr<Scrollbar> m_horizontalScrollbar;
     RefPtr<Scrollbar> m_verticalScrollbar;

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -146,7 +146,7 @@ private:
 
     RefPtr<HTMLMediaElement> m_mediaElement;
     bool m_isListening { false };
-    HashSet<CheckedPtr<PlaybackSessionModelClient>> m_clients;
+    UncheckedKeyHashSet<CheckedPtr<PlaybackSessionModelClient>> m_clients;
     Vector<RefPtr<TextTrack>> m_legibleTracksForMenu;
     Vector<RefPtr<AudioTrack>> m_audioTracksForMenu;
     AudioSessionSoundStageSize m_soundStageSize;

--- a/Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm
@@ -71,7 +71,7 @@ void PublicSuffixStore::enablePublicSuffixCache()
 
     Locker locker { m_publicSuffixCacheLock };
     ASSERT(!m_publicSuffixCache);
-    m_publicSuffixCache = HashSet<PublicSuffix> { };
+    m_publicSuffixCache = UncheckedKeyHashSet<PublicSuffix> { };
 }
 
 void PublicSuffixStore::addPublicSuffix(const PublicSuffix& publicSuffix)

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
@@ -125,7 +125,7 @@ private:
     RefPtr<HTMLVideoElement> m_videoElement;
     RetainPtr<PlatformLayer> m_videoFullscreenLayer;
     bool m_isListening { false };
-    HashSet<CheckedPtr<VideoPresentationModelClient>> m_clients;
+    UncheckedKeyHashSet<CheckedPtr<VideoPresentationModelClient>> m_clients;
     bool m_hasVideo { false };
     bool m_documentIsVisible { true };
     FloatSize m_videoDimensions;

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.h
@@ -232,7 +232,7 @@ private:
         m_references.remove(id);
     }
 
-    HashSet<KeyStoreIDType> m_references;
+    UncheckedKeyHashSet<KeyStoreIDType> m_references;
 };
 
 class ReferenceAwareKeyStore : public KeyStoreBase<ReferenceAwareKeyHandle> {

--- a/Source/WebCore/platform/encryptedmedia/CDMRestrictions.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMRestrictions.h
@@ -35,7 +35,7 @@ namespace WebCore {
 struct CDMRestrictions {
     bool distinctiveIdentifierDenied { false };
     bool persistentStateDenied { false };
-    HashSet<CDMSessionType, IntHash<CDMSessionType>, WTF::StrongEnumHashTraits<CDMSessionType>> deniedSessionTypes;
+    UncheckedKeyHashSet<CDMSessionType, IntHash<CDMSessionType>, WTF::StrongEnumHashTraits<CDMSessionType>> deniedSessionTypes;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h
+++ b/Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h
@@ -93,7 +93,7 @@ private:
     Timer m_inputNotificationTimer;
 
 #if HAVE(MULTIGAMEPADPROVIDER_SUPPORT)
-    HashSet<IOHIDDeviceRef> m_gameControllerManagedGamepads;
+    UncheckedKeyHashSet<IOHIDDeviceRef> m_gameControllerManagedGamepads;
 #endif // HAVE(MULTIGAMEPADPROVIDER_SUPPORT)
 };
 

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitor.h
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitor.h
@@ -96,8 +96,8 @@ private:
     std::optional<FramesPerSecond> maximumClientPreferredFramesPerSecond() const;
     void computeMaxPreferredFramesPerSecond();
 
-    HashSet<CheckedPtr<DisplayRefreshMonitorClient>> m_clients;
-    HashSet<CheckedPtr<DisplayRefreshMonitorClient>>* m_clientsToBeNotified { nullptr };
+    UncheckedKeyHashSet<CheckedPtr<DisplayRefreshMonitorClient>> m_clients;
+    UncheckedKeyHashSet<CheckedPtr<DisplayRefreshMonitorClient>>* m_clientsToBeNotified { nullptr };
 
     PlatformDisplayID m_displayID { 0 };
     std::optional<FramesPerSecond> m_maxClientPreferredFramesPerSecond;

--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -254,14 +254,14 @@ private:
 #endif
 
 #if PLATFORM(MAC)
-    HashSet<AtomString> m_knownFamilies;
+    UncheckedKeyHashSet<AtomString> m_knownFamilies;
 #endif
 
 #if PLATFORM(COCOA)
     FontDatabase m_databaseAllowingUserInstalledFonts { AllowUserInstalledFonts::Yes };
     FontDatabase m_databaseDisallowingUserInstalledFonts { AllowUserInstalledFonts::No };
 
-    using FallbackFontSet = HashSet<RetainPtr<CTFontRef>, WTF::RetainPtrObjectHash<CTFontRef>, WTF::RetainPtrObjectHashTraits<CTFontRef>>;
+    using FallbackFontSet = UncheckedKeyHashSet<RetainPtr<CTFontRef>, WTF::RetainPtrObjectHash<CTFontRef>, WTF::RetainPtrObjectHashTraits<CTFontRef>>;
     FallbackFontSet m_fallbackFonts;
 
     ListHashSet<String> m_seenFamiliesForPrewarming;

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -118,7 +118,7 @@ private:
 
     EnumeratedArray<ResolvedEmojiPolicy, UncheckedKeyHashMap<unsigned, GlyphPageCacheEntry, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>>, ResolvedEmojiPolicy::RequireEmoji> m_cachedPages;
 
-    HashSet<RefPtr<Font>> m_systemFallbackFontSet;
+    UncheckedKeyHashSet<RefPtr<Font>> m_systemFallbackFontSet;
 
     SingleThreadWeakPtr<const Font> m_cachedPrimaryFont;
     RefPtr<FontSelector> m_fontSelector;

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -245,9 +245,9 @@ public:
     virtual unsigned audioDecodedByteCount() const { return 0; }
     virtual unsigned videoDecodedByteCount() const { return 0; }
 
-    HashSet<SecurityOriginData> originsInMediaCache(const String&) { return { }; }
+    UncheckedKeyHashSet<SecurityOriginData> originsInMediaCache(const String&) { return { }; }
     void clearMediaCache(const String&, WallTime) { }
-    void clearMediaCacheForOrigins(const String&, const HashSet<SecurityOriginData>&) { }
+    void clearMediaCacheForOrigins(const String&, const UncheckedKeyHashSet<SecurityOriginData>&) { }
 
     virtual void setPrivateBrowsingMode(bool) { }
 

--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -78,9 +78,9 @@ PlatformDisplay* PlatformDisplay::sharedDisplayIfExists()
 }
 #endif
 
-static HashSet<PlatformDisplay*>& eglDisplays()
+static UncheckedKeyHashSet<PlatformDisplay*>& eglDisplays()
 {
-    static NeverDestroyed<HashSet<PlatformDisplay*>> displays;
+    static NeverDestroyed<UncheckedKeyHashSet<PlatformDisplay*>> displays;
     return displays;
 }
 

--- a/Source/WebCore/platform/graphics/TiledBacking.h
+++ b/Source/WebCore/platform/graphics/TiledBacking.h
@@ -84,7 +84,7 @@ public:
 
     // The client will not receive `willRepaintTile()` for tiles needing display as part of a revalidation.
     virtual void willRevalidateTiles(TiledBacking&, TileGridIdentifier, TileRevalidationType) = 0;
-    virtual void didRevalidateTiles(TiledBacking&, TileGridIdentifier, TileRevalidationType, const HashSet<TileIndex>& tilesNeedingDisplay) = 0;
+    virtual void didRevalidateTiles(TiledBacking&, TileGridIdentifier, TileRevalidationType, const UncheckedKeyHashSet<TileIndex>& tilesNeedingDisplay) = 0;
 
     virtual void didAddGrid(TiledBacking&, TileGridIdentifier) = 0;
     virtual void willRemoveGrid(TiledBacking&, TileGridIdentifier) = 0;

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -59,9 +59,9 @@ namespace WebCore {
 // List of displays ever instantiated from EGL. When terminating all EGL resources, we need to
 // terminate all displays. However, we cannot ask EGL all the displays it has created.
 // We must know all the displays via this set.
-static HashSet<GCGLDisplay>& usedDisplays()
+static UncheckedKeyHashSet<GCGLDisplay>& usedDisplays()
 {
-    static NeverDestroyed<HashSet<GCGLDisplay>> s_usedDisplays;
+    static NeverDestroyed<UncheckedKeyHashSet<GCGLDisplay>> s_usedDisplays;
     return s_usedDisplays;
 }
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -416,9 +416,9 @@ protected:
     void setPackParameters(GCGLint alignment, GCGLint rowLength, GCGLboolean reverseRowOrder);
     bool validateClearBufferv(GCGLenum buffer, size_t valuesSize);
 
-    HashSet<String> m_availableExtensions;
-    HashSet<String> m_requestableExtensions;
-    HashSet<String> m_enabledExtensions;
+    UncheckedKeyHashSet<String> m_availableExtensions;
+    UncheckedKeyHashSet<String> m_requestableExtensions;
+    UncheckedKeyHashSet<String> m_enabledExtensions;
     bool m_webglColorBufferFloatRGB { false };
     bool m_webglColorBufferFloatRGBA { false };
     GCGLuint m_texture { 0 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -167,7 +167,7 @@ private:
     bool m_persistentStateAllowed { true };
     RetainPtr<NSURL> m_storageURL;
     Vector<WeakPtr<CDMInstanceSessionFairPlayStreamingAVFObjC>> m_sessions;
-    HashSet<RetainPtr<AVContentKeyRequest>> m_unexpectedKeyRequests;
+    UncheckedKeyHashSet<RetainPtr<AVContentKeyRequest>> m_unexpectedKeyRequests;
     WeakHashSet<KeyStatusesChangedObserver> m_keyStatusChangedObservers;
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;

--- a/Source/WebCore/platform/graphics/ca/LayerPool.cpp
+++ b/Source/WebCore/platform/graphics/ca/LayerPool.cpp
@@ -50,10 +50,10 @@ LayerPool::~LayerPool()
     allLayerPools().remove(this);
 }
 
-HashSet<CheckedPtr<LayerPool>>& LayerPool::allLayerPools()
+UncheckedKeyHashSet<CheckedPtr<LayerPool>>& LayerPool::allLayerPools()
 {
     RELEASE_ASSERT(isMainThread());
-    static NeverDestroyed<HashSet<CheckedPtr<LayerPool>>> allLayerPools;
+    static NeverDestroyed<UncheckedKeyHashSet<CheckedPtr<LayerPool>>> allLayerPools;
     return allLayerPools.get();
 }
 

--- a/Source/WebCore/platform/graphics/ca/LayerPool.h
+++ b/Source/WebCore/platform/graphics/ca/LayerPool.h
@@ -47,7 +47,7 @@ public:
     WEBCORE_EXPORT LayerPool();
     WEBCORE_EXPORT ~LayerPool();
 
-    static HashSet<CheckedPtr<LayerPool>>& allLayerPools();
+    static UncheckedKeyHashSet<CheckedPtr<LayerPool>>& allLayerPools();
     
     void addLayer(const RefPtr<PlatformCALayer>&);
     RefPtr<PlatformCALayer> takeLayerWithSize(const IntSize&);

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -708,7 +708,7 @@ void TileController::willRevalidateTiles(TileGrid& tileGrid, TileRevalidationTyp
         m_client->willRevalidateTiles(*this, tileGrid.identifier(), revalidationType);
 }
 
-void TileController::didRevalidateTiles(TileGrid& tileGrid, TileRevalidationType revalidationType, const HashSet<TileIndex>& tilesNeedingDisplay)
+void TileController::didRevalidateTiles(TileGrid& tileGrid, TileRevalidationType revalidationType, const UncheckedKeyHashSet<TileIndex>& tilesNeedingDisplay)
 {
     m_boundsAtLastRevalidate = bounds();
 

--- a/Source/WebCore/platform/graphics/ca/TileController.h
+++ b/Source/WebCore/platform/graphics/ca/TileController.h
@@ -136,7 +136,7 @@ public:
     IntRect boundsAtLastRevalidate() const { return m_boundsAtLastRevalidate; }
     IntRect boundsAtLastRevalidateWithoutMargin() const;
     void willRevalidateTiles(TileGrid&, TileRevalidationType);
-    void didRevalidateTiles(TileGrid&, TileRevalidationType, const HashSet<TileIndex>& tilesNeedingDisplay);
+    void didRevalidateTiles(TileGrid&, TileRevalidationType, const UncheckedKeyHashSet<TileIndex>& tilesNeedingDisplay);
 
     bool shouldAggressivelyRetainTiles() const;
     bool shouldTemporarilyRetainTileCohorts() const;

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -498,7 +498,7 @@ void TileGrid::revalidateTiles(OptionSet<ValidationPolicyFlag> validationPolicy)
     }
 
     // Ensure primary tile coverage tiles.
-    HashSet<TileIndex> tilesNeedingDisplay;
+    UncheckedKeyHashSet<TileIndex> tilesNeedingDisplay;
     m_primaryTileCoverageRect = ensureTilesForRect(coverageRect, tilesNeedingDisplay, CoverageType::PrimaryTiles);
 
     // Ensure secondary tiles (requested via prepopulateRect).
@@ -572,7 +572,7 @@ void TileGrid::cohortRemovalTimerFired()
     m_controller->updateTileCoverageMap();
 }
 
-IntRect TileGrid::ensureTilesForRect(const FloatRect& rect, HashSet<TileIndex>& tilesNeedingDisplay, CoverageType newTileType)
+IntRect TileGrid::ensureTilesForRect(const FloatRect& rect, UncheckedKeyHashSet<TileIndex>& tilesNeedingDisplay, CoverageType newTileType)
 {
     if (!m_controller->isInWindow())
         return IntRect();

--- a/Source/WebCore/platform/graphics/ca/TileGrid.h
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.h
@@ -118,7 +118,7 @@ private:
     bool getTileIndexRangeForRect(const IntRect&, TileIndex& topLeft, TileIndex& bottomRight) const;
 
     enum class CoverageType { PrimaryTiles, SecondaryTiles };
-    IntRect ensureTilesForRect(const FloatRect&, HashSet<TileIndex>& tilesNeedingDisplay, CoverageType);
+    IntRect ensureTilesForRect(const FloatRect&, UncheckedKeyHashSet<TileIndex>& tilesNeedingDisplay, CoverageType);
 
     struct TileCohortInfo {
         TileCohort cohort;

--- a/Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.h
+++ b/Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.h
@@ -94,7 +94,7 @@ private:
     static constexpr Seconds cacheEntryLifetime { 500_ms };
     static constexpr int maxCacheSize = 300;
 
-    typedef HashSet<CacheEntry, CacheHash, CacheEntryTraits> CacheHashSet;
+    typedef UncheckedKeyHashSet<CacheEntry, CacheHash, CacheEntryTraits> CacheHashSet;
 
     CGSubimageCacheWithTimer();
     void pruneCacheTimerFired();

--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
@@ -77,10 +77,10 @@ const MemoryCompactLookupOnlyRobinHoodHashSet<String>& defaultSupportedImageType
         auto systemSupportedCFImageTypes = adoptCF(CGImageSourceCopyTypeIdentifiers());
         CFIndex count = CFArrayGetCount(systemSupportedCFImageTypes.get());
 
-        HashSet<String> systemSupportedImageTypes;
+        UncheckedKeyHashSet<String> systemSupportedImageTypes;
         CFArrayApplyFunction(systemSupportedCFImageTypes.get(), CFRangeMake(0, count), [](const void *value, void *context) {
             String imageType = static_cast<CFStringRef>(value);
-            static_cast<HashSet<String>*>(context)->add(imageType);
+            static_cast<UncheckedKeyHashSet<String>*>(context)->add(imageType);
         }, &systemSupportedImageTypes);
 
         MemoryCompactLookupOnlyRobinHoodHashSet<String> filtered;

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -289,7 +289,7 @@ public:
     static Lock lock;
 
 private:
-    HashSet<String, ASCIICaseInsensitiveHash> m_families;
+    UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash> m_families;
 };
 
 Lock FontCacheAllowlist::lock;

--- a/Source/WebCore/platform/graphics/filters/FilterResults.h
+++ b/Source/WebCore/platform/graphics/filters/FilterResults.h
@@ -55,7 +55,7 @@ private:
     UncheckedKeyHashMap<Ref<FilterEffect>, Ref<FilterImage>> m_results;
 
     // The value is a list of FilterEffects, whose FilterImages depend on the key FilterImage.
-    using FilterEffectSet = HashSet<Ref<FilterEffect>>;
+    using FilterEffectSet = UncheckedKeyHashSet<Ref<FilterEffect>>;
     UncheckedKeyHashMap<Ref<FilterImage>, FilterEffectSet> m_resultReferences;
 
     std::unique_ptr<ImageBufferAllocator> m_allocator;

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -151,7 +151,7 @@ struct WebKitWebSrcPrivate {
         uint64_t stopPosition { UINT64_MAX };
 
         bool isRequestPending { true };
-        HashSet<RefPtr<WebCore::SecurityOrigin>> origins;
+        UncheckedKeyHashSet<RefPtr<WebCore::SecurityOrigin>> origins;
 
         RefPtr<PlatformMediaResource> resource;
     };

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -439,9 +439,9 @@ void AppendPipeline::didReceiveInitializationSegment()
                 linkPadWithTrack(pad, *track);
         }
     } else {
-        HashSet<String> videoPadStreamIDs;
-        HashSet<String> audioPadStreamIDs;
-        HashSet<String> textPadStreamIDs;
+        UncheckedKeyHashSet<String> videoPadStreamIDs;
+        UncheckedKeyHashSet<String> audioPadStreamIDs;
+        UncheckedKeyHashSet<String> textPadStreamIDs;
         for (auto pad : GstIteratorAdaptor<GstPad>(GUniquePtr<GstIterator>(gst_element_iterate_src_pads(m_demux.get())))) {
             auto [parsedCaps, streamType, presentationSize] = parseDemuxerSrcPadCaps(adoptGRef(gst_pad_get_current_caps(pad)).get());
             UNUSED_VARIABLE(parsedCaps);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -105,7 +105,7 @@ private:
     // Stores known track IDs, so we can work around ID collisions between multiple source buffers.
     // The registry is placed here to enforce ID uniqueness specifically by player, not by process,
     // since its not an issue if multiple players use the same ID, and we want to preserve IDs as much as possible.
-    HashSet<TrackID, WTF::IntHash<TrackID>, WTF::UnsignedWithZeroKeyHashTraits<TrackID>> m_trackIdRegistry;
+    UncheckedKeyHashSet<TrackID, WTF::IntHash<TrackID>, WTF::UnsignedWithZeroKeyHashTraits<TrackID>> m_trackIdRegistry;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ios/PreviewConverterIOS.mm
+++ b/Source/WebCore/platform/ios/PreviewConverterIOS.mm
@@ -90,9 +90,9 @@ PreviewConverter::PreviewConverter(const ResourceResponse& response, PreviewConv
 {
 }
 
-HashSet<String, ASCIICaseInsensitiveHash> PreviewConverter::platformSupportedMIMETypes()
+UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash> PreviewConverter::platformSupportedMIMETypes()
 {
-    HashSet<String, ASCIICaseInsensitiveHash> supportedMIMETypes;
+    UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash> supportedMIMETypes;
     for (NSString *mimeType in QLPreviewGetSupportedMIMETypesSet())
         supportedMIMETypes.add(mimeType);
     return supportedMIMETypes;

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -227,8 +227,8 @@ private:
     void didCleanupFullscreen() final;
     void fullscreenMayReturnToInline() final;
 
-    HashSet<CheckedPtr<PlaybackSessionModelClient>> m_playbackClients;
-    HashSet<CheckedPtr<VideoPresentationModelClient>> m_presentationClients;
+    UncheckedKeyHashSet<CheckedPtr<PlaybackSessionModelClient>> m_playbackClients;
+    UncheckedKeyHashSet<CheckedPtr<VideoPresentationModelClient>> m_presentationClients;
     RefPtr<VideoPresentationInterfaceIOS> m_interface;
     RefPtr<VideoPresentationModelVideoElement> m_presentationModel;
     RefPtr<PlaybackSessionModelMediaElement> m_playbackModel;

--- a/Source/WebCore/platform/mac/HIDDevice.cpp
+++ b/Source/WebCore/platform/mac/HIDDevice.cpp
@@ -75,7 +75,7 @@ HIDDevice::HIDDevice(IOHIDDeviceRef device)
 
 Vector<HIDElement> HIDDevice::uniqueInputElementsInDeviceTreeOrder() const
 {
-    HashSet<IOHIDElementCookie> encounteredCookies;
+    UncheckedKeyHashSet<IOHIDElementCookie> encounteredCookies;
     Deque<IOHIDElementRef> elementQueue;
 
     RetainPtr<CFArrayRef> elements = adoptCF(IOHIDDeviceCopyMatchingElements(m_rawDevice.get(), NULL, kIOHIDOptionsTypeNone));

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -443,7 +443,7 @@ void Pasteboard::read(PasteboardWebContentReader& reader, WebContentReadingPolic
 {
     auto& strategy = *platformStrategies()->pasteboardStrategy();
     auto platformTypesFromItems = [](const Vector<PasteboardItemInfo>& items) {
-        HashSet<String> types;
+        UncheckedKeyHashSet<String> types;
         for (auto& item : items) {
             for (auto& type : item.platformTypesByFidelity)
                 types.add(type);
@@ -451,7 +451,7 @@ void Pasteboard::read(PasteboardWebContentReader& reader, WebContentReadingPolic
         return types;
     };
 
-    HashSet<String> nonTranscodedTypes;
+    UncheckedKeyHashSet<String> nonTranscodedTypes;
     Vector<String> types;
     if (itemIndex) {
         if (auto itemInfo = strategy.informationForItemAtIndex(*itemIndex, m_pasteboardName, m_changeCount, context())) {

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -54,7 +54,7 @@
 
 namespace WebCore {
 
-using ScrollbarSet = HashSet<SingleThreadWeakRef<Scrollbar>>;
+using ScrollbarSet = UncheckedKeyHashSet<SingleThreadWeakRef<Scrollbar>>;
 
 static ScrollbarSet& scrollbarMap()
 {

--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h
@@ -46,7 +46,7 @@ public:
 
     WEBCORE_EXPORT SerializedPlatformDataCueValue encodableValue() const final;
 
-    WEBCORE_EXPORT static const HashSet<RetainPtr<Class>>& allowedClassesForNativeValues();
+    WEBCORE_EXPORT static const UncheckedKeyHashSet<RetainPtr<Class>>& allowedClassesForNativeValues();
 
 private:
     SerializedPlatformDataCueValue m_value;

--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
@@ -101,9 +101,9 @@ const SerializedPlatformDataCueMac* toSerializedPlatformDataCueMac(const Seriali
     return static_cast<const SerializedPlatformDataCueMac*>(rep);
 }
 
-const HashSet<RetainPtr<Class>>& SerializedPlatformDataCueMac::allowedClassesForNativeValues()
+const UncheckedKeyHashSet<RetainPtr<Class>>& SerializedPlatformDataCueMac::allowedClassesForNativeValues()
 {
-    static NeverDestroyed<HashSet<RetainPtr<Class>>> allowedClasses(HashSet<RetainPtr<Class>> { [NSString class], [NSNumber class], [NSLocale class], [NSDictionary class], [NSArray class], [NSData class] });
+    static NeverDestroyed<UncheckedKeyHashSet<RetainPtr<Class>>> allowedClasses(UncheckedKeyHashSet<RetainPtr<Class>> { [NSString class], [NSNumber class], [NSLocale class], [NSDictionary class], [NSArray class], [NSData class] });
     return allowedClasses;
 }
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -384,7 +384,7 @@ private:
     WeakHashSet<RealtimeMediaSourceObserver> m_observers;
 
     mutable Lock m_audioSampleObserversLock;
-    HashSet<CheckedPtr<AudioSampleObserver>> m_audioSampleObservers WTF_GUARDED_BY_LOCK(m_audioSampleObserversLock);
+    UncheckedKeyHashSet<CheckedPtr<AudioSampleObserver>> m_audioSampleObservers WTF_GUARDED_BY_LOCK(m_audioSampleObserversLock);
 
     mutable Lock m_videoFrameObserversLock;
     HashMap<VideoFrameObserver*, std::unique_ptr<VideoFrameAdaptor>> m_videoFrameObservers WTF_GUARDED_BY_LOCK(m_videoFrameObserversLock);

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h
@@ -133,7 +133,7 @@ private:
     bool m_enabled { true };
 
     mutable Lock m_sinksLock;
-    HashSet<webrtc::AudioTrackSinkInterface*> m_sinks WTF_GUARDED_BY_LOCK(m_sinksLock);
+    UncheckedKeyHashSet<webrtc::AudioTrackSinkInterface*> m_sinks WTF_GUARDED_BY_LOCK(m_sinksLock);
 
 #if !RELEASE_LOG_DISABLED
     size_t m_chunksSent { 0 };

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
@@ -145,7 +145,7 @@ private:
     rtc::scoped_refptr<webrtc::VideoFrameBuffer> m_blackFrame;
 
     mutable Lock m_sinksLock;
-    HashSet<rtc::VideoSinkInterface<webrtc::VideoFrame>*> m_sinks WTF_GUARDED_BY_LOCK(m_sinksLock);
+    UncheckedKeyHashSet<rtc::VideoSinkInterface<webrtc::VideoFrame>*> m_sinks WTF_GUARDED_BY_LOCK(m_sinksLock);
     bool m_areSinksAskingToApplyRotation { false };
 
     bool m_enabled { true };

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
@@ -99,7 +99,7 @@ private:
         OSStatus render(size_t sampleCount, AudioBufferList&, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags&) final;
         void reset() final;
 
-        HashSet<Ref<AudioSampleDataSource>> m_sources WTF_GUARDED_BY_CAPABILITY(mainThread);
+        UncheckedKeyHashSet<Ref<AudioSampleDataSource>> m_sources WTF_GUARDED_BY_CAPABILITY(mainThread);
         Vector<Ref<AudioSampleDataSource>> m_renderSources;
 
         Lock m_pendingRenderSourcesLock;

--- a/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
@@ -91,7 +91,7 @@ private:
     const Ref<WTF::WorkQueue> m_queue;
 
     struct Mixer {
-        HashSet<Ref<AudioSampleDataSource>> sources;
+        UncheckedKeyHashSet<Ref<AudioSampleDataSource>> sources;
         RefPtr<AudioSampleDataSource> registeredMixedSource;
         String deviceID;
     };

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
@@ -41,13 +41,13 @@ static const double s_HumVolume = 0.1;
 static const double s_NoiseFrequency = 3000;
 static const double s_NoiseVolume = 0.05;
 
-static HashSet<MockRealtimeAudioSource*>& allMockRealtimeAudioSourcesStorage()
+static UncheckedKeyHashSet<MockRealtimeAudioSource*>& allMockRealtimeAudioSourcesStorage()
 {
-    static MainThreadNeverDestroyed<HashSet<MockRealtimeAudioSource*>> audioSources;
+    static MainThreadNeverDestroyed<UncheckedKeyHashSet<MockRealtimeAudioSource*>> audioSources;
     return audioSources;
 }
 
-const HashSet<MockRealtimeAudioSource*>& MockRealtimeAudioSourceGStreamer::allMockRealtimeAudioSources()
+const UncheckedKeyHashSet<MockRealtimeAudioSource*>& MockRealtimeAudioSourceGStreamer::allMockRealtimeAudioSources()
 {
     return allMockRealtimeAudioSourcesStorage();
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.h
@@ -35,7 +35,7 @@ class MockRealtimeAudioSourceGStreamer final : public MockRealtimeAudioSource, G
 public:
     static Ref<MockRealtimeAudioSource> createForMockAudioCapturer(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&);
 
-    static const HashSet<MockRealtimeAudioSource*>& allMockRealtimeAudioSources();
+    static const UncheckedKeyHashSet<MockRealtimeAudioSource*>& allMockRealtimeAudioSources();
 
     ~MockRealtimeAudioSourceGStreamer();
 

--- a/Source/WebCore/platform/mock/GeolocationClientMock.h
+++ b/Source/WebCore/platform/mock/GeolocationClientMock.h
@@ -90,7 +90,7 @@ private:
         PermissionStateAllowed,
         PermissionStateDenied,
     } m_permissionState;
-    typedef HashSet<RefPtr<Geolocation>> GeolocationSet;
+    typedef UncheckedKeyHashSet<RefPtr<Geolocation>> GeolocationSet;
     GeolocationSet m_pendingPermission;
 };
 

--- a/Source/WebCore/platform/network/DNSResolveQueue.cpp
+++ b/Source/WebCore/platform/network/DNSResolveQueue.cpp
@@ -122,7 +122,7 @@ void DNSResolveQueue::timerFired()
 
     for (; !m_names.isEmpty() && requestsAllowed > 0; --requestsAllowed) {
         ++m_requestsInFlight;
-        HashSet<String>::iterator currentName = m_names.begin();
+        UncheckedKeyHashSet<String>::iterator currentName = m_names.begin();
         platformResolve(*currentName);
         m_names.remove(currentName);
     }

--- a/Source/WebCore/platform/network/DNSResolveQueue.h
+++ b/Source/WebCore/platform/network/DNSResolveQueue.h
@@ -68,7 +68,7 @@ private:
 
     Timer m_timer;
 
-    HashSet<String> m_names;
+    UncheckedKeyHashSet<String> m_names;
     std::atomic<int> m_requestsInFlight;
     MonotonicTime m_lastProxyEnabledStatusCheckTime;
 };

--- a/Source/WebCore/platform/network/HTTPParsers.h
+++ b/Source/WebCore/platform/network/HTTPParsers.h
@@ -36,7 +36,7 @@
 
 namespace WebCore {
 
-typedef HashSet<String, ASCIICaseInsensitiveHash> HTTPHeaderSet;
+typedef UncheckedKeyHashSet<String, ASCIICaseInsensitiveHash> HTTPHeaderSet;
 
 class ResourceResponse;
 enum class HTTPHeaderName : uint16_t;
@@ -126,7 +126,7 @@ bool isSafeMethod(const String&);
 WEBCORE_EXPORT CrossOriginResourcePolicy parseCrossOriginResourcePolicyHeader(StringView);
 
 template<class HashType>
-bool addToAccessControlAllowList(const String& string, unsigned start, unsigned end, HashSet<String, HashType>& set)
+bool addToAccessControlAllowList(const String& string, unsigned start, unsigned end, UncheckedKeyHashSet<String, HashType>& set)
 {
     StringImpl* stringImpl = string.impl();
     if (!stringImpl)
@@ -153,9 +153,9 @@ bool addToAccessControlAllowList(const String& string, unsigned start, unsigned 
 }
 
 template<class HashType = DefaultHash<String>>
-std::optional<HashSet<String, HashType>> parseAccessControlAllowList(const String& string)
+std::optional<UncheckedKeyHashSet<String, HashType>> parseAccessControlAllowList(const String& string)
 {
-    HashSet<String, HashType> set;
+    UncheckedKeyHashSet<String, HashType> set;
     unsigned start = 0;
     size_t end;
     while ((end = string.find(',', start)) != notFound) {

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
@@ -78,8 +78,8 @@ WEBCORE_EXPORT @interface WebCoreNSURLSession : NSObject {
     RetainPtr<NSOperationQueue> _queue;
     RetainPtr<NSString> _sessionDescription;
     Lock _dataTasksLock;
-    HashSet<RetainPtr<WebCoreNSURLSessionDataTask>> _dataTasks WTF_GUARDED_BY_LOCK(_dataTasksLock);
-    HashSet<RefPtr<WebCore::SecurityOrigin>> _origins WTF_GUARDED_BY_LOCK(_dataTasksLock);
+    UncheckedKeyHashSet<RetainPtr<WebCoreNSURLSessionDataTask>> _dataTasks WTF_GUARDED_BY_LOCK(_dataTasksLock);
+    UncheckedKeyHashSet<RefPtr<WebCore::SecurityOrigin>> _origins WTF_GUARDED_BY_LOCK(_dataTasksLock);
     BOOL _invalidated; // Access on multiple thread, must be accessed via ObjC property.
     NSUInteger _nextTaskIdentifier;
     RefPtr<WTF::WorkQueue> _internalQueue;

--- a/Source/WebCore/platform/network/curl/CurlRequestScheduler.h
+++ b/Source/WebCore/platform/network/curl/CurlRequestScheduler.h
@@ -71,7 +71,7 @@ private:
     bool m_runThread { false };
 
     Vector<Function<void()>> m_taskQueue;
-    HashSet<CurlRequestSchedulerClient*> m_activeJobs;
+    UncheckedKeyHashSet<CurlRequestSchedulerClient*> m_activeJobs;
     HashMap<CURL*, CurlRequestSchedulerClient*> m_clientMaps;
 
     Lock m_multiHandleMutex;

--- a/Source/WebCore/platform/network/mac/UTIUtilities.h
+++ b/Source/WebCore/platform/network/mac/UTIUtilities.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 WEBCORE_EXPORT String MIMETypeFromUTI(const String&);
-WEBCORE_EXPORT HashSet<String> RequiredMIMETypesFromUTI(const String&);
+WEBCORE_EXPORT UncheckedKeyHashSet<String> RequiredMIMETypesFromUTI(const String&);
 RetainPtr<CFStringRef> mimeTypeFromUTITree(CFStringRef);
 WEBCORE_EXPORT String UTIFromMIMEType(const String&);
 bool isDeclaredUTI(const String&);

--- a/Source/WebCore/platform/network/mac/UTIUtilities.mm
+++ b/Source/WebCore/platform/network/mac/UTIUtilities.mm
@@ -52,9 +52,9 @@ String MIMETypeFromUTI(const String& uti)
     return type.get().preferredMIMEType;
 }
 
-HashSet<String> RequiredMIMETypesFromUTI(const String& uti)
+UncheckedKeyHashSet<String> RequiredMIMETypesFromUTI(const String& uti)
 {
-    HashSet<String> mimeTypes;
+    UncheckedKeyHashSet<String> mimeTypes;
 
     auto mainMIMEType = MIMETypeFromUTI(uti);
     if (!mainMIMEType.isEmpty())

--- a/Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp
+++ b/Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp
@@ -120,7 +120,7 @@ static String sanitizeFilename(const String& filename)
         ASSERT(U_SUCCESS(errorCode));
     }
 
-    HashSet<uint16_t> illegalCharactersInFilename;
+    UncheckedKeyHashSet<uint16_t> illegalCharactersInFilename;
     for (unsigned i = 0; i < result.length(); ++i) {
         auto character = result[i];
         if (uset_contains(illegalCharacterSet, character))

--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -94,7 +94,7 @@ private:
         return base64EncodeToString(digest->computeHash());
     }
 
-    HashSet<String> m_certificates;
+    UncheckedKeyHashSet<String> m_certificates;
 };
 
 SoupNetworkSession::SoupNetworkSession(PAL::SessionID sessionID)

--- a/Source/WebCore/platform/win/WindowMessageBroadcaster.h
+++ b/Source/WebCore/platform/win/WindowMessageBroadcaster.h
@@ -44,7 +44,7 @@ namespace WebCore {
         WEBCORE_EXPORT static void removeListener(HWND, WindowMessageListener*);
 
     private:
-        typedef HashSet<WindowMessageListener*> ListenerSet;
+        typedef UncheckedKeyHashSet<WindowMessageListener*> ListenerSet;
 
         static LRESULT CALLBACK SubclassedWndProc(HWND, UINT, WPARAM, LPARAM);
 

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -75,11 +75,11 @@ private:
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     Vector<InteractionRegion> m_interactionRegions;
     UncheckedKeyHashMap<IntRect, InteractionRegion::ContentHint> m_interactionRectsAndContentHints;
-    HashSet<IntRect> m_occlusionRects;
+    UncheckedKeyHashSet<IntRect> m_occlusionRects;
     enum class Inflated : bool { No, Yes };
     UncheckedKeyHashMap<IntRect, Inflated> m_guardRects;
-    HashSet<ElementIdentifier> m_containerRemovalCandidates;
-    HashSet<ElementIdentifier> m_containersToRemove;
+    UncheckedKeyHashSet<ElementIdentifier> m_containerRemovalCandidates;
+    UncheckedKeyHashSet<ElementIdentifier> m_containersToRemove;
     UncheckedKeyHashMap<ElementIdentifier, Vector<InteractionRegion>> m_discoveredRegionsByElement;
 #endif
 };

--- a/Source/WebCore/rendering/GlyphDisplayListCache.h
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.h
@@ -134,7 +134,7 @@ private:
     void remove(const void* run);
 
     UncheckedKeyHashMap<const void*, Ref<GlyphDisplayListCacheEntry>> m_entriesForLayoutRun;
-    HashSet<SingleThreadWeakRef<GlyphDisplayListCacheEntry>> m_entries;
+    UncheckedKeyHashSet<SingleThreadWeakRef<GlyphDisplayListCacheEntry>> m_entries;
     bool m_forceUseGlyphDisplayListForTesting { false };
 };
 

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -250,7 +250,7 @@ private:
     void computeGridContainerIntrinsicSizes();
 
     // Helper methods for step 4. Stretch flexible tracks.
-    typedef HashSet<unsigned, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> TrackIndexSet;
+    typedef UncheckedKeyHashSet<unsigned, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> TrackIndexSet;
     double computeFlexFactorUnitSize(const Vector<GridTrack>& tracks, double flexFactorSum, LayoutUnit& leftOverSpace, const Vector<unsigned, 8>& flexibleTracksIndexes, std::unique_ptr<TrackIndexSet> tracksToTreatAsInflexible = nullptr) const;
     void computeFlexSizedTracksGrowth(double flexFraction, Vector<LayoutUnit>& increments, LayoutUnit& totalGrowth) const;
     double findFrUnitSize(const GridSpan& tracksSpan, LayoutUnit leftOverSpace) const;

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -75,7 +75,7 @@ Vector<MarkedText> MarkedText::subdivide(const Vector<MarkedText>& markedTexts, 
     // 3. Compute intersection.
     Vector<MarkedText> result;
     result.reserveInitialCapacity(numberOfMarkedTexts);
-    HashSet<CheckedPtr<const MarkedText>> processedMarkedTexts;
+    UncheckedKeyHashSet<CheckedPtr<const MarkedText>> processedMarkedTexts;
     unsigned offsetSoFar = offsets[0].value;
     for (unsigned i = 1; i < numberOfOffsets; ++i) {
         if (offsets[i].value > offsets[i - 1].value) {

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -184,7 +184,7 @@ ReferencedSVGResources::SVGElementIdentifierAndTagPairs ReferencedSVGResources::
 
 void ReferencedSVGResources::updateReferencedResources(TreeScope& treeScope, const ReferencedSVGResources::SVGElementIdentifierAndTagPairs& referencedResources)
 {
-    HashSet<AtomString> oldKeys;
+    UncheckedKeyHashSet<AtomString> oldKeys;
     for (auto& key : m_elementClients.keys())
         oldKeys.add(key);
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -208,7 +208,7 @@ void RenderBlockFlow::rebuildFloatingObjectSetFromIntrudingFloats()
     if (m_floatingObjects)
         m_floatingObjects->setHorizontalWritingMode(isHorizontalWritingMode());
 
-    HashSet<CheckedPtr<RenderBox>> oldIntrudingFloatSet;
+    UncheckedKeyHashSet<CheckedPtr<RenderBox>> oldIntrudingFloatSet;
     if (!childrenInline() && m_floatingObjects) {
         const FloatingObjectSet& floatingObjectSet = m_floatingObjects->set();
         auto end = floatingObjectSet.end();

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -125,7 +125,7 @@ private:
     bool m_forward;
     unsigned m_currentOrdinal;
     unsigned m_largestOrdinal;
-    HashSet<unsigned> m_ordinalValues;
+    UncheckedKeyHashSet<unsigned> m_ordinalValues;
     Vector<unsigned> m_sortedOrdinalValues;
     unsigned m_ordinalIteration;
 };

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -5842,7 +5842,7 @@ void RenderLayerCompositor::updateSynchronousScrollingNodes()
     ASSERT(scrollingCoordinator);
 
     auto rootScrollingNodeID = m_renderView.frameView().scrollingNodeID();
-    HashSet<ScrollingNodeID> nodesToClear;
+    UncheckedKeyHashSet<ScrollingNodeID> nodesToClear;
     nodesToClear.reserveInitialCapacity(m_scrollingNodeToLayerMap.size());
     for (auto key : m_scrollingNodeToLayerMap.keys())
         nodesToClear.add(key);

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2336,7 +2336,7 @@ static Vector<FloatRect> borderAndTextRects(const SimpleRange& range, Coordinate
 
     bool useVisibleBounds = behavior.contains(RenderObject::BoundingRectBehavior::UseVisibleBounds);
 
-    HashSet<RefPtr<Element>> selectedElementsSet;
+    UncheckedKeyHashSet<RefPtr<Element>> selectedElementsSet;
     for (Ref node : intersectingNodesWithDeprecatedZeroOffsetStartQuirk(range)) {
         if (RefPtr element = dynamicDowncast<Element>(WTFMove(node)))
             selectedElementsSet.add(element.releaseNonNull());

--- a/Source/WebCore/rendering/RenderSelection.cpp
+++ b/Source/WebCore/rendering/RenderSelection.cpp
@@ -143,7 +143,7 @@ void RenderSelection::clear()
 
 void RenderSelection::repaint() const
 {
-    HashSet<CheckedPtr<RenderBlock>> processedBlocks;
+    UncheckedKeyHashSet<CheckedPtr<RenderBlock>> processedBlocks;
     RenderObject* end = nullptr;
     if (m_renderRange.end())
         end = rendererAfterOffset(*m_renderRange.end(), m_renderRange.endOffset());

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -1289,7 +1289,7 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
             // To make sure we properly repaint the section, we repaint all the overflowing cells that we collected.
             auto cells = copyToVector(m_overflowingCells);
 
-            HashSet<CheckedPtr<RenderTableCell>> spanningCells;
+            UncheckedKeyHashSet<CheckedPtr<RenderTableCell>> spanningCells;
 
             for (unsigned r = dirtiedRows.start; r < dirtiedRows.end; r++) {
                 RenderTableRow* row = m_grid[r].rowRenderer;

--- a/Source/WebCore/rendering/TextAutoSizing.h
+++ b/Source/WebCore/rendering/TextAutoSizing.h
@@ -106,7 +106,7 @@ public:
 private:
     void reset();
 
-    HashSet<RefPtr<Text>> m_autoSizedNodes;
+    UncheckedKeyHashSet<RefPtr<Text>> m_autoSizedNodes;
 };
 
 struct TextAutoSizingTraits : HashTraits<TextAutoSizingKey> {

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -169,7 +169,7 @@ public:
     Style::Color textDecorationColor;
 
     DataRef<StyleCustomPropertyData> customProperties;
-    HashSet<AtomString> customPaintWatchedProperties;
+    UncheckedKeyHashSet<AtomString> customPaintWatchedProperties;
 
     RefPtr<RotateTransformOperation> rotate;
     RefPtr<ScaleTransformOperation> scale;

--- a/Source/WebCore/rendering/svg/SVGTextChunkBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextChunkBuilder.cpp
@@ -62,7 +62,7 @@ AffineTransform SVGTextChunkBuilder::transformationForTextBox(InlineIterator::SV
     return it == m_textBoxTransformations.end() ? AffineTransform() : it->value;
 }
 
-void SVGTextChunkBuilder::buildTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes, const HashSet<InlineIterator::SVGTextBox::Key>& chunkStarts, SVGTextFragmentMap& fragmentMap)
+void SVGTextChunkBuilder::buildTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes, const UncheckedKeyHashSet<InlineIterator::SVGTextBox::Key>& chunkStarts, SVGTextFragmentMap& fragmentMap)
 {
     if (lineLayoutBoxes.isEmpty())
         return;
@@ -87,7 +87,7 @@ void SVGTextChunkBuilder::buildTextChunks(const Vector<InlineIterator::SVGTextBo
         m_textChunks.append(SVGTextChunk(lineLayoutBoxes, first, limit, fragmentMap));
 }
 
-void SVGTextChunkBuilder::layoutTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes, const HashSet<InlineIterator::SVGTextBox::Key>& chunkStarts, SVGTextFragmentMap& fragmentMap)
+void SVGTextChunkBuilder::layoutTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes, const UncheckedKeyHashSet<InlineIterator::SVGTextBox::Key>& chunkStarts, SVGTextFragmentMap& fragmentMap)
 {
     buildTextChunks(lineLayoutBoxes, chunkStarts, fragmentMap);
     if (m_textChunks.isEmpty())

--- a/Source/WebCore/rendering/svg/SVGTextChunkBuilder.h
+++ b/Source/WebCore/rendering/svg/SVGTextChunkBuilder.h
@@ -47,8 +47,8 @@ public:
     float totalAnchorShift() const;
     AffineTransform transformationForTextBox(InlineIterator::SVGTextBoxIterator) const;
 
-    void buildTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes, const HashSet<InlineIterator::SVGTextBox::Key>& chunkStarts, SVGTextFragmentMap&);
-    void layoutTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes, const HashSet<InlineIterator::SVGTextBox::Key>& chunkStarts, SVGTextFragmentMap&);
+    void buildTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes, const UncheckedKeyHashSet<InlineIterator::SVGTextBox::Key>& chunkStarts, SVGTextFragmentMap&);
+    void layoutTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes, const UncheckedKeyHashSet<InlineIterator::SVGTextBox::Key>& chunkStarts, SVGTextFragmentMap&);
 
 private:
     Vector<SVGTextChunk> m_textChunks;

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
@@ -86,7 +86,7 @@ private:
     UncheckedKeyHashMap<InlineIterator::SVGTextBox::Key, Vector<SVGTextFragment>> m_fragmentMap;
 
     SVGTextChunkBuilder m_chunkLayoutBuilder;
-    HashSet<InlineIterator::SVGTextBox::Key> m_lineLayoutChunkStarts;
+    UncheckedKeyHashSet<InlineIterator::SVGTextBox::Key> m_lineLayoutChunkStarts;
 
     SVGTextFragment m_currentTextFragment;
     unsigned m_layoutAttributesPosition { 0 };

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -712,7 +712,7 @@ static AnchorsForAnchorName collectAnchorsForAnchorName(const Document& document
     return anchorsForAnchorName;
 }
 
-AnchorElements AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement(const Element& anchorPositionedElement, const HashSet<AtomString>& anchorNames, const AnchorsForAnchorName& anchorsForAnchorName)
+AnchorElements AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement(const Element& anchorPositionedElement, const UncheckedKeyHashSet<AtomString>& anchorNames, const AnchorsForAnchorName& anchorsForAnchorName)
 {
     AnchorElements anchorElements;
 

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -59,7 +59,7 @@ struct AnchorPositionedState {
     WTF_MAKE_TZONE_ALLOCATED(AnchorPositionedState);
 public:
     AnchorElements anchorElements;
-    HashSet<AtomString> anchorNames;
+    UncheckedKeyHashSet<AtomString> anchorNames;
     AnchorPositionResolutionStage stage;
 };
 
@@ -105,7 +105,7 @@ public:
     static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderBlock& containingBlock);
 
 private:
-    static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const HashSet<AtomString>& anchorNames, const AnchorsForAnchorName&);
+    static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const UncheckedKeyHashSet<AtomString>& anchorNames, const AnchorsForAnchorName&);
 };
 
 } // namespace Style

--- a/Source/WebCore/style/ChildChangeInvalidation.h
+++ b/Source/WebCore/style/ChildChangeInvalidation.h
@@ -45,7 +45,7 @@ private:
     void invalidateForHasAfterMutation();
     void invalidateAfterChange();
     void checkForSiblingStyleChanges();
-    using MatchingHasSelectors = HashSet<const CSSSelector*>;
+    using MatchingHasSelectors = UncheckedKeyHashSet<const CSSSelector*>;
     enum class ChangedElementRelation : uint8_t { SelfOrDescendant, Sibling };
     void invalidateForChangedElement(Element&, MatchingHasSelectors&, ChangedElementRelation);
     void invalidateForChangeOutsideHasScope();

--- a/Source/WebCore/style/InspectorCSSOMWrappers.h
+++ b/Source/WebCore/style/InspectorCSSOMWrappers.h
@@ -57,7 +57,7 @@ private:
     void maybeCollectFromStyleSheets(const Vector<RefPtr<CSSStyleSheet>>&);
 
     UncheckedKeyHashMap<const StyleRule*, RefPtr<CSSStyleRule>> m_styleRuleToCSSOMWrapperMap;
-    HashSet<RefPtr<CSSStyleSheet>> m_styleSheetCSSOMWrapperSet;
+    UncheckedKeyHashSet<RefPtr<CSSStyleSheet>> m_styleSheetCSSOMWrapperSet;
 };
 
 } // namespace Style

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -42,7 +42,7 @@ namespace Style {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PropertyCascade);
 
-PropertyCascade::PropertyCascade(const MatchResult& matchResult, CascadeLevel maximumCascadeLevel, OptionSet<PropertyType> includedProperties, const HashSet<AnimatableCSSProperty>* animatedProperties)
+PropertyCascade::PropertyCascade(const MatchResult& matchResult, CascadeLevel maximumCascadeLevel, OptionSet<PropertyType> includedProperties, const UncheckedKeyHashSet<AnimatableCSSProperty>* animatedProperties)
     : m_matchResult(matchResult)
     , m_includedProperties(includedProperties)
     , m_maximumCascadeLevel(maximumCascadeLevel)
@@ -64,7 +64,7 @@ PropertyCascade::PropertyCascade(const PropertyCascade& parent, CascadeLevel max
 
 PropertyCascade::~PropertyCascade() = default;
 
-PropertyCascade::AnimationLayer::AnimationLayer(const HashSet<AnimatableCSSProperty>& properties)
+PropertyCascade::AnimationLayer::AnimationLayer(const UncheckedKeyHashSet<AnimatableCSSProperty>& properties)
     : properties(properties)
 {
     hasCustomProperties = std::find_if(properties.begin(), properties.end(), [](auto& property) {
@@ -403,7 +403,7 @@ void PropertyCascade::sortLogicalGroupPropertyIDs()
     });
 }
 
-const HashSet<AnimatableCSSProperty> PropertyCascade::overriddenAnimatedProperties() const
+const UncheckedKeyHashSet<AnimatableCSSProperty> PropertyCascade::overriddenAnimatedProperties() const
 {
     if (m_animationLayer)
         return m_animationLayer->overriddenProperties;

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -54,7 +54,7 @@ public:
     static constexpr OptionSet<PropertyType> normalProperties() { return { PropertyType::NonInherited,  PropertyType::Inherited }; }
     static constexpr OptionSet<PropertyType> startingStyleProperties() { return normalProperties() | PropertyType::StartingStyle; }
 
-    PropertyCascade(const MatchResult&, CascadeLevel, OptionSet<PropertyType> includedProperties, const HashSet<AnimatableCSSProperty>* = nullptr);
+    PropertyCascade(const MatchResult&, CascadeLevel, OptionSet<PropertyType> includedProperties, const UncheckedKeyHashSet<AnimatableCSSProperty>* = nullptr);
     PropertyCascade(const PropertyCascade&, CascadeLevel, std::optional<ScopeOrdinal> rollbackScope = { }, std::optional<CascadeLayerPriority> maximumCascadeLayerPriorityForRollback = { });
 
     ~PropertyCascade();
@@ -84,7 +84,7 @@ public:
     std::span<const CSSPropertyID> logicalGroupPropertyIDs() const;
     const UncheckedKeyHashMap<AtomString, Property>& customProperties() const { return m_customProperties; }
 
-    const HashSet<AnimatableCSSProperty> overriddenAnimatedProperties() const;
+    const UncheckedKeyHashSet<AnimatableCSSProperty> overriddenAnimatedProperties() const;
 
     PropertyBitSet& propertyIsPresent() { return m_propertyIsPresent; }
     const PropertyBitSet& propertyIsPresent() const { return m_propertyIsPresent; }
@@ -113,10 +113,10 @@ private:
     const std::optional<CascadeLayerPriority> m_maximumCascadeLayerPriorityForRollback;
 
     struct AnimationLayer {
-        AnimationLayer(const HashSet<AnimatableCSSProperty>&);
+        AnimationLayer(const UncheckedKeyHashSet<AnimatableCSSProperty>&);
 
-        const HashSet<AnimatableCSSProperty>& properties;
-        HashSet<AnimatableCSSProperty> overriddenProperties;
+        const UncheckedKeyHashSet<AnimatableCSSProperty>& properties;
+        UncheckedKeyHashSet<AnimatableCSSProperty> overriddenProperties;
         bool hasCustomProperties { false };
         bool hasFontSize { false };
         bool hasLineHeight { false };

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -106,11 +106,11 @@ struct RuleFeatureSet {
     bool usesMatchElement(MatchElement matchElement) const { return usedMatchElements[enumToUnderlyingType(matchElement)]; }
     void setUsesMatchElement(MatchElement matchElement) { usedMatchElements[enumToUnderlyingType(matchElement)] = true; }
 
-    HashSet<AtomString> idsInRules;
-    HashSet<AtomString> idsMatchingAncestorsInRules;
-    HashSet<AtomString> attributeLowercaseLocalNamesInRules;
-    HashSet<AtomString> attributeLocalNamesInRules;
-    HashSet<AtomString> contentAttributeNamesInRules;
+    UncheckedKeyHashSet<AtomString> idsInRules;
+    UncheckedKeyHashSet<AtomString> idsMatchingAncestorsInRules;
+    UncheckedKeyHashSet<AtomString> attributeLowercaseLocalNamesInRules;
+    UncheckedKeyHashSet<AtomString> attributeLocalNamesInRules;
+    UncheckedKeyHashSet<AtomString> contentAttributeNamesInRules;
     Vector<RuleAndSelector> siblingRules;
     Vector<RuleAndSelector> uncommonAttributeRules;
 
@@ -121,10 +121,10 @@ struct RuleFeatureSet {
     UncheckedKeyHashMap<PseudoClassInvalidationKey, std::unique_ptr<Vector<RuleFeatureWithInvalidationSelector>>> hasPseudoClassRules;
     Vector<RuleAndSelector> scopeBreakingHasPseudoClassRules;
 
-    HashSet<AtomString> classesAffectingHost;
-    HashSet<AtomString> attributesAffectingHost;
-    HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>> pseudoClassesAffectingHost;
-    HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>> pseudoClasses;
+    UncheckedKeyHashSet<AtomString> classesAffectingHost;
+    UncheckedKeyHashSet<AtomString> attributesAffectingHost;
+    UncheckedKeyHashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>> pseudoClassesAffectingHost;
+    UncheckedKeyHashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>> pseudoClasses;
 
     std::array<bool, matchElementCount> usedMatchElements { };
 

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -67,7 +67,7 @@ private:
         struct DynamicContext {
             const MQ::MediaQueryList& queries;
             Vector<size_t> affectedRulePositions { };
-            HashSet<Ref<const StyleRule>> affectedRules { };
+            UncheckedKeyHashSet<Ref<const StyleRule>> affectedRules { };
         };
         Vector<DynamicContext> dynamicContextStack { };
 

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -88,7 +88,7 @@ inline bool isValidVisitedLinkProperty(CSSPropertyID id)
     return false;
 }
 
-Builder::Builder(RenderStyle& style, BuilderContext&& context, const MatchResult& matchResult, CascadeLevel cascadeLevel, OptionSet<PropertyCascade::PropertyType> includedProperties, const HashSet<AnimatableCSSProperty>* animatedPropertes)
+Builder::Builder(RenderStyle& style, BuilderContext&& context, const MatchResult& matchResult, CascadeLevel cascadeLevel, OptionSet<PropertyCascade::PropertyType> includedProperties, const UncheckedKeyHashSet<AnimatableCSSProperty>* animatedPropertes)
     : m_cascade(matchResult, cascadeLevel, includedProperties, animatedPropertes)
     , m_state(*this, style, WTFMove(context))
 {

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -38,7 +38,7 @@ namespace Style {
 class Builder {
     WTF_MAKE_TZONE_ALLOCATED(Builder);
 public:
-    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, CascadeLevel, OptionSet<PropertyCascade::PropertyType> = PropertyCascade::normalProperties(), const HashSet<AnimatableCSSProperty>* animatedProperties = nullptr);
+    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, CascadeLevel, OptionSet<PropertyCascade::PropertyType> = PropertyCascade::normalProperties(), const UncheckedKeyHashSet<AnimatableCSSProperty>* animatedProperties = nullptr);
     ~Builder();
 
     void applyAllProperties();
@@ -53,7 +53,7 @@ public:
 
     BuilderState& state() { return m_state; }
 
-    const HashSet<AnimatableCSSProperty> overriddenAnimatedProperties() const { return m_cascade.overriddenAnimatedProperties(); }
+    const UncheckedKeyHashSet<AnimatableCSSProperty> overriddenAnimatedProperties() const { return m_cascade.overriddenAnimatedProperties(); }
 
 private:
     void applyProperties(int firstProperty, int lastProperty);

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -148,9 +148,9 @@ private:
 
     const CSSToLengthConversionData m_cssToLengthConversionData;
 
-    HashSet<AtomString> m_appliedCustomProperties;
-    HashSet<AtomString> m_inProgressCustomProperties;
-    HashSet<AtomString> m_inCycleCustomProperties;
+    UncheckedKeyHashSet<AtomString> m_appliedCustomProperties;
+    UncheckedKeyHashSet<AtomString> m_inProgressCustomProperties;
+    UncheckedKeyHashSet<AtomString> m_inCycleCustomProperties;
     WTF::BitSet<numCSSProperties> m_inProgressProperties;
     WTF::BitSet<numCSSProperties> m_invalidAtComputedValueTimeProperties;
 

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -426,7 +426,7 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
         return &CubicBezierTimingFunction::defaultTimingFunction();
     };
 
-    HashSet<RefPtr<const TimingFunction>> timingFunctions;
+    UncheckedKeyHashSet<RefPtr<const TimingFunction>> timingFunctions;
     auto uniqueTimingFunctionForKeyframe = [&](Ref<StyleRuleKeyframe> keyframe) -> RefPtr<const TimingFunction> {
         auto timingFunction = timingFunctionForKeyframe(keyframe);
         for (auto existingTimingFunction : timingFunctions) {
@@ -442,7 +442,7 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
 
     using KeyframeUniqueKey = std::tuple<double, RefPtr<const TimingFunction>, CompositeOperation>;
     auto hasDuplicateKeys = [&]() -> bool {
-        HashSet<KeyframeUniqueKey> uniqueKeyframeKeys;
+        UncheckedKeyHashSet<KeyframeUniqueKey> uniqueKeyframeKeys;
         for (auto& keyframe : *keyframes) {
             auto compositeOperation = compositeOperationForKeyframe(keyframe);
             auto timingFunction = uniqueTimingFunctionForKeyframe(keyframe);

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -148,7 +148,7 @@ public:
     static Scope* forOrdinal(Element&, ScopeOrdinal);
 
     struct QueryContainerUpdateContext {
-        HashSet<CheckedRef<Element>> invalidatedContainers;
+        UncheckedKeyHashSet<CheckedRef<Element>> invalidatedContainers;
     };
     bool updateQueryContainerState(QueryContainerUpdateContext&);
 
@@ -225,7 +225,7 @@ private:
 
     Timer m_pendingUpdateTimer;
 
-    mutable HashSet<SingleThreadWeakRef<const CSSStyleSheet>> m_weakCopyOfActiveStyleSheetListForFastLookup;
+    mutable UncheckedKeyHashSet<SingleThreadWeakRef<const CSSStyleSheet>> m_weakCopyOfActiveStyleSheetListForFastLookup;
 
     // Track the currently loading top-level stylesheets needed for rendering.
     // Sheets loaded using the @import directive are not included in this count.

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -369,10 +369,10 @@ const Vector<InvalidationRuleSet>* ScopeRuleSets::hasPseudoClassInvalidationRule
     return ensureInvalidationRuleSets(key, m_hasPseudoClassInvalidationRuleSets, m_features.hasPseudoClassRules);
 }
 
-const HashSet<AtomString>& ScopeRuleSets::customPropertyNamesInStyleContainerQueries() const
+const UncheckedKeyHashSet<AtomString>& ScopeRuleSets::customPropertyNamesInStyleContainerQueries() const
 {
     if (!m_customPropertyNamesInStyleContainerQueries) {
-        HashSet<AtomString> propertyNames;
+        UncheckedKeyHashSet<AtomString> propertyNames;
 
         auto collectPropertyNames = [&](auto* ruleSet) {
             if (!ruleSet)

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -78,7 +78,7 @@ public:
     const Vector<InvalidationRuleSet>* pseudoClassInvalidationRuleSets(const PseudoClassInvalidationKey&) const;
     const Vector<InvalidationRuleSet>* hasPseudoClassInvalidationRuleSets(const PseudoClassInvalidationKey&) const;
 
-    const HashSet<AtomString>& customPropertyNamesInStyleContainerQueries() const;
+    const UncheckedKeyHashSet<AtomString>& customPropertyNamesInStyleContainerQueries() const;
 
     SelectorsForStyleAttribute selectorsForStyleAttribute() const;
 
@@ -130,7 +130,7 @@ private:
     mutable UncheckedKeyHashMap<PseudoClassInvalidationKey, std::unique_ptr<Vector<InvalidationRuleSet>>> m_pseudoClassInvalidationRuleSets;
     mutable UncheckedKeyHashMap<PseudoClassInvalidationKey, std::unique_ptr<Vector<InvalidationRuleSet>>> m_hasPseudoClassInvalidationRuleSets;
 
-    mutable std::optional<HashSet<AtomString>> m_customPropertyNamesInStyleContainerQueries;
+    mutable std::optional<UncheckedKeyHashSet<AtomString>> m_customPropertyNamesInStyleContainerQueries;
 
     mutable std::optional<SelectorsForStyleAttribute> m_cachedSelectorsForStyleAttribute;
 

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -703,7 +703,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
         styleable.setLastStyleChangeEventStyle(RenderStyle::clonePtr(*resolvedStyle.style));
 
         // Apply all keyframe effects to the new style.
-        HashSet<AnimatableCSSProperty> animatedProperties;
+        UncheckedKeyHashSet<AnimatableCSSProperty> animatedProperties;
         auto animatedStyle = RenderStyle::clonePtr(*resolvedStyle.style);
 
         auto animationImpact = styleable.applyKeyframeEffects(*animatedStyle, animatedProperties, previousLastStyleChangeEventStyle.get(), resolutionContext);
@@ -870,7 +870,7 @@ const RenderStyle& TreeResolver::parentAfterChangeStyle(const Styleable& styleab
     return *resolutionContext.parentStyle;
 }
 
-HashSet<AnimatableCSSProperty> TreeResolver::applyCascadeAfterAnimation(RenderStyle& animatedStyle, const HashSet<AnimatableCSSProperty>& animatedProperties, bool isTransition, const MatchResult& matchResult, const Element& element, const ResolutionContext& resolutionContext)
+UncheckedKeyHashSet<AnimatableCSSProperty> TreeResolver::applyCascadeAfterAnimation(RenderStyle& animatedStyle, const UncheckedKeyHashSet<AnimatableCSSProperty>& animatedProperties, bool isTransition, const MatchResult& matchResult, const Element& element, const ResolutionContext& resolutionContext)
 {
     auto builderContext = BuilderContext {
         m_document.get(),

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -87,7 +87,7 @@ private:
     std::unique_ptr<RenderStyle> resolveAgainWithParentStyle(const ResolvedStyle&, const Styleable&, const RenderStyle& parentStyle,  OptionSet<PropertyCascade::PropertyType>, const ResolutionContext&) const;
     const RenderStyle& parentAfterChangeStyle(const Styleable&, const ResolutionContext&) const;
 
-    HashSet<AnimatableCSSProperty> applyCascadeAfterAnimation(RenderStyle&, const HashSet<AnimatableCSSProperty>&, bool isTransition, const MatchResult&, const Element&, const ResolutionContext&);
+    UncheckedKeyHashSet<AnimatableCSSProperty> applyCascadeAfterAnimation(RenderStyle&, const UncheckedKeyHashSet<AnimatableCSSProperty>&, bool isTransition, const MatchResult&, const Element&, const ResolutionContext&);
 
     std::optional<ElementUpdate> resolvePseudoElement(Element&, const PseudoElementIdentifier&, const ElementUpdate&, IsInDisplayNoneTree);
     std::optional<ElementUpdate> resolveAncestorPseudoElement(Element&, const PseudoElementIdentifier&, const ElementUpdate&);

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -488,7 +488,7 @@ static bool transitionMatchesProperty(const Animation& transition, const Animata
     return false;
 }
 
-static void compileTransitionPropertiesInStyle(const RenderStyle& style, CSSPropertiesBitSet& transitionProperties, HashSet<AtomString>& transitionCustomProperties, bool& transitionPropertiesContainAll)
+static void compileTransitionPropertiesInStyle(const RenderStyle& style, CSSPropertiesBitSet& transitionProperties, UncheckedKeyHashSet<AtomString>& transitionCustomProperties, bool& transitionPropertiesContainAll)
 {
     auto* transitions = style.transitions();
     if (!transitions) {
@@ -774,7 +774,7 @@ void Styleable::updateCSSTransitions(const RenderStyle& currentStyle, const Rend
     // First, let's compile the list of all CSS properties found in the current style and the after-change style.
     bool transitionPropertiesContainAll = false;
     CSSPropertiesBitSet transitionProperties;
-    HashSet<AtomString> transitionCustomProperties;
+    UncheckedKeyHashSet<AtomString> transitionCustomProperties;
     compileTransitionPropertiesInStyle(currentStyle, transitionProperties, transitionCustomProperties, transitionPropertiesContainAll);
     compileTransitionPropertiesInStyle(newStyle, transitionProperties, transitionCustomProperties, transitionPropertiesContainAll);
 

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -102,7 +102,7 @@ struct Styleable {
         return element.hasKeyframeEffects(pseudoElementIdentifier);
     }
 
-    OptionSet<AnimationImpact> applyKeyframeEffects(RenderStyle& targetStyle, HashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext& resolutionContext) const
+    OptionSet<AnimationImpact> applyKeyframeEffects(RenderStyle& targetStyle, UncheckedKeyHashSet<AnimatableCSSProperty>& affectedProperties, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext& resolutionContext) const
     {
         return element.ensureKeyframeEffectStack(pseudoElementIdentifier).applyKeyframeEffects(targetStyle, affectedProperties, previousLastStyleChangeEventStyle, resolutionContext);
     }

--- a/Source/WebCore/svg/SVGFontElement.h
+++ b/Source/WebCore/svg/SVGFontElement.h
@@ -31,12 +31,12 @@ namespace WebCore {
 // Describe an SVG <hkern>/<vkern> element
 struct SVGKerningPair {
     UnicodeRanges unicodeRange1;
-    HashSet<String> unicodeName1;
-    HashSet<String> glyphName1;
+    UncheckedKeyHashSet<String> unicodeName1;
+    UncheckedKeyHashSet<String> glyphName1;
 
     UnicodeRanges unicodeRange2;
-    HashSet<String> unicodeName2;
-    HashSet<String> glyphName2;
+    UncheckedKeyHashSet<String> unicodeName2;
+    UncheckedKeyHashSet<String> glyphName2;
     float kerning { 0 };
 };
 

--- a/Source/WebCore/svg/SVGLinearGradientElement.cpp
+++ b/Source/WebCore/svg/SVGLinearGradientElement.cpp
@@ -142,7 +142,7 @@ bool SVGLinearGradientElement::collectGradientAttributes(LinearGradientAttribute
     if (!renderer())
         return false;
 
-    HashSet<Ref<SVGGradientElement>> processedGradients;
+    UncheckedKeyHashSet<Ref<SVGGradientElement>> processedGradients;
     Ref<SVGGradientElement> current { *this };
 
     setGradientAttributes(current.get(), attributes);

--- a/Source/WebCore/svg/SVGParserUtilities.cpp
+++ b/Source/WebCore/svg/SVGParserUtilities.cpp
@@ -260,14 +260,14 @@ std::optional<FloatRect> parseRect(StringView string)
     });
 }
 
-std::optional<HashSet<String>> parseGlyphName(StringView string)
+std::optional<UncheckedKeyHashSet<String>> parseGlyphName(StringView string)
 {
     // FIXME: Parsing error detection is missing.
 
-    return readCharactersForParsing(string, [](auto buffer) -> HashSet<String> {
+    return readCharactersForParsing(string, [](auto buffer) -> UncheckedKeyHashSet<String> {
         skipOptionalSVGSpaces(buffer);
 
-        HashSet<String> values;
+        UncheckedKeyHashSet<String> values;
 
         while (buffer.hasCharactersRemaining()) {
             // Leading and trailing white space, and white space before and after separators, will be ignored.
@@ -366,13 +366,13 @@ template<typename CharacterType> static std::optional<UnicodeRange> parseUnicode
     return range;
 }
 
-std::optional<std::pair<UnicodeRanges, HashSet<String>>> parseKerningUnicodeString(StringView string)
+std::optional<std::pair<UnicodeRanges, UncheckedKeyHashSet<String>>> parseKerningUnicodeString(StringView string)
 {
     // FIXME: Parsing error detection is missing.
 
-    return readCharactersForParsing(string, [](auto buffer) -> std::pair<UnicodeRanges, HashSet<String>> {
+    return readCharactersForParsing(string, [](auto buffer) -> std::pair<UnicodeRanges, UncheckedKeyHashSet<String>> {
         UnicodeRanges rangeList;
-        HashSet<String> stringList;
+        UncheckedKeyHashSet<String> stringList;
 
         while (1) {
             auto inputStart = buffer.position();

--- a/Source/WebCore/svg/SVGParserUtilities.h
+++ b/Source/WebCore/svg/SVGParserUtilities.h
@@ -52,8 +52,8 @@ std::optional<FloatRect> parseRect(StringView);
 std::optional<FloatPoint> parseFloatPoint(StringParsingBuffer<LChar>&);
 std::optional<FloatPoint> parseFloatPoint(StringParsingBuffer<UChar>&);
 
-std::optional<std::pair<UnicodeRanges, HashSet<String>>> parseKerningUnicodeString(StringView);
-std::optional<HashSet<String>> parseGlyphName(StringView);
+std::optional<std::pair<UnicodeRanges, UncheckedKeyHashSet<String>>> parseKerningUnicodeString(StringView);
+std::optional<UncheckedKeyHashSet<String>> parseGlyphName(StringView);
 
 template<typename CharacterType> constexpr bool isSVGSpaceOrComma(CharacterType c)
 {

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -155,7 +155,7 @@ bool SVGRadialGradientElement::collectGradientAttributes(RadialGradientAttribute
     if (!renderer())
         return false;
 
-    HashSet<RefPtr<SVGGradientElement>> processedGradients;
+    UncheckedKeyHashSet<RefPtr<SVGGradientElement>> processedGradients;
     RefPtr<SVGGradientElement> current = this;
 
     setGradientAttributes(*current, attributes);

--- a/Source/WebCore/svg/SVGToOTFFontConversion.cpp
+++ b/Source/WebCore/svg/SVGToOTFFontConversion.cpp
@@ -232,9 +232,9 @@ private:
 
     Vector<char> transcodeGlyphPaths(float width, const SVGElement& glyphOrMissingGlyphElement, std::optional<FloatRect>& boundingBox) const;
 
-    void addCodepointRanges(const UnicodeRanges&, HashSet<Glyph>& glyphSet) const;
-    void addCodepoints(const HashSet<String>& codepoints, HashSet<Glyph>& glyphSet) const;
-    void addGlyphNames(const HashSet<String>& glyphNames, HashSet<Glyph>& glyphSet) const;
+    void addCodepointRanges(const UnicodeRanges&, UncheckedKeyHashSet<Glyph>& glyphSet) const;
+    void addCodepoints(const UncheckedKeyHashSet<String>& codepoints, UncheckedKeyHashSet<Glyph>& glyphSet) const;
+    void addGlyphNames(const UncheckedKeyHashSet<String>& glyphNames, UncheckedKeyHashSet<Glyph>& glyphSet) const;
     void addKerningPair(Vector<KerningData>&, SVGKerningPair&&) const;
     template<typename T> size_t appendKERNSubtable(std::optional<SVGKerningPair> (T::*buildKerningPair)() const, uint16_t coverage);
     size_t finishAppendingKERNSubtable(Vector<KerningData>, uint16_t coverage);
@@ -1018,7 +1018,7 @@ Vector<Glyph, 1> SVGToOTFFontConverter::glyphsForCodepoint(char32_t codepoint) c
     return m_codepointsToIndicesMap.get(codepointToString(codepoint));
 }
 
-void SVGToOTFFontConverter::addCodepointRanges(const UnicodeRanges& unicodeRanges, HashSet<Glyph>& glyphSet) const
+void SVGToOTFFontConverter::addCodepointRanges(const UnicodeRanges& unicodeRanges, UncheckedKeyHashSet<Glyph>& glyphSet) const
 {
     for (auto& unicodeRange : unicodeRanges) {
         for (auto codepoint = unicodeRange.first; codepoint <= unicodeRange.second; ++codepoint) {
@@ -1028,7 +1028,7 @@ void SVGToOTFFontConverter::addCodepointRanges(const UnicodeRanges& unicodeRange
     }
 }
 
-void SVGToOTFFontConverter::addCodepoints(const HashSet<String>& codepoints, HashSet<Glyph>& glyphSet) const
+void SVGToOTFFontConverter::addCodepoints(const UncheckedKeyHashSet<String>& codepoints, UncheckedKeyHashSet<Glyph>& glyphSet) const
 {
     for (auto& codepointString : codepoints) {
         for (auto index : m_codepointsToIndicesMap.get(codepointString))
@@ -1036,7 +1036,7 @@ void SVGToOTFFontConverter::addCodepoints(const HashSet<String>& codepoints, Has
     }
 }
 
-void SVGToOTFFontConverter::addGlyphNames(const HashSet<String>& glyphNames, HashSet<Glyph>& glyphSet) const
+void SVGToOTFFontConverter::addGlyphNames(const UncheckedKeyHashSet<String>& glyphNames, UncheckedKeyHashSet<Glyph>& glyphSet) const
 {
     for (auto& glyphName : glyphNames) {
         if (Glyph glyph = m_glyphNameToIndexMap.get(glyphName))
@@ -1046,8 +1046,8 @@ void SVGToOTFFontConverter::addGlyphNames(const HashSet<String>& glyphNames, Has
 
 void SVGToOTFFontConverter::addKerningPair(Vector<KerningData>& data, SVGKerningPair&& kerningPair) const
 {
-    HashSet<Glyph> glyphSet1;
-    HashSet<Glyph> glyphSet2;
+    UncheckedKeyHashSet<Glyph> glyphSet1;
+    UncheckedKeyHashSet<Glyph> glyphSet2;
 
     addCodepointRanges(kerningPair.unicodeRange1, glyphSet1);
     addCodepointRanges(kerningPair.unicodeRange2, glyphSet2);
@@ -1307,8 +1307,8 @@ void SVGToOTFFontConverter::processGlyphElement(const SVGElement& glyphOrMissing
 
 void SVGToOTFFontConverter::appendLigatureGlyphs()
 {
-    HashSet<uint32_t> ligatureCodepoints;
-    HashSet<uint32_t> nonLigatureCodepoints;
+    UncheckedKeyHashSet<uint32_t> ligatureCodepoints;
+    UncheckedKeyHashSet<uint32_t> nonLigatureCodepoints;
     for (auto& glyph : m_glyphs) {
         auto codePoints = StringView(glyph.codepoints).codePoints();
         auto codePointsIterator = codePoints.begin();

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -455,7 +455,7 @@ void SVGSMILElement::parseBeginOrEnd(StringView parseString, BeginOrEnd beginOrE
     Vector<SMILTimeWithOrigin>& timeList = beginOrEnd == Begin ? m_beginTimes : m_endTimes;
     if (beginOrEnd == End)
         m_hasEndEventConditions = false;
-    HashSet<double> existing;
+    UncheckedKeyHashSet<double> existing;
     for (auto& time : timeList)
         existing.add(time.time().value());
     for (auto string : parseString.split(';')) {

--- a/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
+++ b/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
@@ -310,7 +310,7 @@ public:
 
     bool isAnimatedStylePropertyAttribute(const QualifiedName& attributeName) const override
     {
-        static NeverDestroyed<HashSet<QualifiedName::QualifiedNameImpl*>> animatedStyleAttributes = std::initializer_list<QualifiedName::QualifiedNameImpl*> {
+        static NeverDestroyed<UncheckedKeyHashSet<QualifiedName::QualifiedNameImpl*>> animatedStyleAttributes = std::initializer_list<QualifiedName::QualifiedNameImpl*> {
             SVGNames::cxAttr->impl(),
             SVGNames::cyAttr->impl(),
             SVGNames::rAttr->impl(),

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -597,8 +597,8 @@ template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTrai
     }
 };
 
-template<typename KeyArg, typename HashArg, typename KeyTraitsArg, typename HashTableTraits> struct ArgumentCoder<HashSet<KeyArg, HashArg, KeyTraitsArg, HashTableTraits>> {
-    typedef HashSet<KeyArg, HashArg, KeyTraitsArg, HashTableTraits> HashSetType;
+template<typename KeyArg, typename HashArg, typename KeyTraitsArg, typename HashTableTraits, WTF::ShouldValidateKey shouldValidateKey> struct ArgumentCoder<HashSet<KeyArg, HashArg, KeyTraitsArg, HashTableTraits, shouldValidateKey>> {
+    typedef HashSet<KeyArg, HashArg, KeyTraitsArg, HashTableTraits, shouldValidateKey> HashSetType;
 
     template<typename Encoder>
     static void encode(Encoder& encoder, const HashSetType& hashSet)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -898,7 +898,7 @@ struct WebCore::ShareData {
 enum class WebCore::ShareDataOriginator : bool
 
 using WebCore::TargetedElementIdentifiers = std::pair<WebCore::ElementIdentifier, WebCore::ScriptExecutionContextIdentifier>;
-using WebCore::TargetedElementSelectors = Vector<HashSet<String>>;
+using WebCore::TargetedElementSelectors = Vector<UncheckedKeyHashSet<String>>;
 
 header: <WebCore/ElementTargetingTypes.h>
 [CustomHeader] struct WebCore::TargetedElementAdjustment {
@@ -926,7 +926,7 @@ header: <WebCore/ElementTargetingTypes.h>
     WebCore::FloatRect boundsInClientCoordinates
     WebCore::PositionType positionType
     Vector<WebCore::FrameIdentifier> childFrameIdentifiers
-    HashSet<URL> mediaAndLinkURLs;
+    UncheckedKeyHashSet<URL> mediaAndLinkURLs;
     bool isNearbyTarget
     bool isPseudoElement
     bool isInShadowTree
@@ -4462,7 +4462,7 @@ using WebCore::CDMInstanceSession::KeyStatusVector = Vector<std::pair<Ref<WebCor
 struct WebCore::CDMRestrictions {
     bool distinctiveIdentifierDenied;
     bool persistentStateDenied;
-    HashSet<WebCore::CDMSessionType, IntHash<WebCore::CDMSessionType>, WTF::StrongEnumHashTraits<WebCore::CDMSessionType>> deniedSessionTypes;
+    UncheckedKeyHashSet<WebCore::CDMSessionType, IntHash<WebCore::CDMSessionType>, WTF::StrongEnumHashTraits<WebCore::CDMSessionType>> deniedSessionTypes;
 };
 
 #endif
@@ -5220,7 +5220,7 @@ header: <WebCore/ImageTypes.h>
 };
 
 struct WebCore::CanvasActivityRecord {
-    HashSet<String> textWritten;
+    UncheckedKeyHashSet<String> textWritten;
     bool wasDataRead;
 };
 
@@ -8512,7 +8512,7 @@ using WebCore::GlyphBufferAdvance = WebCore::FloatSize
 using WebCore::Glyph = unsigned short
 
 enum class WebCore::ContentExtensionDefaultEnablement : bool
-using WebCore::ContentExtensionEnablement = std::pair<WebCore::ContentExtensionDefaultEnablement, HashSet<String>>;
+using WebCore::ContentExtensionEnablement = std::pair<WebCore::ContentExtensionDefaultEnablement, UncheckedKeyHashSet<String>>;
 
 #if USE(CG)
 using WebCore::DisplayList::Item = std::variant<WebCore::DisplayList::ApplyDeviceScaleFactor, WebCore::DisplayList::BeginTransparencyLayer, WebCore::DisplayList::BeginTransparencyLayerWithCompositeMode, WebCore::DisplayList::ClearRect, WebCore::DisplayList::ClearDropShadow, WebCore::DisplayList::Clip, WebCore::DisplayList::ClipRoundedRect, WebCore::DisplayList::ClipOut, WebCore::DisplayList::ClipOutRoundedRect, WebCore::DisplayList::ClipOutToPath, WebCore::DisplayList::ClipPath, WebCore::DisplayList::ClipToImageBuffer, WebCore::DisplayList::ConcatenateCTM, WebCore::DisplayList::DrawControlPart, WebCore::DisplayList::DrawDotsForDocumentMarker, WebCore::DisplayList::DrawEllipse, WebCore::DisplayList::DrawFilteredImageBuffer, WebCore::DisplayList::DrawFocusRingPath, WebCore::DisplayList::DrawFocusRingRects, WebCore::DisplayList::DrawGlyphs, WebCore::DisplayList::DrawDecomposedGlyphs, WebCore::DisplayList::DrawDisplayListItems, WebCore::DisplayList::DrawImageBuffer, WebCore::DisplayList::DrawLine, WebCore::DisplayList::DrawLinesForText, WebCore::DisplayList::DrawNativeImage, WebCore::DisplayList::DrawPath, WebCore::DisplayList::DrawPattern, WebCore::DisplayList::DrawRect, WebCore::DisplayList::DrawSystemImage, WebCore::DisplayList::EndTransparencyLayer, WebCore::DisplayList::FillCompositedRect, WebCore::DisplayList::FillEllipse, WebCore::DisplayList::FillPathSegment, WebCore::DisplayList::FillPath, WebCore::DisplayList::FillRect, WebCore::DisplayList::FillRectWithColor, WebCore::DisplayList::FillRectWithGradient, WebCore::DisplayList::FillRectWithGradientAndSpaceTransform, WebCore::DisplayList::FillRectWithRoundedHole, WebCore::DisplayList::FillRoundedRect, WebCore::DisplayList::ResetClip, WebCore::DisplayList::Restore, WebCore::DisplayList::Rotate, WebCore::DisplayList::Save, WebCore::DisplayList::Scale, WebCore::DisplayList::SetCTM, WebCore::DisplayList::SetInlineFillColor, WebCore::DisplayList::SetInlineStroke, WebCore::DisplayList::SetLineCap, WebCore::DisplayList::SetLineDash, WebCore::DisplayList::SetLineJoin, WebCore::DisplayList::SetMiterLimit, WebCore::DisplayList::SetState, WebCore::DisplayList::StrokeEllipse, WebCore::DisplayList::StrokeLine, WebCore::DisplayList::StrokePathSegment, WebCore::DisplayList::StrokePath, WebCore::DisplayList::StrokeRect, WebCore::DisplayList::Translate, WebCore::DisplayList::FillLine, WebCore::DisplayList::FillArc, WebCore::DisplayList::FillClosedArc, WebCore::DisplayList::FillQuadCurve, WebCore::DisplayList::FillBezierCurve, WebCore::DisplayList::StrokeArc, WebCore::DisplayList::StrokeClosedArc, WebCore::DisplayList::StrokeQuadCurve, WebCore::DisplayList::StrokeBezierCurve, WebCore::DisplayList::ApplyFillPattern, WebCore::DisplayList::ApplyStrokePattern, WebCore::DisplayList::BeginPage, WebCore::DisplayList::EndPage, WebCore::DisplayList::SetURLForRect>;
@@ -8687,7 +8687,7 @@ enum class WebCore::FromDownloadAttribute : bool
 };
 
 class WebCore::Allowlist {
-    std::variant<HashSet<WebCore::SecurityOriginData>, WebCore::Allowlist::AllowAllOrigins> origins()
+    std::variant<UncheckedKeyHashSet<WebCore::SecurityOriginData>, WebCore::Allowlist::AllowAllOrigins> origins()
 };
 
 struct WebCore::OwnerPermissionsPolicyData {

--- a/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
@@ -70,7 +70,7 @@ public:
     bool hasLargeReplacedDescendant() const { return m_info.hasLargeReplacedDescendant; }
     bool hasAudibleMedia() const { return m_info.hasAudibleMedia; }
 
-    const HashSet<WTF::URL>& mediaAndLinkURLs() const { return m_info.mediaAndLinkURLs; }
+    const UncheckedKeyHashSet<WTF::URL>& mediaAndLinkURLs() const { return m_info.mediaAndLinkURLs; }
 
     void childFrames(CompletionHandler<void(Vector<Ref<FrameTreeNode>>&&)>&&) const;
 

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -137,8 +137,8 @@ public:
     bool isUpgradeWithUserMediatedFallbackEnabled() { return advancedPrivacyProtections().contains(WebCore::AdvancedPrivacyProtections::HTTPSOnly) || httpsByDefaultMode() == WebCore::HTTPSByDefaultMode::UpgradeWithUserMediatedFallback; }
     bool isUpgradeWithAutomaticFallbackEnabled() { return advancedPrivacyProtections().contains(WebCore::AdvancedPrivacyProtections::HTTPSFirst) || httpsByDefaultMode() == WebCore::HTTPSByDefaultMode::UpgradeWithAutomaticFallback; }
 
-    const Vector<Vector<HashSet<WTF::String>>>& visibilityAdjustmentSelectors() const { return m_data.visibilityAdjustmentSelectors; }
-    void setVisibilityAdjustmentSelectors(Vector<Vector<HashSet<WTF::String>>>&& selectors) { m_data.visibilityAdjustmentSelectors = WTFMove(selectors); }
+    const Vector<Vector<UncheckedKeyHashSet<WTF::String>>>& visibilityAdjustmentSelectors() const { return m_data.visibilityAdjustmentSelectors; }
+    void setVisibilityAdjustmentSelectors(Vector<Vector<UncheckedKeyHashSet<WTF::String>>>&& selectors) { m_data.visibilityAdjustmentSelectors = WTFMove(selectors); }
 
     WebKit::WebsitePushAndNotificationsEnabledPolicy pushAndNotificationsEnabledPolicy() const { return m_data.pushAndNotificationsEnabledPolicy; }
     void setPushAndNotificationsEnabledPolicy(WebKit::WebsitePushAndNotificationsEnabledPolicy policy) { m_data.pushAndNotificationsEnabledPolicy = policy; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -208,7 +208,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (void)_setContentRuleListsEnabled:(BOOL)enabled exceptions:(NSSet<NSString *> *)identifiers
 {
-    HashSet<String> exceptions;
+    UncheckedKeyHashSet<String> exceptions;
     exceptions.reserveInitialCapacity(identifiers.count);
     for (NSString *identifier in identifiers)
         exceptions.add(identifier);
@@ -708,7 +708,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
         WebCore::TargetedElementSelectors selectorsForElement;
         selectorsForElement.reserveInitialCapacity(nsSelectorsForElement.count);
         for (NSSet<NSString *> *nsSelectors in nsSelectorsForElement) {
-            HashSet<String> selectors;
+            UncheckedKeyHashSet<String> selectors;
             selectors.reserveInitialCapacity(nsSelectors.count);
             for (NSString *selector in nsSelectors)
                 selectors.add(selector);

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm
@@ -80,7 +80,7 @@
     WebCore::TargetedElementSelectors selectorsForElement;
     selectorsForElement.reserveInitialCapacity(nsSelectorsForElement.count);
     for (NSSet<NSString *> *nsSelectors in nsSelectorsForElement) {
-        HashSet<String> selectors;
+        UncheckedKeyHashSet<String> selectors;
         selectors.reserveInitialCapacity(nsSelectors.count);
         for (NSString *selector in nsSelectors)
             selectors.add(selector);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -245,7 +245,7 @@ void RemoteScrollingTree::removeWheelEventTestCompletionDeferralForReason(Scroll
     scrollingCoordinatorProxy->removeWheelEventTestCompletionDeferralForReason(nodeID, reason);
 }
 
-void RemoteScrollingTree::propagateSynchronousScrollingReasons(const HashSet<ScrollingNodeID>& synchronousScrollingNodes)
+void RemoteScrollingTree::propagateSynchronousScrollingReasons(const UncheckedKeyHashSet<ScrollingNodeID>& synchronousScrollingNodes)
 {
     m_hasNodesWithSynchronousScrollingReasons = !synchronousScrollingNodes.isEmpty();
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -85,7 +85,7 @@ protected:
     void receivedWheelEventWithPhases(WebCore::PlatformWheelEventPhase phase, WebCore::PlatformWheelEventPhase momentumPhase) override;
     void deferWheelEventTestCompletionForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason) override;
     void removeWheelEventTestCompletionDeferralForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason) override;
-    void propagateSynchronousScrollingReasons(const HashSet<WebCore::ScrollingNodeID>&) WTF_REQUIRES_LOCK(m_treeLock) override;
+    void propagateSynchronousScrollingReasons(const UncheckedKeyHashSet<WebCore::ScrollingNodeID>&) WTF_REQUIRES_LOCK(m_treeLock) override;
 
     // This gets nulled out via invalidate(), since the scrolling thread can hold a ref to the ScrollingTree after the RemoteScrollingCoordinatorProxy has gone away.
     WeakPtr<RemoteScrollingCoordinatorProxy> m_scrollingCoordinatorProxy;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -15690,7 +15690,7 @@ void WebPageProxy::adjustVisibilityForTargetedElements(const Vector<Ref<API::Tar
         return {
             { info->elementIdentifier(), info->documentIdentifier() },
             info->selectors().map([](auto& selectors) {
-                HashSet<String> result;
+                UncheckedKeyHashSet<String> result;
                 result.reserveInitialCapacity(selectors.size());
                 result.add(selectors.begin(), selectors.end());
                 return result;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -177,7 +177,7 @@ private:
     void coverageRectDidChange(WebCore::TiledBacking&, const WebCore::FloatRect&) final;
 
     void willRevalidateTiles(WebCore::TiledBacking&, WebCore::TileGridIdentifier, WebCore::TileRevalidationType) final;
-    void didRevalidateTiles(WebCore::TiledBacking&, WebCore::TileGridIdentifier, WebCore::TileRevalidationType, const HashSet<WebCore::TileIndex>& tilesNeedingDisplay) final;
+    void didRevalidateTiles(WebCore::TiledBacking&, WebCore::TileGridIdentifier, WebCore::TileRevalidationType, const UncheckedKeyHashSet<WebCore::TileIndex>& tilesNeedingDisplay) final;
 
     void willRepaintTilesAfterScaleFactorChange(WebCore::TiledBacking&, WebCore::TileGridIdentifier) final;
     void didRepaintTilesAfterScaleFactorChange(WebCore::TiledBacking&, WebCore::TileGridIdentifier) final;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm
@@ -341,7 +341,7 @@ void AsyncPDFRenderer::willRevalidateTiles(TiledBacking&, TileGridIdentifier gri
     gridState.inFullTileRevalidation = true;
 }
 
-void AsyncPDFRenderer::didRevalidateTiles(TiledBacking& tiledBacking, TileGridIdentifier gridIdentifier, TileRevalidationType revalidationType, const HashSet<TileIndex>& tilesNeedingDisplay)
+void AsyncPDFRenderer::didRevalidateTiles(TiledBacking& tiledBacking, TileGridIdentifier gridIdentifier, TileRevalidationType revalidationType, const UncheckedKeyHashSet<TileIndex>& tilesNeedingDisplay)
 {
     LOG_WITH_STREAM(PDFAsyncRendering, stream << "AsyncPDFRenderer::didRevalidateTiles for grid " << gridIdentifier << " is full revalidation " << (revalidationType == TileRevalidationType::Full) << " scale " << tiledBacking.tilingScaleFactor() << " - tiles to repaint " << tilesNeedingDisplay << " (saved " << m_rendereredTilesForOldState.size() << " old tiles)\n");
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1575,7 +1575,7 @@ void WebProcess::reloadExecutionContextsForOrigin(const ClientOrigin& origin, st
 void WebProcess::deleteWebsiteDataForOrigins(OptionSet<WebsiteDataType> websiteDataTypes, const Vector<WebCore::SecurityOriginData>& originDatas, CompletionHandler<void()>&& completionHandler)
 {
     if (websiteDataTypes.contains(WebsiteDataType::MemoryCache)) {
-        HashSet<RefPtr<SecurityOrigin>> origins;
+        UncheckedKeyHashSet<RefPtr<SecurityOrigin>> origins;
         for (auto& originData : originDatas)
             origins.add(originData.securityOrigin());
 

--- a/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
@@ -536,10 +536,10 @@ TEST_F(WTF_URL, URLRemoveQueryParameters)
     auto url14 = createURL("http://www.webkit.org/?u+v=x+%20y&key1=foo"_s);
     auto url15 = createURL("http://www.webkit.org/?u+v=x+%20y"_s);
 
-    HashSet<String> keyRemovalSet1 { "key"_s };
-    HashSet<String> keyRemovalSet2 { "key1"_s };
-    HashSet<String> keyRemovalSet3 { "key2"_s };
-    HashSet<String> keyRemovalSet4 { "key"_s, "key1"_s };
+    UncheckedKeyHashSet<String> keyRemovalSet1 { "key"_s };
+    UncheckedKeyHashSet<String> keyRemovalSet2 { "key1"_s };
+    UncheckedKeyHashSet<String> keyRemovalSet3 { "key2"_s };
+    UncheckedKeyHashSet<String> keyRemovalSet4 { "key"_s, "key1"_s };
 
     auto checkRemovedParameters = [](int lineNumber, const Vector<String>& removedParameters, std::initializer_list<String>&& expected) {
         Vector<String> expectedParameters { WTFMove(expected) };


### PR DESCRIPTION
#### c9de3ea5b01e1f4edadfc9d155b76b444f8aec7c
<pre>
Make HashSet validate its key by default in release builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=285372">https://bugs.webkit.org/show_bug.cgi?id=285372</a>

Reviewed by Ryosuke Niwa.

Make HashSet validate its key by default in release builds, similarly to
what we did for HashMap.

* Source/JavaScriptCore/API/JSValue.mm:
(createStructHandlerMap):
* Source/JavaScriptCore/API/ObjcRuntimeExtras.h:
(forEachProtocolImplementingProtocol):
* Source/JavaScriptCore/b3/B3CanonicalizePrePostIncrements.cpp:
(JSC::B3::canonicalizePrePostIncrements):
* Source/JavaScriptCore/b3/B3LowerInt64.cpp:
* Source/JavaScriptCore/b3/B3OptimizeAssociativeExpressionTrees.cpp:
(JSC::B3::OptimizeAssociativeExpressionTrees::run):
* Source/JavaScriptCore/b3/B3Procedure.h:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp:
(JSC::B3::Air::GenerateAndAllocateRegisters::prepareForGeneration):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp:
* Source/JavaScriptCore/b3/air/AirCustom.cpp:
(JSC::B3::Air::ShuffleCustom::isValidForm):
* Source/JavaScriptCore/b3/air/AirValidate.cpp:
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::finishCreation):
(JSC::CodeBlock::hasIdentifier):
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/bytecode/DFGExitProfile.h:
* Source/JavaScriptCore/bytecode/SharedJITStubSet.h:
* Source/JavaScriptCore/bytecode/TrackedReferences.h:
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp:
(JSC::UnlinkedCodeBlock::hasIdentifier):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::getAvailablePrivateAccessNames):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
* Source/JavaScriptCore/bytecompiler/StaticPropertyAnalysis.h:
* Source/JavaScriptCore/debugger/Debugger.cpp:
(JSC::Debugger::~Debugger):
(JSC::Debugger::attach):
* Source/JavaScriptCore/debugger/Debugger.h:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::dump):
* Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/dfg/DFGCSEPhase.cpp:
* Source/JavaScriptCore/dfg/DFGClobberSet.cpp:
(JSC::DFG::ClobberSet::direct const):
(JSC::DFG::ClobberSet::super const):
(JSC::DFG::ClobberSet::setOf const):
* Source/JavaScriptCore/dfg/DFGClobberSet.h:
* Source/JavaScriptCore/dfg/DFGCommonData.cpp:
(JSC::DFG::CommonData::installVMTrapBreakpoints):
* Source/JavaScriptCore/dfg/DFGDesiredGlobalProperties.h:
* Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.h:
* Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.h:
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGLivenessAnalysisPhase.cpp:
* Source/JavaScriptCore/dfg/DFGNode.h:
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGPhiChildren.h:
(JSC::DFG::PhiChildren::forAllTransitiveIncomingValues):
* Source/JavaScriptCore/dfg/DFGPutStackSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp:
* Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp:
* Source/JavaScriptCore/dfg/DFGValidate.cpp:
* Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp:
(JSC::DFG::ValueRepReductionPhase::convertValueRepsToDouble):
* Source/JavaScriptCore/dfg/DFGVarargsForwardingPhase.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp:
(JSC::FTL::compileStub):
* Source/JavaScriptCore/ftl/FTLState.cpp:
(JSC::FTL::State::dumpDisassembly):
* Source/JavaScriptCore/heap/CodeBlockSet.cpp:
(JSC::CodeBlockSet::contains):
* Source/JavaScriptCore/heap/CodeBlockSet.h:
* Source/JavaScriptCore/heap/ConservativeRoots.cpp:
(JSC::ConservativeRoots::genericAddPointer):
* Source/JavaScriptCore/heap/ConservativeRoots.h:
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/HeapInlines.h:
* Source/JavaScriptCore/heap/HeapSnapshotBuilder.h:
* Source/JavaScriptCore/heap/HeapUtil.h:
(JSC::HeapUtil::isPointerGCObjectJSCell):
* Source/JavaScriptCore/heap/MarkedBlockSet.h:
(JSC::MarkedBlockSet::recomputeFilter):
(JSC:: const):
* Source/JavaScriptCore/heap/MarkedSpace.cpp:
(JSC::MarkedSpace::enablePreciseAllocationTracking):
* Source/JavaScriptCore/heap/MarkedSpace.h:
(JSC::MarkedSpace:: const):
* Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp:
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::InspectorDebuggerAgent::setShouldBlackboxURL):
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h:
* Source/JavaScriptCore/inspector/remote/RemoteInspector.h:
* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.h:
* Source/JavaScriptCore/jit/JITThunks.h:
* Source/JavaScriptCore/jit/JITWorklist.cpp:
(JSC::JITWorklist::removeMatchingPlansForVM):
* Source/JavaScriptCore/jsc.cpp:
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseInner):
(JSC::Parser&lt;LexerType&gt;::parseImportAttributes):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Scope:: const):
* Source/JavaScriptCore/parser/VariableEnvironment.h:
* Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp:
(JSC::AbstractModuleRecord::resolveExportImpl):
(JSC::getExportedNames):
* Source/JavaScriptCore/runtime/ArgList.h:
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedHashSet::encode):
(JSC::CachedHashSet::decode const):
* Source/JavaScriptCore/runtime/CodeCache.h:
* Source/JavaScriptCore/runtime/DeferredWorkTimer.h:
* Source/JavaScriptCore/runtime/Identifier.h:
* Source/JavaScriptCore/runtime/ImportMap.cpp:
(JSC::ImportMap::addModuleToResolvedModuleSet):
* Source/JavaScriptCore/runtime/ImportMap.h:
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::canonicalizeLocaleList):
(JSC::LanguageTagParser::parseUnicodeLanguageId):
* Source/JavaScriptCore/runtime/IntlPluralRules.cpp:
(JSC::IntlPluralRules::resolvedOptions const):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::haveABadTime):
* Source/JavaScriptCore/runtime/JSRunLoopTimer.h:
* Source/JavaScriptCore/runtime/JSScope.h:
* Source/JavaScriptCore/runtime/LiteralParser.h:
* Source/JavaScriptCore/runtime/NativeCalleeRegistry.h:
(JSC::NativeCalleeRegistry::WTF_REQUIRES_LOCK):
* Source/JavaScriptCore/runtime/PropertyNameArray.h:
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::ProxyObject::performGetOwnPropertyNames):
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::registerForReportAtExit):
* Source/JavaScriptCore/runtime/SamplingProfiler.h:
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::dumpStatistics):
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::forEachPropertyConcurrently):
* Source/JavaScriptCore/runtime/TypeSet.h:
* Source/JavaScriptCore/runtime/VM.h:
* Source/JavaScriptCore/runtime/WeakGCSet.h:
* Source/JavaScriptCore/tools/FunctionAllowlist.h:
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmEntryPlan.h:
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::computeTransitiveTailCalls const):
* Source/JavaScriptCore/wasm/WasmIPIntPlan.h:
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::computeTransitiveTailCalls const):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.h:
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::dumpDisassembly):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseExport):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
* Source/JavaScriptCore/yarr/YarrParser.h:
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/HashSet.h:
(WTF::shouldValidateKey&gt;::swap):
(WTF::shouldValidateKey&gt;::size const):
(WTF::shouldValidateKey&gt;::capacity const):
(WTF::shouldValidateKey&gt;::memoryUse const):
(WTF::shouldValidateKey&gt;::isEmpty const):
(WTF::shouldValidateKey&gt;::begin const):
(WTF::shouldValidateKey&gt;::end const):
(WTF::shouldValidateKey&gt;::find const):
(WTF::shouldValidateKey&gt;::contains const):
(WTF::shouldValidateKey&gt;::ensure):
(WTF::shouldValidateKey&gt;::add):
(WTF::shouldValidateKey&gt;::addVoid):
(WTF::shouldValidateKey&gt;::remove):
(WTF::shouldValidateKey&gt;::removeIf):
(WTF::shouldValidateKey&gt;::clear):
(WTF::shouldValidateKey&gt;::take):
(WTF::shouldValidateKey&gt;::takeAny):
(WTF::shouldValidateKey&gt;::unionWith const):
(WTF::shouldValidateKey&gt;::intersectionWith const):
(WTF::shouldValidateKey&gt;::differenceWith const):
(WTF::shouldValidateKey&gt;::symmetricDifferenceWith const):
(WTF::shouldValidateKey&gt;::formUnion):
(WTF::shouldValidateKey&gt;::formIntersection):
(WTF::shouldValidateKey&gt;::formDifference):
(WTF::shouldValidateKey&gt;::formSymmetricDifference):
(WTF::shouldValidateKey&gt;::isSubset):
(WTF::shouldValidateKey&gt;::isValidValue):
(WTF::= const):
(WTF::shouldValidateKey&gt;::checkConsistency const):
(WTF::W&gt;::swap): Deleted.
(WTF::W&gt;::size const): Deleted.
(WTF::W&gt;::capacity const): Deleted.
(WTF::W&gt;::memoryUse const): Deleted.
(WTF::W&gt;::isEmpty const): Deleted.
(WTF::W&gt;::begin const): Deleted.
(WTF::W&gt;::end const): Deleted.
(WTF::W&gt;::find const): Deleted.
(WTF::W&gt;::contains const): Deleted.
(WTF::TableTraits&gt;::find const): Deleted.
(WTF::TableTraits&gt;::contains const): Deleted.
(WTF::TableTraits&gt;::ensure): Deleted.
(WTF::W&gt;::add): Deleted.
(WTF::W&gt;::addVoid): Deleted.
(WTF::TableTraits&gt;::add): Deleted.
(WTF::W&gt;::remove): Deleted.
(WTF::W&gt;::removeIf): Deleted.
(WTF::W&gt;::clear): Deleted.
(WTF::W&gt;::take): Deleted.
(WTF::W&gt;::takeAny): Deleted.
(WTF::W&gt;::unionWith const): Deleted.
(WTF::W&gt;::intersectionWith const): Deleted.
(WTF::W&gt;::differenceWith const): Deleted.
(WTF::W&gt;::symmetricDifferenceWith const): Deleted.
(WTF::W&gt;::formUnion): Deleted.
(WTF::W&gt;::formIntersection): Deleted.
(WTF::W&gt;::formDifference): Deleted.
(WTF::W&gt;::formSymmetricDifference): Deleted.
(WTF::W&gt;::isSubset): Deleted.
(WTF::TableTraits&gt;::remove): Deleted.
(WTF::TableTraits&gt;::take): Deleted.
(WTF::W&gt;::isValidValue): Deleted.
(WTF::W&gt;::checkConsistency const): Deleted.
* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:
(PAL::WTF_REQUIRES_LOCK):
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::unregisterNamedTimelinesAssociatedWithElement):
* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::fillImplicitKeyframes):
(WebCore::BlendingKeyframes::propertiesSetToInherit const):
* Source/WebCore/animation/BlendingKeyframes.h:
(WebCore::BlendingKeyframes::properties const):
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::animationCanBeRemoved):
(WebCore::DocumentTimeline::applyPendingAcceleratedAnimations):
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::animatedProperties):
(WebCore::propertiesContainTransformRelatedProperty):
(WebCore::KeyframeEffect::computeHasImplicitKeyframeForAcceleratedProperty):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::applyKeyframeEffects):
(WebCore::KeyframeEffectStack::allowsAcceleration const):
(WebCore::KeyframeEffectStack::cascadeDidOverrideProperties):
* Source/WebCore/animation/KeyframeEffectStack.h:
(WebCore::KeyframeEffectStack::acceleratedPropertiesOverriddenByCascade const):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::commitStyles):
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/bindings/js/DOMWrapperWorld.h:
* Source/WebCore/bindings/js/JSDOMGlobalObject.h:
* Source/WebCore/bindings/js/ScriptModuleLoader.h:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::transferArrayBuffers):
(WebCore::containsDuplicates):
(WebCore::canOffscreenCanvasesDetach):
(WebCore::canDetachRTCDataChannels):
(WebCore::canDetachMediaStreamTracks):
(WebCore::canDetachMediaSourceHandles):
(WebCore::SerializedScriptValue::create):
* Source/WebCore/bindings/js/WebCoreJSClientData.h:
* Source/WebCore/bridge/IdentifierRep.cpp:
* Source/WebCore/bridge/runtime_root.cpp:
(JSC::Bindings::RootObject::invalidate):
* Source/WebCore/bridge/runtime_root.h:
* Source/WebCore/contentextensions/CombinedFiltersAlphabet.h:
* Source/WebCore/contentextensions/ContentExtensionActions.cpp:
(WebCore::ContentExtensions::RedirectAction::URLTransformAction::QueryTransform::applyToURL const):
* Source/WebCore/contentextensions/ContentExtensionCompiler.cpp:
* Source/WebCore/contentextensions/ContentExtensionStyleSheet.h:
* Source/WebCore/contentextensions/DFABytecodeInterpreter.h:
* Source/WebCore/contentextensions/DFACombiner.cpp:
(WebCore::ContentExtensions::DFAMerger::getOrCreateCombinedNode):
* Source/WebCore/contentextensions/ImmutableNFANodeBuilder.h:
* Source/WebCore/contentextensions/NFANode.h:
* Source/WebCore/contentextensions/NFAToDFA.cpp:
(WebCore::ContentExtensions::NodeIdSetToUniqueNodeIdSetTranslator::translate):
* Source/WebCore/css/CSSCounterStyleRegistry.cpp:
(WebCore::CSSCounterStyleRegistry::resolveExtendsReference):
* Source/WebCore/css/CSSCounterStyleRegistry.h:
* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::matchingFacesExcludingPreinstalledFonts):
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/css/CSSGridTemplateAreasValue.cpp:
(WebCore::stringForPosition):
* Source/WebCore/css/CSSImportRule.cpp:
(WebCore::CSSImportRule::getChildStyleSheets):
* Source/WebCore/css/CSSImportRule.h:
* Source/WebCore/css/CSSRule.h:
(WebCore::CSSRule::getChildStyleSheets):
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::getChildStyleSheets):
* Source/WebCore/css/CSSStyleRule.h:
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::getChildStyleSheets):
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/MutableStyleProperties.cpp:
(WebCore::MutableStyleProperties::removeProperties):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::filterProperties):
(WebCore::createStyleProperties):
(WebCore::CSSParserImpl::parseDeclarationList):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
* Source/WebCore/dom/DataTransfer.cpp:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::runScrollSteps):
(WebCore::hasRealtimeMediaSource):
(WebCore::findNearestCommonComposedAncestor):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentSharedObjectPool.h:
* Source/WebCore/dom/Element.cpp:
* Source/WebCore/dom/IdTargetObserverRegistry.h:
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::disentanglePorts):
* Source/WebCore/dom/MutationObserver.cpp:
(WebCore::MutationObserver::deliver):
* Source/WebCore/dom/MutationObserver.h:
* Source/WebCore/dom/MutationObserverRegistration.cpp:
(WebCore::MutationObserverRegistration::takeTransientRegistrations):
* Source/WebCore/dom/MutationObserverRegistration.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::nodeSetPreTransformedFromNodeOrStringVector):
(WebCore::firstPrecedingSiblingNotInNodeSet):
(WebCore::firstFollowingSiblingNotInNodeSet):
* Source/WebCore/dom/QualifiedNameCache.h:
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::processContents):
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/ScriptRunner.h:
* Source/WebCore/dom/SimulatedClick.cpp:
(WebCore::simulateClick):
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::ManualSlotAssignment::slotManualAssignmentDidChange):
* Source/WebCore/dom/TreeScopeOrderedMap.h:
* Source/WebCore/dom/VisitedLinkState.h:
* Source/WebCore/dom/WindowEventLoop.h:
* Source/WebCore/dom/messageports/MessagePortChannel.h:
* Source/WebCore/editing/AppendNodeCommand.cpp:
(WebCore::AppendNodeCommand::getNodesInCommand):
* Source/WebCore/editing/AppendNodeCommand.h:
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::EditCommandComposition::getNodesInCommand):
* Source/WebCore/editing/CompositeEditCommand.h:
* Source/WebCore/editing/DeleteFromTextNodeCommand.cpp:
(WebCore::DeleteFromTextNodeCommand::getNodesInCommand):
* Source/WebCore/editing/DeleteFromTextNodeCommand.h:
* Source/WebCore/editing/EditCommand.cpp:
(WebCore::SimpleEditCommand::addNodeAndDescendants):
* Source/WebCore/editing/EditCommand.h:
* Source/WebCore/editing/Editing.cpp:
(WebCore::visibleImageElementsInRangeWithNonLoadedImages):
* Source/WebCore/editing/Editing.h:
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/InsertIntoTextNodeCommand.cpp:
(WebCore::InsertIntoTextNodeCommand::getNodesInCommand):
* Source/WebCore/editing/InsertIntoTextNodeCommand.h:
* Source/WebCore/editing/InsertNodeBeforeCommand.cpp:
(WebCore::InsertNodeBeforeCommand::getNodesInCommand):
* Source/WebCore/editing/InsertNodeBeforeCommand.h:
* Source/WebCore/editing/MergeIdenticalElementsCommand.cpp:
(WebCore::MergeIdenticalElementsCommand::getNodesInCommand):
* Source/WebCore/editing/MergeIdenticalElementsCommand.h:
* Source/WebCore/editing/RemoveNodeCommand.cpp:
(WebCore::RemoveNodeCommand::getNodesInCommand):
* Source/WebCore/editing/RemoveNodeCommand.h:
* Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp:
(WebCore::ReplaceNodeWithSpanCommand::getNodesInCommand):
* Source/WebCore/editing/ReplaceNodeWithSpanCommand.h:
* Source/WebCore/editing/SetNodeAttributeCommand.cpp:
(WebCore::SetNodeAttributeCommand::getNodesInCommand):
* Source/WebCore/editing/SetNodeAttributeCommand.h:
* Source/WebCore/editing/SetSelectionCommand.h:
* Source/WebCore/editing/SpellingCorrectionCommand.cpp:
* Source/WebCore/editing/SplitElementCommand.cpp:
(WebCore::SplitElementCommand::getNodesInCommand):
* Source/WebCore/editing/SplitElementCommand.h:
* Source/WebCore/editing/SplitTextNodeCommand.cpp:
(WebCore::SplitTextNodeCommand::getNodesInCommand):
* Source/WebCore/editing/SplitTextNodeCommand.h:
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::TextManipulationController::scheduleObservationUpdate):
(WebCore::TextManipulationController::completeManipulation):
(WebCore::TextManipulationController::updateInsertions):
(WebCore::TextManipulationController::replace):
* Source/WebCore/editing/TextManipulationController.h:
* Source/WebCore/editing/WrapContentsInDummySpanCommand.cpp:
(WebCore::WrapContentsInDummySpanCommand::getNodesInCommand):
* Source/WebCore/editing/WrapContentsInDummySpanCommand.h:
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::BlobURLRegistry::registerURL):
(WebCore::BlobURLRegistry::unregisterURLsForContext):
* Source/WebCore/fileapi/Blob.h:
* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::BackForwardCache::clearEntriesForOrigins):
* Source/WebCore/history/BackForwardCache.h:
* Source/WebCore/html/Allowlist.h:
(WebCore::Allowlist::Allowlist):
(WebCore::Allowlist::matches const):
* Source/WebCore/html/CanvasBase.cpp:
(WebCore:: const):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/DOMTokenList.cpp:
(WebCore::DOMTokenList::updateTokensFromAttributeValue):
* Source/WebCore/html/HTMLFormControlsCollection.cpp:
(WebCore::HTMLFormControlsCollection::updateNamedElementCache const):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::allMediaElements):
(WebCore::HTMLMediaElement::originsInMediaCache):
(WebCore::HTMLMediaElement::clearMediaCacheForOrigins):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLSlotElement.cpp:
(WebCore::HTMLSlotElement::assign):
* Source/WebCore/html/PermissionsPolicy.cpp:
(WebCore::parseAllowlist):
* Source/WebCore/html/PermissionsPolicy.h:
* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/html/parser/AtomHTMLToken.h:
(WebCore::AtomHTMLToken::initializeAttributes):
* Source/WebCore/layout/LayoutState.h:
* Source/WebCore/layout/formattingContexts/block/BlockFormattingState.h:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::nearestCommonAncestor):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::build):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::candidateContentForLine):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::processRubyContent):
* Source/WebCore/loader/CanvasActivityRecord.h:
* Source/WebCore/loader/CrossOriginPreflightResultCache.h:
(WebCore::CrossOriginPreflightResultCacheItem::CrossOriginPreflightResultCacheItem):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/ResourceLoadObserver.h:
(WebCore::ResourceLoadObserver::setDomainsWithUserInteraction):
* Source/WebCore/loader/ResourceLoadStatistics.cpp:
(WebCore::encodeHashSet):
(WebCore::encodeFontHashSet):
(WebCore::decodeHashSet):
(WebCore::decodeFontHashSet):
(WebCore::appendHashSet):
(WebCore::mergeHashSet):
* Source/WebCore/loader/ResourceLoadStatistics.h:
* Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp:
(WebCore::ApplicationCacheGroup::manifestNotFound):
(WebCore::ApplicationCacheGroup::postListenerTask):
* Source/WebCore/loader/appcache/ApplicationCacheGroup.h:
(WebCore::ApplicationCacheGroup::postListenerTask):
* Source/WebCore/loader/appcache/ApplicationCacheManifestParser.h:
* Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp:
(WebCore::ApplicationCacheStorage::originsWithCache):
* Source/WebCore/loader/appcache/ApplicationCacheStorage.h:
* Source/WebCore/loader/archive/Archive.cpp:
(WebCore::Archive::clearAllSubframeArchives):
* Source/WebCore/loader/archive/Archive.h:
* Source/WebCore/loader/archive/ArchiveFactory.cpp:
(WebCore::ArchiveFactory::registerKnownArchiveMIMETypes):
* Source/WebCore/loader/archive/ArchiveFactory.h:
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::generateValidFileName):
(WebCore::addSubresourcesForCSSStyleSheetsIfNecessary):
(WebCore::LegacyWebArchive::create):
* Source/WebCore/loader/cache/CachedResource.h:
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::removeResourcesWithOrigins):
(WebCore::MemoryCache::originsWithCache const):
* Source/WebCore/loader/cache/MemoryCache.h:
* Source/WebCore/page/CaptionUserPreferences.cpp:
(WebCore::CaptionUserPreferences::sortedTrackListForMenu):
* Source/WebCore/page/CaptionUserPreferences.h:
* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::CaptionUserPreferencesMediaAF::sortedTrackListForMenu):
* Source/WebCore/page/CaptionUserPreferencesMediaAF.h:
* Source/WebCore/page/DOMSelection.cpp:
(WebCore::DOMSelection::getComposedRanges):
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::collectMediaAndLinkURLsRecursive):
(WebCore::collectMediaAndLinkURLs):
(WebCore::ElementTargetingController::topologicallySortElementsHelper):
(WebCore::ElementTargetingController::topologicallySortElements):
(WebCore::ElementTargetingController::findAllTargets):
(WebCore::filterRedundantNearbyTargets):
(WebCore::ElementTargetingController::extractTargets):
(WebCore::ElementTargetingController::resetVisibilityAdjustments):
* Source/WebCore/page/ElementTargetingController.h:
* Source/WebCore/page/ElementTargetingTypes.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleTouchEvent):
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::collectAndProtectWidgets):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::allPages):
(WebCore::Page::forEachWindowEventLoop):
* Source/WebCore/page/Page.h:
(WebCore::Page::maskedURLSchemes const):
(WebCore::Page::rootFrames const):
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::hasStorageAccessForAllLoginDomains):
(WebCore::Quirks::triggerOptionalStorageAccessQuirk const):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/TextIndicator.cpp:
(WebCore::estimatedTextColorsForRange):
(WebCore::hasAnyIllegibleColors):
* Source/WebCore/page/UndoManager.h:
* Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm:
(WebCore::ResourceUsageThread::platformCollectCPUData):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::takeNavigationRequestsToUpgrade):
(WebCore::ContentSecurityPolicy::setInsecureNavigationRequestsToUpgrade):
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.h:
* Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.h:
* Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp:
(WebCore::collectCPUUsage):
(WebCore::ResourceUsageThread::platformCollectCPUData):
* Source/WebCore/page/mac/ImageOverlayControllerMac.mm:
(WebCore::ImageOverlayController::updateDataDetectorHighlights):
* Source/WebCore/page/mac/ServicesOverlayController.h:
* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::buildPhoneNumberHighlights):
(WebCore::ServicesOverlayController::buildSelectionHighlight):
(WebCore::ServicesOverlayController::replaceHighlightsOfTypePreservingEquivalentHighlights):
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::updateTreeFromStateNodeRecursive):
(WebCore::ScrollingTree::nodesWithActiveScrollAnimations):
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::activeOverflowScrollProxyNodes):
(WebCore::ScrollingTree::activePositionedNodes):
(WebCore::ScrollingTree::WTF_REQUIRES_LOCK):
* Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h:
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::propagateSynchronousScrollingReasons):
* Source/WebCore/page/scrolling/ThreadedScrollingTree.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::proofreadingSessionDidReceiveSuggestions):
* Source/WebCore/platform/LegacySchemeRegistry.h:
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::MIMETypeRegistry::additionalSupportedImageMIMETypes):
(WebCore::MIMETypeRegistry::supportedNonImageMIMETypes):
(WebCore::MIMETypeRegistry::supportedMediaMIMETypes):
(WebCore::MIMETypeRegistry::createMIMETypeRegistryThreadGlobalData):
(WebCore::MIMETypeRegistry::isWebArchiveMIMEType):
* Source/WebCore/platform/MIMETypeRegistry.h:
(WebCore::MIMETypeRegistryThreadGlobalData::MIMETypeRegistryThreadGlobalData):
(WebCore::MIMETypeRegistryThreadGlobalData::supportedImageMIMETypesForEncoding const):
* Source/WebCore/platform/PreviewConverter.cpp:
(WebCore::PreviewConverter::supportsMIMEType):
* Source/WebCore/platform/PreviewConverter.h:
* Source/WebCore/platform/PublicSuffixStore.h:
* Source/WebCore/platform/RemoteCommandListener.h:
* Source/WebCore/platform/ScrollSnapAnimatorState.cpp:
(WebCore::ScrollSnapAnimatorState::currentlySnappedBoxes const):
(WebCore::chooseBoxToResnapTo):
* Source/WebCore/platform/ScrollSnapAnimatorState.h:
* Source/WebCore/platform/ScrollView.h:
(WebCore::ScrollView::children const):
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm:
(WebCore::PublicSuffixStore::enablePublicSuffixCache):
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h:
* Source/WebCore/platform/encryptedmedia/CDMProxy.h:
* Source/WebCore/platform/encryptedmedia/CDMRestrictions.h:
* Source/WebCore/platform/gamepad/mac/HIDGamepadProvider.h:
* Source/WebCore/platform/graphics/DisplayRefreshMonitor.h:
* Source/WebCore/platform/graphics/FontCache.h:
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
* Source/WebCore/platform/graphics/MIMETypeCache.cpp:
(WebCore::MIMETypeCache::supportedTypes):
(WebCore::MIMETypeCache::addSupportedTypes):
(WebCore::MIMETypeCache::initializeCache):
* Source/WebCore/platform/graphics/MIMETypeCache.h:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::getSupportedTypes):
(WebCore::addToHash):
(WebCore::MediaPlayer::originsInMediaCache):
(WebCore::MediaPlayer::clearMediaCacheForOrigins):
* Source/WebCore/platform/graphics/MediaPlayer.h:
(WebCore::MediaPlayerFactory::originsInMediaCache const):
(WebCore::MediaPlayerFactory::clearMediaCacheForOrigins const):
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::originsInMediaCache):
(WebCore::MediaPlayerPrivateInterface::clearMediaCacheForOrigins):
* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
* Source/WebCore/platform/graphics/TiledBacking.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::usedDisplays):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm:
(WebCore::AVAssetMIMETypeCache::initializeCache):
* Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm:
(WebCore::AVStreamDataParserMIMETypeCache::supportedTypes):
(WebCore::AVStreamDataParserMIMETypeCache::initializeCache):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::originsInMediaCache):
(WebCore::MediaPlayerPrivateAVFoundationObjC::clearMediaCacheForOrigins):
(WebCore::MediaPlayerPrivateAVFoundationObjC::getSupportedTypes):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::getSupportedTypes):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::getSupportedTypes):
* Source/WebCore/platform/graphics/ca/LayerPool.cpp:
(WebCore::LayerPool::allLayerPools):
* Source/WebCore/platform/graphics/ca/LayerPool.h:
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::didRevalidateTiles):
* Source/WebCore/platform/graphics/ca/TileController.h:
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::revalidateTiles):
(WebCore::TileGrid::ensureTilesForRect):
* Source/WebCore/platform/graphics/ca/TileGrid.h:
* Source/WebCore/platform/graphics/cg/CGSubimageCacheWithTimer.h:
* Source/WebCore/platform/graphics/cg/UTIRegistry.mm:
(WebCore::defaultSupportedImageTypes):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::mimeTypeCache):
(WebCore::MediaPlayerPrivateWebM::getSupportedTypes):
* Source/WebCore/platform/graphics/filters/FilterResults.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::getSupportedDecodingTypes):
(WebCore::GStreamerRegistryScanner::mimeTypeSet const):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::getSupportedTypes):
(WebCore::MediaPlayerPrivateGStreamer::supportsType):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::didReceiveInitializationSegment):
* Source/WebCore/platform/graphics/gstreamer/mse/GStreamerRegistryScannerMSE.cpp:
(WebCore::GStreamerRegistryScannerMSE::getSupportedDecodingTypes):
* Source/WebCore/platform/graphics/gstreamer/mse/GStreamerRegistryScannerMSE.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::getSupportedTypes):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h:
* Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp:
(WebCore::mimeTypeCache):
(WebCore::MediaPlayerPrivateHolePunch::getSupportedTypes):
* Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h:
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp:
(WebCore::mimeTypeCache):
(WebCore::MediaPlayerPrivateMediaFoundation::getSupportedTypes):
(WebCore::MediaPlayerPrivateMediaFoundation::notifyDeleted):
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h:
* Source/WebCore/platform/ios/PreviewConverterIOS.mm:
(WebCore::PreviewConverter::platformSupportedMIMETypes):
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
* Source/WebCore/platform/mac/HIDDevice.cpp:
(WebCore::HIDDevice::uniqueInputElementsInDeviceTreeOrder const):
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::Pasteboard::read):
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
* Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h:
* Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm:
(WebCore::SerializedPlatformDataCueMac::allowedClassesForNativeValues):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h:
* Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h:
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp:
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.h:
* Source/WebCore/platform/mock/GeolocationClientMock.h:
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::mimeTypeCache):
(WebCore::MockMediaPlayerMediaSource::getSupportedTypes):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:
* Source/WebCore/platform/network/CredentialStorage.cpp:
(WebCore::CredentialStorage::originsWithCredentials const):
* Source/WebCore/platform/network/CredentialStorage.h:
* Source/WebCore/platform/network/DNSResolveQueue.cpp:
(WebCore::DNSResolveQueue::timerFired):
* Source/WebCore/platform/network/DNSResolveQueue.h:
* Source/WebCore/platform/network/HTTPParsers.h:
(WebCore::addToAccessControlAllowList):
(WebCore::parseAccessControlAllowList):
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::updatableStorageAccessPromptQuirks):
(WebCore::NetworkStorageSession::grantCrossPageStorageAccess):
(WebCore::NetworkStorageSession::setAppBoundDomains):
(WebCore::NetworkStorageSession::setManagedDomains):
(WebCore::NetworkStorageSession::storageAccessQuirks):
(WebCore::NetworkStorageSession::subResourceDomainsInNeedOfStorageAccessForFirstParty):
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::getHostnamesWithCookies):
(WebCore::NetworkStorageSession::deleteCookiesForHostnames):
(WebCore::NetworkStorageSession::stopListeningForCookieChangeNotifications):
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h:
* Source/WebCore/platform/network/curl/CookieJarDB.cpp:
(WebCore::CookieJarDB::allDomains):
* Source/WebCore/platform/network/curl/CookieJarDB.h:
* Source/WebCore/platform/network/curl/CurlRequestScheduler.h:
* Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp:
(WebCore::NetworkStorageSession::getHostnamesWithCookies):
* Source/WebCore/platform/network/mac/UTIUtilities.h:
* Source/WebCore/platform/network/mac/UTIUtilities.mm:
(WebCore::RequiredMIMETypesFromUTI):
* Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp:
(WebCore::NetworkStorageSession::getHostnamesWithCookies):
* Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp:
(WebCore::sanitizeFilename):
* Source/WebCore/platform/network/soup/SoupNetworkSession.cpp:
(WebCore::SoupNetworkSession::getHostNamesWithHSTSCache):
* Source/WebCore/platform/network/soup/SoupNetworkSession.h:
* Source/WebCore/platform/win/WindowMessageBroadcaster.h:
* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/rendering/GlyphDisplayListCache.h:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::subdivide):
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::ReferencedSVGResources::updateReferencedResources):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::rebuildFloatingObjectSetFromIntrudingFloats):
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateSynchronousScrollingNodes):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::borderAndTextRects):
* Source/WebCore/rendering/RenderSelection.cpp:
(WebCore::RenderSelection::repaint const):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::paintObject):
* Source/WebCore/rendering/TextAutoSizing.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/rendering/svg/SVGTextChunkBuilder.cpp:
(WebCore::SVGTextChunkBuilder::buildTextChunks):
(WebCore::SVGTextChunkBuilder::layoutTextChunks):
* Source/WebCore/rendering/svg/SVGTextChunkBuilder.h:
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorsForAnchorPositionedElement):
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/ChildChangeInvalidation.h:
* Source/WebCore/style/InspectorCSSOMWrappers.h:
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::PropertyCascade):
(WebCore::Style::PropertyCascade::AnimationLayer::AnimationLayer):
(WebCore::Style::PropertyCascade::overriddenAnimatedProperties const):
* Source/WebCore/style/PropertyCascade.h:
* Source/WebCore/style/RuleFeature.h:
* Source/WebCore/style/RuleSetBuilder.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::Builder):
* Source/WebCore/style/StyleBuilder.h:
(WebCore::Style::Builder::overriddenAnimatedProperties const):
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::keyframeRulesForName const):
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::customPropertyNamesInStyleContainerQueries const):
* Source/WebCore/style/StyleScopeRuleSets.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
(WebCore::Style::TreeResolver::applyCascadeAfterAnimation):
* Source/WebCore/style/StyleTreeResolver.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::compileTransitionPropertiesInStyle):
(WebCore::Styleable::updateCSSTransitions const):
* Source/WebCore/style/Styleable.h:
(WebCore::Styleable::applyKeyframeEffects const):
* Source/WebCore/svg/SVGFontElement.h:
* Source/WebCore/svg/SVGLinearGradientElement.cpp:
(WebCore::SVGLinearGradientElement::collectGradientAttributes):
* Source/WebCore/svg/SVGParserUtilities.cpp:
(WebCore::parseGlyphName):
(WebCore::parseKerningUnicodeString):
* Source/WebCore/svg/SVGParserUtilities.h:
* Source/WebCore/svg/SVGRadialGradientElement.cpp:
(WebCore::SVGRadialGradientElement::collectGradientAttributes):
* Source/WebCore/svg/SVGToOTFFontConversion.cpp:
(WebCore::SVGToOTFFontConverter::addCodepointRanges const):
(WebCore::SVGToOTFFontConverter::addCodepoints const):
(WebCore::SVGToOTFFontConverter::addGlyphNames const):
(WebCore::SVGToOTFFontConverter::addKerningPair const):
(WebCore::SVGToOTFFontConverter::appendLigatureGlyphs):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::parseBeginOrEnd):
* Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h:

Canonical link: <a href="https://commits.webkit.org/288477@main">https://commits.webkit.org/288477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3bc11791975df5f7f167ab6ff7b134bb4d5d538

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83529 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88604 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34539 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64989 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22729 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75903 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45275 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/2293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30117 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33589 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76495 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89980 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/82549 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7792 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11020 "Failed to checkout and rebase branch from PR 38528") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72645 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16872 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15593 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2121 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12888 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10750 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16221 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/104966 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10595 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25373 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14071 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12369 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->