### PR TITLE
[libpas] Improve PGM metadata management

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
@@ -92,8 +92,8 @@ struct pas_pgm_storage {
  */
 #define PAS_PGM_MAX_VIRTUAL_MEMORY (1024 * 1024 * 1024)
 
-/* Total MAX_PGM_HASH_ENTRIES {0 - (MAX_PGM_HASH_ENTRIES - 1)} PGM entries are allowed for which metadata is kept alive */
-#define MAX_PGM_HASH_ENTRIES    10
+/* Total MAX_PGM_DEALLOCATED_METADATA_ENTRIES {0 - (MAX_PGM_DEALLOCATED_METADATA_ENTRIES - 1)} PGM entries are allowed for which metadata is kept alive */
+#define MAX_PGM_DEALLOCATED_METADATA_ENTRIES    10
 
 extern PAS_API pas_ptr_hash_map pas_pgm_hash_map;
 extern PAS_API pas_ptr_hash_map_in_flux_stash pas_pgm_hash_map_in_flux_stash;


### PR DESCRIPTION
#### f4ebee8774596e8435dcba922f8ff30579469060
<pre>
[libpas] Improve PGM metadata management
<a href="https://bugs.webkit.org/show_bug.cgi?id=285557">https://bugs.webkit.org/show_bug.cgi?id=285557</a>
<a href="https://rdar.apple.com/142506754">rdar://142506754</a>

Reviewed by Brandon Stewart.

Simplify the metadata management for PGM in libpas. Use a circular
buffer to store metadata upon deallocations.

Add tests to verify improvement.

* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_allocate):
(pas_probabilistic_guard_malloc_deallocate):
(pas_probabilistic_guard_malloc_check_exists):
(pas_probabilistic_guard_malloc_initialize_pgm_as_enabled):
(pas_probabilistic_guard_malloc_pgm_metadata_buffer_full): Deleted.
(pas_probabilistic_guard_malloc_pgm_metadata_buffer_empty): Deleted.
(pas_probabilistic_guard_malloc_pgm_metadata_buffer_add): Deleted.
(pas_probabilistic_guard_malloc_pgm_metadata_buffer_remove): Deleted.
(pas_probabilistic_guard_malloc_manage_metadata): Deleted.
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h:
* Source/bmalloc/libpas/src/test/PGMTests.cpp:
(std::testPGMMetaData):
(std::testPGMMetadataVectorManagement):
(std::testPGMMetadataVectorManagementFewDeallocations):
(std::testPGMMetadataDoubleFreeBehavior):
(addPGMTests):

Canonical link: <a href="https://commits.webkit.org/288785@main">https://commits.webkit.org/288785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bcb51e32bfe285e3d0c598b79f28ec8eb4be593

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84294 "26 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89372 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35303 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65558 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23395 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3003 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45858 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30821 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34352 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77258 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90752 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83311 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11561 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8397 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html media/video-replaces-poster.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74012 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73213 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18137 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17536 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15978 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2926 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11513 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105730 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11362 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25525 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14838 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13135 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->