### PR TITLE
Fix <input type=file> painting in sideways-lr writing mode

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-computed-style-expected.txt
@@ -3,4 +3,6 @@
 PASS horizontal-input block size should match height and inline size should match width
 PASS vertical-lr-input block size should match width and inline size should match height
 PASS vertical-rl-input block size should match width and inline size should match height
+PASS sideways-lr-input block size should match width and inline size should match height
+PASS sideways-rl-input block size should match width and inline size should match height
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-computed-style.html
@@ -9,6 +9,8 @@
 <input type="file" id="horizontal-input" style="writing-mode: horizontal-tb">
 <input type="file" id="vertical-lr-input" style="writing-mode: vertical-lr">
 <input type="file" id="vertical-rl-input" style="writing-mode: vertical-rl">
+<input type="file" id="sideways-lr-input" style="writing-mode: sideways-lr">
+<input type="file" id="sideways-rl-input" style="writing-mode: sideways-rl">
 
 <script>
 for (const element of document.querySelectorAll("[id^='horizontal-']")) {
@@ -24,7 +26,7 @@ for (const element of document.querySelectorAll("[id^='horizontal-']")) {
     }, `${element.id} block size should match height and inline size should match width`);
 }
 
-for (const element of document.querySelectorAll("[id^='vertical-']")) {
+for (const element of document.querySelectorAll("[id^='vertical-'], [id^='sideways-']")) {
     test(() => {
         const style = getComputedStyle(element);
         const blockSize = parseInt(style.blockSize, 10);


### PR DESCRIPTION
#### 9055c855d8be2d1fde1a7b9dcb15bb0dbf29e990
<pre>
Fix &lt;input type=file&gt; painting in sideways-lr writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=285545">https://bugs.webkit.org/show_bug.cgi?id=285545</a>
<a href="https://rdar.apple.com/142491598">rdar://142491598</a>

Reviewed by Alan Baradlay.

Perform the necessary translations to position the text and icon properly when painting `&lt;input type=file&gt;`.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-computed-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-computed-style.html:
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::RenderFileUploadControl::paintControl):

Canonical link: <a href="https://commits.webkit.org/288569@main">https://commits.webkit.org/288569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8b26a9b0b72b2b6709c96859c37897dfbba4b0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34779 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65154 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/22992 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45443 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2492 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30330 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33828 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90221 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11036 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7973 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73597 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72821 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18008 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17091 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15789 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2360 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10988 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16460 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10836 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14311 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->