### PR TITLE
Reduce strong references to WebCore::Frame

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -493,7 +493,7 @@ public:
 private:
     JSGlobalObject& m_globalObject;
     CallFrame& m_callFrame;
-    RefPtr<LocalFrame> m_frame;
+    WeakPtr<LocalFrame> m_frame;
 };
 
 inline void DialogHandler::dialogCreated(DOMWindow& dialog)
@@ -503,6 +503,7 @@ inline void DialogHandler::dialogCreated(DOMWindow& dialog)
         return;
     VM& vm = m_globalObject.vm();
     m_frame = localDOMWindow->frame();
+    RefPtr frame = m_frame.get();
 
     // FIXME: This looks like a leak between the normal world and an isolated
     //        world if dialogArguments comes from an isolated world.
@@ -514,6 +515,9 @@ inline void DialogHandler::dialogCreated(DOMWindow& dialog)
 inline JSValue DialogHandler::returnValue() const
 {
     VM& vm = m_globalObject.vm();
+    RefPtr frame = m_frame.get();
+    if (!frame)
+        return jsUndefined();
     auto* globalObject = toJSDOMWindow(m_frame.get(), normalWorld(vm));
     if (!globalObject)
         return jsUndefined();

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -194,12 +194,14 @@ public:
     {
         if (m_didDisableImage)
             m_cachedResourceLoader->setImagesEnabled(true);
-        if (m_didEnabledDeferredLoading)
-            m_frame->page()->setDefersLoading(false);
+        if (m_didEnabledDeferredLoading) {
+            if (RefPtr frame = m_frame.get())
+                frame->page()->setDefersLoading(false);
+        }
     }
 
 private:
-    Ref<LocalFrame> m_frame;
+    WeakPtr<LocalFrame> m_frame;
     Ref<CachedResourceLoader> m_cachedResourceLoader;
     bool m_didEnabledDeferredLoading { false };
     bool m_didDisableImage { false };

--- a/Source/WebCore/loader/NavigationDisabler.h
+++ b/Source/WebCore/loader/NavigationDisabler.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "LocalFrame.h"
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -36,7 +37,7 @@ public:
         : m_frame(frame)
     {
         if (frame) {
-            if (auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame()))
+            if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame()))
                 ++localFrame->m_navigationDisableCount;
         } else // Disable all navigations when destructing a frame-less document.
             ++s_globalNavigationDisableCount;
@@ -44,8 +45,8 @@ public:
 
     ~NavigationDisabler()
     {
-        if (m_frame) {
-            if (auto* mainFrame = dynamicDowncast<LocalFrame>(m_frame->mainFrame())) {
+        if (RefPtr frame = m_frame.get()) {
+            if (RefPtr mainFrame = dynamicDowncast<LocalFrame>(frame->mainFrame())) {
                 ASSERT(mainFrame->m_navigationDisableCount);
                 --mainFrame->m_navigationDisableCount;
             }
@@ -63,7 +64,7 @@ public:
     }
 
 private:
-    RefPtr<LocalFrame> m_frame;
+    WeakPtr<LocalFrame> m_frame;
 
     static unsigned s_globalNavigationDisableCount;
 };

--- a/Source/WebCore/page/DOMWindowExtension.cpp
+++ b/Source/WebCore/page/DOMWindowExtension.cpp
@@ -71,7 +71,7 @@ void DOMWindowExtension::suspendForBackForwardCache()
     Ref frame = *this->frame();
     frame->protectedLoader()->client().dispatchWillDisconnectDOMWindowExtensionFromGlobalObject(this);
 
-    m_disconnectedFrame = WTFMove(frame);
+    m_disconnectedFrame = frame.get();
 }
 
 void DOMWindowExtension::resumeFromBackForwardCache()
@@ -93,7 +93,7 @@ void DOMWindowExtension::willDestroyGlobalObjectInCachedFrame()
     // while there is still work to do.
     Ref protectedThis { *this };
 
-    if (RefPtr disconnectedFrame = m_disconnectedFrame)
+    if (RefPtr disconnectedFrame = m_disconnectedFrame.get())
         disconnectedFrame->protectedLoader()->client().dispatchWillDestroyGlobalObjectForDOMWindowExtension(this);
     m_disconnectedFrame = nullptr;
 

--- a/Source/WebCore/page/DOMWindowExtension.h
+++ b/Source/WebCore/page/DOMWindowExtension.h
@@ -60,7 +60,7 @@ private:
 
     WeakPtr<LocalDOMWindow, WeakPtrImplWithEventTargetData> m_window;
     Ref<DOMWrapperWorld> m_world;
-    RefPtr<LocalFrame> m_disconnectedFrame;
+    WeakPtr<LocalFrame> m_disconnectedFrame;
     bool m_wasDetached;
 };
 


### PR DESCRIPTION
#### 2d6787eaecd883e5aea220cb2ed096cb82a19802
<pre>
Reduce strong references to WebCore::Frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=285484">https://bugs.webkit.org/show_bug.cgi?id=285484</a>
<a href="https://rdar.apple.com/142447647">rdar://142447647</a>

Reviewed by Brady Eidson.

While browsing the web with debug builds of WebKit with site isolation on,
the most common assertions are various assertions about Frame objects being
kept alive longer than they should be.  When an iframe is removed, we need
the Frame to be destroyed pretty quickly to have the frame tree consistent.
Otherwise, we hit assertions like the one in the Page destructor.
A few objects keep strong references to the Frame because they were written
before we introduced WeakPtr into WebKit.  There is no reason why they
need to prevent the Frame from being destroyed.

* Source/WebCore/bindings/js/JSDOMWindowCustom.cpp:
(WebCore::DialogHandler::dialogCreated):
(WebCore::DialogHandler::returnValue const):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::Editor::Command::execute const):
(WebCore::Editor::Command::isSupported const):
(WebCore::Editor::Command::isEnabled const):
(WebCore::Editor::Command::state const):
(WebCore::Editor::Command::value const):
(WebCore::Editor::Command::allowExecutionWhenDisabled const):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::DeferredLoadingScope::~DeferredLoadingScope):
* Source/WebCore/loader/NavigationDisabler.h:
(WebCore::NavigationDisabler::NavigationDisabler):
(WebCore::NavigationDisabler::~NavigationDisabler):
* Source/WebCore/loader/ProgressTracker.cpp:
(WebCore::ProgressTracker::progressStarted):
(WebCore::ProgressTracker::finalProgressComplete):
(WebCore::ProgressTracker::incrementProgress):
(WebCore::ProgressTracker::progressHeartbeatTimerFired):
* Source/WebCore/loader/ProgressTracker.h:
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::init):
(WebCore::ResourceLoader::frameLoader const):
(WebCore::ResourceLoader::loadDataURL):
(WebCore::ResourceLoader::willSendRequestInternal):
(WebCore::ResourceLoader::shouldAllowResourceToAskForCredentials const):
(WebCore::ResourceLoader::didBlockAuthenticationChallenge):
(WebCore::ResourceLoader::didReceiveResponse):
(WebCore::ResourceLoader::didReceiveBuffer):
(WebCore::ResourceLoader::shouldUseCredentialStorage):
(WebCore::ResourceLoader::isAllowedToAskUserForCredentials const):
(WebCore::ResourceLoader::isPDFJSResourceLoad const):
(WebCore::ResourceLoader::protectedFrame const):
(WebCore::ResourceLoader::frame const):
(WebCore::ResourceLoader::resourceMonitorIfExists):
* Source/WebCore/loader/ResourceLoader.h:
(WebCore::ResourceLoader::frame const): Deleted.
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::willSendRequestInternal):
* Source/WebCore/page/DOMWindowExtension.cpp:
(WebCore::DOMWindowExtension::suspendForBackForwardCache):
(WebCore::DOMWindowExtension::willDestroyGlobalObjectInCachedFrame):
* Source/WebCore/page/DOMWindowExtension.h:

Canonical link: <a href="https://commits.webkit.org/289248@main">https://commits.webkit.org/289248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b032bb4fba18880f67867399424164463e3cf71b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36794 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66656 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24457 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77898 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46945 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4240 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32180 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35871 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74882 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92658 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9635 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75446 "Found 1 new test failure: fast/dom/Window/open-window-min-size.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74585 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18772 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17215 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13391 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13162 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18515 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12940 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->