### PR TITLE
Revert use of separate megapage heap in libpas

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c
@@ -45,16 +45,21 @@ static pas_allocation_result allocate_from_megapages(
     pas_physical_memory_transaction* transaction,
     void* arg)
 {
+    const pas_heap_config* heap_config;
+
     PAS_UNUSED_PARAM(name);
     PAS_ASSERT(heap);
     PAS_ASSERT(transaction);
     PAS_ASSERT(!arg);
     PAS_ASSERT(!alignment.alignment_begin);
 
+    heap_config = pas_heap_config_kind_get_config(heap->config_kind);
+
+    PAS_PROFILE(MEGAPAGES_ALLOCATION, heap, size, alignment.alignment, heap_config);
+
     return pas_large_heap_try_allocate_and_forget(
-        &heap->megapage_large_heap, size, alignment.alignment, pas_non_compact_allocation_mode,
-        pas_heap_config_kind_get_config(heap->config_kind),
-        transaction);
+        &heap->large_heap, size, alignment.alignment, pas_non_compact_allocation_mode,
+        heap_config, transaction);
 }
 
 /* Warning: This creates caches that allow type confusion. Only use this for primitive heaps! */


### PR DESCRIPTION
#### 6bed96b90169acee3768919ebfe47fa3579067e4
<pre>
Revert use of separate megapage heap in libpas
<a href="https://bugs.webkit.org/show_bug.cgi?id=285620">https://bugs.webkit.org/show_bug.cgi?id=285620</a>
<a href="https://rdar.apple.com/142561181">rdar://142561181</a>

Reviewed by Yusuke Suzuki and Mark Lam.

Reverts megapage allocations coming from a separate megapage
large heap, allocating them out of the common large heap instead.
Also adds a profiling macro to let us collect some info about
how often this happens.

* Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c:
(allocate_from_megapages):

Canonical link: <a href="https://commits.webkit.org/288613@main">https://commits.webkit.org/288613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1efa9767224c4ed6be3d4e069f74262fec37716

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83922 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88997 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34930 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11507 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65273 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23110 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2699 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45565 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2628 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30477 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33979 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/76885 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90372 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/82939 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8094 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73727 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11411 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72945 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/18037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17224 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2522 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12975 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11139 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105357 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10987 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25462 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14463 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->