### PR TITLE
[scroll-animations] apply view timeline insets in the correct order

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt
@@ -1,7 +1,7 @@
 
 PASS animation-timeline: view() without timeline range name
 PASS animation-timeline: view(50px) without timeline range name
-FAIL animation-timeline: view(auto 50px) without timeline range name assert_equals: At 0% expected "0" but got "0.416667"
+PASS animation-timeline: view(auto 50px) without timeline range name
 PASS animation-timeline: view(inline) without timeline range name
 PASS animation-timeline: view(x) without timeline range name
 PASS animation-timeline: view(y) without timeline range name

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation-expected.txt
@@ -1,12 +1,12 @@
 
 PASS view-timeline-inset with one value
-FAIL view-timeline-inset with two values assert_equals: expected "0" but got "8"
-FAIL view-timeline-inset with em values assert_equals: expected "0" but got "8"
-FAIL view-timeline-inset with percentage values assert_equals: expected "0" but got "8"
-FAIL view-timeline-inset with negative values assert_equals: expected "0" but got "-1"
-FAIL view-timeline-inset with horizontal scroller assert_equals: expected "0" but got "9"
-FAIL view-timeline-inset with block scroller assert_equals: expected "0" but got "8"
-FAIL view-timeline-inset with inline scroller assert_equals: expected "0" but got "9"
+PASS view-timeline-inset with two values
+PASS view-timeline-inset with em values
+PASS view-timeline-inset with percentage values
+PASS view-timeline-inset with negative values
+FAIL view-timeline-inset with horizontal scroller assert_equals: expected "50" but got "30"
+PASS view-timeline-inset with block scroller
+FAIL view-timeline-inset with inline scroller assert_equals: expected "50" but got "30"
 FAIL view-timeline-inset:auto, block assert_equals: expected "-1" but got "0"
 FAIL view-timeline-inset:auto, block, vertical-lr assert_equals: expected "0" but got "15"
 FAIL view-timeline-inset:auto, block, vertical-rl assert_equals: expected "0" but got "15"
@@ -23,5 +23,5 @@ FAIL view-timeline-inset:auto, x assert_equals: expected "0" but got "15"
 FAIL view-timeline-inset:auto, x, rtl assert_equals: expected "0" but got "15"
 FAIL view-timeline-inset:auto, x, vertical-lr assert_equals: expected "0" but got "15"
 FAIL view-timeline-inset:auto, x, vertical-rl assert_equals: expected "0" but got "15"
-FAIL view-timeline-inset:auto, mix assert_equals: expected "0" but got "8"
+FAIL view-timeline-inset:auto, mix assert_equals: expected "-1" but got "0"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt
@@ -1,10 +1,15 @@
 
-FAIL View timeline with px based inset. assert_equals: Effect at the start of the active phase: 10px 20px expected "0.3" but got "0.314286"
+PASS View timeline with px based inset.
 FAIL View timeline with percent based inset. assert_equals: Effect at the start of the active phase: 10% 20% expected "0.3" but got "0.353333"
 FAIL view timeline with inset auto. promise_test: Unhandled rejection with value: object "TypeError: Type error"
 FAIL view timeline with font relative inset. assert_equals: Effect at the start of the active phase: 1em 2em expected "0.3" but got "0.342667"
 FAIL view timeline with viewport relative insets. assert_equals: Effect at the start of the active phase: 10vw 20vw expected "0.3" but got "0.513333"
-FAIL view timeline inset as string assert_equals: Effect at the start of the active phase: 10px 20px expected "0.3" but got "0.314286"
+FAIL view timeline inset as string assert_throws_js: function "() => {
+    new ViewTimeline({
+      subject: target,
+      inset: "go fish"
+    });
+  }" did not throw
 FAIL view timeline with invalid inset assert_throws_js: function "() => {
     new ViewTimeline({
       subject: target,

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -195,7 +195,7 @@ void ViewTimeline::cacheCurrentTime()
         auto subjectSize = scrollDirection->isVertical ? subjectBounds.height() : subjectBounds.width();
 
         auto insetStartLength = m_insets.start.value_or(Length());
-        auto insetEndLength = m_insets.start.value_or(insetStartLength);
+        auto insetEndLength = m_insets.end.value_or(insetStartLength);
         auto insetStart = floatValueForOffset(insetStartLength, scrollContainerSize);
         auto insetEnd = floatValueForOffset(insetEndLength, scrollContainerSize);
 
@@ -266,8 +266,8 @@ ScrollTimeline::Data ViewTimeline::computeTimelineData() const
 
     return {
         m_cachedCurrentTimeData.scrollOffset,
-        rangeStart + m_cachedCurrentTimeData.insetStart,
-        rangeEnd - m_cachedCurrentTimeData.insetEnd
+        rangeStart + m_cachedCurrentTimeData.insetEnd,
+        rangeEnd - m_cachedCurrentTimeData.insetStart
     };
 }
 


### PR DESCRIPTION
#### b2a0c72d97309460ae0a5d68ce78ec9f9b225c9d
<pre>
[scroll-animations] apply view timeline insets in the correct order
<a href="https://bugs.webkit.org/show_bug.cgi?id=285697">https://bugs.webkit.org/show_bug.cgi?id=285697</a>
<a href="https://rdar.apple.com/142629948">rdar://142629948</a>

Reviewed by Anne van Kesteren.

We had two obvious issues around our handling of view timeline insets. The first issue is that
we never looked at the &quot;end&quot; inset and instead used the &quot;start&quot; value in both cases. The second
issue is that we applied the &quot;start&quot; and &quot;end&quot; insets in the opposite way that was intended: the
&quot;start&quot; inset needs to be applied to the end of the timeline&apos;s range, and the &quot;end&quot; inset to the
start of the timeline&apos;s range. This matches the direction in which the view timeline&apos;s subject
becomes visible.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::cacheCurrentTime):
(WebCore::ViewTimeline::computeTimelineData const):

Canonical link: <a href="https://commits.webkit.org/288684@main">https://commits.webkit.org/288684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c0fe128fe628d5f1136000639199e6d36aafe54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89159 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35092 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86169 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65395 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23236 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76399 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45689 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2776 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30623 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34141 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90539 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8225 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73848 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73061 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17366 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2696 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13015 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11301 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16773 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11149 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14625 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12921 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->