### PR TITLE
URLPattern should expose percent-encoded username and password

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -146,12 +146,12 @@ PASS Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}]
 PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}]
 PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}]
 PASS Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}]
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
+PASS Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"username":"café"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}]
+PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
+PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
 FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
@@ -247,7 +247,7 @@ PASS Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"
 PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"]
 PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
-FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
+PASS Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"]
 FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] assert_equals: compiled pattern property 'pathname' expected "/data\\:channel.html" but got "data\\:channel.html"
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -146,12 +146,12 @@ PASS Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}]
 PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}]
 PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}]
 PASS Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}]
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
+PASS Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"username":"café"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}]
+PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
+PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
 FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
@@ -247,7 +247,7 @@ PASS Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"
 PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"]
 PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
-FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
+PASS Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"]
 FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] assert_equals: compiled pattern property 'pathname' expected "/data\\:channel.html" but got "data\\:channel.html"
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -146,12 +146,12 @@ PASS Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}]
 PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}]
 PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}]
 PASS Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}]
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
+PASS Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"username":"café"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}]
+PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
+PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
 FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
@@ -247,7 +247,7 @@ PASS Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"
 PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"]
 PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
-FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
+PASS Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"]
 FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] assert_equals: compiled pattern property 'pathname' expected "/data\\:channel.html" but got "data\\:channel.html"
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -146,12 +146,12 @@ PASS Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}]
 PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}]
 PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}]
 PASS Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}]
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
+PASS Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"username":"café"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}]
+PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
+PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
 FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
@@ -247,7 +247,7 @@ PASS Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"
 PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"]
 PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
-FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
+PASS Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"]
 FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] assert_equals: compiled pattern property 'pathname' expected "/data\\:channel.html" but got "data\\:channel.html"
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -146,12 +146,12 @@ PASS Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}]
 PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}]
 PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}]
 PASS Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}]
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
+PASS Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"username":"café"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}]
+PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
+PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
 FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
@@ -247,7 +247,7 @@ PASS Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"
 PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"]
 PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
-FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
+PASS Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"]
 FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] assert_equals: compiled pattern property 'pathname' expected "/data\\:channel.html" but got "data\\:channel.html"
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -146,12 +146,12 @@ PASS Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}]
 PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}]
 PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}]
 PASS Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}]
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
+PASS Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"username":"café"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}]
+PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
+PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
 FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
@@ -247,7 +247,7 @@ PASS Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"
 PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"]
 PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
-FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
+PASS Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"]
 FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] assert_equals: compiled pattern property 'pathname' expected "/data\\:channel.html" but got "data\\:channel.html"
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -146,12 +146,12 @@ PASS Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}]
 PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}]
 PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}]
 PASS Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}]
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
+PASS Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"username":"café"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}]
+PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
+PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
 FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
@@ -247,7 +247,7 @@ PASS Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"
 PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"]
 PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
-FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
+PASS Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"]
 FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] assert_equals: compiled pattern property 'pathname' expected "/data\\:channel.html" but got "data\\:channel.html"
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -146,12 +146,12 @@ PASS Pattern: [{"hash":":㐀"}] Inputs: [{"hash":"foo"}]
 PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"café"}]
 PASS Pattern: [{"protocol":"(.*)"}] Inputs: [{"protocol":"cafe"}]
 PASS Pattern: [{"protocol":"foo-bar"}] Inputs: [{"protocol":"foo-bar"}]
-FAIL Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"café"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}] assert_equals: compiled pattern property 'username' expected "caf%c3%a9" but got "café"
-FAIL Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"café"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%C3%A9" but got "café"
-FAIL Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}] assert_equals: compiled pattern property 'password' expected "caf%c3%a9" but got "café"
+PASS Pattern: [{"username":"caf%C3%A9"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"username":"café"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}]
+PASS Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}]
+PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
+PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
 FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
 FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
@@ -247,7 +247,7 @@ PASS Pattern: ["https://\\:bar@example.com"] Inputs: ["https://:bar@example.com"
 PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@example.com"]
 PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
-FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
+PASS Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"]
 FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] assert_equals: compiled pattern property 'pathname' expected "/data\\:channel.html" but got "data\\:channel.html"
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.

--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
@@ -97,7 +97,7 @@ String canonicalizeUsername(StringView value, BaseURLStringType valueType)
     URL dummyURL(dummyURLCharacters);
     dummyURL.setUser(value);
 
-    return dummyURL.user();
+    return dummyURL.encodedUser().toString();
 }
 
 // https://urlpattern.spec.whatwg.org/#canonicalize-a-password, combined with https://urlpattern.spec.whatwg.org/#process-password-for-init
@@ -112,7 +112,7 @@ String canonicalizePassword(StringView value, BaseURLStringType valueType)
     URL dummyURL(dummyURLCharacters);
     dummyURL.setPassword(value);
 
-    return dummyURL.password();
+    return dummyURL.encodedPassword().toString();
 }
 
 // https://urlpattern.spec.whatwg.org/#canonicalize-a-hostname, combined with https://urlpattern.spec.whatwg.org/#process-hostname-for-init


### PR DESCRIPTION
#### d4a57b1efc963b1dd949a5558a159a0eec28c504
<pre>
URLPattern should expose percent-encoded username and password
<a href="https://bugs.webkit.org/show_bug.cgi?id=285691">https://bugs.webkit.org/show_bug.cgi?id=285691</a>
<a href="https://rdar.apple.com/142619227">rdar://142619227</a>

Reviewed by Anne van Kesteren.

As per url spec (<a href="https://url.spec.whatwg.org/#set-the-password)">https://url.spec.whatwg.org/#set-the-password)</a>, use percent-encoded versions for username and password.
Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp:
(WebCore::canonicalizeUsername):
(WebCore::canonicalizePassword):

Canonical link: <a href="https://commits.webkit.org/288884@main">https://commits.webkit.org/288884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f2043e3895abc7599a2d6847d15d5bce11c07d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4395 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89809 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35721 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86755 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12369 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65903 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23734 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87715 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3409 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76950 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46175 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3288 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31162 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34796 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91184 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12009 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74379 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12236 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73504 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18186 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17869 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16314 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3457 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11961 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11795 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15289 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->