### PR TITLE
[WebGPU] CTS test web_platform,copyToTexture,ImageBitmap:from_*

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap-expected.txt
@@ -1,3 +1,1394 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r16float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="r32float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstFormat="rgba32float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r16float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="r32float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg16float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rg32float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba8unorm-srgb";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="bgra8unorm-srgb";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgb10a2unorm";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba16float";dstPremultiplied=false
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=true
+PASS :from_canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstFormat="rgba32float";dstPremultiplied=false
+PASS :copy_subrect_from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstPremultiplied=true
+PASS :copy_subrect_from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstPremultiplied=false
+PASS :copy_subrect_from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstPremultiplied=true
+PASS :copy_subrect_from_ImageData:alpha="none";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstPremultiplied=false
+PASS :copy_subrect_from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstPremultiplied=true
+PASS :copy_subrect_from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstPremultiplied=false
+PASS :copy_subrect_from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstPremultiplied=true
+PASS :copy_subrect_from_ImageData:alpha="none";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstPremultiplied=false
+FAIL :copy_subrect_from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstPremultiplied=true assert_unreached:
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 0,3,0 and 1,3,0 inclusive:
+                                coords ==   X,Y,Z:                           0,3,0                               1,3,0
+      act. texel bytes (little-endian) ==      0x:                     ff ff ff ff                         99 99 99 99
+                           act. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 0.600000,0.600000,0.600000,0.600000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000     0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                     153,153,153,153
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                         0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                              0,255,255,0                   153,-102,153,-102
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:390:25
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 2,4,0 and 3,5,0 inclusive:
+                                coords ==   X,Y,Z:                           2,5,0                               3,5,0
+      act. texel bytes (little-endian) ==      0x:                     ff ff ff ff                         99 99 99 99
+                           act. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 0.600000,0.600000,0.600000,0.600000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000     0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                     153,153,153,153
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                         0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                              0,255,255,0                   153,-102,153,-102
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:390:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+ Reached unreachable code
+FAIL :copy_subrect_from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstPremultiplied=false assert_unreached:
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 0,3,0 and 1,3,0 inclusive:
+                                coords ==   X,Y,Z:                           0,3,0                            1,3,0
+      act. texel bytes (little-endian) ==      0x:                     ff ff ff ff                      ff ff ff 99
+                           act. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 1.00000,1.00000,1.00000,0.600000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000  0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                  255,255,255,153
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                      0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                              0,255,255,0                   255,0,255,-102
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:390:25
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 2,4,0 and 3,5,0 inclusive:
+                                coords ==   X,Y,Z:                           2,5,0                            3,5,0
+      act. texel bytes (little-endian) ==      0x:                     ff ff ff ff                      ff ff ff 99
+                           act. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 1.00000,1.00000,1.00000,0.600000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000  0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                  255,255,255,153
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                      0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                              0,255,255,0                   255,0,255,-102
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:390:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+ Reached unreachable code
+PASS :copy_subrect_from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstPremultiplied=true
+PASS :copy_subrect_from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstPremultiplied=false
+FAIL :copy_subrect_from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstPremultiplied=true assert_unreached:
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 0,3,0 and 1,3,0 inclusive:
+                                coords ==   X,Y,Z:                           0,3,0                               1,3,0
+      act. texel bytes (little-endian) ==      0x:                     ff ff ff ff                         99 99 99 99
+                           act. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 0.600000,0.600000,0.600000,0.600000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000     0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                     153,153,153,153
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                         0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                              0,255,255,0                   153,-102,153,-102
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:390:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 2,4,0 and 3,5,0 inclusive:
+                                coords ==   X,Y,Z:                           2,5,0                               3,5,0
+      act. texel bytes (little-endian) ==      0x:                     ff ff ff ff                         99 99 99 99
+                           act. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 0.600000,0.600000,0.600000,0.600000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000     0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                     153,153,153,153
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                         0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                              0,255,255,0                   153,-102,153,-102
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:390:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+ Reached unreachable code
+FAIL :copy_subrect_from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstPremultiplied=false assert_unreached:
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 0,3,0 and 1,3,0 inclusive:
+                                coords ==   X,Y,Z:                           0,3,0                            1,3,0
+      act. texel bytes (little-endian) ==      0x:                     ff ff ff ff                      ff ff ff 99
+                           act. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 1.00000,1.00000,1.00000,0.600000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000  0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                  255,255,255,153
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                      0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                              0,255,255,0                   255,0,255,-102
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:390:25
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 2,4,0 and 3,5,0 inclusive:
+                                coords ==   X,Y,Z:                           2,5,0                            3,5,0
+      act. texel bytes (little-endian) ==      0x:                     ff ff ff ff                      ff ff ff 99
+                           act. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 1.00000,1.00000,1.00000,0.600000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000  0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                  255,255,255,153
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                      0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                              0,255,255,0                   255,0,255,-102
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:390:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+ Reached unreachable code
+PASS :copy_subrect_from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstPremultiplied=true
+PASS :copy_subrect_from_ImageData:alpha="none";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstPremultiplied=false
+PASS :copy_subrect_from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstPremultiplied=true
+PASS :copy_subrect_from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstPremultiplied=false
+PASS :copy_subrect_from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstPremultiplied=true
+PASS :copy_subrect_from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstPremultiplied=false
+PASS :copy_subrect_from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstPremultiplied=true
+PASS :copy_subrect_from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstPremultiplied=false
+PASS :copy_subrect_from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstPremultiplied=true
+PASS :copy_subrect_from_ImageData:alpha="premultiply";orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstPremultiplied=false
+FAIL :copy_subrect_from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstPremultiplied=true assert_unreached:
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 0,3,0 and 1,3,0 inclusive:
+                                coords ==   X,Y,Z:                           0,3,0                               1,3,0
+      act. texel bytes (little-endian) ==      0x:                     ff ff ff ff                         99 99 99 99
+                           act. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 0.600000,0.600000,0.600000,0.600000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000     0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                     153,153,153,153
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                         0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                              0,255,255,0                   153,-102,153,-102
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:390:25
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 2,4,0 and 3,5,0 inclusive:
+                                coords ==   X,Y,Z:                           2,5,0                               3,5,0
+      act. texel bytes (little-endian) ==      0x:                     ff ff ff ff                         99 99 99 99
+                           act. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 0.600000,0.600000,0.600000,0.600000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000     0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                     153,153,153,153
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                         0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                              0,255,255,0                   153,-102,153,-102
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:390:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+ Reached unreachable code
+FAIL :copy_subrect_from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstPremultiplied=false assert_unreached:
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 0,3,0 and 1,3,0 inclusive:
+                                coords ==   X,Y,Z:                           0,3,0                            1,3,0
+      act. texel bytes (little-endian) ==      0x:                     ff ff ff ff                      ff ff ff 99
+                           act. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 1.00000,1.00000,1.00000,0.600000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000  0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                  255,255,255,153
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                      0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                              0,255,255,0                   255,0,255,-102
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:390:25
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 2,4,0 and 3,5,0 inclusive:
+                                coords ==   X,Y,Z:                           2,5,0                            3,5,0
+      act. texel bytes (little-endian) ==      0x:                     ff ff ff ff                      ff ff ff 99
+                           act. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 1.00000,1.00000,1.00000,0.600000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000  0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                  255,255,255,153
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                      0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                              0,255,255,0                   255,0,255,-102
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:390:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+ Reached unreachable code
+PASS :copy_subrect_from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstPremultiplied=true
+PASS :copy_subrect_from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstPremultiplied=false
+FAIL :copy_subrect_from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstPremultiplied=true assert_unreached:
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 0,3,0 and 1,3,0 inclusive:
+                                coords ==   X,Y,Z:                           0,3,0                               1,3,0
+      act. texel bytes (little-endian) ==      0x:                     ff ff ff ff                         99 99 99 99
+                           act. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 0.600000,0.600000,0.600000,0.600000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000     0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                     153,153,153,153
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                         0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                              0,255,255,0                   153,-102,153,-102
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:390:25
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 2,4,0 and 3,5,0 inclusive:
+                                coords ==   X,Y,Z:                           2,5,0                               3,5,0
+      act. texel bytes (little-endian) ==      0x:                     ff ff ff ff                         99 99 99 99
+                           act. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 0.600000,0.600000,0.600000,0.600000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000     0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                     153,153,153,153
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                         0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                              0,255,255,0                   153,-102,153,-102
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:390:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+ Reached unreachable code
+FAIL :copy_subrect_from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstPremultiplied=false assert_unreached:
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 0,3,0 and 1,3,0 inclusive:
+                                coords ==   X,Y,Z:                           0,3,0                            1,3,0
+      act. texel bytes (little-endian) ==      0x:                     ff ff ff ff                      ff ff ff 99
+                           act. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 1.00000,1.00000,1.00000,0.600000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000  0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                  255,255,255,153
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                      0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                              0,255,255,0                   255,0,255,-102
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:390:25
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 2,4,0 and 3,5,0 inclusive:
+                                coords ==   X,Y,Z:                           2,5,0                            3,5,0
+      act. texel bytes (little-endian) ==      0x:                     ff ff ff ff                      ff ff ff 99
+                           act. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 1.00000,1.00000,1.00000,0.600000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000  0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                  255,255,255,153
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                      0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                              0,255,255,0                   255,0,255,-102
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:390:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+ Reached unreachable code
+PASS :copy_subrect_from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstPremultiplied=true
+PASS :copy_subrect_from_ImageData:alpha="premultiply";orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstPremultiplied=false
+FAIL :copy_subrect_from_2D_Canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstPremultiplied=true assert_unreached:
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 0,3,0 and 1,3,0 inclusive:
+                                coords ==   X,Y,Z:                           0,3,0                           1,3,0
+      act. texel bytes (little-endian) ==      0x:                     00 00 ff ff                     00 00 00 ff
+                           act. colors == R,G,B,A: 0.00000,0.00000,1.00000,1.00000 0.00000,0.00000,0.00000,1.00000
+                           exp. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 1.00000,0.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                     0,0,255,255                       0,0,0,255
+            exp. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                     255,0,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                            -255,-255,0,0                      -255,0,0,0
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:529:25
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 2,4,0 and 3,5,0 inclusive:
+                                coords ==   X,Y,Z:                           2,5,0                           3,5,0
+      act. texel bytes (little-endian) ==      0x:                     00 00 ff ff                     00 00 00 ff
+                           act. colors == R,G,B,A: 0.00000,0.00000,1.00000,1.00000 0.00000,0.00000,0.00000,1.00000
+                           exp. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 1.00000,0.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                     0,0,255,255                       0,0,0,255
+            exp. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                     255,0,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                            -255,-255,0,0                      -255,0,0,0
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:529:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+ Reached unreachable code
+FAIL :copy_subrect_from_2D_Canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=true;dstPremultiplied=false assert_unreached:
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 0,3,0 and 1,3,0 inclusive:
+                                coords ==   X,Y,Z:                           0,3,0                           1,3,0
+      act. texel bytes (little-endian) ==      0x:                     00 00 ff ff                     00 00 00 ff
+                           act. colors == R,G,B,A: 0.00000,0.00000,1.00000,1.00000 0.00000,0.00000,0.00000,1.00000
+                           exp. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 1.00000,0.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                     0,0,255,255                       0,0,0,255
+            exp. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                     255,0,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                            -255,-255,0,0                      -255,0,0,0
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:529:25
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 2,4,0 and 3,5,0 inclusive:
+                                coords ==   X,Y,Z:                           2,5,0                           3,5,0
+      act. texel bytes (little-endian) ==      0x:                     00 00 ff ff                     00 00 00 ff
+                           act. colors == R,G,B,A: 0.00000,0.00000,1.00000,1.00000 0.00000,0.00000,0.00000,1.00000
+                           exp. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 1.00000,0.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                     0,0,255,255                       0,0,0,255
+            exp. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                     255,0,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                            -255,-255,0,0                      -255,0,0,0
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:529:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+ Reached unreachable code
+PASS :copy_subrect_from_2D_Canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstPremultiplied=true
+PASS :copy_subrect_from_2D_Canvas:orientation="none";colorSpaceConversion="none";srcFlipYInCopy=false;dstPremultiplied=false
+FAIL :copy_subrect_from_2D_Canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstPremultiplied=true assert_unreached:
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 0,3,0 and 1,3,0 inclusive:
+                                coords ==   X,Y,Z:                           0,3,0                           1,3,0
+      act. texel bytes (little-endian) ==      0x:                     00 00 ff ff                     00 00 00 ff
+                           act. colors == R,G,B,A: 0.00000,0.00000,1.00000,1.00000 0.00000,0.00000,0.00000,1.00000
+                           exp. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 1.00000,0.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                     0,0,255,255                       0,0,0,255
+            exp. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                     255,0,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                            -255,-255,0,0                      -255,0,0,0
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:529:25
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 2,4,0 and 3,5,0 inclusive:
+                                coords ==   X,Y,Z:                           2,5,0                           3,5,0
+      act. texel bytes (little-endian) ==      0x:                     00 00 ff ff                     00 00 00 ff
+                           act. colors == R,G,B,A: 0.00000,0.00000,1.00000,1.00000 0.00000,0.00000,0.00000,1.00000
+                           exp. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 1.00000,0.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                     0,0,255,255                       0,0,0,255
+            exp. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                     255,0,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                            -255,-255,0,0                      -255,0,0,0
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:529:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+ Reached unreachable code
+FAIL :copy_subrect_from_2D_Canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=true;dstPremultiplied=false assert_unreached:
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 0,3,0 and 1,3,0 inclusive:
+                                coords ==   X,Y,Z:                           0,3,0                           1,3,0
+      act. texel bytes (little-endian) ==      0x:                     00 00 ff ff                     00 00 00 ff
+                           act. colors == R,G,B,A: 0.00000,0.00000,1.00000,1.00000 0.00000,0.00000,0.00000,1.00000
+                           exp. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 1.00000,0.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                     0,0,255,255                       0,0,0,255
+            exp. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                     255,0,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                            -255,-255,0,0                      -255,0,0,0
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:529:25
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 2,4,0 and 3,5,0 inclusive:
+                                coords ==   X,Y,Z:                           2,5,0                           3,5,0
+      act. texel bytes (little-endian) ==      0x:                     00 00 ff ff                     00 00 00 ff
+                           act. colors == R,G,B,A: 0.00000,0.00000,1.00000,1.00000 0.00000,0.00000,0.00000,1.00000
+                           exp. colors == R,G,B,A: 1.00000,1.00000,1.00000,1.00000 1.00000,0.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                     0,0,255,255                       0,0,0,255
+            exp. normal-ULPs-from-zero == R,G,B,A:                 255,255,255,255                     255,0,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                            -255,-255,0,0                      -255,0,0,0
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:529:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+ Reached unreachable code
+PASS :copy_subrect_from_2D_Canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstPremultiplied=true
+PASS :copy_subrect_from_2D_Canvas:orientation="none";colorSpaceConversion="default";srcFlipYInCopy=false;dstPremultiplied=false
+FAIL :copy_subrect_from_2D_Canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstPremultiplied=true assert_unreached:
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 0,3,0 and 1,3,0 inclusive:
+                                coords ==   X,Y,Z:                           0,3,0                           1,3,0
+      act. texel bytes (little-endian) ==      0x:                     00 ff 00 ff                     00 00 ff ff
+                           act. colors == R,G,B,A: 0.00000,1.00000,0.00000,1.00000 0.00000,0.00000,1.00000,1.00000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000 0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                     0,255,0,255                     0,0,255,255
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                     0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                             -255,255,0,0                    0,-255,255,0
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:529:25
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 2,4,0 and 3,5,0 inclusive:
+                                coords ==   X,Y,Z:                           2,5,0                           3,5,0
+      act. texel bytes (little-endian) ==      0x:                     00 ff 00 ff                     00 00 ff ff
+                           act. colors == R,G,B,A: 0.00000,1.00000,0.00000,1.00000 0.00000,0.00000,1.00000,1.00000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000 0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                     0,255,0,255                     0,0,255,255
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                     0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                             -255,255,0,0                    0,-255,255,0
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:529:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+ Reached unreachable code
+FAIL :copy_subrect_from_2D_Canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=true;dstPremultiplied=false assert_unreached:
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 0,3,0 and 1,3,0 inclusive:
+                                coords ==   X,Y,Z:                           0,3,0                           1,3,0
+      act. texel bytes (little-endian) ==      0x:                     00 ff 00 ff                     00 00 ff ff
+                           act. colors == R,G,B,A: 0.00000,1.00000,0.00000,1.00000 0.00000,0.00000,1.00000,1.00000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000 0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                     0,255,0,255                     0,0,255,255
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                     0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                             -255,255,0,0                    0,-255,255,0
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:529:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 2,4,0 and 3,5,0 inclusive:
+                                coords ==   X,Y,Z:                           2,5,0                           3,5,0
+      act. texel bytes (little-endian) ==      0x:                     00 ff 00 ff                     00 00 ff ff
+                           act. colors == R,G,B,A: 0.00000,1.00000,0.00000,1.00000 0.00000,0.00000,1.00000,1.00000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000 0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                     0,255,0,255                     0,0,255,255
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                     0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                             -255,255,0,0                    0,-255,255,0
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:529:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+ Reached unreachable code
+PASS :copy_subrect_from_2D_Canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstPremultiplied=true
+PASS :copy_subrect_from_2D_Canvas:orientation="flipY";colorSpaceConversion="none";srcFlipYInCopy=false;dstPremultiplied=false
+FAIL :copy_subrect_from_2D_Canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstPremultiplied=true assert_unreached:
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 0,3,0 and 1,3,0 inclusive:
+                                coords ==   X,Y,Z:                           0,3,0                           1,3,0
+      act. texel bytes (little-endian) ==      0x:                     00 ff 00 ff                     00 00 ff ff
+                           act. colors == R,G,B,A: 0.00000,1.00000,0.00000,1.00000 0.00000,0.00000,1.00000,1.00000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000 0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                     0,255,0,255                     0,0,255,255
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                     0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                             -255,255,0,0                    0,-255,255,0
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:529:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 2,4,0 and 3,5,0 inclusive:
+                                coords ==   X,Y,Z:                           2,5,0                           3,5,0
+      act. texel bytes (little-endian) ==      0x:                     00 ff 00 ff                     00 00 ff ff
+                           act. colors == R,G,B,A: 0.00000,1.00000,0.00000,1.00000 0.00000,0.00000,1.00000,1.00000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000 0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                     0,255,0,255                     0,0,255,255
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                     0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                             -255,255,0,0                    0,-255,255,0
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:529:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+ Reached unreachable code
+FAIL :copy_subrect_from_2D_Canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=true;dstPremultiplied=false assert_unreached:
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 0,3,0 and 1,3,0 inclusive:
+                                coords ==   X,Y,Z:                           0,3,0                           1,3,0
+      act. texel bytes (little-endian) ==      0x:                     00 ff 00 ff                     00 00 ff ff
+                           act. colors == R,G,B,A: 0.00000,1.00000,0.00000,1.00000 0.00000,0.00000,1.00000,1.00000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000 0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                     0,255,0,255                     0,0,255,255
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                     0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                             -255,255,0,0                    0,-255,255,0
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:529:25
+  - EXPECTATION FAILED: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    Texture level had unexpected contents:
+     between 2,4,0 and 3,5,0 inclusive:
+                                coords ==   X,Y,Z:                           2,5,0                           3,5,0
+      act. texel bytes (little-endian) ==      0x:                     00 ff 00 ff                     00 00 ff ff
+                           act. colors == R,G,B,A: 0.00000,1.00000,0.00000,1.00000 0.00000,0.00000,1.00000,1.00000
+                           exp. colors == R,G,B,A: 1.00000,0.00000,0.00000,1.00000 0.00000,1.00000,0.00000,1.00000
+            act. normal-ULPs-from-zero == R,G,B,A:                     0,255,0,255                     0,0,255,255
+            exp. normal-ULPs-from-zero == R,G,B,A:                     255,0,0,255                     0,255,0,255
+             tolerance ± 1 normal-ULPs
+       diff (act - exp) in normal-ULPs ==                             -255,255,0,0                    0,-255,255,0
+    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:215:33
+    eventualExpectOK@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:357:34
+    expectTexelViewComparisonIsOkInTexture@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1481:28
+    doTestAndCheckResult@http://127.0.0.1:8000/webgpu/webgpu/util/copy_to_texture.js:184:48
+    @http://127.0.0.1:8000/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.spec.js:529:25
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":10},"dstOrigin":{"x":0,"y":0,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":4,"height":4},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":2,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+  - INFO: subcase: copySubRectInfo={"srcOrigin":{"x":10,"y":2},"dstOrigin":{"x":2,"y":2,"z":0},"srcSize":{"width":16,"height":16},"dstSize":{"width":16,"height":16},"copyExtent":{"width":4,"height":4,"depthOrArrayLayers":1}}
+    OK
+ Reached unreachable code
+PASS :copy_subrect_from_2D_Canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstPremultiplied=true
+PASS :copy_subrect_from_2D_Canvas:orientation="flipY";colorSpaceConversion="default";srcFlipYInCopy=false;dstPremultiplied=false
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1662,6 +1662,9 @@ http/tests/webgpu/webgpu/api/validation/queue/submit.html [ Pass ]
 http/tests/webgpu/webgpu/api/validation/queue/destroyed [ Pass ]
 [ arm64 ] http/tests/webgpu/webgpu/api/operation/command_buffer/queries [ Pass ]
 
+# this test is very slow so expect a timeout or pass
+http/tests/webgpu/webgpu/web_platform/copyToTexture/ImageBitmap.html [ Pass Timeout ]
+
 http/tests/webgpu/webgpu/shader/execution/flow_control/switch.html [ Pass ]
 # arm64 release only because the tests are incredibly slow due to their extensiveness
 [ Release arm64 ] http/tests/webgpu/webgpu/shader/execution/shader_io [ Pass ]


### PR DESCRIPTION
#### 5e65a5cb565ee8ee64522f13b5b7d547ddf801d3
<pre>
[WebGPU] CTS test web_platform,copyToTexture,ImageBitmap:from_*
<a href="https://bugs.webkit.org/show_bug.cgi?id=285730">https://bugs.webkit.org/show_bug.cgi?id=285730</a>
<a href="https://rdar.apple.com/142668066">rdar://142668066</a>

Reviewed by Tadeu Zagallo.

Update copyExternalImageToTexture so that that first two of four
subsuites of copyToTexture,ImageBitmap* pass

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::copyToDestinationFormat):
(WebCore::GPUQueue::copyExternalImageToTexture):

Canonical link: <a href="https://commits.webkit.org/288896@main">https://commits.webkit.org/288896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59fb483a140195c87144a4998c1288b99e19242b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89347 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35279 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11866 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65539 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23379 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76571 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45830 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2936 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30801 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34328 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73839 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90728 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11537 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73991 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11763 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73520 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18190 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17513 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15958 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2902 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11489 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16965 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11338 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14814 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13111 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->