### PR TITLE
Trusted Types can be bypassed by event handlers not defined in HTMLElement.idl

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt
@@ -63,22 +63,22 @@ PASS getAttributeType("dummy", "ontoggle", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onvolumechange", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onwaiting", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onwheel", "dummyNs", attrNs)
-FAIL getAttributeType("dummy", "onafterprint", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onbeforeprint", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onbeforeunload", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onhashchange", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onlanguagechange", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onmessage", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onmessageerror", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onoffline", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "ononline", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onpagehide", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onpageshow", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onpopstate", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onrejectionhandled", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onstorage", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onunhandledrejection", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onunload", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onencrypted", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onwaitingforkey", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
+PASS getAttributeType("dummy", "onafterprint", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onbeforeprint", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onbeforeunload", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onhashchange", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onlanguagechange", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onmessage", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onmessageerror", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onoffline", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "ononline", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onpagehide", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onpageshow", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onpopstate", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onrejectionhandled", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onstorage", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onunhandledrejection", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onunload", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onencrypted", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onwaitingforkey", "dummyNs", attrNs)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-event-handlers-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-event-handlers-expected.txt
@@ -192,6 +192,10 @@ CONSOLE MESSAGE: This requires a TrustedScript value else it violates the follow
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
 PASS Event handler onclick should be blocked.
 PASS Event handler onchange should be blocked.
@@ -300,6 +304,6 @@ PASS Event handler div.onpointerenter should be blocked.
 PASS Event handler div.onpointerleave should be blocked.
 PASS Event handler div.onselectstart should be blocked.
 PASS Event handler div.onselectionchange should be blocked.
-FAIL Event handler div.onfullscreenchange should be blocked. assert_throws_js: function "_ => element.setAttribute(name, "2+2")" did not throw
-FAIL Event handler div.onfullscreenerror should be blocked. assert_throws_js: function "_ => element.setAttribute(name, "2+2")" did not throw
+PASS Event handler div.onfullscreenchange should be blocked.
+PASS Event handler div.onfullscreenerror should be blocked.
 

--- a/LayoutTests/platform/win/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt
+++ b/LayoutTests/platform/win/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt
@@ -63,20 +63,20 @@ PASS getAttributeType("dummy", "ontoggle", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onvolumechange", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onwaiting", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onwheel", "dummyNs", attrNs)
-FAIL getAttributeType("dummy", "onafterprint", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onbeforeprint", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onbeforeunload", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onhashchange", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onlanguagechange", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onmessage", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onmessageerror", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onoffline", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "ononline", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onpagehide", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onpageshow", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onpopstate", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onrejectionhandled", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onstorage", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onunhandledrejection", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
-FAIL getAttributeType("dummy", "onunload", "dummyNs", attrNs) assert_equals: for attrNs='' expected (string) "TrustedScript" but got (object) null
+PASS getAttributeType("dummy", "onafterprint", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onbeforeprint", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onbeforeunload", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onhashchange", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onlanguagechange", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onmessage", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onmessageerror", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onoffline", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "ononline", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onpagehide", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onpageshow", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onpopstate", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onrejectionhandled", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onstorage", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onunhandledrejection", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onunload", "dummyNs", attrNs)
 

--- a/Source/WebCore/dom/TrustedType.h
+++ b/Source/WebCore/dom/TrustedType.h
@@ -42,6 +42,7 @@ namespace WebCore {
 
 class Exception;
 class ScriptExecutionContext;
+class QualifiedName;
 
 enum class TrustedType : int8_t {
     TrustedHTML,
@@ -73,5 +74,7 @@ ExceptionOr<String> trustedTypeCompliantString(ScriptExecutionContext&, std::var
 WEBCORE_EXPORT AttributeTypeAndSink trustedTypeForAttribute(const String& elementName, const String& attributeName, const String& elementNamespace, const String& attributeNamespace);
 
 ExceptionOr<bool> canCompile(ScriptExecutionContext&, JSC::CompilationType, String codeString, const JSC::ArgList& args);
+
+bool isEventHandlerAttribute(const QualifiedName& attributeName);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/make-event-names.py
+++ b/Source/WebCore/dom/make-event-names.py
@@ -72,6 +72,7 @@ def main():
 #include "ThreadGlobalData.h"
 #include <array>
 #include <functional>
+#include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/text/AtomString.h>
@@ -153,6 +154,7 @@ public:''')
     }
 ''')
         writeln(f'    std::array<const AtomString, {len(event_names_input)}> allEventNames() const;')
+        writeln(f'    WTF::HashSet<AtomString> allEventHandlerNames() const;')
         writeln('''
 private:
     EventNames();
@@ -246,7 +248,21 @@ EventNames::EventNames()''')
             writeln(f'        {name}Event,')
             if conditional:
                 writeln(f'#endif')
-        writeln('''    } };
+        writeln('''    } };''')
+        writeln('}')
+        writeln('')
+        writeln(f'WTF::HashSet<AtomString> EventNames::allEventHandlerNames() const')
+        writeln('{')
+        writeln(f'    WTF::HashSet<AtomString> set;')
+        for name in sorted(event_names_input.keys()):
+            conditional = event_names_input[name].get('conditional', None)
+            if conditional:
+                writeln(f'#if {conditional}')
+            writeln(f'    set.add("on{name.lower()}"_s);')
+            if conditional:
+                writeln(f'#endif')
+        writeln('''    return set;''')
+        writeln('''
 }
 
 } // namespace WebCore''')


### PR DESCRIPTION
#### 4d3260a66f0b8fb9eed262d966c3841d78388bc4
<pre>
Trusted Types can be bypassed by event handlers not defined in HTMLElement.idl
<a href="https://bugs.webkit.org/show_bug.cgi?id=283927">https://bugs.webkit.org/show_bug.cgi?id=283927</a>

Reviewed by Chris Dumez.

Currently to determine if an attribute is an event handler attribute, we use HTMLElement::eventNameForEventHandlerAttribute.
It turns out this doesn&apos;t include all event handler attributes, missing ones defined for specific elements
such as HTMLBodyElement or HTMLMediaElement.

There exists a HTMLBodyElement::eventNameForWindowEventHandlerAttribute method which I could additionally check,
but this wouldn&apos;t deal with HTMLMediaElement or any other special cases.

To address this issue and prevent regressions a new approach is taken.

make-event-names.py has been updated to generate a HashSet of event handler names.

A new isEventHandlerAttribute method is added which uses this new HashSet to check if the attribute
name exists within it. This replaces the eventNameForEventHandlerAttribute mechanism.

This does mean that attributes with a name that isn&apos;t an event handler content attribute but an event exists for
(e.g. onreadystatechange from XHR) get protected by TrustedTypes. This matches Chromium&apos;s current behaviour, and feels like the safest approach
to avoid introducing bypasses in future.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-event-handlers-expected.txt:
* LayoutTests/platform/win/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt:
* Source/WebCore/dom/TrustedType.cpp:
(WebCore::trustedTypeForAttribute):
(WebCore::isEventHandlerAttribute):
* Source/WebCore/dom/TrustedType.h:
* Source/WebCore/dom/make-event-names.py:
(main):

Canonical link: <a href="https://commits.webkit.org/288723@main">https://commits.webkit.org/288723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/378ec6befee805ef4b327d918a7910728bf099bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88772 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34708 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65109 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22943 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76051 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45398 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2434 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30261 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33757 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73479 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90150 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73547 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72770 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18102 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17030 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15730 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2289 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10917 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16389 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10765 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14240 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->