### PR TITLE
Implement WTFCrashWithInfo on Linux and Armv7

### DIFF
--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -368,7 +368,7 @@ void WTFPrintBacktrace(std::span<void* const> stack)
     WTFPrintBacktraceWithPrefixAndPrintStream(out, stack, "");
 }
 
-#if !defined(NDEBUG) || !(OS(DARWIN) || PLATFORM(PLAYSTATION))
+#if !defined(NDEBUG) || !(OS(DARWIN) || PLATFORM(PLAYSTATION) || OS(LINUX))
 void WTFCrash()
 {
 #if ASAN_ENABLED
@@ -653,87 +653,87 @@ void WTFInitializeLogChannelStatesFromString(WTFLogChannel* channels[], size_t c
 
 } // extern "C"
 
-#if !ASAN_ENABLED && (OS(DARWIN) || PLATFORM(PLAYSTATION)) && (CPU(X86_64) || CPU(ARM64))
+#if !ASAN_ENABLED && (OS(DARWIN) || PLATFORM(PLAYSTATION) || OS(LINUX)) && (CPU(X86_64) || CPU(ARM64) || CPU(ARM_THUMB2))
 
-void WTFCrashWithInfoImpl(int, const char*, const char*, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5, uint64_t misc6)
+void WTFCrashWithInfoImpl(int, const char*, const char*, uintptr_t reason, uintptr_t misc1, uintptr_t misc2, uintptr_t misc3, uintptr_t misc4, uintptr_t misc5, uintptr_t misc6)
 {
-    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
-    register uint64_t misc2GPR __asm__(CRASH_GPR2) = misc2;
-    register uint64_t misc3GPR __asm__(CRASH_GPR3) = misc3;
-    register uint64_t misc4GPR __asm__(CRASH_GPR4) = misc4;
-    register uint64_t misc5GPR __asm__(CRASH_GPR5) = misc5;
-    register uint64_t misc6GPR __asm__(CRASH_GPR6) = misc6;
+    register uintptr_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uintptr_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uintptr_t misc2GPR __asm__(CRASH_GPR2) = misc2;
+    register uintptr_t misc3GPR __asm__(CRASH_GPR3) = misc3;
+    register uintptr_t misc4GPR __asm__(CRASH_GPR4) = misc4;
+    register uintptr_t misc5GPR __asm__(CRASH_GPR5) = misc5;
+    register uintptr_t misc6GPR __asm__(CRASH_GPR6) = misc6;
     __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR), "r"(misc2GPR), "r"(misc3GPR), "r"(misc4GPR), "r"(misc5GPR), "r"(misc6GPR));
     __builtin_unreachable();
 }
 
-void WTFCrashWithInfoImpl(int, const char*, const char*, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5)
+void WTFCrashWithInfoImpl(int, const char*, const char*, uintptr_t reason, uintptr_t misc1, uintptr_t misc2, uintptr_t misc3, uintptr_t misc4, uintptr_t misc5)
 {
-    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
-    register uint64_t misc2GPR __asm__(CRASH_GPR2) = misc2;
-    register uint64_t misc3GPR __asm__(CRASH_GPR3) = misc3;
-    register uint64_t misc4GPR __asm__(CRASH_GPR4) = misc4;
-    register uint64_t misc5GPR __asm__(CRASH_GPR5) = misc5;
+    register uintptr_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uintptr_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uintptr_t misc2GPR __asm__(CRASH_GPR2) = misc2;
+    register uintptr_t misc3GPR __asm__(CRASH_GPR3) = misc3;
+    register uintptr_t misc4GPR __asm__(CRASH_GPR4) = misc4;
+    register uintptr_t misc5GPR __asm__(CRASH_GPR5) = misc5;
     __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR), "r"(misc2GPR), "r"(misc3GPR), "r"(misc4GPR), "r"(misc5GPR));
     __builtin_unreachable();
 }
 
-void WTFCrashWithInfoImpl(int, const char*, const char*, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4)
+void WTFCrashWithInfoImpl(int, const char*, const char*, uintptr_t reason, uintptr_t misc1, uintptr_t misc2, uintptr_t misc3, uintptr_t misc4)
 {
-    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
-    register uint64_t misc2GPR __asm__(CRASH_GPR2) = misc2;
-    register uint64_t misc3GPR __asm__(CRASH_GPR3) = misc3;
-    register uint64_t misc4GPR __asm__(CRASH_GPR4) = misc4;
+    register uintptr_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uintptr_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uintptr_t misc2GPR __asm__(CRASH_GPR2) = misc2;
+    register uintptr_t misc3GPR __asm__(CRASH_GPR3) = misc3;
+    register uintptr_t misc4GPR __asm__(CRASH_GPR4) = misc4;
     __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR), "r"(misc2GPR), "r"(misc3GPR), "r"(misc4GPR));
     __builtin_unreachable();
 }
 
-void WTFCrashWithInfoImpl(int, const char*, const char*, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3)
+void WTFCrashWithInfoImpl(int, const char*, const char*, uintptr_t reason, uintptr_t misc1, uintptr_t misc2, uintptr_t misc3)
 {
-    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
-    register uint64_t misc2GPR __asm__(CRASH_GPR2) = misc2;
-    register uint64_t misc3GPR __asm__(CRASH_GPR3) = misc3;
+    register uintptr_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uintptr_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uintptr_t misc2GPR __asm__(CRASH_GPR2) = misc2;
+    register uintptr_t misc3GPR __asm__(CRASH_GPR3) = misc3;
     __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR), "r"(misc2GPR), "r"(misc3GPR));
     __builtin_unreachable();
 }
 
-void WTFCrashWithInfoImpl(int, const char*, const char*, uint64_t reason, uint64_t misc1, uint64_t misc2)
+void WTFCrashWithInfoImpl(int, const char*, const char*, uintptr_t reason, uintptr_t misc1, uintptr_t misc2)
 {
-    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
-    register uint64_t misc2GPR __asm__(CRASH_GPR2) = misc2;
+    register uintptr_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uintptr_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uintptr_t misc2GPR __asm__(CRASH_GPR2) = misc2;
     __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR), "r"(misc2GPR));
     __builtin_unreachable();
 }
 
-void WTFCrashWithInfoImpl(int, const char*, const char*, uint64_t reason, uint64_t misc1)
+void WTFCrashWithInfoImpl(int, const char*, const char*, uintptr_t reason, uintptr_t misc1)
 {
-    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
-    register uint64_t misc1GPR __asm__(CRASH_GPR1) = misc1;
+    register uintptr_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uintptr_t misc1GPR __asm__(CRASH_GPR1) = misc1;
     __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(reasonGPR), "r"(misc1GPR));
     __builtin_unreachable();
 }
 
-void WTFCrashWithInfoImpl(int, const char*, const char*, uint64_t reason)
+void WTFCrashWithInfoImpl(int, const char*, const char*, uintptr_t reason)
 {
-    register uint64_t reasonGPR __asm__(CRASH_GPR0) = reason;
+    register uintptr_t reasonGPR __asm__(CRASH_GPR0) = reason;
     __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(reasonGPR));
     __builtin_unreachable();
 }
 
 #else
 
-void WTFCrashWithInfoImpl(int, const char*, const char*, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { CRASH(); }
-void WTFCrashWithInfoImpl(int, const char*, const char*, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { CRASH(); }
-void WTFCrashWithInfoImpl(int, const char*, const char*, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { CRASH(); }
-void WTFCrashWithInfoImpl(int, const char*, const char*, uint64_t, uint64_t, uint64_t, uint64_t) { CRASH(); }
-void WTFCrashWithInfoImpl(int, const char*, const char*, uint64_t, uint64_t, uint64_t) { CRASH(); }
-void WTFCrashWithInfoImpl(int, const char*, const char*, uint64_t, uint64_t) { CRASH(); }
-void WTFCrashWithInfoImpl(int, const char*, const char*, uint64_t) { CRASH(); }
+void WTFCrashWithInfoImpl(int, const char*, const char*, uintptr_t, uintptr_t, uintptr_t, uintptr_t, uintptr_t, uintptr_t, uintptr_t) { CRASH(); }
+void WTFCrashWithInfoImpl(int, const char*, const char*, uintptr_t, uintptr_t, uintptr_t, uintptr_t, uintptr_t, uintptr_t) { CRASH(); }
+void WTFCrashWithInfoImpl(int, const char*, const char*, uintptr_t, uintptr_t, uintptr_t, uintptr_t, uintptr_t) { CRASH(); }
+void WTFCrashWithInfoImpl(int, const char*, const char*, uintptr_t, uintptr_t, uintptr_t, uintptr_t) { CRASH(); }
+void WTFCrashWithInfoImpl(int, const char*, const char*, uintptr_t, uintptr_t, uintptr_t) { CRASH(); }
+void WTFCrashWithInfoImpl(int, const char*, const char*, uintptr_t, uintptr_t) { CRASH(); }
+void WTFCrashWithInfoImpl(int, const char*, const char*, uintptr_t) { CRASH(); }
 
 #endif // (OS(DARWIN) || PLATFORM(PLAYSTATION)) && (CPU(X64_64) || CPU(ARM64))
 

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -251,7 +251,7 @@ WTF_EXPORT_PRIVATE bool WTFIsDebuggerAttached(void);
 
 // This ordering was chosen to be consistent with JSC's JIT asserts. We probably shouldn't change this ordering
 // since it would make tooling crash reports much harder. If, for whatever reason, we decide to change the ordering
-// here we should update the abortWithuint64_t functions.
+// here we should update the abortWithReason functions.
 #define CRASH_ARG_GPR0 "rdi"
 #define CRASH_ARG_GPR1 "rsi"
 #define CRASH_ARG_GPR2 "rdx"
@@ -297,15 +297,29 @@ WTF_EXPORT_PRIVATE bool WTFIsDebuggerAttached(void);
 #define CRASH_GPR5 "x22"
 #define CRASH_GPR6 "x23"
 
-#endif // CPU(ARM64)
+#elif CPU(ARM_THUMB2)
+
+#define WTF_FATAL_CRASH_INST "bkpt #0" // Remember to build with -mthumb
+
+// See comment above on the ordering.
+#define CRASH_ARG_GPR0 "r0"
+#define CRASH_ARG_GPR1 "r1"
+#define CRASH_ARG_GPR2 "r2"
+#define CRASH_ARG_GPR3 "r3"
+
+#define CRASH_GPR0 "r4"
+#define CRASH_GPR1 "r5"
+#define CRASH_GPR2 "r6"
+#define CRASH_GPR3 "r8"
+#define CRASH_GPR4 "r9"
+#define CRASH_GPR5 "r10"
+#define CRASH_GPR6 "r11"
+
+#endif // CPU(ARM_THUMB2)
 
 #if ASAN_ENABLED
 #define WTFBreakpointTrap()  __builtin_trap()
-#elif CPU(X86_64) || CPU(X86)
-#define WTFBreakpointTrap()  __asm__ volatile (WTF_FATAL_CRASH_INST)
-#elif CPU(ARM_THUMB2)
-#define WTFBreakpointTrap()  __asm__ volatile ("bkpt #0")
-#elif CPU(ARM64)
+#elif CPU(X86_64) || CPU(X86) || CPU(ARM64) || CPU(ARM_THUMB2)
 #define WTFBreakpointTrap()  __asm__ volatile (WTF_FATAL_CRASH_INST)
 #else
 #define WTFBreakpointTrap() WTFCrash() // Not implemented.
@@ -315,7 +329,7 @@ WTF_EXPORT_PRIVATE bool WTFIsDebuggerAttached(void);
 
 #ifndef CRASH
 
-#if defined(NDEBUG) && (OS(DARWIN) || PLATFORM(PLAYSTATION))
+#if defined(NDEBUG) && (OS(DARWIN) || PLATFORM(PLAYSTATION) || OS(LINUX))
 // Crash with a SIGTRAP i.e EXC_BREAKPOINT.
 // We are not using __builtin_trap because it is only guaranteed to abort, but not necessarily
 // trigger a SIGTRAP. Instead, we use inline asm to ensure that we trigger the SIGTRAP.
@@ -902,13 +916,13 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END \
 
 // The combination of line, file, and function should be a unique number per call to this crash. This tricks the compiler into not coalescing calls to WTFCrashWithInfo.
 // The easiest way to fill these values per translation unit is to pass __LINE__, __FILE__, and WTF_PRETTY_FUNCTION.
-WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void NODELETE WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5, uint64_t misc6);
-WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void NODELETE WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5);
-WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4);
-WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3);
-WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1, uint64_t misc2);
-WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1);
-WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason);
+WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void NODELETE WTFCrashWithInfoImpl(int line, const char* file, const char* function, uintptr_t reason, uintptr_t misc1, uintptr_t misc2, uintptr_t misc3, uintptr_t misc4, uintptr_t misc5, uintptr_t misc6);
+WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void NODELETE WTFCrashWithInfoImpl(int line, const char* file, const char* function, uintptr_t reason, uintptr_t misc1, uintptr_t misc2, uintptr_t misc3, uintptr_t misc4, uintptr_t misc5);
+WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uintptr_t reason, uintptr_t misc1, uintptr_t misc2, uintptr_t misc3, uintptr_t misc4);
+WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uintptr_t reason, uintptr_t misc1, uintptr_t misc2, uintptr_t misc3);
+WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uintptr_t reason, uintptr_t misc1, uintptr_t misc2);
+WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uintptr_t reason, uintptr_t misc1);
+WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uintptr_t reason);
 #if !ASAN_ENABLED && (OS(DARWIN) || PLATFORM(PLAYSTATION)) && (CPU(X86_64) || CPU(ARM64))
 NO_RETURN_DUE_TO_CRASH ALWAYS_INLINE void WTFCrashWithInfo(int line, const char* file, const char* function);
 #else
@@ -916,10 +930,10 @@ NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfo(int line, const cha
 #endif
 
 template<typename T>
-ALWAYS_INLINE uint64_t wtfCrashArg(T* arg) { return reinterpret_cast<uintptr_t>(arg); }
+ALWAYS_INLINE uintptr_t wtfCrashArg(T* arg) { return reinterpret_cast<uintptr_t>(arg); }
 
 template<typename T>
-ALWAYS_INLINE uint64_t wtfCrashArg(T arg) { return static_cast<uint64_t>(arg); }
+ALWAYS_INLINE uintptr_t wtfCrashArg(T arg) { return static_cast<uintptr_t>(arg); }
 
 template<typename T>
 NO_RETURN_DUE_TO_CRASH ALWAYS_INLINE void WTFCrashWithInfo(int line, const char* file, const char* function, T reason)
@@ -963,16 +977,16 @@ NO_RETURN_DUE_TO_CRASH ALWAYS_INLINE void WTFCrashWithInfo(int line, const char*
     WTFCrashWithInfoImpl(line, file, function, wtfCrashArg(reason), wtfCrashArg(misc1), wtfCrashArg(misc2), wtfCrashArg(misc3), wtfCrashArg(misc4), wtfCrashArg(misc5), wtfCrashArg(misc6));
 }
 
-#if !ASAN_ENABLED && (OS(DARWIN) || PLATFORM(PLAYSTATION)) && (CPU(X86_64) || CPU(ARM64))
+#if !ASAN_ENABLED && (OS(DARWIN) || PLATFORM(PLAYSTATION) || OS(LINUX)) && (CPU(X86_64) || CPU(ARM64) || CPU(ARM_THUMB2))
 
 NO_RETURN_DUE_TO_CRASH ALWAYS_INLINE void WTFCrashWithInfo(int line, const char* file, const char* function)
 {
-    uint64_t x0Value = static_cast<uint64_t>(static_cast<int64_t>(line));
-    uint64_t x1Value = reinterpret_cast<uintptr_t>(file);
-    uint64_t x2Value = reinterpret_cast<uintptr_t>(function);
-    register uint64_t x0GPR __asm__(CRASH_ARG_GPR0) = x0Value;
-    register uint64_t x1GPR __asm__(CRASH_ARG_GPR1) = x1Value;
-    register uint64_t x2GPR __asm__(CRASH_ARG_GPR2) = x2Value;
+    uintptr_t x0Value = static_cast<uintptr_t>(static_cast<int64_t>(line));
+    uintptr_t x1Value = reinterpret_cast<uintptr_t>(file);
+    uintptr_t x2Value = reinterpret_cast<uintptr_t>(function);
+    register uintptr_t x0GPR __asm__(CRASH_ARG_GPR0) = x0Value;
+    register uintptr_t x1GPR __asm__(CRASH_ARG_GPR1) = x1Value;
+    register uintptr_t x2GPR __asm__(CRASH_ARG_GPR2) = x2Value;
     __asm__ volatile (WTF_FATAL_CRASH_INST : : "r"(x0GPR), "r"(x1GPR), "r"(x2GPR));
     __builtin_unreachable();
 }


### PR DESCRIPTION
#### 36b66ea17adeb1d4149044a6f20ed4ce3bf0948c
<pre>
Implement WTFCrashWithInfo on Linux and Armv7
<a href="https://bugs.webkit.org/show_bug.cgi?id=285621">https://bugs.webkit.org/show_bug.cgi?id=285621</a>

Reviewed by Yusuke Suzuki.

This allows us to discover additional info when a release build crashes.

* Source/WTF/wtf/Assertions.cpp:
* Source/WTF/wtf/Assertions.h:

Canonical link: <a href="https://commits.webkit.org/308885@main">https://commits.webkit.org/308885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a67b262cab07656a02cb8e12dd6b49fd44ef664

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157262 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102008 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114541 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81558 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133381 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95311 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15849 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13693 "Passed tests") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4698 "Hash 9a67b262 for PR 38736 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140545 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125463 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159597 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9365 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2741 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122595 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122820 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33433 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21100 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133090 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77230 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18144 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9856 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180006 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20701 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84505 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46074 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20435 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20587 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20491 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->