### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in ParsingUtilities.h

### DIFF
--- a/Source/WTF/wtf/text/ParsingUtilities.h
+++ b/Source/WTF/wtf/text/ParsingUtilities.h
@@ -35,8 +35,6 @@
 #include <wtf/text/StringCommon.h>
 #include <wtf/text/StringParsingBuffer.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 template<typename CharacterType> inline bool isNotASCIISpace(CharacterType c)
@@ -71,24 +69,6 @@ template<typename CharacterType, typename DelimiterType> bool skipExactly(String
 {
     if (buffer.hasCharactersRemaining() && *buffer == delimiter) {
         ++buffer;
-        return true;
-    }
-    return false;
-}
-
-template<bool characterPredicate(LChar)> bool skipExactly(const LChar*& position, const LChar* end)
-{
-    if (position < end && characterPredicate(*position)) {
-        ++position;
-        return true;
-    }
-    return false;
-}
-
-template<bool characterPredicate(UChar)> bool skipExactly(const UChar*& position, const UChar* end)
-{
-    if (position < end && characterPredicate(*position)) {
-        ++position;
         return true;
     }
     return false;
@@ -130,12 +110,6 @@ template<bool characterPredicate(UChar)> bool skipExactly(std::span<const UChar>
     return false;
 }
 
-template<typename CharacterType, typename DelimiterType> void skipUntil(const CharacterType*& position, const CharacterType* end, DelimiterType delimiter)
-{
-    while (position < end && *position != delimiter)
-        ++position;
-}
-
 template<typename CharacterType, typename DelimiterType> void skipUntil(StringParsingBuffer<CharacterType>& buffer, DelimiterType delimiter)
 {
     while (buffer.hasCharactersRemaining() && *buffer != delimiter)
@@ -148,18 +122,6 @@ template<typename CharacterType, typename DelimiterType> void skipUntil(std::spa
     while (index < buffer.size() && buffer[index] != delimiter)
         ++index;
     skip(buffer, index);
-}
-
-template<bool characterPredicate(LChar)> void skipUntil(const LChar*& position, const LChar* end)
-{
-    while (position < end && !characterPredicate(*position))
-        ++position;
-}
-
-template<bool characterPredicate(UChar)> void skipUntil(const UChar*& position, const UChar* end)
-{
-    while (position < end && !characterPredicate(*position))
-        ++position;
 }
 
 template<bool characterPredicate(LChar)> void skipUntil(std::span<const LChar>& data)
@@ -204,18 +166,6 @@ template<typename CharacterType, typename DelimiterType> void skipWhile(std::spa
     skip(buffer, index);
 }
 
-template<bool characterPredicate(LChar)> void skipWhile(const LChar*& position, const LChar* end)
-{
-    while (position < end && characterPredicate(*position))
-        ++position;
-}
-
-template<bool characterPredicate(UChar)> void skipWhile(const UChar*& position, const UChar* end)
-{
-    while (position < end && characterPredicate(*position))
-        ++position;
-}
-
 template<bool characterPredicate(LChar)> void skipWhile(std::span<const LChar>& data)
 {
     size_t index = 0;
@@ -244,30 +194,6 @@ template<bool characterPredicate(UChar)> void skipWhile(StringParsingBuffer<UCha
         ++buffer;
 }
 
-template<bool characterPredicate(LChar)> void reverseSkipWhile(const LChar*& position, const LChar* start)
-{
-    while (position >= start && characterPredicate(*position))
-        --position;
-}
-
-template<bool characterPredicate(UChar)> void reverseSkipWhile(const UChar*& position, const UChar* start)
-{
-    while (position >= start && characterPredicate(*position))
-        --position;
-}
-
-template<typename CharacterType> bool skipExactlyIgnoringASCIICase(const CharacterType*& position, const CharacterType* end, ASCIILiteral literal)
-{
-    auto literalLength = literal.length();
-
-    if (position + literalLength > end)
-        return false;
-    if (!equalLettersIgnoringASCIICaseWithLength(std::span { position, literalLength }, literal.span8(), literalLength))
-        return false;
-    position += literalLength;
-    return true;
-}
-
 template<typename CharacterType> bool skipExactlyIgnoringASCIICase(StringParsingBuffer<CharacterType>& buffer, ASCIILiteral literal)
 {
     auto literalLength = literal.length();
@@ -286,8 +212,10 @@ template<typename CharacterType, std::size_t Extent> bool skipLettersExactlyIgno
         return false;
     for (unsigned i = 0; i < letters.size(); ++i) {
         ASSERT(isASCIIAlpha(letters[i]));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (!isASCIIAlphaCaselessEqual(buffer.position()[i], static_cast<char>(letters[i])))
             return false;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
     buffer += letters.size();
     return true;
@@ -350,7 +278,6 @@ using WTF::consume;
 using WTF::consumeAndCastTo;
 using WTF::consumeSpan;
 using WTF::isNotASCIISpace;
-using WTF::reverseSkipWhile;
 using WTF::skip;
 using WTF::skipCharactersExactly;
 using WTF::skipExactly;
@@ -358,6 +285,3 @@ using WTF::skipExactlyIgnoringASCIICase;
 using WTF::skipLettersExactlyIgnoringASCIICase;
 using WTF::skipUntil;
 using WTF::skipWhile;
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-


### PR DESCRIPTION
#### d7ffc1f375451bc86b204d0eff6d7c41f3b96434
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in ParsingUtilities.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=285396">https://bugs.webkit.org/show_bug.cgi?id=285396</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/text/ParsingUtilities.h:
(WTF::skipLettersExactlyIgnoringASCIICase):
* Source/WebCore/html/parser/HTMLSrcsetParser.cpp:
(WebCore::parseImageCandidatesFromSrcsetAttribute):

Canonical link: <a href="https://commits.webkit.org/288445@main">https://commits.webkit.org/288445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccc0994c03016f3fea9d3415bf6af5b3446ebb78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88458 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34390 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85470 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64863 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22611 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75769 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45147 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/29970 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33441 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76340 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73255 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30699 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89832 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/82399 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7678 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73289 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72519 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16737 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15470 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1981 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12873 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10601 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16073 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/104821 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10451 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25353 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13923 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->