### PR TITLE
WebRTC AV1 decoder should be able to handle dynamic resolution increase

### DIFF
--- a/LayoutTests/webrtc/video-av1-expected.txt
+++ b/LayoutTests/webrtc/video-av1-expected.txt
@@ -9,4 +9,7 @@ PASS Track is enabled, video should not be black
 PASS Track is disabled, video should be black
 PASS If disabled, black frames should still be coming
 PASS Track is enabled, video should not be black 2
+PASS Track resolution increases
+PASS Verify video element size changes
+PASS Verfiy video decoding continues
 

--- a/LayoutTests/webrtc/video-av1.html
+++ b/LayoutTests/webrtc/video-av1.html
@@ -122,6 +122,17 @@ promise_test((test) => {
     return checkVideoBlack(false, canvas2, video);
 }, "Track is enabled, video should not be black 2");
 
+promise_test((test) => {
+    return track.applyConstraints({ width:640, height:480 });
+}, "Track resolution increases");
+
+promise_test((test) => {
+    return waitForVideoSize(video, 640, 480, "increase of resolution should be fine");
+}, "Verify video element size changes");
+
+promise_test((test) => {
+    return testFrameDecodedIncreased(receivingConnection);
+}, "Verfiy video decoding continues");
         </script>
     </body>
 </html>


### PR DESCRIPTION
#### 245e94c46483eb9d96c52047c913c195385894b4
<pre>
WebRTC AV1 decoder should be able to handle dynamic resolution increase
<a href="https://rdar.apple.com/142605002">rdar://142605002</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=285681">https://bugs.webkit.org/show_bug.cgi?id=285681</a>

Reviewed by Jean-Yves Avenard.

AV1 VTB decoder may be sent video frames of varying size through the WebRTC code path.
To properly handle this, we parse each encoded frame to get its input format.
If the input format is different from the current input format, we recreate the VTB session.

Covered by added test.

* LayoutTests/webrtc/video-av1-expected.txt:
* LayoutTests/webrtc/video-av1.html:
* Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm:
(-[RTCVideoDecoderVTBAV1 init]):
(-[RTCVideoDecoderVTBAV1 setWidth:height:]):
(-[RTCVideoDecoderVTBAV1 decodeData:size:timeStamp:]):

Canonical link: <a href="https://commits.webkit.org/288783@main">https://commits.webkit.org/288783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b069e226f7ceffc5c7e176e7ca40c3b1b8b1330

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89304 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35237 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65512 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23355 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45805 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2901 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30766 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34286 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73810 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90686 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73966 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11721 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73168 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18135 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17484 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15927 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2860 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11447 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16923 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11296 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14772 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->