### PR TITLE
[GStreamer] Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in Quirks

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.cpp
@@ -48,10 +48,9 @@ GStreamerQuirkBcmNexus::GStreamerQuirkBcmNexus()
 
 std::optional<bool> GStreamerQuirkBcmNexus::isHardwareAccelerated(GstElementFactory* factory)
 {
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-    if (g_str_has_prefix(GST_OBJECT_NAME(factory), "brcm"))
+    auto view = StringView::fromLatin1(GST_OBJECT_NAME(factory));
+    if (view.startsWith("brcm"_s))
         return true;
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return std::nullopt;
 }

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
@@ -39,15 +39,14 @@ GStreamerQuirkBroadcom::GStreamerQuirkBroadcom()
 
 void GStreamerQuirkBroadcom::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
 {
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
+    auto view = StringView::fromLatin1(GST_ELEMENT_NAME(element));
     if (!g_strcmp0(G_OBJECT_TYPE_NAME(element), "Gstbrcmaudiosink"))
         g_object_set(G_OBJECT(element), "async", TRUE, nullptr);
-    else if (g_str_has_prefix(GST_ELEMENT_NAME(element), "brcmaudiodecoder")) {
+    else if (view.startsWith("brcmaudiodecoder"_s)) {
         // Limit BCM audio decoder buffering to 1sec so live progressive playback can start faster.
         if (characteristics.contains(ElementRuntimeCharacteristics::IsLiveStream))
             g_object_set(G_OBJECT(element), "limit_buffering_ms", 1000, nullptr);
     }
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     if (!characteristics.contains(ElementRuntimeCharacteristics::IsMediaStream))
         return;
@@ -60,10 +59,9 @@ void GStreamerQuirkBroadcom::configureElement(GstElement* element, const OptionS
 
 std::optional<bool> GStreamerQuirkBroadcom::isHardwareAccelerated(GstElementFactory* factory)
 {
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-    if (g_str_has_prefix(GST_OBJECT_NAME(factory), "brcm"))
+    auto view = StringView::fromLatin1(GST_OBJECT_NAME(factory));
+    if (view.startsWith("brcm"_s))
         return true;
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return std::nullopt;
 }

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
@@ -73,10 +73,9 @@ void GStreamerQuirkRealtek::configureElement(GstElement* element, const OptionSe
 
 std::optional<bool> GStreamerQuirkRealtek::isHardwareAccelerated(GstElementFactory* factory)
 {
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-    if (g_str_has_prefix(GST_OBJECT_NAME(factory), "omx"))
+    auto view = StringView::fromLatin1(GST_OBJECT_NAME(factory));
+    if (view.startsWith("omx"_s))
         return true;
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return std::nullopt;
 }

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
@@ -32,8 +32,6 @@
 #include "WebKitAudioSinkGStreamer.h"
 #include <wtf/OptionSet.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-
 namespace WebCore {
 
 GST_DEBUG_CATEGORY_STATIC(webkit_rialto_quirks_debug);
@@ -100,7 +98,8 @@ GstElement* GStreamerQuirkRialto::createWebAudioSink()
 
 std::optional<bool> GStreamerQuirkRialto::isHardwareAccelerated(GstElementFactory* factory)
 {
-    if (g_str_has_prefix(GST_OBJECT_NAME(factory), "rialto"))
+    auto view = StringView::fromLatin1(GST_OBJECT_NAME(factory));
+    if (view.startsWith("rialto"_s))
         return true;
 
     return std::nullopt;
@@ -109,7 +108,5 @@ std::optional<bool> GStreamerQuirkRialto::isHardwareAccelerated(GstElementFactor
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
@@ -26,8 +26,6 @@
 #include "GStreamerCommon.h"
 #include <wtf/OptionSet.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-
 namespace WebCore {
 
 GST_DEBUG_CATEGORY_STATIC(webkit_westeros_quirks_debug);
@@ -55,7 +53,8 @@ GStreamerQuirkWesteros::GStreamerQuirkWesteros()
 
 void GStreamerQuirkWesteros::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
 {
-    if (g_str_has_prefix(GST_ELEMENT_NAME(element), "uridecodebin3")) {
+    auto view = StringView::fromLatin1(GST_ELEMENT_NAME(element));
+    if (view.startsWith("uridecodebin3"_s)) {
         GRefPtr<GstCaps> defaultCaps;
         g_object_get(element, "caps", &defaultCaps.outPtr(), nullptr);
         defaultCaps = adoptGRef(gst_caps_merge(gst_caps_ref(m_sinkCaps.get()), defaultCaps.leakRef()));
@@ -75,7 +74,8 @@ void GStreamerQuirkWesteros::configureElement(GstElement* element, const OptionS
 
 std::optional<bool> GStreamerQuirkWesteros::isHardwareAccelerated(GstElementFactory* factory)
 {
-    if (g_str_has_prefix(GST_OBJECT_NAME(factory), "westeros"))
+    auto view = StringView::fromLatin1(GST_OBJECT_NAME(factory));
+    if (view.startsWith("westeros"_s))
         return true;
 
     return std::nullopt;
@@ -84,7 +84,5 @@ std::optional<bool> GStreamerQuirkWesteros::isHardwareAccelerated(GstElementFact
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(GSTREAMER)


### PR DESCRIPTION
#### 43a137c74f583a200a5a9ee2b86f441d4b3ec024
<pre>
[GStreamer] Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in Quirks
<a href="https://bugs.webkit.org/show_bug.cgi?id=285741">https://bugs.webkit.org/show_bug.cgi?id=285741</a>

Reviewed by Xabier Rodriguez-Calvar.

Use StringView for string prefix matching.

* Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.cpp:
(WebCore::GStreamerQuirkBcmNexus::isHardwareAccelerated):
* Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp:
(WebCore::GStreamerQuirkBroadcom::configureElement):
(WebCore::GStreamerQuirkBroadcom::isHardwareAccelerated):
* Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp:
(WebCore::GStreamerQuirkRealtek::isHardwareAccelerated):
* Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp:
(WebCore::GStreamerQuirkRialto::isHardwareAccelerated):
* Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp:
(WebCore::GStreamerQuirkWesteros::isHardwareAccelerated):

Canonical link: <a href="https://commits.webkit.org/288836@main">https://commits.webkit.org/288836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30fa08b04da3924a71f4243711cde1480ff09a42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89265 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35198 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65485 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23322 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45778 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2871 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30733 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34247 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90646 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11456 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8313 "Found 1 new test failure: media/video-canvas-createPattern.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73939 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11682 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72328 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73142 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18160 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17452 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2813 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11408 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16884 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11257 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14733 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13030 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->