### PR TITLE
Check for -Wunsafe-buffer-usage warnings that are hidden by the unified build

### DIFF
--- a/Source/WTF/Scripts/generate-unified-source-bundles.rb
+++ b/Source/WTF/Scripts/generate-unified-source-bundles.rb
@@ -203,7 +203,7 @@ class BundleManager
         @extension = extension
         @fileCount = 0
         @bundleCount = 0
-        @currentBundleText = ""
+        @currentBundleText = "#pragma clang diagnostic ignored \"-Wunknown-pragmas\"\n"
         @maxCount = max
         @extraFiles = []
         @currentDirectory = nil
@@ -241,7 +241,7 @@ class BundleManager
         @extraFiles << bundleFile if @maxCount and @bundleCount > @maxCount
 
         writeFile(bundleFile, @currentBundleText)
-        @currentBundleText = ""
+        @currentBundleText = "#pragma clang diagnostic ignored \"-Wunknown-pragmas\"\n"
         @fileCount = 0
     end
 
@@ -270,6 +270,8 @@ class BundleManager
             flush
         end
         @currentBundleText += "#include \"#{sourceFile}\"\n"
+        @currentBundleText += "#pragma clang diagnostic pop\n"
+        @currentBundleText += "#pragma clang diagnostic pop\n"
         @fileCount += 1
     end
 end


### PR DESCRIPTION
#### f4dcbe04998045bb8f54614c56adc5e37f6f8eaf
<pre>
Check for -Wunsafe-buffer-usage warnings that are hidden by the unified build
<a href="https://bugs.webkit.org/show_bug.cgi?id=285481">https://bugs.webkit.org/show_bug.cgi?id=285481</a>
<a href="https://rdar.apple.com/142442843">rdar://142442843</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WTF/Scripts/generate-unified-source-bundles.rb:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4dcbe04998045bb8f54614c56adc5e37f6f8eaf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37925 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88696 "Hash f4dcbe04 for PR 38610 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34633 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11200 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/88696 "Hash f4dcbe04 for PR 38610 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22789 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75980 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/88696 "Hash f4dcbe04 for PR 38610 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2362 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30185 "Found 1 new test failure: fast/editing/recursive-reapply-edit-command-crash.html (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33681 "Hash f4dcbe04 for PR 38610 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76588 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73425 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30932 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90073 "Hash f4dcbe04 for PR 38610 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/82642 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10890 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7857 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-remove-from-document-networkState.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/90073 "Hash f4dcbe04 for PR 38610 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71805 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/90073 "Hash f4dcbe04 for PR 38610 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16956 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15661 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2214 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10842 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16314 "Built successfully") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105059 "Hash f4dcbe04 for PR 38610 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10690 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/105059 "Hash f4dcbe04 for PR 38610 does not build (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14165 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12462 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->