### PR TITLE
[Cookie Store API] Ensure secure property defaults to true

### DIFF
--- a/LayoutTests/http/tests/cookies/cookie-store-get-secure.https-expected.txt
+++ b/LayoutTests/http/tests/cookies/cookie-store-get-secure.https-expected.txt
@@ -1,0 +1,11 @@
+Tests that if the Cookie Store API get()/getAll() functions are used to fetch an unsecure cookie, they will set it to secure
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Cookie fetched by CookieStore::get() is secure
+PASS Cookie fetched by CookieStore::getAll() is secure
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/cookies/cookie-store-get-secure.https.html
+++ b/LayoutTests/http/tests/cookies/cookie-store-get-secure.https.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src='resources/cookies-test-pre.js'></script>
+<script src='../../../resources/js-test-pre.js'></script>
+</head>
+<body>
+<script>
+description('Tests that if the Cookie Store API get()/getAll() functions are used to fetch an unsecure cookie, they will set it to secure');
+jsTestIsAsync = true;
+
+onload = async () => {
+    internals.setCookie({ name: "cookieName", value: "cookieValue", domain: "127.0.0.1", path: "/", isSameSiteStrict: true });
+
+    let cookies = internals.getCookies();
+    let foundCookie = false;
+    for (let cookie of cookies) {
+        if (foundCookie)
+            break;
+
+        if (cookie.name !== "cookieName")
+            continue;
+
+        foundCookie = true;
+        if (cookie.isSecure) {
+            testFailed("Set cookie should not be secure");
+            finishJSTest();
+        }
+    }
+
+    if (!foundCookie) {
+        testFailed("Cookie was not set");
+        finishJSTest();
+    }
+
+    let cookie = await cookieStore.get("cookieName");
+    if (cookie.secure)
+        testPassed("Cookie fetched by CookieStore::get() is secure");
+    else
+        testFailed("Cookie fetched by CookieStore::get() is not secure");
+
+    cookies = await cookieStore.getAll("cookieName");
+    if (cookies[0].secure)
+        testPassed("Cookie fetched by CookieStore::getAll() is secure");
+    else
+        testFailed("Cookie fetched by CookieStore::getAll() is not secure");
+
+    finishJSTest();
+};
+</script>
+<script src='resources/cookies-test-post.js'></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/cookies/cookie-store-set-secure.https-expected.txt
+++ b/LayoutTests/http/tests/cookies/cookie-store-set-secure.https-expected.txt
@@ -1,0 +1,10 @@
+Tests that the Cookie Store API set() function sets a secure cookie
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Cookie set by CookieStore::set() is secure
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/cookies/cookie-store-set-secure.https.html
+++ b/LayoutTests/http/tests/cookies/cookie-store-set-secure.https.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src='resources/cookies-test-pre.js'></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+</head>
+<body>
+<script>
+description('Tests that the Cookie Store API set() function sets a secure cookie');
+jsTestIsAsync = true;
+
+onload = async () => {
+    await cookieStore.set("cookieName", "cookieValue");
+    let cookies = internals.getCookies();
+
+    let foundCookie = false;
+    for (let cookie of cookies) {
+        if (foundCookie)
+            break;
+
+        if (cookie.name !== "cookieName")
+            continue;
+
+        foundCookie = true;
+        if (!cookie.isSecure)
+            testFailed("Cookie set by CookieStore::set() is not secure");
+        else
+            testPassed("Cookie set by CookieStore::set() is secure")
+    }
+
+    if (!foundCookie)
+        testFailed("Cookie was not set");
+
+    finishJSTest();
+};
+</script>
+<script src='resources/cookies-test-post.js'></script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any-expected.txt
@@ -9,4 +9,5 @@ FAIL CookieListItem - cookieStore.set adds / to path if it does not end with / a
 FAIL CookieListItem - cookieStore.set with sameSite set to strict assert_equals: expected (object) null but got (string) "localhost"
 FAIL CookieListItem - cookieStore.set with sameSite set to lax assert_equals: expected (object) null but got (string) "localhost"
 FAIL CookieListItem - cookieStore.set with sameSite set to none assert_equals: expected (object) null but got (string) "localhost"
+PASS CookieListItem - secure defaults to true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.js
@@ -195,3 +195,15 @@ promise_test(async testCase => {
   }, `CookieListItem - cookieStore.set with sameSite set to ${sameSiteValue}`);
 
 });
+
+promise_test(async testCase => {
+  await cookieStore.delete('cookie-name');
+
+  await cookieStore.set('cookie-name', 'cookie-value');
+  testCase.add_cleanup(async () => {
+    await cookieStore.delete('cookie-name');
+  });
+
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie.secure, true);
+}, 'CookieListItem - secure defaults to true');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.serviceworker-expected.txt
@@ -9,4 +9,5 @@ FAIL CookieListItem - cookieStore.set adds / to path if it does not end with / a
 FAIL CookieListItem - cookieStore.set with sameSite set to strict assert_equals: expected (object) null but got (string) "localhost"
 FAIL CookieListItem - cookieStore.set with sameSite set to lax assert_equals: expected (object) null but got (string) "localhost"
 FAIL CookieListItem - cookieStore.set with sameSite set to none assert_equals: expected (object) null but got (string) "localhost"
+PASS CookieListItem - secure defaults to true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt
@@ -1,11 +1,11 @@
 
-FAIL cookieStore.set with __Secure- name on secure origin promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating '(await cookieStore.get(`${prefix}cookie-name`)).value')"
+PASS cookieStore.set with __Secure- name on secure origin
 PASS cookieStore.set of expired __Secure- cookie name on secure origin
 PASS cookieStore.delete with __Secure- name on secure origin
-FAIL cookieStore.set with __Host- name on secure origin promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating '(await cookieStore.get(`${prefix}cookie-name`)).value')"
+PASS cookieStore.set with __Host- name on secure origin
 PASS cookieStore.set of expired __Host- cookie name on secure origin
 PASS cookieStore.delete with __Host- name on secure origin
 FAIL cookieStore.set with __Host- prefix and a domain option assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with __Host- prefix a path option promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating '(await cookieStore.get(`__Host-cookie-name`)).value')"
+FAIL cookieStore.set with __Host- prefix a path option assert_unreached: Should have rejected: undefined Reached unreachable code
 PASS cookieStore.set with malformed name.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker-expected.txt
@@ -1,11 +1,11 @@
 
-FAIL cookieStore.set with __Secure- name on secure origin promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating '(await cookieStore.get(`${prefix}cookie-name`)).value')"
+PASS cookieStore.set with __Secure- name on secure origin
 PASS cookieStore.set of expired __Secure- cookie name on secure origin
 PASS cookieStore.delete with __Secure- name on secure origin
-FAIL cookieStore.set with __Host- name on secure origin promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating '(await cookieStore.get(`${prefix}cookie-name`)).value')"
+PASS cookieStore.set with __Host- name on secure origin
 PASS cookieStore.set of expired __Host- cookie name on secure origin
 PASS cookieStore.delete with __Host- name on secure origin
 FAIL cookieStore.set with __Host- prefix and a domain option assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with __Host- prefix a path option promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating '(await cookieStore.get(`__Host-cookie-name`)).value')"
+FAIL cookieStore.set with __Host- prefix a path option assert_unreached: Should have rejected: undefined Reached unreachable code
 PASS cookieStore.set with malformed name.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Partitioned cookies accessible on the top-level site they are created in via HTTP assert_equals: Expected __Host-pccookiestore to be available on the top-level site it was created in expected true but got false
-FAIL Partitioned cookies accessible on the top-level site they are created in via DOM assert_equals: Expected __Host-pccookiestore to be available on the top-level site it was created in expected true but got false
-FAIL Partitioned cookies accessible on the top-level site they are created in via CookieStore assert_equals: Expected __Host-pccookiestore to be available on the top-level site it was created in expected true but got false
+PASS Partitioned cookies accessible on the top-level site they are created in via HTTP
+PASS Partitioned cookies accessible on the top-level site they are created in via DOM
+PASS Partitioned cookies accessible on the top-level site they are created in via CookieStore
 PASS Cross-site window opened correctly
 FAIL Partitioned cookies are not accessible on a different top-level site via HTTP assert_equals: Expected __Host-pchttp to not be available on a different top-level site expected false but got true
 FAIL Partitioned cookies are not accessible on a different top-level site via DOM assert_equals: Expected __Host-pchttp to not be available on a different top-level site expected false but got true

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2998,9 +2998,11 @@ http/tests/media/modern-media-controls/time-control/10-minutes-to-1-hour.html [ 
 # DASH media playback support is disabled in the GStreamer ports.
 platform/glib/media/media-can-play-dash.html [ Skip ]
 
-# The CookieStore API is not fully implemented on GTK/WPE yet.
+# The Cookie Store API is not fully implemented on GTK/WPE yet.
 imported/w3c/web-platform-tests/cookie-store [ Skip ]
 imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html [ Skip ]
+http/tests/cookies/cookie-store-get-secure.https.html [ Skip ]
+http/tests/cookies/cookie-store-set-secure.https.html [ Skip ]
 
 # As of the 23.08 release of the BuildStream SDK the GStreamer kate plugin is no longer shipped.
 media/track/in-band/track-in-band-kate-ogg-addtrack.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1189,9 +1189,11 @@ media/video-currenttime-monotonic.html [ Failure ]
 # Screenshots timeline does not capture screenshots for changes in WebKitLegacy.
 webkit.org/b/251113 inspector/timeline/timeline-event-screenshots.html [ Skip ]
 
-# The CookieStore API is not fully implemented on macOS WK1 yet.
+# The Cookie Store API is not supported on WK1.
 imported/w3c/web-platform-tests/cookie-store [ Skip ]
 imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html [ Skip ]
+http/tests/cookies/cookie-store-get-secure.https.html [ Skip ]
+http/tests/cookies/cookie-store-set-secure.https.html [ Skip ]
 
 # View Transitions API is disabled in WK1.
 imported/w3c/web-platform-tests/css/css-view-transitions [ Skip ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1783,9 +1783,11 @@ streams/readable-stream-byob-reader-worker.html [ Skip ]
 streams/readable-stream-byob-request.html [ Skip ]
 streams/readable-stream-byob-request-worker.html [ Skip ]
 
-# The CookieStore API is not fully implemented on Windows port yet.
+# The Cookie Store API is not fully implemented on the Windows port yet.
 imported/w3c/web-platform-tests/cookie-store [ Skip ]
 imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html [ Skip ]
+http/tests/cookies/cookie-store-get-secure.https.html [ Skip ]
+http/tests/cookies/cookie-store-set-secure.https.html [ Skip ]
 
 webkit.org/b/271132 [ Debug ] fast/text/crash-grapheme-cluster-spanning-adjacent-textitems.html [ Skip ] # Crash
 

--- a/Source/WebCore/Modules/cookie-store/CookieListItem.h
+++ b/Source/WebCore/Modules/cookie-store/CookieListItem.h
@@ -42,7 +42,6 @@ struct CookieListItem {
         , domain(WTFMove(cookie.domain))
         , path(WTFMove(cookie.path))
         , expires(cookie.expires)
-        , secure(cookie.secure)
     {
         switch (cookie.sameSite) {
         case Cookie::SameSitePolicy::Strict:
@@ -62,7 +61,7 @@ struct CookieListItem {
     String domain;
     String path;
     std::optional<DOMHighResTimeStamp> expires;
-    bool secure { false };
+    bool secure { true };
     CookieSameSite sameSite { CookieSameSite::Strict };
 };
 

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -476,6 +476,8 @@ void CookieStore::set(CookieInit&& options, Ref<DeferredPromise>&& promise)
         break;
     }
 
+    cookie.secure = true;
+
     m_promises.add(++m_nextPromiseIdentifier, WTFMove(promise));
     auto completionHandler = [promiseIdentifier = m_nextPromiseIdentifier](CookieStore& cookieStore, std::optional<Exception>&& result) {
         auto promise = cookieStore.takePromise(promiseIdentifier);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -216,6 +216,7 @@
 #include "ServiceWorkerRegistrationData.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
+#include "ShouldPartitionCookie.h"
 #include "SourceBuffer.h"
 #include "SpeechSynthesisUtterance.h"
 #include "SpellChecker.h"
@@ -6852,6 +6853,19 @@ bool Internals::validateAV1ConfigurationRecord(const String& parameters)
     if (auto record = WebCore::parseAV1CodecParameters(parameters))
         return WebCore::validateAV1ConfigurationRecord(*record);
     return false;
+}
+
+void Internals::setCookie(CookieData&& cookieData)
+{
+    auto* document = contextDocument();
+    if (!document)
+        return;
+
+    auto* page = document->page();
+    if (!page)
+        return;
+
+    page->cookieJar().setRawCookie(*document, CookieData::toCookie(WTFMove(cookieData)), ShouldPartitionCookie::No);
 }
 
 auto Internals::getCookies() const -> Vector<CookieData>

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1286,7 +1286,7 @@ public:
         String domain;
         String path;
         // Expiration dates are expressed as milliseconds since the UNIX epoch.
-        double expires { 0 };
+        std::optional<double> expires;
         bool isHttpOnly { false };
         bool isSecure { false };
         bool isSession { false };
@@ -1299,7 +1299,7 @@ public:
             , value(cookie.value)
             , domain(cookie.domain)
             , path(cookie.path)
-            , expires(cookie.expires.value_or(0))
+            , expires(cookie.expires)
             , isHttpOnly(cookie.httpOnly)
             , isSecure(cookie.secure)
             , isSession(cookie.session)
@@ -1313,7 +1313,27 @@ public:
         CookieData()
         {
         }
+
+        static Cookie toCookie(CookieData&& cookieData)
+        {
+            Cookie cookie;
+            cookie.name = WTFMove(cookieData.name);
+            cookie.value = WTFMove(cookieData.value);
+            cookie.domain = WTFMove(cookieData.domain);
+            cookie.path = WTFMove(cookieData.path);
+            cookie.expires = WTFMove(cookieData.expires);
+            if (cookieData.isSameSiteNone)
+                cookie.sameSite = Cookie::SameSitePolicy::None;
+            else if (cookieData.isSameSiteLax)
+                cookie.sameSite = Cookie::SameSitePolicy::Lax;
+            else if (cookieData.isSameSiteStrict)
+                cookie.sameSite = Cookie::SameSitePolicy::Strict;
+
+            return cookie;
+        }
     };
+
+    void setCookie(CookieData&&);
     Vector<CookieData> getCookies() const;
 
     void setAlwaysAllowLocalWebarchive(bool);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -338,16 +338,18 @@ enum AV1ConfigurationRange {
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     JSGenerateToJSObject,
+    JSGenerateToNativeObject
 ] dictionary CookieData {
     DOMString name;
     DOMString value;
-    DOMString domain;
-    double expires;
-    boolean isHttpOnly;
-    boolean isSecure;
-    boolean isSession;
-    boolean isSameSiteLax;
-    boolean isSameSiteStrict;
+    DOMString domain = "";
+    DOMString path = "";
+    double? expires = null;
+    boolean isHttpOnly = false;
+    boolean isSecure = false;
+    boolean isSession = false;
+    boolean isSameSiteLax = false;
+    boolean isSameSiteStrict = false;
 };
 
 [
@@ -1287,6 +1289,7 @@ enum RenderingMode {
     boolean validateAV1ConfigurationRecord(DOMString codecParameters);
     boolean validateAV1PerLevelConstraints(DOMString codecParameters, VideoConfiguration configuration);
 
+    undefined setCookie(CookieData cookieData);
     sequence<CookieData> getCookies();
 
     undefined setAlwaysAllowLocalWebarchive(boolean alwaysAllowLocalWebarchive);


### PR DESCRIPTION
#### 44f403689534bcd565dfeebea93c1dd68f63a9ab
<pre>
[Cookie Store API] Ensure secure property defaults to true
<a href="https://bugs.webkit.org/show_bug.cgi?id=285623">https://bugs.webkit.org/show_bug.cgi?id=285623</a>
<a href="https://rdar.apple.com/142442877">rdar://142442877</a>

Reviewed by Chris Dumez and Sihui Liu.

The Cookie Store API spec (<a href="https://wicg.github.io/cookie-store/#secure-cookies)">https://wicg.github.io/cookie-store/#secure-cookies)</a>
says this API should only set cookies as secure and when fetching/modifying non-secure
cookies, it should modify them to be secure as well.

With this patch:
1. CookieStore::set() will now set the secure propety to true when setting a cookie.
2. CookieListItem (which is what is constructed from a cookie and returned when this API
   fetches cookies) will always have secure as true.
3. As a consequence of (2), if CookieStore::get() or getAll() are used to fetch an un-secure
   cookie, they will set it to secure.

Testing:
1. New layout test confirms that CookieListItem defaults to true (will be upstreamed to WPT)
2. New layout test confirms that CookieStore::set always sets a secure cookie
3. New layout test confirms that if CookieStore::get is used to get a un-secure cookie, it
   will set that cookie to be secure.

* LayoutTests/http/tests/cookies/cookie-store-get-secure.https-expected.txt: Added.
* LayoutTests/http/tests/cookies/cookie-store-get-secure.https.html: Added.
* LayoutTests/http/tests/cookies/cookie-store-set-secure.https-expected.txt: Added.
* LayoutTests/http/tests/cookies/cookie-store-set-secure.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.js:
(async set promise_test):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/Modules/cookie-store/CookieListItem.h:
(WebCore::CookieListItem::CookieListItem):
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::set):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setCookie):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/288824@main">https://commits.webkit.org/288824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5dc632f910796857d834efa461d7673a35f0a37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89589 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35518 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65719 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23562 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87553 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76775 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46013 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3136 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31006 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34566 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90970 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8584 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74171 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72599 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73372 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17714 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16157 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3209 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13162 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11726 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17202 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11575 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15051 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->