### PR TITLE
ASAN_TRAP in Style::BuilderConverter::convertInitialLetter

### DIFF
--- a/LayoutTests/fast/css/css-typed-om/css-builder-converter-initial-letter-crash-expected.txt
+++ b/LayoutTests/fast/css/css-typed-om/css-builder-converter-initial-letter-crash-expected.txt
@@ -1,0 +1,5 @@
+This test passes if WebKit does not crash.
+
+
+PASS CSS typed OM should perform type checks
+

--- a/LayoutTests/fast/css/css-typed-om/css-builder-converter-initial-letter-crash.html
+++ b/LayoutTests/fast/css/css-typed-om/css-builder-converter-initial-letter-crash.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>CSS typed OM should perform type checks</title>
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+</head>
+  <body>
+    <p>This test passes if WebKit does not crash.</p>
+    <script>
+      test(t => {
+        const borderImageOutset = document.body.computedStyleMap().get('border-image-outset');
+        assert_throws_js(TypeError, () => {
+          document.body.attributeStyleMap.set('-webkit-initial-letter', borderImageOutset);
+        }, "attributeStyleMap.set() throws an error");  
+      });
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/css/CSSQuadValue.cpp
+++ b/Source/WebCore/css/CSSQuadValue.cpp
@@ -25,11 +25,13 @@
 
 #include "config.h"
 #include "CSSQuadValue.h"
+#include "CSSValue.h"
 
 namespace WebCore {
 
 CSSQuadValue::CSSQuadValue(Quad quad)
     : CSSValue(ClassType::Quad)
+    , m_coalesceIdenticalValues(true)
     , m_quad(WTFMove(quad))
 {
 }
@@ -47,6 +49,15 @@ String CSSQuadValue::customCSSText() const
 bool CSSQuadValue::equals(const CSSQuadValue& other) const
 {
     return m_quad.equals(other.m_quad);
+}
+
+bool CSSQuadValue::canBeCoalesced() const
+{
+    Ref top = m_quad.top();
+    Ref right = m_quad.right();
+    Ref left = m_quad.left();
+    Ref bottom = m_quad.bottom();
+    return m_coalesceIdenticalValues && top->equals(right) && top->equals(left) && top->equals(bottom);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSQuadValue.h
+++ b/Source/WebCore/css/CSSQuadValue.h
@@ -37,10 +37,11 @@ public:
 
     String customCSSText() const;
     bool equals(const CSSQuadValue&) const;
+    bool canBeCoalesced() const;
 
 private:
     explicit CSSQuadValue(Quad);
-
+    bool m_coalesceIdenticalValues { true };
     Quad m_quad;
 };
 

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -29,6 +29,7 @@
 #include "CSSProperty.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
+#include "CSSQuadValue.h"
 #include "CSSStyleValueFactory.h"
 #include "CSSUnparsedValue.h"
 #include "CSSValueList.h"
@@ -127,6 +128,11 @@ ExceptionOr<void> StylePropertyMap::set(Document& document, const AtomString& pr
     if (auto pair = dynamicDowncast<CSSValuePair>(value)) {
         if (pair->canBeCoalesced())
             return Exception { ExceptionCode::NotSupportedError, "Invalid values"_s };
+    }
+
+    if (auto quad = dynamicDowncast<CSSQuadValue>(value)) {
+        if (quad->canBeCoalesced())
+            return Exception { ExceptionCode::TypeError, "Invalid values"_s };
     }
 
     if (!setProperty(propertyID, value.releaseNonNull()))


### PR DESCRIPTION
#### 9649ee33c20c830a78b1fd660123b4a9d2fe5989
<pre>
ASAN_TRAP in Style::BuilderConverter::convertInitialLetter
<a href="https://bugs.webkit.org/show_bug.cgi?id=285459">https://bugs.webkit.org/show_bug.cgi?id=285459</a>
<a href="https://rdar.apple.com/141024836">rdar://141024836</a>

Reviewed by Matthieu Dubet and Ryosuke Niwa.

Added a check to verify the CSSQuad value else throw TypeError.

* LayoutTests/fast/css/css-typed-om/css-builder-converter-initial-letter-crash-expected.txt: Added.
* LayoutTests/fast/css/css-typed-om/css-builder-converter-initial-letter-crash.html: Added.
* Source/WebCore/css/CSSQuadValue.cpp:
(WebCore::CSSQuadValue::CSSQuadValue):
(WebCore::CSSQuadValue::canBeCoalesced const):
* Source/WebCore/css/CSSQuadValue.h:
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
(WebCore::StylePropertyMap::set):

Canonical link: <a href="https://commits.webkit.org/289023@main">https://commits.webkit.org/289023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2c6de1ce10e558a6461f0ad2d5176e4744be4c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90157 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36063 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66158 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23976 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46423 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3573 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31484 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35136 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91579 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9039 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12580 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73067 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18153 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16604 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4368 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13260 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12299 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17756 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12135 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15630 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13881 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->