### PR TITLE
Apple Music (MusicKit SDK) authentication fails when Advanced Privacy Protections are enabled

### DIFF
--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -184,7 +184,8 @@ public:
 
     JSC::ScriptExecutionStatus jscScriptExecutionStatus() const;
 
-    URL currentSourceURL() const;
+    enum class CallStackPosition : bool { BottomMost, TopMost };
+    URL currentSourceURL(CallStackPosition = CallStackPosition::BottomMost) const;
 
     // Called from the constructor and destructors of ActiveDOMObject.
     void didCreateActiveDOMObject(ActiveDOMObject&);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2625,8 +2625,12 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
         newFrame->page()->setOpenedByDOMWithOpener(true);
     }
 
-    if (created == CreatedNewPage::Yes)
-        newFrame->protectedPage()->setOpenedByDOM();
+    if (created == CreatedNewPage::Yes) {
+        RefPtr page = newFrame->page();
+        page->setOpenedByDOM();
+        if (RefPtr openerDocument = openerFrame.document())
+            page->setOpenedByScriptDomain(RegistrableDomain { openerDocument->currentSourceURL(ScriptExecutionContext::CallStackPosition::TopMost) });
+    }
 
     RefPtr localNewFrame = dynamicDowncast<LocalFrame>(newFrame);
     if (localNewFrame && localNewFrame->document()->protectedWindow()->isInsecureScriptAccess(activeWindow, completedURL.string()))

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -411,6 +411,9 @@ public:
     bool openedByDOMWithOpener() const { return m_openedByDOMWithOpener; }
     void setOpenedByDOMWithOpener(bool value) { m_openedByDOMWithOpener = value; }
 
+    const RegistrableDomain& openedByScriptDomain() const { return m_openedByScriptDomain; }
+    void setOpenedByScriptDomain(RegistrableDomain&& domain) { m_openedByScriptDomain = WTFMove(domain); }
+
     WEBCORE_EXPORT void goToItem(LocalFrame& rootFrame, HistoryItem&, FrameLoadType, ShouldTreatAsContinuingLoad);
     void goToItemForNavigationAPI(LocalFrame& rootFrame, HistoryItem&, FrameLoadType, LocalFrame& triggeringFrame, NavigationAPIMethodTracker*);
 
@@ -1713,6 +1716,8 @@ private:
     bool m_shouldDeferScrollEvents { false };
 
     Ref<DocumentSyncData> m_topDocumentSyncData;
+
+    RegistrableDomain m_openedByScriptDomain;
 
 #if HAVE(AUDIT_TOKEN)
     std::optional<audit_token_t> m_presentingApplicationAuditToken;


### PR DESCRIPTION
#### 9688876df5251f65fa50e173ff27fb365c99cb76
<pre>
Apple Music (MusicKit SDK) authentication fails when Advanced Privacy Protections are enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=285715">https://bugs.webkit.org/show_bug.cgi?id=285715</a>
<a href="https://rdar.apple.com/124643257">rdar://124643257</a>

Reviewed by Abrar Rahman Protyasha and Charlie Wolfe.

MusicKit.js currently fails to authenticate users in Private Browsing mode in Safari, when Advanced
Privacy Protections are enabled. This is because MusicKit uses `document.referrer` in the popup
window that handles authentication to sanity check the opener&apos;s identity; since opening this cross-
origin popup window qualifies as a cross-site navigation, we hide `document.referrer` from bindings,
which causes this auth flow to fail.

To fix this, we adjust this protection by allowing the page to read `document.referrer`, only in the
scenario where:

- The document where script is attempting to read the referrer has an opener.
- The domain of the script that opened the document matches the security origin of this document.

Because the script responsible for opening the new window has the same origin as the opened window,
the script could have already simply sent the `document.referrer` to the opened window through
`postMessage` anyways, so hiding `document.referrer` in this scenario doesn&apos;t yield any privacy win
and instead only risks breakage.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::referrerForBindings):

Adjust the check for whether we should hide referrer, so that we avoid hiding it for popups in some
cases. See above for more details.

* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::currentSourceURL const):

Add an option here to return the topmost (i.e. immediate) source origin URL in the call stack,
rather than the bottommost. We use this below to attribute the opening of a window to a script
source origin.

* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::createWindow):

Use `currentSourceURL` with the new flag (see above) to compute the domain of the script running in
the opener, that created this new window.

* Source/WebCore/page/Page.h:
(WebCore::Page::openedByScriptDomain const):
(WebCore::Page::setOpenedByScriptDomain):

Add new getter/setters for `m_openedByScriptDomain`, which tracks the domain of the script that
programmatically opened this frame (e.g. using `window.open()`).

* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, DoNotHideReferrerInPopupWindow)):

Add a new API test to exercise this fix.

(TestWebKitAPI::TEST(AdvancedPrivacyProtections, Canvas2DQuirks)):

Drive-by fix: remove an unnecessary `using namespace`.
Canonical link: <a href="https://commits.webkit.org/288708@main">https://commits.webkit.org/288708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aacf8f7f8383999581b5667df67ff212e6eced12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89248 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35181 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11765 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65469 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23307 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76488 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45762 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2854 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30717 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34229 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90629 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8299 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73923 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72313 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73126 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18089 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17436 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2787 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11391 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16867 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11240 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14716 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13013 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->