### PR TITLE
Fix various -Werror=unsafe-buffer-usage build failures

### DIFF
--- a/Source/WebCore/platform/SharedBufferChunkReader.cpp
+++ b/Source/WebCore/platform/SharedBufferChunkReader.cpp
@@ -74,7 +74,9 @@ bool SharedBufferChunkReader::nextChunk(Vector<uint8_t>& chunk, bool includeSepa
     while (true) {
         while (m_segmentIndex < m_iteratorCurrent->segment->size()) {
             // FIXME: The existing code to check for separators doesn't work correctly with arbitrary separator strings.
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             auto currentCharacter = m_segment[m_segmentIndex++];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             if (currentCharacter != m_separator[m_separatorIndex]) {
                 if (m_separatorIndex > 0) {
                     ASSERT_WITH_SECURITY_IMPLICATION(m_separatorIndex <= m_separator.size());
@@ -95,7 +97,9 @@ bool SharedBufferChunkReader::nextChunk(Vector<uint8_t>& chunk, bool includeSepa
 
         // Read the next segment.
         m_segmentIndex = 0;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (++m_iteratorCurrent == m_iteratorEnd) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             m_segment = nullptr;
             if (m_separatorIndex > 0)
                 chunk.append(byteCast<uint8_t>(m_separator.subspan(0, m_separatorIndex)));
@@ -124,12 +128,14 @@ size_t SharedBufferChunkReader::peek(Vector<uint8_t>& data, size_t requestedSize
         return 0;
 
     size_t availableInSegment = std::min(m_iteratorCurrent->segment->size() - m_segmentIndex, requestedSize);
-    data.append(std::span { m_segment + m_segmentIndex, availableInSegment });
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    data.append(unsafeMakeSpan(m_segment + m_segmentIndex, availableInSegment));
 
     size_t readBytesCount = availableInSegment;
     requestedSize -= readBytesCount;
 
     auto currentSegment = m_iteratorCurrent;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     while (requestedSize && ++currentSegment != m_iteratorEnd) {
         size_t lengthInSegment = std::min(currentSegment->segment->size(), requestedSize);

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp
@@ -36,6 +36,8 @@
 #endif
 #include "SharedBuffer.h"
 
+#include <array>
+
 namespace WebCore {
 
 #if ENABLE(OPENTYPE_MATH)
@@ -362,25 +364,25 @@ void OpenTypeMathData::getMathVariants(Glyph glyph, bool isVertical, Vector<Glyp
     hb_direction_t direction = isVertical ? HB_DIRECTION_BTT : HB_DIRECTION_LTR;
 
     sizeVariants.clear();
-    hb_ot_math_glyph_variant_t variants[10];
+    std::array<hb_ot_math_glyph_variant_t, 10> variants;
     unsigned variantsSize = std::size(variants);
     unsigned count;
     unsigned offset = 0;
     do {
         count = variantsSize;
-        hb_ot_math_get_glyph_variants(m_mathFont.get(), glyph, direction, offset, &count, variants);
+        hb_ot_math_get_glyph_variants(m_mathFont.get(), glyph, direction, offset, &count, variants.data());
         offset += count;
         for (unsigned i = 0; i < count; i++)
             sizeVariants.append(variants[i].glyph);
     } while (count == variantsSize);
 
     assemblyParts.clear();
-    hb_ot_math_glyph_part_t parts[10];
+    std::array<hb_ot_math_glyph_part_t, 10> parts;
     unsigned partsSize = std::size(parts);
     offset = 0;
     do {
         count = partsSize;
-        hb_ot_math_get_glyph_assembly(m_mathFont.get(), glyph, direction, offset, &count, parts, nullptr);
+        hb_ot_math_get_glyph_assembly(m_mathFont.get(), glyph, direction, offset, &count, parts.data(), nullptr);
         offset += count;
         for (unsigned i = 0; i < count; i++) {
             AssemblyPart assemblyPart;

--- a/Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp
@@ -53,7 +53,7 @@ public:
 
     bool write(const void* data, size_t length) override
     {
-        m_vector.append(std::span { static_cast<const uint8_t*>(data), length });
+        m_vector.append(unsafeMakeSpan(static_cast<const uint8_t*>(data), length));
         return true;
     }
 
@@ -124,7 +124,7 @@ Vector<uint8_t> encodeData(SkImage* image, const String& mimeType, std::optional
         if (!data)
             return { };
 
-        return std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(data->data()), data->size() };
+        return unsafeMakeSpan(reinterpret_cast<const uint8_t*>(data->data()), data->size());
     }
 
     SkPixmap pixmap;

--- a/Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp
@@ -167,7 +167,9 @@ void GIFImageDecoder::clearFrameBufferCache(size_t clearBeforeFrame)
     // always use ImageSource::clear(true, ...) to completely free the memory in
     // this case.
     clearBeforeFrame = std::min(clearBeforeFrame, m_frameBufferCache.size() - 1);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
     const Vector<ScalableImageDecoderFrame>::iterator end(m_frameBufferCache.begin() + clearBeforeFrame);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     // We need to preserve frames such that:
     //   * We don't clear |end|
@@ -187,14 +189,18 @@ void GIFImageDecoder::clearFrameBufferCache(size_t clearBeforeFrame)
     //   * If the frame is partial, we're decoding it, so don't clear it; if it
     //     has a disposal method other than DisposalMethod::RestoreToPrevious, stop
     //     scanning, as we'll only need this frame when decoding the next one.
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
     Vector<ScalableImageDecoderFrame>::iterator i(end);
     for (; (i != m_frameBufferCache.begin()) && (i->isInvalid() || (i->disposalMethod() == ScalableImageDecoderFrame::DisposalMethod::RestoreToPrevious)); --i) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         if (i->isComplete() && (i != end))
             i->clear();
     }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
     // Now |i| holds the last frame we need to preserve; clear prior frames.
     for (Vector<ScalableImageDecoderFrame>::iterator j(m_frameBufferCache.begin()); j != i; ++j) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         ASSERT(!j->isPartial());
         if (!j->isInvalid())
             j->clear();

--- a/Source/WebCore/platform/image-decoders/gif/GIFImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/gif/GIFImageReader.cpp
@@ -449,8 +449,10 @@ bool GIFImageReader::parse(size_t dataPosition, size_t len, bool parseSizeOnly)
             // This is the height and width of the "screen" or frame into which images are rendered. The
             // individual images can be smaller than the screen size and located with an origin anywhere
             // within the screen.
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
             m_screenWidth = GETINT16(currentComponent.data());
             m_screenHeight = GETINT16(currentComponent.data() + 2);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
             // CALLBACK: Inform the decoderplugin of our size.
             // Note: A subsequent frame might have dimensions larger than the "screen" dimensions.
@@ -584,7 +586,9 @@ bool GIFImageReader::parse(size_t dataPosition, size_t len, bool parseSizeOnly)
             // the third bit of the field (i.e. method 4) is. We map both to the same value.
                 currentFrame->disposalMethod = WebCore::ScalableImageDecoderFrame::DisposalMethod::RestoreToPrevious;
             }
-            currentFrame->delayTime = GETINT16(currentComponent.data() + 1) * 10;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
+            currentFrame->delayTime = GETINT16(currentComponent.data() + 1) * 10;\
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             GETN(1, GIFConsumeBlock);
             break;
         }
@@ -628,7 +632,9 @@ bool GIFImageReader::parse(size_t dataPosition, size_t len, bool parseSizeOnly)
 
             // Loop entire animation specified # of times. Only read the loop count during the first iteration.
             if (netscapeExtension == 1) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
                 m_loopCount = GETINT16(currentComponent.data() + 1);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
                 // Zero loop count is infinite animation loop request.
                 if (!m_loopCount)
@@ -652,6 +658,7 @@ bool GIFImageReader::parse(size_t dataPosition, size_t len, bool parseSizeOnly)
         case GIFImageHeader: {
             unsigned height, width, xOffset, yOffset;
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
             /* Get image offsets, with respect to the screen origin */
             xOffset = GETINT16(currentComponent.data());
             yOffset = GETINT16(currentComponent.data() + 2);
@@ -659,6 +666,7 @@ bool GIFImageReader::parse(size_t dataPosition, size_t len, bool parseSizeOnly)
             /* Get image width and height. */
             width  = GETINT16(currentComponent.data() + 4);
             height = GETINT16(currentComponent.data() + 6);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
             /* Work around broken GIF files where the logical screen
              * size has weird width or height.  We assume that GIF87a

--- a/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
@@ -207,6 +207,7 @@ static ImageOrientation readImageOrientation(jpeg_decompress_struct* info)
 #if USE(LCMS)
 static bool isICCMarker(jpeg_saved_marker_ptr marker)
 {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
     return marker->marker == iccMarker
         && marker->data_length >= iccHeaderSize
         && marker->data[0] == 'I'
@@ -221,6 +222,7 @@ static bool isICCMarker(jpeg_saved_marker_ptr marker)
         && marker->data[9] == 'L'
         && marker->data[10] == 'E'
         && marker->data[11] == '\0';
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 static RefPtr<SharedBuffer> readICCProfile(jpeg_decompress_struct* info)
@@ -230,16 +232,22 @@ static RefPtr<SharedBuffer> readICCProfile(jpeg_decompress_struct* info)
         if (!isICCMarker(marker))
             continue;
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
         unsigned sequenceNumber = marker->data[12];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         if (!sequenceNumber)
             return nullptr;
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
         unsigned markerCount = marker->data[13];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         if (sequenceNumber > markerCount)
             return nullptr;
 
         unsigned markerSize = marker->data_length - iccHeaderSize;
-        buffer.append(std::span { reinterpret_cast<const uint8_t*>(marker->data + iccHeaderSize), markerSize });
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // non-Apple ports
+        buffer.append(unsafeMakeSpan(reinterpret_cast<const uint8_t*>(marker->data + iccHeaderSize), markerSize));
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     if (buffer.isEmpty())


### PR DESCRIPTION
#### d950ca99af3eb258ff37f5795954f5330d9a1c38
<pre>
Fix various -Werror=unsafe-buffer-usage build failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=285462">https://bugs.webkit.org/show_bug.cgi?id=285462</a>

Reviewed by Chris Dumez.

* Source/WebCore/platform/SharedBufferChunkReader.cpp:
(WebCore::SharedBufferChunkReader::nextChunk):
(WebCore::SharedBufferChunkReader::peek):
* Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp:
* Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp:
(WebCore::encodeData):
* Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp:
(WebCore::GIFImageDecoder::clearFrameBufferCache):
* Source/WebCore/platform/image-decoders/gif/GIFImageReader.cpp:
(GIFImageReader::parse):
* Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp:
(WebCore::isICCMarker):
(WebCore::readICCProfile):

Canonical link: <a href="https://commits.webkit.org/288557@main">https://commits.webkit.org/288557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8175ba9bfb24fa2b628ac6c7c09a21a7a62522c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83589 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34597 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65028 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22769 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2424 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45315 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2333 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30163 "Found 1 new test failure: fast/editing/recursive-reapply-edit-command-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33645 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90037 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73460 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72684 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18004 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16928 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15639 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2178 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10806 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16278 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10654 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14129 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12426 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->