### PR TITLE
[GStreamer][WebRTC] webrtc/video-h264.html consistently times out

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2250,7 +2250,6 @@ webrtc/captureCanvas-webrtc.html [ Pass Timeout ]
 webkit.org/b/252878 webrtc/audio-peer-connection-webaudio.html [ Failure Pass Timeout ]
 webkit.org/b/252878 webrtc/audio-samplerate-change.html [ Pass Timeout ]
 webkit.org/b/252878 webrtc/datachannel/bufferedAmountLowThreshold-default.html [ Failure Pass ]
-webkit.org/b/252878 webrtc/video-h264.html [ Pass Timeout ]
 
 imported/w3c/web-platform-tests/mediacapture-streams/GUM-required-constraint-with-ideal-value.https.html [ Failure ]
 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-MediaElement-preload-none.https.html [ Failure ]
@@ -2352,8 +2351,6 @@ webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSync
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html [ Skip ]
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/protocol/rtp-clockrate.html [ Skip ]
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-senderCaptureTimeOffset.html [ Skip ]
-
-webkit.org/b/215007 webrtc/h264-high.html [ Failure Timeout ]
 
 # We don't support spatial encoding yet.
 webkit.org/b/235885 webrtc/vp9-svc.html [ Skip ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -808,7 +808,9 @@ webkit.org/b/257624 webaudio/suspend-context-while-interrupted.html [ Pass Timeo
 webkit.org/b/257624 webgl/1.0.x/conformance/rendering/texture-switch-performance.html [ Failure Pass ]
 webkit.org/b/257624 webgl/2.0.y/conformance/rendering/texture-switch-performance.html [ Failure Pass ]
 webkit.org/b/257624 webrtc/canvas-to-peer-connection-2d.html [ Failure Pass Timeout ]
-webkit.org/b/257624 webrtc/video-h264.html [ Crash Pass Timeout ]
+
+# Fails on WPE EWS, likely when checking the video pixels. Unable to reproduce this failure locally.
+webrtc/video-h264.html [ Failure ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # 6. SLOW TESTS

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
@@ -84,19 +84,17 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> h264CapsFromCodecString(con
 
     StringBuilder formatBuilder;
     auto profile = StringView::fromLatin1(gstProfile);
-    auto isY444 = profile.findIgnoringASCIICase("high-4:4:4"_s) != notFound;
-    auto isY422 = profile.findIgnoringASCIICase("high-4:2:2"_s) != notFound;
-    auto isY420 = profile.findIgnoringASCIICase("high-10"_s) != notFound;
-    if (isY444)
+    auto isY444TenBits = profile.startsWithIgnoringASCIICase("high-4:4:4"_s);
+    auto isY422TenBits = profile.findIgnoringASCIICase("high-4:2:2"_s) != notFound;
+    auto isI420TenBits = profile.findIgnoringASCIICase("high-10"_s) != notFound;
+    if (isY444TenBits)
         formatBuilder.append("Y444"_s);
-    else if (isY422)
+    else if (isY422TenBits)
         formatBuilder.append("I422"_s);
-    else if (isY420)
-        formatBuilder.append("Y420"_s);
     else
         formatBuilder.append("I420"_s);
 
-    if (isY444 || isY422 || isY420) {
+    if (isY444TenBits || isY422TenBits || isI420TenBits) {
 #if G_BYTE_ORDER == G_LITTLE_ENDIAN
         auto endianness = "LE"_s;
 #else

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
@@ -94,6 +94,12 @@ RefPtr<GStreamerVideoRTPPacketizer> GStreamerVideoRTPPacketizer::create(RefPtr<U
             parameters.constraintsFlags |= 1 << 6;
         } else if (profile == "main"_s)
             parameters.profileIDC = 77;
+        else if (profile == "constrained-high"_s) {
+            parameters.profileIDC = 100;
+            parameters.constraintsFlags |= 1 << 3;
+            parameters.constraintsFlags |= 1 << 2;
+        } else if (profile == "high"_s)
+            parameters.profileIDC = 100;
 
         codec = createAVCCodecParametersString(parameters);
     } else if (encoding == "h265"_s) {


### PR DESCRIPTION
#### 85fd6a98f9ec6eb343231cb499c9de2dfab89f74
<pre>
[GStreamer][WebRTC] webrtc/video-h264.html consistently times out
<a href="https://bugs.webkit.org/show_bug.cgi?id=285398">https://bugs.webkit.org/show_bug.cgi?id=285398</a>

Reviewed by Xabier Rodriguez-Calvar.

To make this test pass the two main changes needed were to have support for high and
constrained-high avc codec strings in the packetizer and then let the VideoEncoderPrivate select the
underlying encoder using the output caps. Without this change x264enc was selected due to its high
rank but it doesn&apos;t support constrained-high, hence the caps negotiation error. For this test now
openh264enc is selected instead.

Driving-by, the input format handling for h264 was reworked a bit, also removing the inexistant Y420
format.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp:
(WebCore::h264CapsFromCodecString):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(videoEncoderSupportsCodec):
(videoEncoderSetCodec):
(webkit_video_encoder_class_init):
(videoEncoderFindForCodec): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp:
(WebCore::GStreamerVideoRTPPacketizer::create):

Canonical link: <a href="https://commits.webkit.org/288701@main">https://commits.webkit.org/288701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/314e79d2d7eecff28c7e371903ec7cbb158ef2ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88965 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34899 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65251 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23083 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45543 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2597 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30443 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33948 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31197 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90341 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73697 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11380 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72916 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18081 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17194 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15882 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2488 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11108 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16580 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10956 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14432 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->