### PR TITLE
Remove dead code in CompleteSubspace::allocatorForSlow

### DIFF
--- a/Source/JavaScriptCore/heap/CompleteSubspace.cpp
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.cpp
@@ -73,7 +73,6 @@ Allocator CompleteSubspace::allocatorForSlow(size_t size)
     
     std::unique_ptr<BlockDirectory> uniqueDirectory = makeUnique<BlockDirectory>(sizeClass);
     BlockDirectory* directory = uniqueDirectory.get();
-    m_directories.append(WTFMove(uniqueDirectory));
     
     directory->setSubspace(this);
     m_space.addBlockDirectory(locker, directory);
@@ -81,8 +80,6 @@ Allocator CompleteSubspace::allocatorForSlow(size_t size)
     std::unique_ptr<LocalAllocator> uniqueLocalAllocator =
         makeUnique<LocalAllocator>(directory);
     LocalAllocator* localAllocator = uniqueLocalAllocator.get();
-    m_localAllocators.append(WTFMove(uniqueLocalAllocator));
-    
     Allocator allocator(localAllocator);
     
     index = MarkedSpace::sizeClassToIndex(sizeClass);

--- a/Source/JavaScriptCore/heap/CompleteSubspace.h
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.h
@@ -57,8 +57,6 @@ private:
     void* tryAllocateSlow(VM&, size_t, GCDeferralContext*);
     
     std::array<Allocator, MarkedSpace::numSizeClasses> m_allocatorForSizeStep;
-    Vector<std::unique_ptr<BlockDirectory>> m_directories;
-    Vector<std::unique_ptr<LocalAllocator>> m_localAllocators;
 };
 
 ALWAYS_INLINE Allocator CompleteSubspace::allocatorFor(size_t size, AllocatorForMode mode)


### PR DESCRIPTION
#### d69cb618064ac905707021a8f31fd8178ae1b648
<pre>
Remove dead code in CompleteSubspace::allocatorForSlow

<a href="https://bugs.webkit.org/show_bug.cgi?id=285408">https://bugs.webkit.org/show_bug.cgi?id=285408</a>

Reviewed by NOBODY (OOPS!).

Remove dead code from CompleteSubspace.

* Source/JavaScriptCore/heap/CompleteSubspace.cpp:
(JSC::CompleteSubspace::allocatorForSlow):
* Source/JavaScriptCore/heap/CompleteSubspace.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d69cb618064ac905707021a8f31fd8178ae1b648

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88533 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34467 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3159 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/11036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64924 "Failure limit exceed. At least found 138 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-object-detached.html accessibility/add-children-pseudo-element.html accessibility/aria-activedescendant-crash.html accessibility/aria-checkbox-checked.html accessibility/aria-checked-mixed-value.html accessibility/aria-controls.html accessibility/aria-current-global-attribute.html accessibility/aria-describedby-on-input.html accessibility/aria-expanded-supported-roles.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22667 "Found 60 new test failures: animations/3d/animate-to-transform-perpective-to-none.html animations/3d/change-transform-in-end-event.html animations/3d/full-rotation-animation.html animations/3d/replace-filling-transform.html animations/3d/state-at-end-event-transform.html animations/3d/transform-origin-vs-functions.html animations/3d/transform-perspective.html animations/CSSKeyframesRule-name-null.html animations/CSSKeyframesRule-parameters.html animations/added-while-suspended.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86507 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2308 "Found 60 new test failures: accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-checked-mixed-value.html accessibility/aria-controlled-table-row-visibility.html accessibility/aria-current-state-changed-notification.html accessibility/aria-describedby-on-input.html accessibility/aria-invalid.html accessibility/aria-labelledby-targeting-slot.html accessibility/aria-multiline.html ... (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/75856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45215 "Found 116 new API test failures: /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-received, /WPE/TestLoaderClient:/webkit/WebKitWebView/history-load, /WPE/TestResources:/webkit/WebKitWebView/history-cache, /TestWebKit:WebKit.OnDeviceChangeCrash, /TestJSC:/jsc/prototypes, /WPE/TestLoaderClient:/webkit/WebKitWebView/load-html, /WPE/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /TestWebKit:WebKit.EvaluateJavaScriptThatThrowsAnException, /TestWebKit:WebKit.GeolocationTransitionToHighAccuracy ... (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2212 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor.any.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30041 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/display-contents/aria-grid.html accessibility/display-contents/aria-hidden.html accessibility/display-contents/element-roles.html accessibility/display-contents/end-text-marker.html accessibility/display-contents/listbox-item.html accessibility/mac/abbr-acronym-tags.html accessibility/mac/accesskey.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33517 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76419 "jscore-tests (failure)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30777 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/aria-combobox.html accessibility/combobox/combobox-active-element-selected-children.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/combobox/mac/combobox-inherited-role.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89909 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/82476 "jscore-tests (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10722 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7729 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/combobox/mac/combobox-inherited-role.html accessibility/combobox/mac/combobox-value.html accessibility/custom-elements/autocomplete.html accessibility/custom-elements/controls-shadow.html ... (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10947 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71663 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/72589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16813 "Found 60 new test failures: http/wpt/webxr/events_transient_pointer_input_source.https.html http/wpt/webxr/xrDevice_requestSession_hand_tracking_feature.https.html http/wpt/webxr/xrDevice_requestSession_previously_enabled_feature_not_requested.https.html http/wpt/webxr/xrFrame_fillJointRadii_missing_joint_pose.html http/wpt/webxr/xrFrame_fillPoses.html http/wpt/webxr/xrFrame_getJointPose.html http/wpt/webxr/xrFrame_getJointPose_missing_joint_pose.html http/wpt/webxr/xrHand.html http/wpt/webxr/xrHandInput_gc.html http/wpt/webxr/xrSession_end_device_reports_shutdown.https.html ... (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15532 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html ... (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10677 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/16146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/104896 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10528 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/25359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12299 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->