### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in HTTPHeaderMap.h

### DIFF
--- a/Source/WebCore/platform/network/HTTPHeaderMap.h
+++ b/Source/WebCore/platform/network/HTTPHeaderMap.h
@@ -61,13 +61,16 @@ public:
 
     class HTTPHeaderMapConstIterator {
     public:
-        HTTPHeaderMapConstIterator(const HTTPHeaderMap& table, CommonHeadersVector::const_iterator commonHeadersIt, UncommonHeadersVector::const_iterator uncommonHeadersIt)
+        HTTPHeaderMapConstIterator(const HTTPHeaderMap& table, size_t commonHeadersIndex, size_t uncommonHeadersIndex)
             : m_table(table)
-            , m_commonHeadersIt(commonHeadersIt)
-            , m_uncommonHeadersIt(uncommonHeadersIt)
+            , m_commonHeadersIndex(commonHeadersIndex)
+            , m_uncommonHeadersIndex(uncommonHeadersIndex)
         {
-            if (!updateKeyValue(m_commonHeadersIt))
-                updateKeyValue(m_uncommonHeadersIt);
+            if (m_commonHeadersIndex < m_table.m_commonHeaders.size()) {
+                ASSERT(!m_uncommonHeadersIndex);
+                updateKeyValue(m_table.m_commonHeaders[m_commonHeadersIndex]);
+            } else if (m_uncommonHeadersIndex < m_table.m_uncommonHeaders.size())
+                updateKeyValue(m_table.m_uncommonHeaders[m_uncommonHeadersIndex]);
         }
 
         struct KeyValue {
@@ -89,48 +92,45 @@ public:
         const KeyValue& operator*() const { return *get(); }
         const KeyValue* operator->() const { return get(); }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         HTTPHeaderMapConstIterator& operator++()
         {
-            if (m_commonHeadersIt != m_table.m_commonHeaders.end()) {
-                if (updateKeyValue(++m_commonHeadersIt))
+            if (m_commonHeadersIndex < m_table.m_commonHeaders.size()) {
+                ASSERT(!m_uncommonHeadersIndex);
+                if (++m_commonHeadersIndex < m_table.m_commonHeaders.size()) {
+                    updateKeyValue(m_table.m_commonHeaders[m_commonHeadersIndex]);
                     return *this;
+                }
             } else
-                ++m_uncommonHeadersIt;
+                ++m_uncommonHeadersIndex;
 
-            updateKeyValue(m_uncommonHeadersIt);
+            if (m_uncommonHeadersIndex < m_table.m_uncommonHeaders.size())
+                updateKeyValue(m_table.m_uncommonHeaders[m_uncommonHeadersIndex]);
             return *this;
         }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         bool operator==(const HTTPHeaderMapConstIterator& other) const
         {
-            return m_commonHeadersIt == other.m_commonHeadersIt && m_uncommonHeadersIt == other.m_uncommonHeadersIt;
+            return m_commonHeadersIndex == other.m_commonHeadersIndex && m_uncommonHeadersIndex == other.m_uncommonHeadersIndex;
         }
 
     private:
-        bool updateKeyValue(CommonHeadersVector::const_iterator it)
+        void updateKeyValue(const CommonHeader& header)
         {
-            if (it == m_table.commonHeaders().end())
-                return false;
-            m_keyValue.key = httpHeaderNameString(it->key);
-            m_keyValue.keyAsHTTPHeaderName = it->key;
-            m_keyValue.value = it->value;
-            return true;
+            m_keyValue.key = httpHeaderNameString(header.key);
+            m_keyValue.keyAsHTTPHeaderName = header.key;
+            m_keyValue.value = header.value;
         }
-        bool updateKeyValue(UncommonHeadersVector::const_iterator it)
+
+        void updateKeyValue(const UncommonHeader& header)
         {
-            if (it == m_table.uncommonHeaders().end())
-                return false;
-            m_keyValue.key = it->key;
+            m_keyValue.key = header.key;
             m_keyValue.keyAsHTTPHeaderName = std::nullopt;
-            m_keyValue.value = it->value;
-            return true;
+            m_keyValue.value = header.value;
         }
 
         const HTTPHeaderMap& m_table;
-        CommonHeadersVector::const_iterator m_commonHeadersIt;
-        UncommonHeadersVector::const_iterator m_uncommonHeadersIt;
+        size_t m_commonHeadersIndex;
+        size_t m_uncommonHeadersIndex;
         KeyValue m_keyValue;
     };
     typedef HTTPHeaderMapConstIterator const_iterator;
@@ -191,8 +191,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     CommonHeadersVector& commonHeaders() { return m_commonHeaders; }
     UncommonHeadersVector& uncommonHeaders() { return m_uncommonHeaders; }
 
-    const_iterator begin() const { return const_iterator(*this, m_commonHeaders.begin(), m_uncommonHeaders.begin()); }
-    const_iterator end() const { return const_iterator(*this, m_commonHeaders.end(), m_uncommonHeaders.end()); }
+    const_iterator begin() const { return const_iterator(*this, 0, 0); }
+    const_iterator end() const { return const_iterator(*this, m_commonHeaders.size(), m_uncommonHeaders.size()); }
 
     friend bool operator==(const HTTPHeaderMap& a, const HTTPHeaderMap& b)
     {


### PR DESCRIPTION
#### 1d0f938c8c893997d18dc9ee72b9c67246411513
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in HTTPHeaderMap.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=285479">https://bugs.webkit.org/show_bug.cgi?id=285479</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/network/HTTPHeaderMap.h:
(WebCore::HTTPHeaderMap::HTTPHeaderMapConstIterator::HTTPHeaderMapConstIterator):
(WebCore::HTTPHeaderMap::HTTPHeaderMapConstIterator::operator++):
(WebCore::HTTPHeaderMap::HTTPHeaderMapConstIterator::operator== const):
(WebCore::HTTPHeaderMap::HTTPHeaderMapConstIterator::updateKeyValue):
(WebCore::HTTPHeaderMap::begin const):
(WebCore::HTTPHeaderMap::end const):

Canonical link: <a href="https://commits.webkit.org/288527@main">https://commits.webkit.org/288527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b560bbd7cdab1fe1a78f3f97f98b0b72dbf417c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88732 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34669 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85746 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65078 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22874 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2476 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76015 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45366 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30224 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33718 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73446 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90111 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10926 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73514 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72739 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16990 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15694 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2250 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12916 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10878 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16350 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10726 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14201 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->