### PR TITLE
[JSC] Loop unrolling phase should inverse the condition if needed before computing the iteration count

### DIFF
--- a/JSTests/stress/loop-unrolling-branch.js
+++ b/JSTests/stress/loop-unrolling-branch.js
@@ -1,0 +1,12 @@
+//@ runDefault("--validateDFGClobberize=1", "--jitPolicyScale=0.0001")
+for (let i = 0; i < 1e3; i++) {
+    (function () {
+        var count = 0;
+        for (let x = 0; x != 3; x++) {
+            count += 1;
+            if (count > 10) break;
+        }
+        if (count != 3)
+            throw new Error("bad!");
+    })();
+}


### PR DESCRIPTION
#### e0d2a13f551fe60f4893b41479de31884fe84751
<pre>
[JSC] Loop unrolling phase should inverse the condition if needed before computing the iteration count
<a href="https://bugs.webkit.org/show_bug.cgi?id=285473">https://bugs.webkit.org/show_bug.cgi?id=285473</a>
<a href="https://rdar.apple.com/142439066">rdar://142439066</a>

Reviewed by Yusuke Suzuki.

Previously, loop unrolling failed to handle cases where the loop&apos;s
&quot;not taken&quot; branch pointed back into the loop, requiring condition
inversion. This led to incorrect comparisons, invalid iteration
counts, and missed optimization opportunities.

This fix introduces `inverseCondition` to track whether the condition
needs inversion and updates `comparisonFunction` to apply the correct
comparison logic dynamically. It improves robustness, ensures accurate
unrolling for complex branching structures, and adds better debug information.

* JSTests/stress/loop-unrolling-branch.js: Added.
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::LoopData::condition const):
(JSC::DFG::LoopUnrollingPhase::locateTail):
(JSC::DFG::LoopUnrollingPhase::identifyInductionVariable):
(JSC::DFG::LoopUnrollingPhase::LoopData::dump const):
(JSC::DFG::LoopUnrollingPhase::comparisonFunction):

Canonical link: <a href="https://commits.webkit.org/288509@main">https://commits.webkit.org/288509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db670f151e53393569df258322f1fbcb945b27fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83611 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88682 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34619 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65038 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22781 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45325 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2359 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30179 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33667 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76574 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73418 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30925 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90059 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/82628 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73473 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71798 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72698 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16945 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15655 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2200 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12909 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10828 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16300 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105045 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10676 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25390 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14151 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12448 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->