### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in PasteboardMac.mm

### DIFF
--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -740,25 +740,22 @@ Vector<String> Pasteboard::readFilePaths()
 }
 
 #if ENABLE(DRAG_SUPPORT)
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 static void flipImageSpec(CoreDragImageSpec* imageSpec)
 {
     auto tempRow = MallocSpan<uint8_t>::malloc(imageSpec->bytesPerRow);
     int planes = imageSpec->isPlanar ? imageSpec->samplesPerPixel : 1;
-
-    for (int p = 0; p < planes; ++p) {
-        auto* topRow = const_cast<uint8_t*>(imageSpec->data[p]);
-        auto* botRow = topRow + (imageSpec->pixelsHigh - 1) * imageSpec->bytesPerRow;
-        for (int i = 0; i < imageSpec->pixelsHigh / 2; ++i, topRow += imageSpec->bytesPerRow, botRow -= imageSpec->bytesPerRow) {
-            auto topRowSpan = unsafeMakeSpan(topRow, imageSpec->bytesPerRow);
-            auto botRowSpan = unsafeMakeSpan(botRow, imageSpec->bytesPerRow);
-            memmoveSpan(tempRow.mutableSpan(), topRowSpan);
-            memmoveSpan(topRowSpan, botRowSpan);
-            memmoveSpan(botRowSpan, tempRow.span());
+    for (auto* plane : std::span { imageSpec->data }.first(planes)) {
+        auto planeSpan = unsafeMakeSpan(const_cast<uint8_t*>(plane), imageSpec->bytesPerRow * imageSpec->pixelsHigh);
+        for (int i = 0; i < imageSpec->pixelsHigh / 2; ++i) {
+            auto topRow = planeSpan.first(imageSpec->bytesPerRow);
+            auto bottomRow = planeSpan.last(imageSpec->bytesPerRow);
+            memmoveSpan(tempRow.mutableSpan(), topRow);
+            memmoveSpan(topRow, bottomRow);
+            memmoveSpan(bottomRow, tempRow.span());
+            planeSpan = planeSpan.subspan(imageSpec->bytesPerRow, planeSpan.size() - 2 * imageSpec->bytesPerRow);
         }
     }
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static void setDragImageImpl(NSImage *image, NSPoint offset)
 {


### PR DESCRIPTION
#### f1ec9d1585cb964315f99f241f7b13e5d5765d41
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE use in PasteboardMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=285552">https://bugs.webkit.org/show_bug.cgi?id=285552</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::flipImageSpec):

Canonical link: <a href="https://commits.webkit.org/288567@main">https://commits.webkit.org/288567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ece142c3378756d7d3f18a4c85c400d5dda1a2a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88852 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85865 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11362 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23003 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45451 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2497 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30341 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33837 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90230 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11045 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/7979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71953 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/72833 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17094 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15797 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12947 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10997 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/16469 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10845 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14320 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12617 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->