### PR TITLE
[compression] Brotli: correctly handle large output when flushing

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any-expected.txt
@@ -2,5 +2,5 @@
 PASS deflate compression with large flush output
 PASS gzip compression with large flush output
 PASS deflate-raw compression with large flush output
-PASS brotli compression with large flush output
+FAIL brotli compression with large flush output promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
 

--- a/Source/WebCore/Modules/compression/CompressionStreamEncoder.h
+++ b/Source/WebCore/Modules/compression/CompressionStreamEncoder.h
@@ -57,6 +57,7 @@ private:
     ExceptionOr<Ref<JSC::ArrayBuffer>> compress(std::span<const uint8_t>);
     ExceptionOr<Ref<JSC::ArrayBuffer>> compressZlib(std::span<const uint8_t>);
 #if PLATFORM(COCOA)
+    bool didDeflateFinishAppleCompressionFramework(int);
     ExceptionOr<Ref<JSC::ArrayBuffer>> compressAppleCompressionFramework(std::span<const uint8_t>);
 #endif
 

--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
@@ -61,6 +61,7 @@ private:
     ExceptionOr<Ref<JSC::ArrayBuffer>> decompress(std::span<const uint8_t>);
     ExceptionOr<Ref<JSC::ArrayBuffer>> decompressZlib(std::span<const uint8_t>);
 #if PLATFORM(COCOA)
+    bool didInflateFinishAppleCompressionFramework(int);
     ExceptionOr<Ref<JSC::ArrayBuffer>> decompressAppleCompressionFramework(std::span<const uint8_t>);
 #endif
 

--- a/Source/WebCore/Modules/compression/cocoa/CompressionStreamEncoderCocoa.mm
+++ b/Source/WebCore/Modules/compression/cocoa/CompressionStreamEncoderCocoa.mm
@@ -24,8 +24,20 @@
 
 #include "config.h"
 #include "CompressionStreamEncoder.h"
+#include <compression.h>
 
 namespace WebCore {
+
+// The compression algorithm is broken up into 2 steps.
+// 1. Compression of Data
+// 2. Flush Remaining Data
+//
+// When src_size is empty we can normally exit performing compression, but during the flush
+// step we may have data buffered and will need to continue to keep flushing out the rest.
+bool CompressionStreamEncoder::didDeflateFinishAppleCompressionFramework(int result)
+{
+    return !m_compressionStream.getPlatformStream().src_size && (!m_didFinish || (m_didFinish && result == COMPRESSION_STATUS_END));
+}
 
 ExceptionOr<Ref<JSC::ArrayBuffer>> CompressionStreamEncoder::compressAppleCompressionFramework(std::span<const uint8_t> input)
 {
@@ -66,7 +78,7 @@ ExceptionOr<Ref<JSC::ArrayBuffer>> CompressionStreamEncoder::compressAppleCompre
             || (m_didFinish && m_compressionStream.getPlatformStream().src_size))
             return Exception { ExceptionCode::TypeError, "Extra bytes past the end."_s };
 
-        if (!m_compressionStream.getPlatformStream().src_size) {
+        if (didDeflateFinishAppleCompressionFramework(result)) {
             shouldDecompress = false;
             output.shrink(allocateSize - m_compressionStream.getPlatformStream().dst_size);
         } else {


### PR DESCRIPTION
#### e3a75750073a2a8728fb4cdd3817d584637996ec
<pre>
[compression] Brotli: correctly handle large output when flushing
<a href="https://bugs.webkit.org/show_bug.cgi?id=285443">https://bugs.webkit.org/show_bug.cgi?id=285443</a>
<a href="https://rdar.apple.com/problem/142424257">rdar://problem/142424257</a>

Reviewed by Alex Christensen.

During the finalize step, the internal buffer of Brotli has the potential to be holding more data than what our buffer can hold.
Therefore we will need to continue to request Brotli for more data, so we do not truncate the results.

* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any-expected.txt
* LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any.js:
(async decompressData):
(promise_test.async t):
* Source/WebCore/Modules/compression/CompressionStreamEncoder.h:
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.h:
* Source/WebCore/Modules/compression/cocoa/CompressionStreamEncoderCocoa.mm:
(WebCore::CompressionStreamEncoder::didDeflateFinishAppleCompressionFramework):
(WebCore::CompressionStreamEncoder::compressAppleCompressionFramework):
* Source/WebCore/Modules/compression/cocoa/DecompressionStreamDecoderCocoa.mm:
(WebCore::DecompressionStreamDecoder::didInflateFinishAppleCompressionFramework):
(WebCore::DecompressionStreamDecoder::decompressAppleCompressionFramework):

Canonical link: <a href="https://commits.webkit.org/288500@main">https://commits.webkit.org/288500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d35b4389dc7e75a2028fe663d3a411debff877b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88674 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34611 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65033 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22784 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86649 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45320 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2340 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30169 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33659 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90051 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7843 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73468 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11091 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72693 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17979 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16938 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15645 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2192 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16292 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10668 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14143 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->