### PR TITLE
REGRESSION(288477@main): Broke TestWebKitAPI.IPCTestingAPI.SerializedTypeInfo

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -1411,7 +1411,7 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers, u
                 result.append(f'{alias_line.strip()}')
             else:
                 underscore_s_after_last_line = '_s' if line_number is len(using_statement.alias_lines) - 1 else ''
-                extra_space_after_comma = ' ' if ',' in alias_line else ''
+                extra_space_after_comma = ' ' if alias_line.endswith(',') else ''
                 result.append(f'            "{alias_line.strip()}{extra_space_after_comma}"{underscore_s_after_last_line}')
         result.append(f'            , "alias"_s }}')
         result.append('        } },')

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -590,7 +590,7 @@ Vector<SerializedTypeInfo> allSerializedTypes()
         } },
         { "WebCore::NonConditionalVariant"_s, {
         {
-            "std::variant<int, double> "_s
+            "std::variant<int, double>"_s
             , "alias"_s }
         } },
     };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -490,6 +490,7 @@ static NSSet<NSString *> *splitTypeFromList(NSString *container, NSString *list)
     bool firstTypeOnly = [container isEqualToString:@"std::span"]
         || [container isEqualToString:@"Vector"]
         || [container isEqualToString:@"std::array"]
+        || [container isEqualToString:@"UncheckedKeyHashSet"]
         || [container isEqualToString:@"HashSet"];
     bool firstTwoTypesOnly = [container isEqualToString:@"HashMap"];
 
@@ -531,6 +532,7 @@ static NSMutableSet<NSString *> *extractTypesFromContainers(NSSet<NSString *> *i
             @"HashMap",
             @"MemoryCompactRobinHoodHashMap",
             @"MemoryCompactLookupOnlyRobinHoodHashSet",
+            @"UncheckedKeyHashSet",
             @"std::pair",
             @"IPC::ArrayReferenceTuple",
             @"std::span",
@@ -669,6 +671,7 @@ TEST(IPCTestingAPI, SerializedTypeInfo)
         @"uint32_t",
         @"int16_t",
         @"uint64_t",
+        @"uintptr_t",
         @"int",
         @"long long",
         @"GCGLint",


### PR DESCRIPTION
#### 5fadf7033575aca8cd24c910b5d994445aa238d3
<pre>
REGRESSION(288477@main): Broke TestWebKitAPI.IPCTestingAPI.SerializedTypeInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=285530">https://bugs.webkit.org/show_bug.cgi?id=285530</a>
<a href="https://rdar.apple.com/142480268">rdar://142480268</a>

Reviewed by Chris Dumez.

This fixes 3 issues:
1. Something added a uintptr_t being sent across IPC on iOS.  This is fine.  I added it.
2. 288477@main added UncheckedKeyHashSet in IPC.  This is fine.  I added it.
3. 288484@main added an extra space in the type name of a using statement.  I removed it.
I verified this fixes the test.

* Source/WebKit/Scripts/generate-serializers.py:
(generate_serialized_type_info):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:
(SerializedTypeInfo)):

Canonical link: <a href="https://commits.webkit.org/288550@main">https://commits.webkit.org/288550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9e9eac2dc21cb31e11afb27a32bba012a892ccb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38056 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/34763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11335 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/88827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/34763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86801 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/2563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/76103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/88827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/83163 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/2483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/30316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33812 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/31063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90205 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11020 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11244 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/71929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/72810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/17080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12935 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10972 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/16444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10820 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14295 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/12592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->