### PR TITLE
[WebGPU] Disable support on VMs and simulators

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_285709-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_285709-expected.txt
@@ -1,0 +1,1 @@
+WebGPU is only supported on Apple4 hardware or later or Mac2 hardware.

--- a/LayoutTests/fast/webgpu/regression/repro_285709.html
+++ b/LayoutTests/fast/webgpu/regression/repro_285709.html
@@ -1,0 +1,16 @@
+<html>
+  <body>
+    <script>
+      const doTest = async () => {
+        try {
+            const adapter = await navigator.gpu.requestAdapter();
+            const device = await adapter.requestDevice();
+        } catch (ex) { console.log(ex); }
+        if (window.testRunner) { testRunner.notifyDone() }
+      };
+      if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+      doTest();
+    </script>
+    WebGPU is only supported on Apple4 hardware or later or Mac2 hardware.
+  </body>
+</html>

--- a/LayoutTests/platform/ios/fast/webgpu/repro_285709-expected.txt
+++ b/LayoutTests/platform/ios/fast/webgpu/repro_285709-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: TypeError: null is not an object (evaluating 'adapter.requestDevice')
+
+WebGPU is only supported on Apple4 hardware or later or Mac2 hardware.


### PR DESCRIPTION
#### 35c4f43f7689a548a0a89b6b4d7e180c3eb0bf58
<pre>
[WebGPU] Disable support on VMs and simulators
<a href="https://bugs.webkit.org/show_bug.cgi?id=285709">https://bugs.webkit.org/show_bug.cgi?id=285709</a>
<a href="https://rdar.apple.com/142642638">rdar://142642638</a>

Reviewed by Alexey Proskuryakov and Tadeu Zagallo.

Simulator was already returning std::nullopt from this function since
simulator support is Apple2 and WebGPU requires Apple4 or later.

VM was reporting a GPU family which was inconsistent with the featureset
it supports, so disable on VMs as well.

* LayoutTests/fast/webgpu/regression/repro_285709-expected.txt: Added.
General hardware expectations.

* LayoutTests/fast/webgpu/regression/repro_285709.html: Added.
* LayoutTests/platform/ios/fast/webgpu/repro_285709-expected.txt: Added.
Add iOS specific expectations which should run on the simulator.

* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::isPhysicalHardware):
(WebGPU::rawHardwareCapabilities):

Canonical link: <a href="https://commits.webkit.org/288946@main">https://commits.webkit.org/288946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b4699837423bd13124064ab369e61350bb3adf8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89726 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35638 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65837 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23662 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46109 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31080 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34713 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74092 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91100 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74307 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73429 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18222 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17795 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16234 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3365 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11878 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17318 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11712 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15206 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13458 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->