### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN in SVGParserUtilities.cpp

### DIFF
--- a/Source/WebCore/svg/SVGParserUtilities.cpp
+++ b/Source/WebCore/svg/SVGParserUtilities.cpp
@@ -65,24 +65,22 @@ template <typename CharacterType, typename FloatType = float> static std::option
         return std::nullopt;
 
     // read the integer part, build right-to-left
-    auto ptrStartIntPart = buffer.position();
+    auto spanStartIntPart = buffer.span();
     
     // Advance to first non-digit.
     skipWhile<isASCIIDigit>(buffer);
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    if (buffer.position() != ptrStartIntPart) {
-        auto ptrScanIntPart = buffer.position() - 1;
+    if (buffer.position() > spanStartIntPart.data()) {
+        size_t indexScanIntPart = buffer.position() - spanStartIntPart.data();
         FloatType multiplier = 1;
-        while (ptrScanIntPart >= ptrStartIntPart) {
-            integer += multiplier * static_cast<FloatType>(*(ptrScanIntPart--) - '0');
+        for (size_t i = indexScanIntPart; i > 0; --i) {
+            integer += multiplier * static_cast<FloatType>(spanStartIntPart[i - 1] - '0');
             multiplier *= 10;
         }
         // Bail out early if this overflows.
         if (!isValidRange(integer))
             return std::nullopt;
     }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     // read the decimals
     if (buffer.hasCharactersRemaining() && *buffer == '.') {


### PR DESCRIPTION
#### eec3108cde033c5b2265ec4d51f237f548e4ceb5
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN in SVGParserUtilities.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=285455">https://bugs.webkit.org/show_bug.cgi?id=285455</a>

Reviewed by Darin Adler.

* Source/WebCore/svg/SVGParserUtilities.cpp:
(WebCore::genericParseNumber):

Canonical link: <a href="https://commits.webkit.org/288487@main">https://commits.webkit.org/288487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f91c7873373f400535c04acb95372e0ddc9f0aac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88653 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34590 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11157 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65020 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22762 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86628 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/2420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75942 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45307 "Found 1 new API test failure: /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/2328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30153 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33638 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90030 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10847 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7831 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72675 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16918 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15629 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12892 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10799 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/16271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10647 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14122 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12419 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->