### PR TITLE
Stop using UncheckedKeyHashSet in IPC code

### DIFF
--- a/Source/WebCore/html/Allowlist.h
+++ b/Source/WebCore/html/Allowlist.h
@@ -39,15 +39,15 @@ public:
     {
     }
     explicit Allowlist(const SecurityOriginData& origin)
-        : m_origins(UncheckedKeyHashSet<SecurityOriginData> { origin })
+        : m_origins(HashSet<SecurityOriginData> { origin })
     {
     }
-    explicit Allowlist(UncheckedKeyHashSet<SecurityOriginData>&& origins)
+    explicit Allowlist(HashSet<SecurityOriginData>&& origins)
         : m_origins(WTFMove(origins))
     {
     }
 
-    using OriginsVariant = std::variant<UncheckedKeyHashSet<SecurityOriginData>, AllowAllOrigins>;
+    using OriginsVariant = std::variant<HashSet<SecurityOriginData>, AllowAllOrigins>;
     explicit Allowlist(OriginsVariant&& origins)
         : m_origins(WTFMove(origins))
     {
@@ -57,7 +57,7 @@ public:
     // This is simplified version of https://w3c.github.io/webappsec-permissions-policy/#matches.
     bool matches(const SecurityOriginData& origin) const
     {
-        return std::visit(WTF::makeVisitor([&origin](const UncheckedKeyHashSet<SecurityOriginData>& origins) -> bool {
+        return std::visit(WTF::makeVisitor([&origin](const HashSet<SecurityOriginData>& origins) -> bool {
             return origins.contains(origin);
         }, [&] (const auto&) {
             return true;

--- a/Source/WebCore/html/PermissionsPolicy.cpp
+++ b/Source/WebCore/html/PermissionsPolicy.cpp
@@ -315,7 +315,7 @@ static Allowlist parseAllowlist(StringView value, const SecurityOriginData& cont
     if (value.isEmpty())
         return Allowlist { targetOrigin };
 
-    UncheckedKeyHashSet<SecurityOriginData> allowedOrigins;
+    HashSet<SecurityOriginData> allowedOrigins;
     while (!value.isEmpty()) {
         auto [token, remainingValue] = splitOnAsciiWhiteSpace(value);
         if (!token.isEmpty()) {

--- a/Source/WebCore/loader/CanvasActivityRecord.h
+++ b/Source/WebCore/loader/CanvasActivityRecord.h
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 struct CanvasActivityRecord {
-    UncheckedKeyHashSet<String> textWritten;
+    HashSet<String> textWritten;
     bool wasDataRead { false };
     
     WEBCORE_EXPORT bool recordWrittenOrMeasuredText(const String&);

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -179,7 +179,7 @@ enum class PushAndNotificationsEnabledPolicy: uint8_t {
 };
 
 enum class ContentExtensionDefaultEnablement : bool { Disabled, Enabled };
-using ContentExtensionEnablement = std::pair<ContentExtensionDefaultEnablement, UncheckedKeyHashSet<String>>;
+using ContentExtensionEnablement = std::pair<ContentExtensionDefaultEnablement, HashSet<String>>;
 
 class DataLoadToken : public CanMakeWeakPtr<DataLoadToken> {
 public:

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -667,7 +667,7 @@ static URL urlForElement(const Element& element)
     return { };
 }
 
-static void collectMediaAndLinkURLsRecursive(const Element& element, UncheckedKeyHashSet<URL>& urls)
+static void collectMediaAndLinkURLsRecursive(const Element& element, HashSet<URL>& urls)
 {
     auto addURLForElement = [&urls](const Element& element) {
         if (auto url = urlForElement(element); !url.isEmpty() && !url.protocolIsData() && !url.protocolIsBlob())
@@ -695,9 +695,9 @@ static void collectMediaAndLinkURLsRecursive(const Element& element, UncheckedKe
     }
 }
 
-static UncheckedKeyHashSet<URL> collectMediaAndLinkURLs(const Element& element)
+static HashSet<URL> collectMediaAndLinkURLs(const Element& element)
 {
-    UncheckedKeyHashSet<URL> urls;
+    HashSet<URL> urls;
     collectMediaAndLinkURLsRecursive(element, urls);
     return urls;
 }

--- a/Source/WebCore/page/ElementTargetingTypes.h
+++ b/Source/WebCore/page/ElementTargetingTypes.h
@@ -38,7 +38,7 @@
 
 namespace WebCore {
 
-using TargetedElementSelectors = Vector<UncheckedKeyHashSet<String>>;
+using TargetedElementSelectors = Vector<HashSet<String>>;
 using TargetedElementIdentifiers = std::pair<ElementIdentifier, ScriptExecutionContextIdentifier>;
 
 struct TargetedElementAdjustment {
@@ -64,7 +64,7 @@ struct TargetedElementInfo {
     FloatRect boundsInClientCoordinates;
     PositionType positionType { PositionType::Static };
     Vector<FrameIdentifier> childFrameIdentifiers;
-    UncheckedKeyHashSet<URL> mediaAndLinkURLs;
+    HashSet<URL> mediaAndLinkURLs;
     bool isNearbyTarget { true };
     bool isPseudoElement { false };
     bool isInShadowTree { false };

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -109,7 +109,7 @@ public:
 
     WEBCORE_EXPORT static bool needsPartitionedCookies(const ResourceRequest&);
 
-    WEBCORE_EXPORT static std::optional<Vector<UncheckedKeyHashSet<String>>> defaultVisibilityAdjustmentSelectors(const URL&);
+    WEBCORE_EXPORT static std::optional<Vector<HashSet<String>>> defaultVisibilityAdjustmentSelectors(const URL&);
 
     bool needsGMailOverflowScrollQuirk() const;
     bool needsIPadSkypeOverflowScrollQuirk() const;

--- a/Source/WebCore/platform/encryptedmedia/CDMRestrictions.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMRestrictions.h
@@ -35,7 +35,7 @@ namespace WebCore {
 struct CDMRestrictions {
     bool distinctiveIdentifierDenied { false };
     bool persistentStateDenied { false };
-    UncheckedKeyHashSet<CDMSessionType, IntHash<CDMSessionType>, WTF::StrongEnumHashTraits<CDMSessionType>> deniedSessionTypes;
+    HashSet<CDMSessionType, IntHash<CDMSessionType>, WTF::StrongEnumHashTraits<CDMSessionType>> deniedSessionTypes;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -898,7 +898,7 @@ struct WebCore::ShareData {
 enum class WebCore::ShareDataOriginator : bool
 
 using WebCore::TargetedElementIdentifiers = std::pair<WebCore::ElementIdentifier, WebCore::ScriptExecutionContextIdentifier>;
-using WebCore::TargetedElementSelectors = Vector<UncheckedKeyHashSet<String>>;
+using WebCore::TargetedElementSelectors = Vector<HashSet<String>>;
 
 header: <WebCore/ElementTargetingTypes.h>
 [CustomHeader] struct WebCore::TargetedElementAdjustment {
@@ -926,7 +926,7 @@ header: <WebCore/ElementTargetingTypes.h>
     WebCore::FloatRect boundsInClientCoordinates
     WebCore::PositionType positionType
     Vector<WebCore::FrameIdentifier> childFrameIdentifiers
-    UncheckedKeyHashSet<URL> mediaAndLinkURLs;
+    HashSet<URL> mediaAndLinkURLs;
     bool isNearbyTarget
     bool isPseudoElement
     bool isInShadowTree
@@ -4462,7 +4462,7 @@ using WebCore::CDMInstanceSession::KeyStatusVector = Vector<std::pair<Ref<WebCor
 struct WebCore::CDMRestrictions {
     bool distinctiveIdentifierDenied;
     bool persistentStateDenied;
-    UncheckedKeyHashSet<WebCore::CDMSessionType, IntHash<WebCore::CDMSessionType>, WTF::StrongEnumHashTraits<WebCore::CDMSessionType>> deniedSessionTypes;
+    HashSet<WebCore::CDMSessionType, IntHash<WebCore::CDMSessionType>, WTF::StrongEnumHashTraits<WebCore::CDMSessionType>> deniedSessionTypes;
 };
 
 #endif
@@ -5220,7 +5220,7 @@ header: <WebCore/ImageTypes.h>
 };
 
 struct WebCore::CanvasActivityRecord {
-    UncheckedKeyHashSet<String> textWritten;
+    HashSet<String> textWritten;
     bool wasDataRead;
 };
 
@@ -8509,7 +8509,7 @@ using WebCore::GlyphBufferAdvance = WebCore::FloatSize
 using WebCore::Glyph = unsigned short
 
 enum class WebCore::ContentExtensionDefaultEnablement : bool
-using WebCore::ContentExtensionEnablement = std::pair<WebCore::ContentExtensionDefaultEnablement, UncheckedKeyHashSet<String>>;
+using WebCore::ContentExtensionEnablement = std::pair<WebCore::ContentExtensionDefaultEnablement, HashSet<String>>;
 
 #if USE(CG)
 using WebCore::DisplayList::Item = std::variant<WebCore::DisplayList::ApplyDeviceScaleFactor, WebCore::DisplayList::BeginTransparencyLayer, WebCore::DisplayList::BeginTransparencyLayerWithCompositeMode, WebCore::DisplayList::ClearRect, WebCore::DisplayList::ClearDropShadow, WebCore::DisplayList::Clip, WebCore::DisplayList::ClipRoundedRect, WebCore::DisplayList::ClipOut, WebCore::DisplayList::ClipOutRoundedRect, WebCore::DisplayList::ClipOutToPath, WebCore::DisplayList::ClipPath, WebCore::DisplayList::ClipToImageBuffer, WebCore::DisplayList::ConcatenateCTM, WebCore::DisplayList::DrawControlPart, WebCore::DisplayList::DrawDotsForDocumentMarker, WebCore::DisplayList::DrawEllipse, WebCore::DisplayList::DrawFilteredImageBuffer, WebCore::DisplayList::DrawFocusRingPath, WebCore::DisplayList::DrawFocusRingRects, WebCore::DisplayList::DrawGlyphs, WebCore::DisplayList::DrawDecomposedGlyphs, WebCore::DisplayList::DrawDisplayListItems, WebCore::DisplayList::DrawImageBuffer, WebCore::DisplayList::DrawLine, WebCore::DisplayList::DrawLinesForText, WebCore::DisplayList::DrawNativeImage, WebCore::DisplayList::DrawPath, WebCore::DisplayList::DrawPattern, WebCore::DisplayList::DrawRect, WebCore::DisplayList::DrawSystemImage, WebCore::DisplayList::EndTransparencyLayer, WebCore::DisplayList::FillCompositedRect, WebCore::DisplayList::FillEllipse, WebCore::DisplayList::FillPathSegment, WebCore::DisplayList::FillPath, WebCore::DisplayList::FillRect, WebCore::DisplayList::FillRectWithColor, WebCore::DisplayList::FillRectWithGradient, WebCore::DisplayList::FillRectWithGradientAndSpaceTransform, WebCore::DisplayList::FillRectWithRoundedHole, WebCore::DisplayList::FillRoundedRect, WebCore::DisplayList::ResetClip, WebCore::DisplayList::Restore, WebCore::DisplayList::Rotate, WebCore::DisplayList::Save, WebCore::DisplayList::Scale, WebCore::DisplayList::SetCTM, WebCore::DisplayList::SetInlineFillColor, WebCore::DisplayList::SetInlineStroke, WebCore::DisplayList::SetLineCap, WebCore::DisplayList::SetLineDash, WebCore::DisplayList::SetLineJoin, WebCore::DisplayList::SetMiterLimit, WebCore::DisplayList::SetState, WebCore::DisplayList::StrokeEllipse, WebCore::DisplayList::StrokeLine, WebCore::DisplayList::StrokePathSegment, WebCore::DisplayList::StrokePath, WebCore::DisplayList::StrokeRect, WebCore::DisplayList::Translate, WebCore::DisplayList::FillLine, WebCore::DisplayList::FillArc, WebCore::DisplayList::FillClosedArc, WebCore::DisplayList::FillQuadCurve, WebCore::DisplayList::FillBezierCurve, WebCore::DisplayList::StrokeArc, WebCore::DisplayList::StrokeClosedArc, WebCore::DisplayList::StrokeQuadCurve, WebCore::DisplayList::StrokeBezierCurve, WebCore::DisplayList::ApplyFillPattern, WebCore::DisplayList::ApplyStrokePattern, WebCore::DisplayList::BeginPage, WebCore::DisplayList::EndPage, WebCore::DisplayList::SetURLForRect>;
@@ -8684,7 +8684,7 @@ enum class WebCore::FromDownloadAttribute : bool
 };
 
 class WebCore::Allowlist {
-    std::variant<UncheckedKeyHashSet<WebCore::SecurityOriginData>, WebCore::Allowlist::AllowAllOrigins> origins()
+    std::variant<HashSet<WebCore::SecurityOriginData>, WebCore::Allowlist::AllowAllOrigins> origins()
 };
 
 struct WebCore::OwnerPermissionsPolicyData {

--- a/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
@@ -70,7 +70,7 @@ public:
     bool hasLargeReplacedDescendant() const { return m_info.hasLargeReplacedDescendant; }
     bool hasAudibleMedia() const { return m_info.hasAudibleMedia; }
 
-    const UncheckedKeyHashSet<WTF::URL>& mediaAndLinkURLs() const { return m_info.mediaAndLinkURLs; }
+    const HashSet<WTF::URL>& mediaAndLinkURLs() const { return m_info.mediaAndLinkURLs; }
 
     void childFrames(CompletionHandler<void(Vector<Ref<FrameTreeNode>>&&)>&&) const;
 

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -137,8 +137,8 @@ public:
     bool isUpgradeWithUserMediatedFallbackEnabled() { return advancedPrivacyProtections().contains(WebCore::AdvancedPrivacyProtections::HTTPSOnly) || httpsByDefaultMode() == WebCore::HTTPSByDefaultMode::UpgradeWithUserMediatedFallback; }
     bool isUpgradeWithAutomaticFallbackEnabled() { return advancedPrivacyProtections().contains(WebCore::AdvancedPrivacyProtections::HTTPSFirst) || httpsByDefaultMode() == WebCore::HTTPSByDefaultMode::UpgradeWithAutomaticFallback; }
 
-    const Vector<Vector<UncheckedKeyHashSet<WTF::String>>>& visibilityAdjustmentSelectors() const { return m_data.visibilityAdjustmentSelectors; }
-    void setVisibilityAdjustmentSelectors(Vector<Vector<UncheckedKeyHashSet<WTF::String>>>&& selectors) { m_data.visibilityAdjustmentSelectors = WTFMove(selectors); }
+    const Vector<Vector<HashSet<WTF::String>>>& visibilityAdjustmentSelectors() const { return m_data.visibilityAdjustmentSelectors; }
+    void setVisibilityAdjustmentSelectors(Vector<Vector<HashSet<WTF::String>>>&& selectors) { m_data.visibilityAdjustmentSelectors = WTFMove(selectors); }
 
     WebKit::WebsitePushAndNotificationsEnabledPolicy pushAndNotificationsEnabledPolicy() const { return m_data.pushAndNotificationsEnabledPolicy; }
     void setPushAndNotificationsEnabledPolicy(WebKit::WebsitePushAndNotificationsEnabledPolicy policy) { m_data.pushAndNotificationsEnabledPolicy = policy; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -208,7 +208,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (void)_setContentRuleListsEnabled:(BOOL)enabled exceptions:(NSSet<NSString *> *)identifiers
 {
-    UncheckedKeyHashSet<String> exceptions;
+    HashSet<String> exceptions;
     exceptions.reserveInitialCapacity(identifiers.count);
     for (NSString *identifier in identifiers)
         exceptions.add(identifier);
@@ -708,7 +708,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
         WebCore::TargetedElementSelectors selectorsForElement;
         selectorsForElement.reserveInitialCapacity(nsSelectorsForElement.count);
         for (NSSet<NSString *> *nsSelectors in nsSelectorsForElement) {
-            UncheckedKeyHashSet<String> selectors;
+            HashSet<String> selectors;
             selectors.reserveInitialCapacity(nsSelectors.count);
             for (NSString *selector in nsSelectors)
                 selectors.add(selector);

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm
@@ -80,7 +80,7 @@
     WebCore::TargetedElementSelectors selectorsForElement;
     selectorsForElement.reserveInitialCapacity(nsSelectorsForElement.count);
     for (NSSet<NSString *> *nsSelectors in nsSelectorsForElement) {
-        UncheckedKeyHashSet<String> selectors;
+        HashSet<String> selectors;
         selectors.reserveInitialCapacity(nsSelectors.count);
         for (NSString *selector in nsSelectors)
             selectors.add(selector);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -15694,7 +15694,7 @@ void WebPageProxy::adjustVisibilityForTargetedElements(const Vector<Ref<API::Tar
         return {
             { info->elementIdentifier(), info->documentIdentifier() },
             info->selectors().map([](auto& selectors) {
-                UncheckedKeyHashSet<String> result;
+                HashSet<String> result;
                 result.reserveInitialCapacity(selectors.size());
                 result.add(selectors.begin(), selectors.end());
                 return result;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -490,7 +490,6 @@ static NSSet<NSString *> *splitTypeFromList(NSString *container, NSString *list)
     bool firstTypeOnly = [container isEqualToString:@"std::span"]
         || [container isEqualToString:@"Vector"]
         || [container isEqualToString:@"std::array"]
-        || [container isEqualToString:@"UncheckedKeyHashSet"]
         || [container isEqualToString:@"HashSet"];
     bool firstTwoTypesOnly = [container isEqualToString:@"HashMap"];
 
@@ -532,7 +531,6 @@ static NSMutableSet<NSString *> *extractTypesFromContainers(NSSet<NSString *> *i
             @"HashMap",
             @"MemoryCompactRobinHoodHashMap",
             @"MemoryCompactLookupOnlyRobinHoodHashSet",
-            @"UncheckedKeyHashSet",
             @"std::pair",
             @"IPC::ArrayReferenceTuple",
             @"std::span",


### PR DESCRIPTION
#### 99ca7d79d4ea8bb82ef84fe3235a247760d21a2b
<pre>
Stop using UncheckedKeyHashSet in IPC code
<a href="https://bugs.webkit.org/show_bug.cgi?id=285548">https://bugs.webkit.org/show_bug.cgi?id=285548</a>

Reviewed by Darin Adler.

Stop using UncheckedKeyHashSet in IPC code. We should rely on UncheckedKeyHashSet
as little as possible for security reasons, particularly in IPC code.

* Source/WebCore/html/Allowlist.h:
(WebCore::Allowlist::Allowlist):
(WebCore::Allowlist::matches const):
* Source/WebCore/html/PermissionsPolicy.cpp:
(WebCore::parseAllowlist):
* Source/WebCore/loader/CanvasActivityRecord.h:
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::collectMediaAndLinkURLsRecursive):
(WebCore::collectMediaAndLinkURLs):
* Source/WebCore/page/ElementTargetingTypes.h:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/platform/encryptedmedia/CDMRestrictions.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/APITargetedElementInfo.h:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _setContentRuleListsEnabled:exceptions:]):
(-[WKWebpagePreferences _setVisibilityAdjustmentSelectorsIncludingShadowHosts:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm:
(-[_WKTargetedElementRequest initWithSelectors:]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::adjustVisibilityForTargetedElements):

Canonical link: <a href="https://commits.webkit.org/288576@main">https://commits.webkit.org/288576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df7e2e4bf77b409a19e31331b682b590f364e716

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88854 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34790 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11364 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65165 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23005 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76129 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45455 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2504 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30344 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33839 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90232 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11047 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/7982 "Found 3 new test failures: fast/selectors/text-field-selection-stroke-color.html pdf/pdf-plugin-printing.html swipe/navigate-event-back-swipe-verify-ua-transition.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73613 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11271 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71957 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72836 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17103 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15800 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2371 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12954 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10999 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16471 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10847 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14322 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12619 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->