### PR TITLE
walmart.com/wallet focuses phone number field when attempting to add a credit card

### DIFF
--- a/LayoutTests/editing/async-clipboard/resources/async-clipboard-helpers.js
+++ b/LayoutTests/editing/async-clipboard/resources/async-clipboard-helpers.js
@@ -45,6 +45,7 @@ function writeToClipboardUsingDataTransfer(data) {
     const input = document.createElement("input");
     document.body.appendChild(input);
     input.value = "a";
+    input.focus();
     input.setSelectionRange(0, 1);
     input.addEventListener("copy", event => {
         for (const type of Object.keys(data))

--- a/LayoutTests/editing/deleting/5290534.html
+++ b/LayoutTests/editing/deleting/5290534.html
@@ -16,6 +16,7 @@ if (window.testRunner)
     
 var search = document.getElementById("search");
 search.setSelectionRange(0, 0);
+search.focus();
 document.execCommand("InsertText", false, "x");
 if (search.value != "x")
     log("Failure: text wasn't added to the search field.");

--- a/LayoutTests/editing/inserting/4960120-1.html
+++ b/LayoutTests/editing/inserting/4960120-1.html
@@ -4,6 +4,6 @@
 <script>
 var textarea = document.getElementById("textarea");
 textarea.setSelectionRange(0, 0);
-
+textarea.focus();
 document.execCommand("InsertLineBreak");
 </script>

--- a/LayoutTests/editing/inserting/insert-text-into-text-field.html
+++ b/LayoutTests/editing/inserting/insert-text-into-text-field.html
@@ -26,6 +26,7 @@ if (window.testRunner)
     testRunner.dumpAsText();
 
 var input = document.getElementById("input");
+input.focus();
 input.setSelectionRange(1, 1);
 document.execCommand("InsertHTML", false, "b");
 if (input.value == "ab")

--- a/LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-plain-text.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-plain-text.html
@@ -45,6 +45,7 @@ function updateResultWithEvent(event) {
 destination.addEventListener("dragover", updateResultWithEvent);
 destination.addEventListener("drop", updateResultWithEvent);
 
+source.focus();
 source.setSelectionRange(0, source.value.length);
 
 if (window.testRunner && window.eventSender && window.internals) {

--- a/LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-plain-text.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-plain-text.html
@@ -41,6 +41,7 @@ function updateResultWithEvent(event) {
     event.preventDefault();
 }
 
+source.focus();
 source.setSelectionRange(0, source.value.length);
 destination.addEventListener("paste", updateResultWithEvent);
 

--- a/LayoutTests/editing/pasteboard/drag-drop-input-textarea.html
+++ b/LayoutTests/editing/pasteboard/drag-drop-input-textarea.html
@@ -17,6 +17,7 @@ function editingTest() {
 
     // Drag a word in the textarea
     var textarea = document.getElementById("textarea");
+    textarea.focus();
     textarea.setSelectionRange(0, 4);
     x = textarea.offsetLeft + 10;
     y = textarea.offsetTop + textarea.offsetHeight / 2;

--- a/LayoutTests/editing/pasteboard/drag-drop-url-text.html
+++ b/LayoutTests/editing/pasteboard/drag-drop-url-text.html
@@ -17,6 +17,7 @@ function editingTest() {
 
     // Drag a URL text in the source
     var source = document.getElementById("source");
+    source.focus();
     source.setSelectionRange(0, source.value.length);
     x = source.offsetLeft + 10;
     y = source.offsetTop + source.offsetHeight / 2;

--- a/LayoutTests/editing/pasteboard/pasting-tabs.html
+++ b/LayoutTests/editing/pasteboard/pasting-tabs.html
@@ -10,6 +10,7 @@ if (window.testRunner)
 <script>
 var textarea = document.getElementById("textarea");
 textarea.setSelectionRange(0, 0);
+textarea.focus();
 document.execCommand("SelectAll");
 document.execCommand("Copy");
 var div = document.getElementById("div");

--- a/LayoutTests/editing/selection/4975120.html
+++ b/LayoutTests/editing/selection/4975120.html
@@ -5,6 +5,7 @@ if (window.testRunner)
 
 function runTest() {
     var input = document.getElementById("input");
+    input.focus();
     input.setSelectionRange(0, 3);
     var frame = frames[0];
     frame.focus();

--- a/LayoutTests/editing/selection/5497643-expected.txt
+++ b/LayoutTests/editing/selection/5497643-expected.txt
@@ -1,4 +1,4 @@
-textareaOffset = nodeIndex(textarea); textarea.setSelectionRange(0, 0); textarea.parentNode.removeChild(textarea);
+textareaOffset = nodeIndex(textarea); textarea.focus(); textarea.setSelectionRange(0, 0); textarea.parentNode.removeChild(textarea);
 PASS getSelection().type is 'Caret'
 PASS getSelection().getRangeAt(0).startContainer is document.body
 PASS getSelection().getRangeAt(0).startOffset is textareaOffset

--- a/LayoutTests/editing/selection/5497643.html
+++ b/LayoutTests/editing/selection/5497643.html
@@ -3,20 +3,24 @@
 <body>
 <p>This tests to make sure that a selection inside a textarea is updated when the textarea is removed from the document.</p>
 <textarea id="textarea"></textarea>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script>
-if (window.testRunner)
-    window.testRunner.dumpAsText();
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
 function nodeIndex(node) {
     return Array.prototype.slice.call(node.parentNode.childNodes).indexOf(node);
 }
-textarea = document.getElementById("textarea");
-evalAndLog("textareaOffset = nodeIndex(textarea); textarea.setSelectionRange(0, 0); textarea.parentNode.removeChild(textarea);");
-shouldBe("getSelection().type", "'Caret'");
-shouldBe("getSelection().getRangeAt(0).startContainer", "document.body");
-shouldBe("getSelection().getRangeAt(0).startOffset", "textareaOffset");
-var successfullyParsed = true;
+window.onload = () => {
+    textarea = document.getElementById("textarea");
+    evalAndLog("textareaOffset = nodeIndex(textarea); textarea.focus(); textarea.setSelectionRange(0, 0); textarea.parentNode.removeChild(textarea);");
+    shouldBe("getSelection().type", "'Caret'");
+    shouldBe("getSelection().getRangeAt(0).startContainer", "document.body");
+    shouldBe("getSelection().getRangeAt(0).startOffset", "textareaOffset");
+    if (window.testRunner)
+        testRunner.notifyDone();
+};
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/editing/selection/delete-selection-with-disconnected-extent.html
+++ b/LayoutTests/editing/selection/delete-selection-with-disconnected-extent.html
@@ -4,6 +4,7 @@ function runTest() {
     if (window.testRunner)
         testRunner.dumpAsText();
 
+    document.querySelector('input').focus();
     document.querySelector('input').setRangeText('aa', 0, 1, 'end');
     getSelection().extend(document.createElement('select'));
     document.execCommand('delete', false);

--- a/LayoutTests/editing/selection/delete-word-granularity-text-control.html
+++ b/LayoutTests/editing/selection/delete-word-granularity-text-control.html
@@ -29,6 +29,7 @@ if (window.eventSender) {
     eventSender.mouseUp();
 }
 
+textarea.focus();
 textarea.setSelectionRange(0, 3);
 document.execCommand('delete');
 

--- a/LayoutTests/editing/selection/deleteFromDocument-shadow-tree-crash.html
+++ b/LayoutTests/editing/selection/deleteFromDocument-shadow-tree-crash.html
@@ -8,7 +8,7 @@ if (window.testRunner) {
 }
 
  function runTest() {
-    document.getElementById('input_0').disabled = true;
+    document.getElementById('input_0').focus();
     document.getElementById('input_0').setRangeText("abc");
     window.getSelection().extend(document.getElementById('input_0'), 0);
     window.getSelection().deleteFromDocument();

--- a/LayoutTests/editing/selection/programmatic-selection-on-mac-is-directionless.html
+++ b/LayoutTests/editing/selection/programmatic-selection-on-mac-is-directionless.html
@@ -43,9 +43,10 @@ function selectLine(node) {
         range.setEnd(container, range.startOffset + 'in'.length);
         selection.addRange(range);
     } else {
-       node.selectionDirection = 'none';
-       node.selectionStart = node.value.search('ine 2');
-       node.selectionEnd = node.selectionStart + 'in'.length;
+        node.focus();
+        node.selectionDirection = 'none';
+        node.selectionStart = node.value.search('ine 2');
+        node.selectionEnd = node.selectionStart + 'in'.length;
     }
 }
 

--- a/LayoutTests/editing/selection/select-iframe-focusin-document-crash.html
+++ b/LayoutTests/editing/selection/select-iframe-focusin-document-crash.html
@@ -17,6 +17,7 @@
             window.addEventListener('focusin', eventHandle);
             var element = iframe.contentWindow.document.getElementById("input");
             element.value = 'demo';
+            element.focus();
             element.selectionStart = 0;
         }
         function eventHandle(event)

--- a/LayoutTests/editing/selection/selection-setSelectionRange-frameselection-expected.txt
+++ b/LayoutTests/editing/selection/selection-setSelectionRange-frameselection-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS setSelectionRange() should not update FrameSelection if the target element is not focused.
+PASS setRangeText() should not update FrameSelection if the target element is not focused.
+

--- a/LayoutTests/editing/selection/selection-setSelectionRange-frameselection.html
+++ b/LayoutTests/editing/selection/selection-setSelectionRange-frameselection.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<input id="notFocused" value="foo">
+<input id="focused" value="a">
+<script>
+test(() => {
+    var notFocused = document.getElementById('notFocused');
+    var focused = document.getElementById('focused');
+    var selection = window.getSelection();
+    selection.removeAllRanges();
+    focused.focus();
+
+    var originalAnchorNode = selection.anchorNode;
+    var originalAnchorOffset = selection.anchorOffset;
+    notFocused.setSelectionRange(3, 3);
+    assert_equals(selection.anchorNode, originalAnchorNode);
+    assert_equals(selection.anchorOffset, originalAnchorOffset);
+}, 'setSelectionRange() should not update FrameSelection if the target element is not focused.');
+
+test(() => {
+    var notFocused = document.getElementById('notFocused');
+    var focused = document.getElementById('focused');
+    var selection = window.getSelection();
+    selection.removeAllRanges();
+    focused.focus();
+
+    var originalAnchorNode = selection.anchorNode;
+    var originalAnchorOffset = selection.anchorOffset;
+    notFocused.setRangeText('barrr', 0, 3, 'select');
+    assert_equals(selection.anchorNode, originalAnchorNode);
+    assert_equals(selection.anchorOffset, originalAnchorOffset);
+}, 'setRangeText() should not update FrameSelection if the target element is not focused.');
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/selection/setSelectionRange-no-frame-crash-expected.txt
+++ b/LayoutTests/editing/selection/setSelectionRange-no-frame-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if it does not crash

--- a/LayoutTests/editing/selection/setSelectionRange-no-frame-crash.html
+++ b/LayoutTests/editing/selection/setSelectionRange-no-frame-crash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+let doc = document.implementation.createHTMLDocument();
+let input = doc.createElement('input');
+input.value = 'hello';
+doc.body.appendChild(input);
+input.setSelectionRange(0, 1);
+</script>
+<p>PASS if it does not crash</p>
+</body>
+</html>

--- a/LayoutTests/editing/selection/setting-selection-does-not-focus-unless-selected-expected.txt
+++ b/LayoutTests/editing/selection/setting-selection-does-not-focus-unless-selected-expected.txt
@@ -1,0 +1,8 @@
+Setting selection through APIs does not focus unless selection is inside the text control.
+
+
+
+PASS setSelectionRange does not focus unless selection is inside the text control.
+PASS selectionStart/selectionEnd does not focus unless selection is inside the text control.
+PASS setRangeText does not focus unless selection is inside the text control.
+

--- a/LayoutTests/editing/selection/setting-selection-does-not-focus-unless-selected.html
+++ b/LayoutTests/editing/selection/setting-selection-does-not-focus-unless-selected.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Setting selection through APIs does not focus unless selection is inside the text control.</title>
+</head>
+<body>
+    <p>Setting selection through APIs does not focus unless selection is inside the text control.</p>
+    <input id="input" value="XXXXXXXX">
+    <textarea id="textarea">XXXXXXXX</textarea>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script>
+        function testSetSelectionRange(element, expectFocus) {
+            const selection = window.getSelection();
+            selection.removeAllRanges();
+            element.setSelectionRange(null, null);
+            assert_equals(document.activeElement == element, expectFocus, `Element is should ${!expectFocus ? "not " : ""}be focused`);
+            assert_equals(element.selectionStart, 0, "selectionStart is correctly set");
+            assert_equals(element.selectionStart, 0, "selectionEnd is correctly set");
+            element.setSelectionRange(2, 4);
+            assert_equals(document.activeElement == element, expectFocus, `Element is should ${!expectFocus ? "not " : ""}be focused`);
+            assert_equals(element.selectionStart, 2, "selectionStart is correctly set");
+            assert_equals(element.selectionEnd, 4, "selectionEnd is correctly set");
+        }
+        function testSelectionStartEnd(element, expectFocus) {
+            element.selectionStart = 3;
+            element.selectionEnd = 5;
+            assert_equals(document.activeElement == element, expectFocus, `Element is should ${!expectFocus ? "not " : ""}be focused`);
+            assert_equals(element.selectionStart, 3, "selectionStart is correctly set");
+            assert_equals(element.selectionEnd, 5, "selectionEnd is correctly set");
+        }
+
+        function testSetRangeText(element, expectFocus) {
+            element.setRangeText('barrr', 0, 3, 'select');
+            assert_equals(document.activeElement == element, expectFocus, `Element is should ${!expectFocus ? "not " : ""}be focused`);
+        }
+
+        test(t => {
+            t.add_cleanup(() => { input.blur(); textarea.blur(); getSelection().removeAllRanges(); });
+            testSetSelectionRange(input, false);
+            testSetSelectionRange(textarea, false);
+            input.focus();
+            testSetSelectionRange(input, true);
+            textarea.focus();
+            testSetSelectionRange(textarea, true);
+        }, "setSelectionRange does not focus unless selection is inside the text control.");
+
+        test(t => {
+            t.add_cleanup(() => { input.blur(); textarea.blur(); getSelection().removeAllRanges(); });
+            testSelectionStartEnd(input, false);
+            testSelectionStartEnd(textarea, false);
+            input.focus();
+            testSelectionStartEnd(input, true);
+            textarea.focus();
+            testSelectionStartEnd(textarea, true);
+        }, "selectionStart/selectionEnd does not focus unless selection is inside the text control.");
+
+        test(t => {
+            t.add_cleanup(() => { input.blur(); textarea.blur(); getSelection().removeAllRanges(); });
+            testSetRangeText(input, false);
+            testSetRangeText(textarea, false);
+            input.focus();
+            testSetRangeText(input, true);
+            textarea.focus();
+            testSetRangeText(textarea, true);
+        }, "setRangeText does not focus unless selection is inside the text control.");
+    </script>
+</body>
+</html>

--- a/LayoutTests/editing/selection/shrink-selection-after-shift-pagedown.html
+++ b/LayoutTests/editing/selection/shrink-selection-after-shift-pagedown.html
@@ -7,6 +7,7 @@
             testRunner.dumpAsText();
         
         var ta = document.getElementById('ta');
+        ta.focus();
         ta.setSelectionRange(4, 16);
 
         var lastSelectedLine;

--- a/LayoutTests/fast/css/content/content-on-focus-change.html
+++ b/LayoutTests/fast/css/content/content-on-focus-change.html
@@ -7,6 +7,7 @@ if(window.testRunner)
 
 function main() {
     input.setSelectionRange(0,31,"forward");
+    input.focus();
 }
 function f1() {
     var input = document.getElementById("input");

--- a/LayoutTests/fast/events/context-no-deselect.html
+++ b/LayoutTests/fast/events/context-no-deselect.html
@@ -8,6 +8,7 @@
 // This test checks that if the user right clicks on selected text,
 // the selected text doesn't change or get deselected.
 var input = document.getElementById("text");
+input.focus();
 input.selectionStart = 5;
 input.selectionEnd = 15;
 

--- a/LayoutTests/fast/forms/datalist/datalist-idTargetChanged-crash.html
+++ b/LayoutTests/fast/forms/datalist/datalist-idTargetChanged-crash.html
@@ -5,6 +5,7 @@ if (window.testRunner) {
 }
 
 onload = () => {
+    inputElement.focus();
     inputElement.setRangeText("foo");
 }
 

--- a/LayoutTests/fast/forms/input-appearance-selection.html
+++ b/LayoutTests/fast/forms/input-appearance-selection.html
@@ -19,6 +19,7 @@ function test () {
 
 function testSelectionRange (testNumber, start, end, expectedStart, expectedEnd, tf, res)
 {
+    tf.focus();
     tf.setSelectionRange(start, end);
     res.innerHTML = res.innerHTML + "<br>Test " + testNumber + ": setSelectionRange(" + start + ", " + end + ")";            
     if (tf.selectionStart == expectedStart && tf.selectionEnd == expectedEnd)

--- a/LayoutTests/fast/forms/input-delete.html
+++ b/LayoutTests/fast/forms/input-delete.html
@@ -7,6 +7,7 @@ function test() {
         testRunner.dumpAsText();
     }
     document.getElementById('tf').setSelectionRange(5, 11);
+    document.getElementById('tf').focus();
     deleteCommand();
     if (document.getElementById('tf').value == "Test Failed") {
         document.getElementById('res').innerHTML = "Failed";

--- a/LayoutTests/fast/forms/input-placeholder-visibility-2-expected.html
+++ b/LayoutTests/fast/forms/input-placeholder-visibility-2-expected.html
@@ -7,6 +7,7 @@
 <div>
 <input id=i1 value="Text">
 <script>
+document.getElementById('i1').focus();
 document.getElementById('i1').setSelectionRange(4, 4);
 </script>
 </body>

--- a/LayoutTests/fast/forms/paste-into-textarea.html
+++ b/LayoutTests/fast/forms/paste-into-textarea.html
@@ -5,6 +5,7 @@ if (window.testRunner)
     testRunner.dumpAsText();
 var e = document.getElementById("test");
 e.setSelectionRange(1, 1);
+e.focus();
 document.execCommand("InsertHTML", false, "(There should be one 'x' before and after this sentence.)");
 if (e.value == "x(There should be one 'x' before and after this sentence.)x")
     document.write("<p>Hooray, test succeeded.</p>");

--- a/LayoutTests/fast/forms/textarea-arrow-navigation.html
+++ b/LayoutTests/fast/forms/textarea-arrow-navigation.html
@@ -24,6 +24,7 @@ function runTest()
     // that when you go down by a line, the cursor will be at the end of the
     // numbered lines:
     textarea.setSelectionRange(5, 5);
+    textarea.focus();
     for (var i = 0; i < 10; i++) {
         // press the 'down arrow' a bunch of times to try to get to the end of the text area
         eventSender.keyDown("downArrow");

--- a/LayoutTests/fast/rendering/render-compositor-null-layer-crash.html
+++ b/LayoutTests/fast/rendering/render-compositor-null-layer-crash.html
@@ -5,7 +5,7 @@ function gc() {
 }
 function main() {
 var x29 = document.getElementById("x29");
-try { x22.selectionEnd = 87; } catch { }
+try { x22.focus(); x22.selectionEnd = 87; } catch { }
 try { x29.prepend(x7); } catch { }
 }
 function f4() {

--- a/LayoutTests/fast/text-extraction/basic-text-extraction.html
+++ b/LayoutTests/fast/text-extraction/basic-text-extraction.html
@@ -25,6 +25,7 @@ body {
 <div contenteditable="true">This is an editable area: <a href="https://webkit.org">WebKit</a> <a href="https://webkit.org/downloads">downloads</a>.</div>
 <script>
 addEventListener("load", async () => {
+    document.querySelector("input").focus();
     document.querySelector("input").setSelectionRange(4, 7);
 
     if (!window.testRunner)

--- a/LayoutTests/fast/text/out-of-flow-line-break-crash.html
+++ b/LayoutTests/fast/text/out-of-flow-line-break-crash.html
@@ -17,6 +17,7 @@ PASS if no crash or assert.
     testRunner.dumpAsText();
   embed.appendChild(meter);
   textarea.setSelectionRange(1,0,"text");
+  textarea.focus();
   container.appendChild(meter);
   document.execCommand("selectAll", false);
   document.execCommand("createLink", false, "#link");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/processing-model/textarea-scroll-selection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/processing-model/textarea-scroll-selection-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL programatic focus() scrolls selection into view including ancestors assert_not_equals: Should've scrolled ancestor to show the selection got disallowed value 0
+PASS programatic focus() scrolls selection into view including ancestors
 

--- a/LayoutTests/resources/accessibility-helper.js
+++ b/LayoutTests/resources/accessibility-helper.js
@@ -327,6 +327,7 @@ async function selectPartialElementTextById(id, startIndex, endIndex, axWebArea)
     const element = document.getElementById(id);
     if (element.setSelectionRange) {
         // For textarea and input elements.
+        element.focus();
         element.setSelectionRange(startIndex, endIndex);
     } else {
         // For contenteditable elements.

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -130,6 +130,7 @@ enum class SDKAlignedBehavior {
     BlockCrossOriginRedirectDownloads,
     BlobFileAccessEnforcement,
     DevolvableWidgets,
+    SetSelectionRangeCachesSelectionIfNotFocusedOrSelected,
 
     NumberOfBehaviors
 };

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -44,6 +44,7 @@
 #include "EditorClient.h"
 #include "ElementAncestorIteratorInlines.h"
 #include "FloatRect.h"
+#include "FocusOptions.h"
 #include "FrameLoader.h"
 #include "FrameSelection.h"
 #include "HTMLAreaElement.h"
@@ -1523,6 +1524,8 @@ void AccessibilityRenderObject::setSelectedTextRange(CharacterRange&& range)
 
     if (isNativeTextControl()) {
         auto& textControl = uncheckedDowncast<RenderTextControl>(*m_renderer).textFormControlElement();
+        FocusOptions focusOptions { .preventScroll = true };
+        textControl.focus(focusOptions);
         textControl.setSelectionRange(range.location, range.location + range.length);
     } else if (m_renderer) {
         ASSERT(node());
@@ -1779,6 +1782,7 @@ void AccessibilityRenderObject::setSelectedVisiblePositionRange(const VisiblePos
         }
 
         setTextSelectionIntent(axObjectCache(), start == end ? AXTextStateChangeTypeSelectionMove : AXTextStateChangeTypeSelectionExtend);
+        textControl->focus();
         textControl->setSelectionRange(start, end);
     } else if (m_renderer) {
         // Make selection and tell the document to use it. If it's zero length, then move to that position.

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -217,6 +217,8 @@ void HTMLTextFormControlElement::setSelectionDirection(const String& direction)
 
 void HTMLTextFormControlElement::select(SelectionRevealMode revealMode, const AXTextStateChangeIntent& intent)
 {
+    FocusOptions focusOptions { .preventScroll = true };
+    focus(focusOptions);
     if (setSelectionRange(0, std::numeric_limits<unsigned>::max(), SelectionHasNoDirection, revealMode, intent))
         scheduleSelectEvent();
 }
@@ -326,22 +328,23 @@ bool HTMLTextFormControlElement::setSelectionRange(unsigned start, unsigned end,
         if (!isConnected())
             return cacheSelection(start, end, direction);
 
+#if PLATFORM(COCOA)
+        bool cacheSelectionIfNotFocusedOrSelected = WTF::linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::SetSelectionRangeCachesSelectionIfNotFocusedOrSelected);
+#else
+        bool cacheSelectionIfNotFocusedOrSelected = true;
+#endif
+        // Cache selection if neither selection or focus is on the input.
+        if (cacheSelectionIfNotFocusedOrSelected && frame && enclosingTextFormControl(frame->selection().selection().start()) != this)
+            return cacheSelection(start, end, direction);
+
         // FIXME: Removing this synchronous layout requires fixing setSelectionWithoutUpdatingAppearance not needing up-to-date style.
         protectedDocument()->updateLayoutIgnorePendingStylesheets();
 
-        if (!isTextField())
-            return false;
-
-        // Double-check our connected state after the layout update.
-        if (!isConnected())
-            return cacheSelection(start, end, direction);
-
-        // Double-check the state of innerTextElement after the layout.
-        innerText = innerTextElement();
-        auto* rendererTextControl = renderer();
-
-        if (innerText && rendererTextControl && (rendererTextControl->style().visibility() == Visibility::Hidden || !innerText->renderBox() || !innerText->renderBox()->height()))
-            return cacheSelection(start, end, direction);
+        // Cache selection if renderer is invisible.
+        if (CheckedPtr renderer = this->renderer()) {
+            if (renderer->style().visibility() == Visibility::Hidden || !innerText->renderBox() || !innerText->renderBox()->height())
+                return cacheSelection(start, end, direction);
+        }
     }
 
     auto previousSelectionStart = m_cachedSelectionStart;


### PR DESCRIPTION
#### 23fb514293aefc19a2b22fcdd21c814e97435ab0
<pre>
walmart.com/wallet focuses phone number field when attempting to add a credit card
<a href="https://bugs.webkit.org/show_bug.cgi?id=284630">https://bugs.webkit.org/show_bug.cgi?id=284630</a>
<a href="https://rdar.apple.com/139075809">rdar://139075809</a>

Reviewed by Ryosuke Niwa.

Setting the selection should not focus unless there is an existing selection.
This matches other browsers while preserving the principle that focus &amp; selection must be in sync (by neither focusing or selecting).

Notably, these APIs now have this behavior:
- element.setSelectionRange()
- element.selectionStart/selectionEnd setters
- element.setRangeText()

These APIs preserve the old behavior by focusing the text controls before selecting:
- element.select()
- accessibility APIs

Here is the relevant Blink commits for the corresponding change there:
<a href="https://github.com/chromium/chromium/commit/530015339e3f6572d239432b69f77ebca1492f73">https://github.com/chromium/chromium/commit/530015339e3f6572d239432b69f77ebca1492f73</a>

In order to limit the risk of breakage in older macOS/iOS apps, this behavior is put behind a linked-on-or-after check.

* LayoutTests/editing/async-clipboard/resources/async-clipboard-helpers.js:
(async writeToClipboardUsingDataTransfer):
* LayoutTests/editing/deleting/5290534.html:
* LayoutTests/editing/inserting/4960120-1.html:
* LayoutTests/editing/inserting/insert-text-into-text-field.html:
* LayoutTests/editing/pasteboard/data-transfer-get-data-on-drop-plain-text.html:
* LayoutTests/editing/pasteboard/data-transfer-get-data-on-paste-plain-text.html:
* LayoutTests/editing/pasteboard/drag-drop-input-textarea.html:
* LayoutTests/editing/pasteboard/drag-drop-url-text.html:
* LayoutTests/editing/pasteboard/pasting-tabs.html:
* LayoutTests/editing/selection/4975120.html:
* LayoutTests/editing/selection/5497643-expected.txt:
* LayoutTests/editing/selection/5497643.html:
* LayoutTests/editing/selection/delete-selection-with-disconnected-extent.html:
* LayoutTests/editing/selection/delete-word-granularity-text-control.html:
* LayoutTests/editing/selection/deleteFromDocument-shadow-tree-crash.html:
* LayoutTests/editing/selection/programmatic-selection-on-mac-is-directionless.html:
* LayoutTests/editing/selection/select-iframe-focusin-document-crash.html:
* LayoutTests/editing/selection/selection-setSelectionRange-frameselection-expected.txt: Added.
* LayoutTests/editing/selection/selection-setSelectionRange-frameselection.html: Added.
* LayoutTests/editing/selection/setSelectionRange-no-frame-crash-expected.txt: Added.
* LayoutTests/editing/selection/setSelectionRange-no-frame-crash.html: Added.
* LayoutTests/editing/selection/setting-selection-does-not-focus-unless-selected-expected.txt: Added.
* LayoutTests/editing/selection/setting-selection-does-not-focus-unless-selected.html: Added.
* LayoutTests/editing/selection/shrink-selection-after-shift-pagedown.html:
* LayoutTests/fast/css/content/content-on-focus-change.html:
* LayoutTests/fast/events/context-no-deselect.html:
* LayoutTests/fast/forms/datalist/datalist-idTargetChanged-crash.html:
* LayoutTests/fast/forms/input-appearance-selection.html:
* LayoutTests/fast/forms/input-delete.html:
* LayoutTests/fast/forms/input-placeholder-visibility-2-expected.html:
* LayoutTests/fast/forms/paste-into-textarea.html:
* LayoutTests/fast/forms/textarea-arrow-navigation.html:
* LayoutTests/fast/rendering/render-compositor-null-layer-crash.html:
* LayoutTests/fast/text-extraction/basic-text-extraction.html:
* LayoutTests/fast/text/out-of-flow-line-break-crash.html:
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/processing-model/textarea-scroll-selection-expected.txt:
* LayoutTests/resources/accessibility-helper.js:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::setSelectedTextRange):
(WebCore::AccessibilityRenderObject::setSelectedVisiblePositionRange const):
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::select):
(WebCore::HTMLTextFormControlElement::setSelectionRange):

Canonical link: <a href="https://commits.webkit.org/288555@main">https://commits.webkit.org/288555@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/841680b785db53c11f92228c37131eb18e14f3ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88776 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34712 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65111 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22946 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45400 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2442 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30265 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33761 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76667 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90154 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/82721 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73554 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72777 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18002 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17034 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15734 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2293 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10921 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16393 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105138 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10769 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25409 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14244 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->