### PR TITLE
Add overload of MetaConsumer::consume that allows operating directly on consumed values without going through a std::variant

### DIFF
--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp
@@ -1145,18 +1145,14 @@ static RefPtr<CSSPrimitiveValue> consumeImageSetResolutionOrTypeFunction(CSSPars
         .unitlessZero = UnitlessZeroQuirk::Allow
     };
 
-    auto result = MetaConsumer<CSS::Resolution<>, ImageSetTypeFunction>::consume(range, context, { }, options);
-    if (!result)
-        return { };
-
-    return WTF::switchOn(*result,
+    return MetaConsumer<CSS::Resolution<>, ImageSetTypeFunction>::consume(range, context, { }, options,
         [&](const ImageSetTypeFunction& typeFunction) -> RefPtr<CSSPrimitiveValue> {
             return CSSPrimitiveValue::create(typeFunction.value);
         },
         [&](const CSS::Resolution<>& resolution) -> RefPtr<CSSPrimitiveValue> {
             return CSSPrimitiveValueResolverBase::resolve(resolution, options);
         }
-    );
+    ).value_or(nullptr);
 }
 
 // https://w3c.github.io/csswg-drafts/css-images-4/#image-set-notation

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h
@@ -54,7 +54,6 @@ struct MetaConsumeResult {
     using type = VariantOrSingle<TypeList>;
 };
 
-
 template<CSSParserTokenType tokenType, typename Consumer, typename = void>
 struct MetaConsumerDispatcher {
     static constexpr bool supported = false;
@@ -116,10 +115,16 @@ struct MetaConsumerDispatcher<IdentToken, Consumer, typename std::void_t<typenam
 // to the MetaConsumerDispatcher to actually call right `consume` function.
 
 // Empty case, used to indicate no more types remain to try.
-template<CSSParserTokenType tokenType, typename ResultType, typename... Ts>
+template<typename... Ts>
 struct MetaConsumerUnroller {
-    template<typename... Args>
-    static std::nullopt_t consume(Args&&...)
+    template<CSSParserTokenType, typename ResultType>
+    static std::nullopt_t consume(CSSParserTokenRange&, const CSSParserContext&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions)
+    {
+        return std::nullopt;
+    }
+
+    template<CSSParserTokenType, typename ResultType, typename F>
+    static std::nullopt_t consume(CSSParserTokenRange&, const CSSParserContext&, CSSCalcSymbolsAllowed, CSSPropertyParserOptions, NOESCAPE F&&)
     {
         return std::nullopt;
     }
@@ -128,54 +133,86 @@ struct MetaConsumerUnroller {
 // Actionable case, checks if the `Consumer` defined for type `T` supports the
 // current token, trying to consume if it does, and in either case, falling
 // back to recursively trying the same on the remainder of the type list `Ts...`.
-template<CSSParserTokenType tokenType, typename ResultType, typename T, typename... Ts>
-struct MetaConsumerUnroller<tokenType, ResultType, T, Ts...> {
-    template<typename... Args>
-    static std::optional<ResultType> consume(Args&&... args)
+template<typename T, typename... Ts>
+struct MetaConsumerUnroller<T, Ts...> {
+    template<CSSParserTokenType tokenType, typename ResultType>
+    static std::optional<ResultType> consume(CSSParserTokenRange& range, const CSSParserContext& context, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options)
     {
         using Consumer = MetaConsumerDispatcher<tokenType, ConsumerDefinition<T>>;
         if constexpr (Consumer::supported) {
-            if (auto result = Consumer::consume(args...))
+            if (auto result = Consumer::consume(range, context, symbolsAllowed, options))
                 return { T { *result } };
         }
-        return MetaConsumerUnroller<tokenType, ResultType, Ts...>::consume(args...);
+        return MetaConsumerUnroller<Ts...>::template consume<tokenType, ResultType>(range, context, symbolsAllowed, options);
+    }
+
+    template<CSSParserTokenType tokenType, typename ResultType, typename F>
+    static std::optional<ResultType> consume(CSSParserTokenRange& range, const CSSParserContext& context, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options, NOESCAPE F&& functor)
+    {
+        using Consumer = MetaConsumerDispatcher<tokenType, ConsumerDefinition<T>>;
+        if constexpr (Consumer::supported) {
+            if (auto result = Consumer::consume(range, context, symbolsAllowed, options))
+                return std::make_optional(functor(T { *result }));
+        }
+        return MetaConsumerUnroller<Ts...>::template consume<tokenType, ResultType>(range, context, symbolsAllowed, options, std::forward<F>(functor));
     }
 };
 
 // The `MetaConsumer` is the main driver of token consumption, dispatching
 // to a `MetaConsumerUnroller` based on token type. Caller use this directly.
 // An example use that attempts to consumer either a <number> or <percentage>
-// looks like:
+// looks like (argument list elided for brevity):
 //
 //    auto result = MetaConsumer<CSS::Percentage<R>, CSS::Number<R>>::consume(range, ...);
 //
-// (Argument list elided for brevity)
-template<typename... Ts>
+// If a caller wants to avoid the overhead of switching on the returned variant
+// result, an alternative overload of `consume` is provided which takes an additional
+// `functor` argument which gets called with the result:
+//
+//    auto result = MetaConsumer<CSS::Percentage<R>, CSS::Number<R>>::consume(range, ...,
+//        [](CSS::Percentage<R> percentage) { ... },
+//        [](CSS::Number<R> number) { ... }
+//    );
+template<typename T, typename... Ts>
 struct MetaConsumer {
-    using ResultType = typename MetaConsumeResult<Ts...>::type;
+    using Unroller = MetaConsumerUnroller<T, Ts...>;
 
-    template<typename... Args>
-    static std::optional<ResultType> consume(CSSParserTokenRange& range, const CSSParserContext& context, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options, Args&&... args)
+    template<typename... F>
+    static decltype(auto) consume(CSSParserTokenRange& range, const CSSParserContext& context, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options, F&&... f)
     {
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+        using ResultType = decltype(visitor(std::declval<T>()));
+
         switch (range.peek().type()) {
         case FunctionToken:
-            return MetaConsumerUnroller<FunctionToken, ResultType, Ts...>::consume(range, context, WTFMove(symbolsAllowed), options, std::forward<Args>(args)...);
+            return Unroller::template consume<FunctionToken, ResultType>(range, context, WTFMove(symbolsAllowed), options, visitor);
 
         case NumberToken:
-            return MetaConsumerUnroller<NumberToken, ResultType, Ts...>::consume(range, context, WTFMove(symbolsAllowed), options, std::forward<Args>(args)...);
+            return Unroller::template consume<NumberToken, ResultType>(range, context, WTFMove(symbolsAllowed), options, visitor);
 
         case PercentageToken:
-            return MetaConsumerUnroller<PercentageToken, ResultType, Ts...>::consume(range, context, WTFMove(symbolsAllowed), options, std::forward<Args>(args)...);
+            return Unroller::template consume<PercentageToken, ResultType>(range, context, WTFMove(symbolsAllowed), options, visitor);
 
         case DimensionToken:
-            return MetaConsumerUnroller<DimensionToken, ResultType, Ts...>::consume(range, context, WTFMove(symbolsAllowed), options, std::forward<Args>(args)...);
+            return Unroller::template consume<DimensionToken, ResultType>(range, context, WTFMove(symbolsAllowed), options, visitor);
 
         case IdentToken:
-            return MetaConsumerUnroller<IdentToken, ResultType, Ts...>::consume(range, context, WTFMove(symbolsAllowed), options, std::forward<Args>(args)...);
+            return Unroller::template consume<IdentToken, ResultType>(range, context, WTFMove(symbolsAllowed), options, visitor);
 
         default:
-            return { };
+            return std::optional<ResultType> { };
         }
+    }
+
+    static decltype(auto) consume(CSSParserTokenRange& range, const CSSParserContext& context, CSSCalcSymbolsAllowed symbolsAllowed, CSSPropertyParserOptions options)
+    {
+        using ResultType = typename MetaConsumeResult<T, Ts...>::type;
+
+        return consume(range, context, WTFMove(symbolsAllowed), options,
+            [](auto&& value) {
+                return ResultType { WTFMove(value) };
+            }
+        );
     }
 };
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRaw.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRaw.h
@@ -137,14 +137,18 @@ template<Range R, SingleValueUnitEnum U, typename V> struct PrimitiveNumericRaw<
     static constexpr auto unit = UnitTraits::canonical;
     double value;
 
-    constexpr PrimitiveNumericRaw(double value)
-        : value { value }
+    template<typename T>
+        requires std::integral<T> || std::floating_point<T>
+    constexpr PrimitiveNumericRaw(T value)
+        : value { static_cast<double>(value) }
     {
     }
 
     // Constructor is required to allow generic code to uniformly initialize primitives.
-    constexpr PrimitiveNumericRaw(UnitType, double value)
-        : value { value }
+    template<typename T>
+        requires std::integral<T> || std::floating_point<T>
+    constexpr PrimitiveNumericRaw(UnitType, T value)
+        : value { static_cast<double>(value) }
     {
     }
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h
@@ -84,7 +84,9 @@ template<NumericRaw RawType> struct PrimitiveNumeric {
     {
     }
 
-    PrimitiveNumeric(double value) requires (requires { { Raw(value) }; })
+    template<typename T>
+        requires std::integral<T> || std::floating_point<T>
+    PrimitiveNumeric(T value) requires (requires { { Raw(value) }; })
         : PrimitiveNumeric { Raw { value } }
     {
     }


### PR DESCRIPTION
#### 8bcd72ff0abb3d065f934d789b5c97d3fb0470e1
<pre>
Add overload of MetaConsumer::consume that allows operating directly on consumed values without going through a std::variant
<a href="https://bugs.webkit.org/show_bug.cgi?id=285707">https://bugs.webkit.org/show_bug.cgi?id=285707</a>

Reviewed by Darin Adler.

As code site simplification and as an optimization to avoid extra variant
dispatch, add overload of MetaConsumer::consume that allows operating directly
on consumed values without going through a std::variant.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+MetaConsumer.h:
    - Implement consume with a functor and re-implement the old version
      as a call to the new one.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Image.cpp:
    - Adopt new overload to prove it out.

* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRaw.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericTypes.h:
    - Add protection from passing CSSValueID to CSS::Numeric and CSS::NumericRaw.

Canonical link: <a href="https://commits.webkit.org/288714@main">https://commits.webkit.org/288714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbbd33ff7670a56e20e882c6f24c751471e3bbb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89182 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35115 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65418 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23257 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45712 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30646 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34164 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73743 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90563 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73871 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11596 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73081 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18093 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17386 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2719 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11324 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16796 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11172 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14648 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->