### PR TITLE
[render-blocking] Render blocking for <link> should not match elements that are on a 'stack of open elements' for the parser.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-040-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-040-expected.txt
@@ -1,0 +1,3 @@
+
+PASS blocking defers until needed element is parsed
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-040.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-040.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/utils.js"></script>
+<title>Frames starts after href element is parsed, and not on the open stack of elements before the end</title>
+
+<link rel=expect href="#second" blocking="render">
+<script>
+async_test((t) => {
+  requestAnimationFrame(() => {
+    t.step(() => assert_true(!!document.getElementById("first"), "first"));
+    t.step(() => assert_true(!!document.getElementById("second"), "second"));
+    t.step(() => assert_true(!!document.getElementById("third"), "third"));
+    t.step(() => assert_false(!!document.getElementById("last")));
+    t.done();
+  });
+}, "blocking defers until needed element is parsed");
+</script>
+</head>
+<body>
+  <div id="first"></div>
+  <script>
+          generateParserDelay();
+  </script>
+  <div id="second">
+    <script>
+            generateParserDelay();
+    </script>
+    <div id="third"></div>
+  </div>
+  <script>
+          generateParserDelay();
+  </script>
+  <div id="fourth"></div>
+  <script>
+          generateParserDelay();
+  </script>
+  <div id="last"></div>
+</body>

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -847,7 +847,6 @@ html/parser/HTMLConstructionSite.cpp
 html/parser/HTMLConstructionSite.h
 html/parser/HTMLDocumentParser.cpp
 html/parser/HTMLDocumentParserFastPath.cpp
-html/parser/HTMLElementStack.cpp
 html/parser/HTMLParserScheduler.cpp
 html/parser/HTMLScriptRunner.cpp
 html/parser/HTMLTreeBuilder.cpp

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3595,6 +3595,11 @@ ScriptableDocumentParser* Document::scriptableDocumentParser() const
     return parser() ? parser()->asScriptableDocumentParser() : nullptr;
 }
 
+HTMLDocumentParser* Document::htmlDocumentParser() const
+{
+    return parser() ? parser()->asHTMLDocumentParser() : nullptr;
+}
+
 ExceptionOr<RefPtr<WindowProxy>> Document::openForBindings(LocalDOMWindow& activeWindow, LocalDOMWindow& firstWindow, const String& url, const AtomString& name, const String& features)
 {
     if (!m_domWindow)
@@ -8582,12 +8587,12 @@ void Document::unblockRenderingOn(Element& element)
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#process-internal-resource-links
-void Document::processInternalResourceLinks(HTMLAnchorElement* anchor)
+void Document::processInternalResourceLinks(Element* element)
 {
     auto copy = copyToVector(m_renderBlockingElements);
-    for (auto& element : copy) {
-        if (RefPtr link = dynamicDowncast<HTMLLinkElement>(element.get()))
-            link->processInternalResourceLink(anchor);
+    for (auto& blockingElement : copy) {
+        if (RefPtr link = dynamicDowncast<HTMLLinkElement>(blockingElement.get()))
+            link->processInternalResourceLink(element);
     }
 }
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -160,6 +160,7 @@ class HTMLCanvasElement;
 class HTMLCollection;
 class HTMLDialogElement;
 class HTMLDocument;
+class HTMLDocumentParser;
 class HTMLElement;
 class HTMLFrameOwnerElement;
 class HTMLHeadElement;
@@ -876,7 +877,8 @@ public:
     DocumentParser* parser() const { return m_parser.get(); }
     inline RefPtr<DocumentParser> protectedParser() const; // Defined in DocumentInlines.h.
     ScriptableDocumentParser* scriptableDocumentParser() const;
-    
+    HTMLDocumentParser* htmlDocumentParser() const;
+
     bool printing() const { return m_printing; }
     void setPrinting(bool p) { m_printing = p; }
 
@@ -1830,7 +1832,7 @@ public:
     enum class ImplicitRenderBlocking : bool { No, Yes };
     void blockRenderingOn(Element&, ImplicitRenderBlocking = ImplicitRenderBlocking::No);
     void unblockRenderingOn(Element&);
-    void processInternalResourceLinks(HTMLAnchorElement* = nullptr);
+    void processInternalResourceLinks(Element* = nullptr);
 
 #if ENABLE(VIDEO)
     WEBCORE_EXPORT void forEachMediaElement(const Function<void(HTMLMediaElement&)>&);

--- a/Source/WebCore/dom/DocumentParser.h
+++ b/Source/WebCore/dom/DocumentParser.h
@@ -32,6 +32,7 @@ namespace WebCore {
 
 class Document;
 class DocumentWriter;
+class HTMLDocumentParser;
 class SegmentedString;
 class ScriptableDocumentParser;
 class WeakPtrImplWithEventTargetData;
@@ -41,6 +42,7 @@ public:
     virtual ~DocumentParser();
 
     virtual ScriptableDocumentParser* asScriptableDocumentParser() { return nullptr; }
+    virtual HTMLDocumentParser* asHTMLDocumentParser() { return nullptr; }
 
     // http://www.whatwg.org/specs/web-apps/current-work/#insertion-point
     virtual bool hasInsertionPoint() { return true; }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2238,9 +2238,9 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
 
         if (CheckedPtr observerRegistry = treeScope().idTargetObserverRegistryIfExists()) {
             if (!oldValue.isEmpty())
-                observerRegistry->notifyObservers(oldValue);
+                observerRegistry->notifyObservers(*this, oldValue);
             if (!newValue.isEmpty())
-                observerRegistry->notifyObservers(newValue);
+                observerRegistry->notifyObservers(*this, newValue);
         }
         break;
     }
@@ -3427,6 +3427,7 @@ void Element::finishParsingChildren()
     setIsParsingChildrenFinished();
 
     Style::ChildChangeInvalidation::invalidateAfterFinishedParsingChildren(*this);
+    document().processInternalResourceLinks(this);
 }
 
 static void appendAttributes(StringBuilder& builder, const Element& element)

--- a/Source/WebCore/dom/IdTargetObserver.h
+++ b/Source/WebCore/dom/IdTargetObserver.h
@@ -31,6 +31,7 @@
 
 namespace WebCore {
 
+class Element;
 class IdTargetObserverRegistry;
 
 class IdTargetObserver : public CanMakeCheckedPtr<IdTargetObserver> {
@@ -38,7 +39,7 @@ class IdTargetObserver : public CanMakeCheckedPtr<IdTargetObserver> {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IdTargetObserver);
 public:
     virtual ~IdTargetObserver();
-    virtual void idTargetChanged() = 0;
+    virtual void idTargetChanged(Element&) = 0;
 
 protected:
     IdTargetObserver(IdTargetObserverRegistry&, const AtomString& id);

--- a/Source/WebCore/dom/IdTargetObserverRegistry.cpp
+++ b/Source/WebCore/dom/IdTargetObserverRegistry.cpp
@@ -64,7 +64,7 @@ void IdTargetObserverRegistry::removeObserver(const AtomString& id, IdTargetObse
     }
 }
 
-void IdTargetObserverRegistry::notifyObserversInternal(const AtomString& id)
+void IdTargetObserverRegistry::notifyObserversInternal(Element& element, const AtomString& id)
 {
     ASSERT(!m_registry.isEmpty());
 
@@ -74,7 +74,7 @@ void IdTargetObserverRegistry::notifyObserversInternal(const AtomString& id)
 
     for (auto& observer : copyToVector(m_notifyingObserversInSet->observers)) {
         if (m_notifyingObserversInSet->observers.contains(observer))
-            observer->idTargetChanged();
+            observer->idTargetChanged(element);
     }
 
     bool hasRemainingObservers = !m_notifyingObserversInSet->observers.isEmpty();

--- a/Source/WebCore/dom/IdTargetObserverRegistry.h
+++ b/Source/WebCore/dom/IdTargetObserverRegistry.h
@@ -36,6 +36,7 @@
 
 namespace WebCore {
 
+class Element;
 class IdTargetObserver;
 
 class IdTargetObserverRegistry final : public CanMakeCheckedPtr<IdTargetObserverRegistry> {
@@ -46,12 +47,12 @@ public:
     IdTargetObserverRegistry();
     ~IdTargetObserverRegistry();
 
-    void notifyObservers(const AtomString& id);
+    void notifyObservers(Element&, const AtomString& id);
 
 private:
     void addObserver(const AtomString& id, IdTargetObserver&);
     void removeObserver(const AtomString& id, IdTargetObserver&);
-    void notifyObserversInternal(const AtomString& id);
+    void notifyObserversInternal(Element&, const AtomString& id);
 
     struct ObserverSet final : public CanMakeCheckedPtr<ObserverSet> {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
@@ -67,13 +68,13 @@ private:
     CheckedPtr<ObserverSet> m_notifyingObserversInSet;
 };
 
-inline void IdTargetObserverRegistry::notifyObservers(const AtomString& id)
+inline void IdTargetObserverRegistry::notifyObservers(Element& element, const AtomString& id)
 {
     ASSERT(!id.isEmpty());
     ASSERT(!m_notifyingObserversInSet);
     if (m_registry.isEmpty())
         return;
-    IdTargetObserverRegistry::notifyObserversInternal(id);
+    IdTargetObserverRegistry::notifyObserversInternal(element, id);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -48,6 +48,7 @@ class Document;
 class Element;
 class FloatPoint;
 class JSDOMGlobalObject;
+class HTMLAnchorElement;
 class HTMLImageElement;
 class HTMLLabelElement;
 class HTMLMapElement;
@@ -131,6 +132,7 @@ public:
     // Anchor name matching is case sensitive in strict mode and not case sensitive in
     // quirks mode for historical compatibility reasons.
     RefPtr<Element> findAnchor(StringView name);
+    bool isMatchingAnchor(HTMLAnchorElement&, StringView name);
 
     inline ContainerNode& rootNode() const; // Defined in ContainerNode.h
     Ref<ContainerNode> protectedRootNode() const;

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -51,7 +51,7 @@ public:
     FormAttributeTargetObserver(const AtomString& id, FormListedElement&);
 
 private:
-    void idTargetChanged() override;
+    void idTargetChanged(Element&) override;
 
     FormListedElement& m_element;
 };
@@ -298,7 +298,7 @@ FormAttributeTargetObserver::FormAttributeTargetObserver(const AtomString& id, F
 {
 }
 
-void FormAttributeTargetObserver::idTargetChanged()
+void FormAttributeTargetObserver::idTargetChanged(Element&)
 {
     m_element.formAttributeTargetChanged();
 }

--- a/Source/WebCore/html/HTMLDataListElement.cpp
+++ b/Source/WebCore/html/HTMLDataListElement.cpp
@@ -86,7 +86,7 @@ void HTMLDataListElement::optionElementChildrenChanged()
 {
     if (auto& id = getIdAttribute(); !id.isEmpty()) {
         if (CheckedPtr observerRegistry = treeScope().idTargetObserverRegistryIfExists())
-            observerRegistry->notifyObservers(id);
+            observerRegistry->notifyObservers(*this, id);
     }
 }
 

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -103,7 +103,7 @@ class ListAttributeTargetObserver final : public IdTargetObserver {
 public:
     ListAttributeTargetObserver(const AtomString& id, HTMLInputElement&);
 
-    void idTargetChanged() override;
+    void idTargetChanged(Element&) override;
 
 private:
     WeakPtr<HTMLInputElement, WeakPtrImplWithEventTargetData> m_element;
@@ -2252,7 +2252,7 @@ ListAttributeTargetObserver::ListAttributeTargetObserver(const AtomString& id, H
 {
 }
 
-void ListAttributeTargetObserver::idTargetChanged()
+void ListAttributeTargetObserver::idTargetChanged(Element&)
 {
     m_element->document().eventLoop().queueTask(TaskSource::DOMManipulation, [element = m_element] {
         if (element)

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -98,7 +98,9 @@ public:
     String fetchPriorityForBindings() const;
     RequestPriority fetchPriority() const;
 
-    void processInternalResourceLink(HTMLAnchorElement* = nullptr);
+    // If element is specified, checks if that Element satisfies the link.
+    // Otherwise checks if any Element in the tree does.
+    void processInternalResourceLink(Element* = nullptr);
 
 private:
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;

--- a/Source/WebCore/html/parser/HTMLDocumentParser.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.cpp
@@ -144,8 +144,6 @@ void HTMLDocumentParser::prepareToStopParsing()
     if (m_scriptRunner) {
         document()->setReadyState(Document::ReadyState::Interactive);
 
-        // FIXME: Bug 279167 - This should be called after every element is popped
-        // from the stack of open elements, not just the last.
         if (!isDetached())
             document()->processInternalResourceLinks();
     }
@@ -641,6 +639,11 @@ void HTMLDocumentParser::resumeScheduledTasks()
 {
     if (RefPtr parserScheduler = m_parserScheduler)
         parserScheduler->resume();
+}
+
+bool HTMLDocumentParser::isOnStackOfOpenElements(Element& element) const
+{
+    return m_treeBuilder->isOnStackOfOpenElements(element);
 }
 
 }

--- a/Source/WebCore/html/parser/HTMLDocumentParser.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.h
@@ -60,6 +60,8 @@ public:
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
+    HTMLDocumentParser* asHTMLDocumentParser() final { return this; }
+
     static void parseDocumentFragment(const String&, DocumentFragment&, Element& contextElement, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent }, CustomElementRegistry* = nullptr);
 
     // For HTMLParserScheduler.
@@ -68,6 +70,8 @@ public:
     // For HTMLTreeBuilder.
     HTMLTokenizer& tokenizer();
     TextPosition textPosition() const final;
+
+    bool isOnStackOfOpenElements(Element&) const;
 
 protected:
     explicit HTMLDocumentParser(HTMLDocument&, OptionSet<ParserContentPolicy> = DefaultParserContentPolicy);

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -3141,4 +3141,9 @@ inline void HTMLTreeBuilder::parseError(const AtomHTMLToken&)
 {
 }
 
+bool HTMLTreeBuilder::isOnStackOfOpenElements(Element& element) const
+{
+    return m_tree.openElements().contains(element);
+}
+
 }

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.h
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.h
@@ -78,6 +78,8 @@ public:
     // Done, close any open tags, etc.
     void finished();
 
+    bool isOnStackOfOpenElements(Element&) const;
+
 private:
     class ExternalCharacterTokenBuffer;
 


### PR DESCRIPTION
#### fb62715ca67c53d52c82cca2eafe460777a2a4ae
<pre>
[render-blocking] Render blocking for &lt;link&gt; should not match elements that are on a &apos;stack of open elements&apos; for the parser.
<a href="https://bugs.webkit.org/show_bug.cgi?id=279167">https://bugs.webkit.org/show_bug.cgi?id=279167</a>
&lt;<a href="https://rdar.apple.com/135846827">rdar://135846827</a>&gt;

Reviewed by Tim Nguyen.

Check if the Element being considered for matching a &lt;link rel=expect&gt; is still
on the stack of open elements from the parser.

This requires adding another call to processInternalResourceLink when an Element
is popped from the stack, and making sure that finishParsingChildren is called
*after* the stack gets mutated (otherwise recursive calls to check the stack
think its still there).

Generalizes the fast path of processInternalResourceLink (where a specific
Element to check is provided) to accept any Element instead of only anchors, and
uses it for the stack pop case.

Pass the Element being mutated into IdTargetObserver, so that this path too can
use the provided Element fast path check. We should now only do the tree-walk
search for an Element when the &lt;link&gt; itself is mutated.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-040-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-040.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::htmlDocumentParser const):
(WebCore::Document::processInternalResourceLinks):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentParser.h:
(WebCore::DocumentParser::asHTMLDocumentParser):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::attributeChanged):
(WebCore::Element::finishParsingChildren):
* Source/WebCore/dom/IdTargetObserver.h:
* Source/WebCore/dom/IdTargetObserverRegistry.cpp:
(WebCore::IdTargetObserverRegistry::notifyObserversInternal):
* Source/WebCore/dom/IdTargetObserverRegistry.h:
(WebCore::IdTargetObserverRegistry::notifyObservers):
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::addElementById):
(WebCore::TreeScope::removeElementById):
(WebCore::TreeScope::findAnchor):
(WebCore::TreeScope::isMatchingAnchor):
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/html/FormListedElement.cpp:
(WebCore::FormAttributeTargetObserver::idTargetChanged):
* Source/WebCore/html/HTMLDataListElement.cpp:
(WebCore::HTMLDataListElement::optionElementChildrenChanged):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::ListAttributeTargetObserver::idTargetChanged):
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::ExpectIdTargetObserver::idTargetChanged):
(WebCore::HTMLLinkElement::processInternalResourceLink):
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(WebCore::HTMLDocumentParser::isOnStackOfOpenElements const):
* Source/WebCore/html/parser/HTMLDocumentParser.h:
* Source/WebCore/html/parser/HTMLElementStack.cpp:
(WebCore::HTMLElementStack::popAll):
(WebCore::HTMLElementStack::popCommon):
(WebCore::HTMLElementStack::removeNonTopCommon):
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::isOnStackOfOpenElements const):
* Source/WebCore/html/parser/HTMLTreeBuilder.h:

Canonical link: <a href="https://commits.webkit.org/289020@main">https://commits.webkit.org/289020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d605a1a8704b1178b089174eb3380c13367bb29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90123 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36030 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66128 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23944 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77224 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46395 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3544 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31451 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35103 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91496 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9002 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74612 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73034 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73732 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18266 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18121 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16573 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4342 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12266 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17719 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12102 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->