### PR TITLE
Support `input[type="range"]` in sideways-lr writing mode

### DIFF
--- a/LayoutTests/fast/forms/range/sideways-lr-dragging-expected.txt
+++ b/LayoutTests/fast/forms/range/sideways-lr-dragging-expected.txt
@@ -1,0 +1,12 @@
+This tests that dragging a slider in sideways-lr writing mode works as expected.
+
+
+PASS slider.value is '0'
+Dragging slider
+PASS slider.value is '100'
+Dragging slider back
+PASS slider.value is '0'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/range/sideways-lr-dragging.html
+++ b/LayoutTests/fast/forms/range/sideways-lr-dragging.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
+        <script>
+            async function drag()
+            {
+                if (!window.testRunner)
+                    return;
+
+                const slider = document.getElementById("slider");
+
+                testRunner.dumpAsText();
+                testRunner.waitUntilDone();
+
+                shouldBe("slider.value", "'0'");
+
+                const thumbCenter = slider.offsetWidth / 2;
+
+                debug("Dragging slider");
+                await UIHelper.dragFromPointToPoint(
+                    slider.offsetLeft + thumbCenter, slider.offsetTop + slider.offsetHeight - thumbCenter, // from
+                    slider.offsetLeft + thumbCenter, slider.offsetTop + thumbCenter, // to
+                    0.1, // duration
+                );
+
+                shouldBe("slider.value", "'100'");
+
+                debug("Dragging slider back");
+                await UIHelper.dragFromPointToPoint(
+                    slider.offsetLeft + thumbCenter, slider.offsetTop + thumbCenter, // from
+                    slider.offsetLeft + thumbCenter, slider.offsetTop + slider.offsetHeight - thumbCenter, // to
+                    0.1, // duration
+                );
+
+                shouldBe("slider.value", "'0'");
+
+                testRunner.notifyDone();
+            }
+        </script>
+    </head>
+    <body onload="drag()">
+        <p>This tests that dragging a slider in sideways-lr writing mode works as expected.</p>
+        <input style="writing-mode: sideways-lr;" type="range" id="slider" value="0">
+        <div id="console"></div>
+    </body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -339,6 +339,7 @@ http/wpt/identity/identitycredentialscontainer-get-hidden.https.html [ Skip ]
 
 # No touch events
 fast/events/touch [ Skip ]
+fast/forms/range/sideways-lr-dragging.html [ Skip ]
 fast/shadow-dom/touch-event-ios.html [ Skip ]
 fast/shadow-dom/touch-event-on-text-assigned-to-slot.html [ Skip ]
 http/tests/frame-throttling/raf-throttle-in-cross-origin-subframe.html [ Skip ]

--- a/Source/WebCore/platform/graphics/controls/SliderTrackPart.cpp
+++ b/Source/WebCore/platform/graphics/controls/SliderTrackPart.cpp
@@ -90,10 +90,10 @@ void SliderTrackPart::drawTicks(GraphicsContext& context, const FloatRect& rect,
 
     bool isVerticalWritingMode = style.states.contains(ControlStyle::State::VerticalWritingMode);
     bool isRightToLeft = style.states.contains(ControlStyle::State::RightToLeft);
-    bool isReversedInlineDirection = (!isHorizontal && !isVerticalWritingMode) || isRightToLeft;
+    bool isInlineFlipped = (!isHorizontal && !isVerticalWritingMode) || isRightToLeft;
 
     for (auto tickRatio : m_tickRatios) {
-        double value = isReversedInlineDirection ? 1.0 - tickRatio : tickRatio;
+        double value = isInlineFlipped ? 1.0 - tickRatio : tickRatio;
         double tickPosition = round(tickRegionMargin + tickRegionWidth * value);
         if (isHorizontal)
             tickRect.setX(tickPosition);

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1477,11 +1477,11 @@ void RenderTheme::paintSliderTicks(const RenderObject& renderer, const PaintInfo
     }
     GraphicsContextStateSaver stateSaver(paintInfo.context());
     paintInfo.context().setFillColor(renderer.style().visitedDependentColorWithColorFilter(CSSPropertyColor));
-    bool isReversedInlineDirection = (!isHorizontal && renderer.writingMode().isHorizontal()) || !renderer.style().isLeftToRightDirection();
+    bool isInlineFlipped = (!isHorizontal && renderer.writingMode().isHorizontal()) || renderer.writingMode().isInlineFlipped();
     for (auto& optionElement : dataList->suggestions()) {
         if (auto optionValue = input->listOptionValueAsDouble(optionElement)) {
             double tickFraction = (*optionValue - min) / (max - min);
-            double tickRatio = isReversedInlineDirection ? 1.0 - tickFraction : tickFraction;
+            double tickRatio = isInlineFlipped ? 1.0 - tickFraction : tickFraction;
             double tickPosition = round(tickRegionSideMargin + tickRegionWidth * tickRatio);
             if (isHorizontal)
                 tickRect.setX(tickPosition);

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -1751,11 +1751,11 @@ void RenderThemeIOS::paintSliderTicks(const RenderObject& box, const PaintInfo& 
     auto deviceScaleFactor = box.document().deviceScaleFactor();
     auto styleColorOptions = box.styleColorOptions();
 
-    bool isReversedInlineDirection = (!isHorizontal && box.writingMode().isHorizontal()) || !box.style().isLeftToRightDirection();
+    bool isInlineFlipped = (!isHorizontal && box.writingMode().isHorizontal()) || box.writingMode().isInlineFlipped();
     for (auto& optionElement : dataList->suggestions()) {
         if (auto optionValue = input->listOptionValueAsDouble(optionElement)) {
             auto tickFraction = (*optionValue - min) / (max - min);
-            auto tickRatio = isReversedInlineDirection ? 1.0 - tickFraction : tickFraction;
+            auto tickRatio = isInlineFlipped ? 1.0 - tickFraction : tickFraction;
             if (isHorizontal)
                 tickRect.setX(rect.x() + tickRatio * (rect.width() - tickRect.width()));
             else


### PR DESCRIPTION
#### b1c49c2d197b012cf591a97289eec7bae8804a87
<pre>
Support `input[type=&quot;range&quot;]` in sideways-lr writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=285571">https://bugs.webkit.org/show_bug.cgi?id=285571</a>
<a href="https://rdar.apple.com/142518818">rdar://142518818</a>

Reviewed by Aditya Keerthi.

Painting already works properly.

To fix dragging the slider, use `WritingMode::isLogicalLeftInlineStart()` instead of checking `isLeftToRightDirection()` / `isBidiLTR()`.

* LayoutTests/fast/forms/range/sideways-lr-dragging-expected.txt: Added.
* LayoutTests/fast/forms/range/sideways-lr-dragging.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::SliderThumbElement::setPositionFromPoint):
* Source/WebCore/platform/graphics/controls/SliderTrackPart.cpp:
(WebCore::SliderTrackPart::drawTicks const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::paintSliderTicks):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::paintSliderTicks):

Canonical link: <a href="https://commits.webkit.org/288752@main">https://commits.webkit.org/288752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78c35495fa0b8c6df073f28ac9eb19efb6c0f9b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89395 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35326 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86402 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11916 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65575 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23409 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87363 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3020 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45868 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/2971 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/30839 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34375 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90776 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11584 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74027 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72434 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18119 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17552 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15996 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2949 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11536 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17012 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11385 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14861 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->