### PR TITLE
[GTK] Monitor window surfaces obscured by other windows (to suspend tabs, stop the frame clock and tell web apps to throttle themselves)

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/ToplevelWindow.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/ToplevelWindow.cpp
@@ -96,25 +96,32 @@ bool ToplevelWindow::isActive() const
 bool ToplevelWindow::isFullscreen() const
 {
 #if USE(GTK4)
-    if (auto* surface = gtk_native_get_surface(GTK_NATIVE(m_window)))
-        return gdk_toplevel_get_state(GDK_TOPLEVEL(surface)) & GDK_TOPLEVEL_STATE_FULLSCREEN;
+    return m_state & GDK_TOPLEVEL_STATE_FULLSCREEN;
 #else
     if (auto* window = gtk_widget_get_window(GTK_WIDGET(m_window)))
         return gdk_window_get_state(window) & GDK_WINDOW_STATE_FULLSCREEN;
-#endif
     return false;
+#endif
 }
 
 bool ToplevelWindow::isMinimized() const
 {
 #if USE(GTK4)
-    if (auto* surface = gtk_native_get_surface(GTK_NATIVE(m_window)))
-        return gdk_toplevel_get_state(GDK_TOPLEVEL(surface)) & GDK_TOPLEVEL_STATE_MINIMIZED;
+    return m_state & GDK_TOPLEVEL_STATE_MINIMIZED;
 #else
     if (auto* window = gtk_widget_get_window(GTK_WIDGET(m_window)))
         return gdk_window_get_state(window) & GDK_WINDOW_STATE_ICONIFIED;
-#endif
     return false;
+#endif
+}
+
+bool ToplevelWindow::isSuspended() const
+{
+#if GTK_CHECK_VERSION(4, 12, 0)
+    return m_state & GDK_TOPLEVEL_STATE_SUSPENDED;
+#else
+    return false;
+#endif
 }
 
 GdkMonitor* ToplevelWindow::monitor() const
@@ -227,6 +234,7 @@ void ToplevelWindow::disconnectSurfaceSignals()
 {
     auto* surface = gtk_native_get_surface(GTK_NATIVE(m_window));
     g_signal_handlers_disconnect_by_data(surface, this);
+    m_state = static_cast<GdkToplevelState>(0);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/gtk/ToplevelWindow.h
+++ b/Source/WebKit/UIProcess/API/gtk/ToplevelWindow.h
@@ -49,6 +49,8 @@ public:
     bool isActive() const;
     bool isFullscreen() const;
     bool isMinimized() const;
+    bool isSuspended() const;
+
     GdkMonitor* monitor() const;
     bool isInMonitor() const;
 


### PR DESCRIPTION
#### 8d7385fad3ffb31d0c438e6b6a50dffb4390840c
<pre>
[GTK] Monitor window surfaces obscured by other windows (to suspend tabs, stop the frame clock and tell web apps to throttle themselves)
<a href="https://bugs.webkit.org/show_bug.cgi?id=285167">https://bugs.webkit.org/show_bug.cgi?id=285167</a>

Reviewed by Adrian Perez de Castro.

Handle GDK_TOPLEVEL_STATE_SUSPENDED when available in GTK4 to update the
view visibility.

* Source/WebKit/UIProcess/API/gtk/ToplevelWindow.cpp:
(WebKit::ToplevelWindow::isFullscreen const):
(WebKit::ToplevelWindow::isMinimized const):
(WebKit::ToplevelWindow::isSuspended const):
(WebKit::ToplevelWindow::disconnectSurfaceSignals):
* Source/WebKit/UIProcess/API/gtk/ToplevelWindow.h:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseUpdateVisibility):
(webkitWebViewBaseToplevelWindowStateChanged):
(webkitWebViewBaseToplevelWindowMonitorChanged):
(webkitWebViewBaseMap):
(webkitWebViewBaseUnmap):

Canonical link: <a href="https://commits.webkit.org/288685@main">https://commits.webkit.org/288685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c26bd3535221f1b829ad6455c48a45c42a5a279

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89244 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35177 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65462 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23299 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76484 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45755 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2849 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34225 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90625 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11435 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73918 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11661 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73122 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17432 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2782 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13016 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11387 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16863 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11236 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14712 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13009 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->