### PR TITLE
[WebGL] Multiple functions in WebGL should check if key is valid before use

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -33,8 +33,16 @@
     void attachShader(uint32_t program, uint32_t shader)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (program)
             program = m_objectNames.get(program);
+        if (UNLIKELY(!m_objectNames.isValidKey(shader))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (shader)
             shader = m_objectNames.get(shader);
         protectedContext()->attachShader(program, shader);
@@ -42,6 +50,10 @@
     void bindAttribLocation(uint32_t arg0, uint32_t index, String&& name)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         protectedContext()->bindAttribLocation(arg0, index, name);
@@ -49,6 +61,10 @@
     void bindBuffer(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg1))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg1)
             arg1 = m_objectNames.get(arg1);
         protectedContext()->bindBuffer(target, arg1);
@@ -56,6 +72,10 @@
     void bindFramebuffer(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg1))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg1)
             arg1 = m_objectNames.get(arg1);
         protectedContext()->bindFramebuffer(target, arg1);
@@ -63,6 +83,10 @@
     void bindRenderbuffer(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg1))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg1)
             arg1 = m_objectNames.get(arg1);
         protectedContext()->bindRenderbuffer(target, arg1);
@@ -70,6 +94,10 @@
     void bindTexture(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg1))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg1)
             arg1 = m_objectNames.get(arg1);
         protectedContext()->bindTexture(target, arg1);
@@ -134,6 +162,10 @@
     void compileShader(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         protectedContext()->compileShader(arg0);
@@ -151,6 +183,10 @@
     void createBuffer(uint32_t name)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         auto result = protectedContext()->createBuffer();
         if (result)
             m_objectNames.add(name, result);
@@ -158,6 +194,10 @@
     void createFramebuffer(uint32_t name)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         auto result = protectedContext()->createFramebuffer();
         if (result)
             m_objectNames.add(name, result);
@@ -165,6 +205,10 @@
     void createProgram(uint32_t name)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         auto result = protectedContext()->createProgram();
         if (result)
             m_objectNames.add(name, result);
@@ -172,6 +216,10 @@
     void createRenderbuffer(uint32_t name)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         auto result = protectedContext()->createRenderbuffer();
         if (result)
             m_objectNames.add(name, result);
@@ -179,6 +227,10 @@
     void createShader(uint32_t name, uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         auto result = protectedContext()->createShader(arg0);
         if (result)
             m_objectNames.add(name, result);
@@ -186,6 +238,10 @@
     void createTexture(uint32_t name)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         auto result = protectedContext()->createTexture();
         if (result)
             m_objectNames.add(name, result);
@@ -198,6 +254,10 @@
     void deleteBuffer(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
@@ -206,6 +266,10 @@
     void deleteFramebuffer(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
@@ -214,6 +278,10 @@
     void deleteProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
@@ -222,6 +290,10 @@
     void deleteRenderbuffer(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
@@ -230,6 +302,10 @@
     void deleteShader(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
@@ -238,6 +314,10 @@
     void deleteTexture(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
@@ -261,8 +341,16 @@
     void detachShader(uint32_t arg0, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
+        if (UNLIKELY(!m_objectNames.isValidKey(arg1))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg1)
             arg1 = m_objectNames.get(arg1);
         protectedContext()->detachShader(arg0, arg1);
@@ -310,6 +398,10 @@
     void framebufferRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg3))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg3)
             arg3 = m_objectNames.get(arg3);
         protectedContext()->framebufferRenderbuffer(target, attachment, renderbuffertarget, arg3);
@@ -317,6 +409,10 @@
     void framebufferTexture2D(uint32_t target, uint32_t attachment, uint32_t textarget, uint32_t arg3, int32_t level)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg3))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg3)
             arg3 = m_objectNames.get(arg3);
         protectedContext()->framebufferTexture2D(target, attachment, textarget, arg3, level);
@@ -335,6 +431,10 @@
     {
         assertIsCurrent(workQueue());
         bool returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (program)
             program = m_objectNames.get(program);
         struct WebCore::GraphicsContextGLActiveInfo arg2 { };
@@ -345,6 +445,10 @@
     {
         assertIsCurrent(workQueue());
         bool returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (program)
             program = m_objectNames.get(program);
         struct WebCore::GraphicsContextGLActiveInfo arg2 { };
@@ -355,6 +459,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         returnValue = protectedContext()->getAttribLocation(arg0, name);
@@ -413,6 +521,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (program)
             program = m_objectNames.get(program);
         returnValue = protectedContext()->getProgrami(program, pname);
@@ -436,6 +548,10 @@
     {
         assertIsCurrent(workQueue());
         String returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         returnValue = protectedContext()->getProgramInfoLog(arg0);
@@ -452,6 +568,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         returnValue = protectedContext()->getShaderi(arg0, pname);
@@ -461,6 +581,10 @@
     {
         assertIsCurrent(workQueue());
         String returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         returnValue = protectedContext()->getShaderInfoLog(arg0);
@@ -478,6 +602,10 @@
     {
         assertIsCurrent(workQueue());
         String returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         returnValue = protectedContext()->getShaderSource(arg0);
@@ -500,6 +628,10 @@
     void getUniformfv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const float>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (program)
             program = m_objectNames.get(program);
         Vector<GCGLfloat, 16> value(valueSize, 0);
@@ -509,6 +641,10 @@
     void getUniformiv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (program)
             program = m_objectNames.get(program);
         Vector<GCGLint, 4> value(valueSize, 0);
@@ -518,6 +654,10 @@
     void getUniformuiv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const uint32_t>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (program)
             program = m_objectNames.get(program);
         Vector<GCGLuint, 4> value(valueSize, 0);
@@ -528,6 +668,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         returnValue = protectedContext()->getUniformLocation(arg0, name);
@@ -549,6 +693,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         returnValue = protectedContext()->isBuffer(arg0);
@@ -565,6 +713,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         returnValue = protectedContext()->isFramebuffer(arg0);
@@ -574,6 +726,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         returnValue = protectedContext()->isProgram(arg0);
@@ -583,6 +739,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         returnValue = protectedContext()->isRenderbuffer(arg0);
@@ -592,6 +752,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         returnValue = protectedContext()->isShader(arg0);
@@ -601,6 +765,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         returnValue = protectedContext()->isTexture(arg0);
@@ -614,6 +782,10 @@
     void linkProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         protectedContext()->linkProgram(arg0);
@@ -646,6 +818,10 @@
     void shaderSource(uint32_t arg0, String&& arg1)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         protectedContext()->shaderSource(arg0, arg1);
@@ -788,6 +964,10 @@
     void useProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         protectedContext()->useProgram(arg0);
@@ -795,6 +975,10 @@
     void validateProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         protectedContext()->validateProgram(arg0);
@@ -927,6 +1111,10 @@
     void createVertexArray(uint32_t name)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         auto result = protectedContext()->createVertexArray();
         if (result)
             m_objectNames.add(name, result);
@@ -934,6 +1122,10 @@
     void deleteVertexArray(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
@@ -943,6 +1135,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         returnValue = protectedContext()->isVertexArray(arg0);
@@ -951,6 +1147,10 @@
     void bindVertexArray(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         protectedContext()->bindVertexArray(arg0);
@@ -968,6 +1168,10 @@
     void framebufferTextureLayer(uint32_t target, uint32_t attachment, uint32_t texture, int32_t level, int32_t layer)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(texture))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (texture)
             texture = m_objectNames.get(texture);
         protectedContext()->framebufferTextureLayer(target, attachment, texture, level, layer);
@@ -1051,6 +1255,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (program)
             program = m_objectNames.get(program);
         returnValue = protectedContext()->getFragDataLocation(program, name);
@@ -1184,6 +1392,10 @@
     void createQuery(uint32_t name)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         auto result = protectedContext()->createQuery();
         if (result)
             m_objectNames.add(name, result);
@@ -1191,6 +1403,10 @@
     void deleteQuery(uint32_t query)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (UNLIKELY(!query))
             return;
         query = m_objectNames.take(query);
@@ -1200,6 +1416,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (query)
             query = m_objectNames.get(query);
         returnValue = protectedContext()->isQuery(query);
@@ -1208,6 +1428,10 @@
     void beginQuery(uint32_t target, uint32_t query)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (query)
             query = m_objectNames.get(query);
         protectedContext()->beginQuery(target, query);
@@ -1228,6 +1452,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLuint returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (query)
             query = m_objectNames.get(query);
         returnValue = protectedContext()->getQueryObjectui(query, pname);
@@ -1236,6 +1464,10 @@
     void createSampler(uint32_t name)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         auto result = protectedContext()->createSampler();
         if (result)
             m_objectNames.add(name, result);
@@ -1243,6 +1475,10 @@
     void deleteSampler(uint32_t sampler)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(sampler))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (UNLIKELY(!sampler))
             return;
         sampler = m_objectNames.take(sampler);
@@ -1252,6 +1488,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(sampler))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (sampler)
             sampler = m_objectNames.get(sampler);
         returnValue = protectedContext()->isSampler(sampler);
@@ -1260,6 +1500,10 @@
     void bindSampler(uint32_t unit, uint32_t sampler)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(sampler))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (sampler)
             sampler = m_objectNames.get(sampler);
         protectedContext()->bindSampler(unit, sampler);
@@ -1267,6 +1511,10 @@
     void samplerParameteri(uint32_t sampler, uint32_t pname, int32_t param)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(sampler))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (sampler)
             sampler = m_objectNames.get(sampler);
         protectedContext()->samplerParameteri(sampler, pname, param);
@@ -1274,6 +1522,10 @@
     void samplerParameterf(uint32_t sampler, uint32_t pname, float param)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(sampler))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (sampler)
             sampler = m_objectNames.get(sampler);
         protectedContext()->samplerParameterf(sampler, pname, param);
@@ -1282,6 +1534,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLfloat returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(sampler))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (sampler)
             sampler = m_objectNames.get(sampler);
         returnValue = protectedContext()->getSamplerParameterf(sampler, pname);
@@ -1291,6 +1547,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(sampler))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (sampler)
             sampler = m_objectNames.get(sampler);
         returnValue = protectedContext()->getSamplerParameteri(sampler, pname);
@@ -1337,6 +1597,10 @@
     void createTransformFeedback(uint32_t name)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         auto result = protectedContext()->createTransformFeedback();
         if (result)
             m_objectNames.add(name, result);
@@ -1344,6 +1608,10 @@
     void deleteTransformFeedback(uint32_t id)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(id))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (UNLIKELY(!id))
             return;
         id = m_objectNames.take(id);
@@ -1353,6 +1621,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(id))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (id)
             id = m_objectNames.get(id);
         returnValue = protectedContext()->isTransformFeedback(id);
@@ -1361,6 +1633,10 @@
     void bindTransformFeedback(uint32_t target, uint32_t id)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(id))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (id)
             id = m_objectNames.get(id);
         protectedContext()->bindTransformFeedback(target, id);
@@ -1378,6 +1654,10 @@
     void transformFeedbackVaryings(uint32_t program, Vector<String>&& varyings, uint32_t bufferMode)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (program)
             program = m_objectNames.get(program);
         protectedContext()->transformFeedbackVaryings(program, varyings, bufferMode);
@@ -1385,6 +1665,10 @@
     void getTransformFeedbackVarying(uint32_t program, uint32_t index, CompletionHandler<void(struct WebCore::GraphicsContextGLActiveInfo&&)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (program)
             program = m_objectNames.get(program);
         struct WebCore::GraphicsContextGLActiveInfo arg2 { };
@@ -1404,6 +1688,10 @@
     void bindBufferBase(uint32_t target, uint32_t index, uint32_t buffer)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(buffer))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (buffer)
             buffer = m_objectNames.get(buffer);
         protectedContext()->bindBufferBase(target, index, buffer);
@@ -1411,6 +1699,10 @@
     void bindBufferRange(uint32_t target, uint32_t index, uint32_t buffer, uint64_t offset, uint64_t arg4)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(buffer))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (buffer)
             buffer = m_objectNames.get(buffer);
         protectedContext()->bindBufferRange(target, index, buffer, static_cast<GCGLintptr>(offset), static_cast<GCGLsizeiptr>(arg4));
@@ -1419,6 +1711,10 @@
     {
         assertIsCurrent(workQueue());
         Vector<GCGLuint> returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (program)
             program = m_objectNames.get(program);
         returnValue = protectedContext()->getUniformIndices(program, uniformNames);
@@ -1428,6 +1724,10 @@
     {
         assertIsCurrent(workQueue());
         Vector<GCGLint> returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (program)
             program = m_objectNames.get(program);
         returnValue = protectedContext()->getActiveUniforms(program, uniformIndices, pname);
@@ -1437,6 +1737,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLuint returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (program)
             program = m_objectNames.get(program);
         returnValue = protectedContext()->getUniformBlockIndex(program, uniformBlockName);
@@ -1446,6 +1750,10 @@
     {
         assertIsCurrent(workQueue());
         String returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (program)
             program = m_objectNames.get(program);
         returnValue = protectedContext()->getActiveUniformBlockName(program, uniformBlockIndex);
@@ -1454,6 +1762,10 @@
     void uniformBlockBinding(uint32_t program, uint32_t uniformBlockIndex, uint32_t uniformBlockBinding)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (program)
             program = m_objectNames.get(program);
         protectedContext()->uniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
@@ -1461,6 +1773,10 @@
     void getActiveUniformBlockiv(uint32_t program, uint32_t uniformBlockIndex, uint32_t pname, size_t paramsSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(program))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (program)
             program = m_objectNames.get(program);
         Vector<GCGLint, 4> params(paramsSize, 0);
@@ -1471,6 +1787,10 @@
     {
         assertIsCurrent(workQueue());
         String returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         returnValue = protectedContext()->getTranslatedShaderSourceANGLE(arg0);
@@ -1484,6 +1804,10 @@
     void createQueryEXT(uint32_t name)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         auto result = protectedContext()->createQueryEXT();
         if (result)
             m_objectNames.add(name, result);
@@ -1491,6 +1815,10 @@
     void deleteQueryEXT(uint32_t query)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (UNLIKELY(!query))
             return;
         query = m_objectNames.take(query);
@@ -1500,6 +1828,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (query)
             query = m_objectNames.get(query);
         returnValue = protectedContext()->isQueryEXT(query);
@@ -1508,6 +1840,10 @@
     void beginQueryEXT(uint32_t target, uint32_t query)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (query)
             query = m_objectNames.get(query);
         protectedContext()->beginQueryEXT(target, query);
@@ -1520,6 +1856,10 @@
     void queryCounterEXT(uint32_t query, uint32_t target)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (query)
             query = m_objectNames.get(query);
         protectedContext()->queryCounterEXT(query, target);
@@ -1535,6 +1875,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (query)
             query = m_objectNames.get(query);
         returnValue = protectedContext()->getQueryObjectiEXT(query, pname);
@@ -1544,6 +1888,10 @@
     {
         assertIsCurrent(workQueue());
         GCGLuint64 returnValue = { };
+        if (UNLIKELY(!m_objectNames.isValidKey(query))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (query)
             query = m_objectNames.get(query);
         returnValue = protectedContext()->getQueryObjectui64EXT(query, pname);
@@ -1643,6 +1991,10 @@
     {
         assertIsCurrent(workQueue());
         messageCheck(webXRPromptAccepted());
+        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         auto result = protectedContext()->createExternalImage(WTFMove(arg0), internalFormat, layer);
         if (result)
             m_objectNames.add(name, result);
@@ -1651,6 +2003,10 @@
     {
         assertIsCurrent(workQueue());
         messageCheck(webXRPromptAccepted());
+        if (UNLIKELY(!m_objectNames.isValidKey(handle))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (UNLIKELY(!handle))
             return;
         handle = m_objectNames.take(handle);
@@ -1660,6 +2016,10 @@
     {
         assertIsCurrent(workQueue());
         messageCheck(webXRPromptAccepted());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg1))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg1)
             arg1 = m_objectNames.get(arg1);
         protectedContext()->bindExternalImage(target, arg1);
@@ -1668,6 +2028,10 @@
     {
         assertIsCurrent(workQueue());
         messageCheck(webXRPromptAccepted());
+        if (UNLIKELY(!m_objectNames.isValidKey(name))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         auto result = protectedContext()->createExternalSync(WTFMove(arg0));
         if (result)
             m_objectNames.add(name, result);
@@ -1677,6 +2041,10 @@
     {
         assertIsCurrent(workQueue());
         messageCheck(webXRPromptAccepted());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (UNLIKELY(!arg0))
             return;
         arg0 = m_objectNames.take(arg0);
@@ -1703,6 +2071,10 @@
     {
         assertIsCurrent(workQueue());
         messageCheck(webXRPromptAccepted());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg0))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg0)
             arg0 = m_objectNames.get(arg0);
         protectedContext()->enableFoveation(arg0);
@@ -1723,6 +2095,10 @@
     {
         assertIsCurrent(workQueue());
         messageCheck(webXRPromptAccepted());
+        if (UNLIKELY(!m_objectNames.isValidKey(arg3))) {
+            ASSERT_IS_TESTING_IPC();
+            return;
+        }
         if (arg3)
             arg3 = m_objectNames.get(arg3);
         protectedContext()->framebufferResolveRenderbuffer(target, attachment, renderbuffertarget, arg3);

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -918,12 +918,20 @@ class webkit_ipc_cpp_impl(object):
                 self.pre_call_stmts += [f"if (UNLIKELY(!{a.name})) {{", f"    ASSERT_IS_TESTING_IPC();", f"    return;", f"}}"]
             if self.is_delete:
                 self.pre_call_stmts += [
+                    f"if (UNLIKELY(!m_objectNames.isValidKey({a.name}))) {{",
+                    f"    ASSERT_IS_TESTING_IPC();",
+                    f"    return;",
+                    f"}}",
                     f"if (UNLIKELY(!{a.name}))",
                     f"    return;",
                     f"{a.name} = m_objectNames.take({a.name});"
                 ]
             else:
                 self.pre_call_stmts += [
+                    f"if (UNLIKELY(!m_objectNames.isValidKey({a.name}))) {{",
+                    f"    ASSERT_IS_TESTING_IPC();",
+                    f"    return;",
+                    f"}}",
                     f"if ({a.name})",
                     f"    {a.name} = m_objectNames.get({a.name});"
                 ]
@@ -967,6 +975,10 @@ class webkit_ipc_cpp_impl(object):
             self.args.args += [cpp_arg(webkit_ipc_get_message_forwarder_type(ipc_return_type), "name")]
             return_value_expr = cpp_expr(return_type, f"auto result")
             self.return_value_expr = return_value_expr
+            self.pre_call_stmts += [f"if (UNLIKELY(!m_objectNames.isValidKey(name))) {{"]
+            self.pre_call_stmts += [f"    ASSERT_IS_TESTING_IPC();"]
+            self.pre_call_stmts += [f"    return;"]
+            self.pre_call_stmts += [f"}}"]
             self.post_call_stmts += [f"if (result)", f"    m_objectNames.add(name, result);"]
             return
         if return_type.is_void():


### PR DESCRIPTION
#### 4e59b0511717a0d2558a9a65969c66746f091654
<pre>
[WebGL] Multiple functions in WebGL should check if key is valid before use
<a href="https://rdar.apple.com/134356797">rdar://134356797</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=278398">https://bugs.webkit.org/show_bug.cgi?id=278398</a>

Reviewed by Kimmo Kinnunen.

The keys come directly from IPC, so we should check they are valid before
calling set() on the HashMap.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(createBuffer):
(createFramebuffer):
(createProgram):
(createRenderbuffer):
(createShader):
(createTexture):
(createVertexArray):
(createQuery):
(createSampler):
(createTransformFeedback):
(createQueryEXT):
(createExternalImage):
(createExternalSync):
* Tools/Scripts/generate-gpup-webgl:
(webkit_ipc_cpp_impl.process_return_value):

Originally-landed-as: 283286.163@safari-7620-branch (76422ca6eb4e). <a href="https://rdar.apple.com/141323228">rdar://141323228</a>
Canonical link: <a href="https://commits.webkit.org/288675@main">https://commits.webkit.org/288675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d76149e29e5757d15ee8a6043a1c26a3dd00014

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89200 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35133 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65424 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/23269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87171 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/2859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45718 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/2801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30663 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34182 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90581 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11390 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73880 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11614 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72268 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18068 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17394 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11342 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/16814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11190 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14666 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12962 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->