### PR TITLE
[GStreamer] Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebAudio

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -131,8 +131,8 @@ AudioDestinationGStreamer::AudioDestinationGStreamer(AudioIOCallback& callback, 
     }
 
     // Probe platform early on for a working audio output device in autoaudiosink.
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-    if (g_str_has_prefix(GST_OBJECT_NAME(audioSink.get()), "autoaudiosink")) {
+    auto nameView = StringView::fromLatin1(GST_OBJECT_NAME(audioSink.get()));
+    if (nameView.startsWith("autoaudiosink"_s)) {
         g_signal_connect(audioSink.get(), "child-added", G_CALLBACK(+[](GstChildProxy*, GObject* object, gchar*, gpointer) {
             if (GST_IS_AUDIO_BASE_SINK(object))
                 g_object_set(GST_AUDIO_BASE_SINK(object), "buffer-time", static_cast<gint64>(100000), nullptr);
@@ -149,7 +149,6 @@ AudioDestinationGStreamer::AudioDestinationGStreamer(AudioIOCallback& callback, 
             return;
         }
     }
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     GstElement* audioConvert = makeGStreamerElement("audioconvert", nullptr);
     GstElement* audioResample = makeGStreamerElement("audioresample", nullptr);

--- a/Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp
@@ -91,10 +91,8 @@ void FFTFrame::doFFT(std::span<const float> data)
 {
     gst_fft_f32_fft(m_fft.get(), data.data(), m_complexData.get());
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-    float* imagData = m_imagData.data();
-    float* realData = m_realData.data();
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    auto imagData = m_imagData.span();
+    auto realData = m_realData.span();
     for (unsigned i = 0; i < unpackedFFTDataSize(m_FFTSize); ++i) {
         imagData[i] = m_complexData[i].i;
         realData[i] = m_complexData[i].r;
@@ -104,11 +102,8 @@ void FFTFrame::doFFT(std::span<const float> data)
 void FFTFrame::doInverseFFT(std::span<float> data)
 {
     //  Merge the real and imaginary vectors to complex vector.
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-    float* realData = m_realData.data();
-    float* imagData = m_imagData.data();
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-
+    auto imagData = m_imagData.span();
+    auto realData = m_realData.span();
     for (size_t i = 0; i < unpackedFFTDataSize(m_FFTSize); ++i) {
         m_complexData[i].i = imagData[i];
         m_complexData[i].r = realData[i];


### PR DESCRIPTION
#### e87e3fee6f55600182d94744a2f8633464c1dca1
<pre>
[GStreamer] Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebAudio
<a href="https://bugs.webkit.org/show_bug.cgi?id=285611">https://bugs.webkit.org/show_bug.cgi?id=285611</a>

Reviewed by Alicia Boya Garcia.

* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::AudioDestinationGStreamer::AudioDestinationGStreamer):
* Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp:
(WebCore::FFTFrame::doFFT):
(WebCore::FFTFrame::doInverseFFT):

Canonical link: <a href="https://commits.webkit.org/288657@main">https://commits.webkit.org/288657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2c7991aa85a7787424ba96ddea88827170acf62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88976 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34910 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85987 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65258 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23092 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45550 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30458 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33959 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73597 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90352 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11167 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8076 "Found 1 new test failure: imported/blink/fast/dom/shadow/make-marquee-bold-by-exec-command-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73704 "Found 1 new test failure: compositing/patterns/direct-pattern-compositing-size.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11391 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72065 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72922 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17207 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2501 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11119 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16591 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10967 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14443 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12739 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->