### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in html/parser

### DIFF
--- a/Source/WebCore/html/parser/HTMLFormattingElementList.cpp
+++ b/Source/WebCore/html/parser/HTMLFormattingElementList.cpp
@@ -30,8 +30,6 @@
 #include <stdio.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 // Biblically, Noah's Ark only had room for two of each animal, but in the
@@ -114,8 +112,10 @@ void HTMLFormattingElementList::removeUpdatingBookmark(Element& element, Bookmar
         m_entries.remove(index);
         // Removing an element from the list can change the position of the bookmarked
         // item. Update the address pointed by the bookmark, when needed.
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (bookmarkIndex > index)
             bookmark.m_mark--;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 }
 
@@ -229,5 +229,3 @@ void HTMLFormattingElementList::show()
 #endif
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
@@ -39,8 +39,6 @@
 #include <wtf/text/ParsingUtilities.h>
 #include <wtf/text/StringBuilder.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static inline bool compareByDensity(const ImageCandidate& first, const ImageCandidate& second)
@@ -55,19 +53,19 @@ enum DescriptorTokenizerState {
 };
 
 template<typename CharType>
-static void appendDescriptorAndReset(const CharType*& descriptorStart, const CharType* position, Vector<StringView>& descriptors)
+static void appendDescriptorAndReset(std::span<const CharType>& descriptorStart, const CharType* position, Vector<StringView>& descriptors)
 {
-    if (position > descriptorStart)
-        descriptors.append(StringView { std::span(descriptorStart, position) });
-    descriptorStart = nullptr;
+    if (position > descriptorStart.data())
+        descriptors.append(StringView { descriptorStart.first(position - descriptorStart.data()) });
+    descriptorStart = { };
 }
 
 // The following is called appendCharacter to match the spec's terminology.
 template<typename CharType>
-static void appendCharacter(const CharType* descriptorStart, const CharType* position)
+static void appendCharacter(std::span<const CharType>& descriptorStart, std::span<const CharType> position)
 {
     // Since we don't copy the tokens, this just set the point where the descriptor tokens start.
-    if (!descriptorStart)
+    if (!descriptorStart.data())
         descriptorStart = position;
 }
 
@@ -75,13 +73,13 @@ template<typename CharType>
 static void tokenizeDescriptors(std::span<const CharType>& position, Vector<StringView>& descriptors)
 {
     DescriptorTokenizerState state = Initial;
-    const CharType* descriptorsStart = position.data();
-    const CharType* currentDescriptorStart = descriptorsStart;
+    auto descriptorsStart = position;
+    auto currentDescriptorStart = descriptorsStart;
     for (; ; skip(position, 1)) {
         switch (state) {
         case Initial:
             if (position.empty()) {
-                appendDescriptorAndReset(currentDescriptorStart, position.data() + position.size(), descriptors);
+                appendDescriptorAndReset(currentDescriptorStart, std::to_address(position.end()), descriptors);
                 return;
             }
             if (isComma(position.front())) {
@@ -91,32 +89,34 @@ static void tokenizeDescriptors(std::span<const CharType>& position, Vector<Stri
             }
             if (isASCIIWhitespace(position.front())) {
                 appendDescriptorAndReset(currentDescriptorStart, position.data(), descriptors);
-                currentDescriptorStart = position.data() + 1;
+                currentDescriptorStart = position.subspan(1);
                 state = AfterToken;
             } else if (position.front() == '(') {
-                appendCharacter(currentDescriptorStart, position.data());
+                appendCharacter(currentDescriptorStart, position);
                 state = InParenthesis;
             } else
-                appendCharacter(currentDescriptorStart, position.data());
+                appendCharacter(currentDescriptorStart, position);
             break;
         case InParenthesis:
             if (position.empty()) {
-                appendDescriptorAndReset(currentDescriptorStart, position.data() + position.size(), descriptors);
+                appendDescriptorAndReset(currentDescriptorStart, std::to_address(position.end()), descriptors);
                 return;
             }
             if (position.front() == ')') {
-                appendCharacter(currentDescriptorStart, position.data());
+                appendCharacter(currentDescriptorStart, position);
                 state = Initial;
             } else
-                appendCharacter(currentDescriptorStart, position.data());
+                appendCharacter(currentDescriptorStart, position);
             break;
         case AfterToken:
             if (position.empty())
                 return;
             if (!isASCIIWhitespace(position.front())) {
                 state = Initial;
-                currentDescriptorStart = position.data();
+                currentDescriptorStart = position;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
                 position = { position.data() - 1, position.data() + position.size() };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             }
             break;
         }
@@ -315,5 +315,3 @@ ImageCandidate bestFitSourceForImageAttributes(float deviceScaleFactor, const At
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 628b4a94fed82f205c0e73ccf9010d6fca0fe4fa
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in html/parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=285410">https://bugs.webkit.org/show_bug.cgi?id=285410</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/html/parser/HTMLFormattingElementList.cpp:
(WebCore::HTMLFormattingElementList::removeUpdatingBookmark):
* Source/WebCore/html/parser/HTMLParserIdioms.cpp:
(WebCore::parseHTMLFloatingPointNumberValueInternal):
(WebCore::parseHTMLListOfOfFloatingPointNumberValuesInternal):
(WebCore::parseHTTPRefreshInternal):
(WebCore::parseHTMLDimensionNumber):
* Source/WebCore/html/parser/HTMLSrcsetParser.cpp:
(WebCore::appendDescriptorAndReset):
(WebCore::appendCharacter):
(WebCore::tokenizeDescriptors):

Canonical link: <a href="https://commits.webkit.org/288467@main">https://commits.webkit.org/288467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14c1d14c6bf25a01b5fd947497885c193ec29d64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83466 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88541 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34475 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64932 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22676 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75844 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45223 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2223 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30050 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73315 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89917 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73359 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71672 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72588 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16821 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15540 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2063 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12884 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16154 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10536 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14007 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->