### PR TITLE
Use smart pointers in WebXROpaqueFramebuffer

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -61,11 +61,11 @@ WebXROpaqueFramebuffer::WebXROpaqueFramebuffer(PlatformXR::LayerHandle handle, R
 
 WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer()
 {
-    if (RefPtr gl = m_context.graphicsContextGL()) {
+    if (RefPtr gl = m_context->graphicsContextGL()) {
         m_drawAttachments.release(*gl);
         m_resolveAttachments.release(*gl);
         m_resolvedFBO.release(*gl);
-        m_context.deleteFramebuffer(m_drawFramebuffer.ptr());
+        m_context->deleteFramebuffer(m_drawFramebuffer.ptr());
     } else {
         // The GraphicsContextGL is gone, so disarm the GCGLOwned objects so
         // their destructors don't assert.
@@ -78,7 +78,7 @@ WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer()
 
 void WebXROpaqueFramebuffer::startFrame(PlatformXR::FrameData::LayerData& data)
 {
-    RefPtr gl = m_context.graphicsContextGL();
+    RefPtr gl = m_context->graphicsContextGL();
     if (!gl)
         return;
 
@@ -122,7 +122,7 @@ void WebXROpaqueFramebuffer::startFrame(PlatformXR::FrameData::LayerData& data)
 
 void WebXROpaqueFramebuffer::endFrame()
 {
-    RefPtr gl = m_context.graphicsContextGL();
+    RefPtr gl = m_context->graphicsContextGL();
     if (!gl)
         return;
 

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -132,7 +132,7 @@ private:
 
     PlatformXR::LayerHandle m_handle;
     Ref<WebGLFramebuffer> m_drawFramebuffer;
-    WebGLRenderingContextBase& m_context;
+    WeakRef<WebGLRenderingContextBase> m_context;
     Attributes m_attributes;
     PlatformXR::Layout m_displayLayout = PlatformXR::Layout::Shared;
     IntSize m_framebufferSize; // Physical Space

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp
@@ -114,12 +114,12 @@ WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer()
 {
     releaseAllDisplayAttachments();
 
-    if (RefPtr gl = m_context.graphicsContextGL()) {
+    if (RefPtr gl = m_context->graphicsContextGL()) {
         m_drawAttachments.release(*gl);
         m_resolveAttachments.release(*gl);
         m_displayFBO.release(*gl);
         m_resolvedFBO.release(*gl);
-        m_context.deleteFramebuffer(m_drawFramebuffer.ptr());
+        m_context->deleteFramebuffer(m_drawFramebuffer.ptr());
     } else {
         // The GraphicsContextGL is gone, so disarm the GCGLOwned objects so
         // their destructors don't assert.
@@ -132,7 +132,7 @@ WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer()
 
 void WebXROpaqueFramebuffer::startFrame(PlatformXR::FrameData::LayerData& data)
 {
-    RefPtr gl = m_context.graphicsContextGL();
+    RefPtr gl = m_context->graphicsContextGL();
     if (!gl)
         return;
 
@@ -197,7 +197,7 @@ void WebXROpaqueFramebuffer::startFrame(PlatformXR::FrameData::LayerData& data)
 
 void WebXROpaqueFramebuffer::endFrame()
 {
-    RefPtr gl = m_context.graphicsContextGL();
+    RefPtr gl = m_context->graphicsContextGL();
     if (!gl)
         return;
 
@@ -393,7 +393,7 @@ bool WebXROpaqueFramebuffer::setupFramebuffer(GraphicsContextGL& gl, const Platf
     const bool needsIntermediateResolve = m_attributes.antialias && layeredLayout;
 
     // Set up recommended samples for WebXR.
-    auto sampleCount = m_attributes.antialias ? std::min(4, m_context.maxSamples()) : 0;
+    auto sampleCount = m_attributes.antialias ? std::min(4, m_context->maxSamples()) : 0;
 
     // Drawing target
     if (framebufferResize) {
@@ -508,7 +508,7 @@ void WebXROpaqueFramebuffer::releaseDisplayAttachmentsAtIndex(size_t index)
     if (index >= m_displayAttachmentsSets.size())
         return;
 
-    RefPtr gl = m_context.graphicsContextGL();
+    RefPtr gl = m_context->graphicsContextGL();
     for (auto& attachments : m_displayAttachmentsSets[index]) {
         if (gl)
             attachments.release(*gl);

--- a/Source/WebCore/html/canvas/WebGLUtilities.h
+++ b/Source/WebCore/html/canvas/WebGLUtilities.h
@@ -229,6 +229,9 @@ public:
 
     ~ScopedWebGLRestoreTexture()
     {
+        if (!m_context->graphicsContextGL() || m_context->m_textureUnits.size() <= m_context->m_activeTextureUnit)
+            return;
+
         auto& textureUnit = m_context->m_textureUnits[m_context->m_activeTextureUnit];
         PlatformGLObject texture = 0;
         switch (m_target) {


### PR DESCRIPTION
#### e3d6e0875a7a26b3fe200084914de415ce5dc1c7
<pre>
Use smart pointers in WebXROpaqueFramebuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=285629">https://bugs.webkit.org/show_bug.cgi?id=285629</a>
<a href="https://rdar.apple.com/122475331">rdar://122475331</a>

Reviewed by Dan Glastonbury.

WebXROpaqueFramebuffer stored a C++ reference to the WebGL context,
but it is not clear who ensures the GL context is retained during
the lifetime of the WebXROpaqueFramebuffer.

Via code inspection, the out of bounds access should only occur
if the reference was invalid or, more likely, WebGLRenderingContextBase::initializeContextState()
was never called, in which case the store / resolve should be a nop.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::WebXROpaqueFramebuffer):
(WebCore::WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer):
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::endFrame):
Bail if the WeakPtr is null.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
Store a WeakPtr instead of a &amp;.

* Source/WebCore/html/canvas/WebGLUtilities.h:
(WebCore::ScopedWebGLRestoreTexture::~ScopedWebGLRestoreTexture):
Ensure we don&apos;t access out of bounds in the texture units.

Canonical link: <a href="https://commits.webkit.org/291611@main">https://commits.webkit.org/291611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a0cc04f82d9b6d9877b78be9f780dbe522a8f88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98445 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43970 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71385 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28767 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9945 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51719 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9627 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2126 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43284 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100476 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20496 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80400 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20748 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80420 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79729 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19821 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24266 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13622 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20480 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25658 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/20167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23627 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/21908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->