### PR TITLE
[scroll-animations] borders on the source should not affect a view timeline subject's offset

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6924,7 +6924,6 @@ webkit.org/b/284299 imported/w3c/web-platform-tests/scroll-animations/view-timel
 
 # webkit.org/b/263872 [scroll-animations] some WPT tests are ImageOnlyFailure
 imported/w3c/web-platform-tests/scroll-animations/css/animation-fill-outside-range-test.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/scroll-animations/css/animation-range-visual-test.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/css/printing/animation-timeline-none-with-progress-print.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/css/printing/scroll-timeline-default-iframe-print.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/scroll-animations/css/printing/scroll-timeline-default-print.tentative.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Animation API call rangeStart overrides animation-range-start assert_approx_equals: values do not match for "timeline's current time before style change" expected 16.666666666666668 +/- 0.125 but got 13.333333969116211
-FAIL Animation API call rangeEnd overrides animation-range-end assert_approx_equals: values do not match for "timeline's current time after first set of range updates" expected 16.666666666666668 +/- 0.125 but got 13.333333969116211
+FAIL Animation API call rangeStart overrides animation-range-start assert_approx_equals: values do not match for "animation's start time after first set of range updates" expected 16.666666666666668 +/- 0.125 but got 0
+FAIL Animation API call rangeEnd overrides animation-range-end assert_approx_equals: values do not match for "iteration duration after first style change" expected 50 +/- 0.125 but got 16.666667938232422
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-normal-matches-cover-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-normal-matches-cover-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Changing the animation range updates the play state assert_approx_equals: values do not match for "currentTime at start of normal range" expected 0 +/- 0.125 but got -3.3333334922790527
+PASS Changing the animation range updates the play state
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation-range-update.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation-range-update.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Ensure that animation is updated on a style change assert_equals: expected "33" but got "30"
+PASS Ensure that animation is updated on a style change
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation-expected.txt
@@ -1,18 +1,18 @@
 
-FAIL Animation with ranges [initial, initial] assert_equals: expected "50" but got "47"
-FAIL Animation with ranges [cover 0%, cover 100%] assert_equals: expected "50" but got "47"
-FAIL Animation with ranges [contain 0%, contain 100%] assert_equals: expected "50" but got "40"
-FAIL Animation with ranges [entry 0%, entry 100%] assert_equals: expected "50" but got "40"
-FAIL Animation with ranges [exit 0%, exit 100%] assert_equals: expected "50" but got "40"
-FAIL Animation with ranges [contain -50%, entry 200%] assert_equals: expected "50" but got "43"
-FAIL Animation with ranges [entry 0%, exit 100%] assert_equals: expected "50" but got "47"
-FAIL Animation with ranges [cover 20px, cover 100px] assert_equals: expected "50" but got "38"
-FAIL Animation with ranges [contain 20px, contain 100px] assert_equals: expected "50" but got "37"
-FAIL Animation with ranges [entry 20px, entry 100px] assert_equals: expected "50" but got "38"
-FAIL Animation with ranges [entry-crossing 20px, entry-crossing 100px] assert_equals: expected "50" but got "38"
-FAIL Animation with ranges [exit 20px, exit 80px] assert_equals: expected "50" but got "33"
-FAIL Animation with ranges [exit-crossing 20px, exit-crossing 80px] assert_equals: expected "50" but got "33"
-FAIL Animation with ranges [contain 20px, contain calc(100px - 10%)] assert_equals: expected "50" but got "36"
-FAIL Animation with ranges [exit 2em, exit 8em] assert_equals: expected "50" but got "33"
+PASS Animation with ranges [initial, initial]
+PASS Animation with ranges [cover 0%, cover 100%]
+PASS Animation with ranges [contain 0%, contain 100%]
+PASS Animation with ranges [entry 0%, entry 100%]
+PASS Animation with ranges [exit 0%, exit 100%]
+PASS Animation with ranges [contain -50%, entry 200%]
+PASS Animation with ranges [entry 0%, exit 100%]
+PASS Animation with ranges [cover 20px, cover 100px]
+PASS Animation with ranges [contain 20px, contain 100px]
+PASS Animation with ranges [entry 20px, entry 100px]
+PASS Animation with ranges [entry-crossing 20px, entry-crossing 100px]
+PASS Animation with ranges [exit 20px, exit 80px]
+PASS Animation with ranges [exit-crossing 20px, exit-crossing 80px]
+PASS Animation with ranges [contain 20px, contain calc(100px - 10%)]
+PASS Animation with ranges [exit 2em, exit 8em]
 FAIL Animation with ranges [exit 2em, exit 8em] (scoped) assert_equals: expected "0" but got "100"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-transform-on-subject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-transform-on-subject-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL ViewTimeline use untransformed box for range calculations assert_approx_equals: progress at contain 50% expected 0.5 +/- 0.000001 but got 0.43333333333333335
+FAIL ViewTimeline use untransformed box for range calculations assert_approx_equals: progress at contain 100% expected 1 +/- 0.000001 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time.tentative-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL View timeline with start and end scroll offsets that do not align with the scroll boundaries assert_approx_equals: values do not match for "Timeline's currentTime at container start boundary" expected -150 +/- 0.125 but got -152.5
-FAIL View timeline does not clamp starting scroll offset at 0 assert_approx_equals: values do not match for "Timeline's currentTime at container start boundary" expected 50 +/- 0.125 but got 47.5
-FAIL View timeline  does not clamp end scroll offset at max scroll assert_approx_equals: values do not match for "Timeline's currentTime at container start boundary" expected -150 +/- 0.125 but got -152.5
+FAIL View timeline with start and end scroll offsets that do not align with the scroll boundaries assert_equals: Effect is in the after phase at effect end time expected "1" but got "0.7"
+FAIL View timeline does not clamp starting scroll offset at 0 assert_equals: Effect inactive at the end offset expected "1" but got "0.7"
+PASS View timeline  does not clamp end scroll offset at max scroll
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/change-animation-range-updates-play-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/change-animation-range-updates-play-state-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Changing the animation range updates the play state assert_approx_equals: values do not match for "undefined" expected 16.666666666666668 +/- 0.125 but got 13.333332061767578
+PASS Changing the animation range updates the play state
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source-expected.txt
@@ -1,8 +1,8 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input1 expected -74 +/- 0.1 but got -56.40625
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input2 expected -48 +/- 0.1 but got -30.40625
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input3 expected -22 +/- 0.1 but got -4.40625
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input4 expected 4 +/- 0.1 but got 21.59375
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input5 expected 30 +/- 0.1 but got 47.59375
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input1 expected -74 +/- 0.1 but got -74.40625
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input2 expected -48 +/- 0.1 but got -48.40625
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input3 expected -22 +/- 0.1 but got -22.40625
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input4 expected 4 +/- 0.1 but got 3.59375
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_approx_equals: Unexpected start offset for input5 expected 30 +/- 0.1 but got 29.59375
 Reservation Details
 Name:
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL View timeline with start and end scroll offsets that do not align with the scroll boundaries assert_approx_equals: values do not match for "Timeline's currentTime at container start boundary" expected -150 +/- 0.125 but got -152.5
-FAIL View timeline does not clamp starting scroll offset at 0 assert_approx_equals: values do not match for "Timeline's currentTime at container start boundary" expected 50 +/- 0.125 but got 47.5
-FAIL View timeline does not clamp end scroll offset at max scroll assert_approx_equals: values do not match for "Timeline's currentTime at container start boundary" expected -150 +/- 0.125 but got -152.5
-FAIL View timeline with container having RTL layout assert_approx_equals: values do not match for "Timeline's currentTime at container start boundary" expected -150 +/- 0.125 but got -147.5
+FAIL View timeline with start and end scroll offsets that do not align with the scroll boundaries assert_equals: Effect is in the after phase at effect end time expected "1" but got "0.7"
+FAIL View timeline does not clamp starting scroll offset at 0 assert_equals: Effect at the end of the active phase expected "1" but got "0.7"
+PASS View timeline does not clamp end scroll offset at max scroll
+FAIL View timeline with container having RTL layout assert_equals: Effect is in the after phase at effect end time expected "1" but got "0.7"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/timeline-offset-in-keyframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/timeline-offset-in-keyframe-expected.txt
@@ -1,7 +1,7 @@
 
 FAIL Timeline offsets in programmatic keyframes promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
-FAIL String offsets in programmatic keyframes assert_approx_equals: [{"offset":"0.5","opacity":0.5}] expected 0.5 +/- 0.000001 but got 0.3999999313354545
+FAIL String offsets in programmatic keyframes promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
 PASS Invalid timeline offset in programmatic keyframe throws
 FAIL Timeline offsets in programmatic keyframes adjust for change in timeline promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
-FAIL Timeline offsets in programmatic keyframes resolved when updating the animation effect assert_approx_equals: Progress at contain 50% before effect change expected 0.5 +/- 0.000001 but got 0.3999999313354545
+FAIL Timeline offsets in programmatic keyframes resolved when updating the animation effect promise_test: Unhandled rejection with value: object "TypeError: The provided value is non-finite"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Getting and setting the animation range assert_equals: Opacity with range set to [normal, normal] expected "0.5" but got "0.466667"
+FAIL Getting and setting the animation range assert_approx_equals: expected 100 +/- 0.000001 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL View timeline with px based inset. assert_equals: Effect at the midpoint of the active range: 0px 0px expected "0.5" but got "0.486667"
-FAIL View timeline with percent based inset. assert_equals: Effect at the midpoint of the active range: 0% 0% expected "0.5" but got "0.486667"
+FAIL View timeline with px based inset. assert_equals: Effect at the start of the active phase: 10px 20px expected "0.3" but got "0.314286"
+FAIL View timeline with percent based inset. assert_equals: Effect at the start of the active phase: 10% 20% expected "0.3" but got "0.353333"
 FAIL view timeline with inset auto. promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL view timeline with font relative inset. assert_equals: Effect at the start of the active phase: 1em 2em expected "0.3" but got "0.329333"
-FAIL view timeline with viewport relative insets. assert_equals: Effect at the start of the active phase: 10vw 20vw expected "0.3" but got "0.5"
-FAIL view timeline inset as string assert_equals: Effect at the midpoint of the active range: 10px expected "0.5" but got "0.485714"
+FAIL view timeline with font relative inset. assert_equals: Effect at the start of the active phase: 1em 2em expected "0.3" but got "0.342667"
+FAIL view timeline with viewport relative insets. assert_equals: Effect at the start of the active phase: 10vw 20vw expected "0.3" but got "0.513333"
+FAIL view timeline inset as string assert_equals: Effect at the start of the active phase: 10px 20px expected "0.3" but got "0.314286"
 FAIL view timeline with invalid inset assert_throws_js: function "() => {
     new ViewTimeline({
       subject: target,

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL View timeline with range as <name> <percent> pair. assert_equals: Effect at the midpoint of the active range: cover 0% to cover 100% expected "0.5" but got "0.486667"
-FAIL View timeline with range and inferred name or offset. assert_equals: Effect at the midpoint of the active range: entry to exit expected "0.5" but got "0.486667"
-FAIL View timeline with range as <name> <px> pair. assert_equals: Effect at the midpoint of the active range: cover 20% to cover 100% expected "0.5" but got "0.45"
+PASS View timeline with range as <name> <percent> pair.
+PASS View timeline with range and inferred name or offset.
+PASS View timeline with range as <name> <px> pair.
 FAIL View timeline with range as <name> <percent+px> pair. assert_equals: Effect at the start of the active phase: contain undefined% to contain undefined% expected "0.3" but got "0.7"
-FAIL View timeline with range as strings. assert_equals: Effect at the midpoint of the active range:  to  expected "0.5" but got "0.473333"
+FAIL View timeline with range as strings. assert_equals: Effect at the start of the active phase:  to  expected "0.3" but got "0.7"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-large-subject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-large-subject-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View timeline with range set via delays. assert_equals: Effect at the midpoint of the active range: cover 0% to cover 100% expected "0.5" but got "0.493333"
+FAIL View timeline with range set via delays. assert_equals: Effect at the midpoint of the active range: entry 0% to entry 100% expected "0.5" but got "0.4"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-snapport-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-snapport-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Default ViewTimeline is not affected by scroll-padding assert_approx_equals: values do not match for "undefined" expected 0 +/- 0.125 but got -2.5
+PASS Default ViewTimeline is not affected by scroll-padding
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-subject-size-changes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-subject-size-changes-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View timeline with subject size change after the creation of the animation assert_equals: Effect at the midpoint of the active range expected "0.5" but got "0.46"
+PASS View timeline with subject size change after the creation of the animation
 


### PR DESCRIPTION
#### aa9d42d039dc171f0a88124101058bd7b7bd7ff8
<pre>
[scroll-animations] borders on the source should not affect a view timeline subject&apos;s offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=285518">https://bugs.webkit.org/show_bug.cgi?id=285518</a>
<a href="https://rdar.apple.com/142476585">rdar://142476585</a>

Reviewed by Simon Fraser.

When we compute the offset from a view timeline&apos;s scroller relative to the source, we use the method
`RenderObject::localToContainerPoint()`. But this method will include the borders on the source, if
any. If we subtract the origin of the box returned by `RenderBox::paddingBoxRect()`, we can remove
those borders.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-normal-matches-cover-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation-range-update.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-transform-on-subject-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/change-animation-range-updates-play-state-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/timeline-offset-in-keyframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-large-subject-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-snapport-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-subject-size-changes-expected.txt:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::cacheCurrentTime):
(WebCore::ViewTimeline::source const):

Canonical link: <a href="https://commits.webkit.org/288541@main">https://commits.webkit.org/288541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/202bb6ceb8dc3056d4f857a40ee06c5a327ff6eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88789 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34725 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85802 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65125 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22952 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76065 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/45414 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2449 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30278 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33774 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90167 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73557 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71890 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72780 "Found 1 new API test failure: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17045 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15744 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2306 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12924 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10934 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16406 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10782 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14257 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12554 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->