### PR TITLE
Ensure WebGL context drawing buffer EGL images are always unbound with the underlying context current during destruction

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -174,7 +174,8 @@ GraphicsContextGLCocoa::GraphicsContextGLCocoa(GraphicsContextGLAttributes&& cre
 
 GraphicsContextGLCocoa::~GraphicsContextGLCocoa()
 {
-    freeDrawingBuffers();
+    if (makeContextCurrent())
+        freeDrawingBuffers();
 }
 
 IOSurface* GraphicsContextGLCocoa::displayBufferSurface()
@@ -463,6 +464,7 @@ bool GraphicsContextGLCocoa::bindNextDrawingBuffer()
 
 void GraphicsContextGLCocoa::freeDrawingBuffers()
 {
+    // Note: due to a ANGLE bug in ReleaseTexImage, the current context should be the context owning the pbuffer and the texture.
     if (drawingBuffer())
         EGL_ReleaseTexImage(m_displayObj, drawingBuffer().pbuffer, EGL_BACK_BUFFER);
     for (auto& buffer : m_drawingBuffers) {

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
@@ -380,6 +380,26 @@ TEST_F(GraphicsContextGLCocoaTest, ClearBufferIncorrectSizes)
     gl = nullptr;
 }
 
+// Test destroying graphics contexts so that the underlying current OpenGL context is different
+// than the underlying OpenGL context of destroyed context.
+TEST_F(GraphicsContextGLCocoaTest, DestroyWithoutMakingCurrent)
+{
+    WebCore::GraphicsContextGLAttributes attributes;
+    attributes.isWebGL2 = true;
+    attributes.depth = true;
+    attributes.stencil = true;
+    RefPtr gl1 = TestedGraphicsContextGLCocoa::create(WTFMove(attributes));
+    gl1->reshape(1, 1);
+    RefPtr gl2 = TestedGraphicsContextGLCocoa::create(WTFMove(attributes));
+    gl2->reshape(1, 1);
+    RefPtr gl3 = TestedGraphicsContextGLCocoa::create(WTFMove(attributes));
+    gl3->reshape(1, 1);
+    // Current context is now 3.
+    gl1 = nullptr; // Test the case where we destroy with other context being current.
+    // Current context is now nullptr.
+    gl2 = nullptr; // Test the case where we destroy without context being current.
+}
+
 TEST_F(GraphicsContextGLCocoaTest, TwoLinks)
 {
     WebCore::GraphicsContextGLAttributes attributes;


### PR DESCRIPTION
#### 83a465951824ff92c746744f034c40948162c564
<pre>
Ensure WebGL context drawing buffer EGL images are always unbound with the underlying context current during destruction
<a href="https://bugs.webkit.org/show_bug.cgi?id=285671">https://bugs.webkit.org/show_bug.cgi?id=285671</a>
<a href="https://rdar.apple.com/122974634">rdar://122974634</a>

Reviewed by Dan Glastonbury.

Make the underlying ANGLE OpenGL context current when unbinding the
drawing buffer. ReleaseTexImage should not need the context,
but ANGLE currently uses the context for flush purposes. Fixing ANGLE
is a large task.

* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::~GraphicsContextGLCocoa):
(WebCore::GraphicsContextGLCocoa::freeDrawingBuffers):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm:
(TestWebKitAPI::TEST_F(GraphicsContextGLCocoaTest, DestroyWithoutMakingCurrent)):

Canonical link: <a href="https://commits.webkit.org/288682@main">https://commits.webkit.org/288682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a713230cc36ed0126689cc0ef9eb0de0725c92d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38330 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89104 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35037 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11615 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65353 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23199 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76348 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45646 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30572 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34086 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73677 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90483 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8179 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73805 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72177 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73022 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18072 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17313 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2641 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11246 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16718 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11094 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14570 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12866 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->