### PR TITLE
wip

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-007.html
@@ -3,6 +3,6 @@
 <link rel="help" href="https://drafts.csswg.org/css-flexbox/#transferred-size-suggestion">
 <link rel="match" href="aspect-ratio-intrinsic-size-007-ref.html">
 <meta name="assert" content="This checks that an automatic preferred physical width is always considered definite whenever computing the transferred size suggestion. That size will be used instead of the flex-item's intrinsic size.">
-<div style="display: flex; flex-direction: column;">
-      <img src="support/large-green-rectangle.svg"/>
+<div style="display: flex; flex-direction: column; min-height: 0px;">
+      <img style="min-height: 0px;" src="support/large-green-rectangle.svg"/>
 </div>

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1263,7 +1263,7 @@ LayoutUnit RenderFlexibleBox::computeFlexBaseSizeForFlexItem(RenderBox& flexItem
     // 9.2.3 E.
     LayoutUnit mainAxisExtent;
     if (!mainAxisIsFlexItemInlineAxis(flexItem)) {
-        //ASSERT(!flexItem.needsLayout());
+        // ASSERT(!flexItem.needsLayout());
         ASSERT(m_intrinsicSizeAlongMainAxis.contains(flexItem));
         mainAxisExtent = m_intrinsicSizeAlongMainAxis.get(flexItem);
     } else {
@@ -1700,13 +1700,8 @@ void RenderFlexibleBox::maybeCacheFlexItemMainIntrinsicSize(RenderBox& flexItem,
         return;
 
     if (auto* renderReplaced = dynamicDowncast<RenderReplaced>(flexItem)) {
-        auto intrinsicSize = renderReplaced->intrinsicSize();
-        if (!intrinsicSize.isEmpty() && flexItemHasAspectRatio(flexItem)) {
-            m_intrinsicSizeAlongMainAxis.set(flexItem, flexItem.computeReplacedLogicalHeight(contentLogicalWidth()) + flexItem.borderAndPaddingLogicalHeight());
-            return;
-        }
-        m_intrinsicSizeAlongMainAxis.remove(flexItem);
-        flexItem.setNeedsLayout(MarkingBehavior::MarkOnlyThis);
+        m_intrinsicSizeAlongMainAxis.set(flexItem, flexItem.computeReplacedLogicalHeight(renderReplaced->maxPreferredLogicalWidth()) + flexItem.borderAndPaddingLogicalHeight());
+        return;
     }
 
     // If this condition is true, then computeMainAxisExtentForFlexItem will call

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -291,8 +291,15 @@ bool RenderImage::shouldCollapseToEmpty() const
     return document().inNoQuirksMode() || (style().logicalWidth().isAuto() && style().logicalHeight().isAuto());
 }
 
+
+// TODO: reduce code duplication with RenderRerplaced::intrinsicSize()
 LayoutSize RenderImage::intrinsicSize() const
 {
+    if (!view().frameView().layoutContext().isInRenderTreeLayout()) {
+        // 'contain' removes the natural aspect ratio / width / height only for the purposes of sizing and layout of the box.
+        return m_intrinsicSize;
+    }
+
     auto intrinsicSize = m_intrinsicSize;
     // Our intrinsicSize is empty if we're rendering generated images with relative width/height. Figure out the right intrinsic size to use.
     if (intrinsicSize.isEmpty() && (imageResource().imageHasRelativeWidth() || imageResource().imageHasRelativeHeight())) {

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -107,6 +107,7 @@ protected:
     void paint(PaintInfo&, const LayoutPoint&) final;
     void layout() override;
 
+    LayoutSize intrinsicSize() const override;
     void intrinsicSizeChanged() override
     {
         imageChanged(imageResource().imagePtr());

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -467,8 +467,6 @@ void RenderReplaced::computeAspectRatioInformationForRenderBox(RenderBox* conten
         }
     } else {
         computeIntrinsicRatioInformation(intrinsicSize, intrinsicRatio);
-        if (!intrinsicRatio.isEmpty() && !intrinsicSize.isZero())
-            m_intrinsicSize = LayoutSize(isHorizontalWritingMode() ? intrinsicSize : intrinsicSize.transposedSize());
     }
     constrainedSize = intrinsicSize;
 }

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -39,7 +39,7 @@ public:
 
     bool setNeedsLayoutIfNeededAfterIntrinsicSizeChange();
 
-    LayoutSize intrinsicSize() const final;
+    LayoutSize intrinsicSize() const override;
     FloatSize intrinsicRatio() const;
     
     bool isContentLikelyVisibleInViewport();
@@ -77,6 +77,9 @@ protected:
     void willBeDestroyed() override;
 
     virtual void layoutShadowContent(const LayoutSize&);
+
+
+    mutable LayoutSize m_intrinsicSize;
 
 private:
     LayoutUnit computeConstrainedLogicalWidth() const;

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -109,7 +109,6 @@ private:
 
     bool hasReplacedLogicalHeight() const;
 
-    mutable LayoutSize m_intrinsicSize;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -92,7 +92,7 @@ bool LegacyRenderSVGRoot::hasIntrinsicAspectRatio() const
 
 FloatSize LegacyRenderSVGRoot::calculateIntrinsicSize() const
 {
-    return FloatSize(floatValueForLength(svgSVGElement().intrinsicWidth(), 0), floatValueForLength(svgSVGElement().intrinsicHeight(), 0));
+    return FloatSize(floatValueForLength(svgSVGElement().intrinsicWidth(), defaultWidth), floatValueForLength(svgSVGElement().intrinsicHeight(), defaultHeight));
 }
 
 void LegacyRenderSVGRoot::computeIntrinsicRatioInformation(FloatSize& intrinsicSize, FloatSize& intrinsicRatio) const

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -66,6 +66,8 @@ public:
     // method during layout when they are invalidated by a filter.
     static void addResourceForClientInvalidation(LegacyRenderSVGResourceContainer*);
 
+    FloatSize calculateIntrinsicSize() const;
+
 private:
     void element() const = delete;
 
@@ -108,8 +110,6 @@ private:
     bool shouldApplyViewportClip() const;
     void updateCachedBoundaries();
     void buildLocalToBorderBoxTransform();
-
-    FloatSize calculateIntrinsicSize() const;
 
     IntSize m_containerSize;
     FloatRect m_objectBoundingBox;


### PR DESCRIPTION
#### a487331f73c061cb6ae7ee971664b2d8f0b1cc54
<pre>
wip
</pre>
----------------------------------------------------------------------
#### 2aed7a8d6bc6cb3c26ff6ec72679936462a962c8
<pre>
Use fit-content for cross axis size
</pre>
----------------------------------------------------------------------
#### bea0740491bfd92b0407ff45551718fc51d61d75
<pre>
wip
</pre>
----------------------------------------------------------------------
#### 5e432bb264403b0adb2e9df64562b51367f4c969
<pre>
Update RenderImage intrinsic size when SVG is added.
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::repaintOrMarkForLayout):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h:
</pre>
----------------------------------------------------------------------
#### acc580ef23e084aa91106151eaba702903e833f3
<pre>
Move generated image logic for relative logical widths/heights.
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

WIP.

* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::intrinsicSize const):
(WebCore::RenderImage::computeIntrinsicRatioInformation const):
* Source/WebCore/rendering/RenderImage.h:
* Source/WebCore/rendering/RenderReplaced.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a487331f73c061cb6ae7ee971664b2d8f0b1cc54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38399 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89706 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67678 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25425 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48043 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5548 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33711 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37512 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75948 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94406 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14823 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10867 "Found 3 new test failures: fast/text/font-face-set-cssom.html ipc/create-media-source-with-invalid-constraints-crash.html js/exception-with-handler-inside-eval-with-dynamic-scope.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76526 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75753 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20125 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18557 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7774 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14839 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20140 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14583 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18027 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16365 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->