### PR TITLE
[SVG2] Add support for the 'ch' length type (except upright vertical ch)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL ch unit in SVGLength undefined is not an object (evaluating 'ch_length.unitType')
-FAIL Convert back to ch from new user unit value undefined is not an object (evaluating 'ch_length.value = ref_width * 4')
-FAIL upright vertical ch unit in SVGLength undefined is not an object (evaluating 'ch_length.value')
+PASS ch unit in SVGLength
+PASS Convert back to ch from new user unit value
+FAIL upright vertical ch unit in SVGLength assert_approx_equals: expected 200 +/- 0.1 but got 100
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt
@@ -1,0 +1,5 @@
+
+PASS ch unit in SVGLength
+PASS Convert back to ch from new user unit value
+PASS upright vertical ch unit in SVGLength
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt
@@ -1,0 +1,5 @@
+
+PASS ch unit in SVGLength
+PASS Convert back to ch from new user unit value
+FAIL upright vertical ch unit in SVGLength assert_approx_equals: expected 181.828125 +/- 0.1 but got 100
+

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) Research In Motion Limited 2011. All rights reserved.
- * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -58,14 +58,17 @@ private:
     ExceptionOr<float> convertValueFromPercentageToUserUnits(float value, SVGLengthMode) const;
     static float convertValueFromPercentageToUserUnits(float value, SVGLengthMode, FloatSize);
 
-    ExceptionOr<float> convertValueFromUserUnitsToEMS(float value) const;
-    ExceptionOr<float> convertValueFromEMSToUserUnits(float value) const;
+    ExceptionOr<float> convertValueFromUserUnitsToEMS(float) const;
+    ExceptionOr<float> convertValueFromEMSToUserUnits(float) const;
 
-    ExceptionOr<float> convertValueFromUserUnitsToEXS(float value) const;
-    ExceptionOr<float> convertValueFromEXSToUserUnits(float value) const;
+    ExceptionOr<float> convertValueFromUserUnitsToEXS(float) const;
+    ExceptionOr<float> convertValueFromEXSToUserUnits(float) const;
 
-    ExceptionOr<float> convertValueFromUserUnitsToLh(float value) const;
-    ExceptionOr<float> convertValueFromLhToUserUnits(float value) const;
+    ExceptionOr<float> convertValueFromUserUnitsToLh(float) const;
+    ExceptionOr<float> convertValueFromLhToUserUnits(float) const;
+
+    ExceptionOr<float> convertValueFromUserUnitsToCh(float) const;
+    ExceptionOr<float> convertValueFromChToUserUnits(float) const;
 
     std::optional<FloatSize> computeViewportSize() const;
 

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -62,6 +62,8 @@ static inline ASCIILiteral lengthTypeToString(SVGLengthType lengthType)
         return "pc"_s;
     case SVGLengthType::Lh:
         return "lh"_s;
+    case SVGLengthType::Ch:
+        return "ch"_s;
     }
 
     ASSERT_NOT_REACHED();
@@ -102,6 +104,8 @@ template<typename CharacterType> static inline SVGLengthType parseLengthType(Str
         return SVGLengthType::Picas;
     if (compareCharacters(firstCharacterPosition, 'l', 'h'))
         return SVGLengthType::Lh;
+    if (compareCharacters(firstCharacterPosition, 'c', 'h'))
+        return SVGLengthType::Ch;
 
     return SVGLengthType::Unknown;
 }
@@ -133,6 +137,8 @@ static inline SVGLengthType primitiveTypeToLengthType(CSSUnitType primitiveType)
         return SVGLengthType::Picas;
     case CSSUnitType::CSS_LH:
         return SVGLengthType::Lh;
+    case CSSUnitType::CSS_CH:
+        return SVGLengthType::Ch;
     default:
         return SVGLengthType::Unknown;
     }
@@ -167,6 +173,8 @@ static inline CSSUnitType lengthTypeToPrimitiveType(SVGLengthType lengthType)
         return CSSUnitType::CSS_PC;
     case SVGLengthType::Lh:
         return CSSUnitType::CSS_LH;
+    case SVGLengthType::Ch:
+        return CSSUnitType::CSS_CH;
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/svg/SVGLengthValue.h
+++ b/Source/WebCore/svg/SVGLengthValue.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -44,7 +44,8 @@ enum class SVGLengthType : uint8_t {
     Inches,
     Points,
     Picas,
-    Lh
+    Lh,
+    Ch
 };
 
 enum class SVGLengthMode : uint8_t {
@@ -78,7 +79,7 @@ public:
     SVGLengthMode lengthMode() const { return m_lengthMode; }
 
     bool isZero() const { return !m_valueInSpecifiedUnits;  }
-    bool isRelative() const { return m_lengthType == SVGLengthType::Percentage || m_lengthType == SVGLengthType::Ems || m_lengthType == SVGLengthType::Exs; }
+    bool isRelative() const { return m_lengthType == SVGLengthType::Percentage || m_lengthType == SVGLengthType::Ems || m_lengthType == SVGLengthType::Exs || m_lengthType == SVGLengthType::Ch; }
 
     float value(const SVGLengthContext&) const;
     float valueAsPercentage() const { return m_lengthType == SVGLengthType::Percentage ? m_valueInSpecifiedUnits / 100 : m_valueInSpecifiedUnits; }


### PR DESCRIPTION
#### 946f8386af931fbf76efce3902c4357670843b69
<pre>
[SVG2] Add support for the &apos;ch&apos; length type (except upright vertical ch)

<a href="https://bugs.webkit.org/show_bug.cgi?id=285498">https://bugs.webkit.org/show_bug.cgi?id=285498</a>
<a href="https://rdar.apple.com/142463263">rdar://142463263</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

This patch adds support for `ch` (character width) length type for SVGLength,
similar to other length types.

Although, this does not add support for `upright vertical character width`
at least on Apple ports.

* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::convertValueToUserUnits const):
(WebCore::SVGLengthContext::convertValueFromUserUnits const):
(WebCore::SVGLengthContext::convertValueFromUserUnitsToCh const):
(WebCore::SVGLengthContext::convertValueFromChToUserUnits const):
* Source/WebCore/svg/SVGLengthContext.h: Removed `value` as argument from functions as well
* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::lengthTypeToString):
(WebCore::parseLengthType):
(WebCore::primitiveTypeToLengthType):
(WebCore::lengthTypeToPrimitiveType):
* Source/WebCore/svg/SVGLengthValue.h:
(WebCore::SVGLengthValue::isRelative const):
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt: Rebaselined
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ch-expected.txt:

Canonical link: <a href="https://commits.webkit.org/288558@main">https://commits.webkit.org/288558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7dca18197be242c5b8227d9462c080a0fc0bcf74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88808 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34744 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65136 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22969 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45425 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2470 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30299 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33793 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31046 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90186 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11001 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7950 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73576 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11225 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71912 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/72799 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18005 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17063 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15763 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10953 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16425 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10801 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14276 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12573 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->