### PR TITLE
Block unused syscalls

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1060,18 +1060,26 @@
     SYS_shared_region_map_and_slide_2_np ;; <rdar://problem/60294880>
     SYS_sysctlbyname))
 
+(define (syscall-quicklook)
+    (syscall-number
+        SYS_mkdirat
+        SYS_openat_nocancel
+        SYS_pread_nocancel
+        SYS_rmdir
+        SYS_sendto
+        SYS_thread_selfusage
+        SYS_unlink))
+
 (define (syscall-unix-rarely-in-use)
     (syscall-number
         SYS_fgetxattr
         SYS_getxattr
         SYS_iopolicysys
-        SYS_openat_nocancel
 #if ASAN_ENABLED
         SYS_sigaltstack
 #endif
         SYS_sigprocmask
         SYS_umask
-        SYS_unlink
         SYS_writev))
 
 (define (syscall-unix-rarely-in-use-blocked-in-lockdown-mode)
@@ -1082,17 +1090,12 @@
         SYS_fsync
         SYS_getattrlistbulk ;; xpc_realpath and directory enumeration
         SYS_getgid
-        SYS_mkdirat
         SYS_open_dprotected_np
-        SYS_pread_nocancel
         SYS_psynch_rw_wrlock
-        SYS_rmdir
-        SYS_sendto
         SYS_setrlimit
 #if PLATFORM(WATCHOS)
         SYS_sigreturn
 #endif
-        SYS_thread_selfusage
         SYS_write))
 
 (deny syscall-unix (with telemetry))
@@ -1107,22 +1110,18 @@
 (allow syscall-unix (syscall-unix-only-in-use-during-launch))
 #endif
 
-
-#if ENABLE(QUICKLOOK_SANDBOX_RESTRICTIONS)
 (allow syscall-unix
     (syscall-unix-rarely-in-use)
-    (syscall-unix-rarely-in-use-blocked-in-lockdown-mode))
+    (syscall-unix-rarely-in-use-blocked-in-lockdown-mode)
+    (syscall-quicklook))
+
+#if ENABLE(QUICKLOOK_SANDBOX_RESTRICTIONS)
 (with-filter
     (require-all
         (state-flag "ParentProcessCanEnableQuickLookStateFlag")
         (require-not (state-flag "EnableQuickLookSandboxResources")))
-    (allow syscall-unix (with report) (with telemetry-backtrace)
-        (syscall-unix-rarely-in-use)
-        (syscall-unix-rarely-in-use-blocked-in-lockdown-mode)))
-#else
-(allow syscall-unix
-    (syscall-unix-rarely-in-use)
-    (syscall-unix-rarely-in-use-blocked-in-lockdown-mode))
+    (deny syscall-unix (with telemetry-backtrace)
+        (syscall-quicklook)))
 #endif
 
 (deny syscall-unix (with no-report) (syscall-number
@@ -1141,12 +1140,13 @@
 
 (with-filter (system-attribute apple-internal)
     (allow syscall-unix (syscall-number SYS_kdebug_trace_string))) ;; Needed for performance sampling, see <rdar://problem/48829655>.
-    
+
 (with-filter (lockdown-mode)
     (deny syscall-unix (with telemetry) (with message "Lockdown mode")
         (syscall-unix-in-use-after-launch-blocked-in-lockdown-mode))
     (deny syscall-unix (with telemetry) (with message "Lockdown mode")
-        (syscall-unix-rarely-in-use-blocked-in-lockdown-mode)))
+        (syscall-unix-rarely-in-use-blocked-in-lockdown-mode)
+        (syscall-quicklook)))
 
 (deny file-ioctl (with telemetry))
 


### PR DESCRIPTION
#### a34553ab54ea021fef6eae2a45d6675f0cffc427
<pre>
Block unused syscalls
<a href="https://bugs.webkit.org/show_bug.cgi?id=285384">https://bugs.webkit.org/show_bug.cgi?id=285384</a>
<a href="https://rdar.apple.com/142355763">rdar://142355763</a>

Reviewed by Sihui Liu.

Based on telemetry, block unused syscalls.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:

Canonical link: <a href="https://commits.webkit.org/289685@main">https://commits.webkit.org/289685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed9f8d111e6de5836be0d512bc4e9645bf728226

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92571 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38452 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15393 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67717 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25461 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79359 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48088 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5587 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37563 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94457 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14874 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10915 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/76567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75802 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20165 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18598 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7838 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13674 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14890 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20192 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14634 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16416 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->