### PR TITLE
Update style checker to forbid memset() / memcpy() / memmove() / ...

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3493,6 +3493,30 @@ def check_safer_cpp(clean_lines, line_number, error):
     if uses_deprecated_timer_smart_pointer_exception:
         error(line_number, 'safercpp/timer_exception', 4, "Do not add IsDeprecatedTimerSmartPointerException.")
 
+    uses_memset = search(r'memset\(', line)
+    if uses_memset:
+        error(line_number, 'safercpp/memset', 4, "Use memsetSpan() / zeroSpan() instead of memset().")
+
+    uses_memset_s = search(r'memset_s\(', line)
+    if uses_memset_s:
+        error(line_number, 'safercpp/memset_s', 4, "Use secureMemsetSpan() instead of memset_s().")
+
+    uses_memcpy = search(r'memcpy\(', line)
+    if uses_memcpy:
+        error(line_number, 'safercpp/memcpy', 4, "Use memcpySpan() instead of memcpy().")
+
+    uses_memmove = search(r'memmove\(', line)
+    if uses_memmove:
+        error(line_number, 'safercpp/memmove', 4, "Use memmoveSpan() instead of memmove().")
+
+    uses_memcmp = search(r'memcmp\(', line)
+    if uses_memcmp:
+        error(line_number, 'safercpp/memcmp', 4, "Use equalSpans() / spanHasPrefix() / spanHasSuffix() / compareSpans() instead of memcmp().")
+
+    uses_memmem = search(r'memmem\(', line)
+    if uses_memmem:
+        error(line_number, 'safercpp/memmem', 4, "Use memmemSpan() instead of memmem().")
+
 
 def check_style(clean_lines, line_number, file_extension, class_state, file_state, enum_state, error):
     """Checks rules from the 'C++ style rules' section of cppguide.html.
@@ -4832,6 +4856,12 @@ class CppChecker(object):
         'runtime/wtf_make_unique',
         'runtime/wtf_move',
         'runtime/wtf_never_destroyed',
+        'safercpp/memcmp',
+        'safercpp/memcpy',
+        'safercpp/memmem',
+        'safercpp/memmove',
+        'safercpp/memset',
+        'safercpp/memset_s',
         'safercpp/weak_ref_exception',
         'safercpp/timer_exception',
         'security/assertion',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -1596,42 +1596,6 @@ class CppStyleTest(CppStyleTestBase):
             'Did you mean "else if"? If not, start a new line for "if".'
             '  [readability/braces] [4]')
 
-    # Test suspicious usage of memset. Specifically, a 0
-    # as the final argument is almost certainly an error.
-    def test_suspicious_usage_of_memset(self):
-        # Normal use is okay.
-        self.assert_lint(
-            '    memset(buf, 0, sizeof(buf))',
-            '')
-
-        # A 0 as the final argument is almost certainly an error.
-        self.assert_lint(
-            '    memset(buf, sizeof(buf), 0)',
-            'Did you mean "memset(buf, 0, sizeof(buf))"?'
-            '  [runtime/memset] [4]')
-        self.assert_lint(
-            '    memset(buf, xsize * ysize, 0)',
-            'Did you mean "memset(buf, 0, xsize * ysize)"?'
-            '  [runtime/memset] [4]')
-
-        # There is legitimate test code that uses this form.
-        # This is okay since the second argument is a literal.
-        self.assert_lint(
-            "    memset(buf, 'y', 0)",
-            '')
-        self.assert_lint(
-            '    memset(buf, 4, 0)',
-            '')
-        self.assert_lint(
-            '    memset(buf, -1, 0)',
-            '')
-        self.assert_lint(
-            '    memset(buf, 0xF1, 0)',
-            '')
-        self.assert_lint(
-            '    memset(buf, 0xcd, 0)',
-            '')
-
     def test_check_posix_threading(self):
         self.assert_lint('sctime_r()', '')
         self.assert_lint('strtok_r()', '')
@@ -6303,6 +6267,36 @@ class WebKitStyleTest(CppStyleTestBase):
         self.assert_lint(
             'IsDeprecatedTimerSmartPointerException should be removed',
             '',
+            'foo.cpp')
+
+        self.assert_lint(
+            'memset(foo, 0);',
+            'Use memsetSpan() / zeroSpan() instead of memset().  [safercpp/memset] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'memset_s(foo, 0);',
+            'Use secureMemsetSpan() instead of memset_s().  [safercpp/memset_s] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'memcpy(destination, source, 10);',
+            'Use memcpySpan() instead of memcpy().  [safercpp/memcpy] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'memmove(destination, source, 10);',
+            'Use memmoveSpan() instead of memmove().  [safercpp/memmove] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'if (!memcmp(a, b)) {',
+            'Use equalSpans() / spanHasPrefix() / spanHasSuffix() / compareSpans() instead of memcmp().  [safercpp/memcmp] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'char* result = memmem(haystack, strlen(haystack), needle, strlen(needle));',
+            'Use memmemSpan() instead of memmem().  [safercpp/memmem] [4]',
             'foo.cpp')
 
     def test_ctype_fucntion(self):


### PR DESCRIPTION
#### bb4760549758d8a574d7878787277dbad5884160
<pre>
Update style checker to forbid memset() / memcpy() / memmove() / ...
<a href="https://bugs.webkit.org/show_bug.cgi?id=285753">https://bugs.webkit.org/show_bug.cgi?id=285753</a>

Reviewed by Darin Adler.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_safer_cpp):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_safer_cpp):

Canonical link: <a href="https://commits.webkit.org/288725@main">https://commits.webkit.org/288725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1806e76f232b4dd45a4615e7af82688510046edf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38555 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/35260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86336 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/3960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11846 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/89327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/35260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87297 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/3960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/76556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/83660 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/3960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/30786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/34309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/3960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/31551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/90709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/11518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/90709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/11744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/72381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/90709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/15943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13031 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/11470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/11319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/14795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/13092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->