### PR TITLE
Digital Credentials API: IdentityRequestProvider is now called DigitalCredentialRequest

### DIFF
--- a/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https.html
+++ b/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https.html
@@ -54,8 +54,8 @@
         await promise_rejects_js(
             t,
             TypeError,
-            navigator.identity.get({ digital: { providers: [] } }),
-            "navigator.identity.get() with an empty list of providers"
+            navigator.identity.get({ digital: { requests: [] } }),
+            "navigator.identity.get() with an empty list of requests"
         );
 
         await test_driver.bless();
@@ -63,7 +63,7 @@
             t,
             TypeError,
             navigator.identity.get({
-                digital: { providers: [{ protocol: "bogus protocol", request: {} }] },
+                digital: { requests: [{ protocol: "bogus protocol", request: {} }] },
             }),
             "navigator.identity.get() with a provider with unknown protocol"
         );

--- a/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html
+++ b/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html
@@ -38,7 +38,7 @@
 
         const p = navigator.identity.get({
             digital: {
-              providers: [],
+                requests: [],
             },
             mediation: "required",
         });

--- a/LayoutTests/http/wpt/identity/idl.https.html
+++ b/LayoutTests/http/wpt/identity/idl.https.html
@@ -13,10 +13,10 @@ partial dictionary CredentialRequestOptions {
 };
 
 dictionary DigitalCredentialRequestOptions {
-    sequence<IdentityRequestProvider> providers;
+    sequence<DigitalCredentialRequest> requests;
 };
 
-dictionary IdentityRequestProvider {
+dictionary DigitalCredentialRequest {
     required DOMString protocol;
     required object request;
 };

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute.https.html
@@ -103,7 +103,7 @@
                         const options = {
                             digital: {
                                 // Results in TypeError when allowed, NotAllowedError when disallowed
-                                providers: [],
+                                requests: [],
                             },
                             mediation: "required",
                         };

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/dc-types.ts
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/dc-types.ts
@@ -6,9 +6,9 @@ export type CredentialMediationRequirement =
   | "silent";
 
 /**
- * @see https://wicg.github.io/digital-credentials/#dom-identityrequestprovider
+ * @see https://wicg.github.io/digital-credentials/#the-digitalcredentialrequest-dictionary
  */
-export interface IdentityRequestProvider {
+export interface DigitalCredentialRequest {
   protocol: string;
   data: object;
 }
@@ -18,9 +18,9 @@ export interface IdentityRequestProvider {
  */
 export interface DigitalCredentialRequestOptions {
   /**
-   * The list of identity request providers
+   * The list of identity requests.
    */
-  providers: IdentityRequestProvider[] | any;
+  requests: DigitalCredentialRequest[] | any;
 }
 
 /**

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub-expected.txt
@@ -1,6 +1,6 @@
 
 
-FAIL Permissions-Policy header digital-credentials-get=() disallows the top-level document. promise_rejects_dom: function "function() { throw e }" threw object "TypeError: At least one provider must be specified." that is not a DOMException NotAllowedError: property "code" is equal to undefined, expected 0
+FAIL Permissions-Policy header digital-credentials-get=() disallows the top-level document. promise_rejects_dom: function "function() { throw e }" threw object "TypeError: At least one request must present." that is not a DOMException NotAllowedError: property "code" is equal to undefined, expected 0
 FAIL Permissions-Policy header digital-credentials-get=() disallows same-origin iframes. assert_false: Digital Credential API expected false got true
 FAIL Header-set policy is overridden in cross-origin iframe using allow attribute. assert_true: Digital Credential API expected true got false
 FAIL Setting digital-credentials-get=(self) disallows the API in same-origin iframes. assert_false: Digital Credential API expected false got true

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https-expected.txt
@@ -1,9 +1,9 @@
 
 
 PASS Calling navigator.identity.get() without an digital member same origin.
-PASS navigator.identity.get() API rejects if there are no providers.
-PASS navigator.identity.get() API rejects if there are no providers for same-origin iframe.
-FAIL navigator.identity.get() API rejects if there are no providers in cross-origin iframe. assert_equals: expected "TypeError" but got "DOMException"
+PASS navigator.identity.get() API rejects if there are no requests.
+PASS navigator.identity.get() API rejects if there are no requests for same-origin iframe.
+FAIL navigator.identity.get() API rejects if there are no requests in cross-origin iframe. assert_equals: expected "TypeError" but got "DOMException"
 PASS navigator.identity.get() promise is rejected if called with an aborted signal.
 PASS navigator.identity.get() promise is rejected if called with an aborted signal in same-origin iframe.
 PASS navigator.identity.get() promise is rejected if called with an aborted signal in cross-origin iframe.

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https.html
@@ -86,18 +86,18 @@
   }, "Calling navigator.identity.get() without an digital member same origin.");
 
   promise_test(async (t) => {
-    for (const provider of [undefined, []]) {
-      const options = makeGetOptions(provider);
+    for (const request of [undefined, []]) {
+      const options = makeGetOptions(request);
       await test_driver.bless("user activation");
       await promise_rejects_js(t, TypeError, navigator.identity.get(options));
     }
-  }, "navigator.identity.get() API rejects if there are no providers.");
+  }, "navigator.identity.get() API rejects if there are no requests.");
 
   promise_test(async (t) => {
     iframeSameOrigin.focus();
     const { contentWindow: iframeWindow } = iframeSameOrigin;
-    for (const provider of [undefined, []]) {
-      const options = makeGetOptions(provider);
+    for (const request of [undefined, []]) {
+      const options = makeGetOptions(request);
       await test_driver.bless("user activation");
       await promise_rejects_js(
         t,
@@ -105,19 +105,19 @@
         iframeWindow.navigator.identity.get(options)
       );
     }
-  }, "navigator.identity.get() API rejects if there are no providers for same-origin iframe.");
+  }, "navigator.identity.get() API rejects if there are no requests for same-origin iframe.");
 
   promise_test(async (t) => {
     iframeCrossOrigin.focus();
-    for (const provider of [undefined, []]) {
-      const options = makeGetOptions(provider);
+    for (const request of [undefined, []]) {
+      const options = makeGetOptions(request);
       const result = await sendMessage(iframeCrossOrigin, {
         action: "get",
         options,
       });
       assert_equals(result.constructor, "TypeError");
     }
-  }, "navigator.identity.get() API rejects if there are no providers in cross-origin iframe.");
+  }, "navigator.identity.get() API rejects if there are no requests in cross-origin iframe.");
 
   promise_test(async (t) => {
     const abortController = new AbortController();

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/helper.js
@@ -2,47 +2,50 @@
 // Import the types from the TypeScript file
 /**
  * @typedef {import('../dc-types').ProviderType} ProviderType
- * @typedef {import('../dc-types').IdentityRequestProvider} IdentityRequestProvider
+ * @typedef {import('../dc-types').DigitalCredentialRequest} DigitalCredentialRequest
  * @typedef {import('../dc-types').DigitalCredentialRequestOptions} DigitalCredentialRequestOptions
  * @typedef {import('../dc-types').CredentialRequestOptions} CredentialRequestOptions
  * @typedef {import('../dc-types').SendMessageData} SendMessageData
  */
 /**
- * @param {ProviderType | ProviderType[]} [providersToUse=["default"]]
+ * @param {ProviderType | ProviderType[]} [requestsToUse=["default"]]
  * @param {CredentialMediationRequirement} [mediation="required"]
  * @returns {CredentialRequestOptions}
  */
-export function makeGetOptions(providersToUse = ["default"], mediation = "required") {
-  if (typeof providersToUse === "string") {
-    if (providersToUse === "default" || providersToUse === "openid4vp"){
-      return makeGetOptions([providersToUse]);
+export function makeGetOptions(
+  requestsToUse = ["default"],
+  mediation = "required"
+) {
+  if (typeof requestsToUse === "string") {
+    if (requestsToUse === "default" || requestsToUse === "openid4vp") {
+      return makeGetOptions([requestsToUse]);
     }
   }
-  if (!Array.isArray(providersToUse) || !providersToUse?.length) {
-    return { digital: { providers: providersToUse }, mediation };
+  if (!Array.isArray(requestsToUse) || !requestsToUse?.length) {
+    return { digital: { requests: requestsToUse }, mediation };
   }
-  const providers = [];
-  for (const provider of providersToUse) {
-    switch (provider) {
+  const requests = [];
+  for (const request of requestsToUse) {
+    switch (request) {
       case "openid4vp":
-        providers.push(makeOID4VPDict());
+        requests.push(makeOID4VPDict());
         break;
       case "default":
-        providers.push(makeIdentityRequestProvider(undefined, undefined));
+        requests.push(makeDigitalCredentialRequest(undefined, undefined));
         break;
       default:
-        throw new Error(`Unknown provider type: ${provider}`);
+        throw new Error(`Unknown request type: ${request}`);
     }
   }
-  return { digital: { providers }, mediation };
+  return { digital: { requests }, mediation };
 }
 /**
  *
  * @param {string} protocol
  * @param {object} data
- * @returns {IdentityRequestProvider}
+ * @returns {DigitalCredentialRequest}
  */
-function makeIdentityRequestProvider(protocol = "protocol", data = {}) {
+function makeDigitalCredentialRequest(protocol = "protocol", data = {}) {
   return {
     protocol,
     data,
@@ -50,12 +53,12 @@ function makeIdentityRequestProvider(protocol = "protocol", data = {}) {
 }
 
 /**
- * Representation of a digital identity object with an OpenID4VP provider.
+ * Representation of a digital identity object with an OpenID4VP request.
  *
- * @returns {IdentityRequestProvider}
+ * @returns {DigitalCredentialRequest}
  **/
 function makeOID4VPDict() {
-  return makeIdentityRequestProvider("openid4vp", {
+  return makeDigitalCredentialRequest("openid4vp", {
     // Canonical example of an OpenID4VP request coming soon.
   });
 }

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub-expected.txt
@@ -1,6 +1,6 @@
 
 
-FAIL Permissions-Policy header digital-credentials-get=() disallows the top-level document. promise_rejects_dom: function "function() { throw e }" threw object "TypeError: At least one provider must be specified." that is not a DOMException NotAllowedError: property "code" is equal to undefined, expected 0
+FAIL Permissions-Policy header digital-credentials-get=() disallows the top-level document. promise_rejects_dom: function "function() { throw e }" threw object "TypeError: At least one request must present." that is not a DOMException NotAllowedError: property "code" is equal to undefined, expected 0
 FAIL Permissions-Policy header digital-credentials-get=() disallows same-origin iframes. assert_false: Digital Credential API expected false got true
 FAIL Header-set policy is overridden in cross-origin iframe using allow attribute. assert_true: Digital Credential API expected true got false
 PASS Setting digital-credentials-get=(self) disallows the API in same-origin iframes.

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https-expected.txt
@@ -1,11 +1,11 @@
 
 
 PASS Calling navigator.identity.get() without an digital member same origin.
-PASS navigator.identity.get() API rejects if there are no providers.
-FAIL navigator.identity.get() API rejects if there are no providers for same-origin iframe. promise_rejects_js: function "function() { throw e }" threw object "NotAllowedError: The document is not focused." ("NotAllowedError") expected instance of function "function TypeError() {
+PASS navigator.identity.get() API rejects if there are no requests.
+FAIL navigator.identity.get() API rejects if there are no requests for same-origin iframe. promise_rejects_js: function "function() { throw e }" threw object "NotAllowedError: The document is not focused." ("NotAllowedError") expected instance of function "function TypeError() {
     [native code]
 }" ("TypeError")
-FAIL navigator.identity.get() API rejects if there are no providers in cross-origin iframe. assert_equals: expected "TypeError" but got "DOMException"
+FAIL navigator.identity.get() API rejects if there are no requests in cross-origin iframe. assert_equals: expected "TypeError" but got "DOMException"
 PASS navigator.identity.get() promise is rejected if called with an aborted signal.
 PASS navigator.identity.get() promise is rejected if called with an aborted signal in same-origin iframe.
 PASS navigator.identity.get() promise is rejected if called with an aborted signal in cross-origin iframe.

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -397,9 +397,9 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/highlight/HighlightRegistry.idl
 
     Modules/identity/DigitalCredential.idl
+    Modules/identity/DigitalCredentialRequest.idl
     Modules/identity/DigitalCredentialRequestOptions.idl
     Modules/identity/IdentityCredentialProtocol.idl
-    Modules/identity/IdentityRequestProvider.idl
     Modules/identity/Navigator+Identity.idl
     Modules/identity/OpenID4VPRequest.idl
 

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -510,9 +510,9 @@ $(PROJECT_DIR)/Modules/geolocation/PositionOptions.idl
 $(PROJECT_DIR)/Modules/highlight/Highlight.idl
 $(PROJECT_DIR)/Modules/highlight/HighlightRegistry.idl
 $(PROJECT_DIR)/Modules/identity/DigitalCredential.idl
+$(PROJECT_DIR)/Modules/identity/DigitalCredentialRequest.idl
 $(PROJECT_DIR)/Modules/identity/DigitalCredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/identity/IdentityCredentialProtocol.idl
-$(PROJECT_DIR)/Modules/identity/IdentityRequestProvider.idl
 $(PROJECT_DIR)/Modules/identity/Navigator+Identity.idl
 $(PROJECT_DIR)/Modules/identity/OpenID4VPRequest.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBCursor.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -869,6 +869,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceOrientationOrMotionPermissi
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceOrientationOrMotionPermissionState.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredential.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredential.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialRequest.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialRequest.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialRequestOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialRequestOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDistanceModelType.cpp
@@ -1691,8 +1693,6 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIIRFilterOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIIRFilterOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityCredentialProtocol.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityCredentialProtocol.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityRequestProvider.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityRequestProvider.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdleDeadline.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdleDeadline.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdleRequestCallback.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -380,10 +380,10 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/highlight/HighlightRegistry.idl \
     $(WebCore)/Modules/highlight/Highlight.idl \
     $(WebCore)/Modules/identity/DigitalCredential.idl \
+    $(WebCore)/Modules/identity/DigitalCredentialRequest.idl \
     $(WebCore)/Modules/identity/DigitalCredentialRequestOptions.idl \
     $(WebCore)/Modules/identity/OpenID4VPRequest.idl \
     $(WebCore)/Modules/identity/IdentityCredentialProtocol.idl \
-    $(WebCore)/Modules/identity/IdentityRequestProvider.idl \
     $(WebCore)/Modules/identity/Navigator+Identity.idl \
     $(WebCore)/Modules/indexeddb/IDBCursor.idl \
     $(WebCore)/Modules/indexeddb/IDBCursorDirection.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -412,9 +412,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Modules/identity/CredentialRequestCoordinator.h
     Modules/identity/CredentialRequestCoordinatorClient.h
+    Modules/identity/DigitalCredentialRequest.h
     Modules/identity/DigitalCredentialRequestOptions.h
     Modules/identity/IdentityCredentialsContainer.h
-    Modules/identity/IdentityRequestProvider.h
     Modules/identity/OpenID4VPRequest.h
 
     Modules/indexeddb/IDBActiveDOMObject.h

--- a/Source/WebCore/Modules/identity/DigitalCredentialRequest.h
+++ b/Source/WebCore/Modules/identity/DigitalCredentialRequest.h
@@ -23,7 +23,16 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-dictionary IdentityRequestProvider {
-    required IdentityCredentialProtocol protocol;
-    required OpenID4VPRequest data;
+#pragma once
+
+#include "IdentityCredentialProtocol.h"
+#include "OpenID4VPRequest.h"
+
+namespace WebCore {
+
+struct DigitalCredentialRequest {
+    IdentityCredentialProtocol protocol;
+    OpenID4VPRequest data;
 };
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/identity/DigitalCredentialRequest.idl
+++ b/Source/WebCore/Modules/identity/DigitalCredentialRequest.idl
@@ -23,16 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include "IdentityCredentialProtocol.h"
-#include "OpenID4VPRequest.h"
-
-namespace WebCore {
-
-struct IdentityRequestProvider {
-    IdentityCredentialProtocol protocol;
-    OpenID4VPRequest data;
+dictionary DigitalCredentialRequest {
+    required IdentityCredentialProtocol protocol;
+    required OpenID4VPRequest data;
 };
-
-} // namespace WebCore

--- a/Source/WebCore/Modules/identity/DigitalCredentialRequestOptions.h
+++ b/Source/WebCore/Modules/identity/DigitalCredentialRequestOptions.h
@@ -25,17 +25,17 @@
 
 #pragma once
 
-#include "IdentityRequestProvider.h"
+#include "DigitalCredentialRequest.h"
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
-struct IdentityRequestProvider;
+struct DigitalCredentialRequest;
 
 struct DigitalCredentialRequestOptions {
-    Vector<IdentityRequestProvider> providers;
+    Vector<DigitalCredentialRequest> requests;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/DigitalCredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/identity/DigitalCredentialRequestOptions.idl
@@ -24,5 +24,5 @@
  */
 
 dictionary DigitalCredentialRequestOptions {
-    required sequence<IdentityRequestProvider> providers;
+    required sequence<DigitalCredentialRequest> requests;
 };

--- a/Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp
+++ b/Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp
@@ -86,8 +86,8 @@ void IdentityCredentialsContainer::get(CredentialRequestOptions&& options, Crede
         return;
     }
 
-    if (options.digital->providers.isEmpty()) {
-        promise.reject(Exception { ExceptionCode::TypeError, "At least one provider must be specified."_s });
+    if (options.digital->requests.isEmpty()) {
+        promise.reject(Exception { ExceptionCode::TypeError, "At least one request must present."_s });
         return;
     }
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3746,6 +3746,7 @@ JSDeviceMotionEvent.cpp
 JSDeviceOrientationEvent.cpp
 JSDeviceOrientationOrMotionPermissionState.cpp
 JSDigitalCredential.cpp
+JSDigitalCredentialRequest.cpp
 JSDigitalCredentialRequestOptions.cpp
 JSDistanceModelType.cpp
 JSDocument.cpp
@@ -4101,7 +4102,6 @@ JSIDBTransactionDurability.cpp
 JSIDBTransactionMode.cpp
 JSIDBVersionChangeEvent.cpp
 JSIdentityCredentialProtocol.cpp
-JSIdentityRequestProvider.cpp
 JSIdleDeadline.cpp
 JSIdleRequestCallback.cpp
 JSIdleRequestOptions.cpp

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6375,13 +6375,13 @@ struct WebCore::MockWebAuthenticationConfiguration {
 struct WebCore::OpenID4VPRequest {
 };
 
-[Nested] struct WebCore::IdentityRequestProvider {
+[Nested] struct WebCore::DigitalCredentialRequest {
     WebCore::IdentityCredentialProtocol protocol;
     WebCore::OpenID4VPRequest data;
 };
 
 struct WebCore::DigitalCredentialRequestOptions {
-    Vector<WebCore::IdentityRequestProvider> providers;
+    Vector<WebCore::DigitalCredentialRequest> requests;
 };
 
 enum class WebCore::IdentityCredentialProtocol : uint8_t {


### PR DESCRIPTION
#### f4b943408774406fc5a2ae7e5f9720fc92506b6f
<pre>
Digital Credentials API: IdentityRequestProvider is now called DigitalCredentialRequest
<a href="https://bugs.webkit.org/show_bug.cgi?id=279932">https://bugs.webkit.org/show_bug.cgi?id=279932</a>
<a href="https://rdar.apple.com/136714198">rdar://136714198</a>

Reviewed by Abrar Rahman Protyasha and Alex Christensen.

Rename IdentityRequestProvider to DigitalCredentialRequest and related classes.
Also update the tests and the IDL file to use `.requests` instead of `.providers`.

See spec change:
<a href="https://github.com/WICG/digital-credentials/pull/165/">https://github.com/WICG/digital-credentials/pull/165/</a>

* LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https.html:
* LayoutTests/http/wpt/identity/identitycredentialscontainer-get-hidden.https.html:
* LayoutTests/http/wpt/identity/idl.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/allow-attribute.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/dc-types.ts:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/helper.js:
(export.makeGetOptions):
(makeDigitalCredentialRequest):
(makeIdentityRequestProvider): Deleted.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/disabled-by-permissions-policy.https.sub-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/digital-credentials/identity-get.tentative.https-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/identity/DigitalCredentialRequest.h: Renamed from Source/WebCore/Modules/identity/IdentityRequestProvider.h.
* Source/WebCore/Modules/identity/DigitalCredentialRequest.idl: Renamed from Source/WebCore/Modules/identity/IdentityRequestProvider.idl.
* Source/WebCore/Modules/identity/DigitalCredentialRequestOptions.h:
* Source/WebCore/Modules/identity/DigitalCredentialRequestOptions.idl:
* Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp:
(WebCore::IdentityCredentialsContainer::get):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/288717@main">https://commits.webkit.org/288717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4aadb068754b085932ae0d46fd4ba77eaa052ba5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89231 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35164 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65453 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23289 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2893 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76475 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45746 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2843 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30704 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34212 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90611 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11423 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73903 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72300 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73108 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18096 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17423 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2767 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11375 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16850 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14699 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->