### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN in iOS-specific files

### DIFF
--- a/Source/WTF/wtf/ObjCRuntimeExtras.h
+++ b/Source/WTF/wtf/ObjCRuntimeExtras.h
@@ -46,6 +46,7 @@ namespace WTF {
 
 WTF_EXPORT_PRIVATE MallocSpan<Method, SystemMalloc> class_copyMethodListSpan(Class);
 WTF_EXPORT_PRIVATE MallocSpan<__unsafe_unretained Protocol *, SystemMalloc> class_copyProtocolListSpan(Class);
+WTF_EXPORT_PRIVATE MallocSpan<objc_property_t, SystemMalloc> class_copyPropertyListSpan(Class);
 WTF_EXPORT_PRIVATE MallocSpan<objc_method_description, SystemMalloc> protocol_copyMethodDescriptionListSpan(Protocol *, BOOL isRequiredMethod, BOOL isInstanceMethod);
 WTF_EXPORT_PRIVATE MallocSpan<objc_property_t, SystemMalloc> protocol_copyPropertyListSpan(Protocol *);
 WTF_EXPORT_PRIVATE MallocSpan<__unsafe_unretained Protocol *, SystemMalloc> protocol_copyProtocolListSpan(Protocol *);
@@ -53,6 +54,7 @@ WTF_EXPORT_PRIVATE MallocSpan<__unsafe_unretained Protocol *, SystemMalloc> prot
 } // namespace WTF
 
 using WTF::class_copyMethodListSpan;
+using WTF::class_copyPropertyListSpan;
 using WTF::class_copyProtocolListSpan;
 using WTF::protocol_copyMethodDescriptionListSpan;
 using WTF::protocol_copyPropertyListSpan;

--- a/Source/WTF/wtf/ObjCRuntimeExtras.mm
+++ b/Source/WTF/wtf/ObjCRuntimeExtras.mm
@@ -45,6 +45,13 @@ MallocSpan<__unsafe_unretained Protocol *, SystemMalloc> class_copyProtocolListS
     return adoptMallocSpan<__unsafe_unretained Protocol *, SystemMalloc>(unsafeMakeSpan(protocols, protocolCount));
 }
 
+MallocSpan<objc_property_t, SystemMalloc> class_copyPropertyListSpan(Class cls)
+{
+    unsigned propertyCount = 0;
+    auto* properties = class_copyPropertyList(cls, &propertyCount);
+    return adoptMallocSpan<objc_property_t, SystemMalloc>(unsafeMakeSpan(properties, propertyCount));
+}
+
 MallocSpan<objc_method_description, SystemMalloc> protocol_copyMethodDescriptionListSpan(Protocol *protocol, BOOL isRequiredMethod, BOOL isInstanceMethod)
 {
     unsigned methodCount = 0;

--- a/Source/WebCore/platform/ios/ColorIOS.mm
+++ b/Source/WebCore/platform/ios/ColorIOS.mm
@@ -31,8 +31,6 @@
 #import "ColorSpaceCG.h"
 #import <UIKit/UIKit.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 Color colorFromCocoaColor(UIColor *color)
@@ -65,7 +63,5 @@ Color colorFromCocoaColor(UIColor *color)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebCore/platform/ios/KeyEventIOS.mm
+++ b/Source/WebCore/platform/ios/KeyEventIOS.mm
@@ -36,13 +36,11 @@
 #import <pal/spi/cocoa/IOKitSPI.h>
 #import <wtf/MainThread.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 int windowsKeyCodeForKeyCode(uint16_t keyCode)
 {
-    static const int windowsKeyCode[] = {
+    static constexpr auto windowsKeyCode = std::to_array<int>({
         /* 0 */ 0, // n/a
         /* 1 */ 0, // n/a
         /* 2 */ 0, // n/a
@@ -173,7 +171,7 @@ int windowsKeyCodeForKeyCode(uint16_t keyCode)
         /* 0x7F */ VK_VOLUME_MUTE, // Mute
         /* 0x80 */ VK_VOLUME_UP, // Volume Up
         /* 0x81 */ VK_VOLUME_DOWN, // Volume Down
-    };
+    });
     // Check if key is a modifier or the keypad comma (on JIS keyboard).
     switch (keyCode) {
     case kHIDUsage_KeypadComma:
@@ -343,7 +341,5 @@ OptionSet<PlatformEvent::Modifier> PlatformKeyboardEvent::currentStateOfModifier
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/ios/WebAVPlayerController.mm
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.mm
@@ -42,8 +42,6 @@
 #import <pal/cf/CoreMediaSoftLink.h>
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 SOFTLINK_AVKIT_FRAMEWORK()
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVPlayerController)
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVTimeRange)
@@ -130,19 +128,14 @@ static double WebAVPlayerControllerLiveStreamSeekableTimeRangeMinimumDuration = 
     if (!propertyNameFromKeyPath.length)
         return target;
 
-    unsigned count;
-    objc_property_t *properties = class_copyPropertyList([_playerController class], &count);
-
-    for (unsigned i = 0; i < count; i++) {
-        objc_property_t property = properties[i];
+    auto properties = class_copyPropertyListSpan([_playerController class]);
+    for (auto& property : properties.span()) {
         NSString *propertyName = [NSString stringWithUTF8String:property_getName(property)];
         if ([propertyNameFromKeyPath isEqualToString:propertyName]) {
             target = _playerController.get();
             break;
         }
     }
-
-    free(properties);
     return target;
 }
 
@@ -1306,8 +1299,6 @@ Class webAVPlayerControllerClass()
 #endif
 
 @end
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // PLATFORM(COCOA) && HAVE(AVKIT)
 

--- a/Source/WebCore/platform/ios/WebCoreMotionManager.mm
+++ b/Source/WebCore/platform/ios/WebCoreMotionManager.mm
@@ -38,8 +38,6 @@
 #import <wtf/MathExtras.h>
 #import <wtf/SoftLinking.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 // Get CoreLocation classes
 SOFT_LINK_FRAMEWORK(CoreLocation)
 
@@ -328,7 +326,5 @@ static const double kGravity = 9.80665;
 }
 
 @end
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif


### PR DESCRIPTION
#### 6bc128b53130a47567d6834b973d00bfe0e41275
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN in iOS-specific files
<a href="https://bugs.webkit.org/show_bug.cgi?id=285494">https://bugs.webkit.org/show_bug.cgi?id=285494</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/ObjCRuntimeExtras.h:
* Source/WTF/wtf/ObjCRuntimeExtras.mm:
(WTF::class_copyPropertyListSpan):
* Source/WebCore/platform/ios/ColorIOS.mm:
* Source/WebCore/platform/ios/KeyEventIOS.mm:
(WebCore::windowsKeyCodeForKeyCode):
* Source/WebCore/platform/ios/WebAVPlayerController.mm:
(-[WebAVPlayerControllerForwarder _forwardingTargetForKeyPath:]):
* Source/WebCore/platform/ios/WebCoreMotionManager.mm:
* Source/WebCore/platform/ios/wak/WKGraphics.mm:
(_FillRectsUsingOperation):
(WKRectFill):
* Source/WebCore/platform/ios/wak/WKView.mm:
(_WKViewGetAncestorViewsIncludingView):
(WKViewConvertPointFromBase):
(WKViewConvertRectFromBase):

Canonical link: <a href="https://commits.webkit.org/288531@main">https://commits.webkit.org/288531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3807fd1077ae6131f83d772189ce7f06eb3fc5e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34667 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11234 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65073 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22884 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76014 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45361 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2389 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30223 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33716 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76622 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/30969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90109 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/82676 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7885 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73512 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72737 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/16992 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15693 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2248 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12918 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10876 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16348 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105093 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10724 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25399 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14199 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12496 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->