### PR TITLE
Style change from overflow:scroll to hidden doesn't repaint correctly.

### DIFF
--- a/LayoutTests/compositing/repaint/not-self-painting-layer-stops-compositing-expected.html
+++ b/LayoutTests/compositing/repaint/not-self-painting-layer-stops-compositing-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <style>
+        #inner {
+            background: green;
+            width: 200px;
+            height: 2000px;
+        }
+        #scroller {
+            width: 200px;
+            height: 200px;
+            overflow: hidden;
+        }
+    </style>
+</head>
+<body>
+    <div id="scroller">
+        <div id="inner"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/repaint/not-self-painting-layer-stops-compositing.html
+++ b/LayoutTests/compositing/repaint/not-self-painting-layer-stops-compositing.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        #inner {
+            background: green;
+            width: 200px;
+            height: 2000px;
+        }
+        #scroller {
+            width: 200px;
+            height: 200px;
+            overflow: scroll;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+            if (testRunner.dontForceRepaint)
+                testRunner.dontForceRepaint();
+        }
+        async function doTest()
+        {
+            await UIHelper.renderingUpdate();
+
+            document.getElementById('scroller').style.overflow = "hidden";
+            
+            await UIHelper.renderingUpdate();
+            await UIHelper.renderingUpdate();
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <div id="scroller">
+        <div id="inner"></div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -97,8 +97,9 @@ enum class LayoutUpToDate : bool { No, Yes };
 
 enum class RepaintStatus : uint8_t {
     NeedsNormalRepaint,
+    NeedsFullRepaintForPositionedMovementLayout,
     NeedsFullRepaint,
-    NeedsFullRepaintForPositionedMovementLayout
+    NeedsFullRepaintEvenIfNotSelfPainting,
 };
 
 enum ClipRectsType {
@@ -751,9 +752,13 @@ public:
     
     LayoutRect repaintRectIncludingNonCompositingDescendants() const;
 
-    void setRepaintStatus(RepaintStatus status) { m_repaintStatus = status; }
+    void setRepaintStatus(RepaintStatus status)
+    {
+        if (status > m_repaintStatus)
+            m_repaintStatus = status;
+    }
     RepaintStatus repaintStatus() const { return m_repaintStatus; }
-    bool needsFullRepaint() const { return m_repaintStatus == RepaintStatus::NeedsFullRepaint || m_repaintStatus == RepaintStatus::NeedsFullRepaintForPositionedMovementLayout; }
+    bool needsFullRepaint() const { return m_repaintStatus > RepaintStatus::NeedsNormalRepaint; }
 
     LayoutUnit staticInlinePosition() const { return m_offsetForPosition.width(); }
     LayoutUnit staticBlockPosition() const { return m_offsetForPosition.height(); }

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -244,7 +244,7 @@ public:
     void rootBackgroundColorOrTransparencyChanged();
     
     // Repaint the appropriate layers when the given RenderLayer starts or stops being composited.
-    void repaintOnCompositingChange(RenderLayer&);
+    void repaintOnCompositingChange(RenderLayer&, LayoutUpToDate);
     
     void repaintInCompositedAncestor(RenderLayer&, const LayoutRect&);
     

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -170,7 +170,7 @@ void RenderLayerModelObject::styleDidChange(StyleDifference diff, const RenderSt
         setHasReflection(false);
 
         // Repaint the about to be destroyed self-painting layer when style change also triggers repaint.
-        if (layer()->isSelfPaintingLayer() && layer()->repaintStatus() == RepaintStatus::NeedsFullRepaint && layer()->cachedClippedOverflowRect())
+        if (layer()->isSelfPaintingLayer() && layer()->repaintStatus() >= RepaintStatus::NeedsFullRepaint && layer()->cachedClippedOverflowRect())
             repaintUsingContainer(containerForRepaint().renderer.get(), *(layer()->cachedClippedOverflowRect()));
 
         layer()->removeOnlyThisLayer(); // calls destroyLayer() which clears m_layer


### PR DESCRIPTION
#### e794bc85d3f220020e1140b1791ce3826a65ba8c
<pre>
Style change from overflow:scroll to hidden doesn&apos;t repaint correctly.
<a href="https://bugs.webkit.org/show_bug.cgi?id=285631">https://bugs.webkit.org/show_bug.cgi?id=285631</a>
&lt;<a href="https://rdar.apple.com/140540582">rdar://140540582</a>&gt;

Reviewed by NOBODY (OOPS!).

Changing style from overflow:scroll (creating a compositing layer) to
overflow:hidden (no compositing layer, and not a self painting layer) doesn&apos;t
repaint the content in the ancestor layer.

Trying to issue a repaint at style change time isn&apos;t correct, since layout might
not be valid. We also can&apos;t see &apos;NeedsFullRepaint&apos;, since the style change might also
might the layer not self painting, and repaint requests for those are ignored.

This adds a new stronger repaint flag that isn&apos;t ignored for not-self-painting layers,
and sets that instead.

This ensures that after the next layout, we issue a repaint with the correct coordinates,
in the right repaint container.

* LayoutTests/compositing/repaint/not-self-painting-layer-stops-compositing-expected.html: Added.
* LayoutTests/compositing/repaint/not-self-painting-layer-stops-compositing.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::recursiveUpdateLayerPositions):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::BackingSharingState::issuePendingRepaints):
(WebCore::RenderLayerCompositor::computeCompositingRequirements):
(WebCore::RenderLayerCompositor::layerGainedCompositedScrollableOverflow):
(WebCore::RenderLayerCompositor::layerStyleChanged):
(WebCore::RenderLayerCompositor::updateBacking):
(WebCore::RenderLayerCompositor::updateLayerCompositingState):
(WebCore::RenderLayerCompositor::repaintOnCompositingChange):
* Source/WebCore/rendering/RenderLayerCompositor.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e794bc85d3f220020e1140b1791ce3826a65ba8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89222 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35155 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86231 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11733 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65443 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23282 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2873 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76457 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45736 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2817 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30685 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34203 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90602 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8276 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73896 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11635 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73102 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17412 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2758 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11363 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16841 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11211 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14687 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12983 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->