### PR TITLE
Invalidate CGIOSurfaceContext when the IOSurface is mutated.

### DIFF
--- a/Source/WebCore/PAL/pal/cg/CoreGraphicsSoftLink.cpp
+++ b/Source/WebCore/PAL/pal/cg/CoreGraphicsSoftLink.cpp
@@ -39,8 +39,12 @@ SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, CoreGraphics, PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreGraphics, CGContextSetOwnerIdentity, void, (CGContextRef context, task_id_token_t owner), (context, owner), PAL_EXPORT)
 #endif
 
-#if USE(CG) && PLATFORM(MAC)
+#if PLATFORM(MAC)
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, CoreGraphics, CGWindowListCreateImage, CGImageRef, (CGRect screenBounds, CGWindowListOption listOption, CGWindowID windowID, CGWindowImageOption imageOption), (screenBounds, listOption, windowID, imageOption), PAL_EXPORT)
+#endif
+
+#if HAVE(IOSURFACE)
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, CoreGraphics, CGIOSurfaceContextInvalidateSurface, void, (CGContextRef context), (context), PAL_EXPORT)
 #endif
 
 #endif

--- a/Source/WebCore/PAL/pal/cg/CoreGraphicsSoftLink.h
+++ b/Source/WebCore/PAL/pal/cg/CoreGraphicsSoftLink.h
@@ -40,8 +40,12 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreGraphics, CGContextSetOwnerIdentity, void
 #define CGContextSetOwnerIdentity PAL::softLink_CoreGraphics_CGContextSetOwnerIdentity
 #endif
 
-#if USE(CG) && PLATFORM(MAC)
+#if PLATFORM(MAC)
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(PAL, CoreGraphics, CGWindowListCreateImage, CGImageRef, (CGRect screenBounds, CGWindowListOption listOption, CGWindowID windowID, CGWindowImageOption imageOption), (screenBounds, listOption, windowID, imageOption))
+#endif
+
+#if HAVE(IOSURFACE)
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(PAL, CoreGraphics, CGIOSurfaceContextInvalidateSurface, void, (CGContextRef context), (context))
 #endif
 
 #endif

--- a/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
@@ -343,6 +343,7 @@ CGImageRef CGIOSurfaceContextCreateImageReference(CGContextRef);
 CGColorSpaceRef CGIOSurfaceContextGetColorSpace(CGContextRef);
 void CGIOSurfaceContextSetDisplayMask(CGContextRef, uint32_t mask);
 IOSurfaceRef CGIOSurfaceContextGetSurface(CGContextRef);
+void CGIOSurfaceContextInvalidateSurface(CGContextRef);
 #endif // HAVE(IOSURFACE)
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -81,7 +81,8 @@ protected:
 
     unsigned bytesPerRow() const override;
 
-    void invalidateCachedNativeImage();
+    // Returns true if this invalidation requires a flush to complete
+    bool invalidateCachedNativeImage();
     void prepareForExternalRead();
     void prepareForExternalWrite();
 


### PR DESCRIPTION
#### f5eb03df43ddddb4df474ca8f2817b546a0c4add
<pre>
Invalidate CGIOSurfaceContext when the IOSurface is mutated.
<a href="https://bugs.webkit.org/show_bug.cgi?id=285637">https://bugs.webkit.org/show_bug.cgi?id=285637</a>
&lt;<a href="https://rdar.apple.com/142515275">rdar://142515275</a>&gt;

Reviewed by Simon Fraser.

* Source/WebCore/PAL/pal/cg/CoreGraphicsSoftLink.cpp:
* Source/WebCore/PAL/pal/cg/CoreGraphicsSoftLink.h:
* Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::invalidateCachedNativeImage):
(WebCore::ImageBufferIOSurfaceBackend::prepareForExternalWrite):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:

Canonical link: <a href="https://commits.webkit.org/288670@main">https://commits.webkit.org/288670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/989e4fa9cc785f83af168fff806edc4a23dcc807

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89042 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34975 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65315 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23149 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45601 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30517 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34024 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73637 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90418 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8130 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73757 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72973 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18065 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17265 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2570 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11184 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16656 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11032 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14508 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12804 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->