### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/image-decoders

### DIFF
--- a/Source/WebCore/platform/image-decoders/ScalableImageDecoder.h
+++ b/Source/WebCore/platform/image-decoders/ScalableImageDecoder.h
@@ -39,8 +39,6 @@
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 // ScalableImageDecoder is a base for all format-specific decoders
@@ -197,7 +195,5 @@ private:
     EncodedDataStatus m_encodedDataStatus { EncodedDataStatus::TypeAvailable };
     bool m_decodingSizeFromSetData { false };
 };
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace WebCore

--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
@@ -257,12 +257,10 @@ bool BMPImageReader::readInfoHeader()
     // to pay attention to the alpha mask here, so there's a special case in
     // processBitmasks() that doesn't always overwrite that value.
     if (isWindowsV4Plus()) {
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         m_bitMasks[0] = readUint32(40);
         m_bitMasks[1] = readUint32(44);
         m_bitMasks[2] = readUint32(48);
         m_bitMasks[3] = readUint32(52);
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     // Detect top-down BMPs.
@@ -380,7 +378,6 @@ bool BMPImageReader::isInfoHeaderValid() const
     return true;
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 bool BMPImageReader::processBitmasks()
 {
     // Create m_bitMasks[] values.
@@ -475,7 +472,6 @@ bool BMPImageReader::processBitmasks()
 
     return true;
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 bool BMPImageReader::processColorTable()
 {
@@ -627,9 +623,7 @@ bool BMPImageReader::processRLEData()
                 // RLE8 has one color index that gets repeated; RLE4 has two
                 // color indexes in the upper and lower 4 bits of the byte,
                 // which are alternated.
-                WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-                size_t colorIndexes[2] = {code, code};
-                WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+                std::array<size_t, 2> colorIndexes { code, code };
                 if (m_infoHeader.biCompression == RLE4) {
                     colorIndexes[0] = (colorIndexes[0] >> 4) & 0xf;
                     colorIndexes[1] &= 0xf;

--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h
@@ -226,17 +226,13 @@ private:
     // in the given pixel data.
     inline unsigned getComponent(uint32_t pixel, int component) const
     {
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return ((pixel & m_bitMasks[component]) >> m_bitShiftsRight[component]) << m_bitShiftsLeft[component];
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     inline unsigned getAlpha(uint32_t pixel) const
     {
         // For images without alpha, return alpha of 0xff.
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return m_bitMasks[3] ? getComponent(pixel, 3) : 0xff;
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     // Sets the current pixel to the color given by |colorIndex|. This also
@@ -326,9 +322,9 @@ private:
     // just combine these into one shift value because the net shift amount
     // could go either direction. (If only "<< -x" were equivalent to
     // ">> x"...)
-    uint32_t m_bitMasks[4];
-    int m_bitShiftsRight[4];
-    int m_bitShiftsLeft[4];
+    std::array<uint32_t, 4> m_bitMasks;
+    std::array<int, 4> m_bitShiftsRight;
+    std::array<int, 4> m_bitShiftsLeft;
 
     // The color palette, for paletted formats.
     Vector<RGBTriple> m_colorTable;

--- a/Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp
@@ -152,8 +152,6 @@ bool GIFImageDecoder::setFailed()
 
 void GIFImageDecoder::clearFrameBufferCache(size_t clearBeforeFrame)
 {
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
     // In some cases, like if the decoder was destroyed while animating, we
     // can be asked to clear more frames than we currently have.
     if (m_frameBufferCache.isEmpty())
@@ -200,8 +198,6 @@ void GIFImageDecoder::clearFrameBufferCache(size_t clearBeforeFrame)
         if (!j->isInvalid())
             j->clear();
     }
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 bool GIFImageDecoder::haveDecodedRow(unsigned frameIndex, const Vector<unsigned char>& rowBuffer, size_t width, size_t rowNumber, unsigned repeatCount, bool writeTransparentPixels)

--- a/Source/WebCore/platform/image-decoders/gif/GIFImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/gif/GIFImageReader.cpp
@@ -398,8 +398,6 @@ bool GIFImageReader::decode(GIFImageDecoder::GIFQuery query, unsigned haltAtFram
 // Return false if a fatal error is encountered.
 bool GIFImageReader::parse(size_t dataPosition, size_t len, bool parseSizeOnly)
 {
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
     if (!len) {
         // No new data has come in since the last call, just ignore this call.
         return true;
@@ -780,8 +778,6 @@ bool GIFImageReader::parse(size_t dataPosition, size_t len, bool parseSizeOnly)
 
     setRemainingBytes(len);
     return true;
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 void GIFImageReader::setRemainingBytes(size_t remainingBytes)

--- a/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp
@@ -60,12 +60,11 @@ void ICOImageDecoder::setData(const FragmentedSharedBuffer& data, bool allDataRe
 
     ScalableImageDecoder::setData(data, allDataReceived);
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    for (BMPReaders::iterator i(m_bmpReaders.begin()); i != m_bmpReaders.end(); ++i) {
-        if (*i)
-            (*i)->setData(*m_data);
+    for (auto& reader : m_bmpReaders) {
+        if (reader)
+            reader->setData(*m_data);
     }
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
     for (size_t i = 0; i < m_pngDecoders.size(); ++i)
         setDataForPNGDecoderAtIndex(i);
 }
@@ -250,17 +249,15 @@ bool ICOImageDecoder::processDirectoryEntries()
     ASSERT(m_decodedOffset == sizeOfDirectory);
     if ((m_decodedOffset > m_data->size()) || ((m_data->size() - m_decodedOffset) < (m_dirEntries.size() * sizeOfDirEntry)))
         return false;
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    for (IconDirectoryEntries::iterator i(m_dirEntries.begin()); i != m_dirEntries.end(); ++i)
-        *i = readDirectoryEntry();  // Updates m_decodedOffset.
+    for (auto& entry : m_dirEntries)
+        entry = readDirectoryEntry(); // Updates m_decodedOffset.
 
     // Make sure the specified image offsets are past the end of the directory
     // entries.
-    for (IconDirectoryEntries::iterator i(m_dirEntries.begin()); i != m_dirEntries.end(); ++i) {
-        if (i->m_imageOffset < m_decodedOffset)
+    for (auto& entry : m_dirEntries) {
+        if (entry.m_imageOffset < m_decodedOffset)
             return setFailed();
     }
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     // Arrange frames in decreasing quality order.
     std::sort(m_dirEntries.begin(), m_dirEntries.end(), compareEntries);

--- a/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
@@ -42,6 +42,7 @@
 
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/text/ParsingUtilities.h>
 
 #if USE(LCMS)
 #include "LCMSUniquePtr.h"
@@ -116,15 +117,14 @@ struct decoder_source_mgr {
     JPEGImageReader* decoder;
 };
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static unsigned readUint16(JOCTET* data, bool isBigEndian)
+static unsigned readUint16(std::span<JOCTET> data, bool isBigEndian)
 {
     if (isBigEndian)
         return (GETJOCTET(data[0]) << 8) | GETJOCTET(data[1]);
     return (GETJOCTET(data[1]) << 8) | GETJOCTET(data[0]);
 }
 
-static unsigned readUint32(JOCTET* data, bool isBigEndian)
+static unsigned readUint32(std::span<JOCTET> data, bool isBigEndian)
 {
     if (isBigEndian)
         return (GETJOCTET(data[0]) << 24) | (GETJOCTET(data[1]) << 16) | (GETJOCTET(data[2]) << 8) | GETJOCTET(data[3]);
@@ -139,24 +139,25 @@ static bool checkExifHeader(jpeg_saved_marker_ptr marker, bool& isBigEndian, uns
     // 'M', 'M' (motorola / big endian byte order), followed by (uint16_t)42,
     // followed by an uint32_t with the offset to the tag block, relative to the
     // tiff file start.
-    const unsigned exifHeaderSize = 14;
+    constexpr unsigned exifHeaderSize = 14;
+    auto markerData = unsafeMakeSpan(marker->data, marker->data_length);
     if (!(marker->marker == exifMarker
-        && marker->data_length >= exifHeaderSize
-        && marker->data[0] == 'E'
-        && marker->data[1] == 'x'
-        && marker->data[2] == 'i'
-        && marker->data[3] == 'f'
-        && marker->data[4] == '\0'
+        && markerData.size() >= exifHeaderSize
+        && markerData[0] == 'E'
+        && markerData[1] == 'x'
+        && markerData[2] == 'i'
+        && markerData[3] == 'f'
+        && markerData[4] == '\0'
         // data[5] is a fill byte
-        && ((marker->data[6] == 'I' && marker->data[7] == 'I')
-            || (marker->data[6] == 'M' && marker->data[7] == 'M'))))
+        && ((markerData[6] == 'I' && markerData[7] == 'I')
+            || (markerData[6] == 'M' && markerData[7] == 'M'))))
         return false;
 
-    isBigEndian = marker->data[6] == 'M';
-    if (readUint16(marker->data + 8, isBigEndian) != 42)
+    isBigEndian = markerData[6] == 'M';
+    if (readUint16(markerData.subspan(8), isBigEndian) != 42)
         return false;
 
-    ifdOffset = readUint32(marker->data + 10, isBigEndian);
+    ifdOffset = readUint32(markerData.subspan(10), isBigEndian);
     return true;
 }
 
@@ -181,23 +182,22 @@ static ImageOrientation readImageOrientation(jpeg_decompress_struct* info)
         // the number of ifd entries, followed by that many entries.
         // When touching this code, it's useful to look at the tiff spec:
         // http://partners.adobe.com/public/developer/en/tiff/TIFF6.pdf
-        JOCTET* ifd = marker->data + ifdOffset;
-        JOCTET* end = marker->data + marker->data_length;
-        if (end - ifd < 2)
+        auto markerData = unsafeMakeSpan(marker->data, marker->data_length).subspan(ifdOffset);
+        if (markerData.size() < 2)
             continue;
-        unsigned tagCount = readUint16(ifd, isBigEndian);
-        ifd += 2; // Skip over the uint16 that was just read.
+        unsigned tagCount = readUint16(markerData, isBigEndian);
+        skip(markerData, 2); // Skip over the uint16 that was just read.
 
         // Every ifd entry is 2 bytes of tag, 2 bytes of contents datatype,
         // 4 bytes of number-of-elements, and 4 bytes of either offset to the
         // tag data, or if the data is small enough, the inlined data itself.
-        const int ifdEntrySize = 12;
-        for (unsigned i = 0; i < tagCount && end - ifd >= ifdEntrySize; ++i, ifd += ifdEntrySize) {
-            unsigned tag = readUint16(ifd, isBigEndian);
-            unsigned type = readUint16(ifd + 2, isBigEndian);
-            unsigned count = readUint32(ifd + 4, isBigEndian);
+        constexpr int ifdEntrySize = 12;
+        for (unsigned i = 0; i < tagCount && markerData.size() >= ifdEntrySize; ++i, skip(markerData, ifdEntrySize)) {
+            unsigned tag = readUint16(markerData, isBigEndian);
+            unsigned type = readUint16(markerData.subspan(2), isBigEndian);
+            unsigned count = readUint32(markerData.subspan(4), isBigEndian);
             if (tag == orientationTag && type == shortType && count == 1)
-                return ImageOrientation::fromEXIFValue(readUint16(ifd + 8, isBigEndian));
+                return ImageOrientation::fromEXIFValue(readUint16(markerData.subspan(8), isBigEndian));
         }
     }
 
@@ -248,7 +248,6 @@ static RefPtr<SharedBuffer> readICCProfile(jpeg_decompress_struct* info)
     return buffer.takeAsContiguous();
 }
 #endif
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 class JPEGImageReader {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(JPEGImageReader);


### PR DESCRIPTION
#### 334ca2793400dc1d97d667e1603faeb241a26ea4
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/image-decoders
<a href="https://bugs.webkit.org/show_bug.cgi?id=285388">https://bugs.webkit.org/show_bug.cgi?id=285388</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/image-decoders/ScalableImageDecoder.h:
* Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp:
(WebCore::BMPImageReader::readInfoHeader):
(WebCore::BMPImageReader::processBitmasks):
(WebCore::BMPImageReader::processRLEData):
* Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h:
(WebCore::BMPImageReader::getComponent const):
(WebCore::BMPImageReader::getAlpha const):
* Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp:
(WebCore::GIFImageDecoder::clearFrameBufferCache):
* Source/WebCore/platform/image-decoders/gif/GIFImageReader.cpp:
(GIFImageReader::parse):
* Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp:
(WebCore::ICOImageDecoder::setData):
(WebCore::ICOImageDecoder::processDirectoryEntries):
(WebCore::ICOImageDecoder::readDirectoryEntry): Deleted.
(WebCore::ICOImageDecoder::imageTypeAtIndex): Deleted.
* Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp:
(WebCore::readUint16):
(WebCore::readUint32):
(WebCore::checkExifHeader):
(WebCore::readImageOrientation):

Canonical link: <a href="https://commits.webkit.org/288451@main">https://commits.webkit.org/288451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cd319b20f679d6696a2911301777550e35b2799

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88483 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34417 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64886 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22633 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75794 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45170 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2176 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29999 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33466 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73278 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89859 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7698 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73316 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72545 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16762 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15495 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2007 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12876 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10626 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16098 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10478 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13948 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12249 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->