### PR TITLE
Make it possible to quirk Storage Access API calls by matching only the origin and path of the trigger page

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
@@ -98,7 +98,7 @@ constexpr NSInteger WPResourceTypeStorageAccessPromptQuirksData = 7;
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) NSDictionary<NSString *, NSArray<NSString *> *> *domainPairings;
 @property (nonatomic, readonly) NSDictionary<NSString *, NSArray<NSString *> *> *quirkDomains;
-@property (nonatomic, readonly) NSArray<NSString *> *triggerPages;
+@property (nonatomic, readonly) NSDictionary<NSString *, NSString *> *triggerPages;
 @end
 
 @interface WPStorageAccessPromptQuirksData : NSObject
@@ -159,7 +159,7 @@ typedef void (^WPRestrictedOpenerDomainsCompletionHandler)(NSArray<WPRestrictedO
 #if !defined(HAS_WEB_PRIVACY_STORAGE_ACCESS_PROMPT_TRIGGER) && HAVE(WEB_PRIVACY_FRAMEWORK)
 @interface WPStorageAccessPromptQuirk (Staging_124689085)
 @property (nonatomic, readonly) NSDictionary<NSString *, NSArray<NSString *> *> *quirkDomains;
-@property (nonatomic, readonly) NSArray<NSString *> *triggerPages;
+@property (nonatomic, readonly) NSDictionary<NSString *, NSString *> *triggerPages;
 @end
 #endif
 

--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -558,10 +558,26 @@ std::optional<RegistrableDomain> NetworkStorageSession::findAdditionalLoginDomai
     return std::nullopt;
 }
 
+static inline bool storageAccessQuirkURLMatchesTriggerPage(const URL& fullURL, const Vector<std::pair<URL, StorageAccessPromptQuirkTriggerMatchType>> triggerPages)
+{
+    for (auto& triggerPage : triggerPages) {
+        switch (std::get<1>(triggerPage)) {
+        case StorageAccessPromptQuirkTriggerMatchType::FullURL:
+            return fullURL == std::get<0>(triggerPage);
+        case StorageAccessPromptQuirkTriggerMatchType::OriginAndPath:
+        default:
+            URL originAndPath = fullURL.isolatedCopy();
+            originAndPath.removeQueryAndFragmentIdentifier();
+            return originAndPath == std::get<0>(triggerPage);
+        }
+    }
+    return false;
+}
+
 Vector<RegistrableDomain> NetworkStorageSession::storageAccessQuirkForTopFrameDomain(const URL& topFrameURL)
 {
     for (auto&& quirk : updatableStorageAccessPromptQuirks()) {
-        if (!quirk.triggerPages.isEmpty() && !quirk.triggerPages.contains(topFrameURL))
+        if (!quirk.triggerPages.isEmpty() && !storageAccessQuirkURLMatchesTriggerPage(topFrameURL, quirk.triggerPages))
             continue;
 
         auto quirkDomains = quirk.quirkDomains;

--- a/Source/WebCore/platform/network/OrganizationStorageAccessPromptQuirk.h
+++ b/Source/WebCore/platform/network/OrganizationStorageAccessPromptQuirk.h
@@ -31,14 +31,18 @@
 
 namespace WebCore {
 
+enum class StorageAccessPromptQuirkTriggerMatchType : bool {
+    FullURL, OriginAndPath
+};
+
 struct OrganizationStorageAccessPromptQuirk {
     String organizationName;
     HashMap<RegistrableDomain, Vector<RegistrableDomain>> quirkDomains;
-    Vector<URL> triggerPages;
+    Vector<std::pair<URL, StorageAccessPromptQuirkTriggerMatchType>> triggerPages;
 
     bool isHashTableDeletedValue() const { return organizationName.isHashTableDeletedValue(); }
 
-    OrganizationStorageAccessPromptQuirk(String&& organizationName, HashMap<RegistrableDomain, Vector<RegistrableDomain>>&& quirkDomains, Vector<URL>&& triggerPages)
+    OrganizationStorageAccessPromptQuirk(String&& organizationName, HashMap<RegistrableDomain, Vector<RegistrableDomain>>&& quirkDomains, Vector<std::pair<URL, StorageAccessPromptQuirkTriggerMatchType>>&& triggerPages)
         : organizationName { WTFMove(organizationName) }
         , quirkDomains { WTFMove(quirkDomains) }
         , triggerPages { WTFMove(triggerPages) }

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -240,12 +240,15 @@ static HashMap<WebCore::RegistrableDomain, Vector<WebCore::RegistrableDomain>> q
     return map;
 }
 
-static Vector<URL> quirkPagesArrayToVector(NSArray<NSString *> *triggerPages)
+static Vector<std::pair<URL, StorageAccessPromptQuirkTriggerMatchType>> quirkPagesDictionaryToVector(NSDictionary<NSString *, NSString *> *triggerPages)
 {
-    Vector<URL> triggers;
-    for (NSString *page : triggerPages) {
-        if (![page isEqualToString:@"*"])
-            triggers.append(URL { page });
+    Vector<std::pair<URL, StorageAccessPromptQuirkTriggerMatchType>> triggers;
+    auto* pageURLStrs = triggerPages.allKeys;
+    for (NSString *pageURLStr : pageURLStrs) {
+        if ([pageURLStr isEqualToString:@"*"])
+            continue;
+        auto matchType = [[triggerPages objectForKey:pageURLStr] isEqualToString:@"OriginAndPath"] ? StorageAccessPromptQuirkTriggerMatchType::OriginAndPath : StorageAccessPromptQuirkTriggerMatchType::FullURL;
+        triggers.append(std::make_pair(URL { pageURLStr }, matchType));
     }
     return triggers;
 }
@@ -274,8 +277,9 @@ void StorageAccessPromptQuirkController::updateList(CompletionHandler<void()>&& 
             auto quirks = [data quirks];
             auto hasQuirkDomainsAndTriggerPages = [PAL::getWPStorageAccessPromptQuirkClass() instancesRespondToSelector:@selector(quirkDomains)] && [PAL::getWPStorageAccessPromptQuirkClass() instancesRespondToSelector:@selector(triggerPages)];
             for (WPStorageAccessPromptQuirk *quirk : quirks) {
+//                [quirk.triggerPages isMemberOfClass:[a class]]
                 if (hasQuirkDomainsAndTriggerPages)
-                    result.append(WebCore::OrganizationStorageAccessPromptQuirk { quirk.name, quirkDomainsDictToMap(quirk.quirkDomains), quirkPagesArrayToVector(quirk.triggerPages) });
+                    result.append(WebCore::OrganizationStorageAccessPromptQuirk { quirk.name, quirkDomainsDictToMap(quirk.quirkDomains), quirkPagesDictionaryToVector(quirk.triggerPages) });
                 else
                     result.append(WebCore::OrganizationStorageAccessPromptQuirk { quirk.name, quirkDomainsDictToMap(quirk.domainPairings), { } });
             }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8111,10 +8111,13 @@ struct WebCore::Length {
     WebCore::SourceGraphic
 }
 
+header: <WebCore/OrganizationStorageAccessPromptQuirk.h>
+enum class WebCore::StorageAccessPromptQuirkTriggerMatchType : bool;
+
 struct WebCore::OrganizationStorageAccessPromptQuirk {
     String organizationName;
     HashMap<WebCore::RegistrableDomain, Vector<WebCore::RegistrableDomain>> quirkDomains;
-    Vector<URL> triggerPages;
+    Vector<std::pair<URL, WebCore::StorageAccessPromptQuirkTriggerMatchType>> triggerPages;
 };
 
 #if ENABLE(SHAREABLE_RESOURCE)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -788,12 +788,17 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
     _websiteDataStore->setStatisticsTestingCallback(nullptr);
 }
 
-- (void)_setStorageAccessPromptQuirkForTesting:(NSString *)topFrameDomain withSubFrameDomains:(NSArray<NSString *> *)subFrameDomains withTriggerPages:(NSArray<NSString *> *)triggerPages completionHandler:(void(^)(void))completionHandler
+- (void)_setStorageAccessPromptQuirkForTesting:(NSString *)topFrameDomain withSubFrameDomains:(NSArray<NSString *> *)subFrameDomains withTriggerPages:(NSDictionary<NSString *, NSString *> *)triggerPages completionHandler:(void(^)(void))completionHandler
 {
     if (!_websiteDataStore->isPersistent())
         return;
 
-    _websiteDataStore->setStorageAccessPromptQuirkForTesting(topFrameDomain, makeVector<String>(subFrameDomains), makeVector<String>(triggerPages), makeBlockPtr(completionHandler));
+    Vector<std::pair<String, String>> triggerPageVector;
+    triggerPageVector.reserveInitialCapacity(triggerPages.count);
+    for (NSString *key in triggerPages)
+        triggerPageVector.append({ key, triggerPages[key] });
+
+    _websiteDataStore->setStorageAccessPromptQuirkForTesting(topFrameDomain, makeVector<String>(subFrameDomains), WTFMove(triggerPageVector), makeBlockPtr(completionHandler));
 }
 
 - (void)_grantStorageAccessForTesting:(NSString *)topFrameDomain withSubFrameDomains:(NSArray<NSString *> *)subFrameDomains completionHandler:(void(^)(void))completionHandler

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -75,7 +75,7 @@ typedef NS_ENUM(uint8_t, _WKRestrictedOpenerType) {
 - (void)_loadedSubresourceDomainsFor:(WKWebView *)webView completionHandler:(void (^)(NSArray<NSString *> *domains))completionHandler WK_API_AVAILABLE(macos(12.0), ios(15.0));
 - (void)_clearLoadedSubresourceDomainsFor:(WKWebView *)webView WK_API_AVAILABLE(macos(12.0), ios(15.0));
 + (void)_allowWebsiteDataRecordsForAllOrigins WK_API_AVAILABLE(macos(10.13.4), ios(11.3));
-- (void)_setStorageAccessPromptQuirkForTesting:(NSString *)topFrameDomain withSubFrameDomains:(NSArray<NSString *> *)subFrameDomains withTriggerPages:(NSArray<NSString *> *)triggerPages completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
+- (void)_setStorageAccessPromptQuirkForTesting:(NSString *)topFrameDomain withSubFrameDomains:(NSArray<NSString *> *)subFrameDomains withTriggerPages:(NSDictionary<NSString *, NSString *> *)triggerPages completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 - (void)_grantStorageAccessForTesting:(NSString *)topFrameDomain withSubFrameDomains:(NSArray<NSString *> *)subFrameDomains completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 
 - (void)_scheduleCookieBlockingUpdate:(void (^)(void))completionHandler WK_API_AVAILABLE(macos(10.15), ios(13.0));

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -527,8 +527,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     for (auto&& entry : StorageAccessPromptQuirkController::sharedSingleton().cachedListData()) {
         if (!entry.triggerPages.isEmpty()) {
-            for (auto&& page : entry.triggerPages)
-                parameters.storageAccessPromptQuirksDomains.add(RegistrableDomain { page });
+            for (auto&& pair : entry.triggerPages)
+                parameters.storageAccessPromptQuirksDomains.add(RegistrableDomain { std::get<0>(pair) });
             continue;
         }
         for (auto&& domain : entry.quirkDomains.keys())

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -346,8 +346,8 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
             HashSet<WebCore::RegistrableDomain> domainSet;
             for (auto&& entry : StorageAccessPromptQuirkController::sharedSingleton().cachedListData()) {
                 if (!entry.triggerPages.isEmpty()) {
-                    for (auto&& page : entry.triggerPages)
-                        domainSet.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString(page.string()));
+                    for (auto&& pair : entry.triggerPages)
+                        domainSet.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString(std::get<0>(pair).string()));
                     continue;
                 }
                 for (auto&& domain : entry.quirkDomains.keys())

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -60,6 +60,7 @@
 #include <WebCore/HTMLMediaElement.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/NotificationResources.h>
+#include <WebCore/OrganizationStorageAccessPromptQuirk.h>
 #include <WebCore/OriginLock.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/ResourceRequest.h>
@@ -1343,7 +1344,16 @@ void WebsiteDataStore::setResourceLoadStatisticsTimeAdvanceForTesting(Seconds ti
     protectedNetworkProcess()->setResourceLoadStatisticsTimeAdvanceForTesting(m_sessionID, time, WTFMove(completionHandler));
 }
 
-void WebsiteDataStore::setStorageAccessPromptQuirkForTesting(String&& topFrameDomain, Vector<String>&& subFrameDomains, Vector<String>&& triggerPages, CompletionHandler<void()>&& completionHandler)
+static inline WebCore::StorageAccessPromptQuirkTriggerMatchType convertStringToTriggerMatchType(const String matchTypeStr)
+{
+    if (matchTypeStr == "OriginAndPath"_s)
+        return WebCore::StorageAccessPromptQuirkTriggerMatchType::OriginAndPath;
+    if (matchTypeStr != "FullURL"_s)
+        ASSERT_NOT_REACHED();
+    return WebCore::StorageAccessPromptQuirkTriggerMatchType::FullURL;
+}
+
+void WebsiteDataStore::setStorageAccessPromptQuirkForTesting(String&& topFrameDomain, Vector<String>&& subFrameDomains, Vector<std::pair<String, String>>&& triggerPages, CompletionHandler<void()>&& completionHandler)
 {
     auto registrableTopFrameDomain = WebCore::RegistrableDomain::fromRawString(WTFMove(topFrameDomain));
     auto registrableTopFrameDomainString = registrableTopFrameDomain.string();
@@ -1354,7 +1364,7 @@ void WebsiteDataStore::setStorageAccessPromptQuirkForTesting(String&& topFrameDo
                 subFrameDomains.map([](auto& domain) { return WebCore::RegistrableDomain::fromRawString(String { domain }); })
             },
         } }, {
-            triggerPages.map([](auto& page) { return URL { page }; })
+            triggerPages.map([](auto& pair) { return std::make_pair(URL { std::get<0>(pair) }, convertStringToTriggerMatchType(std::get<1>(pair))); })
         }
     } };
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -242,7 +242,7 @@ public:
     void mergeStatisticForTesting(const URL&, const URL& topFrameUrl1, const URL& topFrameUrl2, Seconds lastSeen, bool hadUserInteraction, Seconds mostRecentUserInteraction, bool isGrandfathered, bool isPrevalent, bool isVeryPrevalent, unsigned dataRecordsRemoved, CompletionHandler<void()>&&);
     void insertExpiredStatisticForTesting(const URL&, unsigned numberOfOperatingDaysPassed, bool hadUserInteraction, bool isScheduledForAllButCookieDataRemoval, bool isPrevalent, CompletionHandler<void()>&&);
     void setResourceLoadStatisticsTimeAdvanceForTesting(Seconds, CompletionHandler<void()>&&);
-    void setStorageAccessPromptQuirkForTesting(String&& topFrameDomain, Vector<String>&& subFrameDomains, Vector<String>&& triggerPages, CompletionHandler<void()>&&);
+    void setStorageAccessPromptQuirkForTesting(String&& topFrameDomain, Vector<String>&& subFrameDomains, Vector<std::pair<String, String>>&& triggerPages, CompletionHandler<void()>&&);
     void grantStorageAccessForTesting(String&& topFrameDomain, Vector<String>&& subFrameDomains, CompletionHandler<void()>&&);
     void setIsRunningResourceLoadStatisticsTest(bool, CompletionHandler<void()>&&);
     void setPruneEntriesDownTo(size_t, CompletionHandler<void()>&&);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -1498,7 +1498,7 @@ TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithQuirk)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    [dataStore _setStorageAccessPromptQuirkForTesting:@"site1.example" withSubFrameDomains:[NSArray arrayWithObject:@"site2.example"] withTriggerPages:@[] completionHandler:^{
+    [dataStore _setStorageAccessPromptQuirkForTesting:@"site1.example" withSubFrameDomains:[NSArray arrayWithObject:@"site2.example"] withTriggerPages:@{ } completionHandler:^{
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
@@ -1528,12 +1528,13 @@ TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithQuirk)
     TestWebKitAPI::Util::run(&navigationDelegateDone);
 }
 
-TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithTrigger)
+TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithTriggerFullURL)
 {
     using namespace TestWebKitAPI;
     HTTPServer httpServer({
         { "http://site1.example/page1"_s, { "<body>Done</body>"_s  } },
         { "http://site1.example/page2"_s, { "<body>Done</body>"_s  } },
+        { "http://site1.example/page2?key=value"_s, { "<body>Done</body>"_s  } },
         { "http://site1.example/page3"_s, { "<body>Done</body>"_s  } },
         { "http://site2.example/page1"_s, { "<body><script>alert(\"Loaded\");</script></body>"_s  } },
         { "http://site2.example/page2"_s, { "<body>iframe Body</body>"_s  } },
@@ -1556,8 +1557,7 @@ TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithTrigger)
     }];
     TestWebKitAPI::Util::run(&done);
     done = false;
-
-    [dataStore _setStorageAccessPromptQuirkForTesting:@"site1.example" withSubFrameDomains:[NSArray arrayWithObject:@"site2.example"] withTriggerPages:@[@"http://site1.example/page2"] completionHandler:^{
+    [dataStore _setStorageAccessPromptQuirkForTesting:@"site1.example" withSubFrameDomains:[NSArray arrayWithObject:@"site2.example"] withTriggerPages:@{ @"http://site1.example/page2?key=value" : @"FullURL" } completionHandler:^{
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
@@ -1578,7 +1578,7 @@ TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithTrigger)
     auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
     __block bool didReceiveStorageAccessPrompt = false;
     [navigationDelegate setDidPromptForStorageAccess:^(WKWebView *webview, NSString *topFrameDomain, NSString *subFrameDomain, BOOL hasQuirk) {
-        if ([webView.get().URL.absoluteString isEqualToString:@"http://site1.example/page1"] || [webView.get().URL.absoluteString isEqualToString:@"http://site1.example/page2"])
+        if ([webView.get().URL.absoluteString isEqualToString:@"http://site1.example/page1"] || [webView.get().URL.absoluteString isEqualToString:@"http://site1.example/page2?key=value"])
             EXPECT_EQ(hasQuirk, YES);
         else
             EXPECT_EQ(hasQuirk, NO);
@@ -1608,7 +1608,136 @@ TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithTrigger)
     EXPECT_FALSE(gotRequestStorageAccessPanelForQuirksForDomain);
     didReceiveStorageAccessPrompt = false;
 
+    // Test that a partial URL does not match.
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site1.example/page2"]]];
+    Util::run(&finishedNavigation);
+    finishedNavigation = false;
+
+    [webView evaluateJavaScript:@"let iframe = document.createElement(\"iframe\"); iframe.src = \"http://site2.example/page2\"; document.body.appendChild(iframe);" completionHandler:^(id value, NSError *error) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    EXPECT_FALSE(gotRequestStorageAccessPanelForQuirksForDomain);
+    done = false;
+    didReceiveStorageAccessPrompt = false;
+    gotRequestStorageAccessPanelForQuirksForDomain = false;
+
+    // Test that a full URL does match.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site1.example/page2?key=value"]]];
+    Util::run(&finishedNavigation);
+    finishedNavigation = false;
+
+    [webView evaluateJavaScript:@"let iframe = document.createElement(\"iframe\"); iframe.src = \"http://site2.example/page3\"; document.body.appendChild(iframe);" completionHandler:^(id value, NSError *error) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&didReceiveStorageAccessPrompt);
+    EXPECT_TRUE(gotRequestStorageAccessPanelForQuirksForDomain);
+    done = false;
+    didReceiveStorageAccessPrompt = false;
+    gotRequestStorageAccessPanelForQuirksForDomain = false;
+
+    [dataStore _logUserInteraction:[NSURL URLWithString:@"http://site3.example/"] completionHandler:^{
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site1.example/page3"]]];
+    Util::run(&finishedNavigation);
+    finishedNavigation = false;
+
+    [webView evaluateJavaScript:@"let iframe = document.createElement(\"iframe\"); iframe.src = \"http://site3.example/page1\"; document.body.appendChild(iframe);" completionHandler:^(id value, NSError *error) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&didReceiveStorageAccessPrompt);
+    EXPECT_FALSE(gotRequestStorageAccessPanelForQuirksForDomain);
+    done = false;
+    didReceiveStorageAccessPrompt = false;
+}
+
+TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithTriggerOriginAndPath)
+{
+    using namespace TestWebKitAPI;
+    HTTPServer httpServer({
+        { "http://site1.example/page1"_s, { "<body>Done</body>"_s  } },
+        { "http://site1.example/page2?key=value"_s, { "<body>Done</body>"_s  } },
+        { "http://site1.example/page3"_s, { "<body>Done</body>"_s  } },
+        { "http://site2.example/page1"_s, { "<body><script>alert(\"Loaded\");</script></body>"_s  } },
+        { "http://site2.example/page2"_s, { "<body>iframe Body</body>"_s  } },
+        { "http://site3.example/page1"_s, { "<body><script>if (window.internals) { internals.withUserGesture(() => { document.requestStorageAccess(); }); document.body.innerText = \"Requesting storage access\"; } else document.body.innerText = \"Internals not present\";</script></body>"_s  } },
+    });
+
+    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    [storeConfiguration setProxyConfiguration:@{
+        (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
+        (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
+    }];
+
+    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+
+    [dataStore _setResourceLoadStatisticsEnabled:YES];
+
+    __block bool done = false;
+    [dataStore _clearResourceLoadStatistics:^(void) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+    [dataStore _setStorageAccessPromptQuirkForTesting:@"site1.example" withSubFrameDomains:[NSArray arrayWithObject:@"site2.example"] withTriggerPages:@{ @"http://site1.example/page2" : @"OriginAndPath" } completionHandler:^{
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    auto configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    [configuration setWebsiteDataStore:dataStore.get()];
+
+    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    __block bool gotRequestStorageAccessPanelForQuirksForDomain { false };
+    uiDelegate.get().requestStorageAccessPanelForQuirksForDomain = ^(WKWebView *, NSString *, NSString *, NSDictionary<NSString *, NSArray<NSString *> *> *, void  (^completionHandler)(BOOL)) {
+        gotRequestStorageAccessPanelForQuirksForDomain = true;
+        completionHandler(NO);
+    };
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration]);
+
+    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    __block bool didReceiveStorageAccessPrompt = false;
+    [navigationDelegate setDidPromptForStorageAccess:^(WKWebView *webview, NSString *topFrameDomain, NSString *subFrameDomain, BOOL hasQuirk) {
+        if ([webView.get().URL.absoluteString isEqualToString:@"http://site1.example/page1"] || [webView.get().URL.absoluteString isEqualToString:@"http://site1.example/page2?key=value#fragment"])
+            EXPECT_EQ(hasQuirk, YES);
+        else
+            EXPECT_EQ(hasQuirk, NO);
+        didReceiveStorageAccessPrompt = true;
+    }];
+
+    __block bool finishedNavigation = false;
+    navigationDelegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *) {
+        finishedNavigation = true;
+    };
+
+    [webView setNavigationDelegate:navigationDelegate.get()];
+    [webView setUIDelegate:uiDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site1.example/page1"]]];
+
+    Util::run(&finishedNavigation);
+    finishedNavigation = false;
+
+    [webView evaluateJavaScript:@"let iframe = document.createElement(\"iframe\"); iframe.src = \"http://site2.example/page1\"; document.body.appendChild(iframe);" completionHandler:^(id value, NSError *error) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], @"Loaded");
+    EXPECT_FALSE(gotRequestStorageAccessPanelForQuirksForDomain);
+    didReceiveStorageAccessPrompt = false;
+
+    // Test that a URL with a query string and fragment still matches based on origin and path.
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site1.example/page2?key=value#fragment"]]];
     Util::run(&finishedNavigation);
     finishedNavigation = false;
 
@@ -1750,7 +1879,7 @@ TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithQuirk)
     done = false;
 
     __block bool done = false;
-    [dataStore _setStorageAccessPromptQuirkForTesting:@"site1.example" withSubFrameDomains:[NSArray arrayWithObjects:@"site2.example", @"site3.example", nil] withTriggerPages:@[] completionHandler:^{
+    [dataStore _setStorageAccessPromptQuirkForTesting:@"site1.example" withSubFrameDomains:[NSArray arrayWithObjects:@"site2.example", @"site3.example", nil] withTriggerPages:@{ } completionHandler:^{
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
@@ -1947,7 +2076,7 @@ TEST(ResourceLoadStatistics, StorageAccessSupportMultipleSubFrameDomains)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    [dataStore _setStorageAccessPromptQuirkForTesting:@"site1.example" withSubFrameDomains:[NSArray arrayWithObject:@"site2.example"] withTriggerPages:@[] completionHandler:^{
+    [dataStore _setStorageAccessPromptQuirkForTesting:@"site1.example" withSubFrameDomains:[NSArray arrayWithObject:@"site2.example"] withTriggerPages:@{ } completionHandler:^{
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
@@ -2101,7 +2230,7 @@ TEST(ResourceLoadStatistics, StorageAccessGrantMultipleSubFrameDomains)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    [dataStore _setStorageAccessPromptQuirkForTesting:@"site1.example" withSubFrameDomains:[NSArray arrayWithObjects:@"site2.example", @"site3.example", nil] withTriggerPages:@[] completionHandler:^{
+    [dataStore _setStorageAccessPromptQuirkForTesting:@"site1.example" withSubFrameDomains:[NSArray arrayWithObjects:@"site2.example", @"site3.example", nil] withTriggerPages:@{ } completionHandler:^{
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);


### PR DESCRIPTION
#### b04ffea416289deb3233cc05d44b6cffb948418b
<pre>
Make it possible to quirk Storage Access API calls by matching only the origin and path of the trigger page
<a href="https://bugs.webkit.org/show_bug.cgi?id=285375">https://bugs.webkit.org/show_bug.cgi?id=285375</a>
&lt;<a href="https://rdar.apple.com/142340716">rdar://142340716</a>&gt;

Reviewed by NOBODY (OOPS!).

This is work-in-progress since it breaks existing tests and the new tests are not passing.

This patch adds the capability to have quirks trigger on either a full URL or on
any URL that matches the triggering origin and path. This will allow us to with
one quirk rule trigger on both <a href="https://login.example.com/home">https://login.example.com/home</a> and
<a href="https://login.example.com/home?redirectTo=example.com/product/.">https://login.example.com/home?redirectTo=example.com/product/.</a> Such a rule would
then be represented by { &quot;<a href="https://login.example.com/home&quot">https://login.example.com/home&quot</a>;: &quot;OriginAndPath&quot; }.

* Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h:
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::storageAccessQuirkURLMatchesTriggerPage):
(WebCore::NetworkStorageSession::storageAccessQuirkForTopFrameDomain):
* Source/WebCore/platform/network/OrganizationStorageAccessPromptQuirk.h:
(WebCore::OrganizationStorageAccessPromptQuirk::OrganizationStorageAccessPromptQuirk):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::quirkPagesDictionaryToVector):
(WebKit::StorageAccessPromptQuirkController::updateList):
(WebKit::quirkPagesArrayToVector): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _setStorageAccessPromptQuirkForTesting:withSubFrameDomains:withTriggerPages:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::m_ipcTester):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::convertStringToTriggerMatchType):
(WebKit::WebsiteDataStore::setStorageAccessPromptQuirkForTesting):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
(TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithQuirk)):
(TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithTriggerFullURL)):
(TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithTriggerOriginAndPath)):
(TEST(ResourceLoadStatistics, StorageAccessOnRedirectSitesWithQuirk)):
(TEST(ResourceLoadStatistics, StorageAccessSupportMultipleSubFrameDomains)):
(TEST(ResourceLoadStatistics, StorageAccessGrantMultipleSubFrameDomains)):
(TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithTrigger)): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b04ffea416289deb3233cc05d44b6cffb948418b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88924 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34858 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11434 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65219 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23055 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2633 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76187 "Found 1 new API test failure: TestWebKitAPI.ResourceLoadStatistics.StorageAccessPromptSiteWithTriggerFullURL (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45511 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2558 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30408 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33907 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73567 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90300 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73665 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11339 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72881 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17159 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2439 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11067 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16539 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10915 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14390 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12687 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->