### PR TITLE
WebKitTestRunner should generate crash logs when MESSAGE_CHECK fails

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -1678,4 +1678,16 @@ ASCIILiteral errorAsString(Error error)
     return ""_s;
 }
 
+static bool s_shouldCrashOnMessageCheckFailure { false };
+
+bool Connection::shouldCrashOnMessageCheckFailure()
+{
+    return s_shouldCrashOnMessageCheckFailure;
+}
+
+void Connection::setShouldCrashOnMessageCheckFailure(bool shouldCrash)
+{
+    s_shouldCrashOnMessageCheckFailure = shouldCrash;
+}
+
 } // namespace IPC

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -28,6 +28,7 @@
 
 #import "AutomationClient.h"
 #import "CacheModel.h"
+#import "Connection.h"
 #import "DownloadManager.h"
 #import "GPUProcessProxy.h"
 #import "LegacyDownloadClient.h"
@@ -508,6 +509,11 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 + (void)_setLinkedOnOrAfterEverythingForTesting
 {
     [self _setLinkedOnOrAfterEverything];
+}
+
++ (void)_crashOnMessageCheckFailureForTesting
+{
+    IPC::Connection::setShouldCrashOnMessageCheckFailure(true);
 }
 
 + (void)_setLinkedOnOrAfterEverything

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
@@ -160,6 +160,7 @@ WK_CLASS_AVAILABLE(macos(14.5), ios(17.5), visionos(1.2))
 // Test only. Should be called before any web content processes are launched.
 + (void)_forceGameControllerFramework WK_API_AVAILABLE(macos(10.13), ios(11.0));
 + (void)_setLinkedOnOrAfterEverythingForTesting WK_API_AVAILABLE(macos(12.0), ios(15.0));
++ (void)_crashOnMessageCheckFailureForTesting WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 + (void)_setLinkedOnOrBeforeEverythingForTesting WK_API_AVAILABLE(macos(12.0), ios(15.0));
 + (void)_setCaptivePortalModeEnabledGloballyForTesting:(BOOL)isEnabled WK_API_AVAILABLE(macos(13.0), ios(16.0));
 + (void)_clearCaptivePortalModeEnabledGloballyForTesting WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Tools/WebKitTestRunner/ios/mainIOS.mm
+++ b/Tools/WebKitTestRunner/ios/mainIOS.mm
@@ -70,6 +70,7 @@ int main(int argc, const char* argv[])
     _argv = argv;
 
     [WKProcessPool _setLinkedOnOrAfterEverythingForTesting];
+    [WKProcessPool _crashOnMessageCheckFailureForTesting];
 
     UIApplicationMain(argc, (char**)argv, @"WebKitTestRunnerApp", @"WebKitTestRunnerApp");
     return 0;

--- a/Tools/WebKitTestRunner/mac/main.mm
+++ b/Tools/WebKitTestRunner/mac/main.mm
@@ -73,6 +73,7 @@ int main(int argc, const char* argv[])
         setDefaultsToConsistentValuesForTesting();
         disableAppNapInUIProcess(); // For secondary processes, app nap is disabled using WKPreferencesSetPageVisibilityBasedProcessSuppressionEnabled().
         [WKProcessPool _setLinkedOnOrAfterEverythingForTesting];
+        [WKProcessPool _crashOnMessageCheckFailureForTesting];
     }
     WTR::TestController controller(argc, argv);
     return 0;


### PR DESCRIPTION
#### 74f3a290cc3ff942d4662652fa33348183c3a005
<pre>
WebKitTestRunner should generate crash logs when MESSAGE_CHECK fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=285716">https://bugs.webkit.org/show_bug.cgi?id=285716</a>
<a href="https://rdar.apple.com/142653486">rdar://142653486</a>

Reviewed by Charlie Wolfe.

Particularly with site isolation tests, we occasionally see crashes in the test results
but no crash logs.  This will make it so that if the &quot;crash&quot; comes from a MESSAGE_CHECK,
we will be able to see from a crash log which check failed to investigate and fix.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::shouldCrashOnMessageCheckFailure):
(IPC::Connection::setShouldCrashOnMessageCheckFailure):
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(+[WKProcessPool _crashOnMessageCheckFailureForTesting]):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h:
* Tools/WebKitTestRunner/ios/mainIOS.mm:
(main):
* Tools/WebKitTestRunner/mac/main.mm:
(main):

Canonical link: <a href="https://commits.webkit.org/288733@main">https://commits.webkit.org/288733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80a33fa113517d7a33ea0401cf84f8603dfc5cf2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89278 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35211 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86287 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65495 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23335 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45788 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30745 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34260 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73800 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31509 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/90762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8326 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73950 "layout-tests (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73152 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17462 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2834 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13036 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11421 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16897 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11270 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14746 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13043 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->