### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in SVGParserUtilities.cpp

### DIFF
--- a/Source/WebCore/svg/SVGParserUtilities.cpp
+++ b/Source/WebCore/svg/SVGParserUtilities.cpp
@@ -262,7 +262,7 @@ std::optional<UncheckedKeyHashSet<String>> parseGlyphName(StringView string)
 {
     // FIXME: Parsing error detection is missing.
 
-    return readCharactersForParsing(string, [](auto buffer) -> UncheckedKeyHashSet<String> {
+    return readCharactersForParsing(string, [](auto buffer) {
         skipOptionalSVGSpaces(buffer);
 
         UncheckedKeyHashSet<String> values;
@@ -276,19 +276,16 @@ std::optional<UncheckedKeyHashSet<String>> parseGlyphName(StringView string)
             if (buffer.position() == inputStart.data())
                 break;
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-            // walk backwards from the ; to ignore any whitespace
-            auto inputEnd = buffer.position() - 1;
-            while (inputStart.data() < inputEnd && isASCIIWhitespace(*inputEnd))
-                --inputEnd;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+            // Walk backwards from the ; to ignore any whitespace.
+            size_t index = buffer.position() - inputStart.data();
+            while (index > 0 && isASCIIWhitespace(inputStart[index - 1]))
+                --index;
 
-            values.add(inputStart.first(inputEnd - inputStart.data() + 1));
+            values.add(inputStart.first(index));
             skipOptionalSVGSpacesOrDelimiter(buffer, ',');
         }
         return values;
     });
-
 }
 
 template<typename CharacterType> static std::optional<UnicodeRange> parseUnicodeRange(std::span<const CharacterType> span)


### PR DESCRIPTION
#### d3969657a64681f284f52beb06b01c9db112fb1d
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in SVGParserUtilities.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=285490">https://bugs.webkit.org/show_bug.cgi?id=285490</a>

Reviewed by Darin Adler.

* Source/WebCore/svg/SVGParserUtilities.cpp:
(WebCore::parseGlyphName):

Canonical link: <a href="https://commits.webkit.org/288533@main">https://commits.webkit.org/288533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c510c23ffae98a3619ea6ff2983da7a191f1eef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88720 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34657 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65066 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22808 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45354 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30211 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33706 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90099 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73498 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11137 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72724 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16978 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15681 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2238 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12920 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10866 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16338 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10714 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14189 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12486 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->