### PR TITLE
[JSC] Handle int32 for `deleteCount` in `Array#splice`

### DIFF
--- a/JSTests/stress/array-prototype-splice-deleteCount-not-int32.js
+++ b/JSTests/stress/array-prototype-splice-deleteCount-not-int32.js
@@ -1,0 +1,44 @@
+function sameArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected length is ${b.length} but got length ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`Expected ${b[i]} but got ${a[i]} (${i})`);
+    }
+}
+
+{
+    const array = [1, 2, 3, 4, 5];
+    array.splice(1, true);
+    sameArray(array, [1, 3, 4, 5]);
+}
+
+{
+    const array = [1, 2, 3, 4, 5];
+    array.splice(1, false);
+    sameArray(array, [1, 2, 3, 4, 5]);
+}
+
+{
+    const array = [1, 2, 3, 4, 5];
+    array.splice(1, null);
+    sameArray(array, [1, 2, 3, 4, 5]);
+}
+
+{
+    const array = [1, 2, 3, 4, 5];
+    array.splice(1, undefined);
+    sameArray(array, [1, 2, 3, 4, 5]);
+}
+
+{
+    const array = [1, 2, 3, 4, 5];
+    array.splice(1, NaN);
+    sameArray(array, [1, 2, 3, 4, 5]);
+}
+
+{
+    const array = [1, 2, 3, 4, 5];
+    array.splice(1, 1.24);
+    sameArray(array, [1, 3, 4, 5]);
+}


### PR DESCRIPTION
#### 2dca48e9c67c719d2c061c4d4584d830b5a394a6
<pre>
[JSC] Handle int32 for `deleteCount` in `Array#splice`
<a href="https://bugs.webkit.org/show_bug.cgi?id=285581">https://bugs.webkit.org/show_bug.cgi?id=285581</a>

Reviewed by Yusuke Suzuki.

This patch changes to handle int32 for `deleteCount` in
`Array#splice`.

* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* JSTests/stress/array-prototype-splice-deleteCount-not-int32.js: Added.

Canonical link: <a href="https://commits.webkit.org/288782@main">https://commits.webkit.org/288782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/598fd6ed70563b1667d172d1b415a9c3a1f2c204

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38314 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89088 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35021 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3722 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11599 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65343 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23185 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45636 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2704 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30558 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34070 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76977 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73667 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90466 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83030 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73794 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11502 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73011 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18134 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17302 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2624 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11230 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16702 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105449 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11078 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25475 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14554 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->