### PR TITLE
[CoordinatedGraphics] Keep an extra reference of image backing store proxy until the next composition

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -115,6 +115,7 @@ void CoordinatedPlatformLayer::invalidateTarget()
         m_committedContentsBuffer = nullptr;
     }
     m_backingStore = nullptr;
+    m_committedImageBackingStore = nullptr;
     m_target = nullptr;
 }
 
@@ -859,6 +860,9 @@ void CoordinatedPlatformLayer::flushCompositingState(TextureMapper& textureMappe
             m_committedContentsBuffer->activateOnCompositingThread(*this);
     }
 
+    if (m_pendingChanges.contains(Change::ContentsImage))
+        m_committedImageBackingStore = m_imageBackingStore;
+
     if (m_pendingChanges.contains(Change::ContentsColor))
         layer.setSolidColor(m_contentsColor);
 
@@ -927,8 +931,8 @@ void CoordinatedPlatformLayer::flushCompositingState(TextureMapper& textureMappe
 
     if (m_committedContentsBuffer)
         m_committedContentsBuffer->swapBuffer();
-    else if (m_imageBackingStore && m_imageBackingStoreVisible)
-        layer.setContentsLayer(m_imageBackingStore->buffer());
+    else if (m_committedImageBackingStore && m_imageBackingStoreVisible)
+        layer.setContentsLayer(m_committedImageBackingStore->buffer());
     else
         layer.setContentsLayer(nullptr);
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -263,6 +263,7 @@ private:
     RefPtr<CoordinatedBackingStore> m_backingStore WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<CoordinatedAnimatedBackingStoreClient> m_animatedBackingStoreClient WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<CoordinatedImageBackingStore> m_imageBackingStore WTF_GUARDED_BY_LOCK(m_lock);
+    RefPtr<CoordinatedImageBackingStore> m_committedImageBackingStore WTF_GUARDED_BY_LOCK(m_lock);
     bool m_imageBackingStoreVisible WTF_GUARDED_BY_LOCK(m_lock) { false };
     Vector<IntRect, 1> m_dirtyRegion WTF_GUARDED_BY_LOCK(m_lock);
     FilterOperations m_filters WTF_GUARDED_BY_LOCK(m_lock);


### PR DESCRIPTION
#### da3c108d5d85c0b114ece2f45bbd095488274824
<pre>
[CoordinatedGraphics] Keep an extra reference of image backing store proxy until the next composition
<a href="https://bugs.webkit.org/show_bug.cgi?id=285742">https://bugs.webkit.org/show_bug.cgi?id=285742</a>

Reviewed by Miguel Gomez.

Similar to what we do for the contents buffer, we need to keep the
previous image backing store alive until the next composition, since it
can still be used by the compositor thread.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::invalidateTarget):
(WebCore::CoordinatedPlatformLayer::flushCompositingState):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:

Canonical link: <a href="https://commits.webkit.org/288759@main">https://commits.webkit.org/288759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5593ab0baa587ddef8c9d5d851a61e0247e24c02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89266 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35199 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11783 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65487 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23323 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76507 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45780 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30737 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34248 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73792 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90647 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73940 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72332 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73143 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17453 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2814 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13055 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11409 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16885 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11258 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14734 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->