### PR TITLE
Tokenizer::getNextCodePoint is not handling correctly 8bit strings

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -122,13 +122,13 @@ PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"pathname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"search":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
+PASS Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}]
 PASS Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}]
 PASS Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}]
 PASS Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -122,13 +122,13 @@ PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"pathname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"search":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
+PASS Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}]
 PASS Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}]
 PASS Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}]
 PASS Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -122,13 +122,13 @@ PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"pathname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"search":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
+PASS Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}]
 PASS Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}]
 PASS Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}]
 PASS Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -122,13 +122,13 @@ PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"pathname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"search":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
+PASS Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}]
 PASS Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}]
 PASS Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}]
 PASS Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -122,13 +122,13 @@ PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"pathname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"search":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
+PASS Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}]
 PASS Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}]
 PASS Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}]
 PASS Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -122,13 +122,13 @@ PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"pathname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"search":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
+PASS Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}]
 PASS Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}]
 PASS Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}]
 PASS Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -122,13 +122,13 @@ PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"pathname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"search":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
+PASS Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}]
 PASS Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}]
 PASS Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}]
 PASS Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -122,13 +122,13 @@ PASS Pattern: [{"hostname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"pathname":"(café)"}] Inputs: undefined
 PASS Pattern: [{"search":"(café)"}] Inputs: undefined
 PASS Pattern: [{"hash":"(café)"}] Inputs: undefined
-FAIL Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}] Invalid input to canonicalize a URL protocol string.
-FAIL Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}] assert_equals: compiled pattern property 'username' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}] assert_equals: compiled pattern property 'password' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}] assert_equals: compiled pattern property 'hostname' expected ":café" but got "{:caf}é"
-FAIL Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}] assert_equals: compiled pattern property 'pathname' expected "/:café" but got "/:caf%C3%A9"
-FAIL Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}] assert_equals: compiled pattern property 'search' expected ":café" but got ":caf%C3%A9"
-FAIL Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}] assert_equals: compiled pattern property 'hash' expected ":café" but got ":caf%C3%A9"
+PASS Pattern: [{"protocol":":café"}] Inputs: [{"protocol":"foo"}]
+PASS Pattern: [{"username":":café"}] Inputs: [{"username":"foo"}]
+PASS Pattern: [{"password":":café"}] Inputs: [{"password":"foo"}]
+PASS Pattern: [{"hostname":":café"}] Inputs: [{"hostname":"foo"}]
+PASS Pattern: [{"pathname":"/:café"}] Inputs: [{"pathname":"/foo"}]
+PASS Pattern: [{"search":":café"}] Inputs: [{"search":"foo"}]
+PASS Pattern: [{"hash":":café"}] Inputs: [{"hash":"foo"}]
 PASS Pattern: [{"protocol":":℘"}] Inputs: [{"protocol":"foo"}]
 PASS Pattern: [{"username":":℘"}] Inputs: [{"username":"foo"}]
 PASS Pattern: [{"password":":℘"}] Inputs: [{"password":"foo"}]

--- a/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
@@ -43,19 +43,19 @@ bool Token::isNull() const
     return false;
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 // https://urlpattern.spec.whatwg.org/#get-the-next-code-point
 void Tokenizer::getNextCodePoint()
 {
-    if (m_input.is8Bit()) {
-        auto characters = m_input.span8();
-        U8_NEXT_OR_FFFD(characters, m_nextIndex, m_input.length(), m_codepoint);
-    } else {
+    if (m_input.is8Bit())
+        m_codepoint = m_input[m_nextIndex++];
+    else {
+        // FIXME: We should handle surrogates if any.
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         auto characters = m_input.span16();
         U16_NEXT_OR_FFFD(characters, m_nextIndex, m_input.length(), m_codepoint);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 // https://urlpattern.spec.whatwg.org/#seek-and-get-the-next-code-point
 void Tokenizer::seekNextCodePoint(size_t index)


### PR DESCRIPTION
#### 6a49d757b57250726e283eb121dafa9c471f6ba6
<pre>
Tokenizer::getNextCodePoint is not handling correctly 8bit strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=285685">https://bugs.webkit.org/show_bug.cgi?id=285685</a>
<a href="https://rdar.apple.com/142617047">rdar://142617047</a>

Reviewed by Anne van Kesteren.

The tokenizer is handling code points and WTFString either handles code points as 8 bits or UTF16 otherwise.
We update the 8 bit code path as it does not need to check for surrogates.

Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:

Canonical link: <a href="https://commits.webkit.org/288862@main">https://commits.webkit.org/288862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d77e2021e9387802cb80aab7bf28efb1340661a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89517 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35446 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12057 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65664 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23505 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87481 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3120 "Found 4 new test failures: fast/files/blob-stream-frame.html http/tests/app-privacy-report/app-attribution-post-request.html http/tests/websocket/tests/hybi/no-subprotocol.html http/wpt/cache-storage/quota-third-party.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76710 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45958 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3070 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30941 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34493 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73960 "Found 1 new API test failure: TestWebKitAPI.WKAttachmentTests.InsertDataURLImagesAsAttachments (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31711 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90897 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74117 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73318 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18172 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17650 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16096 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3121 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11654 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17130 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11503 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13276 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->