### PR TITLE
Implement trusted-types-eval CSP script-src keyword

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/block-eval-onload-in-nested-about-blank-iframe-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/block-eval-onload-in-nested-about-blank-iframe-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'".
 
 Tests that nested about:blank iframes that try to eval on load inherit the parent's CSP
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/eval-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/eval-blocked-expected.txt
@@ -1,37 +1,37 @@
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/eval-blocked-in-about-blank-iframe-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/eval-blocked-in-about-blank-iframe-expected.txt
@@ -1,4 +1,4 @@
 ALERT: /PASS/
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
  Eval should be blocked in the iframe, but inline script should be allowed.

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/eval-blocked-in-external-script-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/eval-blocked-in-external-script-expected.txt
@@ -1,3 +1,3 @@
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'".
 
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/eval-blocked-in-subframe-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/eval-blocked-in-subframe-expected.txt
@@ -1,38 +1,38 @@
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
 Tests that eval() is blocked in a subframe that disallows eval() when the parent frame allows eval().
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/eval-scripts-setInterval-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/eval-scripts-setInterval-blocked-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Refused to execute a script because 'unsafe-eval' does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to execute a script because 'unsafe-eval' and 'trusted-types-eval' does not appear in the script-src directive of the Content Security Policy.
 ALERT: PASS
 
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/eval-scripts-setTimeout-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/eval-scripts-setTimeout-blocked-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Refused to execute a script because 'unsafe-eval' does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to execute a script because 'unsafe-eval' and 'trusted-types-eval' does not appear in the script-src directive of the Content Security Policy.
 ALERT: PASS
 
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/function-constructor-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/function-constructor-blocked-expected.txt
@@ -1,3 +1,3 @@
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/module-eval-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/module-eval-blocked-expected.txt
@@ -1,37 +1,37 @@
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/module-eval-blocked-in-external-script-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/module-eval-blocked-in-external-script-expected.txt
@@ -1,3 +1,3 @@
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'".
 
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/worker-blob-inherits-csp-blocks-eval-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/worker-blob-inherits-csp-blocks-eval-expected.txt
@@ -1,4 +1,4 @@
 This tests that the Content Security Policy (CSP) of the owner document (this page) blocks a blob-URL Web Worker from using eval() because the parent's CSP does not list unsafe-eval in script-src.
 
-PASS threw exception EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+PASS threw exception EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 .

--- a/LayoutTests/http/tests/security/isolatedWorld/image-load-should-not-bypass-main-world-csp-expected.txt
+++ b/LayoutTests/http/tests/security/isolatedWorld/image-load-should-not-bypass-main-world-csp-expected.txt
@@ -2,7 +2,7 @@ CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/resources/abe.pn
 ALERT: BLOCKED in main world
 CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/resources/abe.png because it does not appear in the img-src directive of the Content Security Policy.
 ALERT: BLOCKED in isolated world
-CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+CONSOLE MESSAGE: EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 
 ALERT: BLOCKED eval() in main world
 ALERT: Called eval() in isolated world

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_report_only_require_trusted_types_eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_report_only_require_trusted_types_eval-expected.txt
@@ -1,0 +1,8 @@
+Scripts injected via `eval` are not allowed with `trusted-types-eval` when `require-trusted-types-for 'script'` is report only.
+
+
+PASS Scripts injected via direct `eval` are not allowed with `trusted-types-eval` when `require-trusted-types-for 'script'` is report only.
+PASS Scripts injected via indirect `eval` are not allowed with `trusted-types-eval` when `require-trusted-types-for 'script'` is report only.
+PASS Scripts injected via `new Function` are not allowed with `trusted-types-eval` when `require-trusted-types-for 'script'` is report only.
+PASS Scripts injected via `setTimeout` are not allowed with `trusted-types-eval` when `require-trusted-types-for 'script'` is report only.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_report_only_require_trusted_types_eval.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_report_only_require_trusted_types_eval.html
@@ -1,0 +1,103 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Scripts injected via `eval` are not allowed with `trusted-types-eval` when `require-trusted-types-for 'script'` is report only.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'nonce-dummy' 'trusted-types-eval' -->
+    <!-- Report Only CSP served: require-trusted-types-for 'script' -->
+</head>
+
+<body>
+    <h1>Scripts injected via `eval` are not allowed with `trusted-types-eval` when `require-trusted-types-for 'script'` is report only.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        trustedTypes.createPolicy('default', { createScript: s => s });
+        var evalScriptRan = false;
+        var indirectEvalScriptRan = false;
+        var functionScriptRan = false;
+        var setTimeoutScriptRan = false;
+
+        async_test(function(t) {
+            var eventHandler = t.step_func_done(function(e) {
+                assert_false(evalScriptRan);
+                assert_equals(e.effectiveDirective, 'script-src');
+                assert_equals(e.blockedURI, 'eval');
+            });
+            window.addEventListener('securitypolicyviolation', eventHandler);
+            t.add_cleanup(() => {
+                window.removeEventListener('securitypolicyviolation', eventHandler);
+            });
+
+            assert_throws_js(Error,
+                function() {
+                    try {
+                        eval("evalScriptRan = true;");
+                    } catch (e) {
+                        throw new Error();
+                    }
+                });
+        }, "Scripts injected via direct `eval` are not allowed with `trusted-types-eval` when `require-trusted-types-for 'script'` is report only.");
+
+        async_test(function(t) {
+            var eventHandler = t.step_func_done(function(e) {
+                assert_false(indirectEvalScriptRan);
+                assert_equals(e.effectiveDirective, 'script-src');
+                assert_equals(e.blockedURI, 'eval');
+            });
+            window.addEventListener('securitypolicyviolation', eventHandler);
+            t.add_cleanup(() => {
+                window.removeEventListener('securitypolicyviolation', eventHandler);
+            });
+
+            assert_throws_js(Error,
+                function() {
+                    try {
+                        eval?.("indirectEvalScriptRan = true;");
+                    } catch (e) {
+                        throw new Error();
+                    }
+                });
+        }, "Scripts injected via indirect `eval` are not allowed with `trusted-types-eval` when `require-trusted-types-for 'script'` is report only.");
+
+        async_test(function(t) {
+            var eventHandler = t.step_func_done(function(e) {
+                assert_false(functionScriptRan);
+                assert_equals(e.effectiveDirective, 'script-src');
+                assert_equals(e.blockedURI, 'eval');
+            });
+            window.addEventListener('securitypolicyviolation', eventHandler);
+            t.add_cleanup(() => {
+                window.removeEventListener('securitypolicyviolation', eventHandler);
+            });
+
+            assert_throws_js(Error,
+                function() {
+                    try {
+                        new Function("functionScriptRan = true;")();
+                    } catch (e) {
+                        throw new Error();
+                    }
+                });
+        }, "Scripts injected via `new Function` are not allowed with `trusted-types-eval` when `require-trusted-types-for 'script'` is report only.");
+
+        async_test(function(t) {
+            var eventHandler = t.step_func_done(function(e) {
+                assert_false(setTimeoutScriptRan);
+                assert_equals(e.effectiveDirective, 'script-src');
+                assert_equals(e.blockedURI, 'eval');
+            });
+            window.addEventListener('securitypolicyviolation', eventHandler);
+            t.add_cleanup(() => {
+                window.removeEventListener('securitypolicyviolation', eventHandler);
+            });
+
+            setTimeout("setTimeoutScriptRan = true;", 0);
+        }, "Scripts injected via `setTimeout` are not allowed with `trusted-types-eval` when `require-trusted-types-for 'script'` is report only.");
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_report_only_require_trusted_types_eval.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_report_only_require_trusted_types_eval.html.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'nonce-dummy' 'trusted-types-eval'
+Content-Security-Policy-Report-Only: require-trusted-types-for 'script';

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_require_trusted_types_eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_require_trusted_types_eval-expected.txt
@@ -1,0 +1,8 @@
+Scripts injected via `eval` are allowed with `trusted-types-eval` and `require-trusted-types-for 'script'`.
+
+
+PASS Script injected via direct `eval` is allowed with `trusted-types-eval` and `require-trusted-types-for 'script'`.
+PASS Script injected via indirect `eval` is allowed with `trusted-types-eval` and `require-trusted-types-for 'script'`.
+PASS Script injected via `new Function` is allowed with `trusted-types-eval` and `require-trusted-types-for 'script'`.
+PASS Script injected via `setTimeout` is allowed with `trusted-types-eval` and `require-trusted-types-for 'script'`.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_require_trusted_types_eval.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_require_trusted_types_eval.html
@@ -1,0 +1,88 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Scripts injected via `eval` are allowed with `trusted-types-eval` and `require-trusted-types-for 'script'`.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'nonce-dummy' 'trusted-types-eval'; require-trusted-types-for 'script'; -->
+</head>
+
+<body>
+    <h1>Scripts injected via `eval` are allowed with `trusted-types-eval` and `require-trusted-types-for 'script'`.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        trustedTypes.createPolicy('default', {createScript: s => s});
+
+        var evalScriptRan = false;
+        var indirectEvalScriptRan = false;
+        var functionScriptRan = false;
+        var setTimeoutScriptRan = false;
+
+        async_test(function(t) {
+            var eventHandler = t.unreached_func('No CSP violation report has fired.');
+            window.addEventListener('securitypolicyviolation', eventHandler);
+            t.add_cleanup(() => {
+                window.removeEventListener('securitypolicyviolation', eventHandler);
+            });
+            try {
+                eval("evalScriptRan = true;");
+            } catch (e) {
+                assert_unreached("`eval` should be allowed with `trusted-types-eval` and `require-trusted-types-for 'script'`.");
+            }
+            assert_true(evalScriptRan);
+            t.done();
+        }, "Script injected via direct `eval` is allowed with `trusted-types-eval` and `require-trusted-types-for 'script'`.");
+
+        async_test(function(t) {
+            var eventHandler = t.unreached_func('No CSP violation report has fired.');
+            window.addEventListener('securitypolicyviolation', eventHandler);
+            t.add_cleanup(() => {
+                window.removeEventListener('securitypolicyviolation', eventHandler);
+            });
+            try {
+                eval?.("indirectEvalScriptRan = true;");
+            } catch (e) {
+                assert_unreached("indirect `eval` should be allowed with `trusted-types-eval` and `require-trusted-types-for 'script'`.");
+            }
+            assert_true(indirectEvalScriptRan);
+            t.done();
+        }, "Script injected via indirect `eval` is allowed with `trusted-types-eval` and `require-trusted-types-for 'script'`.");
+
+        async_test(function(t) {
+            var eventHandler = t.unreached_func('No CSP violation report has fired.');
+            window.addEventListener('securitypolicyviolation', eventHandler);
+            t.add_cleanup(() => {
+                window.removeEventListener('securitypolicyviolation', eventHandler);
+            });
+            try {
+                new Function("functionScriptRan = true;")();
+            } catch (e) {
+                assert_unreached("`new Function` should be allowed with `trusted-types-eval` and `require-trusted-types-for 'script'`.");
+            }
+            assert_true(functionScriptRan);
+            t.done();
+        }, "Script injected via `new Function` is allowed with `trusted-types-eval` and `require-trusted-types-for 'script'`.");
+
+        async_test(function(t) {
+            var eventHandler = t.unreached_func('No CSP violation report has fired.');
+            window.addEventListener('securitypolicyviolation', eventHandler);
+            t.add_cleanup(() => {
+                window.removeEventListener('securitypolicyviolation', eventHandler);
+            });
+            try {
+                setTimeout("setTimeoutScriptRan = true;", 0);
+            } catch (e) {
+                assert_unreached("`setTimeout` should be allowed with `trusted-types-eval` and `require-trusted-types-for 'script'`.");
+            }
+            setTimeout(() => {
+                assert_true(setTimeoutScriptRan);
+                t.done();
+            }, 0);
+        }, "Script injected via `setTimeout` is allowed with `trusted-types-eval` and `require-trusted-types-for 'script'`.");
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_require_trusted_types_eval.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_require_trusted_types_eval.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'nonce-dummy' 'trusted-types-eval'; require-trusted-types-for 'script';

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_without_require_trusted_types_eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_without_require_trusted_types_eval-expected.txt
@@ -1,0 +1,8 @@
+Scripts injected via `eval` are not allowed with `trusted-types-eval` without `require-trusted-types-for 'script'`.
+
+
+PASS Scripts injected via direct `eval` are not allowed with `trusted-types-eval` without `require-trusted-types-for 'script'`.
+PASS Scripts injected via indirect `eval` are not allowed with `trusted-types-eval` without `require-trusted-types-for 'script'`.
+PASS Scripts injected via `new Function` are not allowed with `trusted-types-eval` without `require-trusted-types-for 'script'`.
+PASS Scripts injected via `setTimeout` are not allowed with `trusted-types-eval` without `require-trusted-types-for 'script'`.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_without_require_trusted_types_eval.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_without_require_trusted_types_eval.html
@@ -1,0 +1,101 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Scripts injected via `eval` are not allowed with `trusted-types-eval` without `require-trusted-types-for 'script'`.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'nonce-dummy' 'trusted-types-eval' -->
+</head>
+
+<body>
+    <h1>Scripts injected via `eval` are not allowed with `trusted-types-eval` without `require-trusted-types-for 'script'`.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        var evalScriptRan = false;
+        var indirectEvalScriptRan = false;
+        var functionScriptRan = false;
+        var setTimeoutScriptRan = false;
+
+        async_test(function(t) {
+            var eventHandler = t.step_func_done(function(e) {
+                assert_false(evalScriptRan);
+                assert_equals(e.effectiveDirective, 'script-src');
+                assert_equals(e.blockedURI, 'eval');
+            });
+            window.addEventListener('securitypolicyviolation', eventHandler);
+            t.add_cleanup(() => {
+                window.removeEventListener('securitypolicyviolation', eventHandler);
+            });
+
+            assert_throws_js(Error,
+                function() {
+                    try {
+                        eval("evalScriptRan = true;");
+                    } catch (e) {
+                        throw new Error();
+                    }
+                });
+        }, "Scripts injected via direct `eval` are not allowed with `trusted-types-eval` without `require-trusted-types-for 'script'`.");
+
+        async_test(function(t) {
+            var eventHandler = t.step_func_done(function(e) {
+                assert_false(indirectEvalScriptRan);
+                assert_equals(e.effectiveDirective, 'script-src');
+                assert_equals(e.blockedURI, 'eval');
+            });
+            window.addEventListener('securitypolicyviolation', eventHandler);
+            t.add_cleanup(() => {
+                window.removeEventListener('securitypolicyviolation', eventHandler);
+            });
+
+            assert_throws_js(Error,
+                function() {
+                    try {
+                        eval?.("indirectEvalScriptRan = true;");
+                    } catch (e) {
+                        throw new Error();
+                    }
+                });
+        }, "Scripts injected via indirect `eval` are not allowed with `trusted-types-eval` without `require-trusted-types-for 'script'`.");
+
+        async_test(function(t) {
+            var eventHandler = t.step_func_done(function(e) {
+                assert_false(functionScriptRan);
+                assert_equals(e.effectiveDirective, 'script-src');
+                assert_equals(e.blockedURI, 'eval');
+            });
+            window.addEventListener('securitypolicyviolation', eventHandler);
+            t.add_cleanup(() => {
+                window.removeEventListener('securitypolicyviolation', eventHandler);
+            });
+
+            assert_throws_js(Error,
+                function() {
+                    try {
+                        new Function("functionScriptRan = true;")();
+                    } catch (e) {
+                        throw new Error();
+                    }
+                });
+        }, "Scripts injected via `new Function` are not allowed with `trusted-types-eval` without `require-trusted-types-for 'script'`.");
+
+        async_test(function(t) {
+            var eventHandler = t.step_func_done(function(e) {
+                assert_false(setTimeoutScriptRan);
+                assert_equals(e.effectiveDirective, 'script-src');
+                assert_equals(e.blockedURI, 'eval');
+            });
+            window.addEventListener('securitypolicyviolation', eventHandler);
+            t.add_cleanup(() => {
+                window.removeEventListener('securitypolicyviolation', eventHandler);
+            });
+
+            setTimeout("setTimeoutScriptRan = true;", 0);
+        }, "Scripts injected via `setTimeout` are not allowed with `trusted-types-eval` without `require-trusted-types-for 'script'`.");
+    </script>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_without_require_trusted_types_eval.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_without_require_trusted_types_eval.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'nonce-dummy' 'trusted-types-eval'

--- a/LayoutTests/security/contentSecurityPolicy/worker-inherits-blocks-eval-expected.txt
+++ b/LayoutTests/security/contentSecurityPolicy/worker-inherits-blocks-eval-expected.txt
@@ -1,4 +1,4 @@
 This tests that the Content Security Policy (CSP) of the owner document (this page) blocks a file-URL Web Worker from using eval() because the parent's CSP does not list unsafe-eval in script-src.
 
-PASS threw exception EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+PASS threw exception EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
 .

--- a/Source/JavaScriptCore/debugger/DebuggerEvalEnabler.h
+++ b/Source/JavaScriptCore/debugger/DebuggerEvalEnabler.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CallFrame.h"
+#include "JSGlobalObject.h"
 
 namespace JSC {
 
@@ -46,11 +47,10 @@ public:
         UNUSED_PARAM(mode);
         if (globalObject) {
             m_evalWasDisabled = !globalObject->evalEnabled();
-            m_trustedTypesWereRequired = globalObject->requiresTrustedTypes();
+            m_trustedTypesEnforcement = globalObject->trustedTypesEnforcement();
             if (m_evalWasDisabled)
                 globalObject->setEvalEnabled(true, globalObject->evalDisabledErrorMessage());
-            if (m_trustedTypesWereRequired)
-                globalObject->setRequiresTrustedTypes(false);
+            globalObject->setTrustedTypesEnforcement(TrustedTypesEnforcement::None);
 #if ASSERT_ENABLED
             if (m_mode == Mode::EvalOnGlobalObjectAtDebuggerEntry)
                 globalObject->setGlobalObjectAtDebuggerEntry(globalObject);
@@ -64,8 +64,7 @@ public:
             JSGlobalObject* globalObject = m_globalObject;
             if (m_evalWasDisabled)
                 globalObject->setEvalEnabled(false, globalObject->evalDisabledErrorMessage());
-            if (m_trustedTypesWereRequired)
-                globalObject->setRequiresTrustedTypes(true);
+            globalObject->setTrustedTypesEnforcement(m_trustedTypesEnforcement);
 #if ASSERT_ENABLED
             if (m_mode == Mode::EvalOnGlobalObjectAtDebuggerEntry)
                 globalObject->setGlobalObjectAtDebuggerEntry(nullptr);
@@ -76,7 +75,7 @@ public:
 private:
     JSGlobalObject* const m_globalObject;
     bool m_evalWasDisabled { false };
-    bool m_trustedTypesWereRequired { false };
+    TrustedTypesEnforcement m_trustedTypesEnforcement;
 #if ASSERT_ENABLED
     DebuggerEvalEnabler::Mode m_mode;
 #endif

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -147,7 +147,7 @@ JSValue eval(CallFrame* callFrame, JSValue thisValue, JSScope* callerScopeChain,
     if (programSource.isNull())
         return program;
 
-    if (Options::useTrustedTypes() && globalObject->requiresTrustedTypes() && !isTrusted) {
+    if (globalObject->trustedTypesEnforcement() != TrustedTypesEnforcement::None && !isTrusted) {
         bool canCompileStrings = globalObject->globalObjectMethodTable()->canCompileStrings(globalObject, CompilationType::DirectEval, programSource, *vm.emptyList);
         RETURN_IF_EXCEPTION(scope, { });
         if (!canCompileStrings) {
@@ -157,7 +157,7 @@ JSValue eval(CallFrame* callFrame, JSValue thisValue, JSScope* callerScopeChain,
     }
 
     TopCallFrameSetter topCallFrame(vm, callFrame);
-    if (!globalObject->evalEnabled()) {
+    if (!globalObject->evalEnabled() && globalObject->trustedTypesEnforcement() != TrustedTypesEnforcement::EnforcedWithEvalEnabled) {
         globalObject->globalObjectMethodTable()->reportViolationForUnsafeEval(globalObject, programSource);
         throwException(globalObject, scope, createEvalError(globalObject, globalObject->evalDisabledErrorMessage()));
         return { };

--- a/Source/JavaScriptCore/runtime/DirectEvalExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/DirectEvalExecutable.cpp
@@ -40,7 +40,7 @@ DirectEvalExecutable* DirectEvalExecutable::create(JSGlobalObject* globalObject,
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (!globalObject->evalEnabled()) {
+    if (!globalObject->evalEnabled() && globalObject->trustedTypesEnforcement() != TrustedTypesEnforcement::EnforcedWithEvalEnabled) {
         globalObject->globalObjectMethodTable()->reportViolationForUnsafeEval(globalObject, source.provider() ? source.provider()->source().toString() : nullString());
         throwException(globalObject, scope, createEvalError(globalObject, globalObject->evalDisabledErrorMessage()));
         return nullptr;

--- a/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
@@ -159,7 +159,7 @@ JSObject* constructFunction(JSGlobalObject* globalObject, const ArgList& args, c
     auto code = stringifyFunction(globalObject, args, functionName, functionConstructionMode, scope, functionConstructorParametersEndPosition);
     EXCEPTION_ASSERT(!!scope.exception() == code.isNull());
 
-    if (Options::useTrustedTypes() && globalObject->requiresTrustedTypes()) {
+    if (globalObject->trustedTypesEnforcement() != TrustedTypesEnforcement::None) {
         bool isTrusted = true;
         auto* structure = globalObject->trustedScriptStructure();
         for (size_t i = 0; i < args.size(); i++) {
@@ -181,7 +181,7 @@ JSObject* constructFunction(JSGlobalObject* globalObject, const ArgList& args, c
         }
     }
 
-    if (UNLIKELY(!globalObject->evalEnabled())) {
+    if (UNLIKELY(!globalObject->evalEnabled()) && globalObject->trustedTypesEnforcement() != TrustedTypesEnforcement::EnforcedWithEvalEnabled) {
         scope.clearException();
         globalObject->globalObjectMethodTable()->reportViolationForUnsafeEval(globalObject, !code.isNull() ? WTFMove(code) : nullString());
         throwException(globalObject, scope, createEvalError(globalObject, globalObject->evalDisabledErrorMessage()));

--- a/Source/JavaScriptCore/runtime/IndirectEvalExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/IndirectEvalExecutable.cpp
@@ -41,7 +41,7 @@ inline IndirectEvalExecutable* IndirectEvalExecutable::createImpl(JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (!globalObject->evalEnabled()) {
+    if (!globalObject->evalEnabled() && globalObject->trustedTypesEnforcement() != TrustedTypesEnforcement::EnforcedWithEvalEnabled) {
         globalObject->globalObjectMethodTable()->reportViolationForUnsafeEval(globalObject, source.provider() ? source.provider()->source().toString() : nullString());
         throwException(globalObject, scope, createEvalError(globalObject, globalObject->evalDisabledErrorMessage()));
         return nullptr;

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -140,6 +140,13 @@ enum class CompilationType {
     IndirectEval,
 };
 
+enum class TrustedTypesEnforcement {
+    None,
+    ReportOnly,
+    Enforced,
+    EnforcedWithEvalEnabled
+};
+
 constexpr bool typeExposedByDefault = true;
 
 #define DEFINE_STANDARD_BUILTIN(macro, upperName, lowerName) macro(upperName, lowerName, lowerName, JS ## upperName, upperName, object, typeExposedByDefault)
@@ -594,7 +601,6 @@ public:
 
     bool m_evalEnabled { true };
     bool m_webAssemblyEnabled { true };
-    bool m_requiresTrustedTypes { true };
     bool m_needsSiteSpecificQuirks { false };
     unsigned m_globalLexicalBindingEpoch { 1 };
     String m_evalDisabledErrorMessage;
@@ -603,6 +609,8 @@ public:
     WeakPtr<ConsoleClient> m_consoleClient;
     std::optional<unsigned> m_stackTraceLimit;
     Weak<FunctionExecutable> m_executableForCachedFunctionExecutableForFunctionConstructor;
+
+    TrustedTypesEnforcement m_trustedTypesEnforcement { TrustedTypesEnforcement::None };
 
     template<typename T>
     struct WeakCustomGetterOrSetterHash {
@@ -1091,7 +1099,7 @@ public:
 
     bool evalEnabled() const { return m_evalEnabled; }
     bool webAssemblyEnabled() const { return m_webAssemblyEnabled; }
-    bool requiresTrustedTypes() const { return m_requiresTrustedTypes; }
+    TrustedTypesEnforcement trustedTypesEnforcement() const { return m_trustedTypesEnforcement; }
     const String& evalDisabledErrorMessage() const { return m_evalDisabledErrorMessage; }
     const String& webAssemblyDisabledErrorMessage() const { return m_webAssemblyDisabledErrorMessage; }
     void setEvalEnabled(bool enabled, const String& errorMessage = String())
@@ -1104,9 +1112,10 @@ public:
         m_webAssemblyEnabled = enabled;
         m_webAssemblyDisabledErrorMessage = errorMessage;
     }
-    void setRequiresTrustedTypes(bool required)
+    void setTrustedTypesEnforcement(TrustedTypesEnforcement enforcement)
     {
-        m_requiresTrustedTypes = required;
+        if (Options::useTrustedTypes())
+            m_trustedTypesEnforcement = enforcement;
     }
 
 #if ASSERT_ENABLED

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -480,7 +480,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncEval, (JSGlobalObject* globalObject, CallFram
     if (programSource.isNull())
         return JSValue::encode(x);
 
-    if (Options::useTrustedTypes() && globalObject->requiresTrustedTypes() && !isTrusted) {
+    if (globalObject->trustedTypesEnforcement() != TrustedTypesEnforcement::None && !isTrusted) {
         bool canCompileStrings = globalObject->globalObjectMethodTable()->canCompileStrings(globalObject, CompilationType::IndirectEval, programSource, *vm.emptyList);
         RETURN_IF_EXCEPTION(scope, { });
         if (!canCompileStrings) {
@@ -489,7 +489,7 @@ JSC_DEFINE_HOST_FUNCTION(globalFuncEval, (JSGlobalObject* globalObject, CallFram
         }
     }
 
-    if (!globalObject->evalEnabled()) {
+    if (!globalObject->evalEnabled() && globalObject->trustedTypesEnforcement() != TrustedTypesEnforcement::EnforcedWithEvalEnabled) {
         globalObject->globalObjectMethodTable()->reportViolationForUnsafeEval(globalObject, programSource);
         throwException(globalObject, scope, createEvalError(globalObject, globalObject->evalDisabledErrorMessage()));
         return JSValue::encode(jsUndefined());

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -459,12 +459,12 @@ void ScriptController::setWebAssemblyEnabled(bool value, const String& errorMess
     jsWindowProxy->window()->setWebAssemblyEnabled(value, errorMessage);
 }
 
-void ScriptController::setRequiresTrustedTypes(bool required)
+void ScriptController::setTrustedTypesEnforcement(JSC::TrustedTypesEnforcement enforcement)
 {
     auto* proxy = protectedWindowProxy()->existingJSWindowProxy(mainThreadNormalWorldSingleton());
     if (!proxy)
         return;
-    proxy->window()->setRequiresTrustedTypes(required);
+    proxy->window()->setTrustedTypesEnforcement(enforcement);
 }
 
 bool ScriptController::canAccessFromCurrentOrigin(LocalFrame* frame, Document& accessingDocument)

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -131,7 +131,7 @@ public:
 
     void setEvalEnabled(bool, const String& errorMessage = String());
     void setWebAssemblyEnabled(bool, const String& errorMessage = String());
-    void setRequiresTrustedTypes(bool);
+    void setTrustedTypesEnforcement(JSC::TrustedTypesEnforcement);
 
     static bool canAccessFromCurrentOrigin(LocalFrame*, Document& accessingDocument);
     WEBCORE_EXPORT bool canExecuteScripts(ReasonForCallingCanExecuteScripts);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -328,6 +328,7 @@
 #include "XPathNSResolver.h"
 #include "XPathResult.h"
 #include <JavaScriptCore/ConsoleMessage.h>
+#include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/RegularExpression.h>
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <JavaScriptCore/VM.h>
@@ -4594,7 +4595,7 @@ void Document::disableWebAssembly(const String& errorMessage)
     frame->checkedScript()->setWebAssemblyEnabled(false, errorMessage);
 }
 
-void Document::setRequiresTrustedTypes(bool required)
+void Document::setTrustedTypesEnforcement(JSC::TrustedTypesEnforcement enforcement)
 {
     if (!settings().trustedTypesEnabled())
         return;
@@ -4603,8 +4604,8 @@ void Document::setRequiresTrustedTypes(bool required)
     if (!frame)
         return;
 
-    frame->checkedScript()->setRequiresTrustedTypes(required);
-    m_requiresTrustedTypes = required;
+    frame->checkedScript()->setTrustedTypesEnforcement(enforcement);
+    m_requiresTrustedTypes = enforcement != JSC::TrustedTypesEnforcement::None;
 }
 
 IDBClient::IDBConnectionProxy* Document::idbConnectionProxy()

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -851,7 +851,7 @@ public:
 
     void disableEval(const String& errorMessage) final;
     void disableWebAssembly(const String& errorMessage) final;
-    void setRequiresTrustedTypes(bool required) final;
+    void setTrustedTypesEnforcement(JSC::TrustedTypesEnforcement) final;
 
     bool requiresTrustedTypes() const { return m_requiresTrustedTypes; }
 

--- a/Source/WebCore/dom/EmptyScriptExecutionContext.h
+++ b/Source/WebCore/dom/EmptyScriptExecutionContext.h
@@ -31,6 +31,7 @@
 #include "ReferrerPolicy.h"
 #include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
+#include <JavaScriptCore/JSGlobalObject.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -56,21 +57,21 @@ public:
     }
     const URL& url() const final { return m_url; }
     const URL& cookieURL() const final { return url(); }
-    URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final { return { }; };
+    URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final { return { }; }
     String userAgent(const URL&) const final { return emptyString(); }
     ReferrerPolicy referrerPolicy() const final { return ReferrerPolicy::EmptyString; }
 
-    void disableEval(const String&) final { };
-    void disableWebAssembly(const String&) final { };
-    void setRequiresTrustedTypes(bool) final { };
+    void disableEval(const String&) final { }
+    void disableWebAssembly(const String&) final { }
+    void setTrustedTypesEnforcement(JSC::TrustedTypesEnforcement) final { }
 
     IDBClient::IDBConnectionProxy* idbConnectionProxy() final { return nullptr; }
     SocketProvider* socketProvider() final { return nullptr; }
 
     void addConsoleMessage(std::unique_ptr<Inspector::ConsoleMessage>&&) final { }
-    void addConsoleMessage(MessageSource, MessageLevel, const String&, unsigned long) final { };
+    void addConsoleMessage(MessageSource, MessageLevel, const String&, unsigned long) final { }
 
-    SecurityOrigin& topOrigin() const final { return m_origin.get(); };
+    SecurityOrigin& topOrigin() const final { return m_origin.get(); }
 
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const final { return { }; }
     std::optional<uint64_t> noiseInjectionHashSalt() const { return std::nullopt; }
@@ -116,7 +117,7 @@ private:
             return adoptRef(*new EmptyEventLoop(vm));
         }
 
-        MicrotaskQueue& microtaskQueue() final { return m_queue; };
+        MicrotaskQueue& microtaskQueue() final { return m_queue; }
 
     private:
         explicit EmptyEventLoop(JSC::VM& vm)

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -56,6 +56,7 @@ class Exception;
 class JSPromise;
 class VM;
 enum class ScriptExecutionStatus;
+enum class TrustedTypesEnforcement;
 }
 
 namespace Inspector {
@@ -142,7 +143,7 @@ public:
 
     virtual void disableEval(const String& errorMessage) = 0;
     virtual void disableWebAssembly(const String& errorMessage) = 0;
-    virtual void setRequiresTrustedTypes(bool required) = 0;
+    virtual void setTrustedTypesEnforcement(JSC::TrustedTypesEnforcement) = 0;
 
     virtual IDBClient::IDBConnectionProxy* idbConnectionProxy() = 0;
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -88,6 +88,11 @@ enum class AllowTrustedTypePolicy : uint8_t {
     DisallowedDuplicateName,
 };
 
+enum class IncludeReportOnlyPolicies : bool {
+    Yes,
+    No
+};
+
 using HashAlgorithmSet = uint8_t;
 using HashAlgorithmSetCollection = FixedVector<std::pair<HashAlgorithmSet, FixedVector<String>>>;
 
@@ -157,7 +162,7 @@ public:
     bool allowBaseURI(const URL&, bool overrideContentSecurityPolicy = false) const;
 
     AllowTrustedTypePolicy allowTrustedTypesPolicy(const String&, bool isDuplicate) const;
-    bool requireTrustedTypesForSinkGroup(const String& sinkGroup) const;
+    bool requireTrustedTypesForSinkGroup(const String& sinkGroup, IncludeReportOnlyPolicies = IncludeReportOnlyPolicies::Yes) const;
     bool allowMissingTrustedTypesForSinkGroup(const String& stringContext, const String& sink, const String& sinkGroup, StringView source) const;
 
     void setOverrideAllowInlineStyle(bool);
@@ -288,6 +293,7 @@ private:
     bool m_isReportingEnabled { true };
     bool m_upgradeInsecureRequests { false };
     bool m_hasAPIPolicy { false };
+    bool m_trustedEvalEnabled { true };
     int m_httpStatusCode { 0 };
     OptionSet<ContentSecurityPolicyHashAlgorithm> m_hashAlgorithmsForInlineScripts;
     OptionSet<ContentSecurityPolicyHashAlgorithm> m_hashAlgorithmsForInlineStylesheets;

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -57,6 +57,11 @@ static inline bool checkEval(ContentSecurityPolicySourceListDirective* directive
     return !directive || directive->allowEval();
 }
 
+static inline bool checkTrustedEval(ContentSecurityPolicySourceListDirective* directive)
+{
+    return !directive || directive->allowTrustedEval();
+}
+
 static inline bool checkWasmEval(ContentSecurityPolicySourceListDirective* directive)
 {
     return !directive || directive->allowWasmEval();
@@ -155,7 +160,10 @@ std::unique_ptr<ContentSecurityPolicyDirectiveList> ContentSecurityPolicyDirecti
     directives->parse(header, from);
 
     if (!checkEval(directives->operativeDirective(directives->m_scriptSrc.get(), ContentSecurityPolicyDirectiveNames::scriptSrc)))
-        directives->setEvalDisabledErrorMessage(makeString("Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \""_s, directives->operativeDirective(directives->m_scriptSrc.get(), ContentSecurityPolicyDirectiveNames::scriptSrc)->text(), "\".\n"_s));
+        directives->setEvalDisabledErrorMessage(makeString("Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: \""_s, directives->operativeDirective(directives->m_scriptSrc.get(), ContentSecurityPolicyDirectiveNames::scriptSrc)->text(), "\".\n"_s));
+
+    if (checkTrustedEval(directives->operativeDirective(directives->m_scriptSrc.get(), ContentSecurityPolicyDirectiveNames::scriptSrc)))
+        directives->setTrustedEvalEnabled(true);
 
     if (!checkWasmEval(directives->operativeDirective(directives->m_scriptSrc.get(), ContentSecurityPolicyDirectiveNames::scriptSrc)))
         directives->setWebAssemblyDisabledErrorMessage(makeString("Refused to create a WebAssembly object because 'unsafe-eval' or 'wasm-unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \""_s, directives->operativeDirective(directives->m_scriptSrc.get(), ContentSecurityPolicyDirectiveNames::scriptSrc)->text(), "\".\n"_s));

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
@@ -84,6 +84,7 @@ public:
     bool hasBlockAllMixedContentDirective() const { return m_hasBlockAllMixedContentDirective; }
     bool hasFrameAncestorsDirective() const { return !!m_frameAncestors; }
     bool requiresTrustedTypesForScript() const { return m_requireTrustedTypesForScript; }
+    bool trustedEvalEnabled() const { return m_trustedEvalEnabled; }
 
     const String& evalDisabledErrorMessage() const { return m_evalDisabledErrorMessage; }
     const String& webAssemblyDisabledErrorMessage() const { return m_webAssemblyDisabledErrorMessage; }
@@ -126,6 +127,7 @@ private:
 
     void setEvalDisabledErrorMessage(const String& errorMessage) { m_evalDisabledErrorMessage = errorMessage; }
     void setWebAssemblyDisabledErrorMessage(const String& errorMessage) { m_webAssemblyDisabledErrorMessage = errorMessage; }
+    void setTrustedEvalEnabled(const bool& enabled) { m_trustedEvalEnabled = enabled; }
 
     // FIXME: Make this a const reference once we teach applySandboxPolicy() to store its policy as opposed to applying it directly onto ContentSecurityPolicy.
     ContentSecurityPolicy& m_policy;
@@ -138,6 +140,7 @@ private:
     bool m_upgradeInsecureRequests { false };
     bool m_hasBlockAllMixedContentDirective { false };
     bool m_requireTrustedTypesForScript { false };
+    bool m_trustedEvalEnabled { false };
 
     std::unique_ptr<ContentSecurityPolicyMediaListDirective> m_pluginTypes;
     std::unique_ptr<ContentSecurityPolicySourceListDirective> m_baseURI;

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -321,6 +321,11 @@ template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::
         return source;
     }
 
+    if (skipExactlyIgnoringASCIICase(buffer, "'trusted-types-eval'"_s) && extensionModeAllowsKeywordsForDirective(m_contentSecurityPolicyModeForExtension, m_directiveName)) {
+        m_allowTrustedEval = true;
+        return source;
+    }
+
     if (skipExactlyIgnoringASCIICase(buffer, "'wasm-unsafe-eval'"_s) && extensionModeAllowsKeywordsForDirective(m_contentSecurityPolicyModeForExtension, m_directiveName)) {
         m_allowWasmEval = true;
         return source;

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.h
@@ -53,6 +53,7 @@ public:
 
     bool allowInline() const { return m_allowInline && m_hashes.isEmpty() && m_nonces.isEmpty(); }
     bool allowEval() const { return m_allowEval; }
+    bool allowTrustedEval() const { return m_allowTrustedEval; }
     bool allowWasmEval() const { return m_allowWasmEval; }
     bool allowSelf() const { return m_allowSelf; }
     bool isNone() const { return m_isNone; }
@@ -100,6 +101,7 @@ private:
     bool m_allowStar { false };
     bool m_allowInline { false };
     bool m_allowEval { false };
+    bool m_allowTrustedEval { false };
     bool m_allowWasmEval { false };
     bool m_isNone { false };
     bool m_allowNonParserInsertedScripts { false };

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.h
@@ -47,6 +47,7 @@ public:
     bool allows(const String& nonce) const;
     bool allowInline() const { return m_sourceList.allowInline(); }
     bool allowEval() const { return m_sourceList.allowEval(); }
+    bool allowTrustedEval() const { return m_sourceList.allowTrustedEval(); }
     bool allowWasmEval() const { return m_sourceList.allowWasmEval(); }
     bool allowNonParserInsertedScripts() const { return m_sourceList.allowNonParserInsertedScripts(); }
     bool shouldReportSample() const { return m_sourceList.shouldReportSample(); }

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
@@ -103,9 +103,9 @@ void WorkerOrWorkletGlobalScope::disableWebAssembly(const String& errorMessage)
     m_script->disableWebAssembly(errorMessage);
 }
 
-void WorkerOrWorkletGlobalScope::setRequiresTrustedTypes(bool required)
+void WorkerOrWorkletGlobalScope::setTrustedTypesEnforcement(JSC::TrustedTypesEnforcement enforcement)
 {
-    m_script->setRequiresTrustedTypes(required);
+    m_script->setTrustedTypesEnforcement(enforcement);
 }
 
 bool WorkerOrWorkletGlobalScope::isJSExecutionForbidden() const

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
@@ -98,7 +98,7 @@ private:
     // ScriptExecutionContext.
     void disableEval(const String& errorMessage) final;
     void disableWebAssembly(const String& errorMessage) final;
-    void setRequiresTrustedTypes(bool required) final;
+    void setTrustedTypesEnforcement(JSC::TrustedTypesEnforcement) final;
 
     // EventTarget.
     ScriptExecutionContext* scriptExecutionContext() const final { return const_cast<WorkerOrWorkletGlobalScope*>(this); }

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
@@ -210,12 +210,12 @@ void WorkerOrWorkletScriptController::disableWebAssembly(const String& errorMess
     m_globalScopeWrapper->setWebAssemblyEnabled(false, errorMessage);
 }
 
-void WorkerOrWorkletScriptController::setRequiresTrustedTypes(bool required)
+void WorkerOrWorkletScriptController::setTrustedTypesEnforcement(JSC::TrustedTypesEnforcement enforcement)
 {
     initScriptIfNeeded();
     JSLockHolder lock { vm() };
 
-    m_globalScopeWrapper->setRequiresTrustedTypes(required);
+    m_globalScopeWrapper->setTrustedTypesEnforcement(enforcement);
 }
 
 void WorkerOrWorkletScriptController::evaluate(const ScriptSourceCode& sourceCode, String* returnedExceptionMessage)

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.h
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.h
@@ -98,7 +98,7 @@ public:
 
     void disableEval(const String& errorMessage);
     void disableWebAssembly(const String& errorMessage);
-    void setRequiresTrustedTypes(bool required);
+    void setTrustedTypesEnforcement(JSC::TrustedTypesEnforcement);
 
     void evaluate(const ScriptSourceCode&, String* returnedExceptionMessage = nullptr);
     void evaluate(const ScriptSourceCode&, NakedPtr<JSC::Exception>& returnedException, String* returnedExceptionMessage = nullptr);


### PR DESCRIPTION
#### 003226eb1dbf7deec539b13f1fae3864fd4f7a31
<pre>
Implement trusted-types-eval CSP script-src keyword
<a href="https://bugs.webkit.org/show_bug.cgi?id=285603">https://bugs.webkit.org/show_bug.cgi?id=285603</a>

Reviewed by Ryan Reno.

Add a new script-src keyword that allows evaluating strings as JS,
similar to unsafe-eval but with the added requirement that trusted-types
must also be enabled and enforced.

* LayoutTests/http/tests/security/contentSecurityPolicy/block-eval-onload-in-nested-about-blank-iframe-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/eval-blocked-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/eval-blocked-in-about-blank-iframe-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/eval-blocked-in-external-script-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/eval-blocked-in-subframe-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/eval-scripts-setInterval-blocked-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/eval-scripts-setTimeout-blocked-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/function-constructor-blocked-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/module-eval-blocked-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/module-eval-blocked-in-external-script-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/worker-blob-inherits-csp-blocks-eval-expected.txt:
* LayoutTests/http/tests/security/isolatedWorld/image-load-should-not-bypass-main-world-csp-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_report_only_require_trusted_types_eval-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_report_only_require_trusted_types_eval.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_report_only_require_trusted_types_eval.html.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_require_trusted_types_eval-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_require_trusted_types_eval.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_with_require_trusted_types_eval.html.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_without_require_trusted_types_eval-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_without_require_trusted_types_eval.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-trusted_types_eval_without_require_trusted_types_eval.html.headers: Added.
* LayoutTests/security/contentSecurityPolicy/worker-inherits-blocks-eval-expected.txt:
* Source/JavaScriptCore/debugger/DebuggerEvalEnabler.h:
(JSC::DebuggerEvalEnabler::DebuggerEvalEnabler):
(JSC::DebuggerEvalEnabler::~DebuggerEvalEnabler):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::eval):
* Source/JavaScriptCore/runtime/DirectEvalExecutable.cpp:
(JSC::DirectEvalExecutable::create):
* Source/JavaScriptCore/runtime/FunctionConstructor.cpp:
(JSC::constructFunction):
* Source/JavaScriptCore/runtime/IndirectEvalExecutable.cpp:
(JSC::IndirectEvalExecutable::createImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::trustedTypesEnforcement const):
(JSC::JSGlobalObject::setTrustedTypesEnforcement):
(JSC::JSGlobalObject::requiresTrustedTypes const): Deleted.
(JSC::JSGlobalObject::setRequiresTrustedTypes): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::setTrustedTypesEnforcement):
(WebCore::ScriptController::setRequiresTrustedTypes): Deleted.
* Source/WebCore/bindings/js/ScriptController.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setTrustedTypesEnforcement):
(WebCore::Document::setRequiresTrustedTypes): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/EmptyScriptExecutionContext.h:
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::didCreateWindowProxy const):
(WebCore::ContentSecurityPolicy::applyPolicyToScriptExecutionContext):
(WebCore::ContentSecurityPolicy::allowEval const):
(WebCore::ContentSecurityPolicy::requireTrustedTypesForSinkGroup const):
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::checkTrustedEval):
(WebCore::ContentSecurityPolicyDirectiveList::create):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h:
(WebCore::ContentSecurityPolicyDirectiveList::trustedEvalEnabled const):
(WebCore::ContentSecurityPolicyDirectiveList::setTrustedEvalEnabled):
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp:
(WebCore::ContentSecurityPolicySourceList::parseSource):
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.h:
(WebCore::ContentSecurityPolicySourceList::allowTrustedEval const):
* Source/WebCore/page/csp/ContentSecurityPolicySourceListDirective.h:
(WebCore::ContentSecurityPolicySourceListDirective::allowTrustedEval const):
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp:
(WebCore::WorkerOrWorkletGlobalScope::setTrustedTypesEnforcement):
(WebCore::WorkerOrWorkletGlobalScope::setRequiresTrustedTypes): Deleted.
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.h:
* Source/WebCore/workers/WorkerOrWorkletScriptController.cpp:
(WebCore::WorkerOrWorkletScriptController::setTrustedTypesEnforcement):
(WebCore::WorkerOrWorkletScriptController::setRequiresTrustedTypes): Deleted.
* Source/WebCore/workers/WorkerOrWorkletScriptController.h:

Canonical link: <a href="https://commits.webkit.org/292217@main">https://commits.webkit.org/292217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/928d5a16f4e0360d6039669aed978f77a574e2bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100311 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45768 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23298 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72650 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29927 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85995 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52982 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11030 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3732 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45107 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87938 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3827 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102349 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93890 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22315 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16260 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81648 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81046 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20279 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25615 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3012 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15568 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22285 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27411 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116578 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21944 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23683 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->