### PR TITLE
[GStreamer] Get rid of GST_CALL_PARENT macros

### DIFF
--- a/Source/WebCore/platform/SourcesGStreamer.txt
+++ b/Source/WebCore/platform/SourcesGStreamer.txt
@@ -46,10 +46,10 @@ platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
 platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
 platform/audio/gstreamer/FFTFrameGStreamer.cpp
 platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
-platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp @no-unify
+platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
 
 platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
-platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp @no-unify
+platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
 platform/graphics/gstreamer/GRefPtrGStreamer.cpp
 platform/graphics/gstreamer/GStreamerAudioMixer.cpp
 platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -66,25 +66,25 @@ platform/graphics/gstreamer/MediaEngineConfigurationFactoryGStreamer.cpp
 platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
 platform/graphics/gstreamer/MediaSampleGStreamer.cpp
 platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp
-platform/graphics/gstreamer/TextCombinerGStreamer.cpp @no-unify
-platform/graphics/gstreamer/TextCombinerPadGStreamer.cpp @no-unify
-platform/graphics/gstreamer/TextSinkGStreamer.cpp @no-unify
+platform/graphics/gstreamer/TextCombinerGStreamer.cpp
+platform/graphics/gstreamer/TextCombinerPadGStreamer.cpp
+platform/graphics/gstreamer/TextSinkGStreamer.cpp
 platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
 platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
 platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
 platform/graphics/gstreamer/VideoFrameGStreamer.cpp
 platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
-platform/graphics/gstreamer/VideoSinkGStreamer.cpp @no-unify
+platform/graphics/gstreamer/VideoSinkGStreamer.cpp
 platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
-platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp @no-unify
-platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp @no-unify
+platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
+platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
 
 platform/graphics/gstreamer/eme/CDMFactoryGStreamer.cpp
 platform/graphics/gstreamer/eme/CDMProxyThunder.cpp
 platform/graphics/gstreamer/eme/CDMThunder.cpp
 platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
 platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
-platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp @no-unify
+platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
 
 platform/graphics/gstreamer/mse/AppendPipeline.cpp
 platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp
@@ -94,7 +94,7 @@ platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
 platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.cpp
 platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
 platform/graphics/gstreamer/mse/TrackQueue.cpp
-platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp @no-unify
+platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
 
 platform/gstreamer/GStreamerCodecUtilities.cpp
 platform/gstreamer/GStreamerElementHarness.cpp
@@ -110,8 +110,8 @@ platform/gstreamer/GStreamerQuirkRialto.cpp
 platform/gstreamer/GStreamerQuirkWesteros.cpp
 platform/gstreamer/GStreamerQuirks.cpp
 platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
-platform/gstreamer/VideoEncoderPrivateGStreamer.cpp @no-unify
-platform/gstreamer/WebKitFliteSourceGStreamer.cpp @no-unify
+platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+platform/gstreamer/WebKitFliteSourceGStreamer.cpp
 
 platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
 
@@ -133,9 +133,9 @@ platform/mediastream/gstreamer/GStreamerCapturer.cpp
 platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.cpp
 platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp
 platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
-platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp @no-unify
-platform/mediastream/gstreamer/GStreamerMockDevice.cpp @no-unify
-platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp @no-unify
+platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+platform/mediastream/gstreamer/GStreamerMockDevice.cpp
+platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
 platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
 platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
 platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp

--- a/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
@@ -53,7 +53,7 @@ struct _WebKitWebAudioSrcClass {
     GstBinClass parentClass;
 };
 
-static GstStaticPadTemplate srcTemplate = GST_STATIC_PAD_TEMPLATE("src",
+static GstStaticPadTemplate webAudioSrcTemplate = GST_STATIC_PAD_TEMPLATE("src",
     GST_PAD_SRC,
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS(GST_AUDIO_CAPS_MAKE(GST_AUDIO_NE(F32))));
@@ -90,7 +90,7 @@ struct _WebKitWebAudioSrcPrivate {
 
     _WebKitWebAudioSrcPrivate()
     {
-        sourcePad = webkitGstGhostPadFromStaticTemplate(&srcTemplate, "src", nullptr);
+        sourcePad = webkitGstGhostPadFromStaticTemplate(&webAudioSrcTemplate, "src", nullptr);
 
         g_rec_mutex_init(&mutex);
     }
@@ -163,7 +163,6 @@ static GstCaps* getGStreamerAudioCaps(float sampleRate, unsigned numberOfChannel
         "layout", G_TYPE_STRING, "non-interleaved", nullptr);
 }
 
-#define webkit_web_audio_src_parent_class parent_class
 WEBKIT_DEFINE_TYPE_WITH_CODE(WebKitWebAudioSrc, webkit_web_audio_src, GST_TYPE_BIN, GST_DEBUG_CATEGORY_INIT(webkit_web_audio_src_debug, "webkitwebaudiosrc", 0, "webaudiosrc element"))
 
 static void webkit_web_audio_src_class_init(WebKitWebAudioSrcClass* webKitWebAudioSrcClass)
@@ -171,7 +170,7 @@ static void webkit_web_audio_src_class_init(WebKitWebAudioSrcClass* webKitWebAud
     GObjectClass* objectClass = G_OBJECT_CLASS(webKitWebAudioSrcClass);
     GstElementClass* elementClass = GST_ELEMENT_CLASS(webKitWebAudioSrcClass);
 
-    gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&srcTemplate));
+    gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&webAudioSrcTemplate));
     gst_element_class_set_metadata(elementClass, "WebKit WebAudio source element", "Source", "Handles WebAudio data from WebCore", "Philippe Normand <pnormand@igalia.com>");
 
     objectClass->constructed = webKitWebAudioSrcConstructed;
@@ -199,7 +198,7 @@ static void webkit_web_audio_src_class_init(WebKitWebAudioSrcClass* webKitWebAud
 
 static void webKitWebAudioSrcConstructed(GObject* object)
 {
-    GST_CALL_PARENT(G_OBJECT_CLASS, constructed, (object));
+    G_OBJECT_CLASS(webkit_web_audio_src_parent_class)->constructed(object);
 
     WebKitWebAudioSrc* src = WEBKIT_WEB_AUDIO_SRC(object);
     WebKitWebAudioSrcPrivate* priv = src->priv;
@@ -430,7 +429,7 @@ static GstStateChangeReturn webKitWebAudioSrcChangeState(GstElement* element, Gs
         break;
     }
 
-    returnValue = GST_ELEMENT_CLASS(parent_class)->change_state(element, transition);
+    returnValue = GST_ELEMENT_CLASS(webkit_web_audio_src_parent_class)->change_state(element, transition);
     if (UNLIKELY(returnValue == GST_STATE_CHANGE_FAILURE)) {
         GST_DEBUG_OBJECT(src, "State change failed");
         return returnValue;

--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -41,9 +41,9 @@
 using namespace WebCore;
 
 enum {
-    PROP_0,
-    PROP_STATS,
-    PROP_LAST
+    WEBKIT_GL_VIDEO_SINK_PROP_0,
+    WEBKIT_GL_VIDEO_SINK_PROP_STATS,
+    WEBKIT_GL_VIDEO_SINK_PROP_LAST
 };
 
 struct _WebKitGLVideoSinkPrivate {
@@ -55,9 +55,8 @@ GST_DEBUG_CATEGORY_STATIC(webkit_gl_video_sink_debug);
 #define GST_CAT_DEFAULT webkit_gl_video_sink_debug
 
 #define GST_GL_CAPS_FORMAT "{ A420, RGBx, RGBA, I420, Y444, YV12, Y41B, Y42B, NV12, NV21, VUYA }"
-static GstStaticPadTemplate sinkTemplate = GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
+static GstStaticPadTemplate glVideoSinkTemplate = GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
 
-#define webkit_gl_video_sink_parent_class parent_class
 WEBKIT_DEFINE_TYPE_WITH_CODE(WebKitGLVideoSink, webkit_gl_video_sink, GST_TYPE_BIN,
     GST_DEBUG_CATEGORY_INIT(webkit_gl_video_sink_debug, "webkitglvideosink", 0, "GL video sink element"))
 
@@ -81,7 +80,7 @@ static void initializeDMABufAvailability()
 
 static void webKitGLVideoSinkConstructed(GObject* object)
 {
-    GST_CALL_PARENT(G_OBJECT_CLASS, constructed, (object));
+    G_OBJECT_CLASS(webkit_gl_video_sink_parent_class)->constructed(object);
 
     WebKitGLVideoSink* sink = WEBKIT_GL_VIDEO_SINK(object);
 
@@ -149,7 +148,7 @@ void webKitGLVideoSinkFinalize(GObject* object)
 
     GST_DEBUG_OBJECT(object, "WebKitGLVideoSink finalized.");
 
-    GST_CALL_PARENT(G_OBJECT_CLASS, finalize, (object));
+    G_OBJECT_CLASS(webkit_gl_video_sink_parent_class)->finalize(object);
 }
 
 static GstStateChangeReturn webKitGLVideoSinkChangeState(GstElement* element, GstStateChange transition)
@@ -170,7 +169,7 @@ static GstStateChangeReturn webKitGLVideoSinkChangeState(GstElement* element, Gs
         break;
     }
 
-    return GST_ELEMENT_CLASS(parent_class)->change_state(element, transition);
+    return GST_ELEMENT_CLASS(webkit_gl_video_sink_parent_class)->change_state(element, transition);
 }
 
 static void webKitGLVideoSinkGetProperty(GObject* object, guint propertyId, GValue* value, GParamSpec* paramSpec)
@@ -178,7 +177,7 @@ static void webKitGLVideoSinkGetProperty(GObject* object, guint propertyId, GVal
     WebKitGLVideoSink* sink = WEBKIT_GL_VIDEO_SINK(object);
 
     switch (propertyId) {
-    case PROP_STATS: {
+    case WEBKIT_GL_VIDEO_SINK_PROP_STATS: {
         GUniqueOutPtr<GstStructure> stats;
         g_object_get(sink->priv->appSink.get(), "stats", &stats.outPtr(), nullptr);
         gst_value_set_structure(value, stats.get());
@@ -200,11 +199,11 @@ static void webkit_gl_video_sink_class_init(WebKitGLVideoSinkClass* klass)
     objectClass->finalize = webKitGLVideoSinkFinalize;
     objectClass->get_property = webKitGLVideoSinkGetProperty;
 
-    gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&sinkTemplate));
+    gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&glVideoSinkTemplate));
     gst_element_class_set_static_metadata(elementClass, "WebKit GL video sink", "Sink/Video", "Renders video", "Philippe Normand <philn@igalia.com>");
 
-    g_object_class_install_property(objectClass, PROP_STATS, g_param_spec_boxed("stats",
-        nullptr, nullptr, GST_TYPE_STRUCTURE, static_cast<GParamFlags>(G_PARAM_READABLE | G_PARAM_STATIC_STRINGS)));
+    g_object_class_install_property(objectClass, WEBKIT_GL_VIDEO_SINK_PROP_STATS, g_param_spec_boxed("stats", nullptr,
+        nullptr, GST_TYPE_STRUCTURE, static_cast<GParamFlags>(G_PARAM_READABLE | G_PARAM_STATIC_STRINGS)));
 
     elementClass->change_state = GST_DEBUG_FUNCPTR(webKitGLVideoSinkChangeState);
 }

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
@@ -317,7 +317,6 @@ void installBaseSinkPositionFlushWorkaroundIfNeeded(GstBaseSink* basesink)
 struct WebKitAppSinkWithWorkaroundsPrivate {
 };
 
-#define webkit_app_sink_with_workarounds_parent_class parent_class
 WEBKIT_DEFINE_TYPE(WebKitAppSinkWithWorkarounds, webkit_app_sink_with_workarounds, GST_TYPE_APP_SINK);
 
 static void webkitAppSinkWithWorkAroundsConstructed(GObject* object)

--- a/Source/WebCore/platform/graphics/gstreamer/TextCombinerGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TextCombinerGStreamer.cpp
@@ -33,9 +33,9 @@
 #include "TextCombinerPadGStreamer.h"
 #include <wtf/glib/WTFGType.h>
 
-static GstStaticPadTemplate sinkTemplate = GST_STATIC_PAD_TEMPLATE("sink_%u", GST_PAD_SINK, GST_PAD_REQUEST, GST_STATIC_CAPS_ANY);
+static GstStaticPadTemplate combinerSinkTemplate = GST_STATIC_PAD_TEMPLATE("sink_%u", GST_PAD_SINK, GST_PAD_REQUEST, GST_STATIC_CAPS_ANY);
 
-static GstStaticPadTemplate srcTemplate = GST_STATIC_PAD_TEMPLATE("src", GST_PAD_SRC, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
+static GstStaticPadTemplate combinerSrcTemplate = GST_STATIC_PAD_TEMPLATE("src", GST_PAD_SRC, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
 
 GST_DEBUG_CATEGORY_STATIC(webkitTextCombinerDebug);
 #define GST_CAT_DEFAULT webkitTextCombinerDebug
@@ -44,7 +44,6 @@ struct _WebKitTextCombinerPrivate {
     GRefPtr<GstElement> combinerElement;
 };
 
-#define webkit_text_combiner_parent_class parent_class
 WEBKIT_DEFINE_TYPE_WITH_CODE(WebKitTextCombiner, webkit_text_combiner, GST_TYPE_BIN,
     GST_DEBUG_CATEGORY_INIT(webkitTextCombinerDebug, "webkittextcombiner", 0, "webkit text combiner"))
 
@@ -180,7 +179,7 @@ static void webkitTextCombinerReleasePad(GstElement* element, GstPad* pad)
 
 static void webKitTextCombinerConstructed(GObject* object)
 {
-    GST_CALL_PARENT(G_OBJECT_CLASS, constructed, (object));
+    G_OBJECT_CLASS(webkit_text_combiner_parent_class)->constructed(object);
 
     auto* combiner = WEBKIT_TEXT_COMBINER(object);
     auto* priv = combiner->priv;
@@ -204,8 +203,8 @@ static void webkit_text_combiner_class_init(WebKitTextCombinerClass* klass)
 
     objectClass->constructed = webKitTextCombinerConstructed;
 
-    gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&sinkTemplate));
-    gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&srcTemplate));
+    gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&combinerSinkTemplate));
+    gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&combinerSrcTemplate));
 
     gst_element_class_set_metadata(elementClass, "WebKit text combiner", "Generic",
         "A combiner that accepts any caps, but converts plain text to WebVTT",

--- a/Source/WebCore/platform/graphics/gstreamer/TextCombinerPadGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TextCombinerPadGStreamer.cpp
@@ -48,7 +48,6 @@ enum {
 
 static std::array<GParamSpec*, N_PROPERTIES> sObjProperties;
 
-#define webkit_text_combiner_pad_parent_class parent_class
 WEBKIT_DEFINE_TYPE(WebKitTextCombinerPad, webkit_text_combiner_pad, GST_TYPE_GHOST_PAD);
 
 static gboolean webkitTextCombinerPadEvent(GstPad* pad, GstObject* parent, GstEvent* event)
@@ -137,7 +136,7 @@ static void webkitTextCombinerPadSetProperty(GObject* object, guint propertyId, 
 
 static void webkitTextCombinerPadConstructed(GObject* object)
 {
-    GST_CALL_PARENT(G_OBJECT_CLASS, constructed, (object));
+    G_OBJECT_CLASS(webkit_text_combiner_pad_parent_class)->constructed(object);
     gst_ghost_pad_construct(GST_GHOST_PAD(object));
     gst_pad_set_event_function(GST_PAD_CAST(object), webkitTextCombinerPadEvent);
     gst_pad_set_chain_function(GST_PAD_CAST(object), webkitTextCombinerPadChain);

--- a/Source/WebCore/platform/graphics/gstreamer/TextSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TextSinkGStreamer.cpp
@@ -45,7 +45,6 @@ struct _WebKitTextSinkPrivate {
     std::optional<TrackID> streamId;
 };
 
-#define webkit_text_sink_parent_class parent_class
 WEBKIT_DEFINE_TYPE_WITH_CODE(WebKitTextSink, webkit_text_sink, GST_TYPE_BIN,
     GST_DEBUG_CATEGORY_INIT(webkitTextSinkDebug, "webkittextsink", 0, "webkit text sink"))
 
@@ -75,7 +74,7 @@ static void webkitTextSinkHandleSample(WebKitTextSink* self, GRefPtr<GstSample>&
 
 static void webkitTextSinkConstructed(GObject* object)
 {
-    GST_CALL_PARENT(G_OBJECT_CLASS, constructed, (object));
+    G_OBJECT_CLASS(webkit_text_sink_parent_class)->constructed(object);
 
     auto* sink = WEBKIT_TEXT_SINK(object);
     auto* priv = sink->priv;
@@ -112,7 +111,7 @@ static gboolean webkitTextSinkQuery(GstElement* element, GstQuery* query)
         // Ignore duration and position because we don't want the seek bar to be based on where the cues are.
         return false;
     default:
-        return GST_CALL_PARENT_WITH_DEFAULT(GST_ELEMENT_CLASS, query, (element, query), FALSE);
+        return GST_ELEMENT_CLASS(webkit_text_sink_parent_class)->query(element, query);
     }
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoSinkGStreamer.cpp
@@ -50,7 +50,7 @@ using namespace WebCore;
 
 #define WEBKIT_VIDEO_SINK_PAD_CAPS GST_VIDEO_CAPS_MAKE_WITH_FEATURES(GST_CAPS_FEATURE_META_GST_VIDEO_GL_TEXTURE_UPLOAD_META, GST_CAPS_FORMAT) ";" GST_VIDEO_CAPS_MAKE(GST_CAPS_FORMAT)
 
-static GstStaticPadTemplate s_sinkTemplate = GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS, GST_STATIC_CAPS(WEBKIT_VIDEO_SINK_PAD_CAPS));
+static GstStaticPadTemplate s_videoSinkTemplate = GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS, GST_STATIC_CAPS(WEBKIT_VIDEO_SINK_PAD_CAPS));
 
 
 GST_DEBUG_CATEGORY_STATIC(webkitVideoSinkDebug);
@@ -143,12 +143,11 @@ struct _WebKitVideoSinkPrivate {
     GstCaps* currentCaps { nullptr };
 };
 
-#define webkit_video_sink_parent_class parent_class
 WEBKIT_DEFINE_TYPE_WITH_CODE(WebKitVideoSink, webkit_video_sink, GST_TYPE_VIDEO_SINK, GST_DEBUG_CATEGORY_INIT(webkitVideoSinkDebug, "webkitsink", 0, "webkit video sink"))
 
 static void webkitVideoSinkConstructed(GObject* object)
 {
-    GST_CALL_PARENT(G_OBJECT_CLASS, constructed, (object));
+    G_OBJECT_CLASS(webkit_video_sink_parent_class)->constructed(object);
     g_object_set(GST_BASE_SINK(object), "enable-last-sample", FALSE, nullptr);
 }
 
@@ -188,7 +187,7 @@ static gboolean webkitVideoSinkUnlock(GstBaseSink* baseSink)
     priv->scheduler.stop();
     webkitVideoSinkRepaintCancelled(WEBKIT_VIDEO_SINK(baseSink));
 
-    return GST_CALL_PARENT_WITH_DEFAULT(GST_BASE_SINK_CLASS, unlock, (baseSink), TRUE);
+    return GST_BASE_SINK_CLASS(webkit_video_sink_parent_class)->unlock(baseSink);
 }
 
 static gboolean webkitVideoSinkUnlockStop(GstBaseSink* baseSink)
@@ -197,7 +196,7 @@ static gboolean webkitVideoSinkUnlockStop(GstBaseSink* baseSink)
 
     priv->scheduler.start();
 
-    return GST_CALL_PARENT_WITH_DEFAULT(GST_BASE_SINK_CLASS, unlock_stop, (baseSink), TRUE);
+    return GST_BASE_SINK_CLASS(webkit_video_sink_parent_class)->unlock_stop(baseSink);
 }
 
 static gboolean webkitVideoSinkStop(GstBaseSink* baseSink)
@@ -270,7 +269,7 @@ static gboolean webkitVideoSinkEvent(GstBaseSink* baseSink, GstEvent* event)
         }
         FALLTHROUGH;
     default:
-        return GST_CALL_PARENT_WITH_DEFAULT(GST_BASE_SINK_CLASS, event, (baseSink, event), TRUE);
+        return GST_BASE_SINK_CLASS(webkit_video_sink_parent_class)->event(baseSink, event);
     }
 }
 
@@ -280,7 +279,7 @@ static void webkit_video_sink_class_init(WebKitVideoSinkClass* klass)
     GstBaseSinkClass* baseSinkClass = GST_BASE_SINK_CLASS(klass);
     GstElementClass* elementClass = GST_ELEMENT_CLASS(klass);
 
-    gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&s_sinkTemplate));
+    gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&s_videoSinkTemplate));
     gst_element_class_set_metadata(elementClass, "WebKit video sink", "Sink/Video", "Sends video data from a GStreamer pipeline to WebKit", "Igalia, Alp Toker <alp@atoker.com>");
 
     gobjectClass->constructed = webkitVideoSinkConstructed;

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -159,16 +159,16 @@ struct WebKitWebSrcPrivate {
 };
 
 enum {
-    PROP_0,
-    PROP_LOCATION,
-    PROP_RESOLVED_LOCATION,
-    PROP_KEEP_ALIVE,
-    PROP_EXTRA_HEADERS,
-    PROP_COMPRESS,
-    PROP_METHOD
+    WEBKIT_WEBSRC_PROP_0,
+    WEBKIT_WEBSRC_PROP_LOCATION,
+    WEBKIT_WEBSRC_PROP_RESOLVED_LOCATION,
+    WEBKIT_WEBSRC_PROP_KEEP_ALIVE,
+    WEBKIT_WEBSRC_PROP_EXTRA_HEADERS,
+    WEBKIT_WEBSRC_PROP_COMPRESS,
+    WEBKIT_WEBSRC_PROP_METHOD
 };
 
-static GstStaticPadTemplate srcTemplate = GST_STATIC_PAD_TEMPLATE("src", GST_PAD_SRC, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
+static GstStaticPadTemplate webSrcTemplate = GST_STATIC_PAD_TEMPLATE("src", GST_PAD_SRC, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
 
 GST_DEBUG_CATEGORY_STATIC(webkit_web_src_debug);
 #define GST_CAT_DEFAULT webkit_web_src_debug
@@ -193,7 +193,6 @@ static void webKitWebSrcSetContext(GstElement*, GstContext*);
 static void restartLoaderIfNeeded(WebKitWebSrc*, DataMutexLocker<WebKitWebSrcPrivate::StreamingMembers>&);
 static void stopLoaderIfNeeded(WebKitWebSrc*, DataMutexLocker<WebKitWebSrcPrivate::StreamingMembers>&);
 
-#define webkit_web_src_parent_class parent_class
 WEBKIT_DEFINE_TYPE_WITH_CODE(WebKitWebSrc, webkit_web_src, GST_TYPE_PUSH_SRC,
     G_IMPLEMENT_INTERFACE(GST_TYPE_URI_HANDLER, webKitWebSrcUriHandlerInit);
     GST_DEBUG_CATEGORY_INIT(webkit_web_src_debug, "webkitwebsrc", 0, "websrc element");
@@ -208,34 +207,34 @@ static void webkit_web_src_class_init(WebKitWebSrcClass* klass)
     oklass->get_property = webKitWebSrcGetProperty;
 
     GstElementClass* eklass = GST_ELEMENT_CLASS(klass);
-    gst_element_class_add_static_pad_template(eklass, &srcTemplate);
+    gst_element_class_add_static_pad_template(eklass, &webSrcTemplate);
 
     gst_element_class_set_metadata(eklass, "WebKit Web source element", "Source/Network", "Handles HTTP/HTTPS uris",
         "Philippe Normand <philn@igalia.com>");
 
     /* Allows setting the uri using the 'location' property, which is used
      * for example by gst_element_make_from_uri() */
-    g_object_class_install_property(oklass, PROP_LOCATION,
+    g_object_class_install_property(oklass, WEBKIT_WEBSRC_PROP_LOCATION,
         g_param_spec_string("location", nullptr, nullptr,
             nullptr, static_cast<GParamFlags>(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
-    g_object_class_install_property(oklass, PROP_RESOLVED_LOCATION,
+    g_object_class_install_property(oklass, WEBKIT_WEBSRC_PROP_RESOLVED_LOCATION,
         g_param_spec_string("resolved-location", nullptr, nullptr,
             nullptr, static_cast<GParamFlags>(G_PARAM_READABLE | G_PARAM_STATIC_STRINGS)));
 
-    g_object_class_install_property(oklass, PROP_KEEP_ALIVE,
+    g_object_class_install_property(oklass, WEBKIT_WEBSRC_PROP_KEEP_ALIVE,
         g_param_spec_boolean("keep-alive", nullptr, nullptr,
             FALSE, static_cast<GParamFlags>(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
-    g_object_class_install_property(oklass, PROP_EXTRA_HEADERS,
+    g_object_class_install_property(oklass, WEBKIT_WEBSRC_PROP_EXTRA_HEADERS,
         g_param_spec_boxed("extra-headers", nullptr, nullptr,
             GST_TYPE_STRUCTURE, static_cast<GParamFlags>(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
-    g_object_class_install_property(oklass, PROP_COMPRESS,
+    g_object_class_install_property(oklass, WEBKIT_WEBSRC_PROP_COMPRESS,
         g_param_spec_boolean("compress", nullptr, nullptr,
             FALSE, static_cast<GParamFlags>(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
-    g_object_class_install_property(oklass, PROP_METHOD,
+    g_object_class_install_property(oklass, WEBKIT_WEBSRC_PROP_METHOD,
         g_param_spec_string("method", nullptr, nullptr,
             nullptr, static_cast<GParamFlags>(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
@@ -294,7 +293,7 @@ static void webkitWebSrcReset([[maybe_unused]] WebKitWebSrc* src, DataMutexLocke
 
 static void webKitWebSrcConstructed(GObject* object)
 {
-    GST_CALL_PARENT(G_OBJECT_CLASS, constructed, (object));
+    G_OBJECT_CLASS(webkit_web_src_parent_class)->constructed(object);
 
     WebKitWebSrc* src = WEBKIT_WEB_SRC(object);
     WebKitWebSrcPrivate* priv = src->priv;
@@ -313,21 +312,21 @@ static void webKitWebSrcSetProperty(GObject* object, guint propID, const GValue*
     WebKitWebSrc* src = WEBKIT_WEB_SRC(object);
 
     switch (propID) {
-    case PROP_LOCATION:
+    case WEBKIT_WEBSRC_PROP_LOCATION:
         gst_uri_handler_set_uri(reinterpret_cast<GstURIHandler*>(src), g_value_get_string(value), nullptr);
         break;
-    case PROP_KEEP_ALIVE:
+    case WEBKIT_WEBSRC_PROP_KEEP_ALIVE:
         src->priv->keepAlive = g_value_get_boolean(value);
         break;
-    case PROP_EXTRA_HEADERS: {
+    case WEBKIT_WEBSRC_PROP_EXTRA_HEADERS: {
         const GstStructure* s = gst_value_get_structure(value);
         src->priv->extraHeaders.reset(s ? gst_structure_copy(s) : nullptr);
         break;
     }
-    case PROP_COMPRESS:
+    case WEBKIT_WEBSRC_PROP_COMPRESS:
         src->priv->compress = g_value_get_boolean(value);
         break;
-    case PROP_METHOD:
+    case WEBKIT_WEBSRC_PROP_METHOD:
         src->priv->httpMethod.reset(g_value_dup_string(value));
         break;
     default:
@@ -342,24 +341,24 @@ static void webKitWebSrcGetProperty(GObject* object, guint propID, GValue* value
     WebKitWebSrcPrivate* priv = src->priv;
 
     switch (propID) {
-    case PROP_LOCATION:
+    case WEBKIT_WEBSRC_PROP_LOCATION:
         g_value_set_string(value, priv->originalURI.data());
         break;
-    case PROP_RESOLVED_LOCATION: {
+    case WEBKIT_WEBSRC_PROP_RESOLVED_LOCATION: {
         DataMutexLocker members { priv->dataMutex };
         g_value_set_string(value, members->redirectedURI.isNull() ? priv->originalURI.data() : members->redirectedURI.data());
         break;
     }
-    case PROP_KEEP_ALIVE:
+    case WEBKIT_WEBSRC_PROP_KEEP_ALIVE:
         g_value_set_boolean(value, priv->keepAlive);
         break;
-    case PROP_EXTRA_HEADERS:
+    case WEBKIT_WEBSRC_PROP_EXTRA_HEADERS:
         gst_value_set_structure(value, priv->extraHeaders.get());
         break;
-    case PROP_COMPRESS:
+    case WEBKIT_WEBSRC_PROP_COMPRESS:
         g_value_set_boolean(value, priv->compress);
         break;
-    case PROP_METHOD:
+    case WEBKIT_WEBSRC_PROP_METHOD:
         g_value_set_string(value, priv->httpMethod.get());
         break;
     default:
@@ -379,7 +378,7 @@ static void webKitWebSrcSetContext(GstElement* element, GstContext* context)
         DataMutexLocker members { priv->dataMutex };
         members->loader = reinterpret_cast<WebCore::PlatformMediaResourceLoader*>(g_value_get_pointer(value));
     }
-    GST_ELEMENT_CLASS(parent_class)->set_context(element, context);
+    GST_ELEMENT_CLASS(webkit_web_src_parent_class)->set_context(element, context);
 }
 
 static void restartLoaderIfNeeded(WebKitWebSrc* src, DataMutexLocker<WebKitWebSrcPrivate::StreamingMembers>& members)
@@ -789,7 +788,7 @@ static gboolean webKitWebSrcQuery(GstBaseSrc* baseSrc, GstQuery* query)
     }
 
     if (!result)
-        result = GST_BASE_SRC_CLASS(parent_class)->query(baseSrc, query);
+        result = GST_BASE_SRC_CLASS(webkit_web_src_parent_class)->query(baseSrc, query);
 
     if (GST_QUERY_TYPE(query) == GST_QUERY_SCHEDULING) {
         GstSchedulingFlags flags;
@@ -822,7 +821,7 @@ static gboolean webKitWebSrcEvent(GstBaseSrc* baseSrc, GstEvent* event)
     default:
         break;
     };
-    return GST_BASE_SRC_CLASS(parent_class)->event(baseSrc, event);
+    return GST_BASE_SRC_CLASS(webkit_web_src_parent_class)->event(baseSrc, event);
 }
 
 static gboolean webKitWebSrcUnLock(GstBaseSrc* baseSrc)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -85,7 +85,6 @@ static void setContext(GstElement*, GstContext*);
 GST_DEBUG_CATEGORY(webkit_media_common_encryption_decrypt_debug_category);
 #define GST_CAT_DEFAULT webkit_media_common_encryption_decrypt_debug_category
 
-#define webkit_media_common_encryption_decrypt_parent_class parent_class
 WEBKIT_DEFINE_TYPE(WebKitMediaCommonEncryptionDecrypt, webkit_media_common_encryption_decrypt, GST_TYPE_BASE_TRANSFORM)
 
 static void webkit_media_common_encryption_decrypt_class_init(WebKitMediaCommonEncryptionDecryptClass* klass)
@@ -111,7 +110,7 @@ static void webkit_media_common_encryption_decrypt_class_init(WebKitMediaCommonE
 
 static void constructed(GObject* object)
 {
-    GST_CALL_PARENT(G_OBJECT_CLASS, constructed, (object));
+    G_OBJECT_CLASS(webkit_media_common_encryption_decrypt_parent_class)->constructed(object);
 
     GstBaseTransform* base = GST_BASE_TRANSFORM(object);
     gst_base_transform_set_in_place(base, TRUE);
@@ -209,7 +208,7 @@ static GstCaps* transformCaps(GstBaseTransform* base, GstPadDirection direction,
 
 static gboolean acceptCaps(GstBaseTransform* trans, GstPadDirection direction, GstCaps* caps)
 {
-    gboolean result = GST_BASE_TRANSFORM_CLASS(parent_class)->accept_caps(trans, direction, caps);
+    gboolean result = GST_BASE_TRANSFORM_CLASS(webkit_media_common_encryption_decrypt_parent_class)->accept_caps(trans, direction, caps);
 
     if (result || direction == GST_PAD_SRC)
         return result;
@@ -486,7 +485,7 @@ static gboolean sinkEventHandler(GstBaseTransform* trans, GstEvent* event)
         break;
     }
 
-    return GST_BASE_TRANSFORM_CLASS(parent_class)->sink_event(trans, event);
+    return GST_BASE_TRANSFORM_CLASS(webkit_media_common_encryption_decrypt_parent_class)->sink_event(trans, event);
 }
 
 bool webKitMediaCommonEncryptionDecryptIsAborting(WebKitMediaCommonEncryptionDecrypt* self)
@@ -530,7 +529,7 @@ static GstStateChangeReturn changeState(GstElement* element, GstStateChange tran
         break;
     }
 
-    GstStateChangeReturn result = GST_ELEMENT_CLASS(parent_class)->change_state(element, transition);
+    GstStateChangeReturn result = GST_ELEMENT_CLASS(webkit_media_common_encryption_decrypt_parent_class)->change_state(element, transition);
 
     // Add post-transition code here.
 
@@ -552,7 +551,7 @@ static void setContext(GstElement* element, GstContext* context)
         return;
     }
 
-    GST_ELEMENT_CLASS(parent_class)->set_context(element, context);
+    GST_ELEMENT_CLASS(webkit_media_common_encryption_decrypt_parent_class)->set_context(element, context);
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
@@ -50,7 +50,7 @@ static std::array<ASCIILiteral, 11> cencEncryptionMediaTypes = { "video/mp4"_s, 
     "audio/x-eac3"_s, "audio/x-ac3"_s, "audio/x-flac"_s, "audio/x-opus"_s, "video/x-vp9"_s, "video/x-av1"_s };
 static std::array<ASCIILiteral, 7> webmEncryptionMediaTypes = { "video/webm"_s, "audio/webm"_s, "video/x-vp9"_s, "video/x-av1"_s, "audio/x-opus"_s, "audio/x-vorbis"_s, "video/x-vp8"_s };
 
-static GstStaticPadTemplate srcTemplate = GST_STATIC_PAD_TEMPLATE("src",
+static GstStaticPadTemplate thunderSrcTemplate = GST_STATIC_PAD_TEMPLATE("src",
     GST_PAD_SRC,
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS(
@@ -68,7 +68,6 @@ static GstStaticPadTemplate srcTemplate = GST_STATIC_PAD_TEMPLATE("src",
         "video/x-av1; "
         "audio/x-opus; audio/x-vorbis"));
 
-#define webkit_media_thunder_decrypt_parent_class parent_class
 WEBKIT_DEFINE_TYPE(WebKitMediaThunderDecrypt, webkit_media_thunder_decrypt, WEBKIT_TYPE_MEDIA_CENC_DECRYPT)
 
 static GRefPtr<GstCaps> createSinkPadTemplateCaps()
@@ -112,7 +111,7 @@ static void webkit_media_thunder_decrypt_class_init(WebKitMediaThunderDecryptCla
     GstElementClass* elementClass = GST_ELEMENT_CLASS(klass);
     GRefPtr<GstCaps> gstSinkPadTemplateCaps = createSinkPadTemplateCaps();
     gst_element_class_add_pad_template(elementClass, gst_pad_template_new("sink", GST_PAD_SINK, GST_PAD_ALWAYS, gstSinkPadTemplateCaps.get()));
-    gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&srcTemplate));
+    gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&thunderSrcTemplate));
 
     gst_element_class_set_static_metadata(elementClass, "Decrypt encrypted content using Thunder", GST_ELEMENT_FACTORY_KLASS_DECRYPTOR,
         "Decrypts encrypted media using Thunder.", "Xabier Rodríguez Calvar <calvaris@igalia.com>");

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -50,17 +50,15 @@ using namespace WebCore;
 GST_DEBUG_CATEGORY_STATIC(webkit_media_src_debug);
 #define GST_CAT_DEFAULT webkit_media_src_debug
 
-#define webkit_media_src_parent_class parent_class
-
-static GstStaticPadTemplate srcTemplate = GST_STATIC_PAD_TEMPLATE("src_%s", GST_PAD_SRC,
+static GstStaticPadTemplate mseSrcTemplate = GST_STATIC_PAD_TEMPLATE("src_%s", GST_PAD_SRC,
     GST_PAD_SOMETIMES, GST_STATIC_CAPS_ANY);
 
 enum {
-    PROP_0,
-    PROP_N_AUDIO,
-    PROP_N_VIDEO,
-    PROP_N_TEXT,
-    PROP_LAST
+    WEBKIT_MEDIA_SRC_PROP_0,
+    WEBKIT_MEDIA_SRC_PROP_N_AUDIO,
+    WEBKIT_MEDIA_SRC_PROP_N_VIDEO,
+    WEBKIT_MEDIA_SRC_PROP_N_TEXT,
+    WEBKIT_MEDIA_SRC_PROP_LAST
 };
 
 struct Stream;
@@ -102,8 +100,6 @@ static void webKitMediaSrcGetProperty(GObject*, unsigned propId, GValue*, GParam
 static void webKitMediaSrcStreamFlush(Stream*, bool isSeekingFlush);
 static gboolean webKitMediaSrcSendEvent(GstElement*, GstEvent*);
 static RefPtr<MediaPlayerPrivateGStreamerMSE> webKitMediaSrcPlayer(WebKitMediaSrc*);
-
-#define webkit_media_src_parent_class parent_class
 
 struct WebKitMediaSrcPadPrivate {
     ThreadSafeWeakPtr<Stream> stream;
@@ -261,7 +257,7 @@ static gboolean webKitMediaSrcQuery(GstElement* element, GstQuery* query)
     }
 #endif
 
-    gboolean result = GST_ELEMENT_CLASS(parent_class)->query(element, query);
+    gboolean result = GST_ELEMENT_CLASS(webkit_media_src_parent_class)->query(element, query);
 
     if (GST_QUERY_TYPE(query) != GST_QUERY_SCHEDULING)
         return result;
@@ -282,7 +278,7 @@ static void webkit_media_src_class_init(WebKitMediaSrcClass* klass)
     oklass->constructed = webKitMediaSrcConstructed;
     oklass->get_property = webKitMediaSrcGetProperty;
 
-    gst_element_class_add_static_pad_template_with_gtype(eklass, &srcTemplate, webkit_media_src_pad_get_type());
+    gst_element_class_add_static_pad_template_with_gtype(eklass, &mseSrcTemplate, webkit_media_src_pad_get_type());
 
     gst_element_class_set_static_metadata(eklass, "WebKit MediaSource source element", "Source/Network", "Feeds samples coming from WebKit MediaSource object", "Igalia <aboya@igalia.com>");
 
@@ -295,22 +291,22 @@ static void webkit_media_src_class_init(WebKitMediaSrcClass* klass)
         eklass->query = GST_DEBUG_FUNCPTR(webKitMediaSrcQuery);
 
     g_object_class_install_property(oklass,
-        PROP_N_AUDIO,
+        WEBKIT_MEDIA_SRC_PROP_N_AUDIO,
         g_param_spec_int("n-audio", nullptr, nullptr,
-        0, G_MAXINT, 0, GParamFlags(G_PARAM_READABLE | G_PARAM_STATIC_STRINGS)));
+            0, G_MAXINT, 0, GParamFlags(G_PARAM_READABLE | G_PARAM_STATIC_STRINGS)));
     g_object_class_install_property(oklass,
-        PROP_N_VIDEO,
+        WEBKIT_MEDIA_SRC_PROP_N_VIDEO,
         g_param_spec_int("n-video", nullptr, nullptr,
-        0, G_MAXINT, 0, GParamFlags(G_PARAM_READABLE | G_PARAM_STATIC_STRINGS)));
+            0, G_MAXINT, 0, GParamFlags(G_PARAM_READABLE | G_PARAM_STATIC_STRINGS)));
     g_object_class_install_property(oklass,
-        PROP_N_TEXT,
+        WEBKIT_MEDIA_SRC_PROP_N_TEXT,
         g_param_spec_int("n-text", nullptr, nullptr,
-        0, G_MAXINT, 0, GParamFlags(G_PARAM_READABLE | G_PARAM_STATIC_STRINGS)));
+            0, G_MAXINT, 0, GParamFlags(G_PARAM_READABLE | G_PARAM_STATIC_STRINGS)));
 }
 
 static void webKitMediaSrcConstructed(GObject* object)
 {
-    GST_CALL_PARENT(G_OBJECT_CLASS, constructed, (object));
+    G_OBJECT_CLASS(webkit_media_src_parent_class)->constructed(object);
 
     ASSERT(isMainThread());
     GST_OBJECT_FLAG_SET(object, GST_ELEMENT_FLAG_SOURCE);
@@ -783,13 +779,13 @@ static void webKitMediaSrcGetProperty(GObject* object, unsigned propId, GValue* 
     WebKitMediaSrc* source = WEBKIT_MEDIA_SRC(object);
 
     switch (propId) {
-    case PROP_N_AUDIO:
+    case WEBKIT_MEDIA_SRC_PROP_N_AUDIO:
         g_value_set_int(value, countStreamsOfType(source, WebCore::TrackPrivateBaseGStreamer::TrackType::Audio));
         break;
-    case PROP_N_VIDEO:
+    case WEBKIT_MEDIA_SRC_PROP_N_VIDEO:
         g_value_set_int(value, countStreamsOfType(source, WebCore::TrackPrivateBaseGStreamer::TrackType::Video));
         break;
-    case PROP_N_TEXT:
+    case WEBKIT_MEDIA_SRC_PROP_N_TEXT:
         g_value_set_int(value, countStreamsOfType(source, WebCore::TrackPrivateBaseGStreamer::TrackType::Text));
         break;
     default:

--- a/Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp
@@ -74,7 +74,7 @@ GST_DEBUG_CATEGORY_STATIC(webkit_flite_src_debug);
 
 #define DEFAULT_SAMPLES_PER_BUFFER 1024
 
-static GstStaticPadTemplate srcTemplate = GST_STATIC_PAD_TEMPLATE("src",
+static GstStaticPadTemplate fliteSrcTemplate = GST_STATIC_PAD_TEMPLATE("src",
     GST_PAD_SRC,
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS("audio/x-raw, "
@@ -83,7 +83,6 @@ static GstStaticPadTemplate srcTemplate = GST_STATIC_PAD_TEMPLATE("src",
         "rate = (int) 48000, " "channels = (int) [1, 8]")
 );
 
-#define webkit_flite_src_parent_class parent_class
 WEBKIT_DEFINE_TYPE_WITH_CODE(WebKitFliteSrc, webkit_flite_src, GST_TYPE_BASE_SRC,
     GST_DEBUG_CATEGORY_INIT(webkit_flite_src_debug, "webkitflitesrc", 0, "flitesrc element"));
 
@@ -109,7 +108,7 @@ static void webkitFliteSrcReset(WebKitFliteSrc* src)
 
 static void webkitFliteSrcConstructed(GObject* object)
 {
-    GST_CALL_PARENT(G_OBJECT_CLASS, constructed, (object));
+    G_OBJECT_CLASS(webkit_flite_src_parent_class)->constructed(object);
 
     WebKitFliteSrc* src = WEBKIT_FLITE_SRC(object);
     WebKitFliteSrcPrivate* priv = src->priv;
@@ -202,7 +201,7 @@ static void webkit_flite_src_class_init(WebKitFliteSrcClass* klass)
     objectClass->constructed = webkitFliteSrcConstructed;
 
     GstElementClass* elementClass = GST_ELEMENT_CLASS(klass);
-    gst_element_class_add_static_pad_template(elementClass, &srcTemplate);
+    gst_element_class_add_static_pad_template(elementClass, &fliteSrcTemplate);
     gst_element_class_set_static_metadata(elementClass,
         "WebKit WebSpeech GstFlite source element", "Source",
         "Handles WebSpeech data from WebCore",

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -718,9 +718,9 @@ struct _WebKitMediaStreamSrcPrivate {
 };
 
 enum {
-    PROP_0,
-    PROP_IS_LIVE,
-    PROP_LAST
+    WEBKIT_MEDIASTREAM_SRC_PROP_0,
+    WEBKIT_MEDIASTREAM_SRC_PROP_IS_LIVE,
+    WEBKIT_MEDIASTREAM_SRC_PROP_LAST
 };
 
 void InternalSource::updateFirstVideoSampleSeenFlag()
@@ -838,7 +838,6 @@ static void webkitMediaStreamSrcUriHandlerInit(gpointer gIface, gpointer)
     G_IMPLEMENT_INTERFACE(GST_TYPE_URI_HANDLER, webkitMediaStreamSrcUriHandlerInit); \
     GST_DEBUG_CATEGORY_INIT(webkitMediaStreamSrcDebug, "webkitmediastreamsrc", 0, "mediastreamsrc element");
 
-#define webkit_media_stream_src_parent_class parent_class
 WEBKIT_DEFINE_TYPE_WITH_CODE(WebKitMediaStreamSrc, webkit_media_stream_src, GST_TYPE_BIN, doInit)
 
 static void webkitMediaStreamSrcSetProperty(GObject* object, guint propertyId, const GValue*, GParamSpec* pspec)
@@ -853,7 +852,7 @@ static void webkitMediaStreamSrcSetProperty(GObject* object, guint propertyId, c
 static void webkitMediaStreamSrcGetProperty(GObject* object, guint propertyId, GValue* value, GParamSpec* pspec)
 {
     switch (propertyId) {
-    case PROP_IS_LIVE:
+    case WEBKIT_MEDIASTREAM_SRC_PROP_IS_LIVE:
         g_value_set_boolean(value, TRUE);
         break;
     default:
@@ -864,7 +863,8 @@ static void webkitMediaStreamSrcGetProperty(GObject* object, guint propertyId, G
 
 static void webkitMediaStreamSrcConstructed(GObject* object)
 {
-    GST_CALL_PARENT(G_OBJECT_CLASS, constructed, (object));
+    G_OBJECT_CLASS(webkit_media_stream_src_parent_class)->constructed(object);
+
     WebKitMediaStreamSrc* self = WEBKIT_MEDIA_STREAM_SRC_CAST(object);
     auto* priv = self->priv;
 
@@ -896,7 +896,7 @@ static void webkitMediaStreamSrcDispose(GObject* object)
         }
     }
 
-    GST_CALL_PARENT(G_OBJECT_CLASS, dispose, (object));
+    G_OBJECT_CLASS(webkit_media_stream_src_parent_class)->dispose(object);
 }
 
 static GstStateChangeReturn webkitMediaStreamSrcChangeState(GstElement* element, GstStateChange transition)
@@ -952,7 +952,7 @@ static GstStateChangeReturn webkitMediaStreamSrcChangeState(GstElement* element,
 
 static gboolean webkitMediaStreamSrcQuery(GstElement* element, GstQuery* query)
 {
-    gboolean result = GST_ELEMENT_CLASS(parent_class)->query(element, query);
+    gboolean result = GST_ELEMENT_CLASS(webkit_media_stream_src_parent_class)->query(element, query);
 
     if (GST_QUERY_TYPE(query) != GST_QUERY_SCHEDULING)
         return result;
@@ -975,7 +975,7 @@ static void webkit_media_stream_src_class_init(WebKitMediaStreamSrcClass* klass)
     gobjectClass->get_property = webkitMediaStreamSrcGetProperty;
     gobjectClass->set_property = webkitMediaStreamSrcSetProperty;
 
-    g_object_class_install_property(gobjectClass, PROP_IS_LIVE, g_param_spec_boolean("is-live", nullptr, nullptr,
+    g_object_class_install_property(gobjectClass, WEBKIT_MEDIASTREAM_SRC_PROP_IS_LIVE, g_param_spec_boolean("is-live", nullptr, nullptr,
         TRUE, static_cast<GParamFlags>(G_PARAM_READABLE | G_PARAM_STATIC_STRINGS)));
 
     gstElementClass->change_state = GST_DEBUG_FUNCPTR(webkitMediaStreamSrcChangeState);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
@@ -35,7 +35,6 @@ struct _GStreamerMockDevicePrivate {
 GST_DEBUG_CATEGORY_STATIC(webkitGstMockDeviceDebug);
 #define GST_CAT_DEFAULT webkitGstMockDeviceDebug
 
-#define webkit_mock_device_provider_parent_class parent_class
 WEBKIT_DEFINE_TYPE_WITH_CODE(GStreamerMockDevice, webkit_mock_device, GST_TYPE_DEVICE, GST_DEBUG_CATEGORY_INIT(webkitGstMockDeviceDebug, "webkitmockdevice", 0, "Mock Device"))
 
 static GstElement* webkitMockDeviceCreateElement([[maybe_unused]] GstDevice* device, const char* name)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
@@ -35,7 +35,6 @@ struct _GStreamerMockDeviceProviderPrivate {
 GST_DEBUG_CATEGORY_STATIC(webkitGstMockDeviceProviderDebug);
 #define GST_CAT_DEFAULT webkitGstMockDeviceProviderDebug
 
-#define webkit_mock_device_provider_parent_class parent_class
 WEBKIT_DEFINE_TYPE_WITH_CODE(GStreamerMockDeviceProvider, webkit_mock_device_provider, GST_TYPE_DEVICE_PROVIDER, GST_DEBUG_CATEGORY_INIT(webkitGstMockDeviceProviderDebug, "webkitmockdeviceprovider", 0, "Mock Device Provider"))
 
 static GList* webkitMockDeviceProviderProbe([[maybe_unused]] GstDeviceProvider* provider)


### PR DESCRIPTION
#### 9b495619f313f45dad804224324ef48fa1b368d8
<pre>
[GStreamer] Get rid of GST_CALL_PARENT macros
<a href="https://bugs.webkit.org/show_bug.cgi?id=285665">https://bugs.webkit.org/show_bug.cgi?id=285665</a>

Reviewed by Alicia Boya Garcia.

The GST_CALL_PARENT expects the presence of a parent_class variable, which we were mis-defining
everywhere (the #define was reversed). As this macro provides little value in the end, avoid using
it and we can now build our GStreamer object implementations as part of the unified build, after
de-duplicating the various GstStaticPadTemplate variable names and GObject property enum values
across the code-base.

* Source/WebCore/platform/SourcesGStreamer.txt:
* Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp:
(webKitWebAudioSrcConstructed):
* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(webKitGLVideoSinkConstructed):
(webKitGLVideoSinkFinalize):
(webKitGLVideoSinkChangeState):
* Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp:
* Source/WebCore/platform/graphics/gstreamer/TextCombinerGStreamer.cpp:
(webKitTextCombinerConstructed):
* Source/WebCore/platform/graphics/gstreamer/TextCombinerPadGStreamer.cpp:
(webkitTextCombinerPadConstructed):
* Source/WebCore/platform/graphics/gstreamer/TextSinkGStreamer.cpp:
(webkitTextSinkConstructed):
(webkitTextSinkQuery):
* Source/WebCore/platform/graphics/gstreamer/VideoSinkGStreamer.cpp:
(webkitVideoSinkConstructed):
(webkitVideoSinkUnlock):
(webkitVideoSinkUnlockStop):
(webkitVideoSinkEvent):
* Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp:
(webKitAudioSinkChangeState):
(webKitAudioSinkConstructed):
* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
(webKitWebSrcConstructed):
(webKitWebSrcSetContext):
(webKitWebSrcQuery):
(webKitWebSrcEvent):
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
(constructed):
(sinkEventHandler):
(changeState):
(setContext):
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(webKitMediaSrcQuery):
(webKitMediaSrcConstructed):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(videoEncoderConstructed):
* Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp:
(webkitFliteSrcConstructed):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
(webkitMediaStreamSrcConstructed):
(webkitMediaStreamSrcDispose):
(webkitMediaStreamSrcQuery):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp:

Canonical link: <a href="https://commits.webkit.org/288690@main">https://commits.webkit.org/288690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6caaa3d4ea4a485aae0406c1dc3131b96965903b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89130 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35063 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65370 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23216 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76374 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45663 "Passed tests") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2738 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 4 new passes 8 flakes 6 failures; Uploaded test results; Ignored 4 pre-existing failure based on results-db") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30598 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34112 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90510 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11320 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8201 "Found 1 new test failure: http/tests/workers/service/page-caching.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73823 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11544 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72203 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73036 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18075 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17346 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2667 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11272 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16744 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11120 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14596 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->