### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in RTCVideoDecoderVTBAV1.mm

### DIFF
--- a/Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm
@@ -42,8 +42,6 @@
 #import "VideoToolboxSoftLink.h"
 #import <pal/cf/CoreMediaSoftLink.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 using namespace WebCore;
 
 typedef struct OpaqueVTDecompressionSession*  VTDecompressionSessionRef;
@@ -139,8 +137,8 @@ static std::optional<std::pair<std::span<const uint8_t>, std::span<const uint8_t
             return { };
 
         if (headerType == 1) {
-            std::span<const uint8_t> fullObu { data.data() + startIndex, payloadSize + index - startIndex };
-            std::span<const uint8_t> obuData { data.data() + index, payloadSize };
+            auto fullObu = data.subspan(startIndex, payloadSize + index - startIndex);
+            auto obuData = data.subspan(index, payloadSize);
             return std::make_pair(fullObu, obuData);
         }
 
@@ -377,15 +375,16 @@ static void av1DecompressionOutputCallback(void* decoderRef, void* params, OSSta
     _shouldCheckFormat = true;
 }
 
-- (NSInteger)decodeData:(const uint8_t *)data size:(size_t)size timeStamp:(int64_t)timeStamp {
+- (NSInteger)decodeData:(const uint8_t *)rawData size:(size_t)size timeStamp:(int64_t)timeStamp {
     if (_error != noErr) {
         RELEASE_LOG_ERROR(WebRTC, "RTCVideoDecoderVTBAV1 Last frame decode failed");
         _error = noErr;
         return WEBRTC_VIDEO_CODEC_ERROR;
     }
+    auto data = unsafeMakeSpan(rawData, size);
 
     if (_shouldCheckFormat || !_videoFormat) {
-        auto inputFormat = computeAV1InputFormat({ data, size }, _width, _height);
+        auto inputFormat = computeAV1InputFormat(data, _width, _height);
         if (inputFormat) {
             _shouldCheckFormat = false;
             if (!PAL::CMFormatDescriptionEqual(inputFormat.get(), _videoFormat.get())) {
@@ -402,7 +401,7 @@ static void av1DecompressionOutputCallback(void* decoderRef, void* params, OSSta
     if (!_videoFormat)
         return WEBRTC_VIDEO_CODEC_ERROR;
 
-    auto sampleBuffer = av1BufferToCMSampleBuffer({ data, size }, _videoFormat.get());
+    auto sampleBuffer = av1BufferToCMSampleBuffer(data, _videoFormat.get());
     if (!sampleBuffer)
         return WEBRTC_VIDEO_CODEC_ERROR;
 
@@ -501,7 +500,5 @@ static void av1DecompressionOutputCallback(void* decoderRef, void* params, OSSta
 }
 
 @end
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(LIBWEBRTC)


### PR DESCRIPTION
#### 15974f897d0a4d79ed836b9416e9997f85c2bfa5
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in RTCVideoDecoderVTBAV1.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=285478">https://bugs.webkit.org/show_bug.cgi?id=285478</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm:
(getSequenceHeaderOBU):
(-[RTCVideoDecoderVTBAV1 decodeData:size:timeStamp:]):

Canonical link: <a href="https://commits.webkit.org/288502@main">https://commits.webkit.org/288502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ee7c073273e86f374ff9f68600e634e9e640351

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88686 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34623 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65040 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22786 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45327 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2353 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30201 "Found 1 new test failure: fast/editing/recursive-reapply-edit-command-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33671 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90063 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10880 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7851 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73474 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11103 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72700 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16948 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15651 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2204 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12904 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10832 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/16304 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10680 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14155 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12452 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->