### PR TITLE
Add continuous time wrappers

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -889,7 +889,11 @@
 		E4A0AD391A96245500536DF6 /* WorkQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4A0AD371A96245500536DF6 /* WorkQueue.cpp */; };
 		E4A0AD3D1A96253C00536DF6 /* WorkQueueCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4A0AD3C1A96253C00536DF6 /* WorkQueueCocoa.cpp */; };
 		EB2C86D9267B275D0052CB9A /* CPUTimePOSIX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB2C86D8267B275C0052CB9A /* CPUTimePOSIX.cpp */; };
+		EB33ED2E2D2DD91B00521B7B /* ContinuousTime.h in Headers */ = {isa = PBXBuildFile; fileRef = EB33ED2C2D2DD91B00521B7B /* ContinuousTime.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EB33ED2F2D2DD91B00521B7B /* ContinuousTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB33ED2D2D2DD91B00521B7B /* ContinuousTime.cpp */; };
 		EB61EDC72409CCC1001EFE36 /* SystemTracingCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB61EDC62409CCC0001EFE36 /* SystemTracingCocoa.cpp */; };
+		EBEE51132D2DF488004FEC23 /* ContinuousApproximateTime.h in Headers */ = {isa = PBXBuildFile; fileRef = EBEE51112D2DF488004FEC23 /* ContinuousApproximateTime.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EBEE51142D2DF488004FEC23 /* ContinuousApproximateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EBEE51122D2DF488004FEC23 /* ContinuousApproximateTime.cpp */; };
 		FA0C387B2BEAD56B00583842 /* SmallMap.h in Headers */ = {isa = PBXBuildFile; fileRef = FA0C387A2BEAD56B00583842 /* SmallMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE032AD22463E43B0012D7C7 /* WTFConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE032AD02463E43B0012D7C7 /* WTFConfig.cpp */; };
 		FE03831C2ABC04F700A576A2 /* TZoneMallocInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FE03831A2ABC04F700A576A2 /* TZoneMallocInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1906,8 +1910,12 @@
 		E4A0AD3C1A96253C00536DF6 /* WorkQueueCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WorkQueueCocoa.cpp; sourceTree = "<group>"; };
 		E4D2AE4D268A4C7F00DFEA02 /* SystemMalloc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SystemMalloc.h; sourceTree = "<group>"; };
 		EB2C86D8267B275C0052CB9A /* CPUTimePOSIX.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CPUTimePOSIX.cpp; sourceTree = "<group>"; };
+		EB33ED2C2D2DD91B00521B7B /* ContinuousTime.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContinuousTime.h; sourceTree = "<group>"; };
+		EB33ED2D2D2DD91B00521B7B /* ContinuousTime.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ContinuousTime.cpp; sourceTree = "<group>"; };
 		EB61EDC62409CCC0001EFE36 /* SystemTracingCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SystemTracingCocoa.cpp; sourceTree = "<group>"; };
 		EB95E1EF161A72410089A2F5 /* ByteOrder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ByteOrder.h; sourceTree = "<group>"; };
+		EBEE51112D2DF488004FEC23 /* ContinuousApproximateTime.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContinuousApproximateTime.h; sourceTree = "<group>"; };
+		EBEE51122D2DF488004FEC23 /* ContinuousApproximateTime.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ContinuousApproximateTime.cpp; sourceTree = "<group>"; };
 		EF7D6CD59D8642A8A0DA86AD /* StackTrace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StackTrace.h; sourceTree = "<group>"; };
 		F6D67D3226F90142006E0349 /* Int128.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Int128.h; sourceTree = "<group>"; };
 		F72BBDB107FA424886178B9E /* SymbolImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SymbolImpl.cpp; sourceTree = "<group>"; };
@@ -2208,6 +2216,10 @@
 				0F30CB591FCDF133004B5323 /* ConcurrentPtrHashSet.h */,
 				0FB467831FDE282C003FCB09 /* ConcurrentVector.h */,
 				0FDB698D1B7C643A000C1078 /* Condition.h */,
+				EBEE51122D2DF488004FEC23 /* ContinuousApproximateTime.cpp */,
+				EBEE51112D2DF488004FEC23 /* ContinuousApproximateTime.h */,
+				EB33ED2D2D2DD91B00521B7B /* ContinuousTime.cpp */,
+				EB33ED2C2D2DD91B00521B7B /* ContinuousTime.h */,
 				0F8E85DA1FD485B000691889 /* CountingLock.cpp */,
 				0FFBCBFA1FD37E0F0072AAF0 /* CountingLock.h */,
 				E38C41261EB4E0680042957D /* CPUTime.cpp */,
@@ -3304,6 +3316,8 @@
 				E306FE9B2A9600D40074D0E9 /* constexpr_feature_detect.h in Headers */,
 				1C867D782A254F08000DE93D /* ContextualizedCFString.h in Headers */,
 				1CA6FBAB2A1D75D8001D4402 /* ContextualizedNSString.h in Headers */,
+				EBEE51132D2DF488004FEC23 /* ContinuousApproximateTime.h in Headers */,
+				EB33ED2E2D2DD91B00521B7B /* ContinuousTime.h in Headers */,
 				DDF307C627C086DF006A526F /* ConversionMode.h in Headers */,
 				DD3DC8D127A4BF8E007E5B61 /* CountingLock.h in Headers */,
 				DD3DC92627A4BF8E007E5B61 /* CPUTime.h in Headers */,
@@ -4131,6 +4145,8 @@
 				0F30CB5A1FCDF134004B5323 /* ConcurrentPtrHashSet.cpp in Sources */,
 				1C867D772A254F08000DE93D /* ContextualizedCFString.mm in Sources */,
 				1CA6FBA92A1D75B9001D4402 /* ContextualizedNSString.mm in Sources */,
+				EBEE51142D2DF488004FEC23 /* ContinuousApproximateTime.cpp in Sources */,
+				EB33ED2F2D2DD91B00521B7B /* ContinuousTime.cpp in Sources */,
 				0F8E85DB1FD485B000691889 /* CountingLock.cpp in Sources */,
 				E38C41281EB4E0680042957D /* CPUTime.cpp in Sources */,
 				EB2C86D9267B275D0052CB9A /* CPUTimePOSIX.cpp in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -56,6 +56,8 @@ set(WTF_PUBLIC_HEADERS
     ConcurrentPtrHashSet.h
     ConcurrentVector.h
     Condition.h
+    ContinuousApproximateTime.h
+    ContinuousTime.h
     CountingLock.h
     CrossThreadCopier.h
     CrossThreadQueue.h
@@ -506,6 +508,8 @@ set(WTF_SOURCES
     CompilationThread.cpp
     ConcurrentBuffer.cpp
     ConcurrentPtrHashSet.cpp
+    ContinuousApproximateTime.cpp
+    ContinuousTime.cpp
     CountingLock.cpp
     CrossThreadCopier.cpp
     CrossThreadTaskHandler.cpp

--- a/Source/WTF/wtf/ClockType.h
+++ b/Source/WTF/wtf/ClockType.h
@@ -33,6 +33,8 @@ enum class ClockType {
     Wall,
     Monotonic,
     Approximate,
+    Continuous,
+    ContinuousApproximate,
 };
 
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, ClockType);

--- a/Source/WTF/wtf/ContinuousApproximateTime.cpp
+++ b/Source/WTF/wtf/ContinuousApproximateTime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,37 +20,37 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "config.h"
-#include <wtf/ClockType.h>
+#include <wtf/ContinuousApproximateTime.h>
 
+#include <wtf/MonotonicTime.h>
 #include <wtf/PrintStream.h>
+#include <wtf/WallTime.h>
 
 namespace WTF {
 
-void printInternal(PrintStream& out, ClockType type)
+WallTime ContinuousApproximateTime::approximateWallTime() const
 {
-    switch (type) {
-    case ClockType::Wall:
-        out.print("Wall");
-        return;
-    case ClockType::Monotonic:
-        out.print("Monotonic");
-        return;
-    case ClockType::Approximate:
-        out.print("Approximate");
-        return;
-    case ClockType::Continuous:
-        out.print("Continuous");
-        return;
-    case ClockType::ContinuousApproximate:
-        out.print("ContinuousApproximate");
-        return;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
+    if (isInfinity())
+        return WallTime::fromRawSeconds(m_value);
+    return *this - now() + WallTime::now();
+}
+
+MonotonicTime ContinuousApproximateTime::approximateMonotonicTime() const
+{
+    if (isInfinity())
+        return MonotonicTime::fromRawSeconds(m_value);
+    return *this - now() + MonotonicTime::now();
+}
+
+void ContinuousApproximateTime::dump(PrintStream& out) const
+{
+    out.print("ContinuousApproximate(", m_value, " sec)");
 }
 
 } // namespace WTF
+
 

--- a/Source/WTF/wtf/ContinuousApproximateTime.h
+++ b/Source/WTF/wtf/ContinuousApproximateTime.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ClockType.h>
+#include <wtf/GenericTimeMixin.h>
+
+namespace WTF {
+
+class WallTime;
+class PrintStream;
+
+// The current time according to an approximate continuous monotonic clock, which continues ticking
+// while the system is asleep. On some OSes, ContinuousApproximateTime::now() is faster than
+// ContinuousTime::now().
+class ContinuousApproximateTime final : public GenericTimeMixin<ContinuousApproximateTime> {
+public:
+    static constexpr ClockType clockType = ClockType::ContinuousApproximate;
+
+    // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - ContinuousApproximateTime().
+    constexpr ContinuousApproximateTime() = default;
+
+#if OS(DARWIN)
+    WTF_EXPORT_PRIVATE static ContinuousApproximateTime fromMachContinuousApproximateTime(uint64_t);
+    WTF_EXPORT_PRIVATE uint64_t toMachContinuousApproximateTime() const;
+#endif
+
+    WTF_EXPORT_PRIVATE static ContinuousApproximateTime now();
+
+    WTF_EXPORT_PRIVATE WallTime approximateWallTime() const;
+    WTF_EXPORT_PRIVATE MonotonicTime approximateMonotonicTime() const;
+
+    WTF_EXPORT_PRIVATE void dump(PrintStream&) const;
+
+    struct MarkableTraits;
+
+private:
+    friend class GenericTimeMixin<ContinuousApproximateTime>;
+    constexpr ContinuousApproximateTime(double rawValue)
+        : GenericTimeMixin<ContinuousApproximateTime>(rawValue)
+    {
+    }
+};
+static_assert(sizeof(ContinuousApproximateTime) == sizeof(double));
+
+struct ContinuousApproximateTime::MarkableTraits {
+    static bool isEmptyValue(ContinuousApproximateTime time)
+    {
+        return time.isNaN();
+    }
+
+    static constexpr ContinuousApproximateTime emptyValue()
+    {
+        return ContinuousApproximateTime::nan();
+    }
+};
+
+} // namespace WTF
+
+using WTF::ContinuousApproximateTime;

--- a/Source/WTF/wtf/ContinuousTime.cpp
+++ b/Source/WTF/wtf/ContinuousTime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,37 +20,37 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "config.h"
-#include <wtf/ClockType.h>
+#include <wtf/ContinuousTime.h>
 
+#include <wtf/MonotonicTime.h>
 #include <wtf/PrintStream.h>
+#include <wtf/WallTime.h>
 
 namespace WTF {
 
-void printInternal(PrintStream& out, ClockType type)
+WallTime ContinuousTime::approximateWallTime() const
 {
-    switch (type) {
-    case ClockType::Wall:
-        out.print("Wall");
-        return;
-    case ClockType::Monotonic:
-        out.print("Monotonic");
-        return;
-    case ClockType::Approximate:
-        out.print("Approximate");
-        return;
-    case ClockType::Continuous:
-        out.print("Continuous");
-        return;
-    case ClockType::ContinuousApproximate:
-        out.print("ContinuousApproximate");
-        return;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
+    if (isInfinity())
+        return WallTime::fromRawSeconds(m_value);
+    return *this - now() + WallTime::now();
+}
+
+MonotonicTime ContinuousTime::approximateMonotonicTime() const
+{
+    if (isInfinity())
+        return MonotonicTime::fromRawSeconds(m_value);
+    return *this - now() + MonotonicTime::now();
+}
+
+void ContinuousTime::dump(PrintStream& out) const
+{
+    out.print("Continuous(", m_value, " sec)");
 }
 
 } // namespace WTF
+
 

--- a/Source/WTF/wtf/ContinuousTime.h
+++ b/Source/WTF/wtf/ContinuousTime.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ClockType.h>
+#include <wtf/GenericTimeMixin.h>
+
+namespace WTF {
+
+class WallTime;
+class PrintStream;
+
+// The current time according to a continuous monotonic clock, which continues ticking while the
+// system is asleep.
+class ContinuousTime final : public GenericTimeMixin<ContinuousTime> {
+public:
+    static constexpr ClockType clockType = ClockType::Continuous;
+
+    // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - ContinuousTime().
+    constexpr ContinuousTime() = default;
+
+#if OS(DARWIN)
+    WTF_EXPORT_PRIVATE static ContinuousTime fromMachContinuousTime(uint64_t);
+    WTF_EXPORT_PRIVATE uint64_t toMachContinuousTime() const;
+#endif
+
+    WTF_EXPORT_PRIVATE static ContinuousTime now();
+
+    WTF_EXPORT_PRIVATE WallTime approximateWallTime() const;
+    WTF_EXPORT_PRIVATE MonotonicTime approximateMonotonicTime() const;
+
+    WTF_EXPORT_PRIVATE void dump(PrintStream&) const;
+
+    struct MarkableTraits;
+
+private:
+    friend class GenericTimeMixin<ContinuousTime>;
+    constexpr ContinuousTime(double rawValue)
+        : GenericTimeMixin<ContinuousTime>(rawValue)
+    {
+    }
+};
+static_assert(sizeof(ContinuousTime) == sizeof(double));
+
+struct ContinuousTime::MarkableTraits {
+    static bool isEmptyValue(ContinuousTime time)
+    {
+        return time.isNaN();
+    }
+
+    static constexpr ContinuousTime emptyValue()
+    {
+        return ContinuousTime::nan();
+    }
+};
+
+} // namespace WTF
+
+using WTF::ContinuousTime;

--- a/Source/WTF/wtf/Seconds.cpp
+++ b/Source/WTF/wtf/Seconds.cpp
@@ -28,6 +28,7 @@
 
 #include <wtf/ApproximateTime.h>
 #include <wtf/Condition.h>
+#include <wtf/ContinuousTime.h>
 #include <wtf/Lock.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/PrintStream.h>
@@ -52,6 +53,16 @@ ApproximateTime Seconds::operator+(ApproximateTime other) const
     return other + *this;
 }
 
+ContinuousTime Seconds::operator+(ContinuousTime other) const
+{
+    return other + *this;
+}
+
+ContinuousApproximateTime Seconds::operator+(ContinuousApproximateTime other) const
+{
+    return other + *this;
+}
+
 TimeWithDynamicClockType Seconds::operator+(const TimeWithDynamicClockType& other) const
 {
     return other + *this;
@@ -70,6 +81,16 @@ MonotonicTime Seconds::operator-(MonotonicTime other) const
 ApproximateTime Seconds::operator-(ApproximateTime other) const
 {
     return ApproximateTime::fromRawSeconds(value() - other.secondsSinceEpoch().value());
+}
+
+ContinuousTime Seconds::operator-(ContinuousTime other) const
+{
+    return ContinuousTime::fromRawSeconds(value() - other.secondsSinceEpoch().value());
+}
+
+ContinuousApproximateTime Seconds::operator-(ContinuousApproximateTime other) const
+{
+    return ContinuousApproximateTime::fromRawSeconds(value() - other.secondsSinceEpoch().value());
 }
 
 TimeWithDynamicClockType Seconds::operator-(const TimeWithDynamicClockType& other) const

--- a/Source/WTF/wtf/Seconds.h
+++ b/Source/WTF/wtf/Seconds.h
@@ -32,6 +32,8 @@
 namespace WTF {
 
 class ApproximateTime;
+class ContinuousApproximateTime;
+class ContinuousTime;
 class MonotonicTime;
 class PrintStream;
 class TextStream;
@@ -190,11 +192,15 @@ public:
     WTF_EXPORT_PRIVATE WallTime operator+(WallTime) const;
     WTF_EXPORT_PRIVATE MonotonicTime operator+(MonotonicTime) const;
     WTF_EXPORT_PRIVATE ApproximateTime operator+(ApproximateTime) const;
+    WTF_EXPORT_PRIVATE ContinuousTime operator+(ContinuousTime) const;
+    WTF_EXPORT_PRIVATE ContinuousApproximateTime operator+(ContinuousApproximateTime) const;
     WTF_EXPORT_PRIVATE TimeWithDynamicClockType operator+(const TimeWithDynamicClockType&) const;
     
     WTF_EXPORT_PRIVATE WallTime operator-(WallTime) const;
     WTF_EXPORT_PRIVATE MonotonicTime operator-(MonotonicTime) const;
     WTF_EXPORT_PRIVATE ApproximateTime operator-(ApproximateTime) const;
+    WTF_EXPORT_PRIVATE ContinuousTime operator-(ContinuousTime) const;
+    WTF_EXPORT_PRIVATE ContinuousApproximateTime operator-(ContinuousApproximateTime) const;
     WTF_EXPORT_PRIVATE TimeWithDynamicClockType operator-(const TimeWithDynamicClockType&) const;
     
     friend constexpr bool operator==(Seconds, Seconds) = default;

--- a/Source/WTF/wtf/TimeWithDynamicClockType.cpp
+++ b/Source/WTF/wtf/TimeWithDynamicClockType.cpp
@@ -42,6 +42,10 @@ TimeWithDynamicClockType TimeWithDynamicClockType::now(ClockType type)
         return MonotonicTime::now();
     case ClockType::Approximate:
         return ApproximateTime::now();
+    case ClockType::Continuous:
+        return ContinuousTime::now();
+    case ClockType::ContinuousApproximate:
+        return ContinuousApproximateTime::now();
     }
     RELEASE_ASSERT_NOT_REACHED();
     return TimeWithDynamicClockType();
@@ -70,6 +74,18 @@ ApproximateTime TimeWithDynamicClockType::approximateTime() const
     return ApproximateTime::fromRawSeconds(m_value);
 }
 
+ContinuousTime TimeWithDynamicClockType::continuousTime() const
+{
+    RELEASE_ASSERT(m_type == ClockType::Continuous);
+    return ContinuousTime::fromRawSeconds(m_value);
+}
+
+ContinuousApproximateTime TimeWithDynamicClockType::continuousApproximateTime() const
+{
+    RELEASE_ASSERT(m_type == ClockType::ContinuousApproximate);
+    return ContinuousApproximateTime::fromRawSeconds(m_value);
+}
+
 WallTime TimeWithDynamicClockType::approximateWallTime() const
 {
     switch (m_type) {
@@ -79,6 +95,10 @@ WallTime TimeWithDynamicClockType::approximateWallTime() const
         return monotonicTime().approximateWallTime();
     case ClockType::Approximate:
         return approximateTime().approximateWallTime();
+    case ClockType::Continuous:
+        return continuousTime().approximateWallTime();
+    case ClockType::ContinuousApproximate:
+        return ContinuousApproximateTime().approximateWallTime();
     }
     RELEASE_ASSERT_NOT_REACHED();
     return WallTime();
@@ -93,6 +113,10 @@ MonotonicTime TimeWithDynamicClockType::approximateMonotonicTime() const
         return monotonicTime();
     case ClockType::Approximate:
         return approximateTime().approximateMonotonicTime();
+    case ClockType::Continuous:
+        return continuousTime().approximateMonotonicTime();
+    case ClockType::ContinuousApproximate:
+        return ContinuousApproximateTime().approximateMonotonicTime();
     }
     RELEASE_ASSERT_NOT_REACHED();
     return MonotonicTime();

--- a/Source/WTF/wtf/TimeWithDynamicClockType.h
+++ b/Source/WTF/wtf/TimeWithDynamicClockType.h
@@ -27,6 +27,8 @@
 
 #include <wtf/ApproximateTime.h>
 #include <wtf/ClockType.h>
+#include <wtf/ContinuousApproximateTime.h>
+#include <wtf/ContinuousTime.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/WallTime.h>
 
@@ -57,6 +59,18 @@ public:
     {
     }
 
+    TimeWithDynamicClockType(ContinuousTime time)
+        : m_value(time.secondsSinceEpoch().value())
+        , m_type(ClockType::Continuous)
+    {
+    }
+
+    TimeWithDynamicClockType(ContinuousApproximateTime time)
+        : m_value(time.secondsSinceEpoch().value())
+        , m_type(ClockType::ContinuousApproximate)
+    {
+    }
+
     static TimeWithDynamicClockType fromRawSeconds(double value, ClockType type)
     {
         TimeWithDynamicClockType result;
@@ -81,7 +95,9 @@ public:
     WTF_EXPORT_PRIVATE WallTime wallTime() const;
     WTF_EXPORT_PRIVATE MonotonicTime monotonicTime() const;
     WTF_EXPORT_PRIVATE ApproximateTime approximateTime() const;
-    
+    WTF_EXPORT_PRIVATE ContinuousTime continuousTime() const;
+    WTF_EXPORT_PRIVATE ContinuousApproximateTime continuousApproximateTime() const;
+
     WTF_EXPORT_PRIVATE WallTime approximateWallTime() const;
     WTF_EXPORT_PRIVATE MonotonicTime approximateMonotonicTime() const;
     

--- a/Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp
@@ -28,6 +28,7 @@
 
 #if HAVE(OS_SIGNPOST)
 
+#import "ContinuousTime.h"
 #import <dispatch/dispatch.h>
 #import <mach/mach_time.h>
 
@@ -128,28 +129,9 @@ bool WTFSignpostHandleIndirectLog(os_log_t log, pid_t pid, std::span<const char>
     return true;
 }
 
-static const mach_timebase_info_data_t& machTimebaseInfo()
-{
-    static mach_timebase_info_data_t info;
-    static dispatch_once_t once;
-
-    dispatch_once(&once, ^{
-        mach_timebase_info(&info);
-    });
-
-    return info;
-}
-
 uint64_t WTFCurrentContinuousTime(Seconds deltaFromNow)
 {
-    if (!deltaFromNow)
-        return mach_continuous_time();
-
-    auto& info = machTimebaseInfo();
-    auto now = Seconds((mach_continuous_time() * info.numer) / (1.0e9 * info.denom));
-    auto timestamp = now + deltaFromNow;
-
-    return static_cast<uint64_t>((timestamp.seconds() * 1.0e9 * info.denom) / info.numer);
+    return (ContinuousTime::now() + deltaFromNow).toMachContinuousTime();
 }
 
 #endif

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -27,6 +27,7 @@
 
 #import "ScriptTelemetry.h"
 #import <wtf/CompletionHandler.h>
+#import <wtf/ContinuousApproximateTime.h>
 #import <wtf/Function.h>
 #import <wtf/Ref.h>
 #import <wtf/RetainPtr.h>
@@ -176,12 +177,12 @@ public:
 private:
     friend class NeverDestroyed<RestrictedOpenerDomainsController, MainThreadAccessTraits>;
     RestrictedOpenerDomainsController();
-    void scheduleNextUpdate(uint64_t);
+    void scheduleNextUpdate(ContinuousApproximateTime);
     void update();
 
     RetainPtr<WKWebPrivacyNotificationListener> m_notificationListener;
     HashMap<WebCore::RegistrableDomain, RestrictedOpenerType> m_restrictedOpenerTypes;
-    uint64_t m_nextScheduledUpdateTime { 0 };
+    ContinuousApproximateTime m_nextScheduledUpdateTime;
 };
 
 class ResourceMonitorURLsController {


### PR DESCRIPTION
#### ce9238afa421a5eefce7c51d5c627a8b7eacaf79
<pre>
Add continuous time wrappers
<a href="https://bugs.webkit.org/show_bug.cgi?id=285564">https://bugs.webkit.org/show_bug.cgi?id=285564</a>
<a href="https://rdar.apple.com/142512176">rdar://142512176</a>

Reviewed by Basuke Suzuki.

It&apos;s useful to have a time type which advances while the system is asleep. `MonotonicTime` does not
guarantee this (and definitely doesn&apos;t advance while the system is asleep on Darwin). To that end,
this adds two such time types: `ContinuousTime` and `ContinuousApproximateTime`.

- On Darwin, these are wrappers for `mach_continuous_time` and `mach_continuous_approximate_time`.
- On Linux and OpenBSD, both are wrappers for `CLOCK_BOOTTIME`, which advances while the system is
  asleep (there doesn&apos;t seem to be an &quot;approximate&quot; faster version of that clock).
- On other systems, these just wrap the wall clock, with some protection against time going
  backwards. This is what we were already doing for `MonotonicTime` on some platforms.

We also change the two call sites where we were using continuous time:

- `SystemTracing` was using `mach_continuous_time` since it&apos;s built on top of `os_signpost`, which
  itself expects events in `mach_continuous_time` units. Move this to using `ContinuousTime`.
- `WebPrivacyHelpers` was using `CLOCK_MONOTONIC_RAW_APPROX` (which is just
  `mach_continuous_approximate_time` under the hood). Move this to using
  `ContinuousApproximateTime`.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/ClockType.cpp:
(WTF::printInternal):
* Source/WTF/wtf/ClockType.h:
* Source/WTF/wtf/ContinuousApproximateTime.cpp: Copied from Source/WTF/wtf/ClockType.cpp.
(WTF::ContinuousApproximateTime::approximateWallTime const):
(WTF::ContinuousApproximateTime::approximateMonotonicTime const):
(WTF::ContinuousApproximateTime::dump const):
* Source/WTF/wtf/ContinuousApproximateTime.h: Added.
(WTF::ContinuousApproximateTime::MarkableTraits::isEmptyValue):
(WTF::ContinuousApproximateTime::MarkableTraits::emptyValue):
* Source/WTF/wtf/ContinuousTime.cpp: Copied from Source/WTF/wtf/ClockType.cpp.
(WTF::ContinuousTime::approximateWallTime const):
(WTF::ContinuousTime::approximateMonotonicTime const):
(WTF::ContinuousTime::dump const):
* Source/WTF/wtf/ContinuousTime.h: Added.
(WTF::ContinuousTime::MarkableTraits::isEmptyValue):
(WTF::ContinuousTime::MarkableTraits::emptyValue):
* Source/WTF/wtf/CurrentTime.cpp:
* Source/WTF/wtf/Seconds.cpp:
(WTF::Seconds::operator+ const):
(WTF::Seconds::operator- const):
* Source/WTF/wtf/Seconds.h:
* Source/WTF/wtf/TimeWithDynamicClockType.cpp:
(WTF::TimeWithDynamicClockType::now):
(WTF::TimeWithDynamicClockType::continuousTime const):
(WTF::TimeWithDynamicClockType::continuousApproximateTime const):
(WTF::TimeWithDynamicClockType::approximateWallTime const):
(WTF::TimeWithDynamicClockType::approximateMonotonicTime const):
* Source/WTF/wtf/TimeWithDynamicClockType.h:
* Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp:
(WTFCurrentContinuousTime):
(machTimebaseInfo): Deleted.
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::RestrictedOpenerDomainsController::RestrictedOpenerDomainsController):
(WebKit::RestrictedOpenerDomainsController::scheduleNextUpdate):
(WebKit::RestrictedOpenerDomainsController::lookup const):
(WebKit::approximateContinuousTimeNanoseconds): Deleted.

Canonical link: <a href="https://commits.webkit.org/288621@main">https://commits.webkit.org/288621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10e7a0232b6e5ec44d1ecd6a0b05de3776468c95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88981 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34915 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65265 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23100 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45557 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2611 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30461 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33964 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76870 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90357 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/82924 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8107 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73719 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11396 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72937 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18041 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17214 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2506 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11124 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16596 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105342 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10972 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25458 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14448 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12744 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->