### PR TITLE
[Buildstream SDK] Fix openh264 support

### DIFF
--- a/Tools/buildstream/elements/flatpak/platform.bst
+++ b/Tools/buildstream/elements/flatpak/platform.bst
@@ -67,9 +67,3 @@ config:
       add-ld-path: lib
       download-if: have-intel-gpu
       version: '%{sdk-branch}'
-
-    Extension org.freedesktop.Platform.openh264:
-      directory: '%{lib}/openh264'
-      add-ld-path: extra
-      autodelete: 'false'
-      version: '%{sdk-branch}'

--- a/Tools/buildstream/elements/flatpak/sdk.bst
+++ b/Tools/buildstream/elements/flatpak/sdk.bst
@@ -62,11 +62,6 @@ config:
       version: '3.22'
       download-if: active-gtk-theme
 
-    Extension org.freedesktop.Platform.openh264:
-      directory: '%{lib}/openh264'
-      add-ld-path: extra
-      version: '%{sdk-branch}'
-
     Extension org.freedesktop.Sdk.Extension:
       subdirectories: 'true'
       directory: lib/sdk

--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -31,3 +31,4 @@ config:
   overrides:
     components/dav1d.bst: sdk/dav1d.bst
     components/pango.bst: sdk/pango.bst
+    components/noopenh264.bst: sdk/libopenh264.bst

--- a/Tools/buildstream/elements/sdk-platform.bst
+++ b/Tools/buildstream/elements/sdk-platform.bst
@@ -5,6 +5,7 @@ depends:
 - qt5.bst
 - test-infra.bst
 - filtered.bst
+- filtered-openh264.bst
 
 # replaced (patched) elements:
 - sdk/adwaita-icon-theme.bst

--- a/Tools/buildstream/elements/sdk/libopenh264.bst
+++ b/Tools/buildstream/elements/sdk/libopenh264.bst
@@ -7,10 +7,10 @@ depends:
 - freedesktop-sdk.bst:bootstrap-import.bst
 
 sources:
-- kind: git
+- kind: git_repo
   url: github_com:cisco/openh264.git
   track: master
-  ref: 2e637867315ffeda3cd8970825ec86acc3fc4a30
+  ref: v2.5.0-8-g423eb2c3e47009f4e631b5e413123a003fdff1ed
 variables:
   meson-local: >-
     -Dtests=disabled


### PR DESCRIPTION
#### 246abc5db40b07842b249efdaf5e92600a98ecd9
<pre>
[Buildstream SDK] Fix openh264 support
<a href="https://bugs.webkit.org/show_bug.cgi?id=285418">https://bugs.webkit.org/show_bug.cgi?id=285418</a>

Reviewed by Adrian Perez de Castro.

Remove support for the openh264 extension since we now ship our own build of openh264.

* Tools/buildstream/elements/flatpak/platform.bst:
* Tools/buildstream/elements/flatpak/sdk.bst:
* Tools/buildstream/elements/freedesktop-sdk.bst:
* Tools/buildstream/elements/sdk-platform.bst:
* Tools/buildstream/elements/sdk/libopenh264.bst:

Canonical link: <a href="https://commits.webkit.org/288516@main">https://commits.webkit.org/288516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abc53b7b99626e4ae78b9a9ea96ad7a2aab0941e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88566 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34499 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64956 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22699 "Found 1 new test failure: http/tests/xmlhttprequest/basic-auth-responseURL.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45247 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2245 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30075 "Found 1 new test failure: fast/editing/recursive-reapply-edit-command-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33549 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73331 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89941 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7784 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73381 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/content-with-transparent-background.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72611 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16842 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15562 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2087 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12912 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10709 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12331 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->