### PR TITLE
[Cleanup] Refactor RenderTreeBuilderMultiColumn 2/2.

### DIFF
--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
@@ -39,6 +39,9 @@
 
 namespace WebCore {
 
+static bool gRestoringColumnSpannersForContainer = false;
+static bool gShiftingSpanner = false;
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderTreeBuilder::MultiColumn);
 
 static RenderMultiColumnSet* findSetRendering(const RenderMultiColumnFlow& fragmentedFlow, const RenderObject& renderer)
@@ -154,6 +157,134 @@ void RenderTreeBuilder::MultiColumn::updateAfterDescendants(RenderBlockFlow& flo
     }
 }
 
+RenderObject* RenderTreeBuilder::MultiColumn::resolveMovedChild(RenderFragmentedFlow& enclosingFragmentedFlow, RenderObject* beforeChild)
+{
+    if (!beforeChild)
+        return nullptr;
+
+    auto* beforeChildRenderBox = dynamicDowncast<RenderBox>(*beforeChild);
+    if (!beforeChildRenderBox)
+        return beforeChild;
+
+    auto* renderMultiColumnFlow = dynamicDowncast<RenderMultiColumnFlow>(enclosingFragmentedFlow);
+    if (!renderMultiColumnFlow)
+        return beforeChild;
+
+    // We only need to resolve for column spanners.
+    if (beforeChild->style().columnSpan() != ColumnSpan::All)
+        return beforeChild;
+
+    // The renderer for the actual DOM node that establishes a spanner is moved from its original
+    // location in the render tree to becoming a sibling of the column sets. In other words, it's
+    // moved out from the flow thread (and becomes a sibling of it). When we for instance want to
+    // create and insert a renderer for the sibling node immediately preceding the spanner, we need
+    // to map that spanner renderer to the spanner's placeholder, which is where the new inserted
+    // renderer belongs.
+    if (auto* placeholder = renderMultiColumnFlow->findColumnSpannerPlaceholder(beforeChildRenderBox))
+        return placeholder;
+
+    // This is an invalid spanner, or its placeholder hasn't been created yet. This happens when
+    // moving an entire subtree into the flow thread, when we are processing the insertion of this
+    // spanner's preceding sibling, and we obviously haven't got as far as processing this spanner
+    // yet.
+    return beforeChild;
+}
+
+void RenderTreeBuilder::MultiColumn::restoreColumnSpannersForContainer(RenderMultiColumnFlow& multiColumnFlow, const RenderElement& container)
+{
+    auto& spanners = multiColumnFlow.spannerMap();
+    Vector<RenderMultiColumnSpannerPlaceholder*> placeholdersToRestore;
+    for (auto& spannerAndPlaceholder : spanners) {
+        auto& placeholder = spannerAndPlaceholder.value;
+        if (!placeholder || !placeholder->isDescendantOf(&container))
+            continue;
+        placeholdersToRestore.append(placeholder.get());
+    }
+    for (auto* placeholder : placeholdersToRestore) {
+        auto* spanner = placeholder->spanner();
+        if (!spanner) {
+            ASSERT_NOT_REACHED();
+            continue;
+        }
+        // Move the spanner back to its original position.
+        auto& spannerOriginalParent = *placeholder->parent();
+        // Detaching the spanner takes care of removing the placeholder (and merges the RenderMultiColumnSets).
+        auto spannerToReInsert = m_builder.detach(*spanner->parent(), *spanner, WillBeDestroyed::No);
+        auto restoreColumnSpannersScope = SetForScope { gRestoringColumnSpannersForContainer, true };
+        m_builder.attach(spannerOriginalParent, WTFMove(spannerToReInsert));
+    }
+}
+
+void RenderTreeBuilder::MultiColumn::multiColumnDescendantInserted(RenderMultiColumnFlow& flow, RenderObject& newDescendant)
+{
+    if (gShiftingSpanner || gRestoringColumnSpannersForContainer || newDescendant.isRenderFragmentedFlow())
+        return;
+
+    auto* subtreeRoot = &newDescendant;
+    auto* descendant = subtreeRoot;
+    while (descendant) {
+        // Skip nested multicolumn flows.
+        if (is<RenderMultiColumnFlow>(*descendant)) {
+            descendant = descendant->nextSibling();
+            continue;
+        }
+        if (auto* placeholder = dynamicDowncast<RenderMultiColumnSpannerPlaceholder>(*descendant)) {
+            // A spanner's placeholder has been inserted. The actual spanner renderer is moved from
+            // where it would otherwise occur (if it weren't a spanner) to becoming a sibling of the
+            // column sets.
+            ASSERT(!flow.spannerMap().get(placeholder->spanner()));
+            flow.spannerMap().add(*placeholder->spanner(), placeholder);
+            ASSERT(!placeholder->firstChild()); // There should be no children here, but if there are, we ought to skip them.
+        } else
+            descendant = processPossibleSpannerDescendant(flow, subtreeRoot, *descendant);
+        if (descendant)
+            descendant = descendant->nextInPreOrder(subtreeRoot);
+    }
+}
+
+void RenderTreeBuilder::MultiColumn::multiColumnRelativeWillBeRemoved(RenderMultiColumnFlow& flow, RenderObject& relative, RenderTreeBuilder::CanCollapseAnonymousBlock canCollapseAnonymousBlock)
+{
+    flow.invalidateFragments();
+    if (auto* placeholder = dynamicDowncast<RenderMultiColumnSpannerPlaceholder>(relative)) {
+        // Remove the map entry for this spanner, but leave the actual spanner renderer alone. Also
+        // keep the reference to the spanner, since the placeholder may be about to be re-inserted
+        // in the tree.
+        ASSERT(relative.isDescendantOf(&flow));
+        flow.spannerMap().remove(placeholder->spanner());
+        return;
+    }
+    if (relative.style().columnSpan() == ColumnSpan::All) {
+        if (relative.parent() != flow.parent())
+            return; // not a valid spanner.
+
+        handleSpannerRemoval(flow, relative, canCollapseAnonymousBlock);
+    }
+    // Note that we might end up with empty column sets if all column content is removed. That's no
+    // big deal though (and locating them would be expensive), and they will be found and re-used if
+    // content is added again later.
+}
+
+RenderObject* RenderTreeBuilder::MultiColumn::adjustBeforeChildForMultiColumnSpannerIfNeeded(RenderObject& beforeChild)
+{
+    auto* beforeChildBox = dynamicDowncast<RenderBox>(beforeChild);
+    if (!beforeChildBox)
+        return &beforeChild;
+
+    auto* nextSibling = beforeChildBox->nextSibling();
+    if (!nextSibling)
+        return &beforeChild;
+
+    auto* renderMultiColumnSet = dynamicDowncast<RenderMultiColumnSet>(*nextSibling);
+    if (!renderMultiColumnSet)
+        return &beforeChild;
+
+    auto* multiColumnFlow = renderMultiColumnSet->multiColumnFlow();
+    if (!multiColumnFlow)
+        return &beforeChild;
+
+    return multiColumnFlow->findColumnSpannerPlaceholder(beforeChildBox);
+}
+
 void RenderTreeBuilder::MultiColumn::createFragmentedFlow(RenderBlockFlow& flow)
 {
     flow.setChildrenInline(false); // Do this to avoid wrapping inline children that are just going to move into the flow thread.
@@ -179,33 +310,6 @@ void RenderTreeBuilder::MultiColumn::createFragmentedFlow(RenderBlockFlow& flow)
     }
 
     flow.setMultiColumnFlow(fragmentedFlow);
-}
-
-static bool gRestoringColumnSpannersForContainer = false;
-
-void RenderTreeBuilder::MultiColumn::restoreColumnSpannersForContainer(RenderMultiColumnFlow& multiColumnFlow, const RenderElement& container)
-{
-    auto& spanners = multiColumnFlow.spannerMap();
-    Vector<RenderMultiColumnSpannerPlaceholder*> placeholdersToRestore;
-    for (auto& spannerAndPlaceholder : spanners) {
-        auto& placeholder = spannerAndPlaceholder.value;
-        if (!placeholder || !placeholder->isDescendantOf(&container))
-            continue;
-        placeholdersToRestore.append(placeholder.get());
-    }
-    for (auto* placeholder : placeholdersToRestore) {
-        auto* spanner = placeholder->spanner();
-        if (!spanner) {
-            ASSERT_NOT_REACHED();
-            continue;
-        }
-        // Move the spanner back to its original position.
-        auto& spannerOriginalParent = *placeholder->parent();
-        // Detaching the spanner takes care of removing the placeholder (and merges the RenderMultiColumnSets).
-        auto spannerToReInsert = m_builder.detach(*spanner->parent(), *spanner, WillBeDestroyed::No);
-        auto restoreColumnSpannersScope = SetForScope { gRestoringColumnSpannersForContainer, true };
-        m_builder.attach(spannerOriginalParent, WTFMove(spannerToReInsert));
-    }
 }
 
 void RenderTreeBuilder::MultiColumn::destroyFragmentedFlow(RenderBlockFlow& flow)
@@ -247,69 +351,6 @@ void RenderTreeBuilder::MultiColumn::destroyFragmentedFlow(RenderBlockFlow& flow
     m_builder.destroy(multiColumnFlow);
     for (auto& parentAndSpanner : parentAndSpannerList)
         m_builder.attach(*parentAndSpanner.first, WTFMove(parentAndSpanner.second));
-}
-
-
-RenderObject* RenderTreeBuilder::MultiColumn::resolveMovedChild(RenderFragmentedFlow& enclosingFragmentedFlow, RenderObject* beforeChild)
-{
-    if (!beforeChild)
-        return nullptr;
-
-    auto* beforeChildRenderBox = dynamicDowncast<RenderBox>(*beforeChild);
-    if (!beforeChildRenderBox)
-        return beforeChild;
-
-    auto* renderMultiColumnFlow = dynamicDowncast<RenderMultiColumnFlow>(enclosingFragmentedFlow);
-    if (!renderMultiColumnFlow)
-        return beforeChild;
-
-    // We only need to resolve for column spanners.
-    if (beforeChild->style().columnSpan() != ColumnSpan::All)
-        return beforeChild;
-
-    // The renderer for the actual DOM node that establishes a spanner is moved from its original
-    // location in the render tree to becoming a sibling of the column sets. In other words, it's
-    // moved out from the flow thread (and becomes a sibling of it). When we for instance want to
-    // create and insert a renderer for the sibling node immediately preceding the spanner, we need
-    // to map that spanner renderer to the spanner's placeholder, which is where the new inserted
-    // renderer belongs.
-    if (auto* placeholder = renderMultiColumnFlow->findColumnSpannerPlaceholder(beforeChildRenderBox))
-        return placeholder;
-
-    // This is an invalid spanner, or its placeholder hasn't been created yet. This happens when
-    // moving an entire subtree into the flow thread, when we are processing the insertion of this
-    // spanner's preceding sibling, and we obviously haven't got as far as processing this spanner
-    // yet.
-    return beforeChild;
-}
-
-static bool gShiftingSpanner = false;
-
-void RenderTreeBuilder::MultiColumn::multiColumnDescendantInserted(RenderMultiColumnFlow& flow, RenderObject& newDescendant)
-{
-    if (gShiftingSpanner || gRestoringColumnSpannersForContainer || newDescendant.isRenderFragmentedFlow())
-        return;
-
-    auto* subtreeRoot = &newDescendant;
-    auto* descendant = subtreeRoot;
-    while (descendant) {
-        // Skip nested multicolumn flows.
-        if (is<RenderMultiColumnFlow>(*descendant)) {
-            descendant = descendant->nextSibling();
-            continue;
-        }
-        if (auto* placeholder = dynamicDowncast<RenderMultiColumnSpannerPlaceholder>(*descendant)) {
-            // A spanner's placeholder has been inserted. The actual spanner renderer is moved from
-            // where it would otherwise occur (if it weren't a spanner) to becoming a sibling of the
-            // column sets.
-            ASSERT(!flow.spannerMap().get(placeholder->spanner()));
-            flow.spannerMap().add(*placeholder->spanner(), placeholder);
-            ASSERT(!placeholder->firstChild()); // There should be no children here, but if there are, we ought to skip them.
-        } else
-            descendant = processPossibleSpannerDescendant(flow, subtreeRoot, *descendant);
-        if (descendant)
-            descendant = descendant->nextInPreOrder(subtreeRoot);
-    }
 }
 
 RenderObject* RenderTreeBuilder::MultiColumn::processPossibleSpannerDescendant(RenderMultiColumnFlow& flow, RenderObject*& subtreeRoot, RenderObject& descendant)
@@ -418,47 +459,4 @@ void RenderTreeBuilder::MultiColumn::handleSpannerRemoval(RenderMultiColumnFlow&
     }
 }
 
-void RenderTreeBuilder::MultiColumn::multiColumnRelativeWillBeRemoved(RenderMultiColumnFlow& flow, RenderObject& relative, RenderTreeBuilder::CanCollapseAnonymousBlock canCollapseAnonymousBlock)
-{
-    flow.invalidateFragments();
-    if (auto* placeholder = dynamicDowncast<RenderMultiColumnSpannerPlaceholder>(relative)) {
-        // Remove the map entry for this spanner, but leave the actual spanner renderer alone. Also
-        // keep the reference to the spanner, since the placeholder may be about to be re-inserted
-        // in the tree.
-        ASSERT(relative.isDescendantOf(&flow));
-        flow.spannerMap().remove(placeholder->spanner());
-        return;
-    }
-    if (relative.style().columnSpan() == ColumnSpan::All) {
-        if (relative.parent() != flow.parent())
-            return; // not a valid spanner.
-
-        handleSpannerRemoval(flow, relative, canCollapseAnonymousBlock);
-    }
-    // Note that we might end up with empty column sets if all column content is removed. That's no
-    // big deal though (and locating them would be expensive), and they will be found and re-used if
-    // content is added again later.
-}
-
-RenderObject* RenderTreeBuilder::MultiColumn::adjustBeforeChildForMultiColumnSpannerIfNeeded(RenderObject& beforeChild)
-{
-    auto* beforeChildBox = dynamicDowncast<RenderBox>(beforeChild);
-    if (!beforeChildBox)
-        return &beforeChild;
-
-    auto* nextSibling = beforeChildBox->nextSibling();
-    if (!nextSibling)
-        return &beforeChild;
-
-    auto* renderMultiColumnSet = dynamicDowncast<RenderMultiColumnSet>(*nextSibling);
-    if (!renderMultiColumnSet)
-        return &beforeChild;
-
-    auto* multiColumnFlow = renderMultiColumnSet->multiColumnFlow();
-    if (!multiColumnFlow)
-        return &beforeChild;
-
-    return multiColumnFlow->findColumnSpannerPlaceholder(beforeChildBox);
-}
-
-}
+} // namespace Webcore


### PR DESCRIPTION
#### c27ba7a1cf4d746358870b808cab56ab9ada33c8
<pre>
[Cleanup] Refactor RenderTreeBuilderMultiColumn 2/2.
<a href="https://bugs.webkit.org/show_bug.cgi?id=285437">https://bugs.webkit.org/show_bug.cgi?id=285437</a>
<a href="https://rdar.apple.com/142420503">rdar://142420503</a>

Reviewed by Alan Baradlay.

This change static variables and local/public/private
functions in the class so they are no longer intermingled.

Canonical link: <a href="https://commits.webkit.org/288871@main">https://commits.webkit.org/288871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75854247ebe3fb6b223380f44ea50e470b61fa2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88728 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34665 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85742 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65070 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22817 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86703 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45358 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30452 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33714 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73443 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90107 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73599 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72730 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18178 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16988 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15686 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2246 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10874 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16346 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10722 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14197 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12494 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->