### PR TITLE
SVGScriptElement.className.baseVal erroneously covered by trusted types

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-set-href-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-set-href-expected.txt
@@ -8,9 +8,17 @@ PASS Assign string to non-attached SVGScriptElement.href via setAttribute.
 PASS Assign TrustedScriptURL to non-attached SVGScriptElement.href via setAttribute.
 PASS Assign string to attached SVGScriptElement.href via setAttribute.
 PASS Assign TrustedScriptURL to attached SVGScriptElement.href via setAttribute.
+PASS Assign string to SVGScriptElement.className.baseVal.
+PASS Assign TrustedScriptURL to SVGScriptElement.className.baseVal.
+PASS Assign string to SVGUseElement.href.baseVal.
+PASS Assign TrustedScriptURL to SVGUseElement.href.baseVal.
 PASS Setup default policy
 PASS Assign String to SVGScriptElement.innerHTML w/ default policy.
 PASS Assign string to SVGScriptElement.href.baseVal  w/ default policy.
 PASS Assign string to non-attached SVGScriptElement.href via setAttribute w/ default policy.
 PASS Assign string to attached SVGScriptElement.href via setAttribute w/ default policy.
+PASS Assign string to SVGScriptElement.className.baseVal w/ default policy.
+PASS Assign TrustedScriptURL to SVGScriptElement.className.baseVal w/ default policy.
+PASS Assign string to SVGUseElement.href.baseVal w/ default policy.
+PASS Assign TrustedScriptURL to SVGUseElement.href.baseVal w/ default policy.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-set-href.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-set-href.html
@@ -3,6 +3,7 @@
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="./support/resolve-spv.js"></script>
+  <script src="./support/namespaces.js"></script>
   <meta http-equiv="Content-Security-Policy"
         content="require-trusted-types-for 'script'">
 </head>
@@ -14,8 +15,7 @@
         createScript: x => x, createHTML: x => x, createScriptURL: x => x });
 
     promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
+      const elem = document.createElementNS(NSURI_SVG, "script");
       assert_throws_js(TypeError, _ => {
         elem.href.baseVal = "about:blank";
       });
@@ -24,16 +24,16 @@
     }, "Assign string to SVGScriptElement.href.baseVal.");
 
     promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
+      const elem = document.createElementNS(NSURI_SVG, "script");
       elem.href.baseVal = policy.createScriptURL("about:blank");
+      assert_equals(elem.href.baseVal, "about:blank");
+      assert_equals(elem.getAttribute("href"), "about:blank");
       document.getElementById("svg").appendChild(elem);
       return Promise.resolve();
     }, "Assign TrustedScriptURL to SVGScriptElement.href.baseVal.");
 
     promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
+      const elem = document.createElementNS(NSURI_SVG, "script");
       assert_throws_js(TypeError, _ => {
         elem.setAttribute("href", "about:blank");
       });
@@ -42,16 +42,16 @@
     }, "Assign string to non-attached SVGScriptElement.href via setAttribute.");
 
     promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
+      const elem = document.createElementNS(NSURI_SVG, "script");
       elem.setAttribute("href", policy.createScriptURL("about:blank"));
+      assert_equals(elem.href.baseVal, "about:blank");
+      assert_equals(elem.getAttribute("href"), "about:blank");
       document.getElementById("svg").appendChild(elem);
       return Promise.resolve();
     }, "Assign TrustedScriptURL to non-attached SVGScriptElement.href via setAttribute.");
 
     promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
+      const elem = document.createElementNS(NSURI_SVG, "script");
       document.getElementById("svg").appendChild(elem);
       assert_throws_js(TypeError, _ => {
         elem.setAttribute("href", "about:blank");
@@ -60,15 +60,48 @@
     }, "Assign string to attached SVGScriptElement.href via setAttribute.");
 
     promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
+      const elem = document.createElementNS(NSURI_SVG, "script");
       document.getElementById("svg").appendChild(elem);
       elem.setAttribute("href", policy.createScriptURL("about:blank"));
+      assert_equals(elem.href.baseVal, "about:blank");
+      assert_equals(elem.getAttribute("href"), "about:blank");
       return Promise.resolve();
     }, "Assign TrustedScriptURL to attached SVGScriptElement.href via setAttribute.");
 
-    // Default policy test: We repate the string assignment tests above,
-    // but now expect all of them to pass.
+    promise_test(t => {
+      const elem = document.createElementNS(NSURI_SVG, "script");
+      elem.className.baseVal = "myClass";
+      assert_equals(elem.className.baseVal, "myClass");
+      assert_equals(elem.getAttribute("class"), "myClass");
+      return Promise.resolve();
+    }, "Assign string to SVGScriptElement.className.baseVal.");
+
+    promise_test(t => {
+      const elem = document.createElementNS(NSURI_SVG, "script");
+      elem.className.baseVal = policy.createScriptURL("myClass");
+      assert_equals(elem.className.baseVal, "myClass");
+      assert_equals(elem.getAttribute("class"), "myClass");
+      return Promise.resolve();
+    }, "Assign TrustedScriptURL to SVGScriptElement.className.baseVal.");
+
+    promise_test(t => {
+      const elem = document.createElementNS(NSURI_SVG, "use");
+      elem.href.baseVal = "about:blank";
+      assert_equals(elem.href.baseVal, "about:blank");
+      assert_equals(elem.getAttribute("href"), "about:blank");
+      return Promise.resolve();
+    }, "Assign string to SVGUseElement.href.baseVal.");
+
+    promise_test(t => {
+      const elem = document.createElementNS(NSURI_SVG, "use");
+      elem.href.baseVal = policy.createScriptURL("about:blank");
+      assert_equals(elem.href.baseVal, "about:blank");
+      assert_equals(elem.getAttribute("href"), "about:blank");
+      return Promise.resolve();
+    }, "Assign TrustedScriptURL to SVGUseElement.href.baseVal.");
+
+    // Default policy test: We repeat the string assignment tests above,
+    // but now expect all assignments to succeed.
     promise_test(t => {
       trustedTypes.createPolicy("default", {
         createScript: (x, _, sink) => {
@@ -93,27 +126,62 @@
     }, "Assign String to SVGScriptElement.innerHTML w/ default policy.");
 
     promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
+      const elem = document.createElementNS(NSURI_SVG, "script");
       elem.href.baseVal = "about:blank";
+      assert_equals(elem.href.baseVal, "about:blank");
+      assert_equals(elem.getAttribute("href"), "about:blank");
       document.getElementById("svg").appendChild(elem);
       return Promise.resolve();
     }, "Assign string to SVGScriptElement.href.baseVal  w/ default policy.");
 
     promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
+      const elem = document.createElementNS(NSURI_SVG, "script");
       elem.setAttribute("href", "about:blank");
+      assert_equals(elem.href.baseVal, "about:blank");
+      assert_equals(elem.getAttribute("href"), "about:blank");
       document.getElementById("svg").appendChild(elem);
       return Promise.resolve();
     }, "Assign string to non-attached SVGScriptElement.href via setAttribute w/ default policy.");
 
     promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
+      const elem = document.createElementNS(NSURI_SVG, "script");
       document.getElementById("svg").appendChild(elem);
       elem.setAttribute("href", "about:blank");
+      assert_equals(elem.href.baseVal, "about:blank");
+      assert_equals(elem.getAttribute("href"), "about:blank");
       return Promise.resolve();
     }, "Assign string to attached SVGScriptElement.href via setAttribute w/ default policy.");
+
+    promise_test(t => {
+      const elem = document.createElementNS(NSURI_SVG, "script");
+      elem.className.baseVal = "myClass";
+      assert_equals(elem.className.baseVal, "myClass");
+      assert_equals(elem.getAttribute("class"), "myClass");
+      return Promise.resolve();
+    }, "Assign string to SVGScriptElement.className.baseVal w/ default policy.");
+
+    promise_test(t => {
+      const elem = document.createElementNS(NSURI_SVG, "script");
+      elem.className.baseVal = policy.createScriptURL("myClass");
+      assert_equals(elem.className.baseVal, "myClass");
+      assert_equals(elem.getAttribute("class"), "myClass");
+      return Promise.resolve();
+    }, "Assign TrustedScriptURL to SVGScriptElement.className.baseVal w/ default policy.");
+
+    promise_test(t => {
+      const elem = document.createElementNS(NSURI_SVG, "use");
+      elem.href.baseVal = "about:blank";
+      assert_equals(elem.href.baseVal, "about:blank");
+      assert_equals(elem.getAttribute("href"), "about:blank");
+      return Promise.resolve();
+    }, "Assign string to SVGUseElement.href.baseVal w/ default policy.");
+
+    promise_test(t => {
+      const elem = document.createElementNS(NSURI_SVG, "use");
+      elem.href.baseVal = policy.createScriptURL("about:blank");
+      assert_equals(elem.href.baseVal, "about:blank");
+      assert_equals(elem.getAttribute("href"), "about:blank");
+      return Promise.resolve();
+    }, "Assign TrustedScriptURL to SVGUseElement.href.baseVal w/ default policy.");
   </script>
 </body>

--- a/Source/WebCore/svg/SVGURIReference.cpp
+++ b/Source/WebCore/svg/SVGURIReference.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGURIReference);
 
 SVGURIReference::SVGURIReference(SVGElement* contextElement)
-    : m_href(SVGAnimatedString::create(contextElement))
+    : m_href(SVGAnimatedString::create(contextElement, IsHrefProperty::Yes))
 {
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {

--- a/Source/WebCore/svg/properties/SVGAnimatedString.cpp
+++ b/Source/WebCore/svg/properties/SVGAnimatedString.cpp
@@ -37,7 +37,7 @@ ExceptionOr<void> SVGAnimatedString::setBaseVal(const StringOrTrustedScriptURL& 
     auto stringValueHolder = WTF::switchOn(baseVal,
         [&](const String& str) -> ExceptionOr<String> {
             SVGElement* el = contextElement();
-            if (isScriptElement(*el))
+            if (isScriptElement(*el) && m_isHrefProperty == IsHrefProperty::Yes)
                 return trustedTypeCompliantString(TrustedType::TrustedScriptURL, *(contextElement()->document().scriptExecutionContext()), str, "SVGScriptElement href"_s);
             return String(str);
         },

--- a/Source/WebCore/svg/properties/SVGAnimatedString.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedString.h
@@ -31,23 +31,32 @@ namespace WebCore {
 
 class TrustedScriptURL;
 
+enum class IsHrefProperty : bool {
+    No,
+    Yes,
+};
+
 using StringOrTrustedScriptURL = std::variant<String, RefPtr<TrustedScriptURL>>;
 
 class SVGAnimatedString : public SVGAnimatedPrimitiveProperty<String> {
 public:
-    static Ref<SVGAnimatedString> create(SVGElement* contextElement)
+    static Ref<SVGAnimatedString> create(SVGElement* contextElement, const IsHrefProperty& isHrefProperty = IsHrefProperty::No)
     {
-        return adoptRef(*new SVGAnimatedString(contextElement));
+        return adoptRef(*new SVGAnimatedString(contextElement, isHrefProperty));
     }
 
     virtual ExceptionOr<void> setBaseVal(const StringOrTrustedScriptURL&);
 
 protected:
-    SVGAnimatedString(SVGElement* contextElement)
+    SVGAnimatedString(SVGElement* contextElement, const IsHrefProperty& isHrefProperty = IsHrefProperty::No)
         : SVGAnimatedPrimitiveProperty<String>(contextElement)
+        , m_isHrefProperty(isHrefProperty)
     {
 
     }
+
+private:
+    IsHrefProperty m_isHrefProperty;
 };
 
 }


### PR DESCRIPTION
#### 335fd43a016d8e26fa13dc6fba4e8207d73fea26
<pre>
SVGScriptElement.className.baseVal erroneously covered by trusted types
<a href="https://bugs.webkit.org/show_bug.cgi?id=285510">https://bugs.webkit.org/show_bug.cgi?id=285510</a>

Reviewed by Tim Nguyen.

This patch changes SVGAnimatedString to only go down the Trusted Types codepath
when the property being changed is href rather than any property for an SVGScriptElement.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-set-href-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-set-href.html:
* Source/WebCore/svg/SVGURIReference.cpp:
(WebCore::SVGURIReference::SVGURIReference):
* Source/WebCore/svg/properties/SVGAnimatedString.cpp:
(WebCore::SVGAnimatedString::setBaseVal):
* Source/WebCore/svg/properties/SVGAnimatedString.h:
(WebCore::SVGAnimatedString::create):
(WebCore::SVGAnimatedString::SVGAnimatedString):

Canonical link: <a href="https://commits.webkit.org/288602@main">https://commits.webkit.org/288602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9260da6bbd8407e2d015ba9320ee0a8805e8c652

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88771 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34707 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11274 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65106 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22942 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76050 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45395 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30260 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33756 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90149 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7917 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73545 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11188 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71875 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72769 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18031 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17029 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15729 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2288 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10916 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16388 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10764 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14239 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12536 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->