### PR TITLE
Commit provisional history items that are not cancelled during policy decision

### DIFF
--- a/Source/WebCore/history/BackForwardClient.h
+++ b/Source/WebCore/history/BackForwardClient.h
@@ -49,6 +49,7 @@ public:
     virtual void goToItem(HistoryItem&) = 0;
     virtual void goToProvisionalItem(const HistoryItem&) = 0;
     virtual void clearProvisionalItem(const HistoryItem&) = 0;
+    virtual void commitProvisionalItem(const HistoryItem&) = 0;
 
     virtual RefPtr<HistoryItem> itemAtIndex(int, FrameIdentifier) = 0;
     virtual unsigned backListCount() const = 0;

--- a/Source/WebCore/history/BackForwardController.cpp
+++ b/Source/WebCore/history/BackForwardController.cpp
@@ -162,6 +162,11 @@ void BackForwardController::clearProvisionalItem(const HistoryItem& item)
     protectedClient()->clearProvisionalItem(item);
 }
 
+void BackForwardController::commitProvisionalItem(const HistoryItem& item)
+{
+    protectedClient()->commitProvisionalItem(item);
+}
+
 bool BackForwardController::containsItem(const HistoryItem& item) const
 {
     return protectedClient()->containsItem(item);

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -62,6 +62,7 @@ public:
     void setCurrentItem(HistoryItem&);
     void setProvisionalItem(const HistoryItem&);
     void clearProvisionalItem(const HistoryItem&);
+    void commitProvisionalItem(const HistoryItem&);
 
     unsigned count() const;
     WEBCORE_EXPORT unsigned backCount() const;

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -119,6 +119,7 @@ class EmptyBackForwardClient final : public BackForwardClient {
     void goToItem(HistoryItem&) final { }
     void goToProvisionalItem(const HistoryItem&) final { }
     void clearProvisionalItem(const HistoryItem&) final { }
+    void commitProvisionalItem(const HistoryItem&) final { }
     RefPtr<HistoryItem> itemAtIndex(int, FrameIdentifier) final { return nullptr; }
     unsigned backListCount() const final { return 0; }
     unsigned forwardListCount() const final { return 0; }

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3991,10 +3991,8 @@ void FrameLoader::continueLoadAfterNavigationPolicy(const ResourceRequest& reque
         if (navigationPolicyDecision != NavigationPolicyDecision::LoadWillContinueInAnotherProcess)
             checkLoadComplete();
 
-        if (RefPtr provisionalItem = history().provisionalItem(); provisionalItem && isBackForwardLoadType(policyChecker().loadType())) {
-            if (RefPtr page = frame->page())
-                page->checkedBackForward()->clearProvisionalItem(*provisionalItem);
-        }
+        if (isBackForwardLoadType(policyChecker().loadType()))
+            history().clearProvisionalItem();
         return;
     }
 

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -579,6 +579,7 @@ void HistoryController::updateForCommit()
         ASSERT(m_provisionalItem);
         if (RefPtr provisionalItem = m_provisionalItem) {
             setCurrentItem(provisionalItem.releaseNonNull());
+            commitProvisionalItem();
             m_provisionalItem = nullptr;
         }
 
@@ -625,6 +626,7 @@ void HistoryController::recursiveUpdateForCommit()
         // Now commit the provisional item
         if (RefPtr provisionalItem = m_provisionalItem) {
             setCurrentItem(provisionalItem.releaseNonNull());
+            commitProvisionalItem();
             m_provisionalItem = nullptr;
         }
 
@@ -680,6 +682,7 @@ void HistoryController::recursiveUpdateForSameDocumentNavigation()
     // Commit the provisional item.
     if (RefPtr provisionalItem = m_provisionalItem) {
         setCurrentItem(provisionalItem.releaseNonNull());
+        commitProvisionalItem();
         m_provisionalItem = nullptr;
     }
 
@@ -732,6 +735,24 @@ void HistoryController::clearPreviousItem()
 void HistoryController::setProvisionalItem(RefPtr<HistoryItem>&& item)
 {
     m_provisionalItem = WTFMove(item);
+}
+
+void HistoryController::clearProvisionalItem()
+{
+    if (!m_provisionalItem)
+        return;
+
+    if (RefPtr page = m_frame->page())
+        page->checkedBackForward()->clearProvisionalItem(*m_provisionalItem);
+}
+
+void HistoryController::commitProvisionalItem()
+{
+    if (!m_provisionalItem)
+        return;
+
+    if (RefPtr page = m_frame->page())
+        page->checkedBackForward()->commitProvisionalItem(*m_provisionalItem);
 }
 
 void HistoryController::initializeItem(HistoryItem& item, RefPtr<DocumentLoader> documentLoader)

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -89,6 +89,7 @@ public:
     HistoryItem* provisionalItem() const { return m_provisionalItem.get(); }
     RefPtr<HistoryItem> protectedProvisionalItem() const;
     void setProvisionalItem(RefPtr<HistoryItem>&&);
+    void clearProvisionalItem();
 
     void pushState(RefPtr<SerializedScriptValue>&&, const String& url);
     void replaceState(RefPtr<SerializedScriptValue>&&, const String& url);
@@ -120,6 +121,7 @@ private:
     void updateBackForwardListClippedAtTarget(bool doClip);
     void updateCurrentItem();
     bool isFrameLoadComplete() const { return m_frameLoadComplete; }
+    void commitProvisionalItem();
 
     struct FrameToNavigate;
     static void recursiveGatherFramesToNavigate(LocalFrame&, Vector<FrameToNavigate>&, HistoryItem& targetItem, HistoryItem* fromItem);

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -270,6 +270,22 @@ void WebBackForwardList::clearProvisionalItem(WebBackForwardListFrameItem& frame
     m_provisionalIndex = std::nullopt;
 }
 
+void WebBackForwardList::commitProvisionalItem(WebBackForwardListFrameItem& frameItem)
+{
+    if (!m_provisionalIndex)
+        return;
+
+    if (m_entries[*m_provisionalIndex].ptr() != frameItem.backForwardListItem())
+        return;
+
+    if (*m_provisionalIndex >= m_entries.size()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    m_currentIndex = std::exchange(m_provisionalIndex, std::nullopt);
+}
+
 WebBackForwardListItem* WebBackForwardList::currentItem() const
 {
     ASSERT(!provisionalOrCurrentIndex() || *provisionalOrCurrentIndex() < m_entries.size());

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -89,6 +89,7 @@ public:
 
     void goToProvisionalItem(WebBackForwardListItem&);
     void clearProvisionalItem(WebBackForwardListFrameItem&);
+    void commitProvisionalItem(WebBackForwardListFrameItem&);
 
     Ref<FrameState> completeFrameStateForNavigation(Ref<FrameState>&&);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9504,6 +9504,12 @@ void WebPageProxy::backForwardClearProvisionalItem(IPC::Connection& connection, 
         protectedBackForwardList()->clearProvisionalItem(*frameItem);
 }
 
+void WebPageProxy::backForwardCommitProvisionalItem(IPC::Connection& connection, BackForwardItemIdentifier itemID, BackForwardFrameItemIdentifier frameItemID)
+{
+    if (RefPtr frameItem = WebBackForwardListFrameItem::itemForID(itemID, frameItemID))
+        protectedBackForwardList()->commitProvisionalItem(*frameItem);
+}
+
 void WebPageProxy::backForwardItemAtIndex(int32_t index, FrameIdentifier frameID, CompletionHandler<void(RefPtr<FrameState>&&)>&& completionHandler)
 {
     // FIXME: This should verify that the web process requesting the item hosts the specified frame.

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2876,6 +2876,7 @@ private:
     void backForwardListCounts(CompletionHandler<void(WebBackForwardListCounts&&)>&&);
     void backForwardGoToProvisionalItem(IPC::Connection&, WebCore::BackForwardItemIdentifier, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
     void backForwardClearProvisionalItem(IPC::Connection&, WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier);
+    void backForwardCommitProvisionalItem(IPC::Connection&, WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier);
     void backForwardUpdateItem(IPC::Connection&, Ref<FrameState>&&);
 
     // Undo management

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -217,6 +217,7 @@ messages -> WebPageProxy {
     WillGoToBackForwardListItem(WebCore::BackForwardItemIdentifier itemID, bool inBackForwardCache)
     BackForwardGoToProvisionalItem(WebCore::BackForwardItemIdentifier itemID) -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
     BackForwardClearProvisionalItem(WebCore::BackForwardItemIdentifier itemID, WebCore::BackForwardFrameItemIdentifier frameItemID)
+    BackForwardCommitProvisionalItem(WebCore::BackForwardItemIdentifier itemID, WebCore::BackForwardFrameItemIdentifier frameItemID)
 
     # Undo/Redo messages
     RegisterEditCommandForUndo(uint64_t commandID, String label) AllowedWhenWaitingForSyncReply

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
@@ -102,6 +102,12 @@ void WebBackForwardListProxy::clearProvisionalItem(const HistoryItem& item)
         page->send(Messages::WebPageProxy::BackForwardClearProvisionalItem(item.itemID(), item.frameItemID()));
 }
 
+void WebBackForwardListProxy::commitProvisionalItem(const HistoryItem& item)
+{
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::BackForwardCommitProvisionalItem(item.itemID(), item.frameItemID()));
+}
+
 RefPtr<HistoryItem> WebBackForwardListProxy::itemAtIndex(int itemIndex, FrameIdentifier frameID)
 {
     RefPtr page = m_page.get();

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
@@ -52,6 +52,7 @@ private:
     void goToItem(WebCore::HistoryItem&) override;
     void goToProvisionalItem(const WebCore::HistoryItem&) final;
     void clearProvisionalItem(const WebCore::HistoryItem&) final;
+    void commitProvisionalItem(const WebCore::HistoryItem&) final;
 
     RefPtr<WebCore::HistoryItem> itemAtIndex(int, WebCore::FrameIdentifier) override;
     unsigned backListCount() const override;

--- a/Source/WebKitLegacy/mac/History/BackForwardList.h
+++ b/Source/WebKitLegacy/mac/History/BackForwardList.h
@@ -53,6 +53,7 @@ public:
     void goToItem(WebCore::HistoryItem&) override;
     void goToProvisionalItem(const WebCore::HistoryItem&) final;
     void clearProvisionalItem(const WebCore::HistoryItem&) final;
+    void commitProvisionalItem(const WebCore::HistoryItem&) final { }
 
     RefPtr<WebCore::HistoryItem> backItem();
     RefPtr<WebCore::HistoryItem> currentItem();


### PR DESCRIPTION
#### f2981ff7b1603a22db8857b1387bf2252e465fe1
<pre>
Commit provisional history items that are not cancelled during policy decision
<a href="https://bugs.webkit.org/show_bug.cgi?id=285446">https://bugs.webkit.org/show_bug.cgi?id=285446</a>
<a href="https://rdar.apple.com/142028791">rdar://142028791</a>

Reviewed by Alex Christensen.

In 285421@main, I made the UI process aware of when a web process starts a back/forward navigation but
has not yet committed it. However, we did not always notify the UI process when the item was committed.
If we fail to notify the UI process, it can result in a state where the current index becomes stale and
the provisional index is cleared, leading to a possible out-of-bounds crash when using the current index.

* Source/WebCore/history/BackForwardClient.h:
* Source/WebCore/history/BackForwardController.cpp:
(WebCore::BackForwardController::commitProvisionalItem):
* Source/WebCore/history/BackForwardController.h:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::updateForCommit):
(WebCore::HistoryController::recursiveUpdateForCommit):
(WebCore::HistoryController::recursiveUpdateForSameDocumentNavigation):
(WebCore::HistoryController::clearProvisionalItem):
(WebCore::HistoryController::commitProvisionalItem):
* Source/WebCore/loader/HistoryController.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::commitProvisionalItem):
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::backForwardCommitProvisionalItem):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp:
(WebKit::WebBackForwardListProxy::clearProvisionalItem):
(WebKit::WebBackForwardListProxy::commitProvisionalItem):
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h:
* Source/WebKitLegacy/mac/History/BackForwardList.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm:
(TEST(WebKit, DecidePolicyForNavigationActionCancelAfterDiscardingForwardItems)):

Canonical link: <a href="https://commits.webkit.org/288518@main">https://commits.webkit.org/288518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b62cd3746e78a7f1e70304dddd872d548c8eb06e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88708 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34645 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65052 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22801 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2488 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75992 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45341 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2368 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30199 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33693 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90085 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7868 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73487 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72713 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17987 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16968 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15671 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2226 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10854 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16326 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10702 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12474 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->