### PR TITLE
[Site isolation] Record the page snapshotting to a DisplayList before sinking it to a PDFDocument

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2137,6 +2137,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ImageBufferAllocator.h
     platform/graphics/ImageBufferBackend.h
     platform/graphics/ImageBufferBackendParameters.h
+    platform/graphics/ImageBufferDisplayListBackend.h
     platform/graphics/ImageBufferPixelFormat.h
     platform/graphics/ImageBufferPlatformBackend.h
     platform/graphics/ImageBufferResourceLimits.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2511,6 +2511,7 @@ platform/graphics/ImageBuffer.cpp
 platform/graphics/ImageBufferAllocator.cpp
 platform/graphics/ImageBufferBackend.cpp
 platform/graphics/ImageBufferContextSwitcher.cpp
+platform/graphics/ImageBufferDisplayListBackend.cpp
 platform/graphics/ImageDecoder.cpp
 platform/graphics/ImageFrame.cpp
 platform/graphics/ImageFrameAnimator.cpp

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -34,6 +34,7 @@
 #include "FilterResults.h"
 #include "GraphicsContext.h"
 #include "HostWindow.h"
+#include "ImageBufferDisplayListBackend.h"
 #include "ImageBufferPlatformBackend.h"
 #include "MIMETypeRegistry.h"
 #include "ProcessCapabilities.h"
@@ -107,7 +108,7 @@ RefPtr<ImageBuffer> ImageBuffer::create(const FloatSize& size, RenderingMode ren
 #endif
 
     case RenderingMode::DisplayList:
-        return nullptr;
+        return ImageBuffer::create<ImageBufferDisplayListBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, { });
     }
 
     ASSERT_NOT_REACHED();
@@ -569,6 +570,13 @@ RefPtr<SharedBuffer> ImageBuffer::sinkIntoPDFDocument()
     if (auto* backend = ensureBackend())
         return backend->sinkIntoPDFDocument();
     return nullptr;
+}
+
+RefPtr<SharedBuffer> ImageBuffer::sinkIntoPDFDocument(RefPtr<ImageBuffer> source)
+{
+    if (!source)
+        return nullptr;
+    return source->sinkIntoPDFDocument();
 }
 
 bool ImageBuffer::isInUse() const

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -220,6 +220,7 @@ public:
     static RefPtr<ImageBuffer> sinkIntoImageBufferAfterCrossThreadTransfer(RefPtr<ImageBuffer>);
 #endif
     static std::unique_ptr<SerializedImageBuffer> sinkIntoSerializedImageBuffer(RefPtr<ImageBuffer>&&);
+    WEBCORE_EXPORT static RefPtr<SharedBuffer> sinkIntoPDFDocument(RefPtr<ImageBuffer>);
 
     WEBCORE_EXPORT virtual void convertToLuminanceMask();
     WEBCORE_EXPORT virtual void transformToColorSpace(const DestinationColorSpace& newColorSpace);

--- a/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ImageBufferDisplayListBackend.h"
+
+#include "ImageBuffer.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+std::unique_ptr<ImageBufferDisplayListBackend> ImageBufferDisplayListBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
+{
+    return std::unique_ptr<ImageBufferDisplayListBackend>(new ImageBufferDisplayListBackend(parameters));
+}
+
+ImageBufferDisplayListBackend::ImageBufferDisplayListBackend(const Parameters& parameters)
+    : ImageBufferBackend(parameters)
+    , m_drawingContext(parameters.backendSize)
+{
+}
+
+GraphicsContext& ImageBufferDisplayListBackend::context()
+{
+    return m_drawingContext.context();
+}
+
+RefPtr<NativeImage> ImageBufferDisplayListBackend::copyNativeImage()
+{
+    RefPtr buffer = ImageBuffer::create(size(), RenderingMode::Unaccelerated, RenderingPurpose::Snapshot, 1, DestinationColorSpace::SRGB(), ImageBufferPixelFormat::BGRA8);
+    if (!buffer)
+        return nullptr;
+
+    auto& context = buffer->context();
+    m_drawingContext.replayDisplayList(context);
+
+    return ImageBuffer::sinkIntoNativeImage(WTFMove(buffer));
+}
+
+RefPtr<SharedBuffer> ImageBufferDisplayListBackend::sinkIntoPDFDocument()
+{
+    RefPtr buffer = ImageBuffer::create(size(), RenderingMode::PDFDocument, RenderingPurpose::Snapshot, 1, DestinationColorSpace::SRGB(), ImageBufferPixelFormat::BGRA8);
+    if (!buffer)
+        return nullptr;
+
+    auto& context = buffer->context();
+    m_drawingContext.replayDisplayList(context);
+
+    return ImageBuffer::sinkIntoPDFDocument(WTFMove(buffer));
+}
+
+String ImageBufferDisplayListBackend::debugDescription() const
+{
+    TextStream stream;
+    stream << "ImageBufferDisplayListBackend " << this;
+    return stream.release();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "DisplayListDrawingContext.h"
+#include "ImageBufferBackend.h"
+
+namespace WebCore {
+
+class ImageBufferDisplayListBackend : public ImageBufferBackend {
+public:
+    WEBCORE_EXPORT static std::unique_ptr<ImageBufferDisplayListBackend> create(const Parameters&, const ImageBufferCreationContext&);
+    static size_t calculateMemoryCost(const Parameters&) { return 0; }
+
+    static constexpr RenderingMode renderingMode = RenderingMode::DisplayList;
+
+private:
+    ImageBufferDisplayListBackend(const Parameters&);
+
+    bool canMapBackingStore() const final { return false; }
+    unsigned bytesPerRow() const final { return 0; }
+
+    GraphicsContext& context() final;
+
+    RefPtr<NativeImage> copyNativeImage() final;
+    RefPtr<NativeImage> createNativeImageReference() final { return copyNativeImage(); }
+    void getPixelBuffer(const IntRect&, PixelBuffer&) final { ASSERT_NOT_REACHED(); }
+    void putPixelBuffer(const PixelBuffer&, const IntRect&, const IntPoint&, AlphaPremultiplication) final { ASSERT_NOT_REACHED(); }
+
+    RefPtr<SharedBuffer> sinkIntoPDFDocument() final;
+
+    String debugDescription() const final;
+
+    DisplayList::DrawingContext m_drawingContext;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.cpp
@@ -59,7 +59,6 @@ void DrawingContext::replayDisplayList(GraphicsContext& destContext)
         m_replayedDisplayList = replayer.replay({ }, m_tracksDisplayListReplay).trackedDisplayList;
     else
         replayer.replay();
-    m_displayList.clear();
 }
 
 } // DisplayList

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -745,6 +745,7 @@ WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.cpp
 WebProcess/GPU/graphics/WebGPU/RemoteXRViewProxy.cpp
 WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp
+WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.cpp
 WebProcess/GPU/graphics/ImageBufferRemotePDFDocumentBackend.cpp
 WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
 WebProcess/GPU/graphics/PrepareBackingStoreBuffersData.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6475,6 +6475,8 @@
 		72B53158253C1E4D0049295A /* RemoteResourceCacheProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteResourceCacheProxy.h; sourceTree = "<group>"; };
 		72C11DB52849933700E826DD /* ShareablePixelBuffer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ShareablePixelBuffer.cpp; sourceTree = "<group>"; };
 		72C11DB62849933700E826DD /* ShareablePixelBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShareablePixelBuffer.h; sourceTree = "<group>"; };
+		72F9A6CB2D30C5070019DE4B /* ImageBufferRemoteDisplayListBackend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferRemoteDisplayListBackend.h; sourceTree = "<group>"; };
+		72F9A6CC2D30C5070019DE4B /* ImageBufferRemoteDisplayListBackend.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferRemoteDisplayListBackend.cpp; sourceTree = "<group>"; };
 		74C2F54029AC9C44006C5F97 /* DeferredPaymentRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeferredPaymentRequest.h; sourceTree = "<group>"; };
 		74C2F54229AC9CBF006C5F97 /* DeferredPaymentRequestCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DeferredPaymentRequestCocoa.mm; sourceTree = "<group>"; };
 		75A8D2C4187CCF9F00C39C9E /* WKWebsiteDataStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKWebsiteDataStore.h; sourceTree = "<group>"; };
@@ -12881,6 +12883,8 @@
 				7B64C0B6254C5C250006B4AF /* GraphicsContextGLIdentifier.h */,
 				727A7F39240788F1004D2931 /* ImageBufferBackendHandle.h */,
 				0FA7467E27BB611800B5FF5A /* ImageBufferBackendHandleSharing.h */,
+				72F9A6CC2D30C5070019DE4B /* ImageBufferRemoteDisplayListBackend.cpp */,
+				72F9A6CB2D30C5070019DE4B /* ImageBufferRemoteDisplayListBackend.h */,
 				722074312D07D671009FA90F /* ImageBufferRemotePDFDocumentBackend.cpp */,
 				722074302D07D671009FA90F /* ImageBufferRemotePDFDocumentBackend.h */,
 				727A7F37240788F0004D2931 /* ImageBufferShareableBitmapBackend.cpp */,

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.cpp
@@ -1,0 +1,62 @@
+/*
+* Copyright (C) 2024 Apple Inc.  All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+* EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+* CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+* PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "config.h"
+#include "ImageBufferRemoteDisplayListBackend.h"
+
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(ImageBufferRemoteDisplayListBackend);
+
+std::unique_ptr<ImageBufferRemoteDisplayListBackend> ImageBufferRemoteDisplayListBackend::create(const Parameters& parameters)
+{
+    return std::unique_ptr<ImageBufferRemoteDisplayListBackend> { new ImageBufferRemoteDisplayListBackend { parameters } };
+}
+
+ImageBufferRemoteDisplayListBackend::ImageBufferRemoteDisplayListBackend(const Parameters& parameters)
+    : WebCore::NullImageBufferBackend(parameters)
+{
+}
+
+ImageBufferRemoteDisplayListBackend::~ImageBufferRemoteDisplayListBackend()
+{
+}
+
+RefPtr<NativeImage> ImageBufferRemoteDisplayListBackend::createNativeImageReference()
+{
+    return nullptr;
+}
+
+String ImageBufferRemoteDisplayListBackend::debugDescription() const
+{
+    TextStream stream;
+    stream << "ImageBufferRemoteDisplayListBackend " << this;
+    return stream.release();
+}
+
+} // namespace WebCore

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/NullImageBufferBackend.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebKit {
+
+class RemoteRenderingBackendProxy;
+
+class ImageBufferRemoteDisplayListBackend : public WebCore::NullImageBufferBackend {
+    WTF_MAKE_TZONE_OR_ISO_ALLOCATED(ImageBufferRemoteDisplayListBackend);
+    WTF_MAKE_NONCOPYABLE(ImageBufferRemoteDisplayListBackend);
+public:
+    static std::unique_ptr<ImageBufferRemoteDisplayListBackend> create(const Parameters&);
+
+    virtual ~ImageBufferRemoteDisplayListBackend();
+
+    static constexpr WebCore::RenderingMode renderingMode = WebCore::RenderingMode::DisplayList;
+
+private:
+    ImageBufferRemoteDisplayListBackend(const Parameters&);
+
+    RefPtr<WebCore::NativeImage> createNativeImageReference() override;
+    String debugDescription() const override;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -30,6 +30,7 @@
 
 #include "BufferIdentifierSet.h"
 #include "GPUConnectionToWebProcess.h"
+#include "ImageBufferRemoteDisplayListBackend.h"
 #include "ImageBufferRemotePDFDocumentBackend.h"
 #include "ImageBufferShareableBitmapBackend.h"
 #include "Logging.h"
@@ -252,6 +253,7 @@ RefPtr<ImageBuffer> RemoteRenderingBackendProxy::createImageBuffer(const FloatSi
         break;
 
     case RenderingMode::DisplayList:
+        imageBuffer = RemoteImageBufferProxy::create<ImageBufferRemoteDisplayListBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, *this);
         break;
     }
 

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -48,6 +48,7 @@
 #endif
 
 namespace WebKit {
+using namespace WebCore;
 
 WebMediaStrategy::~WebMediaStrategy() = default;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6596,7 +6596,7 @@ void WebPage::drawRemoteToPDF(FrameIdentifier frameID, const std::optional<Float
     Ref frameView = *localMainFrame->view();
     auto snapshotRect = IntRect { rect.value_or(FloatRect { { }, frameView->contentsSize() }) };
 
-    RefPtr buffer = ImageBuffer::create(snapshotRect.size(), RenderingMode::PDFDocument, RenderingPurpose::Snapshot, 1, DestinationColorSpace::SRGB(), ImageBufferPixelFormat::BGRA8, &m_page->chrome());
+    RefPtr buffer = ImageBuffer::create(snapshotRect.size(), RenderingMode::DisplayList, RenderingPurpose::Snapshot, 1, DestinationColorSpace::SRGB(), ImageBufferPixelFormat::BGRA8, &m_page->chrome());
     if (!buffer)
         return;
 


### PR DESCRIPTION
#### fc01b4369ae0acd8cdda47914bd506df0a6c6f9d
<pre>
[Site isolation] Record the page snapshotting to a DisplayList before sinking it to a PDFDocument
<a href="https://bugs.webkit.org/show_bug.cgi?id=285726#">https://bugs.webkit.org/show_bug.cgi?id=285726#</a>
<a href="https://rdar.apple.com/142664977">rdar://142664977</a>

Reviewed by Matt Woodrow.

Introduce ImageBufferDisplayListBackend and ImageBufferRemoteDisplayListBackend
to support recording the snapshot to a DisplayList.

Make drawRemoteToPDF() creates a ImageBufferRemoteDisplayListBackend. Its GPUProcess
twin ImageBufferDisplayListBackend will record the drawing commands into a
DisplayList.

Make didDrawRemoteToPDF() calls sinkIntoPDFDocument() on the main thread because
DisplayList::Replayer needs a ControlFactory and ControlFactory::shared() has to
be called on the main thread. Then send the result SharedBuffer to the UIProcess.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::create):
(WebCore::ImageBuffer::sinkIntoPDFDocument):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.cpp: Added.
(WebCore::ImageBufferDisplayListBackend::create):
(WebCore::ImageBufferDisplayListBackend::ImageBufferDisplayListBackend):
(WebCore::ImageBufferDisplayListBackend::context):
(WebCore::ImageBufferDisplayListBackend::copyNativeImage):
(WebCore::ImageBufferDisplayListBackend::sinkIntoPDFDocument):
(WebCore::ImageBufferDisplayListBackend::debugDescription const):
* Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.h: Copied from Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.cpp.
(WebCore::ImageBufferDisplayListBackend::calculateMemoryCost):
* Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.cpp:
(WebCore::DisplayList::DrawingContext::replayDisplayList):
The PDFDocument has to be generated on the main thread because the main frame
DisplayList will eventually reference other DisplayLists which were created by
different WorkQueues. So clearing the DisplayList, once it is replayed back, will
delete the resources in the ResourceHeap on the main thread. This will fire the
assertion: &quot;Unsafe to ref/deref from different threads&quot;. So keep the DisplayList
items till they are deleted by the destructor of DisplayList::DrawingContext.

* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::didDrawRemoteToPDF):
(WebKit::allocateImageBufferInternal):
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.cpp: Added.
(WebKit::ImageBufferRemoteDisplayListBackend::create):
(WebKit::ImageBufferRemoteDisplayListBackend::ImageBufferRemoteDisplayListBackend):
(WebKit::ImageBufferRemoteDisplayListBackend::~ImageBufferRemoteDisplayListBackend):
(WebKit::ImageBufferRemoteDisplayListBackend::createNativeImageReference):
(WebKit::ImageBufferRemoteDisplayListBackend::debugDescription const):
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.h: Copied from Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.cpp.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::didCreateBackend):

(WebKit::RemoteImageBufferProxy::ensureBackend const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxy::sendSync):
Fix unrelated mac-safer-cpp errors. Make these functions make early returns.

* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::createImageBuffer):
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::drawRemoteToPDF):

Canonical link: <a href="https://commits.webkit.org/290300@main">https://commits.webkit.org/290300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/caf8287a58618ae10a5fb5b4e3d2fdbe0893ee32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94539 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40314 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17353 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68977 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26631 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49342 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6995 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35649 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-fill-columns-001.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39420 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77349 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96367 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16729 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77848 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77066 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77164 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19054 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21597 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20171 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9896 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16742 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22055 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16483 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19934 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18265 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->