### PR TITLE
Checking for presence of request body in Service Worker causes body to be dropped from request

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-with-body.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-with-body.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Validate body is preserved
+

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-with-body.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-with-body.https.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/test-helpers.sub.js"></script>
+<body>
+<script>
+const SCRIPT = 'resources/fetch-with-body-worker.js';
+const SCOPE = 'resources/blank.html';
+
+let frame, registration;
+
+promise_test(async t => {
+  t.add_cleanup(async() => {
+    if (frame)
+      frame.remove();
+    if (registration)
+      await registration.unregister();
+  });
+
+  await service_worker_unregister(t, SCOPE);
+  registration = await navigator.serviceWorker.register(SCRIPT, {scope: SCOPE});
+  await wait_for_state(t, registration.installing, 'activating');
+  frame = await with_iframe(SCOPE);
+
+  const request1 = new Request("resources/fetch-with-body-worker.py", {
+    method: "GET",
+  });
+
+  const response1 = await frame.contentWindow.fetch(request1);
+  assert_false(response1.ok);
+
+  const request2 = new Request("resources/fetch-with-body-worker.py", {
+    method: "POST",
+    body: "BODY",
+    headers: { "Content-Type": "text/ascii" },
+  });
+
+  const response2 = await frame.contentWindow.fetch(request2);
+  assert_true(response2.ok);
+}, 'Validate body is preserved');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-with-body-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-with-body-worker.js
@@ -1,0 +1,4 @@
+self.addEventListener("fetch", (event) => {
+  event.request.body;
+  event.respondWith(fetch(event.request));
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-with-body-worker.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-with-body-worker.py
@@ -1,0 +1,4 @@
+def main(request, response):
+    if len(request.body):
+        return 200, [], u"BODY"
+    return 400, [], u"NO BODY"

--- a/Source/WebCore/Modules/fetch/FetchBody.h
+++ b/Source/WebCore/Modules/fetch/FetchBody.h
@@ -95,6 +95,8 @@ public:
         m_readableStream = WTFMove(stream);
     }
 
+    void convertReadableStreamToArrayBuffer(FetchBodyOwner&, CompletionHandler<void(std::optional<Exception>&&)>&&);
+
     bool isBlob() const { return std::holds_alternative<Ref<const Blob>>(m_data); }
     bool isFormData() const { return std::holds_alternative<Ref<FormData>>(m_data); }
     bool isReadableStream() const { return std::holds_alternative<Ref<ReadableStream>>(m_data); }

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.h
@@ -81,11 +81,12 @@ public:
 
     String contentType() const { return m_headers->fastGet(HTTPHeaderName::ContentType); }
 
+    FetchBody& body() { return *m_body; }
+
 protected:
     FetchBodyOwner(ScriptExecutionContext*, std::optional<FetchBody>&&, Ref<FetchHeaders>&&);
 
     const FetchBody& body() const { return *m_body; }
-    FetchBody& body() { return *m_body; }
     bool isBodyNull() const { return !m_body; }
     bool isBodyNullOrOpaque() const { return !m_body || m_isBodyOpaque; }
     void cloneBody(FetchBodyOwner&);


### PR DESCRIPTION
#### 6c800745251d53d6486443d63b35828504446c5d
<pre>
Checking for presence of request body in Service Worker causes body to be dropped from request
<a href="https://rdar.apple.com/141454387">rdar://141454387</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284184">https://bugs.webkit.org/show_bug.cgi?id=284184</a>

Reviewed by Chris Dumez.

When getting request.body, we create a readable stream from the request body.
Then, when making the fetch from it, we would not send the request body since we are not handling body converted as a readable stream.
We add support to get back the body as an array buffer from the readable stream.

Covered by the added test.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-with-body.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-with-body.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-with-body-worker.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-with-body-worker.py: Added.
(main):
* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::convertReadableStreamToArrayBuffer):
* Source/WebCore/Modules/fetch/FetchBody.h:
* Source/WebCore/Modules/fetch/FetchBodyOwner.h:
(WebCore::FetchBodyOwner::body):
(WebCore::FetchBodyOwner::body const):
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::fetch):

Canonical link: <a href="https://commits.webkit.org/288514@main">https://commits.webkit.org/288514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16716248a9aaf10ff1ca95aabeae10f7d351eca0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88591 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34526 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3219 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11093 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64983 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22722 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45268 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2266 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30106 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33576 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73361 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89967 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10781 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7786 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/connect-src-star-websocket-allowed.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73410 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11007 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72634 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17985 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16867 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15582 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2110 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10735 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16213 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10586 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14057 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12357 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->