### PR TITLE
Reduce WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in WebCore/platform/graphics/cg

### DIFF
--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
@@ -31,8 +31,6 @@
 #include "GradientColorStops.h"
 #include <pal/spi/cg/CoreGraphicsSPI.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 GradientRendererCG::GradientRendererCG(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops& stops)
@@ -537,6 +535,7 @@ GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolation
 
 // MARK: - Shading strategy.
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 template<typename InterpolationSpace, AlphaPremultiplication alphaPremultiplication>
 void GradientRendererCG::Shading::shadingFunction(void* info, const CGFloat* in, CGFloat* out)
 {
@@ -575,6 +574,7 @@ void GradientRendererCG::Shading::shadingFunction(void* info, const CGFloat* in,
     for (size_t componentIndex = 0; componentIndex < interpolatedColorConvertedToOutputSpace.size(); ++componentIndex)
         out[componentIndex] = interpolatedColorConvertedToOutputSpace[componentIndex];
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 GradientRendererCG::Strategy GradientRendererCG::makeShading(ColorInterpolationMethod colorInterpolationMethod, const GradientColorStops& stops) const
 {
@@ -729,5 +729,3 @@ void GradientRendererCG::drawConicGradient(CGContextRef platformContext, CGPoint
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -50,8 +50,6 @@
 #include <wtf/URL.h>
 #include <wtf/text/TextStream.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GraphicsContextCG);
@@ -1143,9 +1141,10 @@ void GraphicsContextCG::setCGStyle(const std::optional<GraphicsStyle>& style, bo
         [&] (const GraphicsColorMatrix& colorMatrix) {
 #if HAVE(CGSTYLE_COLORMATRIX_BLUR)
             CGColorMatrixStyle colorMatrixStyle = { 1, { 0 } };
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             for (size_t i = 0; i < colorMatrix.values.size(); ++i)
                 colorMatrixStyle.matrix[i] = colorMatrix.values[i];
-
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             auto style = adoptCF(CGStyleCreateColorMatrix(&colorMatrixStyle));
             CGContextSetStyle(context, style.get());
 #else
@@ -1587,7 +1586,5 @@ bool GraphicsContextCG::consumeHasDrawn()
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -50,8 +50,6 @@
 #include "PhotosFormatSoftLink.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageDecoderCG);
@@ -632,9 +630,9 @@ String ImageDecoderCG::decodeUTI(CGImageSourceRef imageSource, const SharedBuffe
 
     auto boxUnsigned = [span = data.span()](unsigned index) -> unsigned {
         constexpr bool isLittleEndian = false;
-        const unsigned* boxBytes = reinterpret_cast<const unsigned*>(span.data());
+        auto value = reinterpretCastSpanStartTo<const unsigned>(span.subspan(index * sizeof(unsigned)));
         // Numbers in the file are BigEndian.
-        return flipBytesIfLittleEndian(boxBytes[index], isLittleEndian);
+        return flipBytesIfLittleEndian(value, isLittleEndian);
     };
 
     auto checkAVIFBrand = [](unsigned brand) -> std::optional<String> {
@@ -738,7 +736,5 @@ bool ImageDecoderCG::shouldUseQuickLookForFullscreen() const
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(CG)

--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -41,8 +41,6 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WorkQueue& sharedImageTranscodingQueue()
@@ -74,7 +72,7 @@ static String transcodeImage(const String& path, const String& destinationUTI, c
     CGDataConsumerCallbacks callbacks = {
         [](void* info, const void* buffer, size_t count) -> size_t {
             auto handle = *static_cast<FileSystem::PlatformFileHandle*>(info);
-            return FileSystem::writeToFile(handle, { static_cast<const uint8_t*>(buffer), count });
+            return FileSystem::writeToFile(handle, unsafeMakeSpan(static_cast<const uint8_t*>(buffer), count));
         },
         nullptr
     };
@@ -251,5 +249,3 @@ RefPtr<ShareableBitmap> decodeImageWithSize(std::span<const uint8_t> data, std::
 
 }
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -35,8 +35,6 @@
 #include <limits>
 #include <pal/spi/cg/CoreGraphicsSPI.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 IntSize PlatformImageNativeImageBackend::size() const
@@ -94,8 +92,8 @@ std::optional<Color> NativeImage::singlePixelSolidColor() const
     if (size() != IntSize(1, 1))
         return std::nullopt;
 
-    unsigned char pixel[4]; // RGBA
-    auto bitmapContext = adoptCF(CGBitmapContextCreate(pixel, 1, 1, 8, sizeof(pixel), sRGBColorSpaceRef(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
+    std::array<uint8_t, 4> pixel; // RGBA
+    auto bitmapContext = adoptCF(CGBitmapContextCreate(pixel.data(), 1, 1, 8, pixel.size(), sRGBColorSpaceRef(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
 
     if (!bitmapContext)
         return std::nullopt;
@@ -165,7 +163,5 @@ void NativeImage::clearSubimages()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(CG)


### PR DESCRIPTION
#### d1f65a28322f79ee84fbd436a3e0c331587ba358
<pre>
Reduce WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in WebCore/platform/graphics/cg
<a href="https://bugs.webkit.org/show_bug.cgi?id=285725">https://bugs.webkit.org/show_bug.cgi?id=285725</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/graphics/cg/ColorCG.cpp:
(WebCore::componentsSpan):
(WebCore::roundAndClampToSRGBALossy):
(WebCore::Color::createAndPreserveColorSpace):
* Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::setCGStyle):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp:
(WebCore::ImageBufferCGBitmapBackend::create):
* Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp:
(WebCore::encode):
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::ImageDecoderCG::decodeUTI):
* Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp:
(WebCore::transcodeImage):
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::pointsSpan):
(WebCore::addUnevenCornersRoundedRect):
(WebCore::pathElementApplierCallback):
(WebCore::copyClosingSubpathsApplierFunction):
* Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm:
(WebCore::ShareableBitmap::createFromImagePixels):

Canonical link: <a href="https://commits.webkit.org/288739@main">https://commits.webkit.org/288739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7160688d2e94ec37d022768d283de299844af3e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89342 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35275 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65544 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23375 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76572 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45835 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30802 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34324 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90724 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11533 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73987 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73189 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17512 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15959 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2898 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13041 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11485 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16961 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11334 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13107 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->