### PR TITLE
URLPattern.match does not correctly handle string input

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -4,7 +4,7 @@ PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
@@ -18,9 +18,9 @@ PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: 
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
@@ -184,8 +184,8 @@ PASS Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}]
 PASS Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}]
 PASS Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}]
 PASS Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}]
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"]
+PASS Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"]
 PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}]
 PASS Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}]
@@ -197,56 +197,56 @@ FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"bas
 FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
 PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo"] Inputs: undefined
 PASS Pattern: ["example.com/foo"] Inputs: undefined
-FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"]
+PASS Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"]
+PASS Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"]
+PASS Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"]
+PASS Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"]
+PASS Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"]
+PASS Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"]
 PASS Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"]
-FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"]
 PASS Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
 PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
-FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["data\\:foobar"] Inputs: ["data:foobar"]
+PASS Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["data:"] Inputs: ["data:"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"]
+PASS Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"]
+PASS Pattern: ["data:"] Inputs: ["data:"]
 PASS Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"]
 PASS Pattern: ["(café)://foo"] Inputs: undefined
 PASS Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}]
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"]
 FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
 FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] assert_equals: test() result expected false but got true
+PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
-FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"]
+PASS Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"]
+PASS Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"]
+PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"]
+PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
+PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
 FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
@@ -292,7 +292,7 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
+PASS Pattern: [{}] Inputs: ["https://example.com/"]
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -4,7 +4,7 @@ PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
@@ -18,9 +18,9 @@ PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: 
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
@@ -184,8 +184,8 @@ PASS Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}]
 PASS Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}]
 PASS Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}]
 PASS Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}]
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"]
+PASS Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"]
 PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}]
 PASS Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}]
@@ -197,56 +197,56 @@ FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"bas
 FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
 PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo"] Inputs: undefined
 PASS Pattern: ["example.com/foo"] Inputs: undefined
-FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"]
+PASS Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"]
+PASS Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"]
+PASS Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"]
+PASS Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"]
+PASS Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"]
+PASS Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"]
 PASS Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"]
-FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"]
 PASS Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
 PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
-FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["data\\:foobar"] Inputs: ["data:foobar"]
+PASS Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["data:"] Inputs: ["data:"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"]
+PASS Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"]
+PASS Pattern: ["data:"] Inputs: ["data:"]
 PASS Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"]
 PASS Pattern: ["(café)://foo"] Inputs: undefined
 PASS Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}]
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"]
 FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
 FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] assert_equals: test() result expected false but got true
+PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
-FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"]
+PASS Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"]
+PASS Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"]
+PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"]
+PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
+PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
 FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
@@ -292,7 +292,7 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
+PASS Pattern: [{}] Inputs: ["https://example.com/"]
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -4,7 +4,7 @@ PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
@@ -18,9 +18,9 @@ PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: 
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
@@ -184,8 +184,8 @@ PASS Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}]
 PASS Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}]
 PASS Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}]
 PASS Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}]
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"]
+PASS Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"]
 PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}]
 PASS Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}]
@@ -197,56 +197,56 @@ FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"bas
 FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
 PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo"] Inputs: undefined
 PASS Pattern: ["example.com/foo"] Inputs: undefined
-FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"]
+PASS Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"]
+PASS Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"]
+PASS Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"]
+PASS Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"]
+PASS Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"]
+PASS Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"]
 PASS Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"]
-FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"]
 PASS Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
 PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
-FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["data\\:foobar"] Inputs: ["data:foobar"]
+PASS Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["data:"] Inputs: ["data:"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"]
+PASS Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"]
+PASS Pattern: ["data:"] Inputs: ["data:"]
 PASS Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"]
 PASS Pattern: ["(café)://foo"] Inputs: undefined
 PASS Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}]
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"]
 FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
 FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] assert_equals: test() result expected false but got true
+PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
-FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"]
+PASS Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"]
+PASS Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"]
+PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"]
+PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
+PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
 FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
@@ -292,7 +292,7 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
+PASS Pattern: [{}] Inputs: ["https://example.com/"]
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -4,7 +4,7 @@ PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
@@ -18,9 +18,9 @@ PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: 
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
@@ -184,8 +184,8 @@ PASS Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}]
 PASS Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}]
 PASS Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}]
 PASS Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}]
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"]
+PASS Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"]
 PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}]
 PASS Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}]
@@ -197,56 +197,56 @@ FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"bas
 FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
 PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo"] Inputs: undefined
 PASS Pattern: ["example.com/foo"] Inputs: undefined
-FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"]
+PASS Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"]
+PASS Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"]
+PASS Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"]
+PASS Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"]
+PASS Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"]
+PASS Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"]
 PASS Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"]
-FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"]
 PASS Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
 PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
-FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["data\\:foobar"] Inputs: ["data:foobar"]
+PASS Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["data:"] Inputs: ["data:"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"]
+PASS Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"]
+PASS Pattern: ["data:"] Inputs: ["data:"]
 PASS Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"]
 PASS Pattern: ["(café)://foo"] Inputs: undefined
 PASS Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}]
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"]
 FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
 FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] assert_equals: test() result expected false but got true
+PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
-FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"]
+PASS Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"]
+PASS Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"]
+PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"]
+PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
+PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
 FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
@@ -292,7 +292,7 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
+PASS Pattern: [{}] Inputs: ["https://example.com/"]
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -4,7 +4,7 @@ PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
@@ -18,9 +18,9 @@ PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: 
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
@@ -184,8 +184,8 @@ PASS Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}]
 PASS Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}]
 PASS Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}]
 PASS Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}]
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"]
+PASS Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"]
 PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}]
 PASS Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}]
@@ -197,56 +197,56 @@ FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"bas
 FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
 PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo"] Inputs: undefined
 PASS Pattern: ["example.com/foo"] Inputs: undefined
-FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"]
+PASS Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"]
+PASS Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"]
+PASS Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"]
+PASS Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"]
+PASS Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"]
+PASS Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"]
 PASS Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"]
-FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"]
 PASS Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
 PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
-FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["data\\:foobar"] Inputs: ["data:foobar"]
+PASS Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["data:"] Inputs: ["data:"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"]
+PASS Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"]
+PASS Pattern: ["data:"] Inputs: ["data:"]
 PASS Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"]
 PASS Pattern: ["(café)://foo"] Inputs: undefined
 PASS Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}]
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"]
 FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
 FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] assert_equals: test() result expected false but got true
+PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
-FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"]
+PASS Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"]
+PASS Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"]
+PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"]
+PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
+PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
 FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
@@ -292,7 +292,7 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
+PASS Pattern: [{}] Inputs: ["https://example.com/"]
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -4,7 +4,7 @@ PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
@@ -18,9 +18,9 @@ PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: 
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
@@ -184,8 +184,8 @@ PASS Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}]
 PASS Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}]
 PASS Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}]
 PASS Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}]
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"]
+PASS Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"]
 PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}]
 PASS Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}]
@@ -197,56 +197,56 @@ FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"bas
 FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
 PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo"] Inputs: undefined
 PASS Pattern: ["example.com/foo"] Inputs: undefined
-FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"]
+PASS Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"]
+PASS Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"]
+PASS Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"]
+PASS Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"]
+PASS Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"]
+PASS Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"]
 PASS Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"]
-FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"]
 PASS Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
 PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
-FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["data\\:foobar"] Inputs: ["data:foobar"]
+PASS Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["data:"] Inputs: ["data:"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"]
+PASS Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"]
+PASS Pattern: ["data:"] Inputs: ["data:"]
 PASS Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"]
 PASS Pattern: ["(café)://foo"] Inputs: undefined
 PASS Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}]
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"]
 FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
 FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] assert_equals: test() result expected false but got true
+PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
-FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"]
+PASS Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"]
+PASS Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"]
+PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"]
+PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
+PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
 FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
@@ -292,7 +292,7 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
+PASS Pattern: [{}] Inputs: ["https://example.com/"]
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -4,7 +4,7 @@ PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
@@ -18,9 +18,9 @@ PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: 
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
@@ -184,8 +184,8 @@ PASS Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}]
 PASS Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}]
 PASS Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}]
 PASS Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}]
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"]
+PASS Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"]
 PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}]
 PASS Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}]
@@ -197,56 +197,56 @@ FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"bas
 FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
 PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo"] Inputs: undefined
 PASS Pattern: ["example.com/foo"] Inputs: undefined
-FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"]
+PASS Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"]
+PASS Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"]
+PASS Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"]
+PASS Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"]
+PASS Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"]
+PASS Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"]
 PASS Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"]
-FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"]
 PASS Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
 PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
-FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["data\\:foobar"] Inputs: ["data:foobar"]
+PASS Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["data:"] Inputs: ["data:"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"]
+PASS Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"]
+PASS Pattern: ["data:"] Inputs: ["data:"]
 PASS Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"]
 PASS Pattern: ["(café)://foo"] Inputs: undefined
 PASS Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}]
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"]
 FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
 FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] assert_equals: test() result expected false but got true
+PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
-FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"]
+PASS Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"]
+PASS Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"]
+PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"]
+PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
+PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
 FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
@@ -292,7 +292,7 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
+PASS Pattern: [{}] Inputs: ["https://example.com/"]
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -4,7 +4,7 @@ PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}]
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}]
@@ -18,9 +18,9 @@ PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: 
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?otherquery#otherhash"}] Inputs: [{"protocol":"https","hostname":"example.com","pathname":"/foo/bar","search":"otherquery","hash":"otherhash"}]
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?otherquery#otherhash"]
+PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar?query#hash"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://example.com/foo/bar/baz"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["https://other.com/foo/bar"]
 PASS Pattern: [{"pathname":"/foo/bar","baseURL":"https://example.com?query#hash"}] Inputs: ["http://other.com/foo/bar"]
@@ -184,8 +184,8 @@ PASS Pattern: [{"search":"q=caf%c3%a9"}] Inputs: [{"search":"q=café"}]
 PASS Pattern: [{"hash":"caf%C3%A9"}] Inputs: [{"hash":"café"}]
 PASS Pattern: [{"hash":"café"}] Inputs: [{"hash":"café"}]
 PASS Pattern: [{"hash":"caf%c3%a9"}] Inputs: [{"hash":"café"}]
-FAIL Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"protocol":"about","pathname":"(blank|sourcedoc)"}] Inputs: ["about:blank"]
+PASS Pattern: [{"protocol":"data","pathname":":number([0-9]+)"}] Inputs: ["data:8675309"]
 PASS Pattern: [{"pathname":"/(\\m)"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo!"}] Inputs: [{"pathname":"/foo!"}]
 PASS Pattern: [{"pathname":"/foo\\:"}] Inputs: [{"pathname":"/foo:"}]
@@ -197,56 +197,56 @@ FAIL Pattern: [{"protocol":"javascript","pathname":"var x = 1;"}] Inputs: [{"bas
 FAIL Pattern: [{"protocol":"(data|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}] assert_equals: compiled pattern property 'pathname' expected "var x = 1;" but got "var%20x%20=%201;"
 PASS Pattern: [{"protocol":"(https|javascript)","pathname":"var x = 1;"}] Inputs: [{"protocol":"javascript","pathname":"var x = 1;"}]
 FAIL Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
 PASS Pattern: ["/foo"] Inputs: undefined
 PASS Pattern: ["example.com/foo"] Inputs: undefined
-FAIL Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"]
+PASS Pattern: ["https://example.com?foo"] Inputs: ["https://example.com/?foo"]
+PASS Pattern: ["https://example.com#foo"] Inputs: ["https://example.com/#foo"]
+PASS Pattern: ["https://example.com:8080?foo"] Inputs: ["https://example.com:8080/?foo"]
+PASS Pattern: ["https://example.com:8080#foo"] Inputs: ["https://example.com:8080/#foo"]
+PASS Pattern: ["https://example.com/?foo"] Inputs: ["https://example.com/?foo"]
+PASS Pattern: ["https://example.com/#foo"] Inputs: ["https://example.com/#foo"]
 PASS Pattern: ["https://example.com/*?foo"] Inputs: ["https://example.com/?foo"]
-FAIL Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/*\\?foo"] Inputs: ["https://example.com/?foo"]
 PASS Pattern: ["https://example.com/:name?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/:name\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/(bar)?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/(bar)\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/{bar}?foo"] Inputs: ["https://example.com/bar?foo"]
-FAIL Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://example.com/{bar}\\?foo"] Inputs: ["https://example.com/bar?foo"]
 PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
 PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
-FAIL Pattern: ["data\\:foobar"] Inputs: ["data:foobar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["data\\:foobar"] Inputs: ["data:foobar"]
+PASS Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"]
 FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["(https://)example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://{sub{.}}example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["data:"] Inputs: ["data:"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://(sub(?:.))?example.com/foo"] Inputs: ["https://example.com/foo"]
+PASS Pattern: ["file:///foo/bar"] Inputs: ["file:///foo/bar"]
+PASS Pattern: ["data:"] Inputs: ["data:"]
 PASS Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"]
 PASS Pattern: ["(café)://foo"] Inputs: undefined
 PASS Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}]
-FAIL Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"] assert_equals: test() result expected true but got false
+PASS Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"]
 FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
 FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
 FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
-FAIL Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"] assert_equals: test() result expected false but got true
+PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
-FAIL Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"] assert_equals: test() result expected true but got false
-FAIL Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"] assert_equals: test() result expected true but got false
+PASS Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"]
+PASS Pattern: ["https://foo@example.com"] Inputs: ["https://foo@example.com"]
+PASS Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"]
+PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"]
+PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
+PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
 FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
@@ -292,7 +292,7 @@ PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{}] Inputs: ["https://example.com/"] assert_object_equals: exec() result for protocol property "0" expected "https" got ""
+PASS Pattern: [{}] Inputs: ["https://example.com/"]
 FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
 FAIL Pattern: [] Inputs: [{}] Not implemented.
 FAIL Pattern: [] Inputs: [] Not implemented.


### PR DESCRIPTION
#### 3a150ae665540912edf5523e047ace9d57d1c02e
<pre>
URLPattern.match does not correctly handle string input
<a href="https://bugs.webkit.org/show_bug.cgi?id=285682">https://bugs.webkit.org/show_bug.cgi?id=285682</a>
<a href="https://rdar.apple.com/142616018">rdar://142616018</a>

Reviewed by Chris Dumez.

The input as a string needs to be combined with the base URL as per <a href="https://urlpattern.spec.whatwg.org/#url-pattern-match">https://urlpattern.spec.whatwg.org/#url-pattern-match</a> step 12.2.
We add this and we do a small refactoring to use the return value of switchOn.

Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::URLPattern::match const):

Canonical link: <a href="https://commits.webkit.org/288689@main">https://commits.webkit.org/288689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37458dc79943dc3a48d585f56e261bfa46908e71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84066 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89141 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35074 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11652 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65381 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23228 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45675 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2753 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30609 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34123 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73707 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90521 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11331 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73832 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11555 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73045 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18076 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17353 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2678 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11283 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16755 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11131 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12903 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->