### PR TITLE
Remove VorbisDecoderEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8296,19 +8296,6 @@ VisuallyContiguousBidiTextSelectionEnabled:
     WebCore:
       default: false
 
-VorbisDecoderEnabled:
-  type: bool
-  status: mature
-  humanReadableName: "Vorbis audio decoder"
-  humanReadableDescription: "Enable Vorbis audio decoder"
-  condition: ENABLE(VORBIS)
-  webcoreBinding: DeprecatedGlobalSettings
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-
 WantsBalancedSetDefersLoadingBehavior:
   type: bool
   status: embedder

--- a/Source/WebCore/page/DeprecatedGlobalSettings.cpp
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.cpp
@@ -46,14 +46,6 @@ DeprecatedGlobalSettings& DeprecatedGlobalSettings::shared()
     return deprecatedGlobalSettings;
 }
 
-#if ENABLE(VORBIS)
-void DeprecatedGlobalSettings::setVorbisDecoderEnabled(bool isEnabled)
-{
-    shared().m_vorbisDecoderEnabled = isEnabled;
-    PlatformMediaSessionManager::setVorbisDecoderEnabled(isEnabled);
-}
-#endif
-
 #if ENABLE(OPUS)
 void DeprecatedGlobalSettings::setOpusDecoderEnabled(bool isEnabled)
 {

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -116,11 +116,6 @@ public:
     static void setArePDFImagesEnabled(bool isEnabled) { shared().m_arePDFImagesEnabled = isEnabled; }
     static bool arePDFImagesEnabled() { return shared().m_arePDFImagesEnabled; }
 
-#if ENABLE(VORBIS)
-    WEBCORE_EXPORT static void setVorbisDecoderEnabled(bool);
-    static bool vorbisDecoderEnabled() { return shared().m_vorbisDecoderEnabled; }
-#endif
-
 #if ENABLE(OPUS)
     WEBCORE_EXPORT static void setOpusDecoderEnabled(bool);
     static bool opusDecoderEnabled() { return shared().m_opusDecoderEnabled; }
@@ -186,10 +181,6 @@ private:
 #endif
 
     bool m_arePDFImagesEnabled { true };
-
-#if ENABLE(VORBIS)
-    bool m_vorbisDecoderEnabled { false };
-#endif
 
 #if ENABLE(OPUS)
     bool m_opusDecoderEnabled { false };

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -43,10 +43,6 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PlatformMediaSessionManager);
 
-#if ENABLE(VORBIS)
-bool PlatformMediaSessionManager::m_vorbisDecoderEnabled;
-#endif
-
 #if ENABLE(OPUS)
 bool PlatformMediaSessionManager::m_opusDecoderEnabled;
 #endif
@@ -766,24 +762,6 @@ bool PlatformMediaSessionManager::shouldDeactivateAudioSession()
 void PlatformMediaSessionManager::setShouldDeactivateAudioSession(bool deactivate)
 {
     deactivateAudioSession() = deactivate;
-}
-
-bool PlatformMediaSessionManager::vorbisDecoderEnabled()
-{
-#if ENABLE(VORBIS)
-    return m_vorbisDecoderEnabled;
-#else
-    return false;
-#endif
-}
-
-void PlatformMediaSessionManager::setVorbisDecoderEnabled(bool enabled)
-{
-#if ENABLE(VORBIS)
-    m_vorbisDecoderEnabled = enabled;
-#else
-    UNUSED_PARAM(enabled);
-#endif
 }
 
 bool PlatformMediaSessionManager::opusDecoderEnabled()

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -65,8 +65,6 @@ public:
     WEBCORE_EXPORT static void setShouldDeactivateAudioSession(bool);
     WEBCORE_EXPORT static bool shouldDeactivateAudioSession();
 
-    WEBCORE_EXPORT static void setVorbisDecoderEnabled(bool);
-    WEBCORE_EXPORT static bool vorbisDecoderEnabled();
     WEBCORE_EXPORT static void setOpusDecoderEnabled(bool);
     WEBCORE_EXPORT static bool opusDecoderEnabled();
     WEBCORE_EXPORT static void setAlternateWebMPlayerEnabled(bool);
@@ -269,9 +267,6 @@ private:
     WeakHashSet<NowPlayingMetadataObserver> m_nowPlayingMetadataObservers;
     TaskCancellationGroup m_taskGroup;
 
-#if ENABLE(VORBIS)
-    static bool m_vorbisDecoderEnabled;
-#endif
 #if ENABLE(OPUS)
     static bool m_opusDecoderEnabled;
 #endif

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
@@ -496,9 +496,6 @@ static Vector<uint8_t> cookieFromVorbisCodecPrivate(std::span<const uint8_t> cod
 bool isVorbisDecoderAvailable()
 {
 #if ENABLE(VORBIS)
-    if (!PlatformMediaSessionManager::vorbisDecoderEnabled())
-        return false;
-
     return registerVorbisDecoderIfNeeded();
 #else
     return false;

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -286,11 +286,6 @@ void GPUProcess::updateGPUProcessPreferences(GPUProcessPreferences&& preferences
         PlatformMediaSessionManager::setOpusDecoderEnabled(*m_preferences.opusDecoderEnabled);
 #endif
 
-#if ENABLE(VORBIS)
-    if (updatePreference(m_preferences.vorbisDecoderEnabled, preferences.vorbisDecoderEnabled))
-        PlatformMediaSessionManager::setVorbisDecoderEnabled(*m_preferences.vorbisDecoderEnabled);
-#endif
-    
 #if USE(MODERN_AVCONTENTKEYSESSION)
     if (updatePreference(m_preferences.shouldUseModernAVContentKeySession, preferences.shouldUseModernAVContentKeySession))
         MediaSessionManagerCocoa::setShouldUseModernAVContentKeySession(*m_preferences.shouldUseModernAVContentKeySession);

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.cpp
@@ -43,11 +43,6 @@ void GPUProcessPreferences::copyEnabledWebPreferences(const WebPreferences& webP
         opusDecoderEnabled = true;
 #endif
 
-#if ENABLE(VORBIS)
-    if (webPreferences.vorbisDecoderEnabled())
-        vorbisDecoderEnabled = true;
-#endif
-
 #if USE(MODERN_AVCONTENTKEYSESSION)
     if (webPreferences.shouldUseModernAVContentKeySession())
         shouldUseModernAVContentKeySession = true;

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.h
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.h
@@ -40,10 +40,6 @@ struct GPUProcessPreferences {
     std::optional<bool> opusDecoderEnabled;
 #endif
 
-#if ENABLE(VORBIS)
-    std::optional<bool> vorbisDecoderEnabled;
-#endif
-
 #if USE(MODERN_AVCONTENTKEYSESSION)
     std::optional<bool> shouldUseModernAVContentKeySession;
 #endif

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in
@@ -26,9 +26,6 @@ struct WebKit::GPUProcessPreferences {
 #if ENABLE(OPUS)
     std::optional<bool> opusDecoderEnabled;
 #endif
-#if ENABLE(VORBIS)
-    std::optional<bool> vorbisDecoderEnabled;
-#endif
 #if USE(MODERN_AVCONTENTKEYSESSION)
     std::optional<bool> shouldUseModernAVContentKeySession;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4827,10 +4827,6 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
     PlatformMediaSessionManager::setUseSCContentSharingPicker(settings.useSCContentSharingPicker());
 #endif
 
-#if ENABLE(VORBIS)
-    PlatformMediaSessionManager::setVorbisDecoderEnabled(DeprecatedGlobalSettings::vorbisDecoderEnabled());
-#endif
-
 #if ENABLE(OPUS)
     PlatformMediaSessionManager::setOpusDecoderEnabled(DeprecatedGlobalSettings::opusDecoderEnabled());
 #endif

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -500,10 +500,6 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     pthread_set_fixedpriority_self();
 #endif
 
-#if ENABLE(VORBIS)
-    PlatformMediaSessionManager::setVorbisDecoderEnabled(DeprecatedGlobalSettings::vorbisDecoderEnabled());
-#endif
-
 #if ENABLE(OPUS)
     PlatformMediaSessionManager::setOpusDecoderEnabled(DeprecatedGlobalSettings::opusDecoderEnabled());
 #endif


### PR DESCRIPTION
#### 42126356563ef6a3008af4fc3e4905e19b0f7e4e
<pre>
Remove VorbisDecoderEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=285676">https://bugs.webkit.org/show_bug.cgi?id=285676</a>

Reviewed by Jean-Yves Avenard.

It&apos;s been stable for a long time.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/DeprecatedGlobalSettings.cpp:
(WebCore::DeprecatedGlobalSettings::setVorbisDecoderEnabled): Deleted.
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::vorbisDecoderEnabled): Deleted.
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::vorbisDecoderEnabled): Deleted.
(WebCore::PlatformMediaSessionManager::setVorbisDecoderEnabled): Deleted.
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm:
(WebCore::isVorbisDecoderAvailable):
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::updateGPUProcessPreferences):
* Source/WebKit/GPUProcess/GPUProcessPreferences.cpp:
(WebKit::GPUProcessPreferences::copyEnabledWebPreferences):
* Source/WebKit/GPUProcess/GPUProcessPreferences.h:
* Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updatePreferences):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/288661@main">https://commits.webkit.org/288661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87c0afb94d640b9a2fc96bf7ccab7ae050fcefe5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89111 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35044 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86121 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11622 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65357 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23203 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87082 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45650 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2722 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30580 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34093 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77000 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90490 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83053 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73807 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72185 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73023 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17323 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2648 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13006 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16725 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105472 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11101 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25481 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14577 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12873 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->