### PR TITLE
[Cocoa] Move WebAVPlayerLayer/View into VIdeoPresentationInterface

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -330,6 +330,7 @@ platform/cocoa/ThemeCocoa.mm
 platform/cocoa/ThermalMitigationNotifier.mm
 platform/cocoa/UserAgentCocoa.mm
 platform/cocoa/VideoPresentationModelVideoElement.mm
+platform/cocoa/VideoPresentationLayerProvider.mm
 platform/cocoa/VideoToolboxSoftLink.cpp
 platform/cocoa/WebCoreAdditions.mm @no-unify
 platform/cocoa/WebCoreNSErrorExtras.mm

--- a/Source/WebCore/platform/cocoa/VideoPresentationLayerProvider.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationLayerProvider.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(VIDEO)
+
+#include "PlatformView.h"
+
+OBJC_CLASS WebAVPlayerLayer;
+OBJC_CLASS WebAVPlayerLayerView;
+
+namespace WebCore {
+
+class VideoPresentationLayerProvider {
+public:
+    WEBCORE_EXPORT virtual ~VideoPresentationLayerProvider();
+
+    PlatformView *layerHostView() const { return m_layerHostView.get(); }
+    void setLayerHostView(RetainPtr<PlatformView>&& layerHostView) { m_layerHostView = WTFMove(layerHostView); }
+
+    WebAVPlayerLayer *playerLayer() const { return m_playerLayer.get(); }
+    virtual void setPlayerLayer(RetainPtr<WebAVPlayerLayer>&& layer) { m_playerLayer = WTFMove(layer); }
+
+#if PLATFORM(IOS_FAMILY)
+    WebAVPlayerLayerView *playerLayerView() const { return m_playerLayerView.get(); }
+    void setPlayerLayerView(RetainPtr<WebAVPlayerLayerView>&& playerLayerView) { m_playerLayerView = WTFMove(playerLayerView); }
+
+    PlatformView *videoView() const { return m_videoView.get(); }
+    void setVideoView(RetainPtr<PlatformView>&& videoView) { m_videoView = WTFMove(videoView); }
+#endif
+
+protected:
+    WEBCORE_EXPORT VideoPresentationLayerProvider();
+
+private:
+    RetainPtr<PlatformView> m_layerHostView;
+    RetainPtr<WebAVPlayerLayer> m_playerLayer;
+
+#if PLATFORM(IOS_FAMILY)
+    RetainPtr<WebAVPlayerLayerView> m_playerLayerView;
+    RetainPtr<PlatformView> m_videoView;
+#endif
+};
+
+}
+
+#endif

--- a/Source/WebCore/platform/cocoa/VideoPresentationLayerProvider.mm
+++ b/Source/WebCore/platform/cocoa/VideoPresentationLayerProvider.mm
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "VideoPresentationLayerProvider.h"
+
+#if ENABLE(VIDEO)
+
+#include "WebAVPlayerLayerView.h"
+
+namespace WebCore {
+
+VideoPresentationLayerProvider::VideoPresentationLayerProvider() = default;
+VideoPresentationLayerProvider::~VideoPresentationLayerProvider() = default;
+
+}
+
+#endif

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.h
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.h
@@ -31,6 +31,7 @@
 
 WEBCORE_EXPORT @interface WebAVPlayerLayerView : __AVPlayerLayerView
 @property (retain) UIView* videoView;
+- (void)transferVideoViewTo:(WebAVPlayerLayerView *)playerLayerView;
 @end
 
 #if HAVE(PICTUREINPICTUREPLAYERLAYERVIEW)

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
@@ -50,6 +50,18 @@ static Class WebAVPlayerLayerView_layerClass(id, SEL)
     return [WebAVPlayerLayer class];
 }
 
+static void WebAVPlayerLayerView_transferVideoViewTo(id aSelf, SEL, WebAVPlayerLayerView *targetPlayerLayerView)
+{
+    WebAVPlayerLayerView *playerLayerView = aSelf;
+    RetainPtr videoView = [playerLayerView videoView];
+    if (!videoView)
+        return;
+
+    [videoView removeFromSuperview];
+    [playerLayerView setVideoView:nil];
+    [targetPlayerLayerView setVideoView:videoView.get()];
+}
+
 static AVPlayerController *WebAVPlayerLayerView_playerController(id aSelf, SEL)
 {
     __AVPlayerLayerView *playerLayer = aSelf;
@@ -160,6 +172,7 @@ WebAVPlayerLayerView *allocWebAVPlayerLayerViewInstance()
         ASSERT(get__AVPlayerLayerViewClass());
         theClass = objc_allocateClassPair(get__AVPlayerLayerViewClass(), "WebAVPlayerLayerView", 0);
         class_addMethod(theClass, @selector(dealloc), (IMP)WebAVPlayerLayerView_dealloc, "v@:");
+        class_addMethod(theClass, @selector(transferVideoViewTo:), (IMP)WebAVPlayerLayerView_transferVideoViewTo, "v@:@");
         class_addMethod(theClass, @selector(setPlayerController:), (IMP)WebAVPlayerLayerView_setPlayerController, "v@:@");
         class_addMethod(theClass, @selector(playerController), (IMP)WebAVPlayerLayerView_playerController, "@@:");
         class_addMethod(theClass, @selector(setVideoView:), (IMP)WebAVPlayerLayerView_setVideoView, "v@:@");

--- a/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
@@ -54,7 +54,6 @@ public:
 
     PlaybackSessionModel* playbackSessionModel() const { return m_model.get(); }
 
-    void setupFullscreen(UIView&, const FloatRect&, const FloatSize&, UIView*, HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) { }
     void enterFullscreen() { }
     bool exitFullscreen(const FloatRect&) { return false; }
     void cleanupFullscreen() { }

--- a/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
@@ -29,6 +29,7 @@
 
 #include "NullPlaybackSessionInterface.h"
 #include "VideoFullscreenCaptions.h"
+#include "VideoPresentationLayerProvider.h"
 #include "VideoPresentationModel.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -38,6 +39,7 @@ class NullVideoPresentationInterface final
     : public VideoPresentationModelClient
     , public PlaybackSessionModelClient
     , public VideoFullscreenCaptions
+    , public VideoPresentationLayerProvider
     , public RefCounted<NullVideoPresentationInterface>
     , public CanMakeCheckedPtr<NullVideoPresentationInterface> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(NullVideoPresentationInterface);
@@ -54,7 +56,7 @@ public:
 
     void setSpatialVideoMetadata(const std::optional<SpatialVideoMetadata>&) { }
     void setVideoPresentationModel(VideoPresentationModel* model) { m_videoPresentationModel = model; }
-    void setupFullscreen(UIView&, const FloatRect&, const FloatSize&, UIView*, HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) { }
+    void setupFullscreen(const FloatRect&, const FloatSize&, UIView*, HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) { }
     void enterFullscreen() { }
     bool exitFullscreen(const FloatRect& finalRect) { return false; }
     void exitFullscreenWithoutAnimationToMode(HTMLMediaElementEnums::VideoFullscreenMode) { }

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h
@@ -50,7 +50,7 @@ private:
     bool pictureInPictureWasStartedWhenEnteringBackground() const final { return false; }
     bool mayAutomaticallyShowVideoPictureInPicture() const final { return false; }
     bool isPlayingVideoInEnhancedFullscreen() const final { return false; }
-    void setupFullscreen(UIView&, const FloatRect&, const FloatSize&, UIView*, HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) final { }
+    void setupFullscreen(const FloatRect&, const FloatSize&, UIView*, HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) final { }
     void hasVideoChanged(bool) final { }
     void finalizeSetup() final { }
     void updateRouteSharingPolicy() final { }

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.h
@@ -55,7 +55,7 @@ public:
 #endif
 
     WEBCORE_EXPORT AVPlayerViewController *avPlayerViewController() const final;
-    WEBCORE_EXPORT void setupFullscreen(UIView& videoView, const FloatRect& initialRect, const FloatSize& videoDimensions, UIView* parentView, HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture);
+    WEBCORE_EXPORT void setupFullscreen(const FloatRect& initialRect, const FloatSize& videoDimensions, UIView* parentView, HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture);
     WEBCORE_EXPORT bool pictureInPictureWasStartedWhenEnteringBackground() const final;
     WEBCORE_EXPORT void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>) final;
     WEBCORE_EXPORT bool mayAutomaticallyShowVideoPictureInPicture() const;
@@ -81,6 +81,7 @@ private:
     void setAllowsPictureInPicturePlayback(bool) final;
     bool isExternalPlaybackActive() const final;
     bool willRenderToLayer() const final;
+    void returnVideoView() final;
 
     RetainPtr<WebAVPlayerViewControllerDelegate> m_playerViewControllerDelegate;
     RetainPtr<WebAVPlayerViewController> m_playerViewController;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
@@ -351,6 +351,7 @@ static WebAVPictureInPictureContentViewController *allocWebAVPictureInPictureCon
 
 NS_ASSUME_NONNULL_BEGIN
 @interface WebAVPlayerViewController : NSObject<AVPlayerViewControllerDelegate>
+@property (readonly, nonatomic) WebAVPlayerLayerView *playerLayerView;
 - (instancetype)initWithFullscreenInterface:(WebCore::VideoPresentationInterfaceAVKitLegacy *)interface;
 - (void)enterFullScreenAnimated:(BOOL)animated completionHandler:(void (^)(BOOL success, NSError *))completionHandler;
 - (void)exitFullScreenAnimated:(BOOL)animated completionHandler:(void (^)(BOOL success, NSError *))completionHandler;
@@ -374,6 +375,7 @@ NS_ASSUME_NONNULL_END
     RetainPtr<UIViewController> _presentingViewController;
 #endif
     RetainPtr<AVPlayerViewController> _avPlayerViewController;
+    RetainPtr<WebAVPlayerLayerView> _playerLayerView;
     RetainPtr<NSTimer> _startPictureInPictureTimer;
     WeakObjCPtr<WebAVPlayerViewControllerDelegate> _delegate;
 
@@ -390,13 +392,18 @@ NS_ASSUME_NONNULL_END
 
     _fullscreenInterface = ThreadSafeWeakPtr { *interface };
 
+    _playerLayerView = adoptNS([WebCore::allocWebAVPlayerLayerViewInstance() init]);
+    RetainPtr playerLayer = (WebAVPlayerLayer *)[_playerLayerView playerLayer];
+    if (interface)
+        [playerLayer setPresentationModel:interface->videoPresentationModel().get()];
+
     OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER);
 
 #if PLATFORM(APPLETV)
     _avPlayerViewController = adoptNS([allocAVPlayerViewControllerInstance() init]);
     [self configurePlayerViewControllerWithFullscreenInterface:interface];
 #else
-    _avPlayerViewController = adoptNS([allocAVPlayerViewControllerInstance() initWithPlayerLayerView:interface->playerLayerView()]);
+    _avPlayerViewController = adoptNS([allocAVPlayerViewControllerInstance() initWithPlayerLayerView:_playerLayerView.get()]);
 #endif
     [_avPlayerViewController setModalPresentationStyle:UIModalPresentationOverFullScreen];
 #if PLATFORM(WATCHOS)
@@ -464,6 +471,11 @@ NS_ASSUME_NONNULL_END
     _pipController = nil;
 #endif
     [super dealloc];
+}
+
+- (WebAVPlayerLayerView *)playerLayerView
+{
+    return _playerLayerView.get();
 }
 
 #if !PLATFORM(APPLETV)
@@ -793,10 +805,10 @@ AVPlayerViewController *VideoPresentationInterfaceAVKitLegacy::avPlayerViewContr
     return [m_playerViewController avPlayerViewController];
 }
 
-void VideoPresentationInterfaceAVKitLegacy::setupFullscreen(UIView& videoView, const FloatRect& initialRect, const FloatSize& videoDimensions, UIView* parentView, HTMLMediaElementEnums::VideoFullscreenMode mode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
+void VideoPresentationInterfaceAVKitLegacy::setupFullscreen(const FloatRect& initialRect, const FloatSize& videoDimensions, UIView* parentView, HTMLMediaElementEnums::VideoFullscreenMode mode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
 {
     [playerController() setContentDimensions:videoDimensions];
-    VideoPresentationInterfaceIOS::setupFullscreen(videoView, initialRect, videoDimensions, parentView, mode, allowsPictureInPicturePlayback, standby, blocksReturnToFullscreenFromPictureInPicture);
+    VideoPresentationInterfaceIOS::setupFullscreen(initialRect, videoDimensions, parentView, mode, allowsPictureInPicturePlayback, standby, blocksReturnToFullscreenFromPictureInPicture);
     if (playerLayer().captionsLayer != captionsLayer())
         playerLayer().captionsLayer = captionsLayer();
 }
@@ -845,6 +857,11 @@ void VideoPresentationInterfaceAVKitLegacy::setupPlayerViewController()
     if (!m_routingContextUID.isEmpty())
         [m_playerViewController setWebKitOverrideRouteSharingPolicy:(NSUInteger)m_routeSharingPolicy routingContextUID:m_routingContextUID];
 
+    if (!m_currentMode.hasPictureInPicture() && !m_changingStandbyOnly) {
+        ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "Moving videoView to fullscreen WebAVPlayerLayerView");
+        [playerLayerView() transferVideoViewTo:[m_playerViewController playerLayerView]];
+    }
+
 #if PLATFORM(WATCHOS)
     m_viewController = videoPresentationModel() ? videoPresentationModel()->createVideoFullscreenViewController(avPlayerViewController()) : nil;
 #endif
@@ -852,6 +869,8 @@ void VideoPresentationInterfaceAVKitLegacy::setupPlayerViewController()
 
 void VideoPresentationInterfaceAVKitLegacy::invalidatePlayerViewController()
 {
+    returnVideoView();
+
     [m_playerViewController setDelegate:nil];
     [m_playerViewController setPlayerController:nil];
     m_playerViewController = nil;
@@ -905,6 +924,11 @@ bool VideoPresentationInterfaceAVKitLegacy::isExternalPlaybackActive() const
 bool VideoPresentationInterfaceAVKitLegacy::willRenderToLayer() const
 {
     return true;
+}
+
+void VideoPresentationInterfaceAVKitLegacy::returnVideoView()
+{
+    [[m_playerViewController playerLayerView] transferVideoViewTo:playerLayerView()];
 }
 
 static std::optional<bool> isPictureInPictureSupported;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -35,6 +35,7 @@
 #include "PlaybackSessionInterfaceIOS.h"
 #include "SpatialVideoMetadata.h"
 #include "VideoFullscreenCaptions.h"
+#include "VideoPresentationLayerProvider.h"
 #include "VideoPresentationModel.h"
 #include <objc/objc.h>
 #include <wtf/Forward.h>
@@ -53,8 +54,6 @@ OBJC_CLASS UIView;
 OBJC_CLASS CALayer;
 OBJC_CLASS NSError;
 OBJC_CLASS WebAVPlayerController;
-OBJC_CLASS WebAVPlayerLayer;
-OBJC_CLASS WebAVPlayerLayerView;
 
 namespace WebCore {
 
@@ -65,6 +64,7 @@ class VideoPresentationInterfaceIOS
     : public VideoPresentationModelClient
     , public PlaybackSessionModelClient
     , public VideoFullscreenCaptions
+    , public VideoPresentationLayerProvider
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoPresentationInterfaceIOS, WTF::DestructionThread::MainRunLoop>
     , public CanMakeCheckedPtr<VideoPresentationInterfaceIOS> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(VideoPresentationInterfaceIOS, WEBCORE_EXPORT);
@@ -85,12 +85,10 @@ public:
     WEBCORE_EXPORT void videoDimensionsChanged(const FloatSize&);
     virtual void setSpatialImmersive(bool) { }
     WEBCORE_EXPORT virtual void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>);
-    WEBCORE_EXPORT virtual void setupFullscreen(UIView& videoView, const FloatRect& initialRect, const FloatSize& videoDimensions, UIView* parentView, HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture);
+    WEBCORE_EXPORT virtual void setupFullscreen(const FloatRect& initialRect, const FloatSize& videoDimensions, UIView* parentView, HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture);
     WEBCORE_EXPORT virtual void externalPlaybackChanged(bool enabled, PlaybackSessionModel::ExternalPlaybackTargetType, const String& localizedDeviceName);
     WEBCORE_EXPORT virtual AVPlayerViewController *avPlayerViewController() const = 0;
     WebAVPlayerController *playerController() const;
-    WebAVPlayerLayerView *playerLayerView() const { return m_playerLayerView.get(); }
-    WebAVPlayerLayer *playerLayer() const;
     WEBCORE_EXPORT void enterFullscreen();
     WEBCORE_EXPORT virtual bool exitFullscreen(const FloatRect& finalRect);
     WEBCORE_EXPORT void exitFullscreenWithoutAnimationToMode(HTMLMediaElementEnums::VideoFullscreenMode);
@@ -212,8 +210,6 @@ protected:
     bool m_changingStandbyOnly { false };
     bool m_allowsPictureInPicturePlayback { false };
     RetainPtr<UIWindow> m_parentWindow;
-    RetainPtr<UIView> m_videoView;
-    RetainPtr<WebAVPlayerLayerView> m_playerLayerView;
 
     virtual void finalizeSetup();
     virtual void updateRouteSharingPolicy() = 0;
@@ -241,6 +237,7 @@ protected:
     virtual void setAllowsPictureInPicturePlayback(bool) = 0;
     virtual bool isExternalPlaybackActive() const = 0;
     virtual bool willRenderToLayer() const = 0;
+    WEBCORE_EXPORT virtual void returnVideoView();
 
 #if PLATFORM(WATCHOS)
     bool m_waitingForPreparedToExit { false };

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -136,7 +136,7 @@ void VideoPresentationInterfaceIOS::setVideoPresentationModel(VideoPresentationM
     videoDimensionsChanged(model ? model->videoDimensions() : FloatSize());
 }
 
-void VideoPresentationInterfaceIOS::setupFullscreen(UIView& videoView, const FloatRect& initialRect, const FloatSize&, UIView* parentView, HTMLMediaElementEnums::VideoFullscreenMode mode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
+void VideoPresentationInterfaceIOS::setupFullscreen(const FloatRect& initialRect, const FloatSize&, UIView* parentView, HTMLMediaElementEnums::VideoFullscreenMode mode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
 {
     ASSERT(standby || mode != HTMLMediaElementEnums::VideoFullscreenModeNone);
     LOG(Fullscreen, "VideoPresentationInterfaceIOS::setupFullscreen(%p)", this);
@@ -145,7 +145,6 @@ void VideoPresentationInterfaceIOS::setupFullscreen(UIView& videoView, const Flo
 
     m_changingStandbyOnly = mode == HTMLMediaElementEnums::VideoFullscreenModeNone && standby;
     m_allowsPictureInPicturePlayback = allowsPictureInPicturePlayback;
-    m_videoView = &videoView;
     m_parentView = parentView;
     m_parentWindow = parentView.window;
 
@@ -235,20 +234,9 @@ void VideoPresentationInterfaceIOS::doSetup()
     }
 #endif // !PLATFORM(WATCHOS)
 
-    if (!m_playerLayerView)
-        m_playerLayerView = adoptNS([allocWebAVPlayerLayerViewInstance() init]);
-    [m_playerLayerView setHidden:isExternalPlaybackActive()];
-    [m_playerLayerView setBackgroundColor:clearUIColor()];
-
-    if (willRenderToLayer()) {
-        [m_playerLayerView setVideoView:m_videoView.get()];
-        if (!m_currentMode.hasPictureInPicture() && !m_changingStandbyOnly) {
-            ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "Moving videoView to fullscreen WebAVPlayerLayerView");
-            [m_playerLayerView addSubview:m_videoView.get()];
-        }
-    }
-
-    playerLayer().presentationModel = videoPresentationModel().get();
+    RetainPtr playerLayerView = this->playerLayerView();
+    [playerLayerView setHidden:isExternalPlaybackActive()];
+    [playerLayerView setBackgroundColor:clearUIColor()];
 
     setupPlayerViewController();
 
@@ -285,10 +273,10 @@ void VideoPresentationInterfaceIOS::videoDimensionsChanged(const FloatSize& vide
 
     playerLayer().videoDimensions = videoDimensions;
     setContentDimensions(videoDimensions);
-    [m_playerLayerView setNeedsLayout];
+    [playerLayerView() setNeedsLayout];
 
 #if HAVE(PICTUREINPICTUREPLAYERLAYERVIEW)
-    WebAVPictureInPicturePlayerLayerView *pipView = (WebAVPictureInPicturePlayerLayerView *)[m_playerLayerView pictureInPicturePlayerLayerView];
+    WebAVPictureInPicturePlayerLayerView *pipView = (WebAVPictureInPicturePlayerLayerView *)[playerLayerView() pictureInPicturePlayerLayerView];
     WebAVPlayerLayer *pipPlayerLayer = (WebAVPlayerLayer *)[pipView layer];
     [pipPlayerLayer setVideoDimensions:playerLayer().videoDimensions];
     [pipView setNeedsLayout];
@@ -297,7 +285,7 @@ void VideoPresentationInterfaceIOS::videoDimensionsChanged(const FloatSize& vide
 
 void VideoPresentationInterfaceIOS::externalPlaybackChanged(bool enabled, PlaybackSessionModel::ExternalPlaybackTargetType, const String&)
 {
-    [m_playerLayerView setHidden:enabled];
+    [playerLayerView() setHidden:enabled];
 }
 
 void VideoPresentationInterfaceIOS::setInlineRect(const FloatRect& inlineRect, bool visible)
@@ -324,11 +312,6 @@ void VideoPresentationInterfaceIOS::setInlineRect(const FloatRect& inlineRect, b
 WebAVPlayerController *VideoPresentationInterfaceIOS::playerController() const
 {
     return m_playbackSessionInterface->playerController();
-}
-
-WebAVPlayerLayer *VideoPresentationInterfaceIOS::playerLayer() const
-{
-    return (WebAVPlayerLayer *)[m_playerLayerView playerLayer];
 }
 
 void VideoPresentationInterfaceIOS::applicationDidBecomeActive()
@@ -384,7 +367,7 @@ void VideoPresentationInterfaceIOS::doEnterFullscreen()
     FloatSize size;
 #if HAVE(PICTUREINPICTUREPLAYERLAYERVIEW)
     if (m_currentMode.hasPictureInPicture()) {
-        auto *pipView = (WebAVPictureInPicturePlayerLayerView *)[m_playerLayerView pictureInPicturePlayerLayerView];
+        auto *pipView = (WebAVPictureInPicturePlayerLayerView *)[playerLayerView() pictureInPicturePlayerLayerView];
         auto *pipPlayerLayer = (WebAVPlayerLayer *)[pipView layer];
         auto videoFrame = [pipPlayerLayer calculateTargetVideoFrame];
         size = FloatSize(videoFrame.size());
@@ -499,7 +482,7 @@ void VideoPresentationInterfaceIOS::exitFullscreenHandler(BOOL success, NSError*
     } else {
         [CATransaction begin];
         [CATransaction setDisableActions:YES];
-        [m_playerLayerView setBackgroundColor:clearUIColor()];
+        [playerLayerView() setBackgroundColor:clearUIColor()];
         [playerViewController().view setBackgroundColor:clearUIColor()];
         [CATransaction commit];
     }
@@ -548,13 +531,9 @@ void VideoPresentationInterfaceIOS::cleanupFullscreen()
     [[playerViewController view] removeFromSuperview];
     [playerViewController removeFromParentViewController];
 
-    [m_playerLayerView setVideoView:nil];
-    [m_playerLayerView removeFromSuperview];
     [[m_viewController view] removeFromSuperview];
 
-    m_playerLayerView = nil;
     m_window = nil;
-    m_videoView = nil;
     m_parentView = nil;
     m_parentWindow = nil;
 
@@ -720,7 +699,7 @@ void VideoPresentationInterfaceIOS::didStopPictureInPicture()
 
     clearMode(HTMLMediaElementEnums::VideoFullscreenModePictureInPicture, !m_exitFullscreenNeedsExitPictureInPicture);
 
-    [m_playerLayerView setBackgroundColor:clearUIColor()];
+    [playerLayerView() setBackgroundColor:clearUIColor()];
     playerViewController().view.backgroundColor = clearUIColor();
 
     if (m_enterFullscreenNeedsExitPictureInPicture)
@@ -732,8 +711,7 @@ void VideoPresentationInterfaceIOS::didStopPictureInPicture()
     if (!m_targetMode.hasFullscreen() && !m_currentMode.hasFullscreen() && !m_hasVideoContentLayer) {
         // We have just exited pip and not entered fullscreen in turn. To avoid getting
         // stuck holding the video content layer, explicitly return it here:
-        if (auto model = videoPresentationModel())
-            model->returnVideoView();
+        returnVideoView();
     }
 }
 
@@ -866,13 +844,17 @@ void VideoPresentationInterfaceIOS::returnToStandby()
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     m_returningToStandby = false;
 
-    auto model = videoPresentationModel();
-    if (model)
-        model->returnVideoView();
+    returnVideoView();
 
     // Continue processing exit picture-in-picture now that
     // it is safe to do so:
     didStopPictureInPicture();
+}
+
+void VideoPresentationInterfaceIOS::returnVideoView()
+{
+    if (auto model = videoPresentationModel())
+        model->returnVideoView();
 }
 
 void VideoPresentationInterfaceIOS::setMode(HTMLMediaElementEnums::VideoFullscreenMode mode, bool shouldNotifyModel)

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -1030,7 +1030,7 @@ void VideoFullscreenControllerContext::setUpFullscreen(HTMLVideoElement& videoEl
 
         m_videoFullscreenView = adoptNS([PAL::allocUIViewInstance() init]);
 
-        m_interface->setupFullscreen(*m_videoFullscreenView.get(), videoElementClientRect, videoDimensions, viewRef.get(), mode, allowsPictureInPicture, false, false);
+        m_interface->setupFullscreen(videoElementClientRect, videoDimensions, viewRef.get(), mode, allowsPictureInPicture, false, false);
     });
 }
 

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -32,6 +32,7 @@
 #include "PlaybackSessionInterfaceMac.h"
 #include "PlaybackSessionModel.h"
 #include "VideoFullscreenCaptions.h"
+#include "VideoPresentationLayerProvider.h"
 #include "VideoPresentationModel.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/RefCounted.h>
@@ -53,6 +54,7 @@ class VideoPresentationInterfaceMac final
     : public VideoPresentationModelClient
     , private PlaybackSessionModelClient
     , public VideoFullscreenCaptions
+    , public VideoPresentationLayerProvider
     , public RefCounted<VideoPresentationInterfaceMac>
     , public CanMakeCheckedPtr<VideoPresentationInterfaceMac> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(VideoPresentationInterfaceMac, WEBCORE_EXPORT);
@@ -78,7 +80,7 @@ public:
     WEBCORE_EXPORT void videoDimensionsChanged(const FloatSize&) final;
     void setPlayerIdentifier(std::optional<MediaPlayerIdentifier> identifier) final { m_playerIdentifier = identifier; }
 
-    WEBCORE_EXPORT void setupFullscreen(NSView& layerHostedView, const IntRect& initialRect, NSWindow *parentWindow, HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicturePlayback);
+    WEBCORE_EXPORT void setupFullscreen(const IntRect& initialRect, NSWindow *parentWindow, HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicturePlayback);
     WEBCORE_EXPORT void enterFullscreen();
     WEBCORE_EXPORT bool exitFullscreen(const IntRect& finalRect, NSWindow *parentWindow);
     WEBCORE_EXPORT void exitFullscreenWithoutAnimationToMode(HTMLMediaElementEnums::VideoFullscreenMode);

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
@@ -461,7 +461,7 @@ WebVideoPresentationInterfaceMacObjC *VideoPresentationInterfaceMac::videoPresen
     return m_webVideoPresentationInterfaceObjC.get();
 }
 
-void VideoPresentationInterfaceMac::setupFullscreen(NSView& layerHostedView, const IntRect& initialRect, NSWindow *parentWindow, HTMLMediaElementEnums::VideoFullscreenMode mode, bool allowsPictureInPicturePlayback)
+void VideoPresentationInterfaceMac::setupFullscreen(const IntRect& initialRect, NSWindow *parentWindow, HTMLMediaElementEnums::VideoFullscreenMode mode, bool allowsPictureInPicturePlayback)
 {
     LOG(Fullscreen, "VideoPresentationInterfaceMac::setupFullscreen(%p), initialRect:{%d, %d, %d, %d}, parentWindow:%p, mode:%d", this, initialRect.x(), initialRect.y(), initialRect.width(), initialRect.height(), parentWindow, mode);
 
@@ -470,7 +470,7 @@ void VideoPresentationInterfaceMac::setupFullscreen(NSView& layerHostedView, con
 
     m_mode |= mode;
 
-    [videoPresentationInterfaceObjC() setUpPIPForVideoView:&layerHostedView withFrame:(NSRect)initialRect inWindow:parentWindow];
+    [videoPresentationInterfaceObjC() setUpPIPForVideoView:layerHostView() withFrame:(NSRect)initialRect inWindow:parentWindow];
 
     RunLoop::main().dispatch([protectedThis = Ref { *this }, this] {
         if (RefPtr model = videoPresentationModel()) {

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -58,7 +58,7 @@ private:
     bool pictureInPictureWasStartedWhenEnteringBackground() const final { return false; }
     bool mayAutomaticallyShowVideoPictureInPicture() const final { return false; }
     bool isPlayingVideoInEnhancedFullscreen() const final { return false; }
-    void setupFullscreen(UIView&, const WebCore::FloatRect&, const WebCore::FloatSize&, UIView*, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) final;
+    void setupFullscreen(const WebCore::FloatRect&, const WebCore::FloatSize&, UIView*, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) final;
     void hasVideoChanged(bool) final { }
     void finalizeSetup() final;
     void updateRouteSharingPolicy() final { }

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -100,14 +100,14 @@ void VideoPresentationInterfaceLMK::setSpatialImmersive(bool immersive)
     linearMediaPlayer().spatialImmersive = immersive;
 }
 
-void VideoPresentationInterfaceLMK::setupFullscreen(UIView& videoView, const WebCore::FloatRect& initialRect, const WebCore::FloatSize& videoDimensions, UIView* parentView, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
+void VideoPresentationInterfaceLMK::setupFullscreen(const WebCore::FloatRect& initialRect, const WebCore::FloatSize& videoDimensions, UIView* parentView, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
 {
     linearMediaPlayer().contentDimensions = videoDimensions;
     if (!linearMediaPlayer().enteredFromInline && playerViewController()) {
         playableViewController().wks_automaticallyDockOnFullScreenPresentation = NO;
         playableViewController().wks_dismissFullScreenOnExitingDocking = NO;
     }
-    VideoPresentationInterfaceIOS::setupFullscreen(videoView, initialRect, videoDimensions, parentView, mode, allowsPictureInPicturePlayback, standby, blocksReturnToFullscreenFromPictureInPicture);
+    VideoPresentationInterfaceIOS::setupFullscreen(initialRect, videoDimensions, parentView, mode, allowsPictureInPicturePlayback, standby, blocksReturnToFullscreenFromPictureInPicture);
 }
 
 void VideoPresentationInterfaceLMK::finalizeSetup()

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -71,20 +71,6 @@ public:
     }
     virtual ~VideoPresentationModelContext();
 
-    PlatformView *layerHostView() const { return m_layerHostView.get(); }
-    void setLayerHostView(RetainPtr<PlatformView>&& layerHostView) { m_layerHostView = WTFMove(layerHostView); }
-
-    WebAVPlayerLayer *playerLayer() const { return m_playerLayer.get(); }
-    void setPlayerLayer(RetainPtr<WebAVPlayerLayer>&&);
-
-#if PLATFORM(IOS_FAMILY)
-    WebAVPlayerLayerView *playerView() const { return m_playerView.get(); }
-    void setPlayerView(RetainPtr<WebAVPlayerLayerView>&& playerView) { m_playerView = WTFMove(playerView); }
-
-    WKVideoView *videoView() const { return m_videoView.get(); }
-    void setVideoView(RetainPtr<WKVideoView>&& videoView) { m_videoView = WTFMove(videoView); }
-#endif
-
     void requestCloseAllMediaPresentations(bool finishedWithMedia, CompletionHandler<void()>&&);
 
 private:
@@ -140,13 +126,6 @@ private:
     WeakPtr<VideoPresentationManagerProxy> m_manager;
     Ref<PlaybackSessionModelContext> m_playbackSessionModel;
     PlaybackSessionContextIdentifier m_contextId;
-    RetainPtr<PlatformView> m_layerHostView;
-    RetainPtr<WebAVPlayerLayer> m_playerLayer;
-
-#if PLATFORM(IOS_FAMILY)
-    RetainPtr<WebAVPlayerLayerView> m_playerView;
-    RetainPtr<WKVideoView> m_videoView;
-#endif
 
     WeakHashSet<WebCore::VideoPresentationModelClient> m_clients;
     WebCore::FloatSize m_videoDimensions;
@@ -222,6 +201,7 @@ private:
     void ensureClientForContext(PlaybackSessionContextIdentifier);
     void addClientForContext(PlaybackSessionContextIdentifier);
     void removeClientForContext(PlaybackSessionContextIdentifier);
+    void invalidateInterface(WebCore::PlatformVideoPresentationInterface&);
 
     void hasVideoInPictureInPictureDidChange(bool);
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -255,12 +255,6 @@ void VideoPresentationModelContext::removeClient(VideoPresentationModelClient& c
     m_clients.remove(client);
 }
 
-void VideoPresentationModelContext::setPlayerLayer(RetainPtr<WebAVPlayerLayer>&& playerLayer)
-{
-    m_playerLayer = WTFMove(playerLayer);
-    [m_playerLayer setVideoDimensions:m_videoDimensions];
-}
-
 void VideoPresentationManagerProxy::setDocumentVisibility(PlaybackSessionContextIdentifier contextId, bool isDocumentVisible)
 {
     if (m_mockVideoPresentationModeEnabled)
@@ -539,12 +533,33 @@ void VideoPresentationManagerProxy::invalidate()
     auto contextMap = std::exchange(m_contextMap, { });
     m_clientCounts.clear();
 
-    for (auto& [model, interface] : contextMap.values()) {
-        interface->invalidate();
-        [model->layerHostView() removeFromSuperview];
-        model->setLayerHostView(nullptr);
-        [model->playerLayer() setPresentationModel:nil];
+    for (auto& [model, interface] : contextMap.values())
+        invalidateInterface(interface);
+}
+
+void VideoPresentationManagerProxy::invalidateInterface(WebCore::PlatformVideoPresentationInterface& interface)
+{
+    interface.setVideoPresentationModel(nullptr);
+
+    if (auto *layerHostView = interface.layerHostView()) {
+        [layerHostView removeFromSuperview];
+        interface.setLayerHostView(nullptr);
     }
+
+    if (auto *playerLayer = interface.playerLayer()) {
+        playerLayer.presentationModel = nil;
+        interface.setPlayerLayer(nullptr);
+    }
+
+#if PLATFORM(IOS_FAMILY)
+    if (auto *playerLayerView = interface.playerLayerView()) {
+        [playerLayerView removeFromSuperview];
+        interface.setPlayerLayerView(nullptr);
+    }
+
+    interface.setVideoView(nullptr);
+#endif
+    interface.invalidate();
 }
 
 void VideoPresentationManagerProxy::requestHideAndExitFullscreen()
@@ -693,9 +708,7 @@ void VideoPresentationManagerProxy::removeClientForContext(PlaybackSessionContex
     ALWAYS_LOG(LOGIDENTIFIER, clientCount);
 
     if (clientCount <= 0) {
-        Ref interface = ensureInterface(contextId);
-        interface->setVideoPresentationModel(nullptr);
-        interface->invalidate();
+        invalidateInterface(ensureInterface(contextId));
         protectedPlaybackSessionManagerProxy()->removeClientForContext(contextId);
         m_clientCounts.remove(contextId);
         m_contextMap.remove(contextId);
@@ -776,7 +789,8 @@ PlatformLayerContainer VideoPresentationManagerProxy::createLayerWithID(Playback
 
     RetainPtr<WKLayerHostView> view = createLayerHostViewWithID(contextId, videoLayerID, initialSize, hostingDeviceScaleFactor);
 
-    if (!protectedModel->playerLayer()) {
+    Ref protectedInterface = interface;
+    if (!protectedInterface->playerLayer()) {
         ALWAYS_LOG(LOGIDENTIFIER, protectedModel->logIdentifier(), ", Creating AVPlayerLayer, initialSize: ", initialSize, ", nativeSize: ", nativeSize);
         auto playerLayer = adoptNS([[WebAVPlayerLayer alloc] init]);
 
@@ -788,7 +802,7 @@ PlatformLayerContainer VideoPresentationManagerProxy::createLayerWithID(Playback
         if (![[view layer] superlayer])
             [playerLayer addSublayer:[view layer]];
 
-        protectedModel->setPlayerLayer(playerLayer.get());
+        protectedInterface->setPlayerLayer(playerLayer.get());
 
         [playerLayer setFrame:CGRectMake(0, 0, initialSize.width(), initialSize.height())];
         [playerLayer setNeedsLayout];
@@ -798,14 +812,14 @@ PlatformLayerContainer VideoPresentationManagerProxy::createLayerWithID(Playback
     if (RefPtr page = m_page.get())
         page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::EnsureUpdatedVideoDimensions(contextId, nativeSize), page->webPageIDInMainFrameProcess());
 
-    return protectedModel->playerLayer();
+    return protectedInterface->playerLayer();
 }
 
 RetainPtr<WKLayerHostView> VideoPresentationManagerProxy::createLayerHostViewWithID(PlaybackSessionContextIdentifier contextId, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatSize& initialSize, float hostingDeviceScaleFactor)
 {
     auto [model, interface] = ensureModelAndInterface(contextId);
 
-    RetainPtr<WKLayerHostView> view = static_cast<WKLayerHostView*>(model->layerHostView());
+    RetainPtr<WKLayerHostView> view = static_cast<WKLayerHostView*>(interface->layerHostView());
     if (!view) {
         view = adoptNS([[WKLayerHostView alloc] init]);
 #if PLATFORM(IOS_FAMILY)
@@ -814,7 +828,7 @@ RetainPtr<WKLayerHostView> VideoPresentationManagerProxy::createLayerHostViewWit
 #if PLATFORM(MAC)
         [view setWantsLayer:YES];
 #endif
-        model->setLayerHostView(view);
+        interface->setLayerHostView(view);
 
 #if USE(EXTENSIONKIT)
         auto hostingView = adoptNS([[BELayerHierarchyHostingView alloc] init]);
@@ -866,7 +880,7 @@ RetainPtr<WKVideoView> VideoPresentationManagerProxy::createViewWithID(PlaybackS
 
     RetainPtr<WKLayerHostView> view = createLayerHostViewWithID(contextId, videoLayerID, initialSize, hostingDeviceScaleFactor);
 
-    if (!model->videoView()) {
+    if (!interface->videoView()) {
         ALWAYS_LOG(LOGIDENTIFIER, model->logIdentifier(), ", Creating AVPlayerLayerView");
         auto initialFrame = CGRectMake(0, 0, initialSize.width(), initialSize.height());
         auto playerView = adoptNS([allocWebAVPlayerLayerViewInstance() initWithFrame:initialFrame]);
@@ -888,15 +902,15 @@ RetainPtr<WKVideoView> VideoPresentationManagerProxy::createViewWithID(PlaybackS
 
         auto videoView = adoptNS([[WKVideoView alloc] initWithFrame:initialFrame playerView:playerView.get()]);
 
-        model->setPlayerLayer(WTFMove(playerLayer));
-        model->setPlayerView(playerView.get());
-        model->setVideoView(videoView.get());
+        interface->setPlayerLayer(WTFMove(playerLayer));
+        interface->setPlayerLayerView(playerView.get());
+        interface->setVideoView(videoView.get());
     }
 
     if (RefPtr page = m_page.get())
         page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::EnsureUpdatedVideoDimensions(contextId, nativeSize), page->webPageIDInMainFrameProcess());
 
-    return model->videoView();
+    return dynamic_objc_cast<WKVideoView>(interface->videoView());
 }
 #endif
 
@@ -949,12 +963,12 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContext
 
 #if PLATFORM(IOS_FAMILY)
     // The video may not have been rendered yet, which would have triggered a call to createViewWithID/createLayerHostViewWithID making the AVPlayerLayer and AVPlayerLayerView not yet set. Create them as needed.
-    if (!model->videoView())
+    if (!interface->videoView())
         createViewWithID(contextId, videoLayerID, initialSize, videoDimensions, hostingDeviceScaleFactor);
-    ASSERT(model->videoView());
+    ASSERT(interface->videoView());
 #endif
 
-    RetainPtr view = model->layerHostView() ? static_cast<WKLayerHostView*>(model->layerHostView()) : createLayerHostViewWithID(contextId, videoLayerID, initialSize, hostingDeviceScaleFactor);
+    RetainPtr view = interface->layerHostView() ? static_cast<WKLayerHostView*>(interface->layerHostView()) : createLayerHostViewWithID(contextId, videoLayerID, initialSize, hostingDeviceScaleFactor);
 #if USE(EXTENSIONKIT)
     RefPtr pageClient = page->pageClient();
     if (UIView *visibilityPropagationView = pageClient ? pageClient->createVisibilityPropagationView() : nullptr)
@@ -966,13 +980,13 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContext
 #if PLATFORM(IOS_FAMILY)
     auto* rootNode = downcast<RemoteLayerTreeDrawingAreaProxy>(*page->drawingArea()).remoteLayerTreeHost().rootNode();
     UIView *parentView = rootNode ? rootNode->uiView() : nil;
-    interface->setupFullscreen(*model->layerHostView(), screenRect, videoDimensions, parentView, videoFullscreenMode, allowsPictureInPicture, standby, blocksReturnToFullscreenFromPictureInPicture);
+    interface->setupFullscreen(screenRect, videoDimensions, parentView, videoFullscreenMode, allowsPictureInPicture, standby, blocksReturnToFullscreenFromPictureInPicture);
 #else
     UNUSED_PARAM(videoDimensions);
     UNUSED_PARAM(blocksReturnToFullscreenFromPictureInPicture);
     IntRect initialWindowRect;
     page->rootViewToWindow(enclosingIntRect(screenRect), initialWindowRect);
-    interface->setupFullscreen(*model->layerHostView(), initialWindowRect, page->platformWindow(), videoFullscreenMode, allowsPictureInPicture);
+    interface->setupFullscreen(initialWindowRect, page->platformWindow(), videoFullscreenMode, allowsPictureInPicture);
 #endif
 }
 
@@ -1258,9 +1272,9 @@ void VideoPresentationManagerProxy::returnVideoContentLayer(PlaybackSessionConte
 void VideoPresentationManagerProxy::returnVideoView(PlaybackSessionContextIdentifier contextId)
 {
 #if PLATFORM(IOS_FAMILY)
-    Ref model = ensureModel(contextId);
-    auto *playerView = model->playerView();
-    auto *videoView = model->layerHostView();
+    Ref interface = ensureInterface(contextId);
+    auto *playerView = interface->playerLayerView();
+    auto *videoView = interface->layerHostView();
     if (playerView && videoView) {
         [playerView addSubview:videoView];
         [playerView setNeedsLayout];
@@ -1339,21 +1353,21 @@ void VideoPresentationManagerProxy::didCleanupFullscreen(PlaybackSessionContextI
     auto [model, interface] = ensureModelAndInterface(contextId);
 
 #if USE(EXTENSIONKIT)
-    if (auto layerHostView = dynamic_objc_cast<WKLayerHostView>(model->layerHostView()))
+    if (auto layerHostView = dynamic_objc_cast<WKLayerHostView>(interface->layerHostView()))
         [layerHostView setVisibilityPropagationView:nil];
 #endif
 
-    [model->layerHostView() removeFromSuperview];
+    [interface->layerHostView() removeFromSuperview];
     interface->removeCaptionsLayer();
-    if (auto playerLayer = model->playerLayer()) {
+    if (auto playerLayer = interface->playerLayer()) {
         // Return the video layer to the player layer
-        auto videoView = model->layerHostView();
+        auto videoView = interface->layerHostView();
         [playerLayer addSublayer:[videoView layer]];
         [playerLayer layoutSublayers];
     } else {
         [CATransaction flush];
-        [model->layerHostView() removeFromSuperview];
-        model->setLayerHostView(nullptr);
+        [interface->layerHostView() removeFromSuperview];
+        interface->setLayerHostView(nullptr);
     }
 
     page->protectedLegacyMainFrameProcess()->send(Messages::VideoPresentationManager::DidCleanupFullscreen(contextId), page->webPageIDInMainFrameProcess());
@@ -1377,7 +1391,7 @@ void VideoPresentationManagerProxy::setVideoLayerFrame(PlaybackSessionContextIde
     MachSendRight fenceSendRight;
 #if PLATFORM(IOS_FAMILY)
 #if USE(EXTENSIONKIT)
-    auto view = dynamic_objc_cast<WKLayerHostView>(model->layerHostView());
+    auto view = dynamic_objc_cast<WKLayerHostView>(interface->layerHostView());
     if (view && view->_hostingView) {
         auto hostingUpdateCoordinator = [BELayerHierarchyHostingTransactionCoordinator coordinatorWithError:nil];
         [hostingUpdateCoordinator addLayerHierarchyHostingView:view->_hostingView.get()];


### PR DESCRIPTION
#### 45ca24f5cf622e4fca9a6a1746fbf82db7edac38
<pre>
[Cocoa] Move WebAVPlayerLayer/View into VIdeoPresentationInterface
<a href="https://bugs.webkit.org/show_bug.cgi?id=282868">https://bugs.webkit.org/show_bug.cgi?id=282868</a>
<a href="https://rdar.apple.com/139549784">rdar://139549784</a>

Reviewed by Eric Carlson.

Move ownership of WebAVPlayerLayer, WebAVPlayerLayerView, the LayerHostView, and WKVideoView
from VideoPresentationModelContext and into VideoPresentationInterface*. But because each
VideoPresentationInterface type is a separate class, introduce a new base class which will
actually own those objects.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/cocoa/VideoPresentationLayerProvider.h: Added.
* Source/WebCore/platform/cocoa/VideoPresentationLayerProvider.mm: Copied from Source/WebCore/platform/cocoa/WebAVPlayerLayerView.h.
(WebCore::VideoPresentationLayerProvider::ensurePlayerLayerView):
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer setVideoSublayer:]):
* Source/WebCore/platform/cocoa/WebAVPlayerLayerView.h:
* Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm:
(WebCore::WebAVPlayerLayerView_transferVideoViewTo):
(WebCore::allocWebAVPlayerLayerViewInstance):
* Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h:
* Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h:
* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm:
(-[WebAVPlayerViewController initWithFullscreenInterface:]):
(-[WebAVPlayerViewController playerLayerView]):
(WebCore::VideoPresentationInterfaceAVKitLegacy::setupFullscreen):
(WebCore::VideoPresentationInterfaceAVKitLegacy::setupPlayerViewController):
(WebCore::VideoPresentationInterfaceAVKitLegacy::invalidatePlayerViewController):
(WebCore::VideoPresentationInterfaceAVKitLegacy::returnVideoView):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
(WebCore::VideoPresentationInterfaceIOS::playerLayerView const): Deleted.
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::setupFullscreen):
(WebCore::VideoPresentationInterfaceIOS::doSetup):
(WebCore::VideoPresentationInterfaceIOS::videoDimensionsChanged):
(WebCore::VideoPresentationInterfaceIOS::externalPlaybackChanged):
(WebCore::VideoPresentationInterfaceIOS::doEnterFullscreen):
(WebCore::VideoPresentationInterfaceIOS::exitFullscreenHandler):
(WebCore::VideoPresentationInterfaceIOS::cleanupFullscreen):
(WebCore::VideoPresentationInterfaceIOS::didStopPictureInPicture):
(WebCore::VideoPresentationInterfaceIOS::returnToStandby):
(WebCore::VideoPresentationInterfaceIOS::returnVideoView):
(WebCore::VideoPresentationInterfaceIOS::playerLayer const): Deleted.
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
(VideoFullscreenControllerContext::setUpFullscreen):
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h:
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm:
(WebCore::VideoPresentationInterfaceMac::setupFullscreen):
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.mm:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::setupFullscreen):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::invalidate):
(WebKit::VideoPresentationManagerProxy::createLayerWithID):
(WebKit::VideoPresentationManagerProxy::createLayerHostViewWithID):
(WebKit::VideoPresentationManagerProxy::createViewWithID):
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
(WebKit::VideoPresentationManagerProxy::returnVideoView):
(WebKit::VideoPresentationManagerProxy::didCleanupFullscreen):
(WebKit::VideoPresentationManagerProxy::setVideoLayerFrame):
(WebKit::VideoPresentationModelContext::setPlayerLayer): Deleted.

Canonical link: <a href="https://commits.webkit.org/288610@main">https://commits.webkit.org/288610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83c6b256028ffe5c31ef262e6b20c6515e96cc39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88828 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34764 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85841 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65151 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22983 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45440 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30317 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33813 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31064 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90206 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11021 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7964 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/connect-src-star-websocket-allowed.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73585 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11245 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72808 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18036 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17077 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15778 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2345 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10973 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16445 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10821 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14296 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12593 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->