### PR TITLE
Pass WebTransportSessionClient as parameter to WebTransportSession constructors

### DIFF
--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -112,20 +112,21 @@ void WebTransport::initializeOverHTTP(SocketProvider& provider, ScriptExecutionC
     // FIXME: Do origin checks as outlined in https://www.w3.org/TR/webtransport/#initialize-webtransport-over-http
 
     // FIXME: Rename SocketProvider to NetworkProvider or something to reflect that it provides a little more than just simple sockets. SocketAndTransportProvider?
-    auto workerContextID = is<WorkerGlobalScope>(context) ? std::optional(context.identifier()) : std::nullopt;
-    context.enqueueTaskWhenSettled(provider.initializeWebTransportSession(context, url), TaskSource::Networking, [this, protectedThis = Ref { *this }, workerContextID] (auto&& result) {
+    RefPtr workerSession = is<WorkerGlobalScope>(context) ? WorkerWebTransportSession::create(context.identifier(), *this).ptr() : nullptr;
+    auto& client = workerSession ? static_cast<WebTransportSessionClient&>(*workerSession) : static_cast<WebTransportSessionClient&>(*this);
+    context.enqueueTaskWhenSettled(provider.initializeWebTransportSession(context, client, url), TaskSource::Networking, [this, protectedThis = Ref { *this }, workerSession] (auto&& result) mutable {
         if (!result) {
             m_state = State::Failed;
             m_ready.second->reject();
             return;
         }
 
-        if (workerContextID)
-            m_session = WorkerWebTransportSession::create(*workerContextID, *this, WTFMove(*result));
-        else
+        if (workerSession) {
+            workerSession->attachSession(WTFMove(*result));
+            m_session = WTFMove(workerSession);
+        } else
             m_session = WTFMove(*result);
 
-        m_session->attachClient(*this);
         m_state = State::Connected;
         m_ready.second->resolve();
     });

--- a/Source/WebCore/Modules/webtransport/WebTransportSession.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportSession.cpp
@@ -32,9 +32,4 @@ namespace WebCore {
 
 WebTransportSession::~WebTransportSession() = default;
 
-void WebTransportSession::attachClient(WebTransportSessionClient& client)
-{
-    m_client = client;
-}
-
 }

--- a/Source/WebCore/Modules/webtransport/WebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSession.h
@@ -52,10 +52,6 @@ public:
     virtual Ref<WritableStreamPromise> createOutgoingUnidirectionalStream() = 0;
     virtual Ref<BidirectionalStreamPromise> createBidirectionalStream() = 0;
     virtual void terminate(uint32_t, CString&&) = 0;
-
-    void attachClient(WebTransportSessionClient&);
-protected:
-    ThreadSafeWeakPtr<WebTransportSessionClient> m_client;
 };
 
 }

--- a/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
+++ b/Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h
@@ -33,16 +33,18 @@ namespace WebCore {
 
 class WebTransport;
 
-class WorkerWebTransportSession : public WebTransportSession, private WebTransportSessionClient {
+class WorkerWebTransportSession : public WebTransportSession, public WebTransportSessionClient {
 public:
-    static Ref<WorkerWebTransportSession> create(ScriptExecutionContextIdentifier, WebTransportSessionClient&, Ref<WebTransportSession>&&);
+    static Ref<WorkerWebTransportSession> create(ScriptExecutionContextIdentifier, WebTransportSessionClient&);
     ~WorkerWebTransportSession();
 
     void ref() const { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
     void deref() const { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
 
+    void attachSession(Ref<WebTransportSession>&&);
+
 private:
-    WorkerWebTransportSession(ScriptExecutionContextIdentifier, WebTransportSessionClient&, Ref<WebTransportSession>&&);
+    WorkerWebTransportSession(ScriptExecutionContextIdentifier, WebTransportSessionClient&);
 
     void receiveDatagram(std::span<const uint8_t>) final;
     void receiveIncomingUnidirectionalStream(WebTransportStreamIdentifier) final;
@@ -57,7 +59,7 @@ private:
 
     const ScriptExecutionContextIdentifier m_contextID;
     ThreadSafeWeakPtr<WebTransportSessionClient> m_client;
-    const Ref<WebTransportSession> m_session;
+    RefPtr<WebTransportSession> m_session;
 };
 
 }

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -1224,7 +1224,7 @@ private:
 class EmptySocketProvider final : public SocketProvider {
 public:
     RefPtr<ThreadableWebSocketChannel> createWebSocketChannel(Document&, WebSocketChannelClient&) final { return nullptr; }
-    Ref<WebTransportSessionPromise> initializeWebTransportSession(ScriptExecutionContext&, const URL&) { return WebTransportSessionPromise::createAndReject(); }
+    Ref<WebTransportSessionPromise> initializeWebTransportSession(ScriptExecutionContext&, WebTransportSessionClient&, const URL&) { return WebTransportSessionPromise::createAndReject(); }
 };
 
 class EmptyHistoryItemClient final : public HistoryItemClient {

--- a/Source/WebCore/page/SocketProvider.h
+++ b/Source/WebCore/page/SocketProvider.h
@@ -36,13 +36,14 @@ class ScriptExecutionContext;
 class ThreadableWebSocketChannel;
 class WebSocketChannelClient;
 class WebTransportSession;
+class WebTransportSessionClient;
 
 using WebTransportSessionPromise = NativePromise<Ref<WebTransportSession>, void>;
 
 class WEBCORE_EXPORT SocketProvider : public ThreadSafeRefCounted<SocketProvider> {
 public:
     virtual RefPtr<ThreadableWebSocketChannel> createWebSocketChannel(Document&, WebSocketChannelClient&) = 0;
-    virtual Ref<WebTransportSessionPromise> initializeWebTransportSession(ScriptExecutionContext&, const URL&) = 0;
+    virtual Ref<WebTransportSessionPromise> initializeWebTransportSession(ScriptExecutionContext&, WebTransportSessionClient&, const URL&) = 0;
 
     virtual ~SocketProvider() { };
 };

--- a/Source/WebKit/WebProcess/Network/WebSocketProvider.h
+++ b/Source/WebKit/WebProcess/Network/WebSocketProvider.h
@@ -35,7 +35,7 @@ public:
     static Ref<WebSocketProvider> create(WebPageProxyIdentifier webPageProxyID) { return adoptRef(*new WebSocketProvider(webPageProxyID)); }
 private:
     RefPtr<WebCore::ThreadableWebSocketChannel> createWebSocketChannel(WebCore::Document&, WebCore::WebSocketChannelClient&) final;
-    Ref<WebCore::WebTransportSessionPromise> initializeWebTransportSession(WebCore::ScriptExecutionContext&, const URL&) final;
+    Ref<WebCore::WebTransportSessionPromise> initializeWebTransportSession(WebCore::ScriptExecutionContext&, WebCore::WebTransportSessionClient&, const URL&) final;
 
     explicit WebSocketProvider(WebPageProxyIdentifier webPageProxyID)
         : m_webPageProxyID(webPageProxyID) { }

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.h
@@ -40,6 +40,7 @@ enum class Error : uint8_t;
 
 namespace WebCore {
 class WebTransportSession;
+class WebTransportSessionClient;
 struct ClientOrigin;
 struct WebTransportStreamIdentifierType;
 using WebTransportStreamIdentifier = ObjectIdentifier<WebTransportStreamIdentifierType>;
@@ -58,7 +59,7 @@ using WebTransportSessionIdentifier = ObjectIdentifier<WebTransportSessionIdenti
 
 class WebTransportSession : public WebCore::WebTransportSession, public IPC::MessageReceiver, public IPC::MessageSender, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebTransportSession, WTF::DestructionThread::MainRunLoop> {
 public:
-    static Ref<WebCore::WebTransportSessionPromise> initialize(Ref<IPC::Connection>&&, const URL&, const WebPageProxyIdentifier&, const WebCore::ClientOrigin&);
+    static Ref<WebCore::WebTransportSessionPromise> initialize(Ref<IPC::Connection>&&, ThreadSafeWeakPtr<WebCore::WebTransportSessionClient>&&, const URL&, const WebPageProxyIdentifier&, const WebCore::ClientOrigin&);
     ~WebTransportSession();
 
     void receiveDatagram(std::span<const uint8_t>);
@@ -76,7 +77,7 @@ public:
 
     void networkProcessCrashed();
 private:
-    WebTransportSession(Ref<IPC::Connection>&&, WebTransportSessionIdentifier);
+    WebTransportSession(Ref<IPC::Connection>&&, ThreadSafeWeakPtr<WebCore::WebTransportSessionClient>&&, WebTransportSessionIdentifier);
 
     // WebTransportSession
     Ref<GenericPromise> sendDatagram(std::span<const uint8_t>) final;
@@ -89,6 +90,7 @@ private:
     uint64_t messageSenderDestinationID() const final;
 
     const Ref<IPC::Connection> m_connection;
+    const ThreadSafeWeakPtr<WebCore::WebTransportSessionClient> m_client;
     const WebTransportSessionIdentifier m_identifier;
 };
 

--- a/Source/WebKitLegacy/WebCoreSupport/LegacySocketProvider.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/LegacySocketProvider.cpp
@@ -34,7 +34,7 @@ RefPtr<WebCore::ThreadableWebSocketChannel> LegacySocketProvider::createWebSocke
     return WebCore::WebSocketChannel::create(document, client, *this);
 }
 
-Ref<WebCore::WebTransportSessionPromise> LegacySocketProvider::initializeWebTransportSession(WebCore::ScriptExecutionContext&, const URL&)
+Ref<WebCore::WebTransportSessionPromise> LegacySocketProvider::initializeWebTransportSession(WebCore::ScriptExecutionContext&, WebCore::WebTransportSessionClient&, const URL&)
 {
     return WebCore::WebTransportSessionPromise::createAndReject();
 }

--- a/Source/WebKitLegacy/WebCoreSupport/LegacySocketProvider.h
+++ b/Source/WebKitLegacy/WebCoreSupport/LegacySocketProvider.h
@@ -32,5 +32,5 @@ public:
     static Ref<LegacySocketProvider> create() { return adoptRef(*new LegacySocketProvider); }
 private:
     RefPtr<WebCore::ThreadableWebSocketChannel> createWebSocketChannel(WebCore::Document&, WebCore::WebSocketChannelClient&) final;
-    Ref<WebCore::WebTransportSessionPromise> initializeWebTransportSession(WebCore::ScriptExecutionContext&, const URL&) final;
+    Ref<WebCore::WebTransportSessionPromise> initializeWebTransportSession(WebCore::ScriptExecutionContext&, WebCore::WebTransportSessionClient&, const URL&) final;
 };


### PR DESCRIPTION
#### cb1b8e27c832efc0133229a5b00b99ae3110a038
<pre>
Pass WebTransportSessionClient as parameter to WebTransportSession constructors
<a href="https://bugs.webkit.org/show_bug.cgi?id=285392">https://bugs.webkit.org/show_bug.cgi?id=285392</a>

Reviewed by Matthew Finkel.

In the process of setting up a session, the session needs a client immediately
because a datagram can be received immediately.  The WebTransport object doesn&apos;t
need a session immediately because it can&apos;t do anything anyways until the session
is set up.  This fixes an issue where, if you set up a WebTransport on a worker
and it receives a datagram immediately, it can hit an assertion sometimes on a
race condition.  This was found by Ankshit when working on
<a href="https://github.com/WebKit/WebKit/pull/38327">https://github.com/WebKit/WebKit/pull/38327</a> which needs this PR to work properly.

* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::WebTransport::initializeOverHTTP):
* Source/WebCore/Modules/webtransport/WebTransportSession.cpp:
(WebCore::WebTransportSession::attachClient): Deleted.
* Source/WebCore/Modules/webtransport/WebTransportSession.h:
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.cpp:
(WebCore::WorkerWebTransportSession::create):
(WebCore::WorkerWebTransportSession::WorkerWebTransportSession):
(WebCore::WorkerWebTransportSession::attachSession):
(WebCore::WorkerWebTransportSession::sendDatagram):
(WebCore::WorkerWebTransportSession::createOutgoingUnidirectionalStream):
(WebCore::WorkerWebTransportSession::createBidirectionalStream):
(WebCore::WorkerWebTransportSession::terminate):
* Source/WebCore/Modules/webtransport/WorkerWebTransportSession.h:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/SocketProvider.h:
* Source/WebKit/WebProcess/Network/WebSocketProvider.cpp:
(WebKit::WebSocketProvider::initializeWebTransportSession):
* Source/WebKit/WebProcess/Network/WebSocketProvider.h:
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::initialize):
(WebKit::WebTransportSession::WebTransportSession):
* Source/WebKit/WebProcess/Network/WebTransportSession.h:
* Source/WebKitLegacy/WebCoreSupport/LegacySocketProvider.cpp:
(LegacySocketProvider::initializeWebTransportSession):
* Source/WebKitLegacy/WebCoreSupport/LegacySocketProvider.h:

Canonical link: <a href="https://commits.webkit.org/288469@main">https://commits.webkit.org/288469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbe4956f2cf9b3a4c8f6ad70a4c4087e1f68e030

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34376 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85456 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64851 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22599 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75764 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45135 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2144 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29965 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33427 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73249 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89818 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10632 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7667 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73277 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10857 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72507 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16731 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15465 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1967 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12885 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10587 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16059 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10437 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13908 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->