### PR TITLE
REGRESSION(288091@main?): [macOS Debug wk2] Crash in  WebCore::MediaRecorderPrivateWriterAVFObjC::writeFrame

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1943,8 +1943,3 @@ webkit.org/b/232282 [ Ventura+ ] fast/scrolling/mac/scrollbars/overlay-scrollbar
 [ Debug ] http/wpt/mediarecorder/pause-recording.html [ Skip ]
 
 webkit.org/b/285033 [ Ventura+ ] http/tests/download/sandboxed-iframe-download-not-allowed.html [ Pass Failure ]
-
-# webkit.org/b/285039 REGRESSION(288091@main?): [macOS Debug wk2] Crash in  WebCore::MediaRecorderPrivateWriterAVFObjC::writeFrame
-[ Debug ] imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-mimetype.html [ Skip ]
-[ Debug ] http/wpt/mediarecorder/pause-recording-timeSlice.html [ Skip ]
-[ Debug ] imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-no-sink.https.html [ Skip ]

--- a/Source/WebKit/GPUProcess/media/RemoteMediaRecorderPrivateWriterManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaRecorderPrivateWriterManager.h
@@ -87,9 +87,13 @@ public:
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
 private:
-    HashMap<RemoteMediaRecorderPrivateWriterIdentifier, Ref<RemoteMediaRecorderPrivateWriterProxy>> m_remoteMediaRecorderPrivateWriters;
-    RefPtr<WebCore::AudioInfo> m_audioInfo;
-    RefPtr<WebCore::VideoInfo> m_videoInfo;
+    struct Writer {
+        RefPtr<RemoteMediaRecorderPrivateWriterProxy> proxy;
+        RefPtr<WebCore::AudioInfo> audioInfo;
+        RefPtr<WebCore::VideoInfo> videoInfo;
+    };
+
+    HashMap<RemoteMediaRecorderPrivateWriterIdentifier, Writer> m_remoteMediaRecorderPrivateWriters;
 
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
 };


### PR DESCRIPTION
#### 70084d91dca4e6a7f11ee762f04a94c6262eb2c7
<pre>
REGRESSION(288091@main?): [macOS Debug wk2] Crash in  WebCore::MediaRecorderPrivateWriterAVFObjC::writeFrame
<a href="https://rdar.apple.com/141840655">rdar://141840655</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=285039">https://bugs.webkit.org/show_bug.cgi?id=285039</a>

Reviewed by Jean-Yves Avenard.

Before the patch, RemoteMediaRecorderPrivateWriterManager would store the audio and video track infos.
But each audio/video track info is specific to each recorder and not to each RemoteMediaRecorderPrivateWriterManager.

This would confuse the GPU process if the same web page was using two recorders together (the same track infos would be used for both).
This patch is moving track info to the writers map instead.

We also make sure that a compromised WebProcess will not be able to create null pointer dereference in GPU process.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebKit/GPUProcess/media/RemoteMediaRecorderPrivateWriterManager.cpp:
(WebKit::RemoteMediaRecorderPrivateWriterManager::create):
(WebKit::RemoteMediaRecorderPrivateWriterManager::addAudioTrack):
(WebKit::RemoteMediaRecorderPrivateWriterManager::addVideoTrack):
(WebKit::RemoteMediaRecorderPrivateWriterManager::allTracksAdded):
(WebKit::RemoteMediaRecorderPrivateWriterManager::writeFrames):
(WebKit::RemoteMediaRecorderPrivateWriterManager::close):
* Source/WebKit/GPUProcess/media/RemoteMediaRecorderPrivateWriterManager.h:

Canonical link: <a href="https://commits.webkit.org/288462@main">https://commits.webkit.org/288462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4920e81b4931f312922b7a41562175f544ca818e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34497 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11062 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64954 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22697 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45245 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30068 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33547 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73329 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89939 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73379 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72609 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17960 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16838 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15555 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2085 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10707 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16176 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10559 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14029 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12329 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->