### PR TITLE
REGRESSION (285564@main): [macOS wk2 Debug ] fast/events/drag-and-drop-autoscroll-inner-frame.html is flaky failure (failure in EWS)

### DIFF
--- a/LayoutTests/fast/events/drag-and-drop-autoscroll-inner-frame.html
+++ b/LayoutTests/fast/events/drag-and-drop-autoscroll-inner-frame.html
@@ -13,7 +13,7 @@
 var x, y, middleTermScrollOffset;
 var iframe, iframeDocument, draggable;
 
-async function setUpTest()
+function setUpTest()
 {
     if (!window.eventSender) {
         log('Please run within DumpRenderTree');
@@ -22,10 +22,10 @@ async function setUpTest()
 
     window.internals.settings.setAutoscrollForDragAndDropEnabled(true);
     testRunner.waitUntilDone();
-    await testIt();
+    testIt();
 }
 
-async function testIt()
+function testIt()
 {
     eventSender.dragMode = false;
 
@@ -39,27 +39,27 @@ async function testIt()
     x = iframe.offsetLeft + draggable.offsetLeft + 7;
     y = iframe.offsetTop + draggable.offsetTop + 7;
 
-    await eventSender.asyncMouseMoveTo(x, y);
-    await eventSender.asyncMouseDown();
+    eventSender.mouseMoveTo(x, y);
+    eventSender.mouseDown();
 
     // Move mouse to the bottom autoscroll border belt.
     y = iframe.offsetTop + iframe.offsetHeight - 10;
-    await eventSender.asyncMouseMoveTo(x, y);
+    eventSender.mouseMoveTo(x, y);
 }
 
-async function recordScroll(e)
+function recordScroll(e)
 {
     iframeDocument.removeEventListener("scroll", recordScroll);
-    await autoscrollTestPart1();
+    autoscrollTestPart1();
 }
 
-async function recordScroll2(e)
+function recordScroll2(e)
 {
     iframeDocument.removeEventListener("scroll", recordScroll2);
-    await autoscrollTestPart2();
+    autoscrollTestPart2();
 }
 
-async function autoscrollTestPart1()
+function autoscrollTestPart1()
 {
     if (iframe.contentDocument.body.scrollTop == 0) {
         testFailed("Autoscroll should have scrolled the iframe downwards, but did not");
@@ -68,7 +68,7 @@ async function autoscrollTestPart1()
     }
 
     testPassed("Autoscroll should have scrolled the iframe downwards, and did.");
-    await eventSender.asyncMouseUp();
+    eventSender.mouseUp();
     iframeDocument.addEventListener("scroll", recordScroll2);
 
     middleTermScrollOffset = iframe.contentDocument.body.scrollTop;
@@ -78,22 +78,22 @@ async function autoscrollTestPart1()
     y = iframe.offsetTop + draggable.offsetTop + 7 - iframe.contentDocument.body.scrollTop ;
 
     // Move mouse to the upper autoscroll border belt.
-    await eventSender.asyncMouseMoveTo(x, y);
-    await eventSender.asyncMouseDown();
+    eventSender.mouseMoveTo(x, y);
+    eventSender.mouseDown();
 
     y = iframe.offsetTop + 10;
-    await eventSender.asyncMouseMoveTo(x, y);
+    eventSender.mouseMoveTo(x, y);
 }
 
-async function autoscrollTestPart2()
+function autoscrollTestPart2()
 {
     shouldBeTrue("iframe.contentDocument.body.scrollTop < middleTermScrollOffset")
-    await finishTest();
+    finishTest();
 }
 
-async function finishTest()
+function finishTest()
 {
-    await eventSender.asyncMouseUp();
+    eventSender.mouseUp();
     testRunner.notifyDone();
 }
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1897,9 +1897,6 @@ media/remote-control-command-is-user-gesture.html [ Timeout ]
 [ Sequoia+ x86_64 ] swipe/navigate-event-back-swipe-verify-ua-transition.html [ Timeout ]
 [ Sequoia+ x86_64 ] swipe/pushState-back-swipe-verify-ua-transition.html [ Timeout ]
 
-# webkit.org/b/282477 [macOS wk2 Debug ] fast/events/drag-and-drop-autoscroll-inner-frame.html is flaky failure (failure in EWS)
-fast/events/drag-and-drop-autoscroll-inner-frame.html [ Pass Failure ]
-
 webkit.org/b/282565 [ Sequoia+ ] imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-sideways-001.html [ ImageOnlyFailure ]
 
 webkit.org/b/282726 http/tests/media/fairplay/legacy-fairplay-hls.html [ Failure ]


### PR DESCRIPTION
#### 8fdc9562c4cafb2302fd675dfb55231d3e4b32bf
<pre>
REGRESSION (285564@main): [macOS wk2 Debug ] fast/events/drag-and-drop-autoscroll-inner-frame.html is flaky failure (failure in EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=282477">https://bugs.webkit.org/show_bug.cgi?id=282477</a>
<a href="https://rdar.apple.com/139103421">rdar://139103421</a>

Unreviewed.

Revert the changes made to one of the tests modified in 285564@main.

* LayoutTests/fast/events/drag-and-drop-autoscroll-inner-frame.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/288624@main">https://commits.webkit.org/288624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcc5739b45beece4b206a5e40e5015985bde3f5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89032 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34965 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11542 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65303 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Passed layout tests; 19 flakes 100 failures; Uploaded test results; 25 flakes 64 failures; Running compile-webkit-without-change") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23140 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45597 "Passed tests") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2657 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 4 new passes 4 flakes 5 failures; Uploaded test results; Running re-run-layout-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30511 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34014 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90408 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11222 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8124 "Build is in progress. Recent messages:OS: Sequoia (15.0.1), Xcode: 16.0; Running apply-patch; Checked out pull request; Passed layout tests; Running layout-tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72117 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/72972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17260 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2560 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12984 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11174 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11022 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14498 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12794 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->