### PR TITLE
Regression(288466@main) ASSERT(valueLength > 0) is hit in parseParameterValue()

### DIFF
--- a/LayoutTests/http/tests/text/font-preloading-via-header-empty-value-crash-expected.txt
+++ b/LayoutTests/http/tests/text/font-preloading-via-header-empty-value-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/http/tests/text/font-preloading-via-header-empty-value-crash.html
+++ b/LayoutTests/http/tests/text/font-preloading-via-header-empty-value-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+This test passes if it doesn't crash.
+<iframe src="resources/font-preloading-via-header-empty-value-crash-iframe.py"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/text/resources/font-preloading-via-header-empty-value-crash-iframe.py
+++ b/LayoutTests/http/tests/text/resources/font-preloading-via-header-empty-value-crash-iframe.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.stdout.write(
+    'Link: <http://127.0.0.1:8000/resources/font.ttf>; as=""; type="font/ttf"\r\n'
+    'Content-Type: text/html\r\n'
+    '\r\n'
+    'TEST\n'
+)

--- a/Source/WebCore/loader/LinkHeader.cpp
+++ b/Source/WebCore/loader/LinkHeader.cpp
@@ -254,7 +254,6 @@ template<typename CharacterType> static bool parseParameterValue(StringParsingBu
         ASSERT(valueLength);
         --valueLength;
     }
-    ASSERT(valueLength > 0);
     value = String(valueStart.first(valueLength));
     return !hasQuotes || completeQuotes;
 }


### PR DESCRIPTION
#### 25cee58a0e3b7acd0c1fd3271753b193a368fdd7
<pre>
Regression(288466@main) ASSERT(valueLength &gt; 0) is hit in parseParameterValue()
<a href="https://bugs.webkit.org/show_bug.cgi?id=285640">https://bugs.webkit.org/show_bug.cgi?id=285640</a>
<a href="https://rdar.apple.com/142559962">rdar://142559962</a>

Reviewed by Ryosuke Niwa.

In 288466@main, I updated LinkHeader.cpp&apos;s parseParameterValue() to address unsafe buffer warnings.
One of the changes made was to stop using pointer arithmetics and use an index in the span instead.
However, I made a mistake and converted this assertion:
```
ASSERT(valueEnd &gt;= valueStart);
```
into
```
ASSERT(valueLength &gt; 0);
```

The equivalent check would have been `valueLength &gt;= 0` but since `valueLength` is of unsigned
type so it is always true. Therefore, I am dropping the assertion. We already make sure that
`valueLength` is non-zero whenever we decrement it.

* LayoutTests/http/tests/text/font-preloading-via-header-empty-value-crash-expected.txt: Added.
* LayoutTests/http/tests/text/font-preloading-via-header-empty-value-crash.html: Added.
* LayoutTests/http/tests/text/resources/font-preloading-via-header-empty-value-crash-iframe.py: Added.
* Source/WebCore/loader/LinkHeader.cpp:
(WebCore::parseParameterValue):

Canonical link: <a href="https://commits.webkit.org/288635@main">https://commits.webkit.org/288635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f468600b83bd4eb73c00674436da4fd9eacebb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89069 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35002 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11580 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65327 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23168 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76319 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45620 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2689 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30542 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34051 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90447 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8149 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73778 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/72996 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17286 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2598 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12993 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11211 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16683 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11059 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14535 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12831 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->