### PR TITLE
Unreviewed, silence unsafe buffer warning in CodePointIterator.h

### DIFF
--- a/Source/WTF/wtf/text/CodePointIterator.h
+++ b/Source/WTF/wtf/text/CodePointIterator.h
@@ -42,11 +42,13 @@ public:
     {
     }
     
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     ALWAYS_INLINE CodePointIterator(const CodePointIterator& begin, const CodePointIterator& end)
         : CodePointIterator({ begin.m_data.data(), end.m_data.data() })
     {
         ASSERT(end.m_data.data() >= begin.m_data.data());
     }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     
     ALWAYS_INLINE char32_t operator*() const;
     ALWAYS_INLINE CodePointIterator& operator++();


### PR DESCRIPTION
#### 4330cbebaa6d620011e4c36ba121c244ca7828d4
<pre>
Unreviewed, silence unsafe buffer warning in CodePointIterator.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=285572">https://bugs.webkit.org/show_bug.cgi?id=285572</a>
<a href="https://rdar.apple.com/142433265">rdar://142433265</a>

* Source/WTF/wtf/text/CodePointIterator.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4330cbebaa6d620011e4c36ba121c244ca7828d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83832 "Failed to checkout and rebase branch from PR 38695") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88906 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34840 "Failed to checkout and rebase branch from PR 38695") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11415 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/34840 "Failed to checkout and rebase branch from PR 38695") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86878 "Failed to checkout and rebase branch from PR 38695") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/76175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/45496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/30395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33889 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/76795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/31147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90282 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/82849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11097 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11321 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/72004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/72869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/17147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12956 "Failed to checkout and rebase branch from PR 38695") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11049 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/16521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/105266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10897 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/105266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14372 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12669 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->