### PR TITLE
[scroll-animations] WPT test scroll-animations/view-timelines/view-timeline-inset.html is a failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt
@@ -1,19 +1,9 @@
 
 PASS View timeline with px based inset.
-FAIL View timeline with percent based inset. assert_equals: Effect at the start of the active phase: 10% 20% expected "0.3" but got "0.353333"
-FAIL view timeline with inset auto. promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL view timeline with font relative inset. assert_equals: Effect at the start of the active phase: 1em 2em expected "0.3" but got "0.342667"
-FAIL view timeline with viewport relative insets. assert_equals: Effect at the start of the active phase: 10vw 20vw expected "0.3" but got "0.513333"
-FAIL view timeline inset as string assert_throws_js: function "() => {
-    new ViewTimeline({
-      subject: target,
-      inset: "go fish"
-    });
-  }" did not throw
-FAIL view timeline with invalid inset assert_throws_js: function "() => {
-    new ViewTimeline({
-      subject: target,
-      inset: [ CSS.rad(1) ]
-    });
-  }" did not throw
+PASS View timeline with percent based inset.
+PASS view timeline with inset auto.
+PASS view timeline with font relative inset.
+PASS view timeline with viewport relative insets.
+PASS view timeline inset as string
+PASS view timeline with invalid inset
 

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "CSSNumericValue.h"
-#include "Length.h"
+#include "CSSPrimitiveValue.h"
 #include "ScrollTimeline.h"
 #include "ViewTimelineOptions.h"
 #include <wtf/Ref.h>
@@ -50,7 +50,7 @@ struct ViewTimelineInsets {
 
 class ViewTimeline final : public ScrollTimeline {
 public:
-    static Ref<ViewTimeline> create(ViewTimelineOptions&& = { });
+    static ExceptionOr<Ref<ViewTimeline>> create(Document&, ViewTimelineOptions&& = { });
     static Ref<ViewTimeline> create(const AtomString&, ScrollAxis, ViewTimelineInsets&&);
 
     const Element* subject() const { return m_subject.get(); }
@@ -73,7 +73,7 @@ private:
     ScrollTimeline::Data computeTimelineData() const final;
     std::pair<WebAnimationTime, WebAnimationTime> intervalForAttachmentRange(const TimelineRange&) const final;
 
-    explicit ViewTimeline(ViewTimelineOptions&& = { });
+    explicit ViewTimeline(ScrollAxis);
     explicit ViewTimeline(const AtomString&, ScrollAxis, ViewTimelineInsets&&);
 
     bool isViewTimeline() const final { return true; }
@@ -89,7 +89,15 @@ private:
 
     void cacheCurrentTime();
 
+    struct SpecifiedViewTimelineInsets {
+        RefPtr<CSSPrimitiveValue> start;
+        RefPtr<CSSPrimitiveValue> end;
+    };
+
+    ExceptionOr<SpecifiedViewTimelineInsets> validateSpecifiedInsets(const ViewTimelineInsetValue, const Document&);
+
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_subject;
+    std::optional<SpecifiedViewTimelineInsets> m_specifiedInsets;
     ViewTimelineInsets m_insets;
     CurrentTimeData m_cachedCurrentTimeData { };
 };

--- a/Source/WebCore/animation/ViewTimeline.idl
+++ b/Source/WebCore/animation/ViewTimeline.idl
@@ -28,7 +28,7 @@
     Exposed=Window,
     JSGenerateToJSObject
 ] interface ViewTimeline : ScrollTimeline {
-    constructor(optional ViewTimelineOptions options = {});
+    [CallWith=CurrentDocument] constructor(optional ViewTimelineOptions options = {});
     readonly attribute Element subject;
     readonly attribute CSSNumericValue startOffset;
     readonly attribute CSSNumericValue endOffset;

--- a/Source/WebCore/animation/ViewTimelineOptions.h
+++ b/Source/WebCore/animation/ViewTimelineOptions.h
@@ -32,10 +32,13 @@
 
 namespace WebCore {
 
+using ViewTimelineIndividualInset = std::variant<RefPtr<CSSNumericValue>, String, RefPtr<CSSKeywordValue>>;
+using ViewTimelineInsetValue = std::variant<String, Vector<ViewTimelineIndividualInset>>;
+
 struct ViewTimelineOptions {
     RefPtr<Element> subject;
     ScrollAxis axis;
-    std::variant<String, Vector<std::variant<RefPtr<CSSNumericValue>, RefPtr<CSSKeywordValue>>>> inset;
+    ViewTimelineInsetValue inset;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/ViewTimelineOptions.idl
+++ b/Source/WebCore/animation/ViewTimelineOptions.idl
@@ -23,8 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+typedef (DOMString or CSSKeywordValue) CSSKeywordish;
+
 dictionary ViewTimelineOptions {
     Element subject;
     ScrollAxis axis = "block";
-    (DOMString or sequence<(CSSNumericValue or CSSKeywordValue)>) inset = "auto";
+    (DOMString or sequence<(CSSNumericValue or CSSKeywordish)>) inset = "auto";
 };


### PR DESCRIPTION
#### 2a171bab90e5b293278fde7c2969ddcfc2ebdda1
<pre>
[scroll-animations] WPT test scroll-animations/view-timelines/view-timeline-inset.html is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=285750">https://bugs.webkit.org/show_bug.cgi?id=285750</a>
<a href="https://rdar.apple.com/142690868">rdar://142690868</a>

Reviewed by Anne van Kesteren.

Our support for view timeline insets was very rudimentary. While we fixed the most egregious issue in 288684@main,
we still had many issues left as shown in the failures in the relevant WPT test.

The main task was to only convert inset values provided via the JS bindings to `CSSPrimitiveValue` such that we may
resolve the insets when the view timeline&apos;s current time is being recomputed, thus correctly handling any relative
value. Values provided via CSS are already fully resolved and are used as-is.

We also implement the behavior where an `&quot;auto&quot;` values means that the values provided through the `scroll-padding`
CSS property on the scroll container should be used.

Additionally, we now raise exceptions for forbidden value types and units.

We also switched the IDL type for `ViewTimelineInsets.inset` to use a `CSSKeywordish` rather than `CSSKeywordValue`
alone so that strings would be allowed. This matches what Chrome implements and one of the cases tested in the test.
The issue <a href="https://github.com/w3c/csswg-drafts/issues/11477">https://github.com/w3c/csswg-drafts/issues/11477</a> was filed to track resolution of this discrepancy between
the spec and WPT.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-inset-expected.txt:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::isValidInset):
(WebCore::ViewTimeline::create):
(WebCore::ViewTimeline::ViewTimeline):
(WebCore::ViewTimeline::validateSpecifiedInsets):
(WebCore::ViewTimeline::cacheCurrentTime):
(WebCore::lengthForInset): Deleted.
(WebCore::insetsFromOptions): Deleted.
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/animation/ViewTimeline.idl:
* Source/WebCore/animation/ViewTimelineOptions.h:
* Source/WebCore/animation/ViewTimelineOptions.idl:

Canonical link: <a href="https://commits.webkit.org/288795@main">https://commits.webkit.org/288795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df977d93db47e19f6bc3c539499e089fe96c6f37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38750 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35456 "Failed to checkout and rebase branch from PR 38848") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86530 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12053 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/89527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/35456 "Failed to checkout and rebase branch from PR 38848") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87491 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/76719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/3081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/30950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34504 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/31722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90907 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11712 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11939 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/72543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/17661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/16105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/3139 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13073 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11664 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11513 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14989 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->