### PR TITLE
REGRESSION (286043@main): [iOS] Adjusting page zoom with -/+ causes page to become too wide or too narrow

### DIFF
--- a/LayoutTests/fast/viewport/ios/no-unnecessary-horizontal-scrolling-after-changing-view-scale-expected.txt
+++ b/LayoutTests/fast/viewport/ios/no-unnecessary-horizontal-scrolling-after-changing-view-scale-expected.txt
@@ -1,0 +1,15 @@
+This test verifies that the width of the viewport and the content width are consistent when zooming out by changing the view scale in a responsive viewport that doesn't lay out wider than the viewport.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Set view scale: 0.85
+PASS visualViewport.width is bodyWidth()
+PASS Set view scale: 0.75
+PASS visualViewport.width is bodyWidth()
+PASS Set view scale: 0.5
+PASS visualViewport.width is bodyWidth()
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/viewport/ios/no-unnecessary-horizontal-scrolling-after-changing-view-scale.html
+++ b/LayoutTests/fast/viewport/ios/no-unnecessary-horizontal-scrolling-after-changing-view-scale.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ShouldIgnoreMetaViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+    body, html {
+        margin: 0;
+        width: 100%;
+        height: 100%;
+    }
+
+    #output {
+        width: 100%;
+        height: 100%;
+        overflow: scroll;
+    }
+    </style>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test.js"></script>
+    <script>
+    if (window.testRunner) {
+        jsTestIsAsync = true;
+        testRunner.setIgnoresViewportScaleLimits(true);
+    }
+
+    function bodyWidth() {
+        return document.body.getBoundingClientRect().width;
+    }
+
+    description("This test verifies that the width of the viewport and the content width are consistent when zooming out by changing the view scale in a responsive viewport that doesn't lay out wider than the viewport.");
+
+    addEventListener("load", async () => {
+        const appendOutput = message => {
+            output.appendChild(document.createTextNode(message));
+            output.appendChild(document.createElement("br"));
+        };
+
+        for (const scale of [0.85, 0.75, 0.5]) {
+            await UIHelper.setViewScale(scale);
+            await UIHelper.ensurePresentationUpdate();
+            testPassed(`Set view scale: ${scale}`);
+            shouldBe("visualViewport.width", "bodyWidth()");
+        }
+
+        finishJSTest();
+    });
+    </script>
+</head>
+
+<body>
+    <p id="description"></p>
+    <pre id="output"></pre>
+</body>
+</html>

--- a/Source/WebCore/page/ViewportConfiguration.cpp
+++ b/Source/WebCore/page/ViewportConfiguration.cpp
@@ -565,7 +565,7 @@ void ViewportConfiguration::updateConfiguration()
     if (canOverrideConfigurationParameters()) {
         if (!viewportArgumentsOverridesWidth)
             m_configuration.width = m_minimumLayoutSize.width();
-        else if (layoutSizeIsExplicitlyScaled())
+        else if (layoutSizeIsExplicitlyScaled() && m_viewportArguments.width > 0)
             m_configuration.width /= effectiveLayoutScale;
     }
 


### PR DESCRIPTION
#### 5fc310e87e86d023ade0d28e09a954085f0ec176
<pre>
REGRESSION (286043@main): [iOS] Adjusting page zoom with -/+ causes page to become too wide or too narrow
<a href="https://bugs.webkit.org/show_bug.cgi?id=285488">https://bugs.webkit.org/show_bug.cgi?id=285488</a>
<a href="https://rdar.apple.com/140818892">rdar://140818892</a>

Reviewed by Aditya Keerthi.

After the changes in 286043@main, adjusting view scale using -/+ buttons in the Safari Page menu now
correctly increase or decrease the layout width of a webpage that has a fixed viewport width, by
forcing the fixed width to be scaled by the (explicitly-set) layout size scale factor.

However, in the case where the viewport is responsive, `m_configuration.width` has already been set
relative to the minimum layout size, which accounts for the view scale (effective layout size scale
factor). As such, we end up doubly scaling `m_configuration.width` by the layout size scale factor,
which leads to excessive horizontal scrolling when zooming out (e.g., zooming out to 0.5 view scale
when the viewport and content are both 1000 px causes the body to become twice as wide as the
viewport).

To address this, we limit the aforementioned change to the case where the viewport argument had
explicitly specified a fixed width — as opposed to `ValueAuto` or `ValueDeviceWidth`.

* LayoutTests/fast/viewport/ios/no-unnecessary-horizontal-scrolling-after-changing-view-scale-expected.txt: Added.
* LayoutTests/fast/viewport/ios/no-unnecessary-horizontal-scrolling-after-changing-view-scale.html: Added.

Add a layout test to exercise this change, by sanity checking the width of `document.body` against
the visual viewport width.

* Source/WebCore/page/ViewportConfiguration.cpp:
(WebCore::ViewportConfiguration::updateConfiguration):

Canonical link: <a href="https://commits.webkit.org/288510@main">https://commits.webkit.org/288510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e970e21aea92d08a567ed94b2b7c2c4404691010

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88712 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34649 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65058 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22802 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86687 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2461 "Found 1 new test failure: fast/forms/ios/file-upload-panel.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/75997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45346 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2374 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30205 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33698 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90091 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7870 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73491 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72717 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17984 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16972 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15676 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2230 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10858 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/16330 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10706 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12478 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->