### PR TITLE
Test if second call to setInlineStyleProperty is needed by tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-repeat-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-repeat-expected.txt
@@ -4,12 +4,12 @@ PASS Can set 'background-repeat' to CSS-wide keywords: inherit
 PASS Can set 'background-repeat' to CSS-wide keywords: unset
 PASS Can set 'background-repeat' to CSS-wide keywords: revert
 PASS Can set 'background-repeat' to var() references:  var(--A)
-FAIL Can set 'background-repeat' to the 'repeat-x' keyword: repeat-x assert_equals: expected "repeat-x" but got "repeat"
-FAIL Can set 'background-repeat' to the 'repeat-y' keyword: repeat-y assert_equals: expected "repeat-y" but got "repeat"
+PASS Can set 'background-repeat' to the 'repeat-x' keyword: repeat-x
+PASS Can set 'background-repeat' to the 'repeat-y' keyword: repeat-y
 PASS Can set 'background-repeat' to the 'repeat' keyword: repeat
-FAIL Can set 'background-repeat' to the 'space' keyword: space assert_equals: expected "space" but got "repeat"
-FAIL Can set 'background-repeat' to the 'round' keyword: round assert_equals: expected "round" but got "repeat"
-FAIL Can set 'background-repeat' to the 'no-repeat' keyword: no-repeat assert_equals: expected "no-repeat" but got "repeat"
+PASS Can set 'background-repeat' to the 'space' keyword: space
+PASS Can set 'background-repeat' to the 'round' keyword: round
+PASS Can set 'background-repeat' to the 'no-repeat' keyword: no-repeat
 PASS Setting 'background-repeat' to a length: 0px throws TypeError
 PASS Setting 'background-repeat' to a length: -3.14em throws TypeError
 PASS Setting 'background-repeat' to a length: 3.14cm throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/logical-expected.txt
@@ -1348,14 +1348,14 @@ PASS Can set 'border-start-start-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-start-start-radius' to CSS-wide keywords: unset
 PASS Can set 'border-start-start-radius' to CSS-wide keywords: revert
 PASS Can set 'border-start-start-radius' to var() references:  var(--A)
-FAIL Can set 'border-start-start-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-start-start-radius' to a percent: 0%
 FAIL Can set 'border-start-start-radius' to a percent: -3.14% Invalid values
-FAIL Can set 'border-start-start-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-start-start-radius' to a percent: calc(0% + 0%) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-start-start-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-start-start-radius' to a percent: 3.14%
+FAIL Can set 'border-start-start-radius' to a percent: calc(0% + 0%) assert_equals: unit expected "percent" but got "px"
+PASS Can set 'border-start-start-radius' to a length: 0px
 FAIL Can set 'border-start-start-radius' to a length: -3.14em Invalid values
-FAIL Can set 'border-start-start-radius' to a length: 3.14cm assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-start-start-radius' to a length: calc(0px + 0em) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
+PASS Can set 'border-start-start-radius' to a length: 3.14cm
+PASS Can set 'border-start-start-radius' to a length: calc(0px + 0em)
 PASS Setting 'border-start-start-radius' to a time: 0s throws TypeError
 PASS Setting 'border-start-start-radius' to a time: -3.14ms throws TypeError
 PASS Setting 'border-start-start-radius' to a time: 3.14s throws TypeError
@@ -1379,14 +1379,14 @@ PASS Can set 'border-start-end-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-start-end-radius' to CSS-wide keywords: unset
 PASS Can set 'border-start-end-radius' to CSS-wide keywords: revert
 PASS Can set 'border-start-end-radius' to var() references:  var(--A)
-FAIL Can set 'border-start-end-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-start-end-radius' to a percent: 0%
 FAIL Can set 'border-start-end-radius' to a percent: -3.14% Invalid values
-FAIL Can set 'border-start-end-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-start-end-radius' to a percent: calc(0% + 0%) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-start-end-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-start-end-radius' to a percent: 3.14%
+FAIL Can set 'border-start-end-radius' to a percent: calc(0% + 0%) assert_equals: unit expected "percent" but got "px"
+PASS Can set 'border-start-end-radius' to a length: 0px
 FAIL Can set 'border-start-end-radius' to a length: -3.14em Invalid values
-FAIL Can set 'border-start-end-radius' to a length: 3.14cm assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-start-end-radius' to a length: calc(0px + 0em) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
+PASS Can set 'border-start-end-radius' to a length: 3.14cm
+PASS Can set 'border-start-end-radius' to a length: calc(0px + 0em)
 PASS Setting 'border-start-end-radius' to a time: 0s throws TypeError
 PASS Setting 'border-start-end-radius' to a time: -3.14ms throws TypeError
 PASS Setting 'border-start-end-radius' to a time: 3.14s throws TypeError
@@ -1410,14 +1410,14 @@ PASS Can set 'border-end-start-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-end-start-radius' to CSS-wide keywords: unset
 PASS Can set 'border-end-start-radius' to CSS-wide keywords: revert
 PASS Can set 'border-end-start-radius' to var() references:  var(--A)
-FAIL Can set 'border-end-start-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-end-start-radius' to a percent: 0%
 FAIL Can set 'border-end-start-radius' to a percent: -3.14% Invalid values
-FAIL Can set 'border-end-start-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-end-start-radius' to a percent: calc(0% + 0%) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-end-start-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-end-start-radius' to a percent: 3.14%
+FAIL Can set 'border-end-start-radius' to a percent: calc(0% + 0%) assert_equals: unit expected "percent" but got "px"
+PASS Can set 'border-end-start-radius' to a length: 0px
 FAIL Can set 'border-end-start-radius' to a length: -3.14em Invalid values
-FAIL Can set 'border-end-start-radius' to a length: 3.14cm assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-end-start-radius' to a length: calc(0px + 0em) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
+PASS Can set 'border-end-start-radius' to a length: 3.14cm
+PASS Can set 'border-end-start-radius' to a length: calc(0px + 0em)
 PASS Setting 'border-end-start-radius' to a time: 0s throws TypeError
 PASS Setting 'border-end-start-radius' to a time: -3.14ms throws TypeError
 PASS Setting 'border-end-start-radius' to a time: 3.14s throws TypeError
@@ -1441,14 +1441,14 @@ PASS Can set 'border-end-end-radius' to CSS-wide keywords: inherit
 PASS Can set 'border-end-end-radius' to CSS-wide keywords: unset
 PASS Can set 'border-end-end-radius' to CSS-wide keywords: revert
 PASS Can set 'border-end-end-radius' to var() references:  var(--A)
-FAIL Can set 'border-end-end-radius' to a percent: 0% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-end-end-radius' to a percent: 0%
 FAIL Can set 'border-end-end-radius' to a percent: -3.14% Invalid values
-FAIL Can set 'border-end-end-radius' to a percent: 3.14% assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
-FAIL Can set 'border-end-end-radius' to a percent: calc(0% + 0%) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-end-end-radius' to a length: 0px assert_equals: expected "CSSUnitValue" but got "CSSStyleValue"
+PASS Can set 'border-end-end-radius' to a percent: 3.14%
+FAIL Can set 'border-end-end-radius' to a percent: calc(0% + 0%) assert_equals: unit expected "percent" but got "px"
+PASS Can set 'border-end-end-radius' to a length: 0px
 FAIL Can set 'border-end-end-radius' to a length: -3.14em Invalid values
-FAIL Can set 'border-end-end-radius' to a length: 3.14cm assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
-FAIL Can set 'border-end-end-radius' to a length: calc(0px + 0em) assert_class_string: relative lengths must compute to a CSSUnitValue expected "[object CSSUnitValue]" but got "[object CSSStyleValue]"
+PASS Can set 'border-end-end-radius' to a length: 3.14cm
+PASS Can set 'border-end-end-radius' to a length: calc(0px + 0em)
 PASS Setting 'border-end-end-radius' to a time: 0s throws TypeError
 PASS Setting 'border-end-end-radius' to a time: -3.14ms throws TypeError
 PASS Setting 'border-end-end-radius' to a time: 3.14s throws TypeError

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -167,7 +167,24 @@ void CSSToStyleMap::mapFillRepeat(CSSPropertyID propertyID, FillLayer& layer, co
         return;
     }
 
-    auto* backgroundRepeatValue = dynamicDowncast<CSSBackgroundRepeatValue>(value);
+    if (RefPtr primitive = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        auto ident = primitive->valueID();
+        switch (ident) {
+        case CSSValueRepeatX:
+            layer.setRepeat(FillRepeatXY { FillRepeat::Repeat, FillRepeat::NoRepeat });
+            return;
+        case CSSValueRepeatY:
+            layer.setRepeat(FillRepeatXY { FillRepeat::NoRepeat, FillRepeat::Repeat });
+            return;
+        default:
+            break;
+        }
+        auto repeat = fromCSSValueID<FillRepeat>(ident);
+        layer.setRepeat(FillRepeatXY { repeat, repeat });
+        return;
+    }
+
+    RefPtr backgroundRepeatValue = dynamicDowncast<CSSBackgroundRepeatValue>(value);
     if (!backgroundRepeatValue)
         return;
 
@@ -681,6 +698,12 @@ template<> constexpr NinePieceImageRule fromCSSValueID(CSSValueID valueID)
 
 void CSSToStyleMap::mapNinePieceImageRepeat(const CSSValue& value, NinePieceImage& image)
 {
+    if (auto valueID = value.valueID(); valueID != CSSValueInvalid) {
+        auto repeat = fromCSSValueID<NinePieceImageRule>(valueID);
+        image.setHorizontalRule(repeat);
+        image.setVerticalRule(repeat);
+    }
+
     if (!value.isPair())
         return;
     image.setHorizontalRule(fromCSSValue<NinePieceImageRule>(value.first()));

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
@@ -449,10 +449,10 @@ RefPtr<CSSValue> consumeRepeatStyle(CSSParserTokenRange& range, const CSSParserC
     // <repeat-style> = repeat-x | repeat-y | [repeat | space | round | no-repeat]{1,2}
     // https://drafts.csswg.org/css-backgrounds/#typedef-repeat-style
 
-    if (consumeIdentRaw<CSSValueRepeatX>(range))
-        return CSSBackgroundRepeatValue::create(CSSValueRepeat, CSSValueNoRepeat);
-    if (consumeIdentRaw<CSSValueRepeatY>(range))
-        return CSSBackgroundRepeatValue::create(CSSValueNoRepeat, CSSValueRepeat);
+    auto repeatXOrY = consumeIdentRaw<CSSValueRepeatX, CSSValueRepeatY>(range);
+    if (repeatXOrY)
+        return CSSPrimitiveValue::create(*repeatXOrY);
+
     auto value1 = consumeIdentRaw<CSSValueRepeat, CSSValueNoRepeat, CSSValueRound, CSSValueSpace>(range);
     if (!value1)
         return nullptr;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Easing.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Easing.cpp
@@ -305,22 +305,12 @@ std::optional<CSS::EasingFunction> consumeUnresolvedEasingFunction(CSSParserToke
     case CSSValueEaseInOut:
         range.consumeIncludingWhitespace();
         return CSS::EasingFunction { CSS::Keyword::EaseInOut { } };
-
     case CSSValueStepStart:
         range.consumeIncludingWhitespace();
-        return CSS::EasingFunction {
-            CSS::StepsEasingFunction {
-                .parameters = { CSS::StepsEasingParameters::Start { CSS::Integer<CSS::Range{1,CSS::Range::infinity}> { 1 } } }
-            }
-        };
-
+        return CSS::EasingFunction { CSS::Keyword::StepStart { } };
     case CSSValueStepEnd:
         range.consumeIncludingWhitespace();
-        return CSS::EasingFunction {
-            CSS::StepsEasingFunction {
-                .parameters = { CSS::StepsEasingParameters::End { CSS::Integer<CSS::Range{1,CSS::Range::infinity}> { 1 } } }
-            }
-        };
+        return CSS::EasingFunction { CSS::Keyword::StepEnd { } };
 
     default:
         break;
@@ -355,6 +345,8 @@ RefPtr<CSSValue> consumeEasingFunction(CSSParserTokenRange& range, const CSSPars
     case CSSValueEaseIn:
     case CSSValueEaseOut:
     case CSSValueEaseInOut:
+    case CSSValueStepStart:
+    case CSSValueStepEnd:
         return consumeIdent(range);
     default:
         break;

--- a/Source/WebCore/css/typedom/CSSStyleValue.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValue.cpp
@@ -69,6 +69,11 @@ Ref<CSSStyleValue> CSSStyleValue::create(RefPtr<CSSValue>&& cssValue, String&& p
     return adoptRef(*new CSSStyleValue(WTFMove(cssValue), WTFMove(property)));
 }
 
+Ref<CSSStyleValue> CSSStyleValue::create(RefPtr<CSSValue>&& cssValue, std::optional<CSSPropertyID> associatedProperty)
+{
+    return adoptRef(*new CSSStyleValue(WTFMove(cssValue), associatedProperty));
+}
+
 Ref<CSSStyleValue> CSSStyleValue::create()
 {
     return adoptRef(*new CSSStyleValue());
@@ -76,6 +81,14 @@ Ref<CSSStyleValue> CSSStyleValue::create()
 
 CSSStyleValue::CSSStyleValue(RefPtr<CSSValue>&& cssValue, String&& property)
     : m_customPropertyName(WTFMove(property))
+    , m_associatedProperty(std::nullopt)
+    , m_propertyValue(WTFMove(cssValue))
+{
+}
+
+CSSStyleValue::CSSStyleValue(RefPtr<CSSValue>&& cssValue, std::optional<CSSPropertyID> associatedProperty)
+    : m_customPropertyName(String())
+    , m_associatedProperty(associatedProperty)
     , m_propertyValue(WTFMove(cssValue))
 {
 }

--- a/Source/WebCore/css/typedom/CSSStyleValue.h
+++ b/Source/WebCore/css/typedom/CSSStyleValue.h
@@ -120,16 +120,21 @@ IGNORE_GCC_WARNINGS_END
     static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseAll(const Document&, const AtomString&, const String&);
 
     static Ref<CSSStyleValue> create(RefPtr<CSSValue>&&, String&& = String());
+    static Ref<CSSStyleValue> create(RefPtr<CSSValue>&&, std::optional<CSSPropertyID>);
     static Ref<CSSStyleValue> create();
 
     virtual RefPtr<CSSValue> toCSSValue() const { return m_propertyValue; }
     virtual RefPtr<CSSValue> toCSSValueWithProperty(CSSPropertyID) const { return toCSSValue(); }
 
+    std::optional<CSSPropertyID> associatedProperty() const { return m_associatedProperty; }
+
 protected:
     CSSStyleValue(RefPtr<CSSValue>&&, String&& = String());
+    CSSStyleValue(RefPtr<CSSValue>&&, std::optional<CSSPropertyID>);
     CSSStyleValue() = default;
     
     String m_customPropertyName;
+    std::optional<CSSPropertyID> m_associatedProperty;
     RefPtr<CSSValue> m_propertyValue;
 };
 

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -50,6 +50,7 @@
 #include "CSSUnitValue.h"
 #include "CSSUnparsedValue.h"
 #include "CSSValueList.h"
+#include "CSSValuePair.h"
 #include "CSSValuePool.h"
 #include "CSSVariableData.h"
 #include "CSSVariableReferenceValue.h"
@@ -327,7 +328,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(const CSSValue&
                 return static_reference_cast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(nameLiteral(CSSValueNone)));
             },
             [&](const auto&) -> ExceptionOr<Ref<CSSStyleValue>> {
-                return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)));
+                return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)), propertyID);
             }
         );
     } else if (RefPtr property = dynamicDowncast<CSSAppleColorFilterPropertyValue>(cssValue)) {
@@ -336,7 +337,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(const CSSValue&
                 return static_reference_cast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(nameLiteral(CSSValueNone)));
             },
             [&](const auto&) -> ExceptionOr<Ref<CSSStyleValue>> {
-                return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)));
+                return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)), propertyID);
             }
         );
     } else if (RefPtr property = dynamicDowncast<CSSBoxShadowPropertyValue>(cssValue)) {
@@ -345,7 +346,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(const CSSValue&
                 return static_reference_cast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(nameLiteral(CSSValueNone)));
             },
             [&](const auto&) -> ExceptionOr<Ref<CSSStyleValue>> {
-                return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)));
+                return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)), propertyID);
             }
         );
     } else if (RefPtr property = dynamicDowncast<CSSTextShadowPropertyValue>(cssValue)) {
@@ -354,7 +355,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(const CSSValue&
                 return static_reference_cast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(nameLiteral(CSSValueNone)));
             },
             [&](const auto&) -> ExceptionOr<Ref<CSSStyleValue>> {
-                return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)));
+                return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)), propertyID);
             }
         );
     } else if (RefPtr property = dynamicDowncast<CSSEasingFunctionValue>(cssValue)) {
@@ -363,9 +364,13 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(const CSSValue&
                 return static_reference_cast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(nameLiteral(keyword)));
             },
             [&](const auto&) -> ExceptionOr<Ref<CSSStyleValue>> {
-                return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)));
+                return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)), propertyID);
             }
         );
+    } else if (RefPtr valuePair = dynamicDowncast<CSSValuePair>(cssValue)) {
+        if (valuePair->canBeCoalesced())
+            return reifyValue(valuePair->first(), propertyID, document);
+        return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)), propertyID);
     } else if (auto* valueList = dynamicDowncast<CSSValueList>(cssValue)) {
         // Reifying the first value in value list.
         // FIXME: Verify this is the expected behavior.
@@ -376,7 +381,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(const CSSValue&
             return reifyValue((*valueList)[0], propertyID, document);
     }
     
-    return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)));
+    return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)), propertyID);
 }
 
 RefPtr<CSSStyleValue> CSSStyleValueFactory::constructStyleValueForCustomPropertySyntaxValue(const CSSCustomPropertyValue::SyntaxValue& syntaxValue)

--- a/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/InlineStylePropertyMap.cpp
@@ -107,20 +107,34 @@ bool InlineStylePropertyMap::setShorthandProperty(CSSPropertyID propertyID, cons
     return !didFailParsing;
 }
 
+static bool isPrimitiveValueCalc(const CSSValue& value)
+{
+    if (auto primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
+        return primitiveValue->isCalculated();
+    return false;
+}
+
 bool InlineStylePropertyMap::setProperty(CSSPropertyID propertyID, Ref<CSSValue>&& value)
 {
     if (!m_element)
         return false;
+
     StyleAttributeMutationScope mutationScope { m_element.get() };
-    bool didFailParsing = false;
+
     // FIXME: We should be able to validate CSSValues without having to serialize to text and go through the
     // parser. This is inefficient.
+
+    bool didFailParsing = false;
     m_element->setInlineStyleProperty(propertyID, value->cssText(), IsImportant::No, &didFailParsing);
-    if (!didFailParsing) {
+    if (didFailParsing)
+        return false;
+
+    // Special case CSSVariableReferenceValue and calc(), as the Typed CSSOM assumes these get set as is.
+    if (is<CSSVariableReferenceValue>(value) || isPrimitiveValueCalc(value))
         m_element->setInlineStyleProperty(propertyID, WTFMove(value));
-        mutationScope.enqueueMutationRecord();
-    }
-    return !didFailParsing;
+
+    mutationScope.enqueueMutationRecord();
+    return true;
 }
 
 bool InlineStylePropertyMap::setCustomProperty(Document&, const AtomString& property, Ref<CSSVariableReferenceValue>&& value)

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -64,6 +64,20 @@ static RefPtr<CSSValue> cssValueFromStyleValues(CSSPropertyID propertyID, Vector
 // https://drafts.css-houdini.org/css-typed-om/#dom-stylepropertymap-set
 ExceptionOr<void> StylePropertyMap::set(Document& document, const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values)
 {
+    // 1. If property is not a custom property name string, set property to property ASCII lowercased.
+    // 2. If property is not a valid CSS property, throw a TypeError.
+
+    // 3. If property is a single-valued property and values has more than one item, throw a TypeError.
+    // 4. If any of the items in values have a non-null [[associatedProperty]] internal slot, and that slot’s value is anything other than property, throw a TypeError.
+    // 5. If the size of values is two or more, and one or more of the items are a CSSUnparsedValue or CSSVariableReferenceValue object, throw a TypeError.
+
+    // NOTE: Having 2+ values implies that you’re setting multiple items of a list-valued property, but the presence of a var() function in the string-based OM disables all syntax parsing, including splitting into individual iterations (because there might be more commas inside of the var() value, so you can’t tell how many items are actually going to show up). This step’s restriction preserves the same semantics in the Typed OM.
+    // 6. Let props be the value of this’s [[declarations]] internal slot.
+    // 7. If props[property] exists, remove it.
+    // 8. Let values to set be an empty list.
+    // 9. For each value in values, create an internal representation for property and value, and append the result to values to set.
+    // 10. Set props[property] to values to set.
+
     if (isCustomPropertyName(property)) {
         auto styleValuesOrException = CSSStyleValueFactory::vectorFromStyleValuesOrStrings(property, WTFMove(values), { document });
         if (styleValuesOrException.hasException())
@@ -103,8 +117,14 @@ ExceptionOr<void> StylePropertyMap::set(Document& document, const AtomString& pr
     if (styleValuesOrException.hasException())
         return styleValuesOrException.releaseException();
     auto styleValues = styleValuesOrException.releaseReturnValue();
-    if (styleValues.size() > 1) {
+    if (styleValues.size() == 1) {
+        if (auto associatedProperty = styleValues[0]->associatedProperty(); associatedProperty && *associatedProperty != propertyID)
+            return Exception { ExceptionCode::TypeError, "CSSStyleValue has an [[associatedProperty]] that does not match the property being set."_s };
+    } else if (styleValues.size() > 1) {
         for (auto& styleValue : styleValues) {
+            if (auto associatedProperty = styleValue->associatedProperty(); associatedProperty && *associatedProperty != propertyID)
+                return Exception { ExceptionCode::TypeError, "CSSStyleValue has an [[associatedProperty]] that does not match the property being set."_s };
+
             if (is<CSSUnparsedValue>(styleValue.get()))
                 return Exception { ExceptionCode::TypeError, "There is more than one value and one is either a CSSVariableReferenceValue or a CSSUnparsedValue"_s };
         }
@@ -120,13 +140,6 @@ ExceptionOr<void> StylePropertyMap::set(Document& document, const AtomString& pr
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(*value); primitiveValue && primitiveValue->isNumberOrInteger()) {
         if (!CSSProperty::allowsNumberOrIntegerInput(propertyID))
             return Exception { ExceptionCode::TypeError, "Invalid value: This property doesn't allow <number> input"_s };
-    }
-
-    // FIXME: CSSValuePair has specific behavior related to coalescing its 2 values when they are equal.
-    // Throw an error when using them with Typed OM to avoid subtle bugs when the serialization isn't representative of the value.
-    if (auto pair = dynamicDowncast<CSSValuePair>(value)) {
-        if (pair->canBeCoalesced())
-            return Exception { ExceptionCode::NotSupportedError, "Invalid values"_s };
     }
 
     if (!setProperty(propertyID, value.releaseNonNull()))


### PR DESCRIPTION
#### 6dbd50e60adeb43660c777af66450fbfae3514f3
<pre>
Test if second call to setInlineStyleProperty is needed by tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=285531">https://bugs.webkit.org/show_bug.cgi?id=285531</a>

Reviewed by NOBODY (OOPS!).

WIP - FOR BOTS

- Adds [[associatedProperty]] support.
- Adds special cases for CSSVariableReferenceValue and Calc.

Ultimately, we need to be able to figure out for CSSPropertyID if
its grammar matches a numeric value of type or a keyword.

* Source/WebCore/css/typedom/CSSStyleValue.cpp:
(WebCore::CSSStyleValue::create):
(WebCore::CSSStyleValue::CSSStyleValue):
* Source/WebCore/css/typedom/CSSStyleValue.h:
(WebCore::CSSStyleValue::associatedProperty const):
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::reifyValue):
* Source/WebCore/css/typedom/InlineStylePropertyMap.cpp:
(WebCore::isPrimitiveValueCalc):
(WebCore::InlineStylePropertyMap::setProperty):
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
(WebCore::StylePropertyMap::set):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dbd50e60adeb43660c777af66450fbfae3514f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88983 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34917 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11494 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65264 "Found 15 new test failures: fast/css/css-typed-om-typeerror-coalescing-pair.html fast/dom/StyleSheet/css-font-variation-settings-crash.html imported/w3c/web-platform-tests/css/css-easing/step-timing-functions-syntax.html imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-timing-function-valid.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-repeat.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-repeat.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23102 "Found 2 new test failures: fast/css/css-typed-om-typeerror-coalescing-pair.html fast/dom/StyleSheet/css-font-variation-settings-crash.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86955 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2687 "Found 2 new test failures: fast/css/css-typed-om-typeerror-coalescing-pair.html fast/dom/StyleSheet/css-font-variation-settings-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76240 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45556 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2617 "Found 13 new test failures: imported/w3c/web-platform-tests/css/css-easing/step-timing-functions-syntax.html imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-timing-function-valid.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-repeat.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-repeat.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-radius.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/font-variant-alternates.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30462 "Found 15 new test failures: fast/css/css-typed-om-typeerror-coalescing-pair.html fast/dom/StyleSheet/css-font-variation-settings-crash.html imported/w3c/web-platform-tests/css/css-easing/step-timing-functions-syntax.html imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-timing-function-valid.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-repeat.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-repeat.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33966 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73605 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31217 "Found 15 new test failures: fast/css/css-typed-om-typeerror-coalescing-pair.html fast/dom/StyleSheet/css-font-variation-settings-crash.html imported/w3c/web-platform-tests/css/css-easing/step-timing-functions-syntax.html imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-timing-function-valid.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-repeat.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-repeat.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90359 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11174 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8084 "Found 15 new test failures: fast/css/css-typed-om-typeerror-coalescing-pair.html fast/dom/StyleSheet/css-font-variation-settings-crash.html imported/w3c/web-platform-tests/css/css-easing/step-timing-functions-syntax.html imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-timing-function-valid.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-repeat.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-repeat.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73713 "Found 15 new test failures: fast/css/css-typed-om-typeerror-coalescing-pair.html fast/dom/StyleSheet/css-font-variation-settings-crash.html imported/w3c/web-platform-tests/css/css-easing/step-timing-functions-syntax.html imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-timing-function-valid.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-repeat.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-repeat.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72931 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17216 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15902 "Found 15 new test failures: fast/css/css-typed-om-typeerror-coalescing-pair.html fast/dom/StyleSheet/css-font-variation-settings-crash.html imported/w3c/web-platform-tests/css/css-easing/step-timing-functions-syntax.html imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-timing-function-valid.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-repeat.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-size.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-outset.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-repeat.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-slice.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/border-image-width.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2509 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11126 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16598 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10974 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12746 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->