### PR TITLE
HTML parser phone number handling should better account for MathML

### DIFF
--- a/LayoutTests/fast/dom/linkify-phone-numbers-expected.html
+++ b/LayoutTests/fast/dom/linkify-phone-numbers-expected.html
@@ -12,5 +12,6 @@
 <pre>408 111 222</pre>
 <code>408 111 222</code>
 <div>$\displaystyle \left(x + 1234567)\right$</div>
+<math><mfrac><mn>389.1067</mn> <mn>29.1067</mn></mfrac><mo>=</mo><mn>13.3683</mn></math>
 </body>
 </html>

--- a/LayoutTests/fast/dom/linkify-phone-numbers.html
+++ b/LayoutTests/fast/dom/linkify-phone-numbers.html
@@ -15,5 +15,6 @@ window.internals?.settings.setTelephoneNumberParsingEnabled(true);
 <pre>408 111 222</pre>
 <code>408 111 222</code>
 <div data-mime-type="text/latex">$\displaystyle \left(x + 1234567)\right$</div>
+<math><mfrac><mn>389.1067</mn> <mn>29.1067</mn></mfrac><mo>=</mo><mn>13.3683</mn></math>
 </body>
 </html>

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -2530,6 +2530,9 @@ static inline bool disallowTelephoneNumberParsing(const ContainerNode& node)
 
 static inline bool shouldParseTelephoneNumbersInNode(const ContainerNode& node)
 {
+    if (node.namespaceURI() != HTMLNames::xhtmlNamespaceURI)
+        return false;
+
     // FIXME: It seems very wasteful to perform a full ancestor walk to check whether we should create
     // telephone number links, when parsing every text node in the document. Ideally, we should maintain
     // the count of elements that disallow telephone number parsing while pushing or popping from the


### PR DESCRIPTION
#### e13876c09f11a7ae201d5a6cc540015ca0f530ca
<pre>
HTML parser phone number handling should better account for MathML
<a href="https://bugs.webkit.org/show_bug.cgi?id=284831">https://bugs.webkit.org/show_bug.cgi?id=284831</a>
<a href="https://rdar.apple.com/141632782">rdar://141632782</a>

Reviewed by Chris Dumez.

When we are not in an HTML subtree it does not make sense to detect
phone numbers and insert HTML a start and end tag tokens when one is
found. It&apos;s especially dubious for MathML.

* LayoutTests/fast/dom/linkify-phone-numbers-expected.html:
* LayoutTests/fast/dom/linkify-phone-numbers.html:
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::shouldParseTelephoneNumbersInNode):

Canonical link: <a href="https://commits.webkit.org/288706@main">https://commits.webkit.org/288706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/216fb29cfefdc8339e1bb86f84333f6175d3b631

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35180 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65468 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23306 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45761 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2855 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30716 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34228 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90628 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11438 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8298 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73924 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72312 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73127 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17434 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2786 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13024 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11390 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16866 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11239 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14715 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13012 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->