### PR TITLE
LinkRelAttribute doesn't tokenize correctly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-rel-attribute-tokenization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-rel-attribute-tokenization-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The rel attribute needs to handle ASCII whitespace correctly
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-rel-attribute-tokenization.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-rel-attribute-tokenization.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<link id=light-link rel=stylesheet href=resources/link-rel-attribute.css>
+<div id=light-div class=green></div>
+
+<script>
+
+function testLinkRelModification(testDiv, testLink) {
+  assert_equals(getComputedStyle(testDiv).color, "rgb(0, 128, 0)");
+  testLink.setAttribute("rel", "test\u000Bstylesheet");
+  assert_equals(getComputedStyle(testDiv).color, "rgb(0, 0, 0)");
+  testLink.setAttribute("rel", "test\u000Cstylesheet");
+  assert_equals(getComputedStyle(testDiv).color, "rgb(0, 128, 0)");
+  testLink.removeAttribute("rel");
+  assert_equals(getComputedStyle(testDiv).color, "rgb(0, 0, 0)");
+  testLink.setAttribute("rel", "\u0009\u000A\u000C\u000D\u0020stylesheet");
+  assert_equals(getComputedStyle(testDiv).color, "rgb(0, 128, 0)");
+  testLink.removeAttribute("rel");
+  assert_equals(getComputedStyle(testDiv).color, "rgb(0, 0, 0)");
+  testLink.setAttribute("rel", "\u0009\u000A\u000C\u000D\u0020stylesheet\u0009\u000A\u000C\u000D\u0020††††");
+  assert_equals(getComputedStyle(testDiv).color, "rgb(0, 128, 0)");
+}
+
+test (() => {
+  testLinkRelModification(document.querySelector("#light-div"),
+                          document.querySelector("#light-link"));
+}, "The rel attribute needs to handle ASCII whitespace correctly");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/302-no-Location-header-text-css.asis
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/bad.css
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/css.py
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/empty-href.css
@@ -22,4 +23,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/link-rel-attribute.css
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/link-style-error.js
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/neutral.css
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type-empty.css
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type-empty.css.headers
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type.css
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type.css.headers
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet.css

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/w3c-import.log
@@ -27,6 +27,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-rel-attribute-ascii-case-insensitive-expected-mismatch.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-rel-attribute-ascii-case-insensitive-notref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-rel-attribute-ascii-case-insensitive.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-rel-attribute-tokenization.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-rel-attribute.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-rellist.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-style-error-01.html
@@ -36,6 +37,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-type-attribute-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-type-attribute.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/style.css
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-bad-mime-type.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-change-href-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-change-href-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-change-href.html
@@ -45,6 +47,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-media.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-non-OK-status.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-not-removed-until-next-stylesheet-loads.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-with-base-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-with-base-ref.html

--- a/Source/WebCore/html/LinkRelAttribute.cpp
+++ b/Source/WebCore/html/LinkRelAttribute.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -35,87 +36,77 @@
 #include "Document.h"
 #include "LinkIconType.h"
 #include "Settings.h"
+#include <wtf/SortedArrayMap.h>
 #include <wtf/text/StringView.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-// Keep LinkRelAttribute::isSupported() in sync when updating this constructor.
+// https://html.spec.whatwg.org/#linkTypes
+
+struct LinkTypeDetails {
+    bool (*isEnabled)(const Document&);
+    void (*updateRel)(LinkRelAttribute&);
+};
+
+static constexpr std::pair<ComparableLettersLiteral, LinkTypeDetails> linkTypesArray[] = {
+    { "alternate"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.isAlternate = true; } } },
+    { "apple-touch-icon"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.iconType = LinkIconType::TouchIcon; } } },
+    { "apple-touch-icon-precomposed"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.iconType = LinkIconType::TouchPrecomposedIcon; } } },
+    { "dns-prefetch"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.isDNSPrefetch = true; } } },
+    { "expect"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.isInternalResourceLink = true; } } },
+    { "icon"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.iconType = LinkIconType::Favicon; } } },
+#if ENABLE(APPLICATION_MANIFEST)
+    { "manifest"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.isApplicationManifest = true; } } },
+#else
+    { "manifest"_s, { [](auto) { return false; }, [](auto) { } } },
+#endif
+    { "modulepreload"_s, { [](auto document) { return document.settings().linkModulePreloadEnabled(); }, [](auto relAttribute) { relAttribute.isLinkModulePreload = true; } } },
+    { "preconnect"_s, { [](auto document) { return document.settings().linkPreconnectEnabled(); }, [](auto relAttribute) { relAttribute.isLinkPreconnect = true; } } },
+    { "prefetch"_s, { [](auto document) { return document.settings().linkPrefetchEnabled(); }, [](auto relAttribute) { relAttribute.isLinkPrefetch = true; } } },
+    { "preload"_s, { [](auto document) { return document.settings().linkPreloadEnabled(); }, [](auto relAttribute) { relAttribute.isLinkPreload = true; } } },
+    { "stylesheet"_s, { [](auto) { return true; }, [](auto relAttribute) { relAttribute.isStyleSheet = true; } } },
+};
+
+static constexpr SortedArrayMap linkTypes { linkTypesArray };
+
 LinkRelAttribute::LinkRelAttribute(Document& document, StringView rel)
 {
-    if (equalLettersIgnoringASCIICase(rel, "stylesheet"_s))
-        isStyleSheet = true;
-    else if (equalLettersIgnoringASCIICase(rel, "icon"_s) || equalLettersIgnoringASCIICase(rel, "shortcut icon"_s))
+    if (auto linkType = linkTypes.tryGet(rel)) {
+        if (linkType->isEnabled(document))
+            linkType->updateRel(*this);
+        return;
+    }
+    if (equalLettersIgnoringASCIICase(rel, "shortcut icon"_s))
         iconType = LinkIconType::Favicon;
-    else if (equalLettersIgnoringASCIICase(rel, "apple-touch-icon"_s))
-        iconType = LinkIconType::TouchIcon;
-    else if (equalLettersIgnoringASCIICase(rel, "apple-touch-icon-precomposed"_s))
-        iconType = LinkIconType::TouchPrecomposedIcon;
-    else if (equalLettersIgnoringASCIICase(rel, "dns-prefetch"_s))
-        isDNSPrefetch = true;
-    else if (document.settings().linkPreconnectEnabled() && equalLettersIgnoringASCIICase(rel, "preconnect"_s))
-        isLinkPreconnect = true;
-    else if (document.settings().linkModulePreloadEnabled() && equalLettersIgnoringASCIICase(rel, "modulepreload"_s))
-        isLinkModulePreload = true;
-    else if (document.settings().linkPreloadEnabled() && equalLettersIgnoringASCIICase(rel, "preload"_s))
-        isLinkPreload = true;
-    else if (document.settings().linkPrefetchEnabled() && equalLettersIgnoringASCIICase(rel, "prefetch"_s))
-        isLinkPrefetch = true;
     else if (equalLettersIgnoringASCIICase(rel, "alternate stylesheet"_s) || equalLettersIgnoringASCIICase(rel, "stylesheet alternate"_s)) {
         isStyleSheet = true;
         isAlternate = true;
-#if ENABLE(APPLICATION_MANIFEST)
-    } else if (equalLettersIgnoringASCIICase(rel, "manifest"_s)) {
-        isApplicationManifest = true;
-#endif
-    } else if (equalLettersIgnoringASCIICase(rel, "expect"_s))
-        isInternalResourceLink = true;
-    else {
+    } else {
         // Tokenize the rel attribute and set bits based on specific keywords that we find.
-        for (auto line : rel.split('\n')) {
-            for (auto word : line.split(' ')) {
-                if (equalLettersIgnoringASCIICase(word, "stylesheet"_s))
-                    isStyleSheet = true;
-                else if (equalLettersIgnoringASCIICase(word, "alternate"_s))
-                    isAlternate = true;
-                else if (equalLettersIgnoringASCIICase(word, "icon"_s))
-                    iconType = LinkIconType::Favicon;
-                else if (equalLettersIgnoringASCIICase(word, "apple-touch-icon"_s))
-                    iconType = LinkIconType::TouchIcon;
-                else if (equalLettersIgnoringASCIICase(word, "apple-touch-icon-precomposed"_s))
-                    iconType = LinkIconType::TouchPrecomposedIcon;
+        unsigned length = rel.length();
+        unsigned start = 0;
+        while (start < length) {
+            if (isASCIIWhitespace(rel[start])) {
+                start++;
+                continue;
             }
+            unsigned end = start + 1;
+            while (end < length && !isASCIIWhitespace(rel[end]))
+                end++;
+            if (auto linkType = linkTypes.tryGet(rel.substring(start, end - start))) {
+                if (linkType->isEnabled(document))
+                    linkType->updateRel(*this);
+            }
+            start = end;
         }
     }
 }
 
-// https://html.spec.whatwg.org/#linkTypes
 bool LinkRelAttribute::isSupported(Document& document, StringView attribute)
 {
-    static constexpr ASCIILiteral supportedAttributes[] = {
-        "alternate"_s, "dns-prefetch"_s, "icon"_s, "stylesheet"_s, "apple-touch-icon"_s, "apple-touch-icon-precomposed"_s,
-#if ENABLE(APPLICATION_MANIFEST)
-        "manifest"_s,
-#endif
-    };
-
-    for (auto supportedAttribute : supportedAttributes) {
-        if (equalIgnoringASCIICase(attribute, supportedAttribute))
-            return true;
-    }
-
-    if (document.settings().linkPreconnectEnabled() && equalLettersIgnoringASCIICase(attribute, "preconnect"_s))
-        return true;
-
-    if (document.settings().linkModulePreloadEnabled() && equalLettersIgnoringASCIICase(attribute, "modulepreload"_s))
-        return true;
-
-    if (document.settings().linkPreloadEnabled() && equalLettersIgnoringASCIICase(attribute, "preload"_s))
-        return true;
-
-    if (document.settings().linkPrefetchEnabled() && equalLettersIgnoringASCIICase(attribute, "prefetch"_s))
-        return true;
-
+    if (auto linkType = linkTypes.tryGet(attribute))
+        return linkType->isEnabled(document);
     return false;
 }
 


### PR DESCRIPTION
#### 13d238d72b7e3987830641bdc7f85ade40159ce1
<pre>
LinkRelAttribute doesn&apos;t tokenize correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=285508">https://bugs.webkit.org/show_bug.cgi?id=285508</a>

Reviewed by Ryosuke Niwa.

Make LinkRelAttribute use SortedArrayMap as a backing store for the
link types so we can reuse the logic and thereby make the overall setup
less error prone and fix several bugs in the process.

Also correct tokenizing by recognizing all ASCII whitespace instead of
just newlines and spaces.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-rel-attribute-tokenization-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/link-rel-attribute-tokenization.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/w3c-import.log:
* Source/WebCore/html/LinkRelAttribute.cpp:
(WebCore::linkTypes):
(WebCore::findLinkType):
(WebCore::LinkRelAttribute::LinkRelAttribute):
(WebCore::LinkRelAttribute::isSupported):

Canonical link: <a href="https://commits.webkit.org/288639@main">https://commits.webkit.org/288639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da46d5454e2fe933a4944e713c07b07d4032a5ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83904 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88978 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34912 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11489 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65261 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23094 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45553 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30457 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33961 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90354 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8079 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73706 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72924 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17210 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2503 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12996 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11121 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16593 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10969 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14445 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->