### PR TITLE
Export functions needed to print `Site`

### DIFF
--- a/Source/WebCore/platform/Site.cpp
+++ b/Source/WebCore/platform/Site.cpp
@@ -52,9 +52,15 @@ bool Site::matches(const URL& url) const
     return url.protocol() == m_protocol && m_domain.matches(url);
 }
 
-String Site::string() const
+String Site::toString() const
 {
     return isEmpty() ? emptyString() : makeString(m_protocol, "://"_s, m_domain.string());
+}
+
+TextStream& operator<<(TextStream& ts, const Site& site)
+{
+    ts << site.toString();
+    return ts;
 }
 
 } // namespace WebKit

--- a/Source/WebCore/platform/Site.h
+++ b/Source/WebCore/platform/Site.h
@@ -42,7 +42,7 @@ public:
 
     const String& protocol() const { return m_protocol; }
     const RegistrableDomain& domain() const { return m_domain; }
-    String string() const;
+    WEBCORE_EXPORT String toString() const;
     bool isEmpty() const { return m_domain.isEmpty(); }
     WEBCORE_EXPORT bool matches(const URL&) const;
 
@@ -65,6 +65,8 @@ private:
     String m_protocol;
     RegistrableDomain m_domain;
 };
+
+WEBCORE_EXPORT TextStream& operator<<(TextStream&, const Site&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -232,7 +232,7 @@ bool NetworkStorageSession::shouldExemptDomainPairFromThirdPartyCookieBlocking(c
 
 String NetworkStorageSession::cookiePartitionIdentifier(const URL& firstPartyForCookies)
 {
-    return Site { firstPartyForCookies }.string();
+    return Site { firstPartyForCookies }.toString();
 }
 
 String NetworkStorageSession::cookiePartitionIdentifier(const ResourceRequest& request)


### PR DESCRIPTION
#### e9079147c3f5890864c3ce563af2ed9588a768e1
<pre>
Export functions needed to print `Site`
<a href="https://bugs.webkit.org/show_bug.cgi?id=285644">https://bugs.webkit.org/show_bug.cgi?id=285644</a>
<a href="https://rdar.apple.com/142585812">rdar://142585812</a>

Reviewed by Alex Christensen.

This is needed to print Site with WTFLogAlways and ALWAYS_LOG_WITH_STREAM outside of WebCore.

* Source/WebCore/platform/Site.cpp:
(WebCore::Site::toString const):
(WebCore::operator&lt;&lt;):
(WebCore::Site::string const): Deleted.
* Source/WebCore/platform/Site.h:
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::cookiePartitionIdentifier):

Canonical link: <a href="https://commits.webkit.org/288631@main">https://commits.webkit.org/288631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c676694e34b164da9775abb39b5a363cfbbb5e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89067 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35000 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11578 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23165 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76316 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45619 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30539 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34049 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/31297 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90444 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11257 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8147 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73774 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72145 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/72990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17282 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2596 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12990 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11209 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/16681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11057 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14533 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12829 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->