### PR TITLE
Unprefix -webkit-user-select

### DIFF
--- a/LayoutTests/editing/selection/user-select-js-property-expected.txt
+++ b/LayoutTests/editing/selection/user-select-js-property-expected.txt
@@ -5,6 +5,6 @@ uneditable
 
 PASS user-select-js-property
 PASS 'webkitUserSelect' in style
-PASS webkitUserSelect of '#bar { -webkit-user-select: none; }' should be 'none'
+PASS webkitUserSelect of '#bar { user-select: none; }' should be 'none'
 PASS webkitUserSelect of '-webkit-user-select:none' should be 'none'
 

--- a/LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt
@@ -240,7 +240,6 @@ zoom: 1;
 -webkit-text-stroke-width: 0px;
 -webkit-user-drag: auto;
 -webkit-user-modify: read-only;
--webkit-user-select: text;
 
 Other attributes that the computed style class supports:
 

--- a/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
@@ -239,7 +239,6 @@ zoom: 1
 -webkit-text-stroke-width: 0px
 -webkit-user-drag: auto
 -webkit-user-modify: read-only
--webkit-user-select: text
 background-position-x: 0%
 background-position-y: 0%
 border-spacing: 0px 0px

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -342,6 +342,7 @@ PASS transition-property
 PASS transition-timing-function
 PASS translate
 PASS unicode-bidi
+PASS user-select
 PASS vector-effect
 PASS vertical-align
 PASS view-timeline-axis

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL Can set 'user-select' to CSS-wide keywords: initial Invalid property user-select
-FAIL Can set 'user-select' to CSS-wide keywords: inherit Invalid property user-select
-FAIL Can set 'user-select' to CSS-wide keywords: unset Invalid property user-select
-FAIL Can set 'user-select' to CSS-wide keywords: revert Invalid property user-select
-FAIL Can set 'user-select' to var() references:  var(--A) Invalid property user-select
-FAIL Can set 'user-select' to the 'auto' keyword: auto Invalid property user-select
-FAIL Can set 'user-select' to the 'text' keyword: text Invalid property user-select
-FAIL Can set 'user-select' to the 'none' keyword: none Invalid property user-select
-FAIL Can set 'user-select' to the 'contain' keyword: contain Invalid property user-select
-FAIL Can set 'user-select' to the 'all' keyword: all Invalid property user-select
+PASS Can set 'user-select' to CSS-wide keywords: initial
+PASS Can set 'user-select' to CSS-wide keywords: inherit
+PASS Can set 'user-select' to CSS-wide keywords: unset
+PASS Can set 'user-select' to CSS-wide keywords: revert
+PASS Can set 'user-select' to var() references:  var(--A)
+FAIL Can set 'user-select' to the 'auto' keyword: auto assert_equals: expected "auto" but got "text"
+PASS Can set 'user-select' to the 'text' keyword: text
+PASS Can set 'user-select' to the 'none' keyword: none
+FAIL Can set 'user-select' to the 'contain' keyword: contain Invalid values
+PASS Can set 'user-select' to the 'all' keyword: all
 PASS Setting 'user-select' to a length: 0px throws TypeError
 PASS Setting 'user-select' to a length: -3.14em throws TypeError
 PASS Setting 'user-select' to a length: 3.14cm throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/inheritance-expected.txt
@@ -25,6 +25,6 @@ PASS Property outline-width has initial value 3px
 PASS Property outline-width does not inherit
 PASS Property resize has initial value none
 PASS Property resize does not inherit
-FAIL Property user-select has initial value auto assert_true: user-select doesn't seem to be supported in the computed style expected true got false
-FAIL Property user-select does not inherit assert_true: expected true got false
+FAIL Property user-select has initial value auto assert_equals: expected "auto" but got "text"
+FAIL Property user-select does not inherit assert_not_equals: got disallowed value "none"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-computed-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Property user-select value 'auto' assert_true: user-select doesn't seem to be supported in the computed style expected true got false
-FAIL Property user-select value 'text' assert_true: user-select doesn't seem to be supported in the computed style expected true got false
-FAIL Property user-select value 'none' assert_true: user-select doesn't seem to be supported in the computed style expected true got false
-FAIL Property user-select value 'contain' assert_true: user-select doesn't seem to be supported in the computed style expected true got false
-FAIL Property user-select value 'all' assert_true: user-select doesn't seem to be supported in the computed style expected true got false
+FAIL Property user-select value 'auto' assert_equals: expected "auto" but got "text"
+PASS Property user-select value 'text'
+PASS Property user-select value 'none'
+FAIL Property user-select value 'contain' assert_true: 'contain' is a supported value for user-select. expected true got false
+PASS Property user-select value 'all'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-valid-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL e.style['user-select'] = "auto" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['user-select'] = "text" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['user-select'] = "none" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['user-select'] = "auto" should set the property value
+PASS e.style['user-select'] = "text" should set the property value
+PASS e.style['user-select'] = "none" should set the property value
 FAIL e.style['user-select'] = "contain" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['user-select'] = "all" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['user-select'] = "all" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/user-select-inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/user-select-inheritance-expected.txt
@@ -2,9 +2,9 @@ abc
 xyz
 def
 
-FAIL user-select:all should not be inherited. assert_equals: user-select:all should be supported. expected (string) "all" but got (undefined) undefined
-FAIL user-select:auto should not be inherited. assert_equals: user-select:auto should be supported. expected (string) "auto" but got (undefined) undefined
-FAIL user-select:contain should not be inherited. assert_equals: user-select:contain should be supported. expected (string) "contain" but got (undefined) undefined
-FAIL user-select:none should not be inherited. assert_equals: user-select:none should be supported. expected (string) "none" but got (undefined) undefined
-FAIL user-select:text should not be inherited. assert_equals: user-select:text should be supported. expected (string) "text" but got (undefined) undefined
+FAIL user-select:all should not be inherited. assert_equals: user-select:all should not be inherited. expected "auto" but got "all"
+FAIL user-select:auto should not be inherited. assert_equals: user-select:auto should be supported. expected "auto" but got "text"
+FAIL user-select:contain should not be inherited. assert_equals: user-select:contain should be supported. expected "contain" but got "text"
+FAIL user-select:none should not be inherited. assert_equals: user-select:none should not be inherited. expected "auto" but got "none"
+FAIL user-select:text should not be inherited. assert_equals: user-select:text should not be inherited. expected "auto" but got "text"
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -268,6 +268,7 @@ PASS perspective-origin
 PASS pointer-events
 PASS position
 PASS position-anchor
+PASS position-try-fallbacks
 PASS position-try-order
 PASS print-color-adjust
 PASS quotes
@@ -367,6 +368,7 @@ PASS transition-property
 PASS transition-timing-function
 PASS translate
 PASS unicode-bidi
+PASS user-select
 PASS vector-effect
 PASS vertical-align
 PASS view-timeline-axis
@@ -424,5 +426,4 @@ PASS -webkit-text-stroke-width
 PASS -webkit-text-zoom
 PASS -webkit-user-drag
 PASS -webkit-user-modify
-PASS -webkit-user-select
 

--- a/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
+++ b/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
@@ -238,7 +238,6 @@ rect: style.getPropertyValue(-webkit-text-stroke-color) : rgb(0, 0, 0)
 rect: style.getPropertyValue(-webkit-text-stroke-width) : 0px
 rect: style.getPropertyValue(-webkit-user-drag) : auto
 rect: style.getPropertyValue(-webkit-user-modify) : read-only
-rect: style.getPropertyValue(-webkit-user-select) : text
 g: style.getPropertyValue(align-content) : normal
 g: style.getPropertyValue(align-items) : normal
 g: style.getPropertyValue(align-self) : auto
@@ -479,5 +478,4 @@ g: style.getPropertyValue(-webkit-text-stroke-color) : rgb(0, 0, 0)
 g: style.getPropertyValue(-webkit-text-stroke-width) : 0px
 g: style.getPropertyValue(-webkit-user-drag) : auto
 g: style.getPropertyValue(-webkit-user-modify) : read-only
-g: style.getPropertyValue(-webkit-user-select) : text
 

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -4288,7 +4288,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
 #endif
         case CSSPropertyViewTimeline:
         case CSSPropertyViewTimelineInset: // FIXME: view-timeline-inset should be animatable (bug 265690)
-        case CSSPropertyWebkitUserSelect:
+        case CSSPropertyUserSelect:
 
         // Not animatable per-spec:
         case CSSPropertyAnimation:

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -8873,7 +8873,7 @@
             },
             "status": "non-standard"
         },
-        "-webkit-user-select": {
+        "user-select": {
             "inherited": true,
             "values": [
                 "auto",
@@ -8886,7 +8886,10 @@
                 "all"
             ],
             "codegen-properties": {
-                "parser-grammar": "<<values>>"
+                "parser-grammar": "<<values>>",
+                "aliases": [
+                    "-webkit-user-select"
+                ]
             },
             "status": {
                 "status": "experimental"

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -4475,7 +4475,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
 #endif
     case CSSPropertyWebkitUserDrag:
         return createConvertingToCSSValueID(style.userDrag());
-    case CSSPropertyWebkitUserSelect:
+    case CSSPropertyUserSelect:
         return createConvertingToCSSValueID(style.userSelect());
     case CSSPropertyBorderBottomLeftRadius:
         return borderRadiusCornerValue(style.borderBottomLeftRadius(), style);

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -381,7 +381,7 @@ static Elements updateSubtree(HTMLElement& element, const TextRecognitionResult&
             rootContainer->setIdAttribute(imageOverlayElementIdentifier());
             rootContainer->setTranslate(false);
             if (document->isImageDocument())
-                rootContainer->setInlineStyleProperty(CSSPropertyWebkitUserSelect, CSSValueText);
+                rootContainer->setInlineStyleProperty(CSSPropertyUserSelect, CSSValueText);
 
             if (mediaControlsContainer)
                 mediaControlsContainer->appendChild(rootContainer);
@@ -581,7 +581,7 @@ void updateWithTextRecognitionResult(HTMLElement& element, const TextRecognition
                 "scale("_s, targetSize.width() / sizeBeforeTransform.width(), ", "_s, targetSize.height() / sizeBeforeTransform.height(), ") "_s
             ));
 
-            textContainer->setInlineStyleProperty(CSSPropertyWebkitUserSelect, applyUserSelectAll ? CSSValueAll : CSSValueNone);
+            textContainer->setInlineStyleProperty(CSSPropertyUserSelect, applyUserSelectAll ? CSSValueAll : CSSValueNone);
 
             if (line.isVertical)
                 textContainer->setInlineStyleProperty(CSSPropertyWritingMode, CSSValueVerticalRl);


### PR DESCRIPTION
#### f7a9411b5610d05068a9fc4d30e57923d0811faf
<pre>
Unprefix -webkit-user-select
<a href="https://bugs.webkit.org/show_bug.cgi?id=208677">https://bugs.webkit.org/show_bug.cgi?id=208677</a>

Reviewed by NOBODY (OOPS!).

Unprefix -webkit-user-select and make it an alias for user-select.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/user-select-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-computed-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::updateSubtree):
(WebCore::ImageOverlay::updateWithTextRecognitionResult):
* LayoutTests/editing/selection/user-select-js-property-expected.txt:
* LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt:
* LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/user-select-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/user-select-inheritance-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/svg/css/getComputedStyle-basic-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7a9411b5610d05068a9fc4d30e57923d0811faf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88815 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34751 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65141 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22977 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2554 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76091 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45430 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2474 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30304 "Found 3 new test failures: fast/editing/recursive-reapply-edit-command-crash.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33800 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73505 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31051 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90193 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11008 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7958 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73583 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71917 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72806 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17067 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15768 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2332 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10960 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16432 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10808 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14283 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->