### PR TITLE
Avoid performing a `canNavigate` check multiple times on the same URL during a load

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1060,6 +1060,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/DeviceOrientationOrMotionPermissionState.h
     dom/Document.h
     dom/DocumentClasses.h
+    dom/DocumentEnums.h
     dom/DocumentEventTiming.h
     dom/DocumentFontLoader.h
     dom/DocumentFragment.h

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4536,27 +4536,27 @@ void Document::stopGatheringRTCLogs()
 }
 #endif
 
-bool Document::canNavigate(Frame* targetFrame, const URL& destinationURL)
+CanNavigateState Document::canNavigate(Frame* targetFrame, const URL& destinationURL)
 {
     if (!m_frame)
-        return false;
+        return CanNavigateState::Unable;
 
     // FIXME: We shouldn't call this function without a target frame, but
     // fast/forms/submit-to-blank-multiple-times.html depends on this function
     // returning true when supplied with a 0 targetFrame.
     if (!targetFrame)
-        return true;
+        return CanNavigateState::Able;
 
     if (!canNavigateInternal(*targetFrame))
-        return false;
+        return CanNavigateState::Unable;
 
     if (isNavigationBlockedByThirdPartyIFrameRedirectBlocking(*targetFrame, destinationURL)) {
         printNavigationErrorMessage(*this, *targetFrame, url(), "The frame attempting navigation of the top-level window is cross-origin or untrusted and the user has never interacted with the frame."_s);
         DOCUMENT_RELEASE_LOG_ERROR(Loading, "Navigation was prevented because it was triggered by a cross-origin or untrusted iframe");
-        return false;
+        return CanNavigateState::Unable;
     }
 
-    return true;
+    return CanNavigateState::Able;
 }
 
 bool Document::canNavigateInternal(Frame& targetFrame)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -32,6 +32,7 @@
 #include "ContainerNode.h"
 #include "ContextDestructionObserverInlines.h"
 #include "DocumentClasses.h"
+#include "DocumentEnums.h"
 #include "DocumentEventTiming.h"
 #include "DocumentSyncData.h"
 #include "FontSelectorClient.h"
@@ -359,43 +360,12 @@ class Update;
 
 enum class PageshowEventPersistence : bool { NotPersisted, Persisted };
 
-enum class NodeListInvalidationType : uint8_t {
-    DoNotInvalidateOnAttributeChanges,
-    InvalidateOnClassAttrChange,
-    InvalidateOnIdNameAttrChange,
-    InvalidateOnNameAttrChange,
-    InvalidateOnForTypeAttrChange,
-    InvalidateForFormControls,
-    InvalidateOnHRefAttrChange,
-    InvalidateOnAnyAttrChange,
-};
-constexpr auto numNodeListInvalidationTypes = enumToUnderlyingType(NodeListInvalidationType::InvalidateOnAnyAttrChange) + 1;
-
 enum class EventHandlerRemoval : bool { One, All };
 using EventTargetSet = WeakHashCountedSet<Node, WeakPtrImplWithEventTargetData>;
-
-enum class DocumentCompatibilityMode : uint8_t {
-    NoQuirksMode = 1,
-    QuirksMode = 1 << 1,
-    LimitedQuirksMode = 1 << 2
-};
 
 enum class DimensionsCheck : uint8_t {
     Width = 1 << 0,
     Height = 1 << 1
-};
-
-enum class LayoutOptions : uint8_t {
-    RunPostLayoutTasksSynchronously = 1 << 0,
-    IgnorePendingStylesheets = 1 << 1,
-    ContentVisibilityForceLayout = 1 << 2,
-    UpdateCompositingLayers = 1 << 3,
-    DoNotLayoutAncestorDocuments = 1 << 4,
-    // Doesn't call RenderLayer::recursiveUpdateLayerPositionsAfterLayout if
-    // possible. The caller should use a LocalFrameView::AutoPreventLayerAccess
-    // for the scope that layout is expected to be flushed to stop any access to
-    // the stale RenderLayers.
-    CanDeferUpdateLayerPositions = 1 << 5
 };
 
 enum class HttpEquivPolicy : uint8_t {
@@ -877,7 +847,7 @@ public:
     void stopGatheringRTCLogs();
 #endif
 
-    bool canNavigate(Frame* targetFrame, const URL& destinationURL = URL());
+    CanNavigateState canNavigate(Frame* targetFrame, const URL& destinationURL = URL());
 
     bool usesStyleBasedEditability() const;
     void setHasElementUsingStyleBasedEditability();

--- a/Source/WebCore/dom/DocumentEnums.h
+++ b/Source/WebCore/dom/DocumentEnums.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer. 
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution. 
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission. 
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class NodeListInvalidationType : uint8_t {
+    DoNotInvalidateOnAttributeChanges,
+    InvalidateOnClassAttrChange,
+    InvalidateOnIdNameAttrChange,
+    InvalidateOnNameAttrChange,
+    InvalidateOnForTypeAttrChange,
+    InvalidateForFormControls,
+    InvalidateOnHRefAttrChange,
+    InvalidateOnAnyAttrChange,
+};
+constexpr auto numNodeListInvalidationTypes = enumToUnderlyingType(NodeListInvalidationType::InvalidateOnAnyAttrChange) + 1;
+
+enum class DocumentCompatibilityMode : uint8_t {
+    NoQuirksMode = 1,
+    QuirksMode = 1 << 1,
+    LimitedQuirksMode = 1 << 2
+};
+
+enum class LayoutOptions : uint8_t {
+    RunPostLayoutTasksSynchronously = 1 << 0,
+    IgnorePendingStylesheets = 1 << 1,
+    ContentVisibilityForceLayout = 1 << 2,
+    UpdateCompositingLayers = 1 << 3,
+    DoNotLayoutAncestorDocuments = 1 << 4,
+    // Doesn't call RenderLayer::recursiveUpdateLayerPositionsAfterLayout if
+    // possible. The caller should use a LocalFrameView::AutoPreventLayerAccess
+    // for the scope that layout is expected to be flushed to stop any access to
+    // the stale RenderLayers.
+    CanDeferUpdateLayerPositions = 1 << 5
+};
+
+enum class CanNavigateState : uint8_t {
+    Unchecked,
+    Unable,
+    Able
+};
+
+} // namespace WebCore

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4246,7 +4246,7 @@ RefPtr<Frame> FrameLoader::findFrameForNavigation(const AtomString& name, Docume
         return nullptr;
 
     RefPtr frame = protectedFrame()->tree().findBySpecifiedName(name, activeDocument->frame() ? *activeDocument->protectedFrame() : protectedFrame().get());
-    if (!activeDocument->canNavigate(frame.get()))
+    if (activeDocument->canNavigate(frame.get()) != CanNavigateState::Able)
         return nullptr;
 
     return frame;

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -425,7 +425,7 @@ public:
         // selecting a target, in case conditions have changed. Other code paths avoid this by targeting
         // without leaving a time window. If we fail the check just silently drop the form submission.
         Ref requestingDocument = submission->state().sourceDocument();
-        if (!requestingDocument->canNavigate(&frame))
+        if (requestingDocument->canNavigate(&frame) != CanNavigateState::Able)
             return;
         FrameLoadRequest frameLoadRequest { requestingDocument.copyRef(), requestingDocument->protectedSecurityOrigin(), { }, { }, initiatedByMainFrame() };
         frameLoadRequest.setLockHistory(lockHistory());

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -95,7 +95,7 @@ bool DOMWindow::closed() const
 
 void DOMWindow::close(Document& document)
 {
-    if (!document.canNavigate(protectedFrame().get()))
+    if (document.canNavigate(protectedFrame().get()) != CanNavigateState::Able)
         return;
     close();
 }

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "DocumentEnums.h"
 #include "EventTarget.h"
 #include "GlobalWindowIdentifier.h"
 #include "ImageBitmap.h"
@@ -112,7 +113,7 @@ public:
     using RefCounted::deref;
 
     WEBCORE_EXPORT Location& location();
-    virtual void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, NavigationHistoryBehavior, SetLocationLocking = SetLocationLocking::LockHistoryBasedOnGestureState) = 0;
+    virtual void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, NavigationHistoryBehavior, SetLocationLocking = SetLocationLocking::LockHistoryBasedOnGestureState, CanNavigateState = CanNavigateState::Unchecked) = 0;
 
     bool closed() const;
     WEBCORE_EXPORT void close();

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -186,7 +186,7 @@ ExceptionOr<void> History::go(Document& document, int distance)
 
     ASSERT(isMainThread());
 
-    if (!document.canNavigate(frame.get()))
+    if (document.canNavigate(frame.get()) != CanNavigateState::Able)
         return { };
 
     frame->protectedNavigationScheduler()->scheduleHistoryNavigation(distance);

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -387,7 +387,7 @@ private:
 
     void closePage() final;
     void eventListenersDidChange() final;
-    void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, NavigationHistoryBehavior, SetLocationLocking) final;
+    void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, NavigationHistoryBehavior, SetLocationLocking, CanNavigateState) final;
 
     bool allowedToChangeWindowGeometry() const;
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -457,7 +457,7 @@ Navigation::Result Navigation::performTraversal(const String& key, Navigation::O
     if (!entry)
         createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::AbortError, "Navigation aborted"_s);
 
-    if (!frame()->isMainFrame() && !window()->protectedDocument()->canNavigate(&frame()->page()->mainFrame()))
+    if (!frame()->isMainFrame() && window()->protectedDocument()->canNavigate(&frame()->page()->mainFrame()) != CanNavigateState::Able)
         return createErrorResult(WTFMove(committed), WTFMove(finished), ExceptionCode::SecurityError, "Invalid state"_s);
 
     RefPtr current = currentEntry();

--- a/Source/WebCore/page/RemoteDOMWindow.h
+++ b/Source/WebCore/page/RemoteDOMWindow.h
@@ -70,7 +70,7 @@ private:
     WEBCORE_EXPORT RemoteDOMWindow(RemoteFrame&, GlobalWindowIdentifier&&);
 
     void closePage() final;
-    void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, NavigationHistoryBehavior, SetLocationLocking) final;
+    void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, NavigationHistoryBehavior, SetLocationLocking, CanNavigateState) final;
 
     WeakPtr<RemoteFrame> m_frame;
 };


### PR DESCRIPTION
#### 17a1ef8126c8d8187ebb7e09f0732da4e5d89501
<pre>
Avoid performing a `canNavigate` check multiple times on the same URL during a load
<a href="https://bugs.webkit.org/show_bug.cgi?id=285706">https://bugs.webkit.org/show_bug.cgi?id=285706</a>
&lt;<a href="https://rdar.apple.com/142633698">rdar://142633698</a>&gt;

Reviewed by Alex Christensen.

The various refactoring involved in SiteIsolation cause `setLocation` to do two checks
of `canNavigate`, when only one check is needed. Since this is a costly operation, we
should avoid this duplicate call.

Both Local- and Remote-DOMWindow instances `setLocation` are called from `Location::setLocation`,
which performs the `canNavigate` check so that it can generate a required JS Exception. This
means the Local- and Remote-DOMWindow copies of this check are unneeded.

Help prevent future developers from failing to call `canNavigate` before `setLocation` by
creating an enum to represent navigability. Trigger an ASSERT if the caller uses the
default `CanNavigateState`. If the caller indicates that the document cannot navigate, fall
back to the current behavior of checking `canNavigate`.

* Source/WebCore/Headers.cmake: Add new header.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj: Ditto.
* Source/WebCore/dom/Document.h: Use new header.
* Source/WebCore/dom/DocumentEnums.h: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::canNavigate): Return a new enum value for navigability.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::findFrameForNavigation): Update canNavigate call for new return type.
* Source/WebCore/loader/NavigationScheduler.cpp:
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::close): Ditto.
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/History.cpp:
(WebCore::History::go): Ditto.
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::setLocation): Implement new logic to confirm navigability is valid, and fall
back to checking canNavigate (the current behavior) if it&apos;s in an unusual state. We should fast-past
to not calling canNavigate in all known use cases, but should avoid a change in behavior if a developer
forgets to check navigation state before calling.
(WebCore::LocalDOMWindow::open): Update to new canNavigate return type.
* Source/WebCore/page/Location.cpp:
(WebCore::Location::setLocation): Pass new canNavigate return type.
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::performTraversal): Ditto.
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::setLocation): Same changes as LocalDOMWindow::setLocation.

Canonical link: <a href="https://commits.webkit.org/289890@main">https://commits.webkit.org/289890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e90c1c8f9d205e0eda32739e7e7b3ee4befe6d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/88155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/93108 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38905 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/90206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/8052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68031 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25754 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/91157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/6157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79748 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48399 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5931 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/34297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/38013 "Hash 2e90c1c8 for PR 38805 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/35041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94952 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15324 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/11365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76890 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75604 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76134 "Found 1 new API test failure: /TestJSC:/jsc/options (failure)") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/18766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20521 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18935 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/8352 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13794 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15341 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20642 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/15085 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18531 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16867 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->