### PR TITLE
AX: [Site Isolation] Hit testing remote frames should account for the scroll offset

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -18,5 +18,4 @@ WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
 WebProcess/WebPage/WebPage.cpp
 WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
-WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
 WebProcess/WebPage/mac/WebPageMac.mm

--- a/Source/WebKit/WebProcess/WebPage/WKAccessibilityWebPageObjectIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/WKAccessibilityWebPageObjectIOS.mm
@@ -74,8 +74,15 @@
 {
     if (!m_page)
         return nil;
-    
+
     WebCore::IntPoint convertedPoint = m_page->accessibilityScreenToRootView(WebCore::IntPoint(point));
+
+    // If we are hit-testing a remote element, offset the hit test by the scroll of the web page.
+    if (RefPtr remoteLocalFrame = [self remoteLocalFrame]) {
+        if (CheckedPtr frameView = remoteLocalFrame->view())
+            convertedPoint.moveBy(frameView->scrollPosition());
+    }
+
     return [[self accessibilityRootObjectWrapper] accessibilityHitTest:convertedPoint];
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
@@ -24,6 +24,7 @@
  */
 
 #import <WebCore/FloatPoint.h>
+#import <WebCore/LocalFrame.h>
 #import <WebCore/PageIdentifier.h>
 #import <wtf/Lock.h>
 #import <wtf/NakedPtr.h>
@@ -72,5 +73,6 @@ class AXCoreObject;
 - (id)accessibilityRootObjectWrapper;
 - (id)accessibilityFocusedUIElement;
 - (WebCore::IntPoint)accessibilityRemoteFrameOffset;
+- (WebCore::LocalFrame *)remoteLocalFrame;
 
 @end

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -62,10 +62,8 @@ namespace ax = WebCore::Accessibility;
     if (auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page->mainFrame())) {
         if (auto* document = localMainFrame->document())
             return document->axObjectCache();
-    } else if (auto* remoteMainFrame = dynamicDowncast<WebCore::RemoteFrame>(page->mainFrame())) {
-        auto& tree = remoteMainFrame->tree();
-        auto* firstFrame = dynamicDowncast<WebCore::LocalFrame>(tree.firstChild());
-        auto* document = firstFrame ? firstFrame->document() : nullptr;
+    } else if (RefPtr remoteLocalFrame = [self remoteLocalFrame]) {
+        CheckedPtr document = remoteLocalFrame ? remoteLocalFrame->document() : nullptr;
         return document ? document->axObjectCache() : nullptr;
     }
 
@@ -193,6 +191,20 @@ namespace ax = WebCore::Accessibility;
 - (id)accessibilityFocusedUIElement
 {
     return [[self accessibilityRootObjectWrapper] accessibilityFocusedUIElement];
+}
+
+- (WebCore::LocalFrame *)remoteLocalFrame
+{
+    if (!m_page)
+        return nullptr;
+
+    auto* page = m_page->corePage();
+    auto* remoteMainFrame = page ? dynamicDowncast<WebCore::RemoteFrame>(page->mainFrame()) : nullptr;
+    if (!remoteMainFrame)
+        return nullptr;
+
+    auto& tree = remoteMainFrame->tree();
+    return dynamicDowncast<WebCore::LocalFrame>(tree.firstChild());
 }
 
 @end

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -340,8 +340,12 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if (protectedSelf->m_page->mainFramePlugIn())
             return convertedPoint;
 
-        if (auto* frameView = protectedSelf->m_page->localMainFrameView())
-            convertedPoint.moveBy(frameView->scrollPosition());
+        if (CheckedPtr localFrameView = protectedSelf->m_page->localMainFrameView())
+            convertedPoint.moveBy(localFrameView->scrollPosition());
+        else if (RefPtr remoteLocalFrame = [protectedSelf remoteLocalFrame]) {
+            if (CheckedPtr frameView = remoteLocalFrame->view())
+                convertedPoint.moveBy(frameView->scrollPosition());
+        }
         if (auto* page = protectedSelf->m_page->corePage())
             convertedPoint.move(0, -page->topContentInset());
         return convertedPoint;


### PR DESCRIPTION
#### 953140b3e76375ea875494bbdbd74019a8cec473
<pre>
AX: [Site Isolation] Hit testing remote frames should account for the scroll offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=285700">https://bugs.webkit.org/show_bug.cgi?id=285700</a>
<a href="https://rdar.apple.com/142633437">rdar://142633437</a>

Reviewed by Chris Fleizach and Tyler Wilcock.

Prior to this patch, elements that were not in the visible bounds of a remote frame
would not be able to be hit tested when scrolled into view, since we did not take into
account the scroll position of the iframe. This now updates the page-level accessibility
hit test to account for this offset on both macOS and iOS.

* Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebKit/WebProcess/WebPage/WKAccessibilityWebPageObjectIOS.mm:
(-[WKAccessibilityWebPageObject accessibilityHitTest:]):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase axObjectCache]):
(-[WKAccessibilityWebPageObjectBase remoteLocalFrame]):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityHitTest:]):

Canonical link: <a href="https://commits.webkit.org/288699@main">https://commits.webkit.org/288699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c62714883ac46377aadb88eee735e04a2c2001f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89218 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35151 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65446 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23280 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76454 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45739 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2831 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34199 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73761 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90598 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8274 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73895 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11631 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72284 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73101 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18084 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17409 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2754 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11359 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16831 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11207 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14683 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12979 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->