### PR TITLE
[IFC] Update TextBreakingPositionCache to use WhiteSpaceCollapse.

### DIFF
--- a/LayoutTests/fast/text/whitespace/whitespace-trailing-trim-expected.txt
+++ b/LayoutTests/fast/text/whitespace/whitespace-trailing-trim-expected.txt
@@ -1,0 +1,1 @@
+PASS if X no crash

--- a/LayoutTests/fast/text/whitespace/whitespace-trailing-trim.html
+++ b/LayoutTests/fast/text/whitespace/whitespace-trailing-trim.html
@@ -1,0 +1,26 @@
+<style>
+#container { 
+  font-family: Ahem;
+  font-size: 20px;
+  text-wrap-mode: nowrap;
+  white-space-collapse: preserve-breaks;
+  direction: RTL;
+  width: 100px;
+}
+</style>
+<div id=container>
+  <div id=content> PASS if
+ X no crash</div>
+</div>
+<script>
+document.body.offsetHeight;
+content.remove();
+
+document.body.offsetHeight;
+container.style.whiteSpace = "normal";
+let same_content = document.createElement("div");
+same_content.appendChild(document.createTextNode(" PASS if\n X no crash"));
+container.appendChild(same_content);
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionCache.cpp
@@ -97,7 +97,7 @@ void TextBreakingPositionCache::clear()
 
 void add(Hasher& hasher, const TextBreakingPositionContext& context)
 {
-    add(hasher, context.whitespace, context.overflowWrap, context.lineBreak, context.wordBreak, context.nbspMode, context.locale);
+    add(hasher, context.whitespaceCollapseBehavior, context.overflowWrap, context.lineBreak, context.wordBreak, context.nbspMode, context.locale);
 }
 
 }


### PR DESCRIPTION
#### 1fc3d9918294db0be3dda280ef838328b0e59c0b
<pre>
[IFC] Update TextBreakingPositionCache to use WhiteSpaceCollapse.
<a href="https://bugs.webkit.org/show_bug.cgi?id=285551">https://bugs.webkit.org/show_bug.cgi?id=285551</a>
&lt;<a href="https://rdar.apple.com/141021052">rdar://141021052</a>&gt;

Reviewed by Alan Baradlay.

This change fixes a bug where TextBreakingPositionContext was tracking validity of
text breaking positions by checking whether RenderStyle::WhiteSpace changed between
the calculation and fetching cached breaking points. This causes issues where setting
TextWrapMode implicitly changes how white space collapses but RenderText&apos;s
RenderStyle is not correctly updated, causing TextBreakingPositionCache to
use stale breaking positions.

This is because there are combinations of textWrapMode() and whiteSpaceCollapse()
that are not supported by the whiteSpace() shorthand, causing combinations that
cannot be represented by the whiteSpace() syntax to be incorrectly classified as
WhiteSpace::Normal. Changing layout contexts between unsupported combinations
causes incorrect usage of cached layouts.

The correct way to avoid this is to hash on the longhand RenderStyle::WhiteSpaceCollapse.

<a href="https://github.com/WebKit/WebKit/blob/e41eca63e27004fb0b1e0a5a3e90e00b134a6d7f/Source/WebCore/rendering/style/RenderStyle.cpp#L2850-L2872">https://github.com/WebKit/WebKit/blob/e41eca63e27004fb0b1e0a5a3e90e00b134a6d7f/Source/WebCore/rendering/style/RenderStyle.cpp#L2850-L2872</a>

A follow up CL will be sent out to remove RenderStyle()::whiteSpace() from WebCore.

This PR also adds WhiteSpaceCollapseBehavior that groups WhiteSpaceCollapse
types that have the same text breaking positions. This lets us avoid
recalculating breaking points when switching between these
WhiteSpaceCollapse types that would have identical breaking points.

<a href="https://drafts.csswg.org/css-text-4/#white-space-collapsing">https://drafts.csswg.org/css-text-4/#white-space-collapsing</a>

<a href="https://commits.webkit.org/265267@main">https://commits.webkit.org/265267@main</a>
<a href="https://commits.webkit.org/269613@main">https://commits.webkit.org/269613@main</a>

Canonical link: <a href="https://commits.webkit.org/289150@main">https://commits.webkit.org/289150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01edabccb3b06a4756dcdacf6218964d445f9342

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90594 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36508 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87554 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66444 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24260 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46726 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31889 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35577 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92184 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75108 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13041 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74238 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18346 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18528 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16962 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4900 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12818 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18225 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12628 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16078 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->