### PR TITLE
Add more validation to Region IPC decoding

### DIFF
--- a/Source/WebCore/platform/graphics/Region.cpp
+++ b/Source/WebCore/platform/graphics/Region.cpp
@@ -53,12 +53,6 @@ Region::Region(const IntRect& rect)
 {
 }
 
-Region::Region(IntRect&& bounds, std::unique_ptr<Region::Shape>&& shape)
-    : m_bounds(WTFMove(bounds))
-    , m_shape(WTFMove(shape))
-{
-}
-
 Region::Region(const Region& other)
     : m_bounds(other.m_bounds)
     , m_shape(other.copyShape())
@@ -101,11 +95,11 @@ Vector<IntRect, 1> Region::rects() const
 
     for (Shape::SpanIterator span = m_shape->spans_begin(), end = m_shape->spans_end(); span != end && span + 1 != end; ++span) {
         int y = span->y;
-        int height = (span + 1)->y - y;
+        int height = (span + 1)->y - y; // Ok since isValidShape ensures increasing Span::y.
 
         for (Shape::SegmentIterator segment = m_shape->segments_begin(span), end = m_shape->segments_end(span); segment != end && segment + 1 != end; segment += 2) {
             int x = *segment;
-            int width = *(segment + 1) - x;
+            int width = *(segment + 1) - x; // Ok since isValidShape ensures increasing segments.
 
             rects.append(IntRect(x, y, width, height));
         }
@@ -276,15 +270,20 @@ struct Region::Shape::CompareIntersectsOperation {
 };
 
 Region::Shape::Shape(const IntRect& rect)
-    : m_segments({ rect.x(), rect.maxX() })
-    , m_spans({ { rect.y(), 0 }, { rect.maxY(), 2 } })
 {
+    if (rect.isEmpty())
+        return;
+    m_segments.append(rect.x());
+    m_segments.append(rect.maxX());
+    m_spans.append({ rect.y(), 0 });
+    m_spans.append({ rect.maxY(), 2 });
 }
 
 Region::Shape::Shape(Vector<int, 32>&& segments, Vector<Span, 16>&& spans)
     : m_segments(WTFMove(segments))
     , m_spans(WTFMove(spans))
 {
+    ASSERT(isValidShape(m_segments.span(), m_spans.span()));
 }
 
 void Region::Shape::appendSpan(int y)
@@ -327,11 +326,6 @@ void Region::Shape::appendSpans(const Shape& shape, SpanIterator begin, SpanIter
         appendSpan(it->y, shape.segments_begin(it), shape.segments_end(it));
 }
 
-void Region::Shape::appendSegment(int x)
-{
-    m_segments.append(x);
-}
-
 Region::Shape::SpanIterator Region::Shape::spans_begin() const
 {
     return m_spans.data();
@@ -370,20 +364,27 @@ Region::Shape::SegmentIterator Region::Shape::segments_end(SpanIterator it) cons
     return m_segments.data() + segmentIndex;
 }
 
-#ifndef NDEBUG
-void Region::Shape::dump() const
+WTF::TextStream& operator<<(WTF::TextStream& ts, const Region::Shape& value)
 {
-    for (auto span = spans_begin(), end = spans_end(); span != end; ++span) {
-        printf("%6d: (", span->y);
-
-        for (auto segment = segments_begin(span), end = segments_end(span); segment != end; ++segment)
-            printf("%d ", *segment);
-        printf(")\n");
+    ts << '\n';
+    TextStream::IndentScope indentScope(ts);
+    ts << indent;
+    for (auto span = value.spans_begin(), end = value.spans_end(); span != end; ++span) {
+        ts << "y: " << span->y << " spans: (";
+        int comma = 0;
+        for (auto segment = value.segments_begin(span), end = value.segments_end(span); segment != end; ++segment)
+            ts << (comma++ > 0 ? ", "_s : ""_s) << *segment;
+        ts << ")\n";
     }
-
-    printf("\n");
+    ts << "spans: (";
+    for (size_t i = 0; i < value.m_spans.size(); ++i)
+        ts << (i > 0 ? ", "_s : ""_s) << "y: " << value.m_spans[i].y << " si: " << value.m_spans[i].segmentIndex;
+    ts << ")\n" << "segments: (";
+    for (size_t i = 0; i < value.m_segments.size(); ++i)
+        ts << (i > 0 ? ", "_s : ""_s) << value.m_segments[i];
+    ts << ")\n";
+    return ts;
 }
-#endif
 
 IntRect Region::Shape::bounds() const
 {
@@ -462,7 +463,7 @@ Region::Shape Region::Shape::shapeOperation(const Shape& shape1, const Shape& sh
     // Iterate over all spans.
     while (spans1 != spans1End && spans2 != spans2End) {
         int y = 0;
-        int test = spans1->y - spans2->y;
+        auto test = spans1->y <=> spans2->y;
 
         if (test <= 0) {
             y = spans1->y;
@@ -489,7 +490,7 @@ Region::Shape Region::Shape::shapeOperation(const Shape& shape1, const Shape& sh
 
         // Now iterate over the segments in each span and construct a new vector of segments.
         while (s1 != segments1End && s2 != segments2End) {
-            int test = *s1 - *s2;
+            auto test = *s1 <=> *s2;
             int x;
 
             if (test <= 0) {
@@ -591,16 +592,6 @@ Region::Shape Region::Shape::subtractShapes(const Shape& shape1, const Shape& sh
     return shapeOperation<SubtractOperation>(shape1, shape2);
 }
 
-#ifndef NDEBUG
-void Region::dump() const
-{
-    printf("Bounds: (%d, %d, %d, %d)\n",
-           m_bounds.x(), m_bounds.y(), m_bounds.width(), m_bounds.height());
-    if (m_shape)
-        m_shape->dump();
-}
-#endif
-
 void Region::intersect(const Region& region)
 {
     if (m_bounds.isEmpty())
@@ -672,10 +663,48 @@ void Region::setShape(Shape&& shape)
         *m_shape = WTFMove(shape);
 }
 
-bool Region::Shape::isValid() const
+static std::span<const int> segmentsForSpanSegmentIndices(std::span<const int> segments, size_t start, size_t end)
 {
-    for (auto span = spans_begin(), end = spans_end(); span != end; ++span) {
-        if (UNLIKELY(span->segmentIndex > m_segments.size()))
+    if (segments.size() <= end)
+        return { };
+    return segments.subspan(start, end - start);
+}
+
+bool Region::Shape::isValidShape(std::span<const int> segments, std::span<const Span> spans)
+{
+    const size_t spansSize = spans.size();
+    const size_t segmentsSize = segments.size();
+    if (!spansSize)
+        return !segmentsSize;
+    if (!segmentsSize)
+        return !spansSize;
+    if (UNLIKELY(spansSize == 1))
+        return false;
+    if (UNLIKELY(segmentsSize % 2))
+        return false;
+    for (size_t i = 0; i < spansSize; ++i) {
+        auto& span = spans[i];
+        if (UNLIKELY(span.segmentIndex > segmentsSize))
+            return false;
+        if (UNLIKELY(span.segmentIndex % 2))
+            return false;
+
+        if (i < spansSize - 1) {
+            auto& nextSpan = spans[i + 1];
+
+            if (UNLIKELY(span.y >= nextSpan.y))
+                return false;
+            if (UNLIKELY(span.segmentIndex > nextSpan.segmentIndex))
+                return false;
+
+            std::span spanSegments = segmentsForSpanSegmentIndices(segments, span.segmentIndex, nextSpan.segmentIndex);
+            int lastX = std::numeric_limits<int>::min();
+            for (int segment : spanSegments) {
+                if (UNLIKELY(lastX > segment))
+                    return false;
+                lastX = segment;
+            }
+        } else if (UNLIKELY(span.segmentIndex != segments.size()))
             return false;
     }
     return true;

--- a/Source/WebCore/platform/graphics/Region.h
+++ b/Source/WebCore/platform/graphics/Region.h
@@ -73,10 +73,6 @@ public:
 
     unsigned gridSize() const { return m_shape ? m_shape->gridSize() : 0; }
 
-#ifndef NDEBUG
-    void dump() const;
-#endif
-    
     struct Span {
         int y { 0 };
         size_t segmentIndex { 0 };
@@ -88,7 +84,7 @@ public:
         WTF_MAKE_TZONE_ALLOCATED_EXPORT(Shape, WEBCORE_EXPORT);
     public:
         Shape() = default;
-        Shape(const IntRect&);
+        WEBCORE_EXPORT Shape(const IntRect&);
 
         IntRect bounds() const;
         bool isEmpty() const { return m_spans.isEmpty(); }
@@ -98,7 +94,7 @@ public:
         typedef const Span* SpanIterator;
         SpanIterator spans_begin() const;
         SpanIterator spans_end() const;
-        
+
         typedef const int* SegmentIterator;
         SegmentIterator segments_begin(SpanIterator) const;
         SegmentIterator segments_end(SpanIterator) const;
@@ -115,25 +111,19 @@ public:
         template<typename CompareOperation>
         static bool compareShapes(const Shape& shape1, const Shape& shape2);
 
-        WEBCORE_EXPORT bool isValid() const;
+        WEBCORE_EXPORT static bool isValidShape(std::span<const int> segments, std::span<const Span> spans);
 
-#ifndef NDEBUG
-        void dump() const;
-#endif
-
-        friend bool operator==(const Shape&, const Shape&) = default;
-
+        static Shape createForTesting(Vector<int, 32>&& segments, Vector<Span, 16>&& spans) { return Shape { WTFMove(segments), WTFMove(spans) }; }
+        std::pair<Vector<int, 32>, Vector<Span, 16>> dataForTesting() const { return { m_segments, m_spans }; }
     private:
-        friend struct IPC::ArgumentCoder<WebCore::Region::Shape, void>;
         WEBCORE_EXPORT Shape(Vector<int, 32>&&, Vector<Span, 16>&&);
         struct UnionOperation;
         struct IntersectOperation;
         struct SubtractOperation;
-        
+
         template<typename Operation>
         static Shape shapeOperation(const Shape& shape1, const Shape& shape2);
 
-        void appendSegment(int x);
         void appendSpan(int y);
         void appendSpan(int y, SegmentIterator begin, SegmentIterator end);
         void appendSpans(const Shape&, SpanIterator begin, SpanIterator end);
@@ -142,21 +132,32 @@ public:
 
         Vector<int, 32> m_segments;
         Vector<Span, 16> m_spans;
+        friend struct IPC::ArgumentCoder<WebCore::Region::Shape, void>;
+        friend bool operator==(const Shape&, const Shape&) = default;
+        WEBCORE_EXPORT friend WTF::TextStream& operator<<(WTF::TextStream&, const Shape&);
     };
-
+    static Region createForTesting(Shape&& shape) { return Region { WTFMove(shape) }; }
+    Shape dataForTesting() const { return data(); }
 private:
     friend struct IPC::ArgumentCoder<WebCore::Region, void>;
-
-    WEBCORE_EXPORT Region(IntRect&&, std::unique_ptr<Region::Shape>&&);
+    explicit Region(Shape&& shape) { setShape(WTFMove(shape)); }
+    Shape data() const;
 
     std::unique_ptr<Shape> copyShape() const { return m_shape ? makeUnique<Shape>(*m_shape) : nullptr; }
-    void setShape(Shape&&);
+    WEBCORE_EXPORT void setShape(Shape&&);
 
     IntRect m_bounds;
     std::unique_ptr<Shape> m_shape;
 
     friend bool operator==(const Region&, const Region&);
 };
+
+inline Region::Shape Region::data() const
+{
+    if (m_shape)
+        return *m_shape;
+    return m_bounds;
+}
 
 static inline Region intersect(const Region& a, const Region& b)
 {
@@ -188,6 +189,7 @@ inline bool operator==(const Region& a, const Region& b)
 }
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Region&);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Region::Shape&);
 
 } // namespace WebCore
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6279,12 +6279,11 @@ struct WebCore::InteractionRegion {
 
 [Nested, AdditionalEncoder=StreamConnectionEncoder] class WebCore::Region::Shape {
     Vector<int, 32> m_segments;
-    Vector<WebCore::Region::Span, 16> m_spans;
+    [Validator='WebCore::Region::Shape::isValidShape(m_segments->span(), m_spans->span())'] Vector<WebCore::Region::Span, 16> m_spans;
 };
 
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::Region {
-    WebCore::IntRect bounds();
-    [Validator='!*copyShape || (*copyShape)->isValid()'] std::unique_ptr<WebCore::Region::Shape> copyShape();
+    WebCore::Region::Shape data();
 }
 
 header: <WebCore/ISOVTTCue.h>

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -216,6 +216,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/ParsedContentRange.cpp
         Tests/WebCore/PathTests.cpp
         Tests/WebCore/PublicSuffix.cpp
+        Tests/WebCore/RegionTests.cpp
         Tests/WebCore/RenderStyleChange.cpp
         Tests/WebCore/ResourceMonitor.cpp
         Tests/WebCore/SecurityOrigin.cpp

--- a/Tools/TestWebKitAPI/Test.h
+++ b/Tools/TestWebKitAPI/Test.h
@@ -88,4 +88,9 @@ inline std::ostream& operator<<(std::ostream& os, const String& string)
     return os << string.utf8().data();
 }
 
+inline std::ostream& operator<<(std::ostream& os, const ASCIILiteral& string)
+{
+    return os << string.characters();
+}
+
 }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -369,6 +369,8 @@
 		7AC7B57120D9BA5B002C09A0 /* CustomBundleObject.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7AC7B56F20D9BA5B002C09A0 /* CustomBundleObject.mm */; };
 		7AEAD47F1E20116C00416EFE /* CrossPartitionFileSchemeAccess.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7AEAD47C1E20113800416EFE /* CrossPartitionFileSchemeAccess.mm */; };
 		7AFEA3172CB83910007EFE75 /* element-targeting-11.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7AFEA30F2CB838FF007EFE75 /* element-targeting-11.html */; };
+		7AEAD4811E20122700416EFE /* CrossPartitionFileSchemeAccess.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7AEAD47D1E20114E00416EFE /* CrossPartitionFileSchemeAccess.html */; };
+		7B0594792CB44CF600B571AC /* RegionTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B0594782CB44CF600B571AC /* RegionTests.cpp */; };
 		7B06F95F2A377E23000DFC95 /* SequenceLockedTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B06F95E2A377E23000DFC95 /* SequenceLockedTest.cpp */; };
 		7B18417C2673860200ED4F8D /* ImageBufferTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B18417B2673860200ED4F8D /* ImageBufferTests.cpp */; };
 		7B2739F32632AB640040F182 /* ThreadAssertionsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B2739F22632AB640040F182 /* ThreadAssertionsTest.cpp */; };
@@ -3023,6 +3025,7 @@
 		7AEAD47C1E20113800416EFE /* CrossPartitionFileSchemeAccess.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CrossPartitionFileSchemeAccess.mm; sourceTree = "<group>"; };
 		7AEAD47D1E20114E00416EFE /* CrossPartitionFileSchemeAccess.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = CrossPartitionFileSchemeAccess.html; path = Tests/mac/CrossPartitionFileSchemeAccess.html; sourceTree = SOURCE_ROOT; };
 		7AFEA30F2CB838FF007EFE75 /* element-targeting-11.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "element-targeting-11.html"; sourceTree = "<group>"; };
+		7B0594782CB44CF600B571AC /* RegionTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RegionTests.cpp; sourceTree = "<group>"; };
 		7B06F95E2A377E23000DFC95 /* SequenceLockedTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SequenceLockedTest.cpp; sourceTree = "<group>"; };
 		7B18417B2673860200ED4F8D /* ImageBufferTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferTests.cpp; sourceTree = "<group>"; };
 		7B2739F22632AB640040F182 /* ThreadAssertionsTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThreadAssertionsTest.cpp; sourceTree = "<group>"; };
@@ -4749,6 +4752,7 @@
 				041A1E33216FFDBC00789E0A /* PublicSuffix.cpp */,
 				EB9AD8C627646E7300D893A4 /* PushDatabase.cpp */,
 				EBA75C48275ED7BE00D6D31C /* PushMessageCrypto.cpp */,
+				7B0594782CB44CF600B571AC /* RegionTests.cpp */,
 				6B4E861B2220A5520022F389 /* RegistrableDomain.cpp */,
 				D84FAD9829FAC1D0008D338F /* RenderStyleChange.cpp */,
 				EB1F62962D19E07E000B3A04 /* ResourceMonitor.cpp */,
@@ -7190,6 +7194,7 @@
 				041A1E34216FFDBC00789E0A /* PublicSuffix.cpp in Sources */,
 				EB9AD8C727646E7400D893A4 /* PushDatabase.cpp in Sources */,
 				EBA75C49275ED7C700D6D31C /* PushMessageCrypto.cpp in Sources */,
+				7B0594792CB44CF600B571AC /* RegionTests.cpp in Sources */,
 				6B4E861C2220A5520022F389 /* RegistrableDomain.cpp in Sources */,
 				7CCE7F0D1A411AE600447C4C /* ReloadPageAfterCrash.cpp in Sources */,
 				7CCE7EC91A411A7E00447C4C /* RenderedImageFromDOMNode.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/RegionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/RegionTests.cpp
@@ -1,0 +1,270 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * modification, are permitted provided that the following conditions
+ * Redistribution and use in source and binary forms, with or without
+ * 1. Redistributions of source code must retain the above copyright
+ * are met:
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "WebCoreTestUtilities.h"
+#include <WebCore/Region.h>
+#include <random>
+#include <wtf/text/StringBuilder.h>
+
+template<typename T>
+static String convertToString(const T& value)
+{
+    TextStream stream(TextStream::LineMode::SingleLine);
+    stream << value;
+    return stream.release();
+}
+
+template<typename T>
+static String convertToTrimmedString(const T& value)
+{
+    return makeStringByReplacingAll(convertToString(value), '\n', ' ').trim(isUnicodeWhitespace);
+}
+
+namespace WebCore {
+
+inline std::ostream& operator<<(std::ostream& os, const WebCore::Region& value)
+{
+    return os << convertToString(value);
+}
+
+inline std::ostream& operator<<(std::ostream& os, const WebCore::Region::Shape& value)
+{
+    return os << convertToString(value);
+}
+
+}
+
+namespace TestWebKitAPI {
+using namespace WebCore;
+using Shape = Region::Shape;
+
+TEST(r, ShapeEmptyIsRepresentable)
+{
+    EXPECT_TRUE(Shape::isValidShape({ }, { }));
+    Shape s1 = Shape::createForTesting({ }, { });
+    EXPECT_TRUE(s1.isEmpty());
+    EXPECT_EQ(Shape { }, s1);
+    EXPECT_EQ(Shape { IntRect { } }, s1);
+    Region r1 = Region::createForTesting(Shape { s1 });
+    EXPECT_TRUE(r1.isEmpty());
+    EXPECT_EQ(s1, r1.dataForTesting());
+}
+
+TEST(RegionTests, ShapeEmptyIsEmpty)
+{
+    EXPECT_TRUE(Shape().isEmpty());
+    EXPECT_TRUE(Shape(IntRect { }).isEmpty());
+}
+
+TEST(RegionTests, IsValidShapeFalse)
+{
+    EXPECT_FALSE(Region::Shape::isValidShape({ }, Vector<Region::Span> { { 0, 0 } }));
+    EXPECT_FALSE(Region::Shape::isValidShape(Vector<int> { 1 }, Vector<Region::Span> { { 0, 1 } }));
+    EXPECT_FALSE(Region::Shape::isValidShape(Vector<int> { 0, 1 }, { }));
+    EXPECT_FALSE(Region::Shape::isValidShape(Vector<int> { 0, 1 }, Vector<Region::Span> { { 0, 2 } }));
+    EXPECT_FALSE(Region::Shape::isValidShape(Vector<int> { 0, 28, 8, 10, 31, 20, 5, 5607747, 11, 639, 23, 25, 20, 9 },
+        Vector<Region::Span> { { 703, 12 }, { 2463700, 2 } }));
+}
+
+TEST(RegionTests, UniteTests1)
+{
+    Region r1;
+    r1.unite(IntRect { 50, 40, 50, 40 });
+    r1.unite(IntRect { 5, 5, 45, 35 });
+    EXPECT_EQ("(rect (5,5) width=45 height=35) (rect (50,40) width=50 height=40)"_s, convertToTrimmedString(r1));
+
+    Region r2;
+    r2.unite(IntRect { 5, 40, 45, 40 });
+    r2.unite(IntRect { 50, 5, 50, 35 });
+    EXPECT_EQ("(rect (50,5) width=50 height=35) (rect (5,40) width=45 height=40)"_s, convertToTrimmedString(r2));
+
+    Region r3;
+    r3.unite(r1);
+    r3.unite(r2);
+    Region r4 { IntRect { 5, 5, 95, 75 } };
+    EXPECT_TRUE(r4.contains(r3));
+    EXPECT_TRUE(r3.contains(r4));
+    EXPECT_EQ(r4, r3);
+    EXPECT_TRUE(r4.isRect());
+    EXPECT_TRUE(r3.isRect());
+}
+
+// Describes how the algorithm stores an individual rectangle.
+TEST(RegionTests, ShapeFormatIndividual)
+{
+    Region r1 { IntRect { 0, 0, 10, 10 } };
+    EXPECT_EQ("y: 0 spans: (0, 10) y: 10 spans: () spans: (y: 0 si: 0, y: 10 si: 2) segments: (0, 10)"_s, convertToTrimmedString(r1.dataForTesting()));
+}
+
+// Describes how the algorithm stores disjoint rectangles.
+// The rect is marked as ended with the span that has y: as the end corner and segmentIndex the same as the previous span.
+// I.e the "y: 50 si: 2" part.
+TEST(RegionTests, ShapeFormatDisjoint)
+{
+    Region r1 { IntRect { 0, 0, 10, 10 } };
+    r1.unite(IntRect { 50, 50, 60, 60 });
+    EXPECT_EQ("y: 0 spans: (0, 10) y: 10 spans: () y: 50 spans: (50, 110) y: 110 spans: () spans: (y: 0 si: 0, y: 10 si: 2, y: 50 si: 2, y: 110 si: 4) segments: (0, 10, 50, 110)"_s, convertToTrimmedString(r1.dataForTesting()));
+}
+
+// Describes how the algorithm stores x-joint mergeable rectangles.
+// It merges them and produces single rect.
+TEST(RegionTests, ShapeFormatTestJointXMergeable)
+{
+    Region r1 { IntRect { 0, 0, 10, 10 } };
+    r1.unite(IntRect { 10, 0, 10, 10 });
+    EXPECT_EQ("y: 0 spans: (0, 20) y: 10 spans: () spans: (y: 0 si: 0, y: 10 si: 2) segments: (0, 20)"_s, convertToTrimmedString(r1.dataForTesting()));
+}
+
+// Describes how the algorithm stores mergeable y-joint rectangles.
+// It merges them and produces a single rect.
+TEST(RegionTests, ShapeFormatTestJointYMergeable)
+{
+    Region r1 { IntRect { 0, 0, 10, 10 } };
+    r1.unite(IntRect { 0, 10, 10, 10 });
+    EXPECT_EQ("y: 0 spans: (0, 10) y: 20 spans: () spans: (y: 0 si: 0, y: 20 si: 2) segments: (0, 10)"_s, convertToTrimmedString(r1.dataForTesting()));
+}
+
+// Describes how the algorithm stores x-joint rectangles.
+// It merges the horizontal parts and produces new rect for the leftover vertical part.
+TEST(RegionTests, ShapeFormatTestJointX)
+{
+    Region r1 { IntRect { 0, 0, 10, 10 } };
+    r1.unite(IntRect { 10, 0, 10, 11 });
+    EXPECT_EQ("y: 0 spans: (0, 20) y: 10 spans: (10, 20) y: 11 spans: () spans: (y: 0 si: 0, y: 10 si: 2, y: 11 si: 4) segments: (0, 20, 10, 20)"_s, convertToTrimmedString(r1.dataForTesting()));
+}
+
+// Describes how the algorithm stores y-joint rectangles.
+// It does not merge anything.
+TEST(RegionTests, ShapeFormatTestJointY)
+{
+    Region r1 { IntRect { 0, 0, 10, 10 } };
+    r1.unite(IntRect { 0, 10, 11, 10 });
+    EXPECT_EQ("y: 0 spans: (0, 10) y: 10 spans: (0, 11) y: 20 spans: () spans: (y: 0 si: 0, y: 10 si: 2, y: 20 si: 4) segments: (0, 10, 0, 11)"_s, convertToTrimmedString(r1.dataForTesting()));
+}
+
+// Describes how the algorithm always produces even number of segments.
+// Other algorithm could share the segments, but not this one.
+TEST(RegionTests, ShapeFormatTestEvenSegments)
+{
+    Region r1 { IntRect { 0, 0, 10, 10 } };
+    r1.unite(IntRect { 10, 10, 10, 10 });
+    EXPECT_EQ("(rect (0,0) width=10 height=10) (rect (10,10) width=10 height=10)"_s, convertToTrimmedString(r1));
+    EXPECT_EQ("y: 0 spans: (0, 10) y: 10 spans: (10, 20) y: 20 spans: () spans: (y: 0 si: 0, y: 10 si: 2, y: 20 si: 4) segments: (0, 10, 10, 20)"_s, convertToTrimmedString(r1.dataForTesting()));
+}
+
+// Describes how the algorithm always produces sorted segment array per Span.
+// The whole segment array is not sorted, only per Span regions of it.
+TEST(RegionTests, ShapeFormatTestSortedSpan)
+{
+    Region r1 { IntRect { 10, 0, 10, 10 } };
+    r1.unite(IntRect { 1, 1, 5, 5 });
+    EXPECT_EQ("(rect (10,0) width=10 height=1) (rect (1,1) width=5 height=5) (rect (10,1) width=10 height=5) (rect (10,6) width=10 height=4)"_s, convertToTrimmedString(r1));
+    EXPECT_EQ("y: 0 spans: (10, 20) y: 1 spans: (1, 6, 10, 20) y: 6 spans: (10, 20) y: 10 spans: () spans: (y: 0 si: 0, y: 1 si: 2, y: 6 si: 6, y: 10 si: 8) segments: (10, 20, 1, 6, 10, 20, 10, 20)"_s, convertToTrimmedString(r1.dataForTesting()));
+}
+
+static IntRect randomRect(std::minstd_rand& rand)
+{
+    std::uniform_int_distribution<> coord(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+    int x0 = coord(rand);
+    int y0 = coord(rand);
+    int x1 = coord(rand);
+    int y1 = coord(rand);
+    if (x0 > x1)
+        std::swap(x0, x1);
+    if (y0 > y1)
+        std::swap(y0, y1);
+    return { x0, y0, x1 - x0, y1 - y0 };
+}
+
+// Tests that Region operations never produce segment-span lists that fail isValidShape.
+TEST(RegionTests, FuzzOperationsIsValidShape)
+{
+    constexpr int iterations = 5000;
+    constexpr bool printPassed = false;
+    std::random_device rd;
+    std::minstd_rand rand(rd());
+    std::uniform_int_distribution<> operationCount(0, 15);
+    std::uniform_int_distribution<> operation(0, 2);
+
+    for (int i = 0; i < iterations; ++i) {
+        Region r;
+        StringBuilder commands;
+        commands.append("Region r;\n"_s);
+        const int operations = operationCount(rand);
+        for (int i = 0; i < operations; ++i) {
+            auto rect = randomRect(rand);
+            ASCIILiteral command;
+            switch (operation(rand)) {
+            case 0:
+                r.unite(rect);
+                command = "unite"_s;
+                break;
+            case 1:
+                r.intersect(rect);
+                command = "intersect"_s;
+                break;
+            case 2:
+                r.subtract(rect);
+                command = "subtract"_s;
+                break;
+            }
+            commands.append("r."_s, command, "(IntRect { "_s, rect.x(), ", "_s, rect.y(), ", "_s, rect.width(), ", "_s, rect.height(), " });\n"_s);
+            (void) r.rects(); // No crash.
+            auto [segments, spans] = r.dataForTesting().dataForTesting();
+            if (!Shape::isValidShape(segments.span(), spans.span()))
+                ASSERT_TRUE(Shape::isValidShape(segments.span(), spans.span())) << commands.toString() << r.dataForTesting();
+        }
+        if (printPassed) {
+            WTFLogAlways("%s", commands.toString().utf8().data());
+            WTFLogAlways("Shape: %s", convertToString(r.dataForTesting()).utf8().data());
+        }
+    }
+}
+
+TEST(RegionTests, IsValidShape1)
+{
+    Region r;
+    r.unite(IntRect { 620280709, 86198313, 951242283, 733368814 });
+    r.subtract(IntRect { 416621960, 440858151, 1275303923, 1424992047 });
+    r.subtract(IntRect { 1329326038, 360395968, 435226361, 1588476209 });
+    auto [segments, spans] = r.dataForTesting().dataForTesting();
+    ASSERT_TRUE(Shape::isValidShape(segments.span(), spans.span())) << r.dataForTesting();
+}
+
+TEST(RegionTests, IsValidShape2)
+{
+    Region r;
+    r.subtract(IntRect { 384928833, 12330228, 959619016, 578249146 });
+    r.intersect(IntRect { 828730499, 921697549, 1295834393, 903531184 });
+    r.intersect(IntRect { 290731592, 195208138, 497331448, 106244923 });
+    r.unite(IntRect { 587928172, 216906104, 1428192965, 1718162329 });
+    r.subtract(IntRect { 1745551117, 534538086, 297055811, 1154752629 });
+    auto [segments, spans] = r.dataForTesting().dataForTesting();
+    ASSERT_TRUE(Shape::isValidShape(segments.span(), spans.span())) << r.dataForTesting();
+}
+
+}


### PR DESCRIPTION
#### 84ae5a0d957b884a72eaaa2bef43aec2ec59f482
<pre>
Add more validation to Region IPC decoding
<a href="https://bugs.webkit.org/show_bug.cgi?id=281040">https://bugs.webkit.org/show_bug.cgi?id=281040</a>
<a href="https://rdar.apple.com/136142756">rdar://136142756</a>

Reviewed by Antti Koivisto.

Region::Shape algorithm is sensitive to the array structure. Validate
the data correctly.

Instead of encoding the bounds and the Shape data, just encode the
shape data. It fully defines the Region.

Use &lt;=&gt; in place of nextY - Y in order to avoid signed integer wrapping
and ensuring that the algorithm works correctly with negative Ys.

* Source/WebCore/platform/graphics/Region.cpp:
(WebCore::Region::rects const):
(WebCore::Region::Shape::Shape):
(WebCore::operator&lt;&lt;):
(WebCore::Region::Shape::shapeOperation):
(WebCore::segmentsForSpanSegmentIndices):
(WebCore::Region::Shape::isValidShape):
(WebCore::m_spans): Deleted.
(WebCore::Region::Shape::appendSegment): Deleted.
(WebCore::Region::Shape::dump const): Deleted.
(WebCore::Region::dump const): Deleted.
(WebCore::Region::Shape::isValid const): Deleted.
* Source/WebCore/platform/graphics/Region.h:
(WebCore::Region::Shape::createForTesting):
(WebCore::Region::Shape::dataForTesting const):
(WebCore::Region::createForTesting):
(WebCore::Region::dataForTesting const):
(WebCore::Region::Region):
(WebCore::Region::data const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/Test.h:
(WTF::operator&lt;&lt;):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/RegionTests.cpp: Added.
(convertToString):
(convertToTrimmedString):
(WebCore::operator&lt;&lt;):
(TestWebKitAPI::TEST(r, ShapeEmptyIsRepresentable)):
(TestWebKitAPI::TEST(RegionTests, ShapeEmptyIsEmpty)):
(TestWebKitAPI::TEST(RegionTests, IsValidShapeFalse)):
(TestWebKitAPI::TEST(RegionTests, UniteTests1)):
(TestWebKitAPI::TEST(RegionTests, ShapeFormatIndividual)):
(TestWebKitAPI::TEST(RegionTests, ShapeFormatDisjoint)):
(TestWebKitAPI::TEST(RegionTests, ShapeFormatTestJointXMergeable)):
(TestWebKitAPI::TEST(RegionTests, ShapeFormatTestJointYMergeable)):
(TestWebKitAPI::TEST(RegionTests, ShapeFormatTestJointX)):
(TestWebKitAPI::TEST(RegionTests, ShapeFormatTestJointY)):
(TestWebKitAPI::TEST(RegionTests, ShapeFormatTestEvenSegments)):
(TestWebKitAPI::TEST(RegionTests, ShapeFormatTestSortedSpan)):
(TestWebKitAPI::randomRect):
(TestWebKitAPI::TEST(RegionTests, FuzzOperationsIsValidShape)):
(TestWebKitAPI::TEST(RegionTests, IsValidShape1)):
(TestWebKitAPI::TEST(RegionTests, IsValidShape2)):

Originally-landed-as: 283286.236@safari-7620-branch (c5f45c2aa95e). <a href="https://rdar.apple.com/141319750">rdar://141319750</a>
Canonical link: <a href="https://commits.webkit.org/288720@main">https://commits.webkit.org/288720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd7a08b3610f9b626611a01e3ce5317371b7797e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84211 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89287 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35220 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11806 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65501 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23343 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45794 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30753 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34269 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90669 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11478 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8336 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/73958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11704 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72348 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73160 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18098 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17472 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2843 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11430 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16906 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11279 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14755 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->