### PR TITLE
Digital Credential: DigitalCredentialsRequest's request member is now called data

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/dc-types.ts
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/dc-types.ts
@@ -10,7 +10,7 @@ export type CredentialMediationRequirement =
  */
 export interface IdentityRequestProvider {
   protocol: string;
-  request: object;
+  data: object;
 }
 
 /**

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/helper.js
@@ -39,13 +39,13 @@ export function makeGetOptions(providersToUse = ["default"], mediation = "requir
 /**
  *
  * @param {string} protocol
- * @param {object} request
+ * @param {object} data
  * @returns {IdentityRequestProvider}
  */
-function makeIdentityRequestProvider(protocol = "protocol", request = {}) {
+function makeIdentityRequestProvider(protocol = "protocol", data = {}) {
   return {
     protocol,
-    request,
+    data,
   };
 }
 

--- a/Source/WebCore/Modules/identity/IdentityRequestProvider.h
+++ b/Source/WebCore/Modules/identity/IdentityRequestProvider.h
@@ -32,7 +32,7 @@ namespace WebCore {
 
 struct IdentityRequestProvider {
     IdentityCredentialProtocol protocol;
-    OpenID4VPRequest request;
+    OpenID4VPRequest data;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/IdentityRequestProvider.idl
+++ b/Source/WebCore/Modules/identity/IdentityRequestProvider.idl
@@ -25,5 +25,5 @@
 
 dictionary IdentityRequestProvider {
     required IdentityCredentialProtocol protocol;
-    required OpenID4VPRequest request;
+    required OpenID4VPRequest data;
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6377,7 +6377,7 @@ struct WebCore::OpenID4VPRequest {
 
 [Nested] struct WebCore::IdentityRequestProvider {
     WebCore::IdentityCredentialProtocol protocol;
-    WebCore::OpenID4VPRequest request;
+    WebCore::OpenID4VPRequest data;
 };
 
 struct WebCore::DigitalCredentialRequestOptions {


### PR DESCRIPTION
#### 42df611a2fa35a5274aedb5c4f01394afdfe6d26
<pre>
Digital Credential: DigitalCredentialsRequest&apos;s request member is now called data
<a href="https://bugs.webkit.org/show_bug.cgi?id=279933">https://bugs.webkit.org/show_bug.cgi?id=279933</a>
<a href="https://rdar.apple.com/136714291">rdar://136714291</a>

Reviewed by Abrar Rahman Protyasha and Alex Christensen.

The `request` member of IdentityRequestProvider is now called data.

Spec change:
<a href="https://github.com/WICG/digital-credentials/pull/165">https://github.com/WICG/digital-credentials/pull/165</a>

* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/dc-types.ts:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/support/helper.js:
(makeIdentityRequestProvider):
* Source/WebCore/Modules/identity/IdentityRequestProvider.h:
* Source/WebCore/Modules/identity/IdentityRequestProvider.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/288669@main">https://commits.webkit.org/288669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74fb428a247c5f3689b7737a1219d3b9d1ab8fa3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88919 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34853 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11429 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65216 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23050 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45508 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30406 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33902 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73564 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31158 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90295 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8026 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73662 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72877 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18064 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17157 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15851 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2434 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16534 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10910 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14385 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->