### PR TITLE
[JSC] iterationCount should not be zero in LoopUnrollingPhase

### DIFF
--- a/JSTests/stress/loop-unrolling-with-zero-iterations.js
+++ b/JSTests/stress/loop-unrolling-with-zero-iterations.js
@@ -1,0 +1,7 @@
+(function () {
+    var count = 0;
+    for (let x = 0; x != 9; x--) {
+        count += 1;
+        if (count > 99999) break;
+    }
+})();

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -366,6 +366,14 @@ public:
                     return false;
                 }
                 ++iterationCount;
+                if (iterationCount.hasOverflowed()) {
+                    dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *data.header(), " since the iteration count overflowed after the update");
+                    return false;
+                }
+            }
+            if (!iterationCount) {
+                dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *data.header(), " since the iteration count is zero");
+                return false;
             }
             data.iterationCount = iterationCount;
         }
@@ -446,6 +454,7 @@ public:
 #endif
 
         BasicBlock* next = data.next;
+        ASSERT(!data.iterationCount.hasOverflowed() && data.iterationCount);
         for (uint32_t cloneCount = data.iterationCount - 1; cloneCount--;) {
             blockClones.clear();
             nodeClones.clear();


### PR DESCRIPTION
#### dd99022353b49f33dc78b57e34c3b18087a2f187
<pre>
[JSC] iterationCount should not be zero in LoopUnrollingPhase
<a href="https://bugs.webkit.org/show_bug.cgi?id=285439">https://bugs.webkit.org/show_bug.cgi?id=285439</a>
<a href="https://rdar.apple.com/142274884">rdar://142274884</a>

Reviewed by Keith Miller and Yusuke Suzuki.

* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::identifyInductionVariable):
(JSC::DFG::LoopUnrollingPhase::unrollLoop):

Canonical link: <a href="https://commits.webkit.org/288482@main">https://commits.webkit.org/288482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d6edace0ca3378a55e38b6db685392d070814dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88619 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34556 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11123 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/64998 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22741 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86594 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45285 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30128 "Found 1 new test failure: fast/editing/recursive-reapply-edit-command-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33604 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76511 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89996 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/82565 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10813 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72652 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16889 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15604 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12889 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10765 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/16237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/104982 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10612 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25377 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14087 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12385 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->