### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in CoreTextChineseCompositionEngine.cpp

### DIFF
--- a/Source/WebCore/platform/text/mac/CoreTextChineseCompositionEngine.cpp
+++ b/Source/WebCore/platform/text/mac/CoreTextChineseCompositionEngine.cpp
@@ -30,8 +30,6 @@
 #include <unicode/uscript.h>
 #include <wtf/unicode/CharacterNames.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 static ChineseCompositionRules::ChineseCharacterClass characterToCharacterClass(UTF32Char character)
 {
     if (character == zeroWidthSpace)
@@ -145,17 +143,17 @@ CompositionRules::CharacterSpacingType ChineseCompositionRules::characterSpacing
 {
     using namespace CompositionRules;
 
-    static const CompositionRules::CharacterSpacingType chineseSpacingTable[NumClasses][NumClasses] = {
-                    /* Opening,    Closing,    Whitespace, FullWidth,   HalfWidth,   HalfWidthOpen, HalfWidthClose,   Centered    Other */
-/* Opening */       {  _1_4_be_re, _______,    _______,    _______,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
-/* Closing */       {  _1_2_eq_re, _1_4_af_re, _______,    _1_4_af_re,  _1_4_af_re,  _1_4_af_re,    _1_4_af_re,       _1_2_eq_re, _1_4_af_re }, // NOLINT
-/* Whitespace */    {  _1_4_be_re, _______,    _______,    _______,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
-/* FullWidth */     {  _1_4_be_re, _______,    _______,    _______,     _1_8_be,     _1_8_be,       _______,          _______,    _______    }, // NOLINT
-/* HalfWidth */     {  _1_4_be_re, _______,    _______,    _1_8_be,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
-/* HalfWidthOpen */ {  _1_4_be_re, _______,    _______,    _______,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
-/* HalfWidthClose */{  _1_4_be_re, _______,    _______,    _1_8_be,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
-/* Centered */      {  _1_2_eq_re, _______,    _______,    _______,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
-/* Other */         {  _1_4_be_re, _______,    _______,    _______,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
+    static constexpr std::array chineseSpacingTable {
+                                /* Opening,    Closing,    Whitespace, FullWidth,   HalfWidth,   HalfWidthOpen, HalfWidthClose,   Centered    Other */
+/* Opening */        std::array {  _1_4_be_re, _______,    _______,    _______,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
+/* Closing */        std::array {  _1_2_eq_re, _1_4_af_re, _______,    _1_4_af_re,  _1_4_af_re,  _1_4_af_re,    _1_4_af_re,       _1_2_eq_re, _1_4_af_re }, // NOLINT
+/* Whitespace */     std::array {  _1_4_be_re, _______,    _______,    _______,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
+/* FullWidth */      std::array {  _1_4_be_re, _______,    _______,    _______,     _1_8_be,     _1_8_be,       _______,          _______,    _______    }, // NOLINT
+/* HalfWidth */      std::array {  _1_4_be_re, _______,    _______,    _1_8_be,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
+/* HalfWidthOpen */  std::array {  _1_4_be_re, _______,    _______,    _______,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
+/* HalfWidthClose */ std::array {  _1_4_be_re, _______,    _______,    _1_8_be,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
+/* Centered */       std::array {  _1_2_eq_re, _______,    _______,    _______,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
+/* Other */          std::array {  _1_4_be_re, _______,    _______,    _______,     _______,     _______,       _______,          _______,    _______    }, // NOLINT
     };
     auto beforeGeneralCategoryMask = U_GET_GC_MASK(beforeCharacter);
     auto afterGeneralCategoryMask = U_GET_GC_MASK(afterCharacter);
@@ -182,5 +180,3 @@ CompositionRules::CharacterSpacingType ChineseCompositionRules::characterSpacing
 
     return chineseSpacingTable[beforeClass][afterClass];
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### a2e1c49734644753d244223025b58341cf8cbd2d
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in CoreTextChineseCompositionEngine.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=285491">https://bugs.webkit.org/show_bug.cgi?id=285491</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/text/mac/CoreTextChineseCompositionEngine.cpp:
(ChineseCompositionRules::characterSpacing):

Canonical link: <a href="https://commits.webkit.org/288532@main">https://commits.webkit.org/288532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa627a3cb6dd171fcd111d70cb10d6f831a819e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88723 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34660 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65067 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22811 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76011 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45355 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2381 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30275 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33709 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73440 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90102 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10917 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7877 "Found 1 new test failure: http/wpt/mediarecorder/MediaRecorder-video-h264-profiles.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73501 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71836 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72726 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16980 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15690 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2241 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12919 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10869 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16341 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10717 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14192 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12489 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->