### PR TITLE
Digital Credentials: DigitalCredential's data attribute should be an object

### DIFF
--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -26,22 +26,22 @@
 #include "config.h"
 #include "DigitalCredential.h"
 
-#include <JavaScriptCore/Uint8Array.h>
+#include <wtf/UUID.h>
 #include <wtf/text/Base64.h>
 
 #if ENABLE(WEB_AUTHN)
 
 namespace WebCore {
 
-Ref<DigitalCredential> DigitalCredential::create(Ref<Uint8Array>&& data, IdentityCredentialProtocol protocol)
+Ref<DigitalCredential> DigitalCredential::create(JSC::Strong<JSC::JSObject>&& data, IdentityCredentialProtocol protocol)
 {
     return adoptRef(*new DigitalCredential(WTFMove(data), protocol));
 }
 
 DigitalCredential::~DigitalCredential() = default;
 
-DigitalCredential::DigitalCredential(Ref<Uint8Array>&& data, IdentityCredentialProtocol protocol)
-    : BasicCredential(base64URLEncodeToString(data->span()), Type::DigitalCredential, Discovery::CredentialStore)
+DigitalCredential::DigitalCredential(JSC::Strong<JSC::JSObject>&& data, IdentityCredentialProtocol protocol)
+    : BasicCredential(createVersion4UUIDString(), Type::DigitalCredential, Discovery::CredentialStore)
     , m_protocol(protocol)
     , m_data(WTFMove(data))
 {

--- a/Source/WebCore/Modules/identity/DigitalCredential.h
+++ b/Source/WebCore/Modules/identity/DigitalCredential.h
@@ -42,13 +42,13 @@ using DigitalCredentialPromise = DOMPromiseDeferred<IDLInterface<DigitalCredenti
 
 class DigitalCredential final : public BasicCredential {
 public:
-    static Ref<DigitalCredential> create(Ref<Uint8Array>&& data, IdentityCredentialProtocol);
+    static Ref<DigitalCredential> create(JSC::Strong<JSC::JSObject>&&, IdentityCredentialProtocol);
 
     virtual ~DigitalCredential();
 
-    Uint8Array* data() const
+    const JSC::Strong<JSC::JSObject>& data() const
     {
-        return m_data.get();
+        return m_data;
     };
 
     IdentityCredentialProtocol protocol() const
@@ -57,12 +57,12 @@ public:
     }
 
 private:
-    DigitalCredential(Ref<Uint8Array>&& data, IdentityCredentialProtocol);
+    DigitalCredential(JSC::Strong<JSC::JSObject>&&, IdentityCredentialProtocol);
 
     Type credentialType() const final { return Type::DigitalCredential; }
 
     IdentityCredentialProtocol m_protocol;
-    RefPtr<Uint8Array> m_data;
+    const JSC::Strong<JSC::JSObject> m_data;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/DigitalCredential.idl
+++ b/Source/WebCore/Modules/identity/DigitalCredential.idl
@@ -29,6 +29,6 @@
     EnabledBySetting=DigitalCredentialsEnabled,
     Conditional=WEB_AUTHN,
 ] interface DigitalCredential : BasicCredential {
-    [SameObject] readonly attribute Uint8Array data;
+    [SameObject] readonly attribute object data;
     readonly attribute IdentityCredentialProtocol protocol;
 };


### PR DESCRIPTION
#### 2a3695d1b744833e6ac74ff4cec94faee774354f
<pre>
Digital Credentials: DigitalCredential&apos;s data attribute should be an object
<a href="https://bugs.webkit.org/show_bug.cgi?id=276651">https://bugs.webkit.org/show_bug.cgi?id=276651</a>
<a href="https://rdar.apple.com/132302920">rdar://132302920</a>

Reviewed by Abrar Rahman Protyasha and Alex Christensen.

Implements the DigitalCredential&apos;s data attribute as an object.

Spec change:
<a href="https://github.com/WICG/digital-credentials/pull/141">https://github.com/WICG/digital-credentials/pull/141</a>

* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::DigitalCredential::create):
(WebCore::DigitalCredential::DigitalCredential):
* Source/WebCore/Modules/identity/DigitalCredential.h:
* Source/WebCore/Modules/identity/DigitalCredential.idl:

Canonical link: <a href="https://commits.webkit.org/288674@main">https://commits.webkit.org/288674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6292bebf5759354c740ce8f96665abf1f3817b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89054 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34987 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65313 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23153 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45607 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30527 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34036 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73641 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90431 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11244 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8137 "Found 1 new test failure: swipe/navigate-event-back-swipe-verify-ua-transition.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73762 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72978 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18067 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17273 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2583 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11196 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16668 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11044 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14520 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12816 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->