### PR TITLE
Get sendReportToEndpoints to accept a span

### DIFF
--- a/Source/WebCore/Modules/reporting/ReportingClient.h
+++ b/Source/WebCore/Modules/reporting/ReportingClient.h
@@ -41,7 +41,7 @@ struct WEBCORE_EXPORT ReportingClient {
 
     virtual void notifyReportObservers(Ref<Report>&&) = 0;
     virtual String endpointURIForToken(const String&) const = 0;
-    virtual void sendReportToEndpoints(const URL& baseURL, const Vector<String>& endpointURIs, const Vector<String>& endpointTokens, Ref<FormData>&& report, ViolationReportType) = 0;
+    virtual void sendReportToEndpoints(const URL& baseURL, std::span<const String> endpointURIs, std::span<const String> endpointTokens, Ref<FormData>&& report, ViolationReportType) = 0;
     virtual String httpUserAgent() const = 0;
 };
 

--- a/Source/WebCore/Modules/reporting/ReportingScope.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingScope.cpp
@@ -181,7 +181,8 @@ void ReportingScope::generateTestReport(String&& message, String&& group)
         if (group.isNull())
             group = "default"_s;
         
-        document->sendReportToEndpoints(testReportURL, { }, { group }, WTFMove(reportFormData), ViolationReportType::Test);
+        FixedVector endpoints { group };
+        document->sendReportToEndpoints(testReportURL, { }, WTFMove(endpoints), WTFMove(reportFormData), ViolationReportType::Test);
     }
 
     auto bodyType = testReportBody->type();

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10879,7 +10879,7 @@ String Document::httpUserAgent() const
     return userAgent(url());
 }
 
-void Document::sendReportToEndpoints(const URL& baseURL, const Vector<String>& endpointURIs, const Vector<String>& endpointTokens, Ref<FormData>&& report, ViolationReportType reportType)
+void Document::sendReportToEndpoints(const URL& baseURL, std::span<const String> endpointURIs, std::span<const String> endpointTokens, Ref<FormData>&& report, ViolationReportType reportType)
 {
     for (auto& url : endpointURIs)
         PingLoader::sendViolationReport(*frame(), URL { baseURL, url }, report.copyRef(), reportType);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1945,7 +1945,7 @@ public:
     bool hasSleepDisabler() const { return !!m_sleepDisabler; }
 
     void notifyReportObservers(Ref<Report>&&) final;
-    void sendReportToEndpoints(const URL& baseURL, const Vector<String>& endpointURIs, const Vector<String>& endpointTokens, Ref<FormData>&& report, ViolationReportType) final;
+    void sendReportToEndpoints(const URL& baseURL, std::span<const String> endpointURIs, std::span<const String> endpointTokens, Ref<FormData>&& report, ViolationReportType) final;
     String httpUserAgent() const final;
 
     virtual void didChangeViewSize() { }

--- a/Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp
+++ b/Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp
@@ -125,7 +125,8 @@ void sendCOEPInheritenceViolation(ReportingClient& reportingClient, const URL& e
         body.setString("type"_s, type);
         body.setString("blockedURL"_s, PingLoader::sanitizeURLForReport(blockedURL));
     });
-    reportingClient.sendReportToEndpoints(embedderURL, { }, { endpoint }, WTFMove(reportFormData), ViolationReportType::COEPInheritenceViolation);
+    FixedVector endpoints { endpoint };
+    reportingClient.sendReportToEndpoints(embedderURL, { }, WTFMove(endpoints), WTFMove(reportFormData), ViolationReportType::COEPInheritenceViolation);
 }
 
 // https://fetch.spec.whatwg.org/#queue-a-cross-origin-embedder-policy-corp-violation-report
@@ -144,7 +145,8 @@ void sendCOEPCORPViolation(ReportingClient& reportingClient, const URL& embedder
         body.setString("blockedURL"_s, PingLoader::sanitizeURLForReport(blockedURL));
         body.setString("destination"_s, convertEnumerationToString(destination));
     });
-    reportingClient.sendReportToEndpoints(embedderURL, { }, { endpoint }, WTFMove(reportFormData), ViolationReportType::CORPViolation);
+    FixedVector endpoints { endpoint };
+    reportingClient.sendReportToEndpoints(embedderURL, { }, WTFMove(endpoints), WTFMove(reportFormData), ViolationReportType::CORPViolation);
 }
 
 void CrossOriginEmbedderPolicy::encode(WTF::Persistence::Encoder& encoder) const

--- a/Source/WebCore/loader/CrossOriginOpenerPolicy.cpp
+++ b/Source/WebCore/loader/CrossOriginOpenerPolicy.cpp
@@ -92,7 +92,8 @@ static void sendViolationReportWhenNavigatingToCOOPResponse(ReportingClient& rep
         body.setString("type"_s, "navigation-to-response"_s);
         body.setString("referrer"_s, referrer);
     });
-    reportingClient.sendReportToEndpoints(coopURL, { }, { endpoint }, WTFMove(report), ViolationReportType::CrossOriginOpenerPolicy);
+    FixedVector endpoints { endpoint };
+    reportingClient.sendReportToEndpoints(coopURL, { }, WTFMove(endpoints), WTFMove(report), ViolationReportType::CrossOriginOpenerPolicy);
 }
 
 // https://html.spec.whatwg.org/multipage/origin.html#coop-violation-navigation-from
@@ -109,7 +110,8 @@ static void sendViolationReportWhenNavigatingAwayFromCOOPResponse(ReportingClien
         body.setString("type"_s, "navigation-from-response"_s);
     });
 
-    reportingClient.sendReportToEndpoints(coopURL, { }, { endpoint }, WTFMove(report), ViolationReportType::CrossOriginOpenerPolicy);
+    FixedVector endpoints { endpoint };
+    reportingClient.sendReportToEndpoints(coopURL, { }, WTFMove(endpoints), WTFMove(report), ViolationReportType::CrossOriginOpenerPolicy);
 }
 
 // https://html.spec.whatwg.org/multipage/origin.html#matching-coop

--- a/Source/WebCore/loader/SubresourceIntegrity.cpp
+++ b/Source/WebCore/loader/SubresourceIntegrity.cpp
@@ -223,7 +223,7 @@ void reportHashesIfNeeded(const CachedResource& resource)
         return;
 
     bool canExposeHashes = isResponseEligible(resource);
-    for (auto& [algorithmSet, fixedEndpoints] : hashesToReport) {
+    for (auto& [algorithmSet, endpoints] : hashesToReport) {
         auto hashAlgorithm = findStrongestAlgorithm(algorithmSet);
         if (!hashAlgorithm)
             return;
@@ -238,10 +238,7 @@ void reportHashesIfNeeded(const CachedResource& resource)
             body.setString("type"_s, "subresource"_s);
             body.setString("destination"_s, "script"_s);
         });
-        Vector<String> endpoints;
-        for (auto endpoint : fixedEndpoints)
-            endpoints.append(endpoint);
-        document->sendReportToEndpoints(documentURL, { }, WTFMove(endpoints), WTFMove(report), ViolationReportType::CSPHashReport);
+        document->sendReportToEndpoints(documentURL, { }, endpoints, WTFMove(report), ViolationReportType::CSPHashReport);
     }
 }
 

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -779,7 +779,7 @@ String WorkerGlobalScope::endpointURIForToken(const String& token) const
     return reportingScope().endpointURIForToken(token);
 }
 
-void WorkerGlobalScope::sendReportToEndpoints(const URL&, const Vector<String>& /*endpointURIs*/, const Vector<String>& /*endpointTokens*/, Ref<FormData>&&, ViolationReportType)
+void WorkerGlobalScope::sendReportToEndpoints(const URL&, const std::span<const String> /*endpointURIs*/, const std::span<const String> /*endpointTokens*/, Ref<FormData>&&, ViolationReportType)
 {
     notImplemented();
 }

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -215,7 +215,7 @@ private:
     // ReportingClient.
     void notifyReportObservers(Ref<Report>&&) final;
     String endpointURIForToken(const String&) const final;
-    void sendReportToEndpoints(const URL& baseURL, const Vector<String>& endpointURIs, const Vector<String>& endpointTokens, Ref<FormData>&& report, ViolationReportType) final;
+    void sendReportToEndpoints(const URL& baseURL, const std::span<const String> endpointURIs, const std::span<const String> endpointTokens, Ref<FormData>&& report, ViolationReportType) final;
     String httpUserAgent() const final { return m_userAgent; }
 
     URL m_url;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -2095,7 +2095,7 @@ String NetworkResourceLoader::endpointURIForToken(const String& reportTo) const
     return m_reportingEndpoints.get(reportTo);
 }
 
-void NetworkResourceLoader::sendReportToEndpoints(const URL& baseURL, const Vector<String>& endpointURIs, const Vector<String>& endpointTokens, Ref<FormData>&& report, WebCore::ViolationReportType reportType)
+void NetworkResourceLoader::sendReportToEndpoints(const URL& baseURL, std::span<const String> endpointURIs, std::span<const String> endpointTokens, Ref<FormData>&& report, WebCore::ViolationReportType reportType)
 {
     Vector<String> updatedEndpointURIs = endpointURIs;
     Vector<String> updatedEndpointTokens;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -270,7 +270,7 @@ private:
     // ReportingClient
     void notifyReportObservers(Ref<WebCore::Report>&&) final;
     String endpointURIForToken(const String&) const final;
-    void sendReportToEndpoints(const URL& baseURL, const Vector<String>& endpointURIs, const Vector<String>& endpointTokens, Ref<WebCore::FormData>&& report, WebCore::ViolationReportType) final;
+    void sendReportToEndpoints(const URL& baseURL, std::span<const String> endpointURIs, std::span<const String> endpointTokens, Ref<WebCore::FormData>&& report, WebCore::ViolationReportType) final;
     String httpUserAgent() const final { return originalRequest().httpUserAgent(); }
     void initializeReportingEndpoints(const WebCore::ResourceResponse&);
     WebCore::FrameIdentifier frameIdentifierForReport() const;


### PR DESCRIPTION
#### d2bb4ab5a2b69cd3be0e5b0b64de0bed7436ab09
<pre>
Get sendReportToEndpoints to accept a span

<a href="https://bugs.webkit.org/show_bug.cgi?id=285500">https://bugs.webkit.org/show_bug.cgi?id=285500</a>

Reviewed by NOBODY (OOPS!).

To reduce some needless conversion from FixedVector to Vector, this PR
ensures that sendReportToEndpoints accepts both as input.

Followup based on <a href="https://github.com/WebKit/WebKit/pull/38282#discussion_r1904367684">https://github.com/WebKit/WebKit/pull/38282#discussion_r1904367684</a>

* Source/WebCore/Modules/reporting/ReportingClient.h: s/const
  Vector&lt;String&gt;&amp;/std::span&lt;const String&gt;/
* Source/WebCore/Modules/reporting/ReportingScope.cpp:
(WebCore::ReportingScope::generateTestReport): Pass a FixedVector
instead of an initializer list.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::sendReportToEndpoints): s/const
  Vector&lt;String&gt;&amp;/std::span&lt;const String&gt;/
* Source/WebCore/dom/Document.h: s/const
  Vector&lt;String&gt;&amp;/std::span&lt;const String&gt;/
* Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp:
(WebCore::sendCOEPInheritenceViolation): Pass a FixedVector
instead of an initializer list.
(WebCore::sendCOEPCORPViolation): Pass a FixedVector
instead of an initializer list.
* Source/WebCore/loader/CrossOriginOpenerPolicy.cpp:
(WebCore::sendViolationReportWhenNavigatingToCOOPResponse): Pass a FixedVector
instead of an initializer list.
(WebCore::sendViolationReportWhenNavigatingAwayFromCOOPResponse): Pass a FixedVector
instead of an initializer list.
* Source/WebCore/loader/SubresourceIntegrity.cpp:
(WebCore::reportHashesIfNeeded): Remove conversion to Vector.
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::reportViolation const): WTFMove the
passed vectors.
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::sendReportToEndpoints): s/const
  Vector&lt;String&gt;&amp;/std::span&lt;const String&gt;/
* Source/WebCore/workers/WorkerGlobalScope.h: s/const
  Vector&lt;String&gt;&amp;/std::span&lt;const String&gt;/
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::sendReportToEndpoints): s/const
  Vector&lt;String&gt;&amp;/std::span&lt;const String&gt;/
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h: s/const
  Vector&lt;String&gt;&amp;/std::span&lt;const String&gt;/
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2bb4ab5a2b69cd3be0e5b0b64de0bed7436ab09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36036 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12685 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66133 "Found 2 new test failures: fast/text/basic/013.html fast/text/basic/generic-family-changes.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23950 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77230 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46399 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31458 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35109 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91502 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74615 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73735 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18127 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16579 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4346 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12272 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17724 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12108 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15604 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->