### PR TITLE
[JSC] Do page-zero-purging for wasm memory when growing happens

### DIFF
--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
@@ -79,7 +79,7 @@ BufferMemoryResult BufferMemoryManager::tryAllocateFastMemory()
         if (m_fastMemories.size() >= m_maxFastMemoryCount)
             return BufferMemoryResult(nullptr, BufferMemoryResult::SyncTryToReclaimMemory);
 
-        void* result = Gigacage::tryAllocateZeroedVirtualPages(Gigacage::Primitive, BufferMemoryHandle::fastMappedBytes());
+        void* result = Gigacage::tryAllocateVirtualPages(Gigacage::Primitive, BufferMemoryHandle::fastMappedBytes());
         if (!result)
             return BufferMemoryResult(nullptr, BufferMemoryResult::SyncTryToReclaimMemory);
 
@@ -110,7 +110,7 @@ BufferMemoryResult BufferMemoryManager::tryAllocateGrowableBoundsCheckingMemory(
 {
     BufferMemoryResult result = [&] {
         Locker locker { m_lock };
-        void* result = Gigacage::tryAllocateZeroedVirtualPages(Gigacage::Primitive, mappedCapacity);
+        void* result = Gigacage::tryAllocateVirtualPages(Gigacage::Primitive, mappedCapacity);
         if (!result)
             return BufferMemoryResult(nullptr, BufferMemoryResult::SyncTryToReclaimMemory);
 

--- a/Source/WTF/wtf/Gigacage.h
+++ b/Source/WTF/wtf/Gigacage.h
@@ -77,6 +77,7 @@ WTF_EXPORT_PRIVATE void* tryZeroedMalloc(Kind, size_t);
 WTF_EXPORT_PRIVATE void* tryRealloc(Kind, void*, size_t);
 inline void free(Kind, void* p) { fastFree(p); }
 
+WTF_EXPORT_PRIVATE void* tryAllocateVirtualPages(Kind, size_t size);
 WTF_EXPORT_PRIVATE void* tryAllocateZeroedVirtualPages(Kind, size_t size);
 WTF_EXPORT_PRIVATE void freeVirtualPages(Kind, void* basePtr, size_t size);
 
@@ -93,6 +94,7 @@ WTF_EXPORT_PRIVATE void* tryZeroedMalloc(Kind, size_t);
 WTF_EXPORT_PRIVATE void* tryRealloc(Kind, void*, size_t);
 WTF_EXPORT_PRIVATE void free(Kind, void*);
 
+WTF_EXPORT_PRIVATE void* tryAllocateVirtualPages(Kind, size_t size);
 WTF_EXPORT_PRIVATE void* tryAllocateZeroedVirtualPages(Kind, size_t size);
 WTF_EXPORT_PRIVATE void freeVirtualPages(Kind, void* basePtr, size_t size);
 

--- a/Source/bmalloc/bmalloc/VMAllocate.h
+++ b/Source/bmalloc/bmalloc/VMAllocate.h
@@ -157,6 +157,8 @@ inline void vmRevokePermissions(void* p, size_t vmSize)
 
 inline void vmZeroAndPurge(void* p, size_t vmSize, VMTag usage = VMTag::Malloc)
 {
+    if (!vmSize)
+        return;
     vmValidate(p, vmSize);
     int flags = MAP_PRIVATE | MAP_ANON | MAP_FIXED | BMALLOC_NORESERVE;
     int tag = static_cast<int>(usage);

--- a/Source/bmalloc/bmalloc/bmalloc.cpp
+++ b/Source/bmalloc/bmalloc/bmalloc.cpp
@@ -60,7 +60,7 @@ void freeOutOfLine(void* object, HeapKind kind)
     free(object, kind);
 }
 
-void* tryLargeZeroedMemalignVirtual(size_t requiredAlignment, size_t requestedSize, CompactAllocationMode mode, HeapKind kind)
+void* tryLargeMemalignVirtual(size_t requiredAlignment, size_t requestedSize, CompactAllocationMode mode, HeapKind kind)
 {
     RELEASE_BASSERT(isPowerOfTwo(requiredAlignment));
 
@@ -92,9 +92,22 @@ void* tryLargeZeroedMemalignVirtual(size_t requiredAlignment, size_t requestedSi
         }
 #endif
     }
+    return result;
+}
 
-    if (result)
+void vmZeroAndPurge(void* p, size_t vmSize, VMTag usage)
+{
+    bmalloc::vmZeroAndPurge(p, vmSize, usage);
+}
+
+void* tryLargeZeroedMemalignVirtual(size_t requiredAlignment, size_t requestedSize, CompactAllocationMode mode, HeapKind kind)
+{
+    auto* result = tryLargeMemalignVirtual(requiredAlignment, requestedSize, mode, kind);
+    if (result) {
+        size_t pageSize = vmPageSize();
+        size_t size = roundUpToMultipleOf(pageSize, requestedSize);
         vmZeroAndPurge(result, size);
+    }
     return result;
 }
 

--- a/Source/bmalloc/bmalloc/bmalloc.h
+++ b/Source/bmalloc/bmalloc/bmalloc.h
@@ -178,7 +178,9 @@ BINLINE void* realloc(void* object, size_t newSize, CompactAllocationMode mode, 
 // This API will give you zeroed pages that are ready to be used. These pages
 // will page fault on first access. It returns to you memory that initially only
 // uses up virtual address space, not `size` bytes of physical memory.
+BEXPORT void* tryLargeMemalignVirtual(size_t alignment, size_t size, CompactAllocationMode mode, HeapKind kind = HeapKind::Primary);
 BEXPORT void* tryLargeZeroedMemalignVirtual(size_t alignment, size_t size, CompactAllocationMode mode, HeapKind kind = HeapKind::Primary);
+BEXPORT void vmZeroAndPurge(void* p, size_t vmSize, VMTag usage = VMTag::Malloc);
 
 BINLINE void free(void* object, HeapKind kind = HeapKind::Primary)
 {


### PR DESCRIPTION
#### 40a9f644efc16f66744090b05685caf2d2b8c0f1
<pre>
[JSC] Do page-zero-purging for wasm memory when growing happens
<a href="https://bugs.webkit.org/show_bug.cgi?id=285584">https://bugs.webkit.org/show_bug.cgi?id=285584</a>
<a href="https://rdar.apple.com/142534018">rdar://142534018</a>

Reviewed by NOBODY (OOPS!).

Analyzing Wasm startup time deeply and we identified that our
fast-memory initialization is super slow. The reason is it is purging
entire memory region regardless of whether we use all of them.
But V8 etc. does not do that: they purge pages when it gets grown.
That&apos;s pretty much the right decision since wasm explicitly grows the
memory so we should do purging when it becomes accessible. This patch
changes it so that we purge when the new page region gets accessible
(permission gets added).

* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::tryAllocateResizableMemory):
(JSC::ArrayBuffer::resize):
(JSC::SharedArrayBufferContents::grow):
* Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp:
(JSC::BufferMemoryManager::tryAllocateFastMemory):
(JSC::BufferMemoryManager::tryAllocateGrowableBoundsCheckingMemory):
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::tryCreate):
(JSC::Wasm::Memory::grow):
* Source/WTF/wtf/Gigacage.cpp:
(Gigacage::tryAllocateVirtualPages):
* Source/WTF/wtf/Gigacage.h:
* Source/bmalloc/bmalloc/bmalloc.cpp:
(bmalloc::api::tryLargeMemalignVirtual):
(bmalloc::api::vmZeroAndPurge):
(bmalloc::api::tryLargeZeroedMemalignVirtual):
* Source/bmalloc/bmalloc/bmalloc.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40a9f644efc16f66744090b05685caf2d2b8c0f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83885 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88959 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34893 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65248 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23081 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2663 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76218 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45540 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2592 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30439 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33942 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76848 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90335 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/82902 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8060 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73692 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72911 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17193 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15879 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2482 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11102 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16574 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105320 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10950 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25452 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12722 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->