### PR TITLE
LibWebRTCAudioModule should implement GetStats

### DIFF
--- a/LayoutTests/webrtc/audio-playout-stats-expected.txt
+++ b/LayoutTests/webrtc/audio-playout-stats-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Audio silent data being sent in case track is muted
+

--- a/LayoutTests/webrtc/audio-playout-stats.html
+++ b/LayoutTests/webrtc/audio-playout-stats.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <audio controls id=audio></audio>
+        <script src ="routines.js"></script>
+        <script>
+function getAudioPlayoutStats(connection)
+{
+    return connection.getStats().then((report) => {
+        var stats;
+        report.forEach((statItem) => {
+            if (statItem.type === "media-playout") {
+                stats = statItem;
+            }
+        });
+        return stats;
+    });
+}
+
+async function validateAudioPlayoutStats(connection, counter)
+{
+    if (!counter)
+        counter = 0;
+
+    const stats = await getAudioPlayoutStats(connection);
+    if (stats && stats.totalSamplesCount && stats.totalPlayoutDelay && stats.totalSamplesDuration)
+        return true;
+
+   if (counter > 100)
+       return false;
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+    return validateAudioPlayoutStats(connection, ++counter);
+}
+
+promise_test(async test => {
+    let receivingConnection;
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true});
+    const remoteStream = await new Promise((resolve, reject) => {
+        createConnections((connection) => {
+            connection.addTrack(stream.getAudioTracks()[0], stream);
+        }, (connection) => {
+            receivingConnection = connection;
+            connection.ontrack = e => resolve(e.streams[0]);
+        });
+        setTimeout(() => reject("Test timed out"), 5000);
+    });
+    audio.srcObject = remoteStream;
+    await audio.play();
+
+    assert_true(await validateAudioPlayoutStats(receivingConnection));
+    audio.pause();
+}, "Audio silent data being sent in case track is muted");
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h
@@ -82,6 +82,8 @@ public:
     void setLogger(Ref<const Logger>&&, uint64_t);
 #endif
 
+    uint64_t bufferedAmount() const { return m_lastBufferedAmount; }
+
     static constexpr float EquivalentToMaxVolume = 0.95;
 
 private:
@@ -109,7 +111,7 @@ private:
     int64_t m_converterInputOffset { 0 };
     std::optional<int64_t> m_inputSampleOffset;
     int64_t m_outputSampleOffset { 0 };
-    uint64_t m_lastBufferedAmount { 0 };
+    std::atomic<uint64_t> m_lastBufferedAmount { 0 };
 
     AudioSampleDataConverter m_converter;
 

--- a/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp
+++ b/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp
@@ -159,7 +159,7 @@ void AudioTrackPrivateMediaStream::trackEnded(MediaStreamTrackPrivate&)
 
 void AudioTrackPrivateMediaStream::updateRenderer()
 {
-    if (!m_shouldPlay || !volume() || m_muted || m_streamTrack->muted() || m_streamTrack->ended() || !m_streamTrack->enabled()) {
+    if (!m_shouldPlay) {
         stopRenderer();
         return;
     }
@@ -199,8 +199,10 @@ void AudioTrackPrivateMediaStream::createNewRenderer()
 
     float volume = this->volume();
     m_renderer = createRenderer(*this);
-    if (RefPtr renderer = m_renderer)
-        renderer->setVolume(volume);
+    if (RefPtr renderer = m_renderer) {
+        bool shouldBeAudible = !m_muted && !m_streamTrack->muted() && !m_streamTrack->ended() && m_streamTrack->enabled();
+        renderer->setVolume(shouldBeAudible ? volume : 0);
+    }
 
     if (isPlaying)
         startRenderer();

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
@@ -62,12 +62,19 @@ AudioMediaStreamTrackRendererUnit::~AudioMediaStreamTrackRendererUnit() = defaul
 
 void AudioMediaStreamTrackRendererUnit::setLastDeviceUsed(const String& deviceID)
 {
-    if (supportsPerDeviceRendering())
+    if (supportsPerDeviceRendering()) {
+        Locker locker { m_unitForDelayLock };
+        m_unitForDelay = ensureDeviceUnit(deviceID);
         return;
+    }
 
     UNUSED_PARAM(deviceID);
     Ref unit = ensureDeviceUnit(AudioMediaStreamTrackRenderer::defaultDeviceID());
     unit->setLastDeviceUsed(deviceID);
+
+    Locker locker { m_unitForDelayLock };
+    if (!m_unitForDelay)
+        m_unitForDelay = WTFMove(unit);
 }
 
 void AudioMediaStreamTrackRendererUnit::deleteUnitsIfPossible()
@@ -140,6 +147,16 @@ void AudioMediaStreamTrackRendererUnit::retrieveFormatDescription(CompletionHand
 
     Ref unit = ensureDeviceUnit(AudioMediaStreamTrackRenderer::defaultDeviceID());
     unit->retrieveFormatDescription(WTFMove(callback));
+}
+
+AudioMediaStreamTrackRendererUnit::Stats AudioMediaStreamTrackRendererUnit::stats() const
+{
+    RefPtr<Unit> unitForDelay;
+    {
+        Locker locker { m_unitForDelayLock };
+        unitForDelay = m_unitForDelay;
+    }
+    return unitForDelay ? unitForDelay->stats() : Stats { };
 }
 
 AudioMediaStreamTrackRendererUnit::Unit::Unit(const String& deviceID)
@@ -217,7 +234,11 @@ void AudioMediaStreamTrackRendererUnit::Unit::setLastDeviceUsed(const String& de
 void AudioMediaStreamTrackRendererUnit::Unit::retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&& callback)
 {
     assertIsMainThread();
-    m_internalUnit->retrieveFormatDescription(WTFMove(callback));
+    m_internalUnit->retrieveFormatDescription([protectedThis = Ref { *this }, callback = WTFMove(callback)](auto&& result) mutable {
+        if (result)
+            protectedThis->m_sampleRate = result->sampleRate();
+        callback(WTFMove(result));
+    });
 }
 
 void AudioMediaStreamTrackRendererUnit::Unit::start()
@@ -276,6 +297,14 @@ OSStatus AudioMediaStreamTrackRendererUnit::Unit::render(size_t sampleCount, Aud
 
     updateRenderSourcesIfNecessary();
 
+    if (m_sampleRate) {
+        Locker locker(m_statsLock);
+        m_totalSamplesCount += sampleCount;
+        m_totalSamplesDuration += MediaTime(sampleCount, m_sampleRate);
+        double delay = sampleCount / m_sampleRate;
+        m_totalPlayoutDelay += sampleCount * delay;
+    }
+
     // Mix all sources.
     bool hasCopiedData = false;
     for (auto& source : m_renderSources) {
@@ -285,6 +314,16 @@ OSStatus AudioMediaStreamTrackRendererUnit::Unit::render(size_t sampleCount, Aud
     if (!hasCopiedData)
         actionFlags = kAudioUnitRenderAction_OutputIsSilence;
     return 0;
+}
+
+AudioMediaStreamTrackRendererUnit::Stats AudioMediaStreamTrackRendererUnit::Unit::stats() const
+{
+    Locker locker(m_statsLock);
+    return {
+        .totalSamplesDuration = m_totalSamplesDuration.toDouble(),
+        .totalPlayoutDelay = m_totalPlayoutDelay,
+        .totalSamplesCount = m_totalSamplesCount
+    };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
@@ -63,6 +63,13 @@ public:
     void removeSource(const String&, AudioSampleDataSource&) final;
     void addResetObserver(const String&, ResetObserver&) final;
 
+    struct Stats {
+        double totalSamplesDuration { 0 };
+        double totalPlayoutDelay { 0 };
+        uint64_t totalSamplesCount { 0 };
+    };
+    Stats stats() const;
+
 private:
     AudioMediaStreamTrackRendererUnit();
 
@@ -88,6 +95,8 @@ private:
         void retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&&);
         void setLastDeviceUsed(const String&);
 
+        Stats stats() const;
+
     private:
         explicit Unit(const String&);
 
@@ -109,6 +118,13 @@ private:
         const Ref<AudioMediaStreamTrackRendererInternalUnit> m_internalUnit WTF_GUARDED_BY_CAPABILITY(mainThread);
         WeakHashSet<ResetObserver> m_resetObservers WTF_GUARDED_BY_CAPABILITY(mainThread);
         const bool m_isDefaultUnit { false };
+
+        std::atomic<double> m_sampleRate { 0 };
+
+        uint64_t m_totalSamplesCount { 0 };
+        MediaTime m_totalSamplesDuration;
+        double m_totalPlayoutDelay { 0 };
+        mutable Lock m_statsLock;
     };
 
     Ref<Unit> ensureDeviceUnit(const String&);
@@ -116,6 +132,9 @@ private:
 
     HashMap<String, Ref<Unit>> m_units WTF_GUARDED_BY_CAPABILITY(mainThread);
     Timer m_deleteUnitsTimer;
+
+    mutable Lock m_unitForDelayLock;
+    RefPtr<Unit> m_unitForDelay WTF_GUARDED_BY_LOCK(m_unitForDelayLock);
 };
 
 }

--- a/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
@@ -216,7 +216,14 @@ void IncomingAudioMediaStreamTrackRendererUnit::renderAudioChunk(uint64_t curren
 
     uint64_t timeStamp = currentAudioSampleCount * m_outputStreamDescription->sampleRate() / LibWebRTCAudioFormat::sampleRate;
 
+    bool hasUpdatedDelay = false;
+    double currentDelay = 0;
     for (auto& renderMixer : m_renderMixers.values()) {
+        if (!hasUpdatedDelay) {
+            hasUpdatedDelay = true;
+            currentDelay = renderMixer.mixedSource->bufferedAmount() / m_outputStreamDescription->sampleRate();
+        }
+
         // Mix all sources.
         bool hasCopiedData = false;
         for (auto& source : renderMixer.inputSources) {
@@ -229,6 +236,21 @@ void IncomingAudioMediaStreamTrackRendererUnit::renderAudioChunk(uint64_t curren
             renderMixer.mixedSource->pushSamples(PAL::toMediaTime(startTime), *m_audioBufferList, m_sampleCount);
         renderMixer.writeCount += m_sampleCount;
     }
+    m_currentDelay = currentDelay;
+}
+
+auto IncomingAudioMediaStreamTrackRendererUnit::stats() -> Stats
+{
+    auto stats = AudioMediaStreamTrackRendererUnit::singleton().stats();
+
+    m_totalPlayoutDelay += (stats.totalSamplesCount - m_previousTotalSamplesCount) * m_currentDelay;
+    m_previousTotalSamplesCount = stats.totalSamplesCount;
+
+    return Stats {
+        .totalSamplesDuration = stats.totalSamplesDuration,
+        .totalPlayoutDelay = stats.totalPlayoutDelay + m_totalPlayoutDelay,
+        .totalSamplesCount = stats.totalSamplesCount
+    };
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
@@ -64,6 +64,13 @@ public:
     void ref() { m_audioModule.get()->ref(); };
     void deref() { m_audioModule.get()->deref(); };
 
+    struct Stats {
+        double totalSamplesDuration { 0 };
+        double totalPlayoutDelay { 0 };
+        uint64_t totalSamplesCount { 0 };
+    };
+    Stats stats();
+
 private:
     struct Mixer;
     void start(Mixer&);
@@ -111,6 +118,9 @@ private:
     std::unique_ptr<WebAudioBufferList> m_audioBufferList WTF_GUARDED_BY_CAPABILITY(m_queue.get());
     size_t m_sampleCount { 0 };
 
+    double m_totalPlayoutDelay { 0 };
+    uint64_t m_previousTotalSamplesCount { 0 };
+    std::atomic<double> m_currentDelay { 0 };
 #if !RELEASE_LOG_DISABLED
     RefPtr<const Logger> m_logger;
     const uint64_t m_logIdentifier;

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
@@ -157,6 +157,22 @@ BaseAudioMediaStreamTrackRendererUnit& LibWebRTCAudioModule::incomingAudioMediaS
 }
 #endif
 
+std::optional<LibWebRTCAudioModule::Stats> LibWebRTCAudioModule::GetStats() const
+{
+    if (!m_isRenderingIncomingAudioCounter)
+        return std::nullopt;
+
+    auto stats = m_incomingAudioMediaStreamTrackRendererUnit->stats();
+    if (!stats.totalSamplesCount)
+        return std::nullopt;
+
+    return LibWebRTCAudioModule::Stats {
+        .total_samples_duration_s = stats.totalSamplesDuration,
+        .total_playout_delay_s = stats.totalPlayoutDelay,
+        .total_samples_count = stats.totalSamplesCount
+    };
+}
+
 } // namespace WebCore
 
 #endif // USE(LIBWEBRTC)

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h
@@ -141,6 +141,8 @@ private:
     int GetRecordAudioParameters(webrtc::AudioParameters*) const final { return shouldNotBeCalled(-1); }
 #endif
 
+    std::optional<Stats> GetStats() const final;
+
 private:
     void pollAudioData();
     void pollFromSource();


### PR DESCRIPTION
#### 7bb205c7d63055c8ba96667a2abfcf880f5b6dab
<pre>
LibWebRTCAudioModule should implement GetStats
<a href="https://bugs.webkit.org/show_bug.cgi?id=285217">https://bugs.webkit.org/show_bug.cgi?id=285217</a>
<a href="https://rdar.apple.com/142122809">rdar://142122809</a>

Reviewed by NOBODY (OOPS!).

This patch implements webrtc::AudioDeviceModule::GetStats so as to expose:
- <a href="https://www.w3.org/TR/webrtc-stats/#dom-rtcaudioplayoutstats-totalplayoutdelay">https://www.w3.org/TR/webrtc-stats/#dom-rtcaudioplayoutstats-totalplayoutdelay</a>
- <a href="https://www.w3.org/TR/webrtc-stats/#dom-rtcaudioplayoutstats-totalsamplescount">https://www.w3.org/TR/webrtc-stats/#dom-rtcaudioplayoutstats-totalsamplescount</a>
- <a href="https://www.w3.org/TR/webrtc-stats/#dom-rtcaudioplayoutstats-totalsamplesduration">https://www.w3.org/TR/webrtc-stats/#dom-rtcaudioplayoutstats-totalsamplesduration</a>

To do so, LibWebRTCAudioModule asks IncomingAudioMediaStreamTrackRendererUnit for its stats.

IncomingAudioMediaStreamTrackRendererUnit is mixing webrtc remote audio and buffers the mix in a source that is then sent to AudioMediaStreamTrackRendererUnit.
IncomingAudioMediaStreamTrackRendererUnit thus grabs audio stats from AudioMediaStreamTrackRendererUnit and add the delay added by the source mix.

AudioMediaStreamTrackRendererUnit is computing the delay based on the frame size used by the audio unit.

* LayoutTests/webrtc/audio-playout-stats-expected.txt: Added.
* LayoutTests/webrtc/audio-playout-stats.html: Added.
* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h:
(WebCore::AudioSampleDataSource::bufferedAmount const):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp:
(WebCore::AudioMediaStreamTrackRendererUnit::setLastDeviceUsed):
(WebCore::AudioMediaStreamTrackRendererUnit::stats const):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::retrieveFormatDescription):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::render):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::stats const):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp:
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::renderAudioChunk):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::stats):
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp:
(WebCore::LibWebRTCAudioModule::GetStats const):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCAudioModule.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c52c11ca1d9e2fe255dce98bc448353dc65f57dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34734 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11303 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65127 "Found 1 new test failure: webrtc/audio-playout-stats.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22960 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86772 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2541 "Found 1 new test failure: webrtc/audio-playout-stats.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45416 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2462 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30287 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33783 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73494 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31032 "Found 1 new test failure: webrtc/audio-playout-stats.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90176 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10991 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7939 "Found 25 new test failures: fast/mediastream/audio-unit-reconfigure.html http/wpt/webrtc/getUserMedia-processSwapping.html imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-peerconnection.https.html imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback.html imported/w3c/web-platform-tests/webrtc-encoded-transform/script-change-transform.https.html imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-buffer-source.html imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-captureTimestamp.html imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-senderCaptureTimeOffset.html imported/w3c/web-platform-tests/webrtc/protocol/candidate-exchange.https.html imported/w3c/web-platform-tests/webrtc/recvonly-transceiver-can-become-sendrecv.https.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73567 "Found 1 new test failure: webrtc/audio-playout-stats.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11215 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71899 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72790 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17050 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15753 "Found 1 new test failure: webrtc/audio-playout-stats.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2315 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10943 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16415 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10791 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14266 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12563 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->