### PR TITLE
Make regExpConstructorEscape() handle OOME more gracefully.

### DIFF
--- a/JSTests/stress/regexp-escape-oom.js
+++ b/JSTests/stress/regexp-escape-oom.js
@@ -1,0 +1,10 @@
+//@ runDefault
+
+var exception;
+try {
+    RegExp.escape('퀀'.repeat?.(2 ** 30));
+} catch (e) {
+    exception = e;
+}
+if (exception != 'RangeError: Out of memory')
+  throw 'FAILED';

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -285,7 +285,7 @@ inline bool StringBuilder::is8Bit() const
 
 template<typename CharacterType> inline std::span<const CharacterType> StringBuilder::span() const
 {
-    if (!m_length)
+    if (!m_length || hasOverflowed())
         return { };
     if (!m_string.isNull()) {
         ASSERT(m_string.length() == m_length);


### PR DESCRIPTION
#### 211efd9b429266d3f8ee0d488e033b2ad34a7880
<pre>
Make regExpConstructorEscape() handle OOME more gracefully.
<a href="https://bugs.webkit.org/show_bug.cgi?id=285575">https://bugs.webkit.org/show_bug.cgi?id=285575</a>
<a href="https://rdar.apple.com/142475010">rdar://142475010</a>

Reviewed by Yusuke Suzuki.

Changed regExpConstructorEscape() to use the StringBuilder with OverflowPolicy::RecordOverflow.
With this, we can throw an OOME instead of crashing when an imminent overflow is detected.

Also fixed StringBuilder::span() to be able to handle overflows for OverflowPolicy::RecordOverflow.

* JSTests/stress/regexp-escape-oom.js: Added.
(catch):
* Source/JavaScriptCore/runtime/RegExpConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::span const):

Canonical link: <a href="https://commits.webkit.org/288648@main">https://commits.webkit.org/288648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/751e3799aa1a6c9a23d79fdb45cc392a61698497

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34855 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65222 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23056 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45514 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2556 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30409 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33904 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76810 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73566 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90297 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/82864 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8040 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73666 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72882 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17161 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15854 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2436 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13000 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11064 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16536 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105281 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10912 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25439 "Found 1 new JSC stress test failure: stress/regexp-escape-oom.js.default (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->