### PR TITLE
AX: In ENABLE(AX_THREAD_TEXT_APIS), we fail to include trailing newlines in the returned range for the AXRangeForLine attribute

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1877,16 +1877,16 @@ CharacterRange AccessibilityRenderObject::doAXRangeForLine(unsigned lineNumber) 
     // Get the end of the line based on the starting position.
     auto lineEnd = endOfLine(lineStart);
 
-    int index1 = indexForVisiblePosition(lineStart);
-    int index2 = indexForVisiblePosition(lineEnd);
+    int lineStartIndex = indexForVisiblePosition(lineStart);
+    int lineEndIndex = indexForVisiblePosition(lineEnd);
 
     if (isHardLineBreak(lineEnd))
-        ++index2;
+        ++lineEndIndex;
 
-    if (index1 < 0 || index2 < 0 || index2 <= index1)
+    if (lineStartIndex < 0 || lineEndIndex < 0 || lineEndIndex <= lineStartIndex)
         return { };
 
-    return { static_cast<unsigned>(index1), static_cast<unsigned>(index2 - index1) };
+    return { static_cast<unsigned>(lineStartIndex), static_cast<unsigned>(lineEndIndex - lineStartIndex) };
 }
 
 // The composed character range in the text associated with this accessibility object that


### PR DESCRIPTION
#### 07681dd80dbd6d21b57377dd7169116ac89adff9
<pre>
AX: In ENABLE(AX_THREAD_TEXT_APIS), we fail to include trailing newlines in the returned range for the AXRangeForLine attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=285460">https://bugs.webkit.org/show_bug.cgi?id=285460</a>
<a href="https://rdar.apple.com/142433642">rdar://142433642</a>

Reviewed by Chris Fleizach.

In `AccessibilityRenderObject::doAXRangeForLine`, we extend the returned range by one if the last character is a newline:

<a href="https://github.com/WebKit/WebKit/blob/1538792f6d0149ec77015a26a1a5485ad406f2de/Source/WebCore/accessibility/AccessibilityRenderObject.cpp#L1883#L1884">https://github.com/WebKit/WebKit/blob/1538792f6d0149ec77015a26a1a5485ad406f2de/Source/WebCore/accessibility/AccessibilityRenderObject.cpp#L1883#L1884</a>

We need to match this behavior in `ENABLE(AX_THREAD_TEXT_APIS)` mode. We normally don&apos;t do this (which is arguably the more
intuitive behavior). So to facilitate this, this commit splits `findMarker(AXDirection, AXTextUnit, AXTextUnitBoundary, std::optional&lt;AXID&gt; stopAtID)`
into sub-fuctions `findWord`, `findSentence`, `findLine`, and `findParagraph`, rather than handling them all in what was
`findMarker`. This means we only have to pass a new `IncludeTrailingLineBreak` flag to `findLine`. This also is a little more
clean, as `findMarker` used to unconditionally do work that was only used for one `AXTextUnit`.

* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::characterRangeForLine const):
(WebCore::AXTextMarker::findMarker const):
(WebCore::AXTextMarker::findLine const):
(WebCore::AXTextMarker::findParagraph const):
(WebCore::AXTextMarker::findWordOrSentence const):
(WebCore::AXTextMarker::previousParagraphStart const):
(WebCore::AXTextMarker::toTextRunMarker const):
(WebCore::AXTextMarker::isInTextRun const):
(WebCore::AXTextMarker::lineRange const):
(WebCore::AXTextMarker::sentenceRange const):
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::AXTextMarker::findWord const):
(WebCore::AXTextMarker::findSentence const):
(WebCore::AXTextMarker::findLine const):
(WebCore::AXTextMarker::previousLineStart const):
(WebCore::AXTextMarker::nextLineEnd const):
(WebCore::AXTextMarker::nextWordStart const):
(WebCore::AXTextMarker::nextWordEnd const):
(WebCore::AXTextMarker::previousWordStart const):
(WebCore::AXTextMarker::previousWordEnd const):
(WebCore::AXTextMarker::previousSentenceStart const):
(WebCore::AXTextMarker::nextSentenceEnd const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::doAXRangeForLine const):

Canonical link: <a href="https://commits.webkit.org/288524@main">https://commits.webkit.org/288524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f654904677ce1729dad85cdbc920efbf3226f963

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34635 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65045 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22790 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75981 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45332 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2370 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30186 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33683 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73427 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90075 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10892 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7859 "Found 1 new test failure: http/wpt/mediarecorder/MediaRecorder-video-h264-profiles.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73478 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72704 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17992 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16959 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15662 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2216 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10844 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16316 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10692 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14167 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12464 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->