### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in WebCore/platform/graphics/coretext

### DIFF
--- a/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
@@ -40,8 +40,6 @@
 #include <CoreText/CoreText.h>
 #include <wtf/Vector.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static CGContextDelegateRef beginLayer(CGContextDelegateRef delegate, CGRenderingStateRef rstate, CGGStateRef gstate, CGRect rect, CFDictionaryRef, CGContextDelegateRef)
@@ -514,5 +512,3 @@ void DrawGlyphsRecorder::drawNativeText(CTFontRef font, CGFloat fontSize, CTLine
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -37,8 +37,6 @@
 
 #include <pal/spi/cf/CoreTextSPI.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 FontCascade::FontCascade(const FontPlatformData& fontData, FontSmoothingMode fontSmoothingMode)
@@ -524,5 +522,3 @@ bool FontCascade::canUseGlyphDisplayList(const RenderStyle& style)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/coretext/SimpleFontDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/SimpleFontDataCoreText.cpp
@@ -30,8 +30,6 @@
 #include <CoreText/CoreText.h>
 #include <pal/spi/cf/CoreTextSPI.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static CTParagraphStyleRef paragraphStyleWithCompositionLanguageNone()
@@ -58,8 +56,8 @@ static CFNumberRef zeroValue()
 
 RetainPtr<CFDictionaryRef> Font::getCFStringAttributes(bool enableKerning, FontOrientation orientation, const AtomString& locale) const
 {
-    CFTypeRef keys[5];
-    CFTypeRef values[5];
+    std::array<CFTypeRef, 5> keys;
+    std::array<CFTypeRef, 5> values;
 
     keys[0] = kCTFontAttributeName;
     values[0] = platformData().ctFont();
@@ -91,9 +89,7 @@ RetainPtr<CFDictionaryRef> Font::getCFStringAttributes(bool enableKerning, FontO
 
     ASSERT(count <= std::size(keys));
 
-    return adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys, values, count, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    return adoptCF(CFDictionaryCreate(kCFAllocatorDefault, keys.data(), values.data(), count, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### df1d0be63f4e8ebd83003443bf64de0125ae6c92
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in WebCore/platform/graphics/coretext
<a href="https://bugs.webkit.org/show_bug.cgi?id=285570">https://bugs.webkit.org/show_bug.cgi?id=285570</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm:
(WebCore::CTRunGetStringIndicesPtrSpan):
(WebCore::CTRunGetGlyphsSpan):
(WebCore::CTRunGetAdvancesSpan):
(WebCore::ComplexTextController::ComplexTextRun::ComplexTextRun):
(WebCore::provideStringAndAttributes):
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp:
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::platformCharWidthInit):
(WebCore::Font::applyTransforms const):
(WebCore::Font::platformSupportsCodePoint const):
* Source/WebCore/platform/graphics/coretext/SimpleFontDataCoreText.cpp:
(WebCore::Font::getCFStringAttributes const):

Canonical link: <a href="https://commits.webkit.org/288596@main">https://commits.webkit.org/288596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66f1fc77fc76d5b44a7614db514d607020d4dc7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88899 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34833 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65200 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23035 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2613 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76168 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45490 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2543 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30387 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33882 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73550 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90275 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11090 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8012 "Found 4 new test failures: http/tests/security/contentSecurityPolicy/connect-src-star-websocket-allowed.html http/tests/websocket/tests/hybi/websocket-constructor-protocols.html http/wpt/mediarecorder/record-96KHz-sources.html media/video-replaces-poster.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73645 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/71996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72864 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17140 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2414 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12963 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11042 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16514 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10890 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14365 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12662 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->