### PR TITLE
[CoordinatedGraphics] Wait for tile buffers to be rendered before painting to texture mapper

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -65,9 +65,6 @@ void CoordinatedBackingStore::paintToTextureMapper(TextureMapper& textureMapper,
         return;
 
     ASSERT(!m_size.isZero());
-
-    processPendingUpdates(textureMapper);
-
     Vector<CoordinatedBackingStoreTile*, 16> tilesToPaint;
     Vector<CoordinatedBackingStoreTile*, 16> previousTilesToPaint;
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -792,7 +792,7 @@ void CoordinatedPlatformLayer::waitUntilPaintingComplete()
         m_backingStoreProxy->waitUntilPaintingComplete();
 }
 
-void CoordinatedPlatformLayer::flushCompositingState()
+void CoordinatedPlatformLayer::flushCompositingState(TextureMapper& textureMapper)
 {
     ASSERT(!isMainThread());
     Locker locker { m_lock };
@@ -917,6 +917,8 @@ void CoordinatedPlatformLayer::flushCompositingState()
             m_backingStore->removeTile(tileID);
         for (const auto& tileUpdate : update.tilesToUpdate())
             m_backingStore->updateTile(tileUpdate.tileID, tileUpdate.dirtyRect, tileUpdate.tileRect, tileUpdate.buffer.copyRef(), { });
+
+        m_backingStore->processPendingUpdates(textureMapper);
     } else {
         layer.setBackingStore(nullptr);
         layer.setAnimatedBackingStoreClient(nullptr);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -45,6 +45,7 @@ class CoordinatedPlatformLayer;
 class CoordinatedTileBuffer;
 class GraphicsLayerCoordinated;
 class NativeImage;
+class TextureMapper;
 class TextureMapperLayer;
 class TextureMapperPlatformLayerProxy;
 
@@ -164,7 +165,7 @@ public:
     void setShowRepaintCounter(bool);
 
     void updateContents(bool affectedByTransformAnimation);
-    void flushCompositingState();
+    void flushCompositingState(TextureMapper&);
 
     bool hasPendingTilesCreation() const { return m_pendingTilesCreation; }
     bool hasImageBackingStore() const { return !!m_imageBackingStore; }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
@@ -118,9 +118,9 @@ void CoordinatedGraphicsScene::updateSceneState()
     if (!m_textureMapper)
         m_textureMapper = TextureMapper::create();
 
-    m_sceneState->rootLayer().flushCompositingState();
+    m_sceneState->rootLayer().flushCompositingState(*m_textureMapper);
     for (auto& layer : m_sceneState->committedLayers())
-        layer->flushCompositingState();
+        layer->flushCompositingState(*m_textureMapper);
 }
 
 void CoordinatedGraphicsScene::purgeGLResources()


### PR DESCRIPTION
#### f67a8f0bac71cf86fa44004ea8f8bbd617e523f7
<pre>
[CoordinatedGraphics] Wait for tile buffers to be rendered before painting to texture mapper
<a href="https://bugs.webkit.org/show_bug.cgi?id=285736">https://bugs.webkit.org/show_bug.cgi?id=285736</a>

Reviewed by Miguel Gomez.

In 288158@main I moved the tiles updates processing to
CoordinatedBackingStore::paintToTextureMapper(), but it can happen that
the layer paint is skipped. We should always wait for buffers in the
composition to make sure there aren&apos;t painting thread running after the
composition. This patch moves processing updates to flushCompositingState()
so that it happens before painting as it was done before 288158@main.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp:
(WebCore::CoordinatedBackingStore::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::flushCompositingState):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedGraphicsScene.cpp:
(WebKit::CoordinatedGraphicsScene::updateSceneState):

Canonical link: <a href="https://commits.webkit.org/288695@main">https://commits.webkit.org/288695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3b62f2889632c8c2e7a3fdf318a4ec24ceef4f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35191 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65478 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23315 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87228 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45771 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2864 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/30728 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34240 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90639 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11449 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73935 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73139 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17446 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2805 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13022 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11401 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16877 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11250 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14726 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->