### PR TITLE
ObjectAllocationSinking shouldn't produce Phis to the values it's about to phantom.

### DIFF
--- a/JSTests/stress/phantom-put-by-offset-to-self-over-control-flow.js
+++ b/JSTests/stress/phantom-put-by-offset-to-self-over-control-flow.js
@@ -1,0 +1,9 @@
+(function () {
+  var x = {};
+  x.a = x;
+  for (let y = 0; y < 2; y++) {
+    x.a = x;
+  }
+  for (let z = 0; z < 1e5; z++) {}
+})();
+

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -1913,6 +1913,12 @@ private:
                 if (m_heapAtHead[block].getAllocation(location.base()).isEscapedAllocation())
                     return nullptr;
 
+                // If we point to a single dead allocation, we will directly use its materialization since it would be invalid to
+                // create a Phi for a Phantom.
+                Node* identifier = m_heapAtHead[block].follow(location);
+                if (identifier && m_sinkCandidates.contains(identifier))
+                    return nullptr;
+
                 Node* phiNode = m_graph.addNode(SpecHeapTop, Phi, block->at(0)->origin.withInvalidExit());
                 phiNode->mergeFlags(NodeResultJS);
                 return phiNode;

--- a/Source/JavaScriptCore/dfg/DFGSSACalculator.h
+++ b/Source/JavaScriptCore/dfg/DFGSSACalculator.h
@@ -166,14 +166,13 @@ public:
     
     Variable* variable(unsigned index) { return &m_variables[index]; }
     
-    // The PhiInsertionFunctor takes a Variable and a BasicBlock and either inserts a Phi and
+    // The functor takes a Variable and a BasicBlock and either inserts a Phi and
     // returns the Node for that Phi, or it decides that it's not worth it to insert a Phi at that
     // block because of some additional pruning condition (typically liveness) and returns
     // nullptr. If a non-null Node* is returned, a new Def is created, so that
     // nonLocalReachingDef() will find it later. Note that it is generally always sound to not
     // prune any Phis (that is, to always have the functor insert a Phi and never return nullptr).
-    template<typename PhiInsertionFunctor>
-    void computePhis(const PhiInsertionFunctor& functor)
+    void computePhis(const Invocable<Node*(Variable*, BasicBlock*)> auto& functor)
     {
         DFG_ASSERT(m_graph, nullptr, m_graph.m_ssaDominators);
         


### PR DESCRIPTION
#### 016bc646b9f34f98005253d86ab1838541e8c970
<pre>
ObjectAllocationSinking shouldn&apos;t produce Phis to the values it&apos;s about to phantom.
<a href="https://bugs.webkit.org/show_bug.cgi?id=285461">https://bugs.webkit.org/show_bug.cgi?id=285461</a>
<a href="https://rdar.apple.com/142276606">rdar://142276606</a>

Reviewed by Yusuke Suzuki.

In <a href="https://commits.webkit.org/283558@main">https://commits.webkit.org/283558@main</a> we removed the incorrect Phi omission for values materialized values
but for values that we&apos;re about to sink we shouldn&apos;t link those to a Phi as we&apos;ll crash in lowerDFGToB3.

This patch skips the Phi/Upsilon as long as what we&apos;re targeting is a sink candidate (they&apos;re locked in at this
point). An alternative fix would be to remove the Phi/Upsilons after we convert to a phantom but that seems slower.

* JSTests/stress/phantom-put-by-offset-to-self-over-control-flow.js: Added.
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSSACalculator.h:
(JSC::DFG::SSACalculator::computePhis):

Canonical link: <a href="https://commits.webkit.org/288507@main">https://commits.webkit.org/288507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44f5497184924a1091322458a31c4631f90bde65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88656 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34593 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65024 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22765 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45311 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33641 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76548 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73403 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90033 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/82602 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7833 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73455 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71771 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72678 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16921 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15636 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2174 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12907 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10802 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16274 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105019 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10650 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25387 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14125 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12422 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->