### PR TITLE
Sometimes a null port can get sent over to create a SharedMemoryHandle, this asserts on the constructor

### DIFF
--- a/LayoutTests/http/tests/ipc/null-port-on-sharedmemoryhandle-creation-expected.txt
+++ b/LayoutTests/http/tests/ipc/null-port-on-sharedmemoryhandle-creation-expected.txt
@@ -1,0 +1,1 @@
+This test passes if Webkit does not crash

--- a/LayoutTests/http/tests/ipc/null-port-on-sharedmemoryhandle-creation.html
+++ b/LayoutTests/http/tests/ipc/null-port-on-sharedmemoryhandle-creation.html
@@ -1,0 +1,45 @@
+<!doctype html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html>
+<head>
+<script>
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+    if (window.IPC) {
+        import('./coreipc.js').then(({
+            CoreIPC
+        }) => {
+            const streamConnection = CoreIPC.newStreamConnection();
+            CoreIPC.GPU.GPUConnectionToWebProcess.CreateGraphicsContextGL(0, {
+                identifier: 262156,
+                attributes: {
+                    alpha: false,
+                    depth: false,
+                    stencil: false,
+                    antialias: false,
+                    premultipliedAlpha: false,
+                    preserveDrawingBuffer: false,
+                    powerPreference: 1,
+                    isWebGL2: false,
+                    windowGPUID: 3988976645964476,
+                    failContextCreationForTesting: 3
+                },
+                renderingBackendIdentifier: 262157,
+                serverConnection: streamConnection
+            });
+            CoreIPC.GPU.GPUConnectionToWebProcess.CreateGPU(0, {
+                identifier: 262162,
+                renderingBackendIdentifier: 262157,
+                serverConnection: streamConnection
+            });
+        });
+    }
+
+    function callDone() {
+        window.testRunner?.notifyDone();
+    }
+</script>
+</head>
+<body onload="setTimeout(callDone, 200)">
+    <p>This test passes if Webkit does not crash</p>
+</body>
+</html>

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2623,13 +2623,13 @@ header: <wtf/MachSendRight.h>
 
 [CustomHeader, RValue] class WebCore::SharedMemoryHandle {
 #if USE(UNIX_DOMAIN_SOCKETS)
-    [Validator='!!m_handle'] UnixFileDescriptor m_handle;
+    [Validator='!!m_handle && *m_handle'] UnixFileDescriptor m_handle;
 #endif
 #if OS(DARWIN)
-    [Validator='!!m_handle'] MachSendRight m_handle;
+    [Validator='!!m_handle && *m_handle'] MachSendRight m_handle;
 #endif
 #if OS(WINDOWS)
-    [Validator='!!m_handle'] Win32Handle m_handle;
+    [Validator='!!m_handle && *m_handle'] Win32Handle m_handle;
 #endif
     size_t m_size;
 };

--- a/Tools/Scripts/webkitperl/httpd.pm
+++ b/Tools/Scripts/webkitperl/httpd.pm
@@ -119,6 +119,7 @@ sub getDefaultConfigForTestDirectory
     my $testharnesscssDirectory = File::Spec->catfile($testDirectory, "resources", "testharness.css");
     my $testharnessjsDirectory = File::Spec->catfile($testDirectory, "resources", "testharness.js");
     my $testharnessreportjsDirectory = File::Spec->catfile($testDirectory, "resources", "testharnessreport.js");
+    my $coreipcjsDirectory = File::Spec->catfile($testDirectory, "ipc", "coreipc.js");
 
     my $typesConfig = File::Spec->catfile($testDirectory, "http", "conf", "mime.types");
     my $httpdLockFile = File::Spec->catfile($httpdPidDir, "httpd.lock");
@@ -133,6 +134,7 @@ sub getDefaultConfigForTestDirectory
         "-c", "Alias /testharness.css \"$testharnesscssDirectory\"",
         "-c", "Alias /testharness.js \"$testharnessjsDirectory\"",
         "-c", "Alias /testharnessreport.js \"$testharnessreportjsDirectory\"",
+        "-c", "Alias /ipc/coreipc.js \"$coreipcjsDirectory\"",
         "-c", "TypesConfig \"$typesConfig\"",
         # Apache wouldn't run CGIs with permissions==700 otherwise
         "-c", "PidFile \"$httpdPidFile\"",


### PR DESCRIPTION
#### 3824d61a613194816b8c6afa7057214491925d4d
<pre>
Sometimes a null port can get sent over to create a SharedMemoryHandle, this asserts on the constructor
<a href="https://rdar.apple.com/139876500">rdar://139876500</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=285539">https://bugs.webkit.org/show_bug.cgi?id=285539</a>

Reviewed by Ryosuke Niwa.

This fixes the bug by adding a verification on the decoder for the IPC handle that makes sure it&apos;s not a null or invalid handle.

* LayoutTests/http/tests/ipc/null-port-on-sharedmemoryhandle-creation-expected.txt: Added.
* LayoutTests/http/tests/ipc/null-port-on-sharedmemoryhandle-creation.html: Added.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/Scripts/webkitperl/httpd.pm:
(getDefaultConfigForTestDirectory):

Canonical link: <a href="https://commits.webkit.org/288584@main">https://commits.webkit.org/288584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c2298270e9a6fc35cf7aacfcd4775b4ce028988

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88872 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34807 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65179 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23017 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2596 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76144 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45468 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2516 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30359 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33856 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73535 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90249 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73623 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11288 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72845 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17116 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2388 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12959 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11016 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16488 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10864 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14339 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->