### PR TITLE
[css-conditional] Negative cqmin/cqmax units are inverted

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-selection.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-selection.html
@@ -30,10 +30,10 @@
 
   function assert_unit_equals(element, actual, expected) {
     try {
-      element.style.padding = actual;
-      ref.style.padding = expected;
-      assert_equals(getComputedStyle(element).paddingLeft,
-                    getComputedStyle(ref).paddingLeft);
+      element.style.margin = actual;
+      ref.style.margin = expected;
+      assert_equals(getComputedStyle(element).marginLeft,
+                    getComputedStyle(ref).marginLeft);
     } finally {
       element.style = '';
       ref.style = '';
@@ -51,6 +51,8 @@
       assert_unit_equals(child, '10cqb', '40px');
       assert_unit_equals(child, '10cqmin', '10px');
       assert_unit_equals(child, '10cqmax', '40px');
+      assert_unit_equals(child, '-10cqmin', '-10px');
+      assert_unit_equals(child, '-10cqmax', '-40px');
 
       c3.className = ''; // cqw, cqi now selects c2 instead.
       assert_unit_equals(child, '10cqw', '30px');
@@ -59,6 +61,8 @@
       assert_unit_equals(child, '10cqb', '40px');
       assert_unit_equals(child, '10cqmin', '30px');
       assert_unit_equals(child, '10cqmax', '40px');
+      assert_unit_equals(child, '-10cqmin', '-30px');
+      assert_unit_equals(child, '-10cqmax', '-40px');
 
     } finally {
       for (let c of [c1, c2, c3, c4, child])

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -383,9 +383,13 @@ double computeNonCalcLengthDouble(double value, CSS::LengthUnit lengthUnit, cons
     }
 
     case Cqmax:
+        if (value < 0)
+            return std::min(computeNonCalcLengthDouble(value, Cqb, conversionData), computeNonCalcLengthDouble(value, Cqi, conversionData));
         return std::max(computeNonCalcLengthDouble(value, Cqb, conversionData), computeNonCalcLengthDouble(value, Cqi, conversionData));
 
     case Cqmin:
+        if (value < 0)
+            return std::max(computeNonCalcLengthDouble(value, Cqb, conversionData), computeNonCalcLengthDouble(value, Cqi, conversionData));
         return std::min(computeNonCalcLengthDouble(value, Cqb, conversionData), computeNonCalcLengthDouble(value, Cqi, conversionData));
     }
 


### PR DESCRIPTION
#### 773a6d98d0642746c91ec9417a46950251536978
<pre>
[css-conditional] Negative cqmin/cqmax units are inverted
<a href="https://bugs.webkit.org/show_bug.cgi?id=285451">https://bugs.webkit.org/show_bug.cgi?id=285451</a>
<a href="https://rdar.apple.com/142456739">rdar://142456739</a>

Reviewed by Cameron McCormack.

Make sure we invert min/max when we consider negative values for cqmin/cqmax.

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-units-selection.html:
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
(WebCore::Style::computeNonCalcLengthDouble):

Canonical link: <a href="https://commits.webkit.org/288523@main">https://commits.webkit.org/288523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26072abc4cbafc1720f6cc8067017c99257f2178

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37958 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88729 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34666 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11233 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65072 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22818 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76010 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45360 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30219 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33715 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73444 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90108 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7882 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73510 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72735 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17991 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16989 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15689 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2247 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10875 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16347 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10723 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14198 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->