### PR TITLE
Document Leak Occurs when opening Context Menu

### DIFF
--- a/LayoutTests/editing/mac/spelling/disable-automatic-spelling-correction-context-menu-item-does-not-leak-expected.txt
+++ b/LayoutTests/editing/mac/spelling/disable-automatic-spelling-correction-context-menu-item-does-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that opening the context menu does not leak the document object.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/mac/spelling/disable-automatic-spelling-correction-context-menu-item-does-not-leak.html
+++ b/LayoutTests/editing/mac/spelling/disable-automatic-spelling-correction-context-menu-item-does-not-leak.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/document-leak-test.js"></script>
+</head>
+<script>
+    description("Tests that opening the context menu does not leak the document object.");
+    onload = () => runDocumentLeakTestSynchronously("disable-automatic-spelling-correction-context-menu-item.html");
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/editing/mac/spelling/disable-automatic-spelling-correction-context-menu-item.html
+++ b/LayoutTests/editing/mac/spelling/disable-automatic-spelling-correction-context-menu-item.html
@@ -6,18 +6,24 @@
 <body>
     <div><input id="top" autocorrect="off"></input></div>
     <div><input id="bottom"></input></div>
-</body>
 <p id="description"></p>
 <p id="console"></p>
 </body>
 <script>
 function isSpellingCorrectionMenuItemEnabled(element)
 {
+    if (window.frameElement)
+        window.frameElement.scrollIntoView(true);
+
     const elementRect = element.getBoundingClientRect();
     eventSender.mouseMoveTo(elementRect.left + elementRect.width / 2, elementRect.top + elementRect.height / 2);
 
     const spellingMenuItem = eventSender.contextClick().find(item => item.title === "Spelling and Grammar");
-    return spellingMenuItem.children.find(item => item.title === "Correct Spelling Automatically").enabled;
+    var isFound = spellingMenuItem.children.find(item => item.title === "Correct Spelling Automatically").enabled;
+    // open the context menu through the UI process
+    eventSender.mouseDown(2);
+    eventSender.mouseUp(2);
+    return isFound;
 }
 
 description("Verifies that autocorrect='off' disables the 'Correct Spelling Automatically' context menu item on macOS. To manually test, check that the menu item is disabled when right clicking the top text field, but enabled when clicking the bottom text field.");
@@ -28,6 +34,11 @@ bottomInput = document.getElementById("bottom");
 if (window.eventSender) {
     shouldBeFalse("isSpellingCorrectionMenuItemEnabled(topInput)");
     shouldBeTrue("isSpellingCorrectionMenuItemEnabled(bottomInput)");
+    // remove focus from the input element by clicking somewhere else or this document won't be gc'able on an iframe-based document leak test
+    eventSender.mouseMoveTo(0, 0);
+    eventSender.mouseDown();
 }
+
+onload = () => parent.postMessage("iframe loaded");
 </script>
 </html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1331,6 +1331,7 @@ editing/secure-input/reset-state-on-navigation.html [ Failure ]
 
 # Context menu API is not exposed on DumpRenderTree.
 editing/mac/spelling/disable-automatic-spelling-correction-context-menu-item.html [ Skip ]
+editing/mac/spelling/disable-automatic-spelling-correction-context-menu-item-does-not-leak.html [ Skip ]
 
 # Color input is not yet implemented on Mac WK1. Currently, using it erroneously triggers an ASSERT_NOT_REACHED.
 webkit.org/b/119094 fast/forms/color/input-color-onchange-event.html [ Skip ]

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -259,6 +259,7 @@ void ContextMenuController::didDismissContextMenu()
 {
     if (RefPtr menuProvider = m_menuProvider)
         menuProvider->didDismissContextMenu();
+    m_context = ContextMenuContext();
 }
 
 static void openNewWindow(const URL& urlToLoad, LocalFrame& frame, Event* event, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy)

--- a/Source/WebCore/page/ContextMenuController.h
+++ b/Source/WebCore/page/ContextMenuController.h
@@ -65,7 +65,6 @@ public:
 
     WEBCORE_EXPORT void checkOrEnableIfNeeded(ContextMenuItem&) const;
 
-    void setContextMenuContext(const ContextMenuContext& context) { m_context = context; }
     const ContextMenuContext& context() const { return m_context; }
     const HitTestResult& hitTestResult() const { return m_context.hitTestResult(); }
 
@@ -80,7 +79,7 @@ public:
 private:
     std::unique_ptr<ContextMenu> maybeCreateContextMenu(Event&, OptionSet<HitTestRequest::Type> hitType, ContextMenuContext::Type);
     void showContextMenu(Event&);
-    
+
     void appendItem(ContextMenuItem&, ContextMenu* parentMenu);
 
     void createAndAppendFontSubMenu(ContextMenuItem&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9853,8 +9853,10 @@ void WebPageProxy::didShowContextMenu()
 
 void WebPageProxy::didDismissContextMenu()
 {
-    send(Messages::WebPage::DidDismissContextMenu());
-
+    RunLoop::main().dispatch([weakPage = WeakPtr { *this }] {
+        if (RefPtr page = weakPage.get())
+            page->send(Messages::WebPage::DidDismissContextMenu());
+    });
     if (RefPtr pageClient = this->pageClient())
         pageClient->didDismissContextMenu();
 }


### PR DESCRIPTION
#### f6d0421a9a80067b17a9f324a57341cf563eee94
<pre>
Document Leak Occurs when opening Context Menu
<a href="https://bugs.webkit.org/show_bug.cgi?id=284189">https://bugs.webkit.org/show_bug.cgi?id=284189</a>
<a href="https://rdar.apple.com/137308000">rdar://137308000</a>

Reviewed by NOBODY (OOPS!).
When a context click occurs, the ContextMenu is created.
The Page currently owns the ContextMenuController, which owns the
ContextMenu. The context menu&apos;s context strongly holds onto the event
target of the context click, as well as HitTestResults which hold
Refs to Nodes.
The document that the context click occured
on can&apos;t be destructed because of this strong reference to the Node that
is held by the context menu&apos;s context. Because a new context object
is already being created for every new context click, ensure that we
destroy the held context when dismissing the context menu so that
the Page does not indirectly hold onto a node during document
destruction.

* LayoutTests/editing/mac/spelling/disable-automatic-spelling-correction-context-menu-item-does-not-leak-expected.txt: Added.
* LayoutTests/editing/mac/spelling/disable-automatic-spelling-correction-context-menu-item-does-not-leak.html: Added.
* LayoutTests/editing/mac/spelling/disable-automatic-spelling-correction-context-menu-item.html:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/resources/document-leak-test.js:
(async runDocumentLeakTestSynchronously):
(cleanIframeUponMessageReceived):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::didDismissContextMenu):
* Source/WebCore/page/ContextMenuController.h:
(WebCore::ContextMenuController::setContextMenuContext): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didDismissContextMenu):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6d0421a9a80067b17a9f324a57341cf563eee94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84123 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/3741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38424 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/35131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86208 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/3832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/11710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/89198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/35131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87169 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/3832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/76439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/3832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/30665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/34180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/3832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/31424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/90579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/11388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/11710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/90579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/11612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/72269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/90579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/11340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/16812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/11188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/14664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/12960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->