### PR TITLE
Parse negation of the JSC_useAllocationProfiling environment variable

### DIFF
--- a/Source/WTF/wtf/WTFConfig.cpp
+++ b/Source/WTF/wtf/WTFConfig.cpp
@@ -134,6 +134,10 @@ void Config::initialize()
             || equalLettersIgnoringASCIICase(useAllocationProfiling, "yes"_s)
             || equal(useAllocationProfiling, "1"_s))
             reservedConfigBytes[WebConfig::ReservedByteForAllocationProfiling] = 1;
+        else if (equalLettersIgnoringASCIICase(useAllocationProfiling, "false"_s)
+            || equalLettersIgnoringASCIICase(useAllocationProfiling, "no"_s)
+            || equal(useAllocationProfiling, "0"_s))
+            reservedConfigBytes[WebConfig::ReservedByteForAllocationProfiling] = 0;
 
         const char* useAllocationProfilingModeRaw = getenv("JSC_allocationProfilingMode");
         if (useAllocationProfilingModeRaw && reservedConfigBytes[WebConfig::ReservedByteForAllocationProfiling] == 1) {


### PR DESCRIPTION
#### fc9b7ed3bd00ef954dab8926783b057ace539c2f
<pre>
Parse negation of the JSC_useAllocationProfiling environment variable
<a href="https://bugs.webkit.org/show_bug.cgi?id=285711">https://bugs.webkit.org/show_bug.cgi?id=285711</a>
<a href="https://rdar.apple.com/142648614">rdar://142648614</a>

Reviewed by Mark Lam.

Adds parsing for negative values of the JSC_useAllocationProfiling environment variable
to WTF::Config::initialize().

* Source/WTF/wtf/WTFConfig.cpp:
(WTF::Config::initialize):

Canonical link: <a href="https://commits.webkit.org/288679@main">https://commits.webkit.org/288679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b495084ececbc2b75fe4ccaecd9b9546564b631d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89209 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35141 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65433 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23277 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76449 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45726 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2812 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30676 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34190 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77097 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90589 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83150 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11398 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73891 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11622 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72279 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73097 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18070 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17399 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2745 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11350 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16822 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105569 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11198 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25503 "Found 10 new JSC stress test failures: stress/json-stringify-inspector-check.js.no-llint, stress/regexp-escape-oom.js.default, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.default-wasm, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.wasm-eager, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.wasm-no-cjit, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14674 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/12970 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->