### PR TITLE
REGRESSION(287869@main?): [macOS Debug wk2] ASSERTION FAILED: frame->presentationTime() >= m_lastMuxedSampleStartTime in WebCore::MediaRecorderPrivateEncoder::interleaveAndEnqueueNextFrame()

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1938,8 +1938,4 @@ webkit.org/b/284492 [ Sequoia+ ] imported/w3c/web-platform-tests/fetch/api/cors/
 
 webkit.org/b/232282 [ Ventura+ ] fast/scrolling/mac/scrollbars/overlay-scrollbar-hovered.html [ Pass Failure ]
 
-# webkit.org/b/284853 REGRESSION(287869@main?): [macOS Debug wk2] ASSERTION FAILED: WebCore::MediaRecorderPrivateEncoder::interleaveAndEnqueueNextFrame() in http/wpt/mediarecorder tests (flaky in EWS)
-[ Debug ] http/wpt/mediarecorder/MediaRecorder-video-bitrate.html [ Skip ]
-[ Debug ] http/wpt/mediarecorder/pause-recording.html [ Skip ]
-
 webkit.org/b/285033 [ Ventura+ ] http/tests/download/sandboxed-iframe-download-not-allowed.html [ Pass Failure ]

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h
@@ -98,7 +98,6 @@ private:
 
     Ref<FragmentedSharedBuffer> takeData();
 
-    MediaTime nextVideoFrameTime(const MediaTime&);
     MediaTime lastMuxedSampleTime() const;
 
     void generateMIMEType();
@@ -108,7 +107,7 @@ private:
     RefPtr<AudioSampleBufferConverter> audioConverter() const;
     void enqueueCompressedAudioSampleBuffers();
 
-    void appendVideoFrame(const MediaTime&, Ref<VideoFrame>&&);
+    void appendVideoFrame(MediaTime, Ref<VideoFrame>&&);
     Ref<GenericPromise> encodePendingVideoFrames();
     void processVideoEncoderActiveConfiguration(const VideoEncoder::Config&, const VideoEncoderActiveConfiguration&);
     void enqueueCompressedVideoFrame(VideoEncoder::EncodedFrame&&);
@@ -132,6 +131,7 @@ private:
     bool m_writerIsStarted WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { false };
     bool m_writerIsClosed WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { false };
     MediaTime m_lastMuxedSampleStartTime WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    bool m_lastMuxedSampleIsVideo WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { false };
     MediaTime m_lastMuxedAudioSampleEndTime WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     bool m_hasMuxedAudioFrameSinceEndSegment WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { false };
     bool m_hasMuxedVideoFrameSinceEndSegment WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { false };
@@ -172,12 +172,11 @@ private:
     Deque<UniqueRef<MediaSamplesBlock>> m_encodedVideoFrames WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     Deque<UniqueRef<MediaSamplesBlock>> m_interleavedFrames WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     bool m_firstVideoFrameProcessed WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { false };
+    std::optional<MonotonicTime> m_currentVideoSegmentStartTime WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    uint64_t m_previousSegmentVideoDurationUs WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { 0 };
     MediaTime m_lastEnqueuedRawVideoFrame WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { MediaTime::negativeInfiniteTime() };
     MediaTime m_lastVideoKeyframeTime WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     MediaTime m_lastReceivedCompressedVideoFrame WTF_GUARDED_BY_CAPABILITY(queueSingleton()) { MediaTime::negativeInfiniteTime() };
-    MediaTime m_currentVideoDuration WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    std::optional<MediaTime> m_firstVideoFrameTime WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    std::optional<MonotonicTime> m_resumeWallTime WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     std::optional<CGAffineTransform> m_videoTransform;
     RefPtr<GenericNonExclusivePromise> m_videoEncoderCreationPromise;
 


### PR DESCRIPTION
#### f75e1eb03f2587e613a564ac94c78089b07beb95
<pre>
REGRESSION(287869@main?): [macOS Debug wk2] ASSERTION FAILED: frame-&gt;presentationTime() &gt;= m_lastMuxedSampleStartTime in WebCore::MediaRecorderPrivateEncoder::interleaveAndEnqueueNextFrame()
<a href="https://bugs.webkit.org/show_bug.cgi?id=284853">https://bugs.webkit.org/show_bug.cgi?id=284853</a>
<a href="https://rdar.apple.com/141646476">rdar://141646476</a>

Reviewed by Youenn Fablet.

This is a tentative fix involving four parts:
- We remove the assertion as it was mostly in place for development purposes; instead we log the errors.
  The assertion would normally occur if the incoming data was going to cause an invalid webm (non monotonically increasing timestamps).
- Add assertion that the compressed frames timestamp are increasing monotonically as it&apos;s one explanation that
  would trigger the earlier assertion with http/wpt/mediarecorder/MediaRecorder-video-bitrate.html
- Calculate the incoming video frame time at the time it is received to reduce the likelihood of frames
  having the same timestamp.
- Drop incoming video frames as soon as the pause() has been called as it could have caused
  an invalid calculation of the video frame time due to inconsistency between m_currentVideoDuration and m_resumeWallTime

Covered by existing tests, re-enable tests skipped in 287971@main.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::pause):
(WebCore::MediaRecorderPrivateEncoder::resume):
(WebCore::MediaRecorderPrivateEncoder::appendVideoFrame):
(WebCore::MediaRecorderPrivateEncoder::enqueueCompressedVideoFrame):
(WebCore::MediaRecorderPrivateEncoder::interleaveAndEnqueueNextFrame):
(WebCore::MediaRecorderPrivateEncoder::currentTime const):
(WebCore::MediaRecorderPrivateEncoder::currentEndTime const):
(WebCore::MediaRecorderPrivateEncoder::nextVideoFrameTime): Deleted. Perform the calculation in appendVideoFrame instead.
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h:

Canonical link: <a href="https://commits.webkit.org/288583@main">https://commits.webkit.org/288583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b0dda42ddaa146125f43660ef22405b2e9e4039

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88881 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34816 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65186 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23019 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45475 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2521 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30367 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33865 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90258 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7998 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73629 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72851 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18017 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17123 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2397 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11025 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16497 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10873 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14348 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12645 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->