### PR TITLE
[scroll-animations] setting a new progress-based timeline on an animation should reset its `ready` promise

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Changing animation-timeline changes the timeline (sanity check) assert_equals: expected "140px" but got "0px"
-FAIL animation-timeline ignored after setting timeline with JS (ScrollTimeline from JS) assert_equals: expected "180px" but got "0px"
-FAIL animation-timeline ignored after setting timeline with JS (ScrollTimeline from CSS) assert_equals: expected "140px" but got "0px"
+PASS Changing animation-timeline changes the timeline (sanity check)
+PASS animation-timeline ignored after setting timeline with JS (ScrollTimeline from JS)
+PASS animation-timeline ignored after setting timeline with JS (ScrollTimeline from CSS)
 PASS animation-timeline ignored after setting timeline with JS (document timeline)
 FAIL animation-timeline ignored after setting timeline with JS (null) assert_equals: expected "120px" but got "0px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt
@@ -2,17 +2,17 @@
 PASS Setting a scroll timeline on a play-pending animation synchronizes currentTime of the animation with the scroll position.
 PASS Setting a scroll timeline on a pause-pending animation fixes the currentTime of the animation based on the scroll position once resumed
 PASS Setting a scroll timeline on a reversed play-pending animation synchronizes the currentTime of the animation with the scroll position.
-FAIL Setting a scroll timeline on a running animation synchronizes the currentTime of the animation with the scroll position. assert_approx_equals: Timeline's currentTime aligns with the scroll position even when paused expected a number but got a "object"
+PASS Setting a scroll timeline on a running animation synchronizes the currentTime of the animation with the scroll position.
 PASS Setting a scroll timeline on a paused animation fixes the currentTime of the animation based on the scroll position when resumed
 PASS Setting a scroll timeline on a reversed paused animation fixes the currentTime of the animation based on the scroll position when resumed
 PASS Transitioning from a scroll timeline to a document timeline on a running animation preserves currentTime
 PASS Transitioning from a scroll timeline to a document timeline on a pause-pending animation preserves currentTime
 PASS Transition from a scroll timeline to a document timeline on a reversed paused animation maintains correct currentTime
 PASS Transitioning from a scroll timeline to a null timeline on a running animation preserves current progress.
-FAIL Switching from a null timeline to a scroll timeline on an animation with a resolved start time preserved the play state promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
-FAIL Switching from one scroll timeline to another updates currentTime promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
+PASS Switching from a null timeline to a scroll timeline on an animation with a resolved start time preserved the play state
+PASS Switching from one scroll timeline to another updates currentTime
 PASS Switching from a document timeline to a scroll timeline updates currentTime when unpaused via CSS.
 PASS Switching from a document timeline to a scroll timeline and updating currentTime preserves the progress while paused.
 FAIL Switching from a document timeline to a scroll timeline on an infinite duration animation. assert_approx_equals: values do not match for "undefined" expected 100 +/- 0.125 but got 200
-FAIL Changing from a scroll-timeline to a view-timeline updates start time. promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'actual.unit')"
+PASS Changing from a scroll-timeline to a view-timeline updates start time.
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2004,6 +2004,7 @@ webkit.org/b/281211 [ Debug ] imported/w3c/web-platform-tests/css/css-view-trans
 
 webkit.org/b/263870 imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored.html [ Skip ]
 webkit.org/b/263870 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range.html [ Skip ]
+imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative.html [ Skip ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebAnimations-related bugs

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1048,6 +1048,8 @@ webkit.org/b/263870 imported/w3c/web-platform-tests/scroll-animations/scroll-tim
 
 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/progress-based-effect-delay.tentative.html [ ImageOnlyFailure ]
 
+imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative.html [ Skip ]
+
 #//////////////////////////////////////////////////////////////////////////////////////////
 # Compositing
 #//////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -319,7 +319,13 @@ void WebAnimation::setTimeline(RefPtr<AnimationTimeline>&& timeline)
         if (previousPlayState == PlayState::Finished || previousPlayState == PlayState::Running) {
             // 5. If previous play state is "finished" or "running":
             //    Schedule a pending play task.
+            // FIXME: re-creating the ready promise is not part of the spec but Chrome implements this
+            // behavior and it makes sense since the new start time won't be computed until the timeline
+            // is updated. This is covered by https://github.com/w3c/csswg-drafts/issues/11465.
+            auto wasAlreadyPending = pending();
             m_timeToRunPendingPlayTask = TimeToRunPendingTask::WhenReady;
+            if (!wasAlreadyPending)
+                m_readyPromise = makeUniqueRef<ReadyPromise>(*this, &WebAnimation::readyPromiseResolve);
         } else if (previousPlayState == PlayState::Paused && previousProgress) {
             // 6. If previous play state is "paused" and previous progress is resolved:
             //    Set hold time to previous progress * end time.


### PR DESCRIPTION
#### cd7e705f7687c5a170307275db9c6e99e6667018
<pre>
[scroll-animations] setting a new progress-based timeline on an animation should reset its `ready` promise
<a href="https://bugs.webkit.org/show_bug.cgi?id=285667">https://bugs.webkit.org/show_bug.cgi?id=285667</a>
<a href="https://rdar.apple.com/142608438">rdar://142608438</a>

Reviewed by Anne van Kesteren.

We were failing some scroll-animations WPT tests related to switching timelines dynamically because these tests
relied on the animation&apos;s `ready` promise being reset upon setting a new progress-based timeline. While the spec
doesn&apos;t currently state that this should occur, it makes sense that it would if the animation was not already
pending since a new start time will be computed in the next animation frame.

A spec issue was filed at <a href="https://github.com/w3c/csswg-drafts/issues/11465">https://github.com/w3c/csswg-drafts/issues/11465</a> to clear this up.

So when we schedule a pending play task, we also reset the `ready` promise in case the animation was not already
in the pending state.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-ignored.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/setting-timeline.tentative-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setTimeline):

Canonical link: <a href="https://commits.webkit.org/288655@main">https://commits.webkit.org/288655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7494432ad960b52bb793a921afc11ca52244acc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38342 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/35049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86126 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11627 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/89116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/35049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87087 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/2799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/76359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/2730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/30583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/34098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/31342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/90496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11306 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/90496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11530 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/72188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/90496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/17329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13004 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11258 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/16730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/11106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14582 "Built successfully") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12878 "Failed to checkout and rebase branch from PR 38776") | | | 
<!--EWS-Status-Bubble-End-->