### PR TITLE
Move groupId handling from MediaStreamTrack to RealtimeMediaSource

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getUserMedia.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getUserMedia.https-expected.txt
@@ -4,8 +4,8 @@ This test checks for the presence of the navigator.mediaDevices.getUserMedia met
 
 
 PASS mediaDevices.getUserMedia() is present on navigator
-FAIL groupId is correctly supported by getUserMedia() for video devices assert_equals: expected (undefined) undefined but got (object) object "[object InputDeviceInfo]"
-FAIL groupId is correctly supported by getUserMedia() for audio devices assert_equals: expected (undefined) undefined but got (object) object "[object InputDeviceInfo]"
+PASS groupId is correctly supported by getUserMedia() for video devices
+PASS groupId is correctly supported by getUserMedia() for audio devices
 FAIL getUserMedia() supports setting none as resizeMode. assert_true: resizeMode should be supported expected true got undefined
 FAIL getUserMedia() supports setting crop-and-scale as resizeMode. assert_true: resizeMode should be supported expected true got undefined
 FAIL getUserMedia() fails with exact invalid resizeMode. assert_true: resizeMode should be supported expected true got undefined

--- a/Source/WebCore/Modules/mediastream/InputDeviceInfo.cpp
+++ b/Source/WebCore/Modules/mediastream/InputDeviceInfo.cpp
@@ -43,7 +43,7 @@ InputDeviceInfo::InputDeviceInfo(CaptureDeviceWithCapabilities&& deviceWithCapab
 
 MediaTrackCapabilities InputDeviceInfo::getCapabilities() const
 {
-    return toMediaTrackCapabilities(m_capabilities, groupId());
+    return toMediaTrackCapabilities(m_capabilities);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -95,7 +95,6 @@ public:
     MediaTrackSupportedConstraints getSupportedConstraints();
 
     String deviceIdToPersistentId(const String& deviceId) const { return m_audioOutputDeviceIdToPersistentId.get(deviceId); }
-    String hashedGroupId(const String& groupId);
 
     void willStartMediaCapture(bool microphone, bool camera);
 
@@ -131,8 +130,6 @@ private:
     Markable<UserMediaClient::DeviceChangeObserverToken> m_deviceChangeToken;
     const EventNames& m_eventNames; // Need to cache this so we can use it from GC threads.
     bool m_listeningForDeviceChanges { false };
-
-    String m_groupIdHashSalt;
 
     OptionSet<GestureAllowedRequest> m_requestTypesForCurrentGesture;
     WeakPtr<UserGestureToken> m_currentGestureToken;

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -94,13 +94,6 @@ MediaStreamTrack::MediaStreamTrack(ScriptExecutionContext& context, Ref<MediaStr
     ASSERT(isMainThread());
     ASSERT(is<Document>(context));
 
-    auto& settings = m_private->settings();
-    if (settings.supportsGroupId()) {
-        RefPtr window = downcast<Document>(context).domWindow();
-        if (RefPtr mediaDevices = window ? NavigatorMediaDevices::mediaDevices(window->navigator()) : nullptr)
-            m_groupId = mediaDevices->hashedGroupId(settings.groupId());
-    }
-
     m_isInterrupted = m_private->interrupted();
 
     if (m_private->isAudio())
@@ -283,7 +276,7 @@ MediaStreamTrack::TrackSettings MediaStreamTrack::getSettings() const
     if (settings.supportsDeviceId())
         result.deviceId = settings.deviceId();
     if (settings.supportsGroupId())
-        result.groupId = m_groupId;
+        result.groupId = settings.groupId();
     if (settings.supportsDisplaySurface() && settings.displaySurface() != DisplaySurfaceType::Invalid)
         result.displaySurface = RealtimeMediaSourceSettings::displaySurface(settings.displaySurface());
 
@@ -305,7 +298,7 @@ MediaStreamTrack::TrackSettings MediaStreamTrack::getSettings() const
 
 MediaStreamTrack::TrackCapabilities MediaStreamTrack::getCapabilities() const
 {
-    auto result = toMediaTrackCapabilities(m_private->capabilities(), m_groupId);
+    auto result = toMediaTrackCapabilities(m_private->capabilities());
 
     auto settings = m_private->settings();
     if (settings.supportsDisplaySurface() && settings.displaySurface() != DisplaySurfaceType::Invalid)

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -229,7 +229,6 @@ private:
     MediaTrackConstraints m_constraints;
 
     String m_mediaStreamId;
-    String m_groupId;
     State m_readyState { State::Live };
     bool m_muted { false };
     bool m_ended { false };

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp
@@ -107,7 +107,7 @@ static Vector<bool> powerEfficientCapabilityVector(bool powerEfficient)
     return result;
 }
 
-MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabilities& capabilities, const String& groupId)
+MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabilities& capabilities)
 {
     MediaTrackCapabilities result;
     if (capabilities.supportsWidth())
@@ -131,7 +131,7 @@ MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabil
     if (capabilities.supportsDeviceId())
         result.deviceId = capabilities.deviceId();
     if (capabilities.supportsGroupId())
-        result.groupId = groupId;
+        result.groupId = capabilities.groupId();
     if (capabilities.supportsFocusDistance())
         result.focusDistance = capabilityDoubleRange(capabilities.focusDistance());
     if (capabilities.supportsWhiteBalanceMode())

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h
@@ -56,7 +56,7 @@ struct MediaTrackCapabilities {
     std::optional<Vector<bool>> powerEfficient;
 };
 
-MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabilities&, const String& groupId);
+MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabilities&);
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -109,26 +109,26 @@ RealtimeMediaSource::RealtimeMediaSource(const CaptureDevice& device, MediaDevic
     , m_name({ device.label() })
     , m_device(device)
 {
-    initializePersistentId();
+    initializeIds();
 }
 
-RealtimeMediaSource::~RealtimeMediaSource()
-{
-}
+RealtimeMediaSource::~RealtimeMediaSource() = default;
 
 void RealtimeMediaSource::setPersistentId(const String& persistentID)
 {
     m_device.setPersistentId(persistentID);
-    initializePersistentId();
+    initializeIds();
 }
 
-void RealtimeMediaSource::initializePersistentId()
+void RealtimeMediaSource::initializeIds()
 {
     if (m_device.persistentId().isEmpty())
         m_device.setPersistentId(createVersion4UUIDString());
 
     m_hashedID = RealtimeMediaSourceCenter::hashStringWithSalt(m_device.persistentId(), m_idHashSalts.persistentDeviceSalt);
     m_ephemeralHashedID = RealtimeMediaSourceCenter::hashStringWithSalt(m_device.persistentId(), m_idHashSalts.ephemeralDeviceSalt);
+
+    m_hashedGroupId = RealtimeMediaSourceCenter::hashStringWithSalt(m_device.groupId(), m_idHashSalts.ephemeralDeviceSalt);
 }
 
 void RealtimeMediaSource::addAudioSampleObserver(AudioSampleObserver& observer)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -150,6 +150,7 @@ public:
     virtual Ref<RealtimeMediaSource> clone() { return *this; }
 
     const String& hashedId() const;
+    const String& hashedGroupId() const;
     const MediaDeviceHashSalts& deviceIDHashSalts() const;
 
     const String& persistentID() const { return m_device.persistentId(); }
@@ -366,7 +367,7 @@ private:
     virtual double observedFrameRate() const { return 0.0; }
 
     void updateHasStartedProducingData();
-    void initializePersistentId();
+    void initializeIds();
 
 #if !RELEASE_LOG_DISABLED
     RefPtr<const Logger> m_logger;
@@ -379,6 +380,7 @@ private:
     MediaDeviceHashSalts m_idHashSalts;
     String m_hashedID;
     String m_ephemeralHashedID;
+    String m_hashedGroupId;
     Type m_type;
     String m_name;
     WeakHashSet<RealtimeMediaSourceObserver> m_observers;
@@ -469,6 +471,11 @@ inline bool RealtimeMediaSource::isProducingData() const
 
 inline void RealtimeMediaSource::setIsInBackground(bool)
 {
+}
+
+inline const String& RealtimeMediaSource::hashedGroupId() const
+{
+    return m_hashedGroupId;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -476,7 +476,7 @@ const RealtimeMediaSourceSettings& AVVideoCaptureSource::settings()
     settings.setWidth(size.width());
     settings.setHeight(size.height());
     settings.setDeviceId(hashedId());
-    settings.setGroupId(captureDevice().groupId());
+    settings.setGroupId(hashedGroupId());
     settings.setBackgroundBlur(!!device().portraitEffectActive);
 
     RealtimeMediaSourceSupportedConstraints supportedConstraints;
@@ -525,6 +525,7 @@ const RealtimeMediaSourceCapabilities& AVVideoCaptureSource::capabilities()
 
     RealtimeMediaSourceCapabilities capabilities(settings().supportedConstraints());
     capabilities.setDeviceId(hashedId());
+    capabilities.setGroupId(hashedGroupId());
 
     AVCaptureDevice *videoDevice = device();
     if ([videoDevice position] == AVCaptureDevicePositionFront)

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -262,6 +262,7 @@ const RealtimeMediaSourceCapabilities& CoreAudioCaptureSource::capabilities()
 
         RealtimeMediaSourceCapabilities capabilities(settings().supportedConstraints());
         capabilities.setDeviceId(hashedId());
+        capabilities.setGroupId(hashedGroupId());
         capabilities.setEchoCancellation(RealtimeMediaSourceCapabilities::EchoCancellation::ReadWrite);
         capabilities.setVolume({ 0.0, 1.0 });
         capabilities.setSampleRate(unit.sampleRateCapacities());
@@ -279,7 +280,7 @@ const RealtimeMediaSourceSettings& CoreAudioCaptureSource::settings()
         settings.setVolume(volume());
         settings.setSampleRate(unit.isRenderingAudio() ? unit.actualSampleRate() : sampleRate());
         settings.setDeviceId(hashedId());
-        settings.setGroupId(captureDevice().groupId());
+        settings.setGroupId(hashedGroupId());
         settings.setLabel(name());
         settings.setEchoCancellation(echoCancellation());
 

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
@@ -94,7 +94,7 @@ const RealtimeMediaSourceSettings& MockRealtimeAudioSource::settings()
     if (!m_currentSettings) {
         RealtimeMediaSourceSettings settings;
         settings.setDeviceId(hashedId());
-        settings.setGroupId(captureDevice().groupId());
+        settings.setGroupId(hashedGroupId());
         settings.setVolume(volume());
         settings.setEchoCancellation(echoCancellation());
         settings.setSampleRate(sampleRate());
@@ -128,6 +128,7 @@ const RealtimeMediaSourceCapabilities& MockRealtimeAudioSource::capabilities()
         RealtimeMediaSourceCapabilities capabilities(settings().supportedConstraints());
 
         capabilities.setDeviceId(hashedId());
+        capabilities.setGroupId(hashedGroupId());
         capabilities.setVolume({ 0.0, 1.0 });
         capabilities.setEchoCancellation(RealtimeMediaSourceCapabilities::EchoCancellation::ReadWrite);
         capabilities.setSampleRate({ 44100, 96000 });

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -213,7 +213,7 @@ const RealtimeMediaSourceCapabilities& MockRealtimeVideoSource::capabilities()
         auto facingMode = std::get<MockCameraProperties>(m_device.properties).facingMode;
         if (facingMode != VideoFacingMode::Unknown)
             capabilities.addFacingMode(facingMode);
-        capabilities.setDeviceId(hashedId());
+        capabilities.setGroupId(hashedGroupId());
         updateCapabilities(capabilities);
 
         if (facingMode == VideoFacingMode::Environment) {
@@ -322,7 +322,7 @@ const RealtimeMediaSourceSettings& MockRealtimeVideoSource::settings()
         settings.setLogicalSurface(false);
     }
     settings.setDeviceId(hashedId());
-    settings.setGroupId(captureDevice().groupId());
+    settings.setGroupId(hashedGroupId());
 
     settings.setFrameRate(frameRate());
     auto size = this->size();


### PR DESCRIPTION
#### 8e0a2a00aa01e4eb75ff39050f1a08c0819f1554
<pre>
Move groupId handling from MediaStreamTrack to RealtimeMediaSource
<a href="https://rdar.apple.com/142420841">rdar://142420841</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=285438">https://bugs.webkit.org/show_bug.cgi?id=285438</a>

Reviewed by Eric Carlson.

Previoulsy, groupId was computed in MediaStreamTrack as its hash is scoped by Document.
We are now handling groupId within RealtimeMediaSource and provide the document scoped hash when creating the RealtimeMediaSource.
We remove the current handling (shared between MediaDevices and MediaStreamTrack).

We update the capture sources to provide groupId values, including the mocks.

Covered by existing tests.

* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getUserMedia.https-expected.txt:
* Source/WebCore/Modules/mediastream/InputDeviceInfo.cpp:
(WebCore::InputDeviceInfo::getCapabilities const):
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::MediaDevices):
(WebCore::MediaDevices::exposeDevices):
(WebCore::MediaDevices::hashedGroupId): Deleted.
* Source/WebCore/Modules/mediastream/MediaDevices.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::MediaStreamTrack):
(WebCore::MediaStreamTrack::getSettings const):
(WebCore::MediaStreamTrack::getCapabilities const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp:
(WebCore::toMediaTrackCapabilities):
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::m_device):
(WebCore::RealtimeMediaSource::setPersistentId):
(WebCore::RealtimeMediaSource::initializeIds):
(WebCore::RealtimeMediaSource::~RealtimeMediaSource): Deleted.
(WebCore::RealtimeMediaSource::initializePersistentId): Deleted.
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
(WebCore::RealtimeMediaSource::hashedGroupId const):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::settings):
(WebCore::AVVideoCaptureSource::capabilities):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::capabilities):
(WebCore::CoreAudioCaptureSource::settings):
* Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp:
(WebCore::MockRealtimeAudioSource::settings):
(WebCore::MockRealtimeAudioSource::capabilities):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::capabilities):
(WebCore::MockRealtimeVideoSource::settings):

Canonical link: <a href="https://commits.webkit.org/288520@main">https://commits.webkit.org/288520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60605312d2f4a3ed38da70b55ed131e489d0d597

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34691 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65094 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22925 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76037 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45382 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30247 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33740 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90133 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73532 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11172 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72756 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17989 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17015 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15716 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2272 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10900 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16372 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10748 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14223 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->