### PR TITLE
Re-baseline OverlayRegions tests

### DIFF
--- a/LayoutTests/overlay-region/fixed-node-updates-expected.txt
+++ b/LayoutTests/overlay-region/fixed-node-updates-expected.txt
@@ -76,13 +76,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -98,10 +100,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/fixed-overlay-drawn-rect-expected.txt
+++ b/LayoutTests/overlay-region/fixed-overlay-drawn-rect-expected.txt
@@ -72,13 +72,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -94,10 +96,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/full-page-dynamic-expected.txt
+++ b/LayoutTests/overlay-region/full-page-dynamic-expected.txt
@@ -90,13 +90,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -112,10 +114,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/full-page-expected.txt
+++ b/LayoutTests/overlay-region/full-page-expected.txt
@@ -90,13 +90,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -112,10 +114,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/full-page-horizontal-expected.txt
+++ b/LayoutTests/overlay-region/full-page-horizontal-expected.txt
@@ -72,13 +72,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 28 height: 6])
-                      (layer position [x: 17 y: 17]))))))))
+                      (layer position [x: 17 y: 17])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -94,10 +96,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/full-page-overflow-expected.txt
+++ b/LayoutTests/overlay-region/full-page-overflow-expected.txt
@@ -70,13 +70,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 12 height: 96])
                                                       (layer position [x: 6 y: 6])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 90])
                                                           (layer position [x: 6 y: 6]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                                                          (layer position [x: 6 y: 6]))))))))
+                                                          (layer position [x: 6 y: 6])
+                                                          (layer cornerRadius 3))))))))
                                             (view [class: <class not in allowed list of classes>]
                                               (layer bounds [x: 0 y: 0 width: 800 height: 12])
                                               (layer position [x: 400 y: 400])
@@ -92,13 +94,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 96 height: 12])
                                                       (layer position [x: 400 y: 400])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                                                           (layer position [x: 48 y: 48]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                                                          (layer position [x: 48 y: 48]))))))))))))
+                                                          (layer position [x: 48 y: 48])
+                                                          (layer cornerRadius 3))))))))))))
                                     (view [class: WKCompositingView]
                                       (layer bounds [x: 0 y: 0 width: 800 height: 600])
                                       (layer position [x: 400 y: 400])
@@ -163,13 +167,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -185,10 +191,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/full-page-overflow-scrolling-expected.txt
+++ b/LayoutTests/overlay-region/full-page-overflow-scrolling-expected.txt
@@ -70,13 +70,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 12 height: 96])
                                                       (layer position [x: 6 y: 6])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 90])
                                                           (layer position [x: 6 y: 6]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                                                          (layer position [x: 6 y: 6]))))))))
+                                                          (layer position [x: 6 y: 6])
+                                                          (layer cornerRadius 3))))))))
                                             (view [class: <class not in allowed list of classes>]
                                               (layer bounds [x: 0 y: 0 width: 800 height: 12])
                                               (layer position [x: 400 y: 400])
@@ -92,13 +94,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 96 height: 12])
                                                       (layer position [x: 400 y: 400])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                                                           (layer position [x: 48 y: 48]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                                                          (layer position [x: 48 y: 48]))))))))))))
+                                                          (layer position [x: 48 y: 48])
+                                                          (layer cornerRadius 3))))))))))))
                                     (view [class: WKCompositingView]
                                       (layer bounds [x: 0 y: 0 width: 800 height: 600])
                                       (layer position [x: 400 y: 400])
@@ -163,13 +167,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -185,10 +191,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/full-page-overflow-snapping-expected.txt
+++ b/LayoutTests/overlay-region/full-page-overflow-snapping-expected.txt
@@ -68,13 +68,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 12 height: 96])
                                                       (layer position [x: 6 y: 6])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 90])
                                                           (layer position [x: 6 y: 6]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                                                          (layer position [x: 6 y: 6]))))))))
+                                                          (layer position [x: 6 y: 6])
+                                                          (layer cornerRadius 3))))))))
                                             (view [class: <class not in allowed list of classes>]
                                               (layer bounds [x: 0 y: 0 width: 800 height: 12])
                                               (layer position [x: 400 y: 400])
@@ -90,13 +92,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 96 height: 12])
                                                       (layer position [x: 400 y: 400])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                                                           (layer position [x: 48 y: 48]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                                                          (layer position [x: 48 y: 48]))))))))))))
+                                                          (layer position [x: 48 y: 48])
+                                                          (layer cornerRadius 3))))))))))))
                                     (view [class: WKCompositingView]
                                       (layer bounds [x: 0 y: 0 width: 800 height: 600])
                                       (layer position [x: 400 y: 400])
@@ -161,13 +165,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -183,10 +189,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/full-page-scrolling-expected.txt
+++ b/LayoutTests/overlay-region/full-page-scrolling-expected.txt
@@ -91,13 +91,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -113,10 +115,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/many-candidates-expected.txt
+++ b/LayoutTests/overlay-region/many-candidates-expected.txt
@@ -84,13 +84,15 @@
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 12 height: 96])
                                                           (layer position [x: 6 y: 6])
+                                                          (layer cornerRadius 6)
                                                           (subviews
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 6 height: 90])
                                                               (layer position [x: 6 y: 6]))
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                                                              (layer position [x: 6 y: 6]))))))))
+                                                              (layer position [x: 6 y: 6])
+                                                              (layer cornerRadius 3))))))))
                                                 (view [class: <class not in allowed list of classes>]
                                                   (layer bounds [x: 0 y: 0 width: 640 height: 12])
                                                   (layer position [x: 320 y: 320])
@@ -106,13 +108,15 @@
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 96 height: 12])
                                                           (layer position [x: 320 y: 320])
+                                                          (layer cornerRadius 6)
                                                           (subviews
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                                                               (layer position [x: 48 y: 48]))
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                                                              (layer position [x: 48 y: 48]))))))))))))))
+                                                              (layer position [x: 48 y: 48])
+                                                              (layer cornerRadius 3))))))))))))))
                                     (view [class: WKTransformView]
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                       (layer position [x: 192 y: 192])
@@ -160,13 +164,15 @@
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 12 height: 96])
                                                           (layer position [x: 6 y: 6])
+                                                          (layer cornerRadius 6)
                                                           (subviews
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 6 height: 90])
                                                               (layer position [x: 6 y: 6]))
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                                                              (layer position [x: 6 y: 6]))))))))
+                                                              (layer position [x: 6 y: 6])
+                                                              (layer cornerRadius 3))))))))
                                                 (view [class: <class not in allowed list of classes>]
                                                   (layer bounds [x: 0 y: 0 width: 640 height: 12])
                                                   (layer position [x: 320 y: 320])
@@ -182,13 +188,15 @@
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 96 height: 12])
                                                           (layer position [x: 320 y: 320])
+                                                          (layer cornerRadius 6)
                                                           (subviews
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                                                               (layer position [x: 48 y: 48]))
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                                                              (layer position [x: 48 y: 48]))))))))))))))
+                                                              (layer position [x: 48 y: 48])
+                                                              (layer cornerRadius 3))))))))))))))
                                     (view [class: WKCompositingView]
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                       (layer position [x: 0 y: 0]))
@@ -240,13 +248,15 @@
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 12 height: 96])
                                                           (layer position [x: 6 y: 6])
+                                                          (layer cornerRadius 6)
                                                           (subviews
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 6 height: 90])
                                                               (layer position [x: 6 y: 6]))
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                                                              (layer position [x: 6 y: 6]))))))))
+                                                              (layer position [x: 6 y: 6])
+                                                              (layer cornerRadius 3))))))))
                                                 (view [class: <class not in allowed list of classes>]
                                                   (layer bounds [x: 0 y: 0 width: 656 height: 12])
                                                   (layer position [x: 328 y: 328])
@@ -262,13 +272,15 @@
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 96 height: 12])
                                                           (layer position [x: 328 y: 328])
+                                                          (layer cornerRadius 6)
                                                           (subviews
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                                                               (layer position [x: 48 y: 48]))
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                                                              (layer position [x: 48 y: 48]))))))))))))))))))))))))))
+                                                              (layer position [x: 48 y: 48])
+                                                              (layer cornerRadius 3))))))))))))))))))))))))))
             (view [class: UIView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
@@ -292,13 +304,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -314,10 +328,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/map-expected.txt
+++ b/LayoutTests/overlay-region/map-expected.txt
@@ -68,13 +68,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 12 height: 96])
                                                       (layer position [x: 6 y: 6])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 90])
                                                           (layer position [x: 6 y: 6]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                                                          (layer position [x: 6 y: 6]))))))))
+                                                          (layer position [x: 6 y: 6])
+                                                          (layer cornerRadius 3))))))))
                                             (view [class: <class not in allowed list of classes>]
                                               (layer bounds [x: 0 y: 0 width: 640 height: 12])
                                               (layer position [x: 320 y: 320])
@@ -90,13 +92,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 96 height: 12])
                                                       (layer position [x: 320 y: 320])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                                                           (layer position [x: 48 y: 48]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 28 height: 6])
-                                                          (layer position [x: 17 y: 17]))))))))))))))))))))))))
+                                                          (layer position [x: 17 y: 17])
+                                                          (layer cornerRadius 3))))))))))))))))))))))))
             (view [class: UIView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
@@ -120,13 +124,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -142,10 +148,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/map-small-expected.txt
+++ b/LayoutTests/overlay-region/map-small-expected.txt
@@ -65,13 +65,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 12 height: 96])
                                                       (layer position [x: 6 y: 6])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 90])
                                                           (layer position [x: 6 y: 6]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                                                          (layer position [x: 6 y: 6]))))))))
+                                                          (layer position [x: 6 y: 6])
+                                                          (layer cornerRadius 3))))))))
                                             (view [class: <class not in allowed list of classes>]
                                               (layer bounds [x: 0 y: 0 width: 160 height: 12])
                                               (layer position [x: 80 y: 80])
@@ -87,13 +89,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 96 height: 12])
                                                       (layer position [x: 80 y: 80])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                                                           (layer position [x: 48 y: 48]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 28 height: 6])
-                                                          (layer position [x: 17 y: 17]))))))))))))))))))))))))
+                                                          (layer position [x: 17 y: 17])
+                                                          (layer cornerRadius 3))))))))))))))))))))))))
             (view [class: UIView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0])
               (layer position [x: 400 y: 400]))
@@ -117,13 +121,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -139,10 +145,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/merging-expected.txt
+++ b/LayoutTests/overlay-region/merging-expected.txt
@@ -72,13 +72,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 12 height: 96])
                                                       (layer position [x: 6 y: 6])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 90])
                                                           (layer position [x: 6 y: 6]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                                                          (layer position [x: 6 y: 6]))))))))
+                                                          (layer position [x: 6 y: 6])
+                                                          (layer cornerRadius 3))))))))
                                             (view [class: <class not in allowed list of classes>]
                                               (layer bounds [x: 0 y: 0 width: 640 height: 12])
                                               (layer position [x: 320 y: 320])
@@ -94,13 +96,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 96 height: 12])
                                                       (layer position [x: 320 y: 320])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                                                           (layer position [x: 48 y: 48]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 28 height: 6])
-                                                          (layer position [x: 17 y: 17]))))))))))))
+                                                          (layer position [x: 17 y: 17])
+                                                          (layer cornerRadius 3))))))))))))
                                     (view [class: WKTransformView]
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                       (layer position [x: 80 y: 80])
@@ -234,13 +238,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -256,10 +262,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/no-merging-expected.txt
+++ b/LayoutTests/overlay-region/no-merging-expected.txt
@@ -77,13 +77,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 12 height: 96])
                                                       (layer position [x: 6 y: 6])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 90])
                                                           (layer position [x: 6 y: 6]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                                                          (layer position [x: 6 y: 6]))))))))
+                                                          (layer position [x: 6 y: 6])
+                                                          (layer cornerRadius 3))))))))
                                             (view [class: <class not in allowed list of classes>]
                                               (layer bounds [x: 0 y: 0 width: 640 height: 12])
                                               (layer position [x: 320 y: 320])
@@ -99,13 +101,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 96 height: 12])
                                                       (layer position [x: 320 y: 320])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                                                           (layer position [x: 48 y: 48]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 28 height: 6])
-                                                          (layer position [x: 17 y: 17]))))))))))))
+                                                          (layer position [x: 17 y: 17])
+                                                          (layer cornerRadius 3))))))))))))
                                     (view [class: WKTransformView]
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                       (layer position [x: 80 y: 80])
@@ -228,13 +232,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -250,10 +256,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/overlay-background-expected.txt
+++ b/LayoutTests/overlay-region/overlay-background-expected.txt
@@ -99,13 +99,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -121,10 +123,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/overlay-element-expected.txt
+++ b/LayoutTests/overlay-region/overlay-element-expected.txt
@@ -69,13 +69,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -91,10 +93,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/overlay-element-overflow-expected.txt
+++ b/LayoutTests/overlay-region/overlay-element-overflow-expected.txt
@@ -69,13 +69,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 12 height: 96])
                                                       (layer position [x: 6 y: 6])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 90])
                                                           (layer position [x: 6 y: 6]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                                                          (layer position [x: 6 y: 6]))))))))
+                                                          (layer position [x: 6 y: 6])
+                                                          (layer cornerRadius 3))))))))
                                             (view [class: <class not in allowed list of classes>]
                                               (layer bounds [x: 0 y: 0 width: 800 height: 12])
                                               (layer position [x: 400 y: 400])
@@ -91,13 +93,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 96 height: 12])
                                                       (layer position [x: 400 y: 400])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                                                           (layer position [x: 48 y: 48]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                                                          (layer position [x: 48 y: 48]))))))))))))
+                                                          (layer position [x: 48 y: 48])
+                                                          (layer cornerRadius 3))))))))))))
                                     (view [class: WKTransformView]
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                       (subviews
@@ -127,13 +131,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -149,10 +155,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/snapping-expected.txt
+++ b/LayoutTests/overlay-region/snapping-expected.txt
@@ -73,13 +73,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 12 height: 96])
                                                       (layer position [x: 6 y: 6])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 90])
                                                           (layer position [x: 6 y: 6]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                                                          (layer position [x: 6 y: 6]))))))))
+                                                          (layer position [x: 6 y: 6])
+                                                          (layer cornerRadius 3))))))))
                                             (view [class: <class not in allowed list of classes>]
                                               (layer bounds [x: 0 y: 0 width: 728 height: 12])
                                               (layer position [x: 364 y: 364])
@@ -95,13 +97,15 @@
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 96 height: 12])
                                                       (layer position [x: 364 y: 364])
+                                                      (layer cornerRadius 6)
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                                                           (layer position [x: 48 y: 48]))
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                                                          (layer position [x: 48 y: 48]))))))))))))
+                                                          (layer position [x: 48 y: 48])
+                                                          (layer cornerRadius 3))))))))))))
                                     (view [class: WKCompositingView]
                                       (layer bounds [x: 0 y: 0 width: 728 height: 540])
                                       (layer position [x: 436 y: 436])
@@ -197,13 +201,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -219,10 +225,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))

--- a/LayoutTests/overlay-region/split-scrollers-expected.txt
+++ b/LayoutTests/overlay-region/split-scrollers-expected.txt
@@ -77,13 +77,15 @@
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 12 height: 96])
                                                           (layer position [x: 6 y: 6])
+                                                          (layer cornerRadius 6)
                                                           (subviews
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 6 height: 90])
                                                               (layer position [x: 6 y: 6]))
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                                                              (layer position [x: 6 y: 6]))))))))
+                                                              (layer position [x: 6 y: 6])
+                                                              (layer cornerRadius 3))))))))
                                                 (view [class: <class not in allowed list of classes>]
                                                   (layer bounds [x: 0 y: 0 width: 160 height: 12])
                                                   (layer position [x: 80 y: 80])
@@ -99,13 +101,15 @@
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 96 height: 12])
                                                           (layer position [x: 80 y: 80])
+                                                          (layer cornerRadius 6)
                                                           (subviews
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                                                               (layer position [x: 48 y: 48]))
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                                                              (layer position [x: 48 y: 48]))))))))))))))
+                                                              (layer position [x: 48 y: 48])
+                                                              (layer cornerRadius 3))))))))))))))
                                     (view [class: WKTransformView]
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                       (layer position [x: 160 y: 160])
@@ -162,13 +166,15 @@
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 12 height: 96])
                                                           (layer position [x: 6 y: 6])
+                                                          (layer cornerRadius 6)
                                                           (subviews
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 6 height: 90])
                                                               (layer position [x: 6 y: 6]))
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 6 height: 28])
-                                                              (layer position [x: 6 y: 6]))))))))
+                                                              (layer position [x: 6 y: 6])
+                                                              (layer cornerRadius 3))))))))
                                                 (view [class: <class not in allowed list of classes>]
                                                   (layer bounds [x: 0 y: 0 width: 640 height: 12])
                                                   (layer position [x: 320 y: 320])
@@ -184,13 +190,15 @@
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 96 height: 12])
                                                           (layer position [x: 320 y: 320])
+                                                          (layer cornerRadius 6)
                                                           (subviews
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                                                               (layer position [x: 48 y: 48]))
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                                                              (layer position [x: 48 y: 48]))))))))))))))
+                                                              (layer position [x: 48 y: 48])
+                                                              (layer cornerRadius 3))))))))))))))
                                     (view [class: WKCompositingView]
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                       (layer position [x: 0 y: 0]))))))))))))))
@@ -217,13 +225,15 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 96 height: 12])
                   (layer position [x: 400 y: 400])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 90 height: 6])
-                      (layer position [x: 48 y: 48]))))))))
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 3))))))))
         (view [class: <class not in allowed list of classes>]
           (layer bounds [x: 0 y: 0 width: 12 height: 600])
           (layer position [x: 791 y: 791])
@@ -239,10 +249,12 @@
                 (view [class: <class not in allowed list of classes>]
                   (layer bounds [x: 0 y: 0 width: 12 height: 96])
                   (layer position [x: 6 y: 6])
+                  (layer cornerRadius 6)
                   (subviews
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6]))
                     (view [class: <class not in allowed list of classes>]
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
-                      (layer position [x: 6 y: 6]))))))))))))
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 3))))))))))))


### PR DESCRIPTION
#### cad457dc2f56f406faaa401713585efd3830fc97
<pre>
Re-baseline OverlayRegions tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=285445">https://bugs.webkit.org/show_bug.cgi?id=285445</a>
&lt;<a href="https://rdar.apple.com/142425497">rdar://142425497</a>&gt;

Reviewed by Tim Nguyen.

We added corner radius to the text dump format.
(These tests are currently skipped in EWS.)

* LayoutTests/overlay-region/fixed-node-updates-expected.txt:
* LayoutTests/overlay-region/fixed-overlay-drawn-rect-expected.txt:
* LayoutTests/overlay-region/full-page-dynamic-expected.txt:
* LayoutTests/overlay-region/full-page-expected.txt:
* LayoutTests/overlay-region/full-page-horizontal-expected.txt:
* LayoutTests/overlay-region/full-page-overflow-expected.txt:
* LayoutTests/overlay-region/full-page-overflow-scrolling-expected.txt:
* LayoutTests/overlay-region/full-page-overflow-snapping-expected.txt:
* LayoutTests/overlay-region/full-page-scrolling-expected.txt:
* LayoutTests/overlay-region/many-candidates-expected.txt:
* LayoutTests/overlay-region/map-expected.txt:
* LayoutTests/overlay-region/map-small-expected.txt:
* LayoutTests/overlay-region/merging-expected.txt:
* LayoutTests/overlay-region/no-merging-expected.txt:
* LayoutTests/overlay-region/overlay-background-expected.txt:
* LayoutTests/overlay-region/overlay-element-expected.txt:
* LayoutTests/overlay-region/overlay-element-overflow-expected.txt:
* LayoutTests/overlay-region/snapping-expected.txt:
* LayoutTests/overlay-region/split-scrollers-expected.txt:

Canonical link: <a href="https://commits.webkit.org/288485@main">https://commits.webkit.org/288485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7fe75767c31ab38335f8e5f01a275082e7f72a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37856 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88628 "Hash d7fe7576 for PR 38575 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34565 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11132 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/88628 "Hash d7fe7576 for PR 38575 does not build (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/22759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75923 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/88628 "Hash d7fe7576 for PR 38575 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2313 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30137 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33613 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30871 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90005 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7816 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73433 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11045 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72658 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17974 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16893 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15613 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2146 "Failed to checkout and rebase branch from PR 38575") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10774 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10622 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14096 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12394 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->