### PR TITLE
Support URLPattern optional parameters

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -293,9 +293,9 @@ FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js:
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
-FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
-FAIL Pattern: [] Inputs: [{}] Not implemented.
-FAIL Pattern: [] Inputs: [] Not implemented.
+PASS Pattern: [] Inputs: ["https://example.com/"]
+PASS Pattern: [] Inputs: [{}]
+PASS Pattern: [] Inputs: []
 PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -293,9 +293,9 @@ FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js:
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
-FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
-FAIL Pattern: [] Inputs: [{}] Not implemented.
-FAIL Pattern: [] Inputs: [] Not implemented.
+PASS Pattern: [] Inputs: ["https://example.com/"]
+PASS Pattern: [] Inputs: [{}]
+PASS Pattern: [] Inputs: []
 PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -293,9 +293,9 @@ FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js:
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
-FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
-FAIL Pattern: [] Inputs: [{}] Not implemented.
-FAIL Pattern: [] Inputs: [] Not implemented.
+PASS Pattern: [] Inputs: ["https://example.com/"]
+PASS Pattern: [] Inputs: [{}]
+PASS Pattern: [] Inputs: []
 PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -293,9 +293,9 @@ FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js:
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
-FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
-FAIL Pattern: [] Inputs: [{}] Not implemented.
-FAIL Pattern: [] Inputs: [] Not implemented.
+PASS Pattern: [] Inputs: ["https://example.com/"]
+PASS Pattern: [] Inputs: [{}]
+PASS Pattern: [] Inputs: []
 PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -293,9 +293,9 @@ FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js:
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
-FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
-FAIL Pattern: [] Inputs: [{}] Not implemented.
-FAIL Pattern: [] Inputs: [] Not implemented.
+PASS Pattern: [] Inputs: ["https://example.com/"]
+PASS Pattern: [] Inputs: [{}]
+PASS Pattern: [] Inputs: []
 PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -293,9 +293,9 @@ FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js:
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
-FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
-FAIL Pattern: [] Inputs: [{}] Not implemented.
-FAIL Pattern: [] Inputs: [] Not implemented.
+PASS Pattern: [] Inputs: ["https://example.com/"]
+PASS Pattern: [] Inputs: [{}]
+PASS Pattern: [] Inputs: []
 PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -293,9 +293,9 @@ FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js:
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
-FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
-FAIL Pattern: [] Inputs: [{}] Not implemented.
-FAIL Pattern: [] Inputs: [] Not implemented.
+PASS Pattern: [] Inputs: ["https://example.com/"]
+PASS Pattern: [] Inputs: [{}]
+PASS Pattern: [] Inputs: []
 PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -293,9 +293,9 @@ FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js:
 FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
-FAIL Pattern: [] Inputs: ["https://example.com/"] Not implemented.
-FAIL Pattern: [] Inputs: [{}] Not implemented.
-FAIL Pattern: [] Inputs: [] Not implemented.
+PASS Pattern: [] Inputs: ["https://example.com/"]
+PASS Pattern: [] Inputs: [{}]
+PASS Pattern: [] Inputs: []
 PASS Pattern: [{"pathname":"(foo)(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"{(foo)bar}(.*)"}] Inputs: [{"pathname":"foobarbaz"}]
 PASS Pattern: [{"pathname":"(foo)?(.*)"}] Inputs: [{"pathname":"foobarbaz"}]

--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -257,10 +257,8 @@ ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context,
 // https://urlpattern.spec.whatwg.org/#urlpattern-initialize
 ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context, std::optional<URLPatternInput>&& input, URLPatternOptions&& options)
 {
-    if (!input) {
-        // FIXME: File a bug to URLPattern owners to tell them that spec does not mention supporting empty URLPattern objects. Spec and test cases have diverged!
-        return Exception { ExceptionCode::NotSupportedError, "Not implemented."_s };
-    }
+    if (!input)
+        input = URLPatternInit { };
 
     return create(context, WTFMove(*input), String { }, WTFMove(options));
 }
@@ -271,21 +269,20 @@ URLPattern::~URLPattern() = default;
 ExceptionOr<bool> URLPattern::test(ScriptExecutionContext& context, std::optional<URLPatternInput>&& input, String&& baseURL) const
 {
     if (!input)
-        return Exception { ExceptionCode::NotSupportedError };
+        input = URLPatternInit { };
 
     auto maybeResult = match(context, WTFMove(*input), WTFMove(baseURL));
     if (maybeResult.hasException())
         return maybeResult.releaseException();
 
     return !!maybeResult.returnValue();
-
 }
 
 // https://urlpattern.spec.whatwg.org/#dom-urlpattern-exec
 ExceptionOr<std::optional<URLPatternResult>> URLPattern::exec(ScriptExecutionContext& context, std::optional<URLPatternInput>&& input, String&& baseURL) const
 {
     if (!input)
-        return Exception { ExceptionCode::NotSupportedError };
+        input = URLPatternInit { };
 
     return match(context, WTFMove(*input), WTFMove(baseURL));
 }


### PR DESCRIPTION
#### 6a6a2c865253b5057658dd69eb23aac38a179eec
<pre>
Support URLPattern optional parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=285683">https://bugs.webkit.org/show_bug.cgi?id=285683</a>
<a href="https://rdar.apple.com/142616185">rdar://142616185</a>

Reviewed by Anne van Kesteren.

As per WebIDL, URLPattern constructor, test and match take an option URLPatternInput.
We emulate this within the WebCore C++ layer since binding generator is not skillful enough to understand which variant of URLPatternInput to use (URLPatternInit).

Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::URLPattern::create):
(WebCore::URLPattern::test const):
(WebCore::URLPattern::exec const):

Canonical link: <a href="https://commits.webkit.org/288787@main">https://commits.webkit.org/288787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db06c041173d9a371873735c1a09b1bec85ece6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89504 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35434 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12030 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65658 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23498 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87469 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3111 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45950 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30931 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34481 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73951 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90885 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11690 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8510 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74109 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73309 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18138 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17642 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16086 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3101 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11642 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17118 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11491 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14967 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13264 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->