### PR TITLE
[webkitscmpy] Add commit message parser

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_parser.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_parser.py
@@ -1,0 +1,353 @@
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+import re
+import sys
+
+from enum import Enum
+
+
+class ParseState(Enum):
+    STATE_TITLE = 1
+    STATE_REVIEWED_BY = 2
+    STATE_DESCRIPTION = 3
+    STATE_TESTS = 4
+    STATE_MODIFIED_FILES = 5
+
+
+MODIFIED_FILE_PATTERN = re.compile('^(\\*.*:)(.*)$')
+MODIFIED_FILE_ADDED_PATTERN = re.compile('^\\*.*: Added.$')
+MODIFIED_FILE_DELETED_PATTERN = re.compile('^\\*.*: Removed.$')
+MODIFIED_FUNCTION_PATTERN = re.compile('^(\\(.*\\):)(.*)$')
+MODIFIED_FUNCTION_REMOVED_PATTERN = re.compile('^\\(.*\\): Deleted.$')
+TEST_PATTERN = re.compile('^Tests?: .*$')
+NO_TEST_PATTERN = re.compile('^No new tests \\(OOPS!\\)\\.$')
+TEST_CONTENT_PATTERN = re.compile('^ +.*$')
+REVIEWED_BY_PATTERN = re.compile('^Reviewed by .*$')
+
+
+class CommitMessageParser:
+    def __init__(self):
+        """
+        Parsing happens in two phases:
+        Pass 1 separates the commit message in 5 parts described below.
+        Pass 2 gathers the comments corresponding to the modified files & functions.
+        """
+
+        # Result of parsing pass 1:
+        # These are all represented as a list of strings.
+        #
+        # The title of the commit message.
+        self.title_lines = []
+        # The "Reviewed by" line.
+        self.reviewed_by_lines = []
+        # The description of the commit.
+        self.description_lines = []
+        # The tests information.
+        self.tests_lines = []
+        # The modified files & functions.
+        self.modified_files_lines = []
+
+        # Result of parsing pass 2:
+        #
+        # The map of comments. The key is the line containing the filename returned by prepare-ChangeLog minus the comments.
+        # The value is a list of strings.
+        self.files_to_comments = {}
+        # The map to the list of functions with comments. The key is the line containing the filename returned by
+        # prepare-ChangeLog minus the comments. The value is another map that has the comments of the functions.
+        # On this map, the key is the line containing the function name returned by prepare-ChangeLog minus the comments.
+        # The value is a list of strings.
+        self.files_to_functions = {}
+
+    def parse_file(self, path):
+        """Parse the commit message
+
+        :param path:
+        Path to the file containing the commit message to parse.
+        """
+        with open(path) as f:
+            self.parse_message(f.readlines())
+
+    def parse_message(self, message):
+        """Parse the commit message
+
+        :param message:
+        String containing the commit message to parse.
+        """
+        state = ParseState.STATE_TITLE
+
+        self.title_lines = []
+        self.reviewed_by_lines = []
+        self.description_lines = []
+        self.tests_lines = []
+        self.modified_files_lines = []
+
+        for line in message.split('\n'):
+            line = line.rstrip()
+
+            if line.startswith('#'):
+                continue
+
+            if state == ParseState.STATE_TITLE:
+                if REVIEWED_BY_PATTERN.match(line):
+                    state = ParseState.STATE_REVIEWED_BY
+                    self.reviewed_by_lines.append(line)
+                elif MODIFIED_FILE_PATTERN.match(line):
+                    state = ParseState.STATE_MODIFIED_FILES
+                    self.modified_files_lines.append(line)
+                elif TEST_PATTERN.match(line) or NO_TEST_PATTERN.match(line):
+                    state = ParseState.STATE_TESTS
+                    self.tests_lines.append(line)
+                else:
+                    self.title_lines.append(line)
+
+            # Parse the section with "Reviewed by"
+            elif state == ParseState.STATE_REVIEWED_BY:
+                if REVIEWED_BY_PATTERN.match(line):
+                    self.reviewed_by_lines.append(line)
+                elif line == '':
+                    state = ParseState.STATE_DESCRIPTION
+                else:
+                    state = ParseState.STATE_DESCRIPTION
+                    self.description_lines.append(line)
+
+            # Parse the section with the description of the commit.
+            elif state == ParseState.STATE_DESCRIPTION:
+                if MODIFIED_FILE_PATTERN.match(line):
+                    state = ParseState.STATE_MODIFIED_FILES
+                    self.modified_files_lines.append(line)
+                elif TEST_PATTERN.match(line) or NO_TEST_PATTERN.match(line):
+                    state = ParseState.STATE_TESTS
+                    self.tests_lines.append(line)
+                else:
+                    self.description_lines.append(line)
+
+            # Parse the test section.
+            elif state == ParseState.STATE_TESTS:
+                if TEST_PATTERN.match(line) or NO_TEST_PATTERN.match(line):
+                    self.tests_lines.append(line)
+                elif TEST_CONTENT_PATTERN.match(line):
+                    self.tests_lines.append(line)
+                elif MODIFIED_FILE_PATTERN.match(line):
+                    state = ParseState.STATE_MODIFIED_FILES
+                    self.modified_files_lines.append(line)
+                elif line == '':
+                    state = ParseState.STATE_MODIFIED_FILES
+                else:
+                    state = ParseState.STATE_MODIFIED_FILES
+                    self.modified_files_lines.append(line)
+
+            # Parse the section with the list of modified files & functions.
+            elif state == ParseState.STATE_MODIFIED_FILES:
+                self.modified_files_lines.append(line)
+
+        self.title_lines = self.delete_trailing_blank_lines(self.title_lines)
+        self.description_lines = self.delete_trailing_blank_lines(self.description_lines)
+        self.modified_files_lines = self.delete_trailing_blank_lines(self.modified_files_lines)
+
+        self._parse_modified_files_lines()
+
+    def _parse_modified_files_lines(self):
+        """Parse the list of modified files & functions passed as a list of strings.
+
+        :param modified_file_lines:
+        The modified files & functions. It's passed as a list of strings.
+        It's in the format generated by prepare-ChangeLog.
+        """
+        current_file = None
+        current_function = None
+
+        current_comments = []
+        files_to_comments = {}
+        files_to_functions = {}
+
+        for line in self.modified_files_lines:
+            if MODIFIED_FILE_DELETED_PATTERN.match(line):
+                current_file = line
+                current_function = None
+                current_comments = ['']
+                files_to_comments[current_file] = current_comments
+                files_to_functions[current_file] = {}
+
+            elif MODIFIED_FILE_ADDED_PATTERN.match(line):
+                current_file = line
+                current_function = None
+                current_comments = ['']
+                files_to_comments[current_file] = current_comments
+                files_to_functions[current_file] = {}
+
+            else:
+                m = MODIFIED_FILE_PATTERN.match(line)
+                if m:
+                    current_file = m.group(1)
+                    comment = m.group(2)
+
+                    current_function = None
+                    current_comments = [comment]
+
+                    files_to_comments[current_file] = current_comments
+                    files_to_functions[current_file] = {}
+
+                elif MODIFIED_FUNCTION_REMOVED_PATTERN.match(line):
+                    if not current_file:
+                        logging.warning("Ignoring a function outside of a context of a file: " + line)
+                        continue
+
+                    current_function = line
+                    current_comments = ['']
+                    files_to_functions[current_file][current_function] = current_comments
+
+                else:
+                    m = MODIFIED_FUNCTION_PATTERN.match(line)
+                    if m:
+                        current_function = m.group(1)
+                        comment = m.group(2)
+                        current_comments = [comment]
+
+                        files_to_functions[current_file][current_function] = current_comments
+                    else:
+                        if not current_function and not current_file:
+                            logging.warning("Ignoring a comment outside of a context of a file or a function: " + line)
+                            continue
+
+                        current_comments.append(line)
+
+        self.files_to_comments = files_to_comments
+        self.files_to_functions = files_to_functions
+
+    def apply_comments_to_modified_files_lines(self, modified_files_lines):
+        """Apply the comments given via files_to_comments & files_to_functions to the list of modified files & functions
+        passed as modified_files_lines.
+
+        :param modified_file_lines:
+        The modified files & functions along with test information. It's passed as a list of strings.
+        It's in the format generated by prepare-ChangeLog.
+
+        :return:
+        The function returns a list of string that is the result of applying the comments to the updated list of
+        modified files & functions.
+        """
+        result = []
+        for line in modified_files_lines:
+            if line == '':
+                result.append(line)
+
+            elif TEST_PATTERN.match(line) or NO_TEST_PATTERN.match(line):
+                result.append(line)
+
+            elif TEST_CONTENT_PATTERN.match(line):
+                result.append(line)
+
+            elif MODIFIED_FILE_DELETED_PATTERN.match(line):
+                current_file = line
+                current_function = None
+                lines = self.files_to_comments.get(current_file)
+                if lines:
+                    if len(lines) > 0:
+                        line = current_file + lines[0]
+                        result.append(line)
+                        result += lines[1:]
+                else:
+                    result.append(line)
+
+            elif MODIFIED_FILE_ADDED_PATTERN.match(line):
+                current_file = line
+                current_function = None
+                lines = self.files_to_comments.get(current_file)
+                if lines:
+                    if len(lines) > 0:
+                        line = current_file + lines[0]
+                        result.append(line)
+                        result += lines[1:]
+                else:
+                    result.append(line)
+
+            else:
+                m = MODIFIED_FILE_PATTERN.match(line)
+                if m:
+                    current_file = m.group(1)
+                    current_function = None
+                    lines = self.files_to_comments.get(current_file)
+                    if lines:
+                        if len(lines) > 0:
+                            line = current_file + lines[0]
+                            result.append(line)
+                            result += lines[1:]
+                    else:
+                        result.append(line)
+
+                elif MODIFIED_FUNCTION_REMOVED_PATTERN.match(line):
+                    if not current_file:
+                        logging.warning("Ignoring a function outside of a context of a file: " + line)
+                        continue
+
+                    current_function = line
+
+                    current_functions = self.files_to_functions.get(current_file)
+                    if current_functions:
+                        lines = current_functions.get(current_function)
+                        if lines:
+                            if len(lines) > 0:
+                                line = current_function + lines[0]
+                                result.append(line)
+                                result += lines[1:]
+                        else:
+                            result.append(line)
+                    else:
+                        result.append(line)
+
+                else:
+                    m = MODIFIED_FUNCTION_PATTERN.match(line)
+                    if m:
+                        current_function = m.group(1)
+                        comment = m.group(2)
+
+                        current_functions = self.files_to_functions.get(current_file)
+                        if current_functions:
+                            lines = current_functions.get(current_function)
+                            if lines:
+                                if len(lines) > 0:
+                                    line = current_function + lines[0]
+                                    result.append(line)
+                                    result += lines[1:]
+                            else:
+                                result.append(line)
+                        else:
+                            result.append(line)
+                    else:
+                        logging.warning("Ignoring an unexpected line: " + line)
+
+        return result
+
+    def delete_trailing_blank_lines(lines):
+        chomp_at = 0
+        for line in reversed(lines):
+            if line != '':
+                break
+
+            chomp_at -= 1
+
+        if chomp_at < 0:
+            return lines[:chomp_at]
+
+        return lines


### PR DESCRIPTION
#### ab87e1500e6b16c7bf7375f2cbcf8372d85e2378
<pre>
[webkitscmpy] Add commit message parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=285525">https://bugs.webkit.org/show_bug.cgi?id=285525</a>
<a href="https://rdar.apple.com/142479234">rdar://142479234</a>

Reviewed by Jonathan Bedard.

Add CommitMessageParser which will separate a commit message
into its components (title, review, description, tests, modified).

This enables revising the changelog when amending while keeping
the user&apos;s comments.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_parser.py: Added.
(ParseState):
(CommitMessageParser):
(CommitMessageParser.__init__):
(CommitMessageParser.parse_file):
(CommitMessageParser._parse_modified_files_lines):
(CommitMessageParser.apply_comments_to_modified_files_lines):
(delete_trailing_blank_lines):

Canonical link: <a href="https://commits.webkit.org/288565@main">https://commits.webkit.org/288565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b600a6946a618bd26386af57cbe7d42abc909c30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88865 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/34800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85877 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11375 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/34800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86838 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/2590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/76135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/45460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/83200 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/2510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/30350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33849 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/31100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90242 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11057 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/83428 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11281 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/71963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/72839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17108 "Failed to checkout and rebase branch from PR 38651") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12946 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11009 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10857 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14332 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/12629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->