### PR TITLE
Assertion when using non-absolute / non-font-relative units in ctx.letterSpacing/ctx.wordSpacing

### DIFF
--- a/LayoutTests/fast/canvas/canvas-letterSpacing-wordSpacing-units-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-letterSpacing-wordSpacing-units-expected.txt
@@ -1,0 +1,5 @@
+Regression test for bug 285404
+
+Test passes by not crashing.
+
+

--- a/LayoutTests/fast/canvas/canvas-letterSpacing-wordSpacing-units.html
+++ b/LayoutTests/fast/canvas/canvas-letterSpacing-wordSpacing-units.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Regression test for bug <a href="http://webkit.org/b/285404">285404</a></p>
+<p>Test passes by not crashing.</p>
+<canvas id="test"></canvas>
+</body>
+<script>
+if (window.testRunner)
+   testRunner.dumpAsText();
+
+const units = [
+ 'px', 'cm', 'mm', 'q', 'in', 'pt', 'pc', 'em', 'ex', 'lh', 'cap', 'ch', 'ic', 'rcap', 'rch', 'rem', 'rex', 'ric', 'rlh', 'vw', 'vh', 'vmin', 'vmax', 'vb', 'vi', 'svw', 'svh', 'svmin', 'svmax', 'svb', 'svi', 'lvw', 'lvh', 'lvmin', 'lvmax', 'lvb', 'lvi', 'dvw', 'dvh', 'dvmin', 'dvmax', 'dvb', 'dvi', 'cqw', 'cqh', 'cqi', 'cqb', 'cqmin', 'cqmax'
+];
+
+var canvas = document.getElementById("test");
+var context = canvas.getContext("2d");
+for (unit of units) {
+  context.letterSpacing = `10${unit}`;
+  context.wordSpacing = `10${unit}`;
+}
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.invalid.spacing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/text/2d.text.drawing.style.invalid.spacing.html
@@ -28,6 +28,7 @@ _addTest(function(canvas, ctx) {
     _assertSame(ctx.wordSpacing, '0px', "ctx.wordSpacing", "'0px'");
     _assertSame(ctx.letterSpacing, '0px', "ctx.letterSpacing", "'0px'");
   }
+  test_word_spacing('1lh')
   test_word_spacing('0s');
   test_word_spacing('1min');
   test_word_spacing('1deg');

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -3051,6 +3051,71 @@ std::optional<CanvasRenderingContext2DBase::RenderingMode> CanvasRenderingContex
     return std::nullopt;
 }
 
+// FIXME: The HTML spec currently doesn't define how <length> units should be resolved, so we only
+// allow units where the resolution is straightforward. See https://github.com/whatwg/html/issues/10893.
+static bool unitAllowedForSpacing(CSS::LengthUnit lenghtUnit)
+{
+    using enum CSS::LengthUnit;
+
+    switch (lenghtUnit) {
+    case Px:
+    case Cm:
+    case Mm:
+    case Q:
+    case In:
+    case Pt:
+    case Pc:
+    case Em:
+    case QuirkyEm:
+    case Ex:
+    case Cap:
+    case Ch:
+    case Ic:
+    case Rcap:
+    case Rch:
+    case Rem:
+    case Rex:
+    case Ric:
+        return true;
+
+    case Lh:
+    case Rlh:
+    case Vw:
+    case Vh:
+    case Vmin:
+    case Vmax:
+    case Vb:
+    case Vi:
+    case Svw:
+    case Svh:
+    case Svmin:
+    case Svmax:
+    case Svb:
+    case Svi:
+    case Lvw:
+    case Lvh:
+    case Lvmin:
+    case Lvmax:
+    case Lvb:
+    case Lvi:
+    case Dvw:
+    case Dvh:
+    case Dvmin:
+    case Dvmax:
+    case Dvb:
+    case Dvi:
+    case Cqw:
+    case Cqh:
+    case Cqi:
+    case Cqb:
+    case Cqmin:
+    case Cqmax:
+        return false;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 void CanvasRenderingContext2DBase::setLetterSpacing(const String& letterSpacing)
 {
     if (state().letterSpacing == letterSpacing)
@@ -3066,8 +3131,8 @@ void CanvasRenderingContext2DBase::setLetterSpacing(const String& letterSpacing)
     auto rawLength = parsedValue->raw();
     if (!rawLength)
         return;
-
-    // FIXME: Ensure rawLength->unit is supported by `Style::computeUnzoomedNonCalcLengthDouble`.
+    if (!unitAllowedForSpacing(rawLength->unit))
+        return;
 
     auto& fontCascade = fontProxy()->fontCascade();
     double pixels = Style::computeUnzoomedNonCalcLengthDouble(rawLength->value, rawLength->unit, CSSPropertyLetterSpacing, &fontCascade);
@@ -3091,8 +3156,8 @@ void CanvasRenderingContext2DBase::setWordSpacing(const String& wordSpacing)
     auto rawLength = parsedValue->raw();
     if (!rawLength)
         return;
-
-    // FIXME: Ensure rawLength->unit is supported by `Style::computeUnzoomedNonCalcLengthDouble`.
+    if (!unitAllowedForSpacing(rawLength->unit))
+        return;
 
     auto& fontCascade = fontProxy()->fontCascade();
     double pixels = Style::computeUnzoomedNonCalcLengthDouble(rawLength->value, rawLength->unit, CSSPropertyWordSpacing, &fontCascade);


### PR DESCRIPTION
#### ddefac0cb41ffb082140c9aa388104c4950c6246
<pre>
Assertion when using non-absolute / non-font-relative units in ctx.letterSpacing/ctx.wordSpacing
<a href="https://bugs.webkit.org/show_bug.cgi?id=285404">https://bugs.webkit.org/show_bug.cgi?id=285404</a>

Reviewed by Darin Adler.

Fixes a debug only assertion when setting ctx.letterSpacing/ctx.wordSpacing
to non-absolute / non-font-relative units in the length passed in.

* LayoutTests/fast/canvas/canvas-letterSpacing-wordSpacing-units-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-letterSpacing-wordSpacing-units.html: Added.
    - Adds test that setting letterSpacing / wordSpacing doesn&apos;t crash for any unit.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::unitAllowedForSpacing):
(WebCore::CanvasRenderingContext2DBase::setLetterSpacing):
(WebCore::CanvasRenderingContext2DBase::setWordSpacing):
    - Add check for supported units.

Canonical link: <a href="https://commits.webkit.org/288468@main">https://commits.webkit.org/288468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/410969bda15c08fda25cc20b0d8b95c6bf1ae6a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88492 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34426 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85504 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64892 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22638 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45176 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30010 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33475 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73286 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89868 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10680 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7705 "Found 1 new test failure: http/tests/websocket/tests/hybi/websocket-allowed-setting-cookie-as-third-party.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73319 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72548 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17963 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16768 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15504 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2016 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10635 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16107 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10487 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13957 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12258 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->