### PR TITLE
Adopt more spans in ImageBackingStore.h

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBackingStore.h
+++ b/Source/WebCore/platform/graphics/ImageBackingStore.h
@@ -30,9 +30,9 @@
 #include "IntSize.h"
 #include "NativeImage.h"
 #include "SharedBuffer.h"
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#include <wtf/text/ParsingUtilities.h>
 
 namespace WebCore {
 
@@ -70,7 +70,7 @@ public:
 
         buffer.grow(bufferSize);
         m_pixels = FragmentedSharedBuffer::DataSegment::create(WTFMove(buffer));
-        m_pixelsPtr = reinterpret_cast<uint32_t*>(const_cast<uint8_t*>(m_pixels->span().data()));
+        m_pixelsSpan = spanReinterpretCast<uint32_t>(spanConstCast<uint8_t>(m_pixels->span()));
         m_size = size;
         m_frameRect = IntRect(IntPoint(), m_size);
         clear();
@@ -89,7 +89,7 @@ public:
 
     void clear()
     {
-        memset(m_pixelsPtr, 0, m_size.area() * sizeof(uint32_t));
+        zeroSpan(m_pixelsSpan);
     }
 
     void clearRect(const IntRect& rect)
@@ -97,11 +97,10 @@ public:
         if (rect.isEmpty() || !inBounds(rect))
             return;
 
-        size_t rowBytes = rect.width() * sizeof(uint32_t);
-        uint32_t* start = pixelAt(rect.x(), rect.y());
+        auto pixels = pixelsStartingAt(rect.x(), rect.y());
         for (int i = 0; i < rect.height(); ++i) {
-            memset(start, 0, rowBytes);
-            start += m_size.width();
+            zeroSpan(pixels.first(rect.width()));
+            skip(pixels, m_size.width());
         }
     }
 
@@ -110,12 +109,12 @@ public:
         if (rect.isEmpty() || !inBounds(rect))
             return;
 
-        uint32_t* start = pixelAt(rect.x(), rect.y());
+        auto pixels = pixelsStartingAt(rect.x(), rect.y());
         uint32_t pixelValue = this->pixelValue(r, g, b, a);
         for (int i = 0; i < rect.height(); ++i) {
             for (int j = 0; j < rect.width(); ++j)
-                start[j] = pixelValue;
-            start += m_size.width();
+                pixels[j] = pixelValue;
+            skip(pixels, m_size.width());
         }
     }
 
@@ -124,25 +123,30 @@ public:
         if (rect.isEmpty() || !inBounds(rect))
             return;
 
-        size_t rowBytes = rect.width() * sizeof(uint32_t);
-        uint32_t* src = pixelAt(rect.x(), rect.y());
-        uint32_t* dest = src + m_size.width();
+        auto sourcePixels = pixelsStartingAt(rect.x(), rect.y());
+        auto destinationPixels = sourcePixels.subspan(m_size.width());
+        auto sourceRow = sourcePixels.first(rect.width());
         for (int i = 1; i < rect.height(); ++i) {
-            memcpy(dest, src, rowBytes);
-            dest += m_size.width();
+            memcpySpan(destinationPixels, sourceRow);
+            skip(destinationPixels, m_size.width());
         }
     }
 
-    uint32_t* pixelAt(int x, int y) const
+    std::span<uint32_t> pixelsStartingAt(int x, int y)
     {
         ASSERT(inBounds(IntPoint(x, y)));
-        return m_pixelsPtr + y * m_size.width() + x;
+        return m_pixelsSpan.subspan(y * m_size.width() + x);
     }
 
-    void setPixel(uint32_t* dest, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+    uint32_t& pixelAt(int x, int y)
     {
-        ASSERT(dest);
-        *dest = pixelValue(r, g, b, a);
+        ASSERT(inBounds(IntPoint(x, y)));
+        return m_pixelsSpan[y * m_size.width() + x];
+    }
+
+    void setPixel(uint32_t& destination, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+    {
+        destination = pixelValue(r, g, b, a);
     }
 
     void setPixel(int x, int y, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
@@ -150,15 +154,15 @@ public:
         setPixel(pixelAt(x, y), r, g, b, a);
     }
 
-    void blendPixel(uint32_t* dest, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+    void blendPixel(uint32_t& destination, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
     {
         if (!a)
             return;
 
-        auto pixel = asSRGBA(PackedColor::ARGB { *dest }).resolved();
+        auto pixel = asSRGBA(PackedColor::ARGB { destination }).resolved();
 
         if (a >= 255 || !pixel.alpha) {
-            setPixel(dest, r, g, b, a);
+            setPixel(destination, r, g, b, a);
             return;
         }
 
@@ -177,7 +181,7 @@ public:
         if (!m_premultiplyAlpha)
             result = unpremultiplied(result);
 
-        *dest = PackedColor::ARGB { result }.value;
+        destination = PackedColor::ARGB { result }.value;
     }
 
     static bool isOverSize(const IntSize& size)
@@ -210,7 +214,7 @@ private:
         ASSERT(!m_size.isEmpty() && !isOverSize(m_size));
         Vector<uint8_t> buffer(other.m_pixels->span());
         m_pixels = FragmentedSharedBuffer::DataSegment::create(WTFMove(buffer));
-        m_pixelsPtr = reinterpret_cast<uint32_t*>(const_cast<uint8_t*>(m_pixels->span().data()));
+        m_pixelsSpan = spanReinterpretCast<uint32_t>(spanConstCast<uint8_t>(m_pixels->span()));
     }
 
     bool inBounds(const IntPoint& point) const
@@ -238,12 +242,10 @@ private:
 
     // m_pixels type should be identical to the one set in ImageBackingStoreCairo.cpp
     RefPtr<FragmentedSharedBuffer::DataSegment> m_pixels;
-    uint32_t* m_pixelsPtr { nullptr };
+    std::span<uint32_t> m_pixelsSpan;
     IntSize m_size;
     IntRect m_frameRect; // This will always just be the entire buffer except for GIF and PNG frames
     bool m_premultiplyAlpha { true };
 };
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/cg/ImageBackingStoreCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBackingStoreCG.cpp
@@ -43,7 +43,7 @@ PlatformImagePtr ImageBackingStore::image() const
     size_t bytesPerRow = bytesPerPixel * width;
 
     auto colorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
-    auto dataProvider = adoptCF(CGDataProviderCreateWithData(m_pixels.get(), m_pixelsPtr, height * bytesPerRow, dataProviderReleaseCallback));
+    auto dataProvider = adoptCF(CGDataProviderCreateWithData(m_pixels.get(), m_pixelsSpan.data(), height * bytesPerRow, dataProviderReleaseCallback));
 
     if (!dataProvider)
         return nullptr;

--- a/Source/WebCore/platform/image-decoders/avif/AVIFImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/avif/AVIFImageReader.cpp
@@ -108,7 +108,7 @@ void AVIFImageReader::decodeFrame(size_t frameIndex, ScalableImageDecoderFrame& 
     decodedRGBImage.alphaPremultiplied = m_decoder->premultiplyAlpha();
     decodedRGBImage.format = AVIF_RGB_FORMAT_BGRA;
     decodedRGBImage.rowBytes = imageSize.width() * sizeof(uint32_t);
-    decodedRGBImage.pixels = reinterpret_cast<uint8_t*>(buffer.backingStore()->pixelAt(0, 0));
+    decodedRGBImage.pixels = reinterpret_cast<uint8_t*>(buffer.backingStore()->pixelsStartingAt(0, 0).data());
 
     if (avifImageYUVToRGB(m_avifDecoder->image, &decodedRGBImage) != AVIF_RESULT_OK) {
         m_decoder->setFailed();

--- a/Source/WebCore/platform/image-decoders/cairo/ImageBackingStoreCairo.cpp
+++ b/Source/WebCore/platform/image-decoders/cairo/ImageBackingStoreCairo.cpp
@@ -35,7 +35,7 @@ PlatformImagePtr ImageBackingStore::image() const
 {
     m_pixels->ref();
     RefPtr<cairo_surface_t> surface = adoptRef(cairo_image_surface_create_for_data(
-        reinterpret_cast<unsigned char*>(const_cast<uint32_t*>(m_pixelsPtr)),
+        reinterpret_cast<unsigned char*>(const_cast<uint32_t*>(m_pixelsSpan.data())),
         CAIRO_FORMAT_ARGB32, size().width(), size().height(), size().width() * sizeof(uint32_t)));
     static cairo_user_data_key_t s_surfaceDataKey;
     cairo_surface_set_user_data(surface.get(), &s_surfaceDataKey, m_pixels.get(), [](void* data) {

--- a/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
@@ -387,17 +387,18 @@ void JPEGXLImageDecoder::imageOut(size_t x, size_t y, size_t numPixels, const ui
     if (buffer.isInvalid())
         return;
 
-    uint32_t* row = buffer.backingStore()->pixelAt(x, y);
-    uint32_t* currentAddress = row;
+    auto row = buffer.backingStore()->pixelsStartingAt(x, y);
+    auto currentAddress = row;
     for (size_t i = 0; i < numPixels; i++) {
         uint8_t r = *pixels++;
         uint8_t g = *pixels++;
         uint8_t b = *pixels++;
         uint8_t a = *pixels++;
-        buffer.backingStore()->setPixel(currentAddress++, r, g, b, a);
+        buffer.backingStore()->setPixel(currentAddress[0], r, g, b, a);
+        currentAddress = currentAddress.subspan(1);
     }
 
-    maybePerformColorSpaceConversion(row, row, numPixels);
+    maybePerformColorSpaceConversion(row.data(), row.data(), numPixels);
 }
 
 #if USE(LCMS)

--- a/Source/WebCore/platform/image-decoders/skia/ImageBackingStoreSkia.cpp
+++ b/Source/WebCore/platform/image-decoders/skia/ImageBackingStoreSkia.cpp
@@ -36,7 +36,7 @@ PlatformImagePtr ImageBackingStore::image() const
 {
     m_pixels->ref();
     auto info = SkImageInfo::MakeN32(size().width(), size().height(), m_premultiplyAlpha ? kPremul_SkAlphaType : kUnpremul_SkAlphaType, SkColorSpace::MakeSRGB());
-    SkPixmap pixmap(info, m_pixelsPtr, info.minRowBytes64());
+    SkPixmap pixmap(info, m_pixelsSpan.data(), info.minRowBytes64());
     return SkImages::RasterFromPixmap(pixmap, [](const void*, void* context) {
         static_cast<DataSegment*>(context)->deref();
     }, m_pixels.get());

--- a/Source/WebCore/platform/image-decoders/webp/WEBPImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/webp/WEBPImageDecoder.cpp
@@ -276,14 +276,14 @@ void WEBPImageDecoder::applyPostProcessing(size_t frameIndex, WebPIDecoder* deco
         const int canvasY = top + y;
         for (int x = 0; x < decodedWidth; x++) {
             const int canvasX = left + x;
-            auto* address = buffer.backingStore()->pixelAt(canvasX, canvasY);
+            auto& destinationPixel = buffer.backingStore()->pixelAt(canvasX, canvasY);
             WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-            uint8_t* pixel = decoderBuffer.u.RGBA.rgba + (y * frameRect.width() + x) * sizeof(uint32_t);
+            uint8_t* sourcePixels = decoderBuffer.u.RGBA.rgba + (y * frameRect.width() + x) * sizeof(uint32_t);
             WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-            if (blend && (pixel[3] < 255))
-                buffer.backingStore()->blendPixel(address, pixel[0], pixel[1], pixel[2], pixel[3]);
+            if (blend && (sourcePixels[3] < 255))
+                buffer.backingStore()->blendPixel(destinationPixel, sourcePixels[0], sourcePixels[1], sourcePixels[2], sourcePixels[3]);
             else
-                buffer.backingStore()->setPixel(address, pixel[0], pixel[1], pixel[2], pixel[3]);
+                buffer.backingStore()->setPixel(destinationPixel, sourcePixels[0], sourcePixels[1], sourcePixels[2], sourcePixels[3]);
         }
     }
 }


### PR DESCRIPTION
#### 1db6fc53597cc71b6be16c96fe3ba78a08a6a980
<pre>
Adopt more spans in ImageBackingStore.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=285389">https://bugs.webkit.org/show_bug.cgi?id=285389</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/graphics/ImageBackingStore.h:
(WebCore::ImageBackingStore::setSize):
(WebCore::ImageBackingStore::clear):
(WebCore::ImageBackingStore::clearRect):
(WebCore::ImageBackingStore::fillRect):
(WebCore::ImageBackingStore::repeatFirstRow):
(WebCore::ImageBackingStore::pixelAt const):
(WebCore::ImageBackingStore::setPixel):
(WebCore::ImageBackingStore::blendPixel):
(WebCore::ImageBackingStore::ImageBackingStore):
* Source/WebCore/platform/image-decoders/avif/AVIFImageReader.cpp:
(WebCore::AVIFImageReader::decodeFrame):
* Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp:
(WebCore::GIFImageDecoder::haveDecodedRow):
* Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp:
(WebCore::setPixel):
(WebCore::JPEGImageDecoder::outputScanlines):
* Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp:
(WebCore::JPEGXLImageDecoder::imageOut):
* Source/WebCore/platform/image-decoders/png/PNGImageDecoder.cpp:
(WebCore::PNGImageDecoder::rowAvailable):
(WebCore::PNGImageDecoder::frameComplete):
* Source/WebCore/platform/image-decoders/webp/WEBPImageDecoder.cpp:
(WebCore::WEBPImageDecoder::applyPostProcessing):

Canonical link: <a href="https://commits.webkit.org/288455@main">https://commits.webkit.org/288455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f65c5a9bebd26a4e4a63e596b5b8553a453061f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88523 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34457 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11021 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/64918 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22658 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86497 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/2302 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75829 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45205 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2204 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30035 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33507 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89899 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73343 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10937 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72571 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16802 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15527 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12878 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10667 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/16136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10518 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13989 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12289 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->