### PR TITLE
Unreviewed, reverting 288451@main (334ca2793400)

### DIFF
--- a/Source/WebCore/platform/image-decoders/ScalableImageDecoder.h
+++ b/Source/WebCore/platform/image-decoders/ScalableImageDecoder.h
@@ -39,6 +39,8 @@
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
 namespace WebCore {
 
 // ScalableImageDecoder is a base for all format-specific decoders
@@ -195,5 +197,7 @@ private:
     EncodedDataStatus m_encodedDataStatus { EncodedDataStatus::TypeAvailable };
     bool m_decodingSizeFromSetData { false };
 };
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace WebCore

--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
@@ -257,10 +257,12 @@ bool BMPImageReader::readInfoHeader()
     // to pay attention to the alpha mask here, so there's a special case in
     // processBitmasks() that doesn't always overwrite that value.
     if (isWindowsV4Plus()) {
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         m_bitMasks[0] = readUint32(40);
         m_bitMasks[1] = readUint32(44);
         m_bitMasks[2] = readUint32(48);
         m_bitMasks[3] = readUint32(52);
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     // Detect top-down BMPs.
@@ -378,6 +380,7 @@ bool BMPImageReader::isInfoHeaderValid() const
     return true;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 bool BMPImageReader::processBitmasks()
 {
     // Create m_bitMasks[] values.
@@ -472,6 +475,7 @@ bool BMPImageReader::processBitmasks()
 
     return true;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 bool BMPImageReader::processColorTable()
 {
@@ -623,7 +627,9 @@ bool BMPImageReader::processRLEData()
                 // RLE8 has one color index that gets repeated; RLE4 has two
                 // color indexes in the upper and lower 4 bits of the byte,
                 // which are alternated.
-                std::array<size_t, 2> colorIndexes { code, code };
+                WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+                size_t colorIndexes[2] = {code, code};
+                WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                 if (m_infoHeader.biCompression == RLE4) {
                     colorIndexes[0] = (colorIndexes[0] >> 4) & 0xf;
                     colorIndexes[1] &= 0xf;

--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h
@@ -226,13 +226,17 @@ private:
     // in the given pixel data.
     inline unsigned getComponent(uint32_t pixel, int component) const
     {
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return ((pixel & m_bitMasks[component]) >> m_bitShiftsRight[component]) << m_bitShiftsLeft[component];
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     inline unsigned getAlpha(uint32_t pixel) const
     {
         // For images without alpha, return alpha of 0xff.
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return m_bitMasks[3] ? getComponent(pixel, 3) : 0xff;
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     // Sets the current pixel to the color given by |colorIndex|. This also
@@ -322,9 +326,9 @@ private:
     // just combine these into one shift value because the net shift amount
     // could go either direction. (If only "<< -x" were equivalent to
     // ">> x"...)
-    std::array<uint32_t, 4> m_bitMasks;
-    std::array<int, 4> m_bitShiftsRight;
-    std::array<int, 4> m_bitShiftsLeft;
+    uint32_t m_bitMasks[4];
+    int m_bitShiftsRight[4];
+    int m_bitShiftsLeft[4];
 
     // The color palette, for paletted formats.
     Vector<RGBTriple> m_colorTable;

--- a/Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp
@@ -153,6 +153,8 @@ bool GIFImageDecoder::setFailed()
 
 void GIFImageDecoder::clearFrameBufferCache(size_t clearBeforeFrame)
 {
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
     // In some cases, like if the decoder was destroyed while animating, we
     // can be asked to clear more frames than we currently have.
     if (m_frameBufferCache.isEmpty())
@@ -199,6 +201,8 @@ void GIFImageDecoder::clearFrameBufferCache(size_t clearBeforeFrame)
         if (!j->isInvalid())
             j->clear();
     }
+
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 bool GIFImageDecoder::haveDecodedRow(unsigned frameIndex, const Vector<unsigned char>& rowBuffer, size_t width, size_t rowNumber, unsigned repeatCount, bool writeTransparentPixels)

--- a/Source/WebCore/platform/image-decoders/gif/GIFImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/gif/GIFImageReader.cpp
@@ -398,6 +398,8 @@ bool GIFImageReader::decode(GIFImageDecoder::GIFQuery query, unsigned haltAtFram
 // Return false if a fatal error is encountered.
 bool GIFImageReader::parse(size_t dataPosition, size_t len, bool parseSizeOnly)
 {
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
     if (!len) {
         // No new data has come in since the last call, just ignore this call.
         return true;
@@ -778,6 +780,8 @@ bool GIFImageReader::parse(size_t dataPosition, size_t len, bool parseSizeOnly)
 
     setRemainingBytes(len);
     return true;
+
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 void GIFImageReader::setRemainingBytes(size_t remainingBytes)

--- a/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp
@@ -60,11 +60,12 @@ void ICOImageDecoder::setData(const FragmentedSharedBuffer& data, bool allDataRe
 
     ScalableImageDecoder::setData(data, allDataReceived);
 
-    for (auto& reader : m_bmpReaders) {
-        if (reader)
-            reader->setData(*m_data);
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    for (BMPReaders::iterator i(m_bmpReaders.begin()); i != m_bmpReaders.end(); ++i) {
+        if (*i)
+            (*i)->setData(*m_data);
     }
-
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     for (size_t i = 0; i < m_pngDecoders.size(); ++i)
         setDataForPNGDecoderAtIndex(i);
 }
@@ -249,15 +250,17 @@ bool ICOImageDecoder::processDirectoryEntries()
     ASSERT(m_decodedOffset == sizeOfDirectory);
     if ((m_decodedOffset > m_data->size()) || ((m_data->size() - m_decodedOffset) < (m_dirEntries.size() * sizeOfDirEntry)))
         return false;
-    for (auto& entry : m_dirEntries)
-        entry = readDirectoryEntry(); // Updates m_decodedOffset.
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    for (IconDirectoryEntries::iterator i(m_dirEntries.begin()); i != m_dirEntries.end(); ++i)
+        *i = readDirectoryEntry();  // Updates m_decodedOffset.
 
     // Make sure the specified image offsets are past the end of the directory
     // entries.
-    for (auto& entry : m_dirEntries) {
-        if (entry.m_imageOffset < m_decodedOffset)
+    for (IconDirectoryEntries::iterator i(m_dirEntries.begin()); i != m_dirEntries.end(); ++i) {
+        if (i->m_imageOffset < m_decodedOffset)
             return setFailed();
     }
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     // Arrange frames in decreasing quality order.
     std::sort(m_dirEntries.begin(), m_dirEntries.end(), compareEntries);


### PR DESCRIPTION
#### 483b55121c8ebe497a7581b7fe24b921ef982df6
<pre>
Unreviewed, reverting 288451@main (334ca2793400)
<a href="https://bugs.webkit.org/show_bug.cgi?id=285458">https://bugs.webkit.org/show_bug.cgi?id=285458</a>

Introduced many -Werror=unsafe-buffer-usage failures

Reverted change:

    Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/image-decoders
    <a href="https://bugs.webkit.org/show_bug.cgi?id=285388">https://bugs.webkit.org/show_bug.cgi?id=285388</a>
    288451@main (334ca2793400)
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/483b55121c8ebe497a7581b7fe24b921ef982df6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83576 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88647 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34584 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65017 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22758 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45304 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2322 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30148 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33632 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73396 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90024 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73448 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72671 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16916 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15624 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2165 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10793 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16265 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10641 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->