### PR TITLE
[JSC] Reduce use of assertNoException in InternalFunction

### DIFF
--- a/JSTests/stress/reduce-assertNoException.js
+++ b/JSTests/stress/reduce-assertNoException.js
@@ -1,0 +1,42 @@
+//@ runDefault("--watchdog=500", "--watchdog-exception-ok")
+function placeholder() {}
+function main() {
+  const z48431 = [0.4, 1145324612];
+  for (let v4 = 0; v4 < 100; v4++) {
+    const v6 = Array(46139);
+    let v7 = undefined;
+    const v9 = class V9 extends Int16Array {
+      constructor(v11, v12, v13) {
+        super();
+      }
+      split() {
+        return 'Test262Error: ' + this.message;
+      }
+    };
+    const v16 = new v9();
+    function v18(v19, v20, v21, v22) {
+      v7 = forceGCSlowPaths;
+    }
+  }
+  const z570009 = [0.4, 1145324612];
+  const z676068 = [0.4, 1145324612];
+  const v23 = 0;
+  const v24 = 100;
+  const z106237 = [0.4, 1145324612];
+  const z788844 = [0.4, 1145324612];
+  const z115753 = [0.4, 1145324612];
+  const z913254 = [0.4, 1145324612];
+  const z438038 = [0.4, 1145324612];
+  const v25 = 1;
+  for (let v29 = 0; v29 < 1099511627776n; v29++) {
+    async function* v30(v31, v32, v33, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) {}
+    const v34 = v30();
+  }
+  const z637976 = [0.4, 1145324612];
+  gc();
+  const z112286 = [0.4, 134217728n];
+  const z709419 = [0.4, 1145324612];
+}
+noDFG(main);
+noFTL(main);
+main();

--- a/Source/JavaScriptCore/runtime/InternalFunction.cpp
+++ b/Source/JavaScriptCore/runtime/InternalFunction.cpp
@@ -166,7 +166,7 @@ Structure* InternalFunction::createSubclassStructure(JSGlobalObject* globalObjec
 
     // .prototype can't be a getter if we canUseAllocationProfiles().
     JSValue prototypeValue = targetFunction->get(globalObject, vm.propertyNames->prototype);
-    scope.assertNoException();
+    RETURN_IF_EXCEPTION(scope, nullptr);
 
     if (JSObject* prototype = jsDynamicCast<JSObject*>(prototypeValue))
         return rareData->createInternalFunctionAllocationStructureFromBase(vm, baseGlobalObject, prototype, baseClass);


### PR DESCRIPTION
#### ec4125195221e7035956058d3a2351edc0a1c89c
<pre>
[JSC] Reduce use of assertNoException in InternalFunction
<a href="https://bugs.webkit.org/show_bug.cgi?id=285573">https://bugs.webkit.org/show_bug.cgi?id=285573</a>
<a href="https://rdar.apple.com/142478305">rdar://142478305</a>

Reviewed by Mark Lam.

assertNoException is not robust against termination exception.
Let&apos;s avoid using it in InternalFunction.

* JSTests/stress/reduce-assertNoException.js: Added.
(placeholder):
(main.const.v9):
(main.const.v9.prototype.split):
(main.v18):
(main.async v30):
* Source/JavaScriptCore/runtime/InternalFunction.cpp:
(JSC::InternalFunction::createSubclassStructure):

Canonical link: <a href="https://commits.webkit.org/288580@main">https://commits.webkit.org/288580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed73bdf2a35d16da94379b9a66bb61264280449b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88913 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34847 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11422 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65210 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23045 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76179 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45502 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/2544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30399 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33896 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76802 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90289 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/82856 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11104 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73654 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72008 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/72871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17151 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12958 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11056 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/16528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105273 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10904 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25438 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14379 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12676 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->