### PR TITLE
AX: deferModalChange unnecessarily causes a children-changed, and changing aria-hidden unnecessarily resets m_modalNodesInitialized

### DIFF
--- a/LayoutTests/accessibility/mac/dynamic-modal-expected.txt
+++ b/LayoutTests/accessibility/mac/dynamic-modal-expected.txt
@@ -5,8 +5,8 @@ Show button reachable: true
 
 Clicking on show button
 
-New focus: dialog_ok
-Show button reachable: false
+PASS: accessibilityController.focusedElement?.domIdentifier === 'dialog_ok' === true
+PASS: !!accessibilityController.accessibleElementById('show') === false
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/mac/dynamic-modal.html
+++ b/LayoutTests/accessibility/mac/dynamic-modal.html
@@ -5,17 +5,16 @@
 <script src="../../resources/js-test.js"></script>
 </head>
 <style>
-  *[role="dialog"] { border: 1px solid black; padding: 1em; margin: 1em; }
-  :focus { outline: 3px solid #ccf; outline-offset: 3px; }
+*[role="dialog"] { border: 1px solid black; padding: 1em; margin: 1em; }
+:focus { outline: 3px solid #ccf; outline-offset: 3px; }
 </style>
 <body>
 
-  <p>
+<p>
     <button id="show" autofocus>Show</button>
-  </p>
+</p>
 
-  <div id="wrapper">
-  </div>
+<div id="wrapper"></div>
 
 <script>
 document.getElementById("show").addEventListener("click", () => {
@@ -30,7 +29,7 @@ document.getElementById("show").addEventListener("click", () => {
     }, 0);
 });
 
-var testOutput = "This tests nested aria-modal dialogs\n\n";
+var output = "This tests nested aria-modal dialogs\n\n";
 
 if (window.accessibilityController) {
     window.jsTestIsAsync = true;
@@ -40,32 +39,17 @@ if (window.accessibilityController) {
             focus = accessibilityController.focusedElement;
             return focus && focus.domIdentifier;
         });
+        output += `Initial focus: ${focus.domIdentifier}\n`;
+        output += `Show button reachable: ${accessibilityController.accessibleElementById("show") != null}\n`;
 
-        focus = accessibilityController.focusedElement;
-        testOutput += `Initial focus: ${focus.domIdentifier}\n`;
-
-        show = accessibilityController.accessibleElementById("show");
-        testOutput += `Show button reachable: ${show != null}\n`;
-
-        testOutput += "\nClicking on show button\n\n";
+        output += "\nClicking on show button\n\n";
         document.getElementById("show").click();
 
-        await waitFor(() => {
-            focus = accessibilityController.focusedElement;
-            return focus.domIdentifier != "ok";
-        });
+        output += await expectAsync("accessibilityController.focusedElement?.domIdentifier === 'dialog_ok'", "true");
+        // The show button should be inaccessible.
+        output += await expectAsync("!!accessibilityController.accessibleElementById('show')", "false");
 
-        focus = accessibilityController.focusedElement;
-        testOutput += `New focus: ${focus.domIdentifier}\n`;
-
-        await waitFor(() => {
-            return !accessibilityController.accessibleElementById("show");
-        });
-
-        show = accessibilityController.accessibleElementById("show");
-        testOutput += `Show button reachable: ${show != null}\n`;
-
-        debug(testOutput);
+        debug(output);
         finishJSTest();
     });
 }


### PR DESCRIPTION
#### 6913057b93bbc24e15172526c3f5989ced285fa6
<pre>
AX: deferModalChange unnecessarily causes a children-changed, and changing aria-hidden unnecessarily resets m_modalNodesInitialized
<a href="https://bugs.webkit.org/show_bug.cgi?id=285688">https://bugs.webkit.org/show_bug.cgi?id=285688</a>
<a href="https://rdar.apple.com/problem/142617733">rdar://problem/142617733</a>

Reviewed by Chris Fleizach.

AXObjectCache::deferModalChange started issuing a children-changed event in this commit:

<a href="https://github.com/WebKit/WebKit/commit/9b24060ac33142c1ba4a717e9661e04b5fa59bf4">https://github.com/WebKit/WebKit/commit/9b24060ac33142c1ba4a717e9661e04b5fa59bf4</a>

Which fixed 7 tests in ITM. However, I don&apos;t think this behavior is correct. There is nothing about becoming a potential
modal node that affects any objects children. If the computed modal is changed, we will submit the appropriate children-changed
events, but in this spot we are just incurring unnecessary work.

This commit also removes unnecessary work done in AXObjectCache::handleAttributeChange where we would reset m_modalNodesInitialized
to false when aria-hidden changes when a modal is active. Resetting m_modalNodesInitialized to false causes findModalNodes()
to run, but this function doesn&apos;t consider aria-hidden in any way, so this behavior causes unnecessary work.

* LayoutTests/accessibility/mac/dynamic-modal-expected.txt:
* LayoutTests/accessibility/mac/dynamic-modal.html:
Simplify test.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::deferModalChange):
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::performDeferredCacheUpdate):

Canonical link: <a href="https://commits.webkit.org/288680@main">https://commits.webkit.org/288680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/931caccb62dbfce60d022148d7bf810dd20108a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89168 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35101 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86178 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65401 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23244 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76406 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45695 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2774 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30630 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34150 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31391 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90548 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11358 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73853 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72236 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73067 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18071 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17372 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2705 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11310 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16782 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11158 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14634 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12930 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->