### PR TITLE
Remove LazyIframeLoadingEnabled preference

### DIFF
--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt
@@ -968,7 +968,7 @@ PASS HTMLIFrameElement interface: attribute allowFullscreen
 PASS HTMLIFrameElement interface: attribute width
 PASS HTMLIFrameElement interface: attribute height
 PASS HTMLIFrameElement interface: attribute referrerPolicy
-FAIL HTMLIFrameElement interface: attribute loading assert_true: The prototype object must have a property "loading" expected true got false
+PASS HTMLIFrameElement interface: attribute loading
 PASS HTMLIFrameElement interface: attribute contentDocument
 PASS HTMLIFrameElement interface: attribute contentWindow
 PASS HTMLIFrameElement interface: operation getSVGDocument()
@@ -989,7 +989,7 @@ PASS HTMLIFrameElement interface: document.createElement("iframe") must inherit 
 PASS HTMLIFrameElement interface: document.createElement("iframe") must inherit property "width" with the proper type
 PASS HTMLIFrameElement interface: document.createElement("iframe") must inherit property "height" with the proper type
 PASS HTMLIFrameElement interface: document.createElement("iframe") must inherit property "referrerPolicy" with the proper type
-FAIL HTMLIFrameElement interface: document.createElement("iframe") must inherit property "loading" with the proper type assert_inherits: property "loading" not found in prototype chain
+PASS HTMLIFrameElement interface: document.createElement("iframe") must inherit property "loading" with the proper type
 PASS HTMLIFrameElement interface: document.createElement("iframe") must inherit property "contentDocument" with the proper type
 PASS HTMLIFrameElement interface: document.createElement("iframe") must inherit property "contentWindow" with the proper type
 PASS HTMLIFrameElement interface: document.createElement("iframe") must inherit property "getSVGDocument()" with the proper type

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Multiple queued lazy load navigations do not crash the page assert_true: The iframe's src should be updated to reflect the latest `src` mutation expected true got false
+FAIL Multiple queued lazy load navigations do not crash the page assert_true: The iframe should be navigated to the resource provided by the latest `src` mutation expected true got false
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4210,20 +4210,6 @@ LayoutViewportHeightExpansionFactor:
     WebCore:
       default: 0
 
-LazyIframeLoadingEnabled:
-  type: bool
-  status: stable
-  category: html
-  humanReadableName: "Lazy iframe loading"
-  humanReadableDescription: "Enable lazy iframe loading support"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 LazyImageLoadingEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -184,12 +184,12 @@ ReferrerPolicy HTMLIFrameElement::referrerPolicy() const
     return parseReferrerPolicy(attributeWithoutSynchronization(referrerpolicyAttr), ReferrerPolicySource::ReferrerPolicyAttribute).value_or(ReferrerPolicy::EmptyString);
 }
 
-const AtomString& HTMLIFrameElement::loadingForBindings() const
+const AtomString& HTMLIFrameElement::loading() const
 {
     return equalLettersIgnoringASCIICase(attributeWithoutSynchronization(HTMLNames::loadingAttr), "lazy"_s) ? lazyAtom() : eagerAtom();
 }
 
-void HTMLIFrameElement::setLoadingForBindings(const AtomString& value)
+void HTMLIFrameElement::setLoading(const AtomString& value)
 {
     setAttributeWithoutSynchronization(loadingAttr, value);
 }
@@ -223,7 +223,7 @@ static bool isFrameLazyLoadable(const Document& document, const URL& url, const 
 
 bool HTMLIFrameElement::shouldLoadFrameLazily()
 {
-    if (!m_lazyLoadFrameObserver && document().settings().lazyIframeLoadingEnabled() && !document().quirks().shouldDisableLazyIframeLoadingQuirk()) {
+    if (!m_lazyLoadFrameObserver && !document().quirks().shouldDisableLazyIframeLoadingQuirk()) {
         URL completeURL = document().completeURL(frameURL());
         if (isFrameLazyLoadable(document(), completeURL, attributeWithoutSynchronization(HTMLNames::loadingAttr))) {
             auto currentReferrerPolicy = referrerPolicy();

--- a/Source/WebCore/html/HTMLIFrameElement.h
+++ b/Source/WebCore/html/HTMLIFrameElement.h
@@ -46,8 +46,8 @@ public:
     String referrerPolicyForBindings() const;
     ReferrerPolicy referrerPolicy() const final;
 
-    const AtomString& loadingForBindings() const;
-    void setLoadingForBindings(const AtomString&);
+    const AtomString& loading() const;
+    void setLoading(const AtomString&);
 
     String srcdoc() const;
     ExceptionOr<void> setSrcdoc(std::variant<RefPtr<TrustedHTML>, String>&&);

--- a/Source/WebCore/html/HTMLIFrameElement.idl
+++ b/Source/WebCore/html/HTMLIFrameElement.idl
@@ -33,7 +33,7 @@
     [Reflect, CEReactions=NotNeeded] attribute DOMString width;
     [Reflect, CEReactions=NotNeeded] attribute DOMString height;
     [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings] attribute [AtomString] DOMString referrerPolicy;
-    [CEReactions=NotNeeded, EnabledBySetting=LazyIframeLoadingEnabled, ImplementedAs=loadingForBindings] attribute [AtomString] DOMString loading;
+    [CEReactions=NotNeeded] attribute [AtomString] DOMString loading;
     [CheckSecurityForNode] readonly attribute Document? contentDocument;
     readonly attribute WindowProxy? contentWindow;
     [CheckSecurityForNode] Document? getSVGDocument();

--- a/Tools/DumpRenderTree/TestOptions.cpp
+++ b/Tools/DumpRenderTree/TestOptions.cpp
@@ -124,7 +124,6 @@ const TestFeatures& TestOptions::defaults()
             { "DigitalCredentialsEnabled", false },
             { "GenericCueAPIEnabled", false },
             { "LoginStatusAPIEnabled", false },
-            { "LazyIframeLoadingEnabled", false },
             { "LazyImageLoadingEnabled", false },
             { "RequestIdleCallbackEnabled", false },
             { "WebAuthenticationEnabled", false },


### PR DESCRIPTION
#### c5eb9e77b856d060bff1a846c36681c125c91cd4
<pre>
Remove LazyIframeLoadingEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=285659">https://bugs.webkit.org/show_bug.cgi?id=285659</a>

Reviewed by Ryosuke Niwa.

It&apos;s been stable for over a year. Also remove ImplementedAs from IDL as
it&apos;s not needed.

* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/dom/idlharness.https_include=HTML._-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::loading const):
(WebCore::HTMLIFrameElement::setLoading):
(WebCore::HTMLIFrameElement::shouldLoadFrameLazily):
(WebCore::HTMLIFrameElement::loadingForBindings const): Deleted.
(WebCore::HTMLIFrameElement::setLoadingForBindings): Deleted.
* Source/WebCore/html/HTMLIFrameElement.h:
* Source/WebCore/html/HTMLIFrameElement.idl:
* Tools/DumpRenderTree/TestOptions.cpp:
(WTR::TestOptions::defaults):

Canonical link: <a href="https://commits.webkit.org/288664@main">https://commits.webkit.org/288664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0952cd558a488b8a71176297c0a025b8bbcef85d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89127 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35060 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11638 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65372 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23215 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76373 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45665 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30597 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34109 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77016 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90507 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83069 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11317 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8200 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72202 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17339 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2664 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13007 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11269 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16741 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105488 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11117 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25484 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14593 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12889 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->