### PR TITLE
Adds code for loading USDZ with RealityKit

### DIFF
--- a/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
+++ b/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
@@ -46,6 +46,8 @@ typedef struct {
 
 @interface WKSRKEntity : NSObject
 @property (nonatomic, weak) id <WKSRKEntityDelegate> delegate;
+@property (nonatomic, copy, nullable) NSString *name;
+
 @property (nonatomic, readonly) simd_float3 boundingBoxExtents;
 @property (nonatomic, readonly) simd_float3 boundingBoxCenter;
 @property (nonatomic) WKEntityTransform transform;
@@ -56,7 +58,10 @@ typedef struct {
 @property (nonatomic) bool paused;
 @property (nonatomic) NSTimeInterval currentTime;
 
++ (bool)isLoadFromDataAvailable;
++ (void)loadFromData:(NSData *)data completionHandler:(void (^)(WKSRKEntity * _Nullable entity))completionHandler;
 - (instancetype)initWithCoreEntity:(REEntityRef)coreEntity;
+- (void)setParentCoreEntity:(REEntityRef)parentCoreEntity;
 - (void)setUpAnimationWithAutoPlay:(BOOL)autoPlay;
 - (void)applyIBLData:(NSData *)data withCompletion:(void (^)(BOOL success))completion;
 - (void)removeIBL;


### PR DESCRIPTION
#### 466928ec2d517ff4c91e72ed5fa896d939c20016
<pre>
Adds code for loading USDZ with RealityKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=285619">https://bugs.webkit.org/show_bug.cgi?id=285619</a>
<a href="https://rdar.apple.com/125094281">rdar://125094281</a>

Reviewed by Ada Chan.

Uses RealityKit Swift API to load an Entity from data. For compatibility
reasons, keep older CoreRE path for models loading.
Added &apos;isLoadFromDataAvailable&apos; to RealityKitBridging to switch between
two loading paths.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::RKModelLoaderUSD::load):
(WebKit::loadREModelUsingRKUSDLoader):
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
(WebKit::ModelProcessModelPlayerProxy::load):
* Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift:
(WKSRKEntity.isLoadFromDataAvailable):
(WKSRKEntity.load(from:completionHandler:)):
(WKSRKEntity.name):
(WKSRKEntity.animationPlaybackStateDidUpdate):
(WKSRKEntity.setParent(_:)):
* Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h:

Canonical link: <a href="https://commits.webkit.org/288738@main">https://commits.webkit.org/288738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d28ebe2aebd785ed7954aec5d8064dc92c32bbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89227 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35160 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11739 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65449 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23283 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45742 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2833 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34208 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73765 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90607 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11416 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8281 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73901 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11640 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72401 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73106 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18109 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17416 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15964 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2763 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11368 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16846 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11216 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14692 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12988 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->