### PR TITLE
[ARMv7] Refactor to support cached calls and future handlerIC work.

### DIFF
--- a/JSTests/stress/put-by-id-megamorphic-reallocating-no-guard.js
+++ b/JSTests/stress/put-by-id-megamorphic-reallocating-no-guard.js
@@ -1,0 +1,30 @@
+//@ requireOptions("--useConcurrentJIT=0", "--useFTLJIT=0", "--jitAllowList=test", "--jitPolicyScale=0.1")
+// jsc --useConcurrentJIT=0 -m --dumpDisassembly=1 --jitAllowList=test --jitPolicyScale=0.1 JSTests/stress/put-by-id-megamorphic-reallocating-no-guard.js
+
+function test(o, v, i) {
+    o[v] = i
+}
+
+for (var i = 0; i < 100; ++i) {
+    let array = []
+    for (let i = 0; i < 10; ++i) {
+        var o = {};
+        o["i" + i] = i;
+        o["j" + i] = i;
+        o["k" + i] = i;
+        o["l" + i] = i;
+        o["m" + i] = i;
+        o["n" + i] = i;
+        o["o" + i] = i;
+        o["p" + i] = i;
+        o["q" + i] = i;
+        o[0] = i;
+        o["r" + i] = i;
+        array.push(o);
+    }
+
+    let instance = array[i % array.length];
+    test(instance, "f", i)
+    if (instance.f != i)
+        throw "A"
+}

--- a/JSTests/stress/put-by-id-megamorphic-reallocating-with-guard.js
+++ b/JSTests/stress/put-by-id-megamorphic-reallocating-with-guard.js
@@ -1,0 +1,28 @@
+//@ requireOptions("--useConcurrentJIT=0", "--useFTLJIT=0", "--jitAllowList=test", "--jitPolicyScale=0.1")
+// jsc --useConcurrentJIT=0 -m --dumpDisassembly=1 --jitAllowList=test --jitPolicyScale=0.1 JSTests/stress/put-by-id-megamorphic-reallocating-with-guard.js
+
+function test(o, i) {
+    o.f = i
+}
+
+for (var i = 0; i < 100; ++i) {
+    let array = []
+    for (let i = 0; i < 10; ++i) {
+        var o = {};
+        o["i" + i] = i;
+        o["j" + i] = i;
+        o["k" + i] = i;
+        o["l" + i] = i;
+        o["m" + i] = i;
+        o["n" + i] = i;
+        o["o" + i] = i;
+        o["p" + i] = i;
+        o["q" + i] = i;
+        o["r" + i] = i;
+        array.push(o);
+    }
+    let instance = array[i % array.length];
+    test(instance, i)
+    if (instance.f != i)
+        throw "A"
+}

--- a/JSTests/stress/put-by-indexed-int32.js
+++ b/JSTests/stress/put-by-indexed-int32.js
@@ -1,0 +1,31 @@
+//@ requireOptions("--useConcurrentJIT=0", "--useFTLJIT=0", "--jitAllowList=test", "--jitPolicyScale=0.1")
+
+function test(o, v, i) {
+    o[v] = i
+}
+
+for (var i = 0; i < 100; ++i) {
+    let array = []
+    for (let i = 0; i < 10; ++i) {
+        var o = {};
+        o["i" + i] = i;
+        o["j" + i] = i;
+        o["k" + i] = i;
+        o["l" + i] = i;
+        o["m" + i] = i;
+        o["n" + i] = i;
+        o["o" + i] = i;
+        o["p" + i] = i;
+        o["q" + i] = i;
+        o[0] = i;
+        o[1] = i;
+        o[2] = i;
+        array.push(o);
+    }
+
+    let instance = array[i % array.length];
+
+    test(instance, 3, i)
+    if (instance[3] != i)
+        throw "B"
+}

--- a/JSTests/stress/typed-array-byte-length.js
+++ b/JSTests/stress/typed-array-byte-length.js
@@ -1,0 +1,16 @@
+//@ requireOptions("--useConcurrentJIT=0", "--useFTLJIT=0", "--jitAllowList=test", "--jitPolicyScale=0.1")
+// jsc ---useConcurrentJIT=0 -m --dumpDisassembly=1 --jitAllowList=test --jitPolicyScale=0.1 JSTests/stress/typed-array-byte-length.js
+
+let arr = new Uint8Array(new ArrayBuffer(40));
+let arr2 = new Uint8Array(new ArrayBuffer(80));
+
+function test(a) {
+    return a.byteLength
+}
+
+for (let i = 0; i < 1000; ++i) {
+    if (test(arr) != 40)
+        throw "A"
+    if (test(arr2) != 80)
+        throw "B"
+}

--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -593,22 +593,20 @@ void LinkBuffer::dumpCode(void* code, size_t size)
 #if CPU(ARM_THUMB2)
     // Dump the generated code in an asm file format that can be assembled and then disassembled
     // for debugging purposes. For example, save this output as jit.s:
-    //   gcc -arch armv7 -c jit.s
-    //   otool -tv jit.o
-    static unsigned codeCount = 0;
+    //    export FILE=jit && gcc -march=armv7 -c "$FILE.s" && objdump -D "$FILE.o" --disassembler-options=force-thumb > "$FILE.txt"
     unsigned short* tcode = static_cast<unsigned short*>(code);
     size_t tsize = size / sizeof(short);
     char nameBuf[128];
-    snprintf(nameBuf, sizeof(nameBuf), "_jsc_jit%u", codeCount++);
+    snprintf(nameBuf, sizeof(nameBuf), "_jsc_jit_%p", code);
     dataLogF("\t.syntax unified\n"
-            "\t.section\t__TEXT,__text,regular,pure_instructions\n"
-            "\t.globl\t%s\n"
-            "\t.align 2\n"
-            "\t.code 16\n"
-            "\t.thumb_func\t%s\n"
-            "# %p\n"
-            "%s:\n", nameBuf, nameBuf, code, nameBuf);
-        
+        "\t.thumb\n"
+        "\t.globl\t%s\n"
+        "\t.align 2\n"
+        "\t.code 16\n"
+        "\t.thumb_func\n"
+        "# %p\n"
+        "%s:\n", nameBuf, code, nameBuf);
+
     for (unsigned i = 0; i < tsize; i++)
         dataLogF("\t.short\t0x%x\n", tcode[i]);
 #endif

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -3796,6 +3796,11 @@ public:
         m_assembler.csel<64>(dest, thenCase, elseCase, ARM64Condition(cond));
     }
 
+    void moveConditionallyPtr(RelationalCondition cond, RegisterID left, TrustedImm32 right, RegisterID thenCase, RegisterID elseCase, RegisterID dest)
+    {
+        return moveConditionally64(cond, left, right, thenCase, elseCase, dest);
+    }
+
     void moveConditionallyTest32(ResultCondition cond, RegisterID testReg, RegisterID mask, RegisterID src, RegisterID dest)
     {
         m_assembler.tst<32>(testReg, mask);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -3241,6 +3241,11 @@ public:
         moveDoubleOrNop(elseCase, dest);
     }
 
+    void moveConditionallyPtr(RelationalCondition cond, RegisterID left, TrustedImm32 right, RegisterID thenCase, RegisterID elseCase, RegisterID dest)
+    {
+        return moveConditionally32(cond, left, right, thenCase, elseCase, dest);
+    }
+
     ALWAYS_INLINE DataLabel32 moveWithPatch(TrustedImm32 imm, RegisterID dst)
     {
         padBeforePatch();

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -6407,6 +6407,11 @@ public:
             cmov(x86Condition(invert(cond)), elseCase, dest);
     }
 
+    void moveConditionallyPtr(RelationalCondition cond, RegisterID left, TrustedImm32 right, RegisterID thenCase, RegisterID elseCase, RegisterID dest)
+    {
+        return moveConditionally64(cond, left, right, thenCase, elseCase, dest);
+    }
+
     void moveConditionallyTest64(ResultCondition cond, RegisterID testReg, RegisterID mask, RegisterID src, RegisterID dest)
     {
         m_assembler.testq_rr(testReg, mask);

--- a/Source/JavaScriptCore/assembler/ProbeContext.h
+++ b/Source/JavaScriptCore/assembler/ProbeContext.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "GPRInfo.h"
 #include "MacroAssembler.h"
 #include "ProbeStack.h"
 #include <wtf/TZoneMalloc.h>
@@ -249,6 +250,16 @@ public:
     template<typename T> T gpr(RegisterID id) const { return cpu.gpr<T>(id); }
     template<typename T> T spr(SPRegisterID id) const { return cpu.spr<T>(id); }
     template<typename T> T fpr(FPRegisterID id) const { return cpu.fpr<T>(id); }
+
+    JSValue jsr(JSValueRegs regs) const
+    {
+#if CPU(ARM_THUMB2)
+        EncodedJSValue e = (gpr<uint64_t>(regs.tagGPR()) << 32) | gpr<uint64_t>(regs.payloadGPR());
+        return JSValue::decode(e);
+#else
+        return JSValue::decode(gpr<uint64_t>(regs.payloadGPR()));
+#endif
+    }
 
     void*& pc() { return cpu.pc(); }
     void*& fp() { return cpu.fp(); }

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.cpp
@@ -31,6 +31,7 @@
 #include "DFGJITCode.h"
 #include "DisallowMacroScratchRegisterUsage.h"
 #include "FunctionCodeBlock.h"
+#include "JIT.h"
 #include "JITThunks.h"
 #include "JSCellInlines.h"
 #include "JSWebAssemblyModule.h"

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -2048,7 +2048,7 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         auto tempRegs = JSValueRegs(scratch2GPR, scratchGPR);
 #endif
         jit.loadValue(CCallHelpers::BaseIndex(scratch3GPR, scratch2GPR, CCallHelpers::TimesEight), tempRegs);
-        failAndIgnore.append(jit.branchIfEmpty(tempRegs.payloadGPR()));
+        failAndIgnore.append(jit.branchIfEmpty(tempRegs));
         if (forInBy(accessCase.m_type))
             jit.moveTrustedValue(jsBoolean(true), valueRegs);
         else
@@ -2337,6 +2337,9 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         auto allocator = makeDefaultScratchAllocator(scratchGPR);
 
         GPRReg scratch2GPR = allocator.allocateScratchGPR();
+#if USE(JSVALUE32_64)
+        GPRReg scratch3GPR = allocator.allocateScratchGPR();
+#endif
         ScratchRegisterAllocator::PreservedState preservedState;
 
         CCallHelpers::JumpList failAndIgnore;
@@ -2358,10 +2361,10 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
 #if USE(JSVALUE64)
             auto tempRegs = JSValueRegs(scratchGPR);
 #else
-            auto tempRegs = JSValueRegs(scratch2GPR, scratchGPR);
+            auto tempRegs = JSValueRegs(scratch3GPR, scratchGPR);
 #endif
             jit.loadValue(CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::TimesEight, ArrayStorage::vectorOffset()), tempRegs);
-            failAndIgnore.append(jit.branchIfEmpty(tempRegs.payloadGPR()));
+            failAndIgnore.append(jit.branchIfEmpty(tempRegs));
             if (forInBy(accessCase.m_type))
                 jit.moveTrustedValue(jsBoolean(true), valueRegs);
             else
@@ -2407,10 +2410,10 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
 #if USE(JSVALUE64)
                 auto tempRegs = JSValueRegs(scratchGPR);
 #else
-                auto tempRegs = JSValueRegs(scratch2GPR, scratchGPR);
+                auto tempRegs = JSValueRegs(scratch3GPR, scratchGPR);
 #endif
                 jit.loadValue(CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::TimesEight), tempRegs);
-                failAndIgnore.append(jit.branchIfEmpty(tempRegs.payloadGPR()));
+                failAndIgnore.append(jit.branchIfEmpty(tempRegs));
                 if (forInBy(accessCase.m_type))
                     jit.moveTrustedValue(jsBoolean(true), valueRegs);
                 else
@@ -3439,7 +3442,6 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
             ASSERT(scratchGPR != GPRInfo::handlerGPR);
             // handlerGPR can be the same to BaselineJITRegisters::Call::calleeJSR.
             if constexpr (GPRInfo::handlerGPR == BaselineJITRegisters::Call::calleeJSR.payloadGPR()) {
-                ASSERT(noOverlap(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR()));
                 jit.swap(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
                 jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos() + sizeof(DataOnlyCallLinkInfo) * index), scratchGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
             } else {
@@ -3447,14 +3449,12 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
                 jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos() + sizeof(DataOnlyCallLinkInfo) * index), GPRInfo::handlerGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
             }
 #if USE(JSVALUE32_64)
-            // We *always* know that the proxy function, if non-null, is a cell.
             jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
 #endif
             CallLinkInfo::emitDataICFastPath(jit);
         } else {
             jit.move(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
 #if USE(JSVALUE32_64)
-            // We *always* know that the proxy function, if non-null, is a cell.
             jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
 #endif
             m_callLinkInfos[index] = makeUnique<OptimizingCallLinkInfo>(m_stubInfo.codeOrigin, nullptr);
@@ -4175,7 +4175,6 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
     if (useHandlerIC()) {
         // handlerGPR can be the same to BaselineJITRegisters::Call::calleeJSR.
         if constexpr (GPRInfo::handlerGPR == BaselineJITRegisters::Call::calleeJSR.payloadGPR()) {
-            ASSERT(noOverlap(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR()));
             jit.swap(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
             jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos() + sizeof(DataOnlyCallLinkInfo) * index), scratchGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
         } else {
@@ -4184,7 +4183,6 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
         }
 
 #if USE(JSVALUE32_64)
-        // We *always* know that the proxy function, if non-null, is a cell.
         jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
 #endif
 
@@ -4192,8 +4190,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
     } else {
         jit.move(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
 #if USE(JSVALUE32_64)
-    // We *always* know that the proxy function, if non-null, is a cell.
-    jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
+        jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
 #endif
         // ARMv7 clobbers metadataTable register. Thus we need to restore them back here.
         if (is32Bit())
@@ -6718,6 +6715,8 @@ MacroAssemblerCodeRef<JITThunkPtrTag> setPrivateBrandHandler(VM&)
 AccessGenerationResult InlineCacheCompiler::compileHandler(const GCSafeConcurrentJSLocker&, Vector<AccessCase*, 16>&& poly, CodeBlock* codeBlock, AccessCase& accessCase)
 {
     SuperSamplerScope superSamplerScope(false);
+    if (is32Bit())
+        return { };
 
     if (!accessCase.couldStillSucceed())
         return AccessGenerationResult::MadeNoChanges;

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -86,8 +86,18 @@ void AccessGenerationResult::dump(PrintStream& out) const
 
 void InlineCacheHandler::dump(PrintStream& out) const
 {
+    out.print("Handler ", m_cacheType, " { ");
     if (m_callTarget)
-        out.print(m_callTarget);
+        out.print(m_callTarget, " ");
+    if (m_jumpTarget)
+        out.print(m_jumpTarget, " ");
+    if (m_structureID)
+        out.print(RawHex(m_structureID.bits()), " ");
+    if (m_offset != invalidOffset)
+        out.print(m_offset, " ");
+    if (m_uid)
+        out.print(m_uid, " ");
+    out.println("u.s2: { ", RawHex(u.s2.m_newStructureID.bits()), ", ", u.s2.m_newSize, ", ", u.s2.m_oldSize, " } }");
 }
 
 static TypedArrayType toTypedArrayType(AccessCase::AccessType accessType)
@@ -465,7 +475,6 @@ static bool forInBy(AccessCase::AccessType type)
     return false;
 }
 
-#if CPU(ADDRESS64)
 static bool isStateless(AccessCase::AccessType type)
 {
     switch (type) {
@@ -595,7 +604,6 @@ static bool isStateless(AccessCase::AccessType type)
 
     return false;
 }
-#endif
 
 static bool doesJSCalls(AccessCase::AccessType type)
 {
@@ -1185,7 +1193,11 @@ void InlineCacheCompiler::emitExplicitExceptionHandler()
 
 ScratchRegisterAllocator InlineCacheCompiler::makeDefaultScratchAllocator(GPRReg extraToLock)
 {
-    ScratchRegisterAllocator allocator(m_stubInfo.usedRegisters.toRegisterSet());
+    auto usedRegisters = m_stubInfo.usedRegisters;
+    // On some platforms, this is a callee-save register and might not be in usedRegisters already.
+    if (useHandlerIC())
+        usedRegisters.add(GPRInfo::handlerGPR, IgnoreVectors);
+    ScratchRegisterAllocator allocator(usedRegisters.toRegisterSet());
     allocator.lock(m_stubInfo.baseRegs());
     allocator.lock(m_stubInfo.valueRegs());
     allocator.lock(m_stubInfo.m_extraGPR);
@@ -1198,7 +1210,8 @@ ScratchRegisterAllocator InlineCacheCompiler::makeDefaultScratchAllocator(GPRReg
     allocator.lock(m_stubInfo.m_arrayProfileGPR);
     allocator.lock(extraToLock);
 
-    if (useHandlerIC())
+    // 32-bit does not have enough registers to avoid re-using this.
+    if (useHandlerIC() && !is32Bit())
         allocator.lock(GPRInfo::handlerGPR);
 
     return allocator;
@@ -1206,17 +1219,33 @@ ScratchRegisterAllocator InlineCacheCompiler::makeDefaultScratchAllocator(GPRReg
 
 #if CPU(X86_64)
 static constexpr size_t prologueSizeInBytesDataIC = 1;
+static constexpr size_t dataICSavedRegisters = 2; // return PC is saved too.
 #elif CPU(ARM64E)
 static constexpr size_t prologueSizeInBytesDataIC = 8;
+static constexpr size_t dataICSavedRegisters = 2;
 #elif CPU(ARM64)
 static constexpr size_t prologueSizeInBytesDataIC = 4;
+static constexpr size_t dataICSavedRegisters = 2;
 #elif CPU(ARM_THUMB2)
+static constexpr size_t dataICSavedRegisters = 2;
+#if ASSERT_ENABLED
 static constexpr size_t prologueSizeInBytesDataIC = 6;
+#else
+static constexpr size_t prologueSizeInBytesDataIC = 6;
+#endif
 #elif CPU(RISCV64)
+static constexpr size_t dataICSavedRegisters = 2;
 static constexpr size_t prologueSizeInBytesDataIC = 12;
 #else
 #error "unsupported architecture"
 #endif
+
+static constexpr size_t dataICFrameSizeExtra = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(maxFrameExtentForSlowPathCall + dataICSavedRegisters * sizeof(CPURegister)) - dataICSavedRegisters * sizeof(CPURegister);
+
+static void exceptionCheck(CCallHelpers& jit, VM& vm)
+{
+    jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
+}
 
 void InlineCacheCompiler::emitDataICPrologue(CCallHelpers& jit)
 {
@@ -1228,18 +1257,18 @@ void InlineCacheCompiler::emitDataICPrologue(CCallHelpers& jit)
 #endif
 
 #if CPU(X86_64)
-    static_assert(!maxFrameExtentForSlowPathCall);
+    static_assert(!dataICFrameSizeExtra);
     jit.push(CCallHelpers::framePointerRegister);
 #elif CPU(ARM64)
-    static_assert(!maxFrameExtentForSlowPathCall);
+    static_assert(!dataICFrameSizeExtra);
     jit.tagReturnAddress();
     jit.pushPair(CCallHelpers::framePointerRegister, CCallHelpers::linkRegister);
 #elif CPU(ARM_THUMB2)
-    static_assert(maxFrameExtentForSlowPathCall);
+    static_assert(dataICFrameSizeExtra);
     jit.pushPair(CCallHelpers::framePointerRegister, CCallHelpers::linkRegister);
-    jit.subPtr(CCallHelpers::TrustedImm32(maxFrameExtentForSlowPathCall), CCallHelpers::stackPointerRegister);
+    jit.subPtr(CCallHelpers::TrustedImm32(dataICFrameSizeExtra), CCallHelpers::stackPointerRegister);
 #elif CPU(RISCV64)
-    static_assert(!maxFrameExtentForSlowPathCall);
+    static_assert(!dataICFrameSizeExtra);
     jit.pushPair(CCallHelpers::framePointerRegister, CCallHelpers::linkRegister);
 #else
 #error "unsupported architecture"
@@ -1252,8 +1281,8 @@ void InlineCacheCompiler::emitDataICPrologue(CCallHelpers& jit)
 
 void InlineCacheCompiler::emitDataICEpilogue(CCallHelpers& jit)
 {
-    if constexpr (!!maxFrameExtentForSlowPathCall)
-        jit.addPtr(CCallHelpers::TrustedImm32(maxFrameExtentForSlowPathCall), CCallHelpers::stackPointerRegister);
+    if constexpr (!!dataICFrameSizeExtra)
+        jit.addPtr(CCallHelpers::TrustedImm32(dataICFrameSizeExtra), CCallHelpers::stackPointerRegister);
     jit.emitFunctionEpilogueWithEmptyFrame();
 }
 
@@ -1285,6 +1314,7 @@ CCallHelpers::JumpList InlineCacheCompiler::emitDataICCheckUid(CCallHelpers& jit
 
 void InlineCacheCompiler::emitDataICJumpNextHandler(CCallHelpers& jit)
 {
+    JIT_COMMENT(jit, "emitDataICJumpNextHandler");
     jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfNext()), GPRInfo::handlerGPR);
     jit.farJump(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfJumpTarget()), JITStubRoutinePtrTag);
 }
@@ -1305,9 +1335,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByIdSlowPathCodeGenerator(VM& vm
     jit.setupArguments<SlowOperation>(baseJSR, stubInfoGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 1>() == stubInfoGPR, "Needed for branch to slow operation via StubInfo");
     jit.call(CCallHelpers::Address(stubInfoGPR, StructureStubInfo::offsetOfSlowOperation()), OperationPtrTag);
-
-    jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
-
+    exceptionCheck(jit, vm);
     InlineCacheCompiler::emitDataICEpilogue(jit);
     jit.ret();
 
@@ -1333,9 +1361,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByIdWithThisSlowPathCodeGenerato
     jit.setupArguments<SlowOperation>(baseJSR, thisJSR, stubInfoGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 2>() == stubInfoGPR, "Needed for branch to slow operation via StubInfo");
     jit.call(CCallHelpers::Address(stubInfoGPR, StructureStubInfo::offsetOfSlowOperation()), OperationPtrTag);
-
-    jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
-
+    exceptionCheck(jit, vm);
     InlineCacheCompiler::emitDataICEpilogue(jit);
     jit.ret();
 
@@ -1362,9 +1388,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValSlowPathCodeGenerator(VM& v
     jit.setupArguments<SlowOperation>(baseJSR, propertyJSR, stubInfoGPR, profileGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 2>() == stubInfoGPR, "Needed for branch to slow operation via StubInfo");
     jit.call(CCallHelpers::Address(stubInfoGPR, StructureStubInfo::offsetOfSlowOperation()), OperationPtrTag);
-
-    jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
-
+    exceptionCheck(jit, vm);
     InlineCacheCompiler::emitDataICEpilogue(jit);
     jit.ret();
 
@@ -1390,9 +1414,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getPrivateNameSlowPathCodeGenerator
     jit.setupArguments<SlowOperation>(baseJSR, propertyJSR, stubInfoGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 2>() == stubInfoGPR, "Needed for branch to slow operation via StubInfo");
     jit.call(CCallHelpers::Address(stubInfoGPR, StructureStubInfo::offsetOfSlowOperation()), OperationPtrTag);
-
-    jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
-
+    exceptionCheck(jit, vm);
     InlineCacheCompiler::emitDataICEpilogue(jit);
     jit.ret();
 
@@ -1401,7 +1423,6 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getPrivateNameSlowPathCodeGenerator
     return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "get_private_name_slow"_s, "DataIC get_private_name_slow");
 }
 
-#if USE(JSVALUE64)
 static MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithThisSlowPathCodeGenerator(VM& vm)
 {
     CCallHelpers jit;
@@ -1421,9 +1442,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithThisSlowPathCodeGenerat
     jit.setupArguments<SlowOperation>(baseJSR, propertyJSR, thisJSR, stubInfoGPR, profileGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 3>() == stubInfoGPR, "Needed for branch to slow operation via StubInfo");
     jit.call(CCallHelpers::Address(stubInfoGPR, StructureStubInfo::offsetOfSlowOperation()), OperationPtrTag);
-
-    jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
-
+    exceptionCheck(jit, vm);
     InlineCacheCompiler::emitDataICEpilogue(jit);
     jit.ret();
 
@@ -1431,7 +1450,6 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithThisSlowPathCodeGenerat
     LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::InlineCache);
     return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "get_by_val_with_this_slow"_s, "DataIC get_by_val_with_this_slow");
 }
-#endif
 
 static MacroAssemblerCodeRef<JITThunkPtrTag> putByIdSlowPathCodeGenerator(VM& vm)
 {
@@ -1450,9 +1468,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByIdSlowPathCodeGenerator(VM& vm
     jit.setupArguments<SlowOperation>(valueJSR, baseJSR, stubInfoGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 2>() == stubInfoGPR, "Needed for branch to slow operation via StubInfo");
     jit.call(CCallHelpers::Address(stubInfoGPR, StructureStubInfo::offsetOfSlowOperation()), OperationPtrTag);
-
-    jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
-
+    exceptionCheck(jit, vm);
     InlineCacheCompiler::emitDataICEpilogue(jit);
     jit.ret();
 
@@ -1465,7 +1481,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValSlowPathCodeGenerator(VM& v
 {
     CCallHelpers jit;
 
-    using SlowOperatoin = decltype(operationPutByValStrictOptimize);
+    using SlowOperation = decltype(operationPutByValStrictOptimize);
 
     using BaselineJITRegisters::PutByVal::baseJSR;
     using BaselineJITRegisters::PutByVal::propertyJSR;
@@ -1477,15 +1493,12 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValSlowPathCodeGenerator(VM& v
 
     // Call slow operation
     jit.prepareCallOperation(vm);
-    jit.setupArguments<SlowOperatoin>(baseJSR, propertyJSR, valueJSR, stubInfoGPR, profileGPR);
+    jit.setupArguments<SlowOperation>(baseJSR, propertyJSR, valueJSR, stubInfoGPR, profileGPR);
     jit.call(CCallHelpers::Address(stubInfoGPR, StructureStubInfo::offsetOfSlowOperation()), OperationPtrTag);
-#if CPU(ARM_THUMB2)
     // ARMv7 clobbers metadataTable register. Thus we need to restore them back here.
-    JIT::emitMaterializeMetadataAndConstantPoolRegisters(jit);
-#endif
-
-    jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
-
+    if (is32Bit())
+        JIT::emitMaterializeMetadataAndConstantPoolRegisters(jit);
+    exceptionCheck(jit, vm);
     InlineCacheCompiler::emitDataICEpilogue(jit);
     jit.ret();
 
@@ -1511,9 +1524,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> instanceOfSlowPathCodeGenerator(VM&
     jit.setupArguments<SlowOperation>(valueJSR, protoJSR, stubInfoGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 2>() == stubInfoGPR, "Needed for branch to slow operation via StubInfo");
     jit.call(CCallHelpers::Address(stubInfoGPR, StructureStubInfo::offsetOfSlowOperation()), OperationPtrTag);
-
-    jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
-
+    exceptionCheck(jit, vm);
     InlineCacheCompiler::emitDataICEpilogue(jit);
     jit.ret();
 
@@ -1538,9 +1549,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> delByIdSlowPathCodeGenerator(VM& vm
     jit.setupArguments<SlowOperation>(baseJSR, stubInfoGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 1>() == stubInfoGPR, "Needed for branch to slow operation via StubInfo");
     jit.call(CCallHelpers::Address(stubInfoGPR, StructureStubInfo::offsetOfSlowOperation()), OperationPtrTag);
-
-    jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
-
+    exceptionCheck(jit, vm);
     InlineCacheCompiler::emitDataICEpilogue(jit);
     jit.ret();
 
@@ -1566,9 +1575,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> delByValSlowPathCodeGenerator(VM& v
     jit.setupArguments<SlowOperation>(baseJSR, propertyJSR, stubInfoGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 2>() == stubInfoGPR, "Needed for branch to slow operation via StubInfo");
     jit.call(CCallHelpers::Address(stubInfoGPR, StructureStubInfo::offsetOfSlowOperation()), OperationPtrTag);
-
-    jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
-
+    exceptionCheck(jit, vm);
     InlineCacheCompiler::emitDataICEpilogue(jit);
     jit.ret();
 
@@ -1603,14 +1610,8 @@ MacroAssemblerCodeRef<JITThunkPtrTag> InlineCacheCompiler::generateSlowPathCode(
         return vm.getCTIStub(getByValSlowPathCodeGenerator);
     }
 
-    case AccessType::GetByValWithThis: {
-#if USE(JSVALUE64)
+    case AccessType::GetByValWithThis:
         return vm.getCTIStub(getByValWithThisSlowPathCodeGenerator);
-#else
-        RELEASE_ASSERT_NOT_REACHED();
-        return { };
-#endif
-    }
 
     case AccessType::GetPrivateName:
     case AccessType::HasPrivateBrand:
@@ -2040,22 +2041,16 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         jit.neg32(scratch2GPR);
         jit.loadPtr(CCallHelpers::Address(baseGPR, ScopedArguments::offsetOfStorage()), scratch3GPR);
 #if USE(JSVALUE64)
-        jit.loadValue(CCallHelpers::BaseIndex(scratch3GPR, scratch2GPR, CCallHelpers::TimesEight), JSValueRegs(scratchGPR));
-        failAndIgnore.append(jit.branchIfEmpty(scratchGPR));
+        auto tempRegs = JSValueRegs(scratchGPR);
+#else
+        auto tempRegs = JSValueRegs(scratch2GPR, scratchGPR);
+#endif
+        jit.loadValue(CCallHelpers::BaseIndex(scratch3GPR, scratch2GPR, CCallHelpers::TimesEight), tempRegs);
+        failAndIgnore.append(jit.branchIfEmpty(tempRegs.payloadGPR()));
         if (forInBy(accessCase.m_type))
             jit.moveTrustedValue(jsBoolean(true), valueRegs);
         else
-            jit.move(scratchGPR, valueRegs.payloadGPR());
-#else
-        jit.loadValue(CCallHelpers::BaseIndex(scratch3GPR, scratch2GPR, CCallHelpers::TimesEight), JSValueRegs(scratch2GPR, scratchGPR));
-        failAndIgnore.append(jit.branchIfEmpty(scratch2GPR));
-        if (forInBy(accessCase.m_type))
-            jit.moveTrustedValue(jsBoolean(true), valueRegs);
-        else {
-            jit.move(scratchGPR, valueRegs.payloadGPR());
-            jit.move(scratch2GPR, valueRegs.tagGPR());
-        }
-#endif
+            jit.moveValueRegs(tempRegs, valueRegs);
 
         done.link(&jit);
 
@@ -2340,9 +2335,6 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         auto allocator = makeDefaultScratchAllocator(scratchGPR);
 
         GPRReg scratch2GPR = allocator.allocateScratchGPR();
-#if USE(JSVALUE32_64)
-        GPRReg scratch3GPR = allocator.allocateScratchGPR();
-#endif
         ScratchRegisterAllocator::PreservedState preservedState;
 
         CCallHelpers::JumpList failAndIgnore;
@@ -2360,23 +2352,19 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
             failAndIgnore.append(jit.branch32(CCallHelpers::AboveOrEqual, propertyGPR, CCallHelpers::Address(scratchGPR, ArrayStorage::vectorLengthOffset())));
 
             jit.zeroExtend32ToWord(propertyGPR, scratch2GPR);
+
 #if USE(JSVALUE64)
-            jit.loadValue(CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::TimesEight, ArrayStorage::vectorOffset()), JSValueRegs(scratchGPR));
-            failAndIgnore.append(jit.branchIfEmpty(scratchGPR));
+            auto tempRegs = JSValueRegs(scratchGPR);
+#else
+            auto tempRegs = JSValueRegs(scratch2GPR, scratchGPR);
+#endif
+            jit.loadValue(CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::TimesEight, ArrayStorage::vectorOffset()), tempRegs);
+            failAndIgnore.append(jit.branchIfEmpty(tempRegs.payloadGPR()));
             if (forInBy(accessCase.m_type))
                 jit.moveTrustedValue(jsBoolean(true), valueRegs);
             else
-                jit.move(scratchGPR, valueRegs.payloadGPR());
-#else
-            jit.loadValue(CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::TimesEight, ArrayStorage::vectorOffset()), JSValueRegs(scratch3GPR, scratchGPR));
-            failAndIgnore.append(jit.branchIfEmpty(scratch3GPR));
-            if (forInBy(accessCase.m_type))
-                jit.moveTrustedValue(jsBoolean(true), valueRegs);
-            else {
-                jit.move(scratchGPR, valueRegs.payloadGPR());
-                jit.move(scratch3GPR, valueRegs.tagGPR());
-            }
-#endif
+                jit.moveValueRegs(tempRegs, valueRegs);
+
         } else {
             IndexingType expectedShape;
             switch (accessCase.m_type) {
@@ -2415,22 +2403,17 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
                     jit.boxDouble(m_scratchFPR, valueRegs);
             } else {
 #if USE(JSVALUE64)
-                jit.loadValue(CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::TimesEight), JSValueRegs(scratchGPR));
-                failAndIgnore.append(jit.branchIfEmpty(scratchGPR));
+                auto tempRegs = JSValueRegs(scratchGPR);
+#else
+                auto tempRegs = JSValueRegs(scratch2GPR, scratchGPR);
+#endif
+                jit.loadValue(CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::TimesEight), tempRegs);
+                failAndIgnore.append(jit.branchIfEmpty(tempRegs.payloadGPR()));
                 if (forInBy(accessCase.m_type))
                     jit.moveTrustedValue(jsBoolean(true), valueRegs);
                 else
-                    jit.move(scratchGPR, valueRegs.payloadGPR());
-#else
-                jit.loadValue(CCallHelpers::BaseIndex(scratchGPR, scratch2GPR, CCallHelpers::TimesEight), JSValueRegs(scratch3GPR, scratchGPR));
-                failAndIgnore.append(jit.branchIfEmpty(scratch3GPR));
-                if (forInBy(accessCase.m_type))
-                    jit.moveTrustedValue(jsBoolean(true), valueRegs);
-                else {
-                    jit.move(scratchGPR, valueRegs.payloadGPR());
-                    jit.move(scratch3GPR, valueRegs.tagGPR());
-                }
-#endif
+                    jit.moveValueRegs(tempRegs, valueRegs);
+
             }
         }
 
@@ -2816,7 +2799,6 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
     }
 
     case AccessCase::IndexedMegamorphicLoad: {
-#if USE(JSVALUE64)
         ASSERT(!accessCase.viaGlobalProxy());
 
         CCallHelpers::JumpList slowCases;
@@ -2829,17 +2811,17 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         ScratchRegisterAllocator::PreservedState preservedState = allocator.preserveReusedRegistersByPushing(jit, ScratchRegisterAllocator::ExtraStackSpace::NoExtraSpace);
 
         CCallHelpers::JumpList notString;
-        GPRReg propertyGPR = m_stubInfo.propertyGPR();
+        auto propertyJSR = m_stubInfo.propertyRegs();
         if (!m_stubInfo.propertyIsString) {
-            slowCases.append(jit.branchIfNotCell(propertyGPR));
-            slowCases.append(jit.branchIfNotString(propertyGPR));
+            slowCases.append(jit.branchIfNotCell(propertyJSR));
+            slowCases.append(jit.branchIfNotString(propertyJSR.payloadGPR()));
         }
 
-        jit.loadPtr(CCallHelpers::Address(propertyGPR, JSString::offsetOfValue()), scratch4GPR);
+        jit.loadPtr(CCallHelpers::Address(propertyJSR.payloadGPR(), JSString::offsetOfValue()), scratch4GPR);
         slowCases.append(jit.branchIfRopeStringImpl(scratch4GPR));
         slowCases.append(jit.branchTest32(CCallHelpers::Zero, CCallHelpers::Address(scratch4GPR, StringImpl::flagsOffset()), CCallHelpers::TrustedImm32(StringImpl::flagIsAtom())));
 
-        slowCases.append(jit.loadMegamorphicProperty(vm, baseGPR, scratch4GPR, nullptr, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
+        slowCases.append(jit.loadMegamorphicProperty(vm, baseGPR, scratch4GPR, nullptr, valueRegs, scratchGPR, scratch2GPR, scratch3GPR));
 
         allocator.restoreReusedRegistersByPopping(jit, preservedState);
         succeed();
@@ -2850,12 +2832,10 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
             m_failAndRepatch.append(jit.jump());
         } else
             m_failAndRepatch.append(slowCases);
-#endif
         return;
     }
 
     case AccessCase::LoadMegamorphic: {
-#if USE(JSVALUE64)
         ASSERT(!accessCase.viaGlobalProxy());
         CCallHelpers::JumpList failAndRepatch;
         auto* uid = accessCase.m_identifier.uid();
@@ -2870,9 +2850,9 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         CCallHelpers::JumpList slowCases;
         if (useHandlerIC()) {
             jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfUid()), scratch4GPR);
-            slowCases.append(jit.loadMegamorphicProperty(vm, baseGPR, scratch4GPR, nullptr, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
+            slowCases.append(jit.loadMegamorphicProperty(vm, baseGPR, scratch4GPR, nullptr, valueRegs, scratchGPR, scratch2GPR, scratch3GPR));
         } else
-            slowCases.append(jit.loadMegamorphicProperty(vm, baseGPR, InvalidGPRReg, uid, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
+            slowCases.append(jit.loadMegamorphicProperty(vm, baseGPR, InvalidGPRReg, uid, valueRegs, scratchGPR, scratch2GPR, scratch3GPR));
 
         allocator.restoreReusedRegistersByPopping(jit, preservedState);
         succeed();
@@ -2883,12 +2863,10 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
             m_failAndRepatch.append(jit.jump());
         } else
             m_failAndRepatch.append(slowCases);
-#endif
         return;
     }
 
     case AccessCase::StoreMegamorphic: {
-#if USE(JSVALUE64)
         ASSERT(!accessCase.viaGlobalProxy());
         CCallHelpers::JumpList failAndRepatch;
         auto* uid = accessCase.m_identifier.uid();
@@ -2902,12 +2880,13 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
 
         CCallHelpers::JumpList slow;
         CCallHelpers::JumpList reallocating;
+        GPRReg storeEntryGPR = InvalidGPRReg;
 
         if (useHandlerIC()) {
             jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfUid()), scratch4GPR);
-            std::tie(slow, reallocating) = jit.storeMegamorphicProperty(vm, baseGPR, scratch4GPR, nullptr, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR);
+            std::tie(slow, reallocating, storeEntryGPR) = jit.storeMegamorphicProperty(vm, baseGPR, { scratch4GPR }, valueRegs, scratchGPR, scratch2GPR, scratch3GPR);
         } else
-            std::tie(slow, reallocating) = jit.storeMegamorphicProperty(vm, baseGPR, InvalidGPRReg, uid, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR);
+            std::tie(slow, reallocating, storeEntryGPR) = jit.storeMegamorphicProperty(vm, baseGPR, { uid }, valueRegs, scratchGPR, scratch2GPR, scratch3GPR);
 
         CCallHelpers::Label doneLabel = jit.label();
         allocator.restoreReusedRegistersByPopping(jit, preservedState);
@@ -2925,19 +2904,17 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
             // Handle the case where we are allocating out-of-line using an operation.
             InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
             jit.makeSpaceOnStackForCCall();
-            jit.setupArguments<decltype(operationPutByMegamorphicReallocating)>(CCallHelpers::TrustedImmPtr(&vm), baseGPR, valueRegs.payloadGPR(), scratch3GPR);
+            jit.setupArguments<decltype(operationPutByMegamorphicReallocating)>(CCallHelpers::TrustedImmPtr(&vm), baseGPR, valueRegs, storeEntryGPR);
             jit.prepareCallOperation(vm);
             jit.callOperation<OperationPtrTag>(operationPutByMegamorphicReallocating);
             jit.reclaimSpaceOnStackForCCall();
             restoreLiveRegistersFromStackForCall(spillState, { });
             jit.jump().linkTo(doneLabel, &jit);
         }
-#endif
         return;
     }
 
     case AccessCase::InMegamorphic: {
-#if USE(JSVALUE64)
         ASSERT(!accessCase.viaGlobalProxy());
         CCallHelpers::JumpList failAndRepatch;
         auto* uid = accessCase.m_identifier.uid();
@@ -2952,9 +2929,9 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         CCallHelpers::JumpList slowCases;
         if (useHandlerIC()) {
             jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfUid()), scratch4GPR);
-            slowCases.append(jit.hasMegamorphicProperty(vm, baseGPR, scratch4GPR, nullptr, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
+            slowCases.append(jit.hasMegamorphicProperty(vm, baseGPR, scratch4GPR, nullptr, valueRegs, scratchGPR, scratch2GPR, scratch3GPR));
         } else
-            slowCases.append(jit.hasMegamorphicProperty(vm, baseGPR, InvalidGPRReg, uid, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
+            slowCases.append(jit.hasMegamorphicProperty(vm, baseGPR, InvalidGPRReg, uid, valueRegs, scratchGPR, scratch2GPR, scratch3GPR));
 
         allocator.restoreReusedRegistersByPopping(jit, preservedState);
         succeed();
@@ -2965,12 +2942,10 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
             m_failAndRepatch.append(jit.jump());
         } else
             m_failAndRepatch.append(slowCases);
-#endif
         return;
     }
 
     case AccessCase::IndexedMegamorphicIn: {
-#if USE(JSVALUE64)
         ASSERT(!accessCase.viaGlobalProxy());
 
         CCallHelpers::JumpList slowCases;
@@ -2983,17 +2958,17 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         ScratchRegisterAllocator::PreservedState preservedState = allocator.preserveReusedRegistersByPushing(jit, ScratchRegisterAllocator::ExtraStackSpace::NoExtraSpace);
 
         CCallHelpers::JumpList notString;
-        GPRReg propertyGPR = m_stubInfo.propertyGPR();
+        auto propertyJSR = m_stubInfo.propertyRegs();
         if (!m_stubInfo.propertyIsString) {
-            slowCases.append(jit.branchIfNotCell(propertyGPR));
-            slowCases.append(jit.branchIfNotString(propertyGPR));
+            slowCases.append(jit.branchIfNotCell(propertyJSR));
+            slowCases.append(jit.branchIfNotString(propertyJSR.payloadGPR()));
         }
 
-        jit.loadPtr(CCallHelpers::Address(propertyGPR, JSString::offsetOfValue()), scratch4GPR);
+        jit.loadPtr(CCallHelpers::Address(propertyJSR.payloadGPR(), JSString::offsetOfValue()), scratch4GPR);
         slowCases.append(jit.branchIfRopeStringImpl(scratch4GPR));
         slowCases.append(jit.branchTest32(CCallHelpers::Zero, CCallHelpers::Address(scratch4GPR, StringImpl::flagsOffset()), CCallHelpers::TrustedImm32(StringImpl::flagIsAtom())));
 
-        slowCases.append(jit.hasMegamorphicProperty(vm, baseGPR, scratch4GPR, nullptr, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
+        slowCases.append(jit.hasMegamorphicProperty(vm, baseGPR, scratch4GPR, nullptr, valueRegs, scratchGPR, scratch2GPR, scratch3GPR));
 
         allocator.restoreReusedRegistersByPopping(jit, preservedState);
         succeed();
@@ -3004,36 +2979,40 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
             m_failAndRepatch.append(jit.jump());
         } else
             m_failAndRepatch.append(slowCases);
-#endif
         return;
     }
 
     case AccessCase::IndexedMegamorphicStore: {
-#if USE(JSVALUE64)
         ASSERT(!accessCase.viaGlobalProxy());
 
         CCallHelpers::JumpList slowCases;
 
         auto allocator = makeDefaultScratchAllocator(scratchGPR);
         GPRReg scratch2GPR = allocator.allocateScratchGPR();
+
+        GPRReg uidGPR = allocator.allocateScratchGPR();
         GPRReg scratch3GPR = allocator.allocateScratchGPR();
-        GPRReg scratch4GPR = allocator.allocateScratchGPR();
 
         ScratchRegisterAllocator::PreservedState preservedState = allocator.preserveReusedRegistersByPushing(jit, ScratchRegisterAllocator::ExtraStackSpace::SpaceForCCall);
 
         CCallHelpers::JumpList notString;
-        GPRReg propertyGPR = m_stubInfo.propertyGPR();
+        auto propertyJSR = m_stubInfo.propertyRegs();
+
         if (!m_stubInfo.propertyIsString) {
-            slowCases.append(jit.branchIfNotCell(propertyGPR));
-            slowCases.append(jit.branchIfNotString(propertyGPR));
+            slowCases.append(jit.branchIfNotCell(propertyJSR));
+            slowCases.append(jit.branchIfNotString(propertyJSR.payloadGPR()));
         }
 
-        jit.loadPtr(CCallHelpers::Address(propertyGPR, JSString::offsetOfValue()), scratch4GPR);
-        slowCases.append(jit.branchIfRopeStringImpl(scratch4GPR));
-        slowCases.append(jit.branchTest32(CCallHelpers::Zero, CCallHelpers::Address(scratch4GPR, StringImpl::flagsOffset()), CCallHelpers::TrustedImm32(StringImpl::flagIsAtom())));
+        const auto& loadUID = [&](GPRReg dst) {
+            jit.loadPtr(CCallHelpers::Address(propertyJSR.payloadGPR(), JSString::offsetOfValue()), dst);
+        };
 
-        auto [slow, reallocating] = jit.storeMegamorphicProperty(vm, baseGPR, scratch4GPR, nullptr, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR);
-        slowCases.append(WTFMove(slow));
+        loadUID(uidGPR);
+        slowCases.append(jit.branchIfRopeStringImpl(uidGPR));
+        slowCases.append(jit.branchTest32(CCallHelpers::Zero, CCallHelpers::Address(uidGPR, StringImpl::flagsOffset()), CCallHelpers::TrustedImm32(StringImpl::flagIsAtom())));
+
+        auto [slow, reallocating, storeEntryGPR] = jit.storeMegamorphicProperty(vm, baseGPR, { uidGPR }, valueRegs, scratchGPR, scratch2GPR, scratch3GPR);
+        slowCases.append(slow);
 
         CCallHelpers::Label doneLabel = jit.label();
         allocator.restoreReusedRegistersByPopping(jit, preservedState);
@@ -3051,14 +3030,13 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
             // Handle the case where we are allocating out-of-line using an operation.
             InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
             jit.makeSpaceOnStackForCCall();
-            jit.setupArguments<decltype(operationPutByMegamorphicReallocating)>(CCallHelpers::TrustedImmPtr(&vm), baseGPR, valueRegs.payloadGPR(), scratch3GPR);
+            jit.setupArguments<decltype(operationPutByMegamorphicReallocating)>(CCallHelpers::TrustedImmPtr(&vm), baseGPR, valueRegs, storeEntryGPR);
             jit.prepareCallOperation(vm);
             jit.callOperation<OperationPtrTag>(operationPutByMegamorphicReallocating);
             jit.reclaimSpaceOnStackForCCall();
             restoreLiveRegistersFromStackForCall(spillState, { });
             jit.jump().linkTo(doneLabel, &jit);
         }
-#endif
         return;
     }
 
@@ -3357,11 +3335,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
                 storageGPR = scratchGPR;
             }
 
-#if USE(JSVALUE64)
-            jit.load64(CCallHelpers::Address(storageGPR, offsetRelativeToBase(accessCase.m_offset)), scratchGPR);
-#else
-            jit.load32(CCallHelpers::Address(storageGPR, offsetRelativeToBase(accessCase.m_offset) + PayloadOffset), scratchGPR);
-#endif
+            jit.loadPtr(CCallHelpers::Address(storageGPR, offsetRelativeToBase(accessCase.m_offset)), scratchGPR);
         }
 
         if (accessCase.m_type == AccessCase::IntrinsicGetter) {
@@ -3444,6 +3418,11 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
         if (!isGetter)
             jit.storeValue(valueRegs, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(1).offset() * sizeof(Register)));
 
+#if USE(JSVALUE32_64)
+        // We *always* know that the getter/setter, if non-null, is a cell.
+        jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
+#endif
+
         if (useHandlerIC()) {
             ASSERT(scratchGPR != GPRInfo::handlerGPR);
             // handlerGPR can be the same to BaselineJITRegisters::Call::calleeJSR.
@@ -3457,10 +3436,6 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
             CallLinkInfo::emitDataICFastPath(jit);
         } else {
             jit.move(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
-#if USE(JSVALUE32_64)
-            // We *always* know that the getter/setter, if non-null, is a cell.
-            jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
-#endif
             m_callLinkInfos[index] = makeUnique<OptimizingCallLinkInfo>(m_stubInfo.codeOrigin, nullptr);
             auto* callLinkInfo = m_callLinkInfos[index].get();
             callLinkInfo->setUpCall(CallLinkInfo::Call);
@@ -3479,7 +3454,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
         if (m_stubInfo.useDataIC) {
             jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), scratchGPR);
             if (useHandlerIC())
-                jit.addPtr(CCallHelpers::TrustedImm32(-(sizeof(CallerFrameAndPC) + maxFrameExtentForSlowPathCall + m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), scratchGPR);
+                jit.addPtr(CCallHelpers::TrustedImm32(-(sizeof(CallerFrameAndPC) + dataICFrameSizeExtra + m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), scratchGPR);
             else
                 jit.addPtr(CCallHelpers::TrustedImm32(-(m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), scratchGPR);
             jit.addPtr(scratchGPR, GPRInfo::callFrameRegister, CCallHelpers::stackPointerRegister);
@@ -4176,6 +4151,11 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
 
     jit.storeCell(scratchGPR, calleeFrame.withOffset(CallFrameSlot::callee * sizeof(Register)));
 
+#if USE(JSVALUE32_64)
+    // We *always* know that the proxy function, if non-null, is a cell.
+    jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
+#endif
+
     if (useHandlerIC()) {
         // handlerGPR can be the same to BaselineJITRegisters::Call::calleeJSR.
         if constexpr (GPRInfo::handlerGPR == BaselineJITRegisters::Call::calleeJSR.payloadGPR()) {
@@ -4189,14 +4169,9 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
         CallLinkInfo::emitDataICFastPath(jit);
     } else {
         jit.move(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
-#if USE(JSVALUE32_64)
-        // We *always* know that the proxy function, if non-null, is a cell.
-        jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
-#endif
-#if CPU(ARM_THUMB2)
         // ARMv7 clobbers metadataTable register. Thus we need to restore them back here.
-        JIT::emitMaterializeMetadataAndConstantPoolRegisters(jit);
-#endif
+        if (is32Bit())
+            JIT::emitMaterializeMetadataAndConstantPoolRegisters(jit);
         m_callLinkInfos[index] = makeUnique<OptimizingCallLinkInfo>(m_stubInfo.codeOrigin, nullptr);
         auto* callLinkInfo = m_callLinkInfos[index].get();
         callLinkInfo->setUpCall(CallLinkInfo::Call);
@@ -4210,7 +4185,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
     if (m_stubInfo.useDataIC) {
         jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), m_scratchGPR);
         if (useHandlerIC())
-            jit.addPtr(CCallHelpers::TrustedImm32(-(sizeof(CallerFrameAndPC) + maxFrameExtentForSlowPathCall + m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), m_scratchGPR);
+            jit.addPtr(CCallHelpers::TrustedImm32(-(sizeof(CallerFrameAndPC) + dataICFrameSizeExtra + m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), m_scratchGPR);
         else
             jit.addPtr(CCallHelpers::TrustedImm32(-(m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), m_scratchGPR);
         jit.addPtr(m_scratchGPR, GPRInfo::callFrameRegister, CCallHelpers::stackPointerRegister);
@@ -4255,13 +4230,8 @@ bool InlineCacheCompiler::canEmitIntrinsicGetter(StructureStubInfo& stubInfo, JS
         TypeInfo info = structure->typeInfo();
         return info.isObject() && !info.overridesGetPrototype();
     }
-    case SpeciesGetterIntrinsic: {
-#if USE(JSVALUE32_64)
-        return false;
-#else
-        return !structure->classInfoForCells()->isSubClassOf(JSScope::info());
-#endif
-    }
+    case SpeciesGetterIntrinsic:
+        return is64Bit() && !structure->classInfoForCells()->isSubClassOf(JSScope::info());
     case WebAssemblyInstanceExportsIntrinsic:
         return structure->typeInfo().type() == WebAssemblyInstanceType;
     default:
@@ -4279,8 +4249,7 @@ void InlineCacheCompiler::emitIntrinsicGetter(IntrinsicGetterAccessCase& accessC
 
     switch (accessCase.intrinsic()) {
     case TypedArrayLengthIntrinsic: {
-#if USE(JSVALUE64)
-        if (isResizableOrGrowableSharedTypedArrayIncludingDataView(accessCase.structure()->classInfoForCells())) {
+        if (is64Bit() && isResizableOrGrowableSharedTypedArrayIncludingDataView(accessCase.structure()->classInfoForCells())) {
             auto allocator = makeDefaultScratchAllocator(m_scratchGPR);
             GPRReg scratch2GPR = allocator.allocateScratchGPR();
 
@@ -4296,7 +4265,6 @@ void InlineCacheCompiler::emitIntrinsicGetter(IntrinsicGetterAccessCase& accessC
             succeed();
             return;
         }
-#endif
 
 #if USE(LARGE_TYPED_ARRAYS)
         jit.load64(MacroAssembler::Address(baseGPR, JSArrayBufferView::offsetOfLength()), valueGPR);
@@ -4312,8 +4280,7 @@ void InlineCacheCompiler::emitIntrinsicGetter(IntrinsicGetterAccessCase& accessC
     case TypedArrayByteLengthIntrinsic: {
         TypedArrayType type = typedArrayType(accessCase.structure()->typeInfo().type());
 
-#if USE(JSVALUE64)
-        if (isResizableOrGrowableSharedTypedArrayIncludingDataView(accessCase.structure()->classInfoForCells())) {
+        if (is64Bit() && isResizableOrGrowableSharedTypedArrayIncludingDataView(accessCase.structure()->classInfoForCells())) {
             auto allocator = makeDefaultScratchAllocator(m_scratchGPR);
             GPRReg scratch2GPR = allocator.allocateScratchGPR();
 
@@ -4329,7 +4296,6 @@ void InlineCacheCompiler::emitIntrinsicGetter(IntrinsicGetterAccessCase& accessC
             succeed();
             return;
         }
-#endif
 
 #if USE(LARGE_TYPED_ARRAYS)
         jit.load64(MacroAssembler::Address(baseGPR, JSArrayBufferView::offsetOfLength()), valueGPR);
@@ -4349,8 +4315,7 @@ void InlineCacheCompiler::emitIntrinsicGetter(IntrinsicGetterAccessCase& accessC
     }
 
     case TypedArrayByteOffsetIntrinsic: {
-#if USE(JSVALUE64)
-        if (isResizableOrGrowableSharedTypedArrayIncludingDataView(accessCase.structure()->classInfoForCells())) {
+        if (is64Bit() && isResizableOrGrowableSharedTypedArrayIncludingDataView(accessCase.structure()->classInfoForCells())) {
             auto allocator = makeDefaultScratchAllocator(m_scratchGPR);
             GPRReg scratch2GPR = allocator.allocateScratchGPR();
 
@@ -4376,7 +4341,6 @@ void InlineCacheCompiler::emitIntrinsicGetter(IntrinsicGetterAccessCase& accessC
             succeed();
             return;
         }
-#endif
 
 #if USE(LARGE_TYPED_ARRAYS)
         jit.load64(MacroAssembler::Address(baseGPR, JSArrayBufferView::offsetOfByteOffset()), valueGPR);
@@ -4543,11 +4507,7 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
             if (!canUseMegamorphicGetById(vm(), identifier.uid()))
                 allAreSimpleLoadOrMiss = false;
 
-#if USE(JSVALUE32_64)
-            allAreSimpleLoadOrMiss = false;
-#endif
-
-            if (allAreSimpleLoadOrMiss)
+            if (allAreSimpleLoadOrMiss && !is32Bit())
                 return AccessCase::create(vm(), codeBlock, AccessCase::LoadMegamorphic, useHandlerIC() ? nullptr : identifier);
             return nullptr;
         }
@@ -4569,11 +4529,7 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
                 }
             }
 
-#if USE(JSVALUE32_64)
-            allAreSimpleLoadOrMiss = false;
-#endif
-
-            if (allAreSimpleLoadOrMiss)
+            if (allAreSimpleLoadOrMiss && !is32Bit())
                 return AccessCase::create(vm(), codeBlock, AccessCase::IndexedMegamorphicLoad, nullptr);
             return nullptr;
         }
@@ -4604,11 +4560,7 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
             if (!canUseMegamorphicPutById(vm(), identifier.uid()))
                 allAreSimpleReplaceOrTransition = false;
 
-#if USE(JSVALUE32_64)
-            allAreSimpleReplaceOrTransition = false;
-#endif
-
-            if (allAreSimpleReplaceOrTransition)
+            if (allAreSimpleReplaceOrTransition && !is32Bit())
                 return AccessCase::create(vm(), codeBlock, AccessCase::StoreMegamorphic, useHandlerIC() ? nullptr : identifier);
             return nullptr;
         }
@@ -4633,12 +4585,7 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
                     break;
                 }
             }
-
-#if USE(JSVALUE32_64)
-            allAreSimpleReplaceOrTransition = false;
-#endif
-
-            if (allAreSimpleReplaceOrTransition)
+            if (allAreSimpleReplaceOrTransition && !is32Bit())
                 return AccessCase::create(vm(), codeBlock, AccessCase::IndexedMegamorphicStore, nullptr);
             return nullptr;
         }
@@ -4664,11 +4611,7 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
             if (!canUseMegamorphicInById(vm(), identifier.uid()))
                 allAreSimpleHitOrMiss = false;
 
-#if USE(JSVALUE32_64)
-            allAreSimpleHitOrMiss = false;
-#endif
-
-            if (allAreSimpleHitOrMiss)
+            if (allAreSimpleHitOrMiss && !is32Bit())
                 return AccessCase::create(vm(), codeBlock, AccessCase::InMegamorphic, useHandlerIC() ? nullptr : identifier);
             return nullptr;
         }
@@ -4689,11 +4632,7 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
                 }
             }
 
-#if USE(JSVALUE32_64)
-            allAreSimpleHitOrMiss = false;
-#endif
-
-            if (allAreSimpleHitOrMiss)
+            if (allAreSimpleHitOrMiss && !is32Bit())
                 return AccessCase::create(vm(), codeBlock, AccessCase::IndexedMegamorphicIn, nullptr);
             return nullptr;
         }
@@ -5107,8 +5046,6 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
     return finishCodeGeneration(WTFMove(stub));
 }
 
-#if CPU(ADDRESS64)
-
 template<bool ownProperty>
 static void loadHandlerImpl(VM&, CCallHelpers& jit, JSValueRegs baseJSR, JSValueRegs resultJSR, GPRReg scratch1GPR, GPRReg scratch2GPR)
 {
@@ -5193,7 +5130,7 @@ static void customGetterHandlerImpl(VM& vm, CCallHelpers& jit, JSValueRegs baseJ
 {
     if constexpr (!isAccessor) {
         jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfHolder()), scratch3GPR);
-        jit.moveConditionally64(CCallHelpers::Equal, scratch3GPR, CCallHelpers::TrustedImm32(0), baseJSR.payloadGPR(), scratch3GPR, baseJSR.payloadGPR());
+        jit.moveConditionallyPtr(CCallHelpers::Equal, scratch3GPR, CCallHelpers::TrustedImm32(0), baseJSR.payloadGPR(), scratch3GPR, baseJSR.payloadGPR());
     }
 
     jit.transfer32(CCallHelpers::Address(stubInfoGPR, StructureStubInfo::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
@@ -5217,7 +5154,7 @@ static void customGetterHandlerImpl(VM& vm, CCallHelpers& jit, JSValueRegs baseJ
     }
     jit.setupResults(resultJSR);
     jit.reclaimSpaceOnStackForCCall();
-    jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
+    exceptionCheck(jit, vm);
 }
 
 // FIXME: We may need to implement it in offline asm eventually to share it with non JIT environment.
@@ -5265,10 +5202,17 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdCustomValueHandler(VM& vm)
 
 static void getterHandlerImpl(VM&, CCallHelpers& jit, JSValueRegs baseJSR, JSValueRegs resultJSR, GPRReg stubInfoGPR, GPRReg scratch1GPR, GPRReg scratch2GPR)
 {
+#if USE(JSVALUE64)
+    JSValueRegs scratch1JSR(scratch1GPR);
+#else
+    JSValueRegs scratch1JSR(InvalidGPRReg, scratch1GPR);
+#endif
+    assert(noOverlap(scratch1GPR, scratch2GPR, stubInfoGPR, baseJSR.payloadGPR(), GPRInfo::handlerGPR, GPRInfo::jitDataRegister));
+
     jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfHolder()), scratch1GPR);
-    jit.moveConditionally64(CCallHelpers::Equal, scratch1GPR, CCallHelpers::TrustedImm32(0), baseJSR.payloadGPR(), scratch1GPR, scratch1GPR);
+    jit.moveConditionallyPtr(CCallHelpers::Equal, scratch1GPR, CCallHelpers::TrustedImm32(0), baseJSR.payloadGPR(), scratch1GPR, scratch1GPR);
     jit.load32(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfOffset()), scratch2GPR);
-    jit.loadProperty(scratch1GPR, scratch2GPR, JSValueRegs { scratch1GPR });
+    jit.loadProperty(scratch1GPR, scratch2GPR, scratch1JSR);
 
     jit.transfer32(CCallHelpers::Address(stubInfoGPR, StructureStubInfo::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
 
@@ -5323,7 +5267,7 @@ static void getterHandlerImpl(VM&, CCallHelpers& jit, JSValueRegs baseJSR, JSVal
     jit.setupResults(resultJSR);
 
     jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), scratch1GPR);
-    jit.addPtr(CCallHelpers::TrustedImm32(-static_cast<int32_t>(sizeof(CallerFrameAndPC) + maxFrameExtentForSlowPathCall)), scratch1GPR);
+    jit.addPtr(CCallHelpers::TrustedImm32(-static_cast<int32_t>(sizeof(CallerFrameAndPC) + dataICFrameSizeExtra)), scratch1GPR);
     jit.addPtr(scratch1GPR, GPRInfo::callFrameRegister, CCallHelpers::stackPointerRegister);
 
     done.link(&jit);
@@ -5401,6 +5345,9 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdProxyObjectLoadHandler(VM&)
     jit.store32(CCallHelpers::TrustedImm32(numberOfParameters), calleeFrame.withOffset(CallFrameSlot::argumentCountIncludingThis * sizeof(Register) + PayloadOffset));
     jit.storeCell(baseJSR.payloadGPR(), calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(0).offset() * sizeof(Register)));
     jit.transferPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfHolder()), calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(1).offset() * sizeof(Register)));
+#if USE(JSVALUE32_64)
+    jit.store32(MacroAssembler::TrustedImm32(JSValue::CellTag), calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(1).offset() * sizeof(Register) + TagOffset));
+#endif
     jit.storeCell(baseJSR.payloadGPR(), calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(2).offset() * sizeof(Register)));
     jit.loadPtr(CCallHelpers::Address(stubInfoGPR, StructureStubInfo::offsetOfGlobalObject()), scratch1GPR);
     jit.loadPtr(CCallHelpers::Address(scratch1GPR, JSGlobalObject::offsetOfPerformProxyObjectGetFunction()), scratch1GPR);
@@ -5418,7 +5365,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdProxyObjectLoadHandler(VM&)
     jit.setupResults(resultJSR);
 
     jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), scratch1GPR);
-    jit.addPtr(CCallHelpers::TrustedImm32(-static_cast<int32_t>(sizeof(CallerFrameAndPC) + maxFrameExtentForSlowPathCall)), scratch1GPR);
+    jit.addPtr(CCallHelpers::TrustedImm32(-static_cast<int32_t>(sizeof(CallerFrameAndPC) + dataICFrameSizeExtra)), scratch1GPR);
     jit.addPtr(scratch1GPR, GPRInfo::callFrameRegister, CCallHelpers::stackPointerRegister);
 
     InlineCacheCompiler::emitDataICEpilogue(jit);
@@ -5441,6 +5388,12 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdModuleNamespaceLoadHandler(VM&)
     using BaselineJITRegisters::GetById::scratch2GPR;
     using BaselineJITRegisters::GetById::resultJSR;
 
+#if USE(JSVALUE64)
+    JSValueRegs tempRegs(scratch1GPR);
+#else
+    JSValueRegs tempRegs(scratch1GPR, scratch2GPR);
+#endif
+
     InlineCacheCompiler::emitDataICPrologue(jit);
 
     CCallHelpers::JumpList fallThrough;
@@ -5450,9 +5403,9 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdModuleNamespaceLoadHandler(VM&)
     fallThrough.append(jit.branchPtr(CCallHelpers::NotEqual, baseJSR.payloadGPR(), CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfModuleNamespaceObject())));
 
     jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfModuleVariableSlot()), scratch1GPR);
-    jit.loadValue(CCallHelpers::Address(scratch1GPR), JSValueRegs { scratch1GPR });
-    failAndIgnore.append(jit.branchIfEmpty(JSValueRegs { scratch1GPR }));
-    jit.moveValueRegs(JSValueRegs { scratch1GPR }, resultJSR);
+    jit.loadValue(CCallHelpers::Address(scratch1GPR), tempRegs);
+    failAndIgnore.append(jit.branchIfEmpty(tempRegs));
+    jit.moveValueRegs(tempRegs, resultJSR);
     InlineCacheCompiler::emitDataICEpilogue(jit);
     jit.ret();
 
@@ -5499,6 +5452,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> putByIdReplaceHandler(VM&)
 template<bool allocating, bool reallocating>
 static void transitionHandlerImpl(VM& vm, CCallHelpers& jit, CCallHelpers::JumpList& allocationFailure, JSValueRegs baseJSR, JSValueRegs valueJSR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR, GPRReg scratch4GPR)
 {
+    ASSERT(noOverlap(baseJSR, valueJSR, scratch1GPR, scratch2GPR, scratch3GPR, scratch4GPR, GPRInfo::handlerGPR));
     if constexpr (!allocating) {
         JIT_COMMENT(jit, "storeProperty");
         jit.load32(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfOffset()), scratch1GPR);
@@ -5531,7 +5485,7 @@ static void transitionHandlerImpl(VM& vm, CCallHelpers& jit, CCallHelpers::JumpL
             {
                 auto empty = jit.branchTest32(CCallHelpers::Zero, scratch3GPR);
                 auto loop = jit.label();
-                jit.transferPtr(CCallHelpers::Address(scratch1GPR, -static_cast<ptrdiff_t>(sizeof(IndexingHeader))), CCallHelpers::Address(scratch2GPR));
+                jit.transfer64(CCallHelpers::Address(scratch1GPR, -static_cast<ptrdiff_t>(sizeof(IndexingHeader))), CCallHelpers::Address(scratch2GPR));
                 jit.addPtr(CCallHelpers::TrustedImm32(sizeof(JSValue)), scratch1GPR);
                 jit.addPtr(CCallHelpers::TrustedImm32(sizeof(JSValue)), scratch2GPR);
                 jit.branchSub32(CCallHelpers::NonZero, CCallHelpers::TrustedImm32(sizeof(JSValue)), scratch3GPR).linkTo(loop, &jit);
@@ -5661,7 +5615,7 @@ static void customSetterHandlerImpl(VM& vm, CCallHelpers& jit, JSValueRegs baseJ
 {
     if constexpr (!isAccessor) {
         jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfHolder()), scratch3GPR);
-        jit.moveConditionally64(CCallHelpers::Equal, scratch3GPR, CCallHelpers::TrustedImm32(0), baseJSR.payloadGPR(), scratch3GPR, baseJSR.payloadGPR());
+        jit.moveConditionallyPtr(CCallHelpers::Equal, scratch3GPR, CCallHelpers::TrustedImm32(0), baseJSR.payloadGPR(), scratch3GPR, baseJSR.payloadGPR());
     }
 
     jit.transfer32(CCallHelpers::Address(stubInfoGPR, StructureStubInfo::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
@@ -5674,10 +5628,10 @@ static void customSetterHandlerImpl(VM& vm, CCallHelpers& jit, JSValueRegs baseJ
 
     // bool (*PutValueFunc)(JSGlobalObject*, EncodedJSValue thisObject, EncodedJSValue value, PropertyName);
     jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfGlobalObject()), scratch1GPR);
-    jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfUid()), scratch2GPR);
+    jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfUid()), scratch3GPR);
     if (Options::useJITCage()) {
-        jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfCustomAccessor()), scratch3GPR);
-        jit.setupArguments<PutValueFuncWithPtr>(scratch1GPR, CCallHelpers::CellValue(baseJSR.payloadGPR()), valueJSR, scratch2GPR, scratch3GPR);
+        jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfCustomAccessor()), scratch2GPR);
+        jit.setupArguments<PutValueFuncWithPtr>(scratch1GPR, CCallHelpers::CellValue(baseJSR.payloadGPR()), valueJSR, scratch3GPR, scratch2GPR);
         jit.callOperation<OperationPtrTag>(vmEntryCustomSetter);
     } else {
         jit.setupArguments<PutValueFunc>(scratch1GPR, CCallHelpers::CellValue(baseJSR.payloadGPR()), valueJSR, scratch2GPR);
@@ -5685,7 +5639,7 @@ static void customSetterHandlerImpl(VM& vm, CCallHelpers& jit, JSValueRegs baseJ
     }
 
     jit.reclaimSpaceOnStackForCCall();
-    jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
+    exceptionCheck(jit, vm);
 }
 
 // FIXME: We may need to implement it in offline asm eventually to share it with non JIT environment.
@@ -5732,10 +5686,15 @@ MacroAssemblerCodeRef<JITThunkPtrTag> putByIdCustomValueHandler(VM& vm)
 template<bool isStrict>
 static void setterHandlerImpl(VM&, CCallHelpers& jit, JSValueRegs baseJSR, JSValueRegs valueJSR, GPRReg stubInfoGPR, GPRReg scratch1GPR, GPRReg scratch2GPR)
 {
+#if USE(JSVALUE64)
+    JSValueRegs tempRegs(scratch1GPR);
+#else
+    JSValueRegs tempRegs(InvalidGPRReg, scratch1GPR);
+#endif
     jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfHolder()), scratch1GPR);
-    jit.moveConditionally64(CCallHelpers::Equal, scratch1GPR, CCallHelpers::TrustedImm32(0), baseJSR.payloadGPR(), scratch1GPR, scratch1GPR);
+    jit.moveConditionallyPtr(CCallHelpers::Equal, scratch1GPR, CCallHelpers::TrustedImm32(0), baseJSR.payloadGPR(), scratch1GPR, scratch1GPR);
     jit.load32(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfOffset()), scratch2GPR);
-    jit.loadProperty(scratch1GPR, scratch2GPR, JSValueRegs { scratch1GPR });
+    jit.loadProperty(scratch1GPR, scratch2GPR, tempRegs);
 
     jit.transfer32(CCallHelpers::Address(stubInfoGPR, StructureStubInfo::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
 
@@ -5792,7 +5751,7 @@ static void setterHandlerImpl(VM&, CCallHelpers& jit, JSValueRegs baseJSR, JSVal
     CallLinkInfo::emitDataICFastPath(jit);
 
     jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), scratch1GPR);
-    jit.addPtr(CCallHelpers::TrustedImm32(-static_cast<int32_t>(sizeof(CallerFrameAndPC) + maxFrameExtentForSlowPathCall)), scratch1GPR);
+    jit.addPtr(CCallHelpers::TrustedImm32(-static_cast<int32_t>(sizeof(CallerFrameAndPC) + dataICFrameSizeExtra)), scratch1GPR);
     jit.addPtr(scratch1GPR, GPRInfo::callFrameRegister, CCallHelpers::stackPointerRegister);
 }
 
@@ -5885,6 +5844,14 @@ MacroAssemblerCodeRef<JITThunkPtrTag> deleteByIdDeleteHandler(VM&)
     using BaselineJITRegisters::DelById::scratch3GPR;
     using BaselineJITRegisters::DelById::resultJSR;
 
+#if USE(JSVALUE64)
+    JSValueRegs tempRegs(scratch2GPR);
+    GPRReg scratch4GPR = scratch3GPR;
+#else
+    JSValueRegs tempRegs(scratch3GPR, scratch2GPR);
+    GPRReg scratch4GPR = resultJSR.tagGPR();
+#endif
+
     InlineCacheCompiler::emitDataICPrologue(jit);
 
     CCallHelpers::JumpList fallThrough;
@@ -5892,8 +5859,8 @@ MacroAssemblerCodeRef<JITThunkPtrTag> deleteByIdDeleteHandler(VM&)
     fallThrough.append(InlineCacheCompiler::emitDataICCheckStructure(jit, baseJSR.payloadGPR(), scratch1GPR));
 
     jit.load32(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfOffset()), scratch1GPR);
-    jit.moveTrustedValue(JSValue(), JSValueRegs { scratch3GPR });
-    jit.storeProperty(JSValueRegs { scratch3GPR }, baseJSR.payloadGPR(), scratch1GPR, scratch2GPR);
+    jit.moveTrustedValue(JSValue(), tempRegs);
+    jit.storeProperty(tempRegs, baseJSR.payloadGPR(), scratch1GPR, scratch4GPR);
     jit.transfer32(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfNewStructureID()), CCallHelpers::Address(baseJSR.payloadGPR(), JSCell::structureIDOffset()));
 
     jit.move(MacroAssembler::TrustedImm32(true), resultJSR.payloadGPR());
@@ -5930,7 +5897,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> deleteByIdIgnoreHandlerImpl(VM&)
     InlineCacheCompiler::emitDataICJumpNextHandler(jit);
 
     LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::InlineCache);
-    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "DeleteById handler"_s, "DeleteById handler");
+    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "DeleteById handler (ignore)"_s, "DeleteById handler (ignore)");
 }
 
 MacroAssemblerCodeRef<JITThunkPtrTag> deleteByIdDeleteNonConfigurableHandler(VM& vm)
@@ -6252,7 +6219,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValTransitionHandlerImpl(VM& v
 
     // At this point, we will not go to slow path, so clobbering the other registers are fine.
     // We use propertyJSR and profileGPR for scratch register purpose.
-    transitionHandlerImpl<allocating, reallocating>(vm, jit, allocationFailure, baseJSR, valueJSR, scratch1GPR, scratch2GPR, propertyJSR.payloadGPR(), profileGPR);
+    transitionHandlerImpl<allocating, reallocating>(vm, jit, allocationFailure, baseJSR, valueJSR, scratch1GPR, profileGPR, propertyJSR.payloadGPR(), scratch2GPR);
     InlineCacheCompiler::emitDataICEpilogue(jit);
     jit.ret();
 
@@ -6353,7 +6320,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValTransitionOutOfLineHandlerI
     InlineCacheCompiler::emitDataICJumpNextHandler(jit);
 
     LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::InlineCache);
-    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "PutByVal Transition handler"_s, "PutByVal Transition handler");
+    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "PutByVal Transition handler OOL"_s, "PutByVal Transition handler OOL");
 }
 
 MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithStringTransitionReallocatingOutOfLineHandler(VM& vm)
@@ -6556,6 +6523,14 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> deleteByValDeleteHandlerImpl(VM&)
     using BaselineJITRegisters::DelByVal::scratch3GPR;
     using BaselineJITRegisters::DelByVal::resultJSR;
 
+#if USE(JSVALUE64)
+    JSValueRegs tempRegs(scratch2GPR);
+    GPRReg scratch4GPR = scratch3GPR;
+#else
+    JSValueRegs tempRegs(scratch3GPR, scratch2GPR);
+    GPRReg scratch4GPR = baseJSR.tagGPR();
+#endif
+
     InlineCacheCompiler::emitDataICPrologue(jit);
 
     CCallHelpers::JumpList fallThrough;
@@ -6564,8 +6539,8 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> deleteByValDeleteHandlerImpl(VM&)
     fallThrough.append(InlineCacheCompiler::emitDataICCheckUid(jit, isSymbol, propertyJSR, scratch1GPR));
 
     jit.load32(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfOffset()), scratch1GPR);
-    jit.moveTrustedValue(JSValue(), JSValueRegs { scratch3GPR });
-    jit.storeProperty(JSValueRegs { scratch3GPR }, baseJSR.payloadGPR(), scratch1GPR, scratch2GPR);
+    jit.moveTrustedValue(JSValue(), tempRegs);
+    jit.storeProperty(tempRegs, baseJSR.payloadGPR(), scratch1GPR, scratch4GPR);
     jit.transfer32(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfNewStructureID()), CCallHelpers::Address(baseJSR.payloadGPR(), JSCell::structureIDOffset()));
 
     jit.move(MacroAssembler::TrustedImm32(true), resultJSR.payloadGPR());
@@ -6798,6 +6773,7 @@ AccessGenerationResult InlineCacheCompiler::compileOneAccessCaseHandler(const Ve
     };
 
     // At this point we're convinced that 'cases' contains cases that we want to JIT now and we won't change that set anymore.
+    dataLogLnIf(InlineCacheCompilerInternal::verbose, "One case: ", accessCase, " poly: ", listDump(poly));
 
     std::optional<SharedJITStubSet::StatelessCacheKey> statelessType;
     if (isStateless(accessCase.m_type)) {
@@ -7630,76 +7606,6 @@ MacroAssemblerCodeRef<JITStubRoutinePtrTag> InlineCacheCompiler::compileGetByDOM
     vm.m_sharedJITStubs->setDOMJITCode(cacheKey, code);
     return code;
 }
-
-#else
-MacroAssemblerCodeRef<JITThunkPtrTag> getByIdLoadOwnPropertyHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByIdLoadPrototypePropertyHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByIdMissHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByIdCustomAccessorHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByIdCustomValueHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByIdGetterHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByIdProxyObjectLoadHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByIdModuleNamespaceLoadHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByIdReplaceHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByIdTransitionNonAllocatingHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByIdTransitionNewlyAllocatingHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByIdTransitionReallocatingHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByIdTransitionReallocatingOutOfLineHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByIdCustomAccessorHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByIdCustomValueHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByIdStrictSetterHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByIdSloppySetterHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> inByIdHitHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> inByIdMissHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> deleteByIdDeleteHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> deleteByIdDeleteNonConfigurableHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> deleteByIdDeleteMissHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> instanceOfHitHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> instanceOfMissHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithStringLoadOwnPropertyHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithStringLoadPrototypePropertyHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithStringMissHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithStringCustomAccessorHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithStringCustomValueHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithStringGetterHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithSymbolLoadOwnPropertyHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithSymbolLoadPrototypePropertyHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithSymbolMissHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithSymbolCustomAccessorHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithSymbolCustomValueHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithSymbolGetterHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithStringReplaceHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithStringTransitionNonAllocatingHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithStringTransitionNewlyAllocatingHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithStringTransitionReallocatingHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithStringTransitionReallocatingOutOfLineHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithStringCustomAccessorHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithStringCustomValueHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithStringStrictSetterHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithStringSloppySetterHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithSymbolReplaceHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithSymbolTransitionNonAllocatingHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithSymbolTransitionNewlyAllocatingHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithSymbolTransitionReallocatingHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithSymbolTransitionReallocatingOutOfLineHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithSymbolCustomAccessorHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithSymbolCustomValueHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithSymbolStrictSetterHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithSymbolSloppySetterHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> inByValWithStringHitHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> inByValWithStringMissHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> inByValWithSymbolHitHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> inByValWithSymbolMissHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> deleteByValWithStringDeleteHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> deleteByValWithStringDeleteNonConfigurableHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> deleteByValWithStringDeleteMissHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> deleteByValWithSymbolDeleteHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> deleteByValWithSymbolDeleteNonConfigurableHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> deleteByValWithSymbolDeleteMissHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> checkPrivateBrandHandler(VM&) { return { }; }
-MacroAssemblerCodeRef<JITThunkPtrTag> setPrivateBrandHandler(VM&) { return { }; }
-AccessGenerationResult InlineCacheCompiler::compileHandler(const GCSafeConcurrentJSLocker&, Vector<AccessCase*, 16>&&, CodeBlock*, AccessCase&) { return { }; }
-#endif
 
 PolymorphicAccess::PolymorphicAccess() = default;
 PolymorphicAccess::~PolymorphicAccess() = default;

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -477,6 +477,8 @@ static bool forInBy(AccessCase::AccessType type)
 
 static bool isStateless(AccessCase::AccessType type)
 {
+    if (is32Bit())
+        return false;
     switch (type) {
     case AccessCase::Load:
     case AccessCase::Transition:
@@ -1211,7 +1213,7 @@ ScratchRegisterAllocator InlineCacheCompiler::makeDefaultScratchAllocator(GPRReg
     allocator.lock(extraToLock);
 
     // 32-bit does not have enough registers to avoid re-using this.
-    if (useHandlerIC() && !is32Bit())
+    if (useHandlerIC() && is64Bit())
         allocator.lock(GPRInfo::handlerGPR);
 
     return allocator;
@@ -2800,6 +2802,8 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
 
     case AccessCase::IndexedMegamorphicLoad: {
         ASSERT(!accessCase.viaGlobalProxy());
+        if (is32Bit())
+            return;
 
         CCallHelpers::JumpList slowCases;
 
@@ -2837,6 +2841,9 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
 
     case AccessCase::LoadMegamorphic: {
         ASSERT(!accessCase.viaGlobalProxy());
+        if (is32Bit())
+            return;
+
         CCallHelpers::JumpList failAndRepatch;
         auto* uid = accessCase.m_identifier.uid();
 
@@ -2868,6 +2875,9 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
 
     case AccessCase::StoreMegamorphic: {
         ASSERT(!accessCase.viaGlobalProxy());
+        if (is32Bit())
+            return;
+
         CCallHelpers::JumpList failAndRepatch;
         auto* uid = accessCase.m_identifier.uid();
 
@@ -2916,6 +2926,9 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
 
     case AccessCase::InMegamorphic: {
         ASSERT(!accessCase.viaGlobalProxy());
+        if (is32Bit())
+            return;
+
         CCallHelpers::JumpList failAndRepatch;
         auto* uid = accessCase.m_identifier.uid();
 
@@ -2947,6 +2960,8 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
 
     case AccessCase::IndexedMegamorphicIn: {
         ASSERT(!accessCase.viaGlobalProxy());
+        if (is32Bit())
+            return;
 
         CCallHelpers::JumpList slowCases;
 
@@ -2984,6 +2999,8 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
 
     case AccessCase::IndexedMegamorphicStore: {
         ASSERT(!accessCase.viaGlobalProxy());
+        if (is32Bit())
+            return;
 
         CCallHelpers::JumpList slowCases;
 
@@ -3418,24 +3435,28 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
         if (!isGetter)
             jit.storeValue(valueRegs, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(1).offset() * sizeof(Register)));
 
-#if USE(JSVALUE32_64)
-        // We *always* know that the getter/setter, if non-null, is a cell.
-        jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
-#endif
-
         if (useHandlerIC()) {
             ASSERT(scratchGPR != GPRInfo::handlerGPR);
             // handlerGPR can be the same to BaselineJITRegisters::Call::calleeJSR.
             if constexpr (GPRInfo::handlerGPR == BaselineJITRegisters::Call::calleeJSR.payloadGPR()) {
+                ASSERT(noOverlap(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR()));
                 jit.swap(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
                 jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos() + sizeof(DataOnlyCallLinkInfo) * index), scratchGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
             } else {
                 jit.move(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
                 jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos() + sizeof(DataOnlyCallLinkInfo) * index), GPRInfo::handlerGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
             }
+#if USE(JSVALUE32_64)
+            // We *always* know that the proxy function, if non-null, is a cell.
+            jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
+#endif
             CallLinkInfo::emitDataICFastPath(jit);
         } else {
             jit.move(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
+#if USE(JSVALUE32_64)
+            // We *always* know that the proxy function, if non-null, is a cell.
+            jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
+#endif
             m_callLinkInfos[index] = makeUnique<OptimizingCallLinkInfo>(m_stubInfo.codeOrigin, nullptr);
             auto* callLinkInfo = m_callLinkInfos[index].get();
             callLinkInfo->setUpCall(CallLinkInfo::Call);
@@ -4151,14 +4172,10 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
 
     jit.storeCell(scratchGPR, calleeFrame.withOffset(CallFrameSlot::callee * sizeof(Register)));
 
-#if USE(JSVALUE32_64)
-    // We *always* know that the proxy function, if non-null, is a cell.
-    jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
-#endif
-
     if (useHandlerIC()) {
         // handlerGPR can be the same to BaselineJITRegisters::Call::calleeJSR.
         if constexpr (GPRInfo::handlerGPR == BaselineJITRegisters::Call::calleeJSR.payloadGPR()) {
+            ASSERT(noOverlap(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR()));
             jit.swap(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
             jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos() + sizeof(DataOnlyCallLinkInfo) * index), scratchGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
         } else {
@@ -4166,9 +4183,18 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
             jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos() + sizeof(DataOnlyCallLinkInfo) * index), GPRInfo::handlerGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
         }
 
+#if USE(JSVALUE32_64)
+        // We *always* know that the proxy function, if non-null, is a cell.
+        jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
+#endif
+
         CallLinkInfo::emitDataICFastPath(jit);
     } else {
         jit.move(scratchGPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
+#if USE(JSVALUE32_64)
+    // We *always* know that the proxy function, if non-null, is a cell.
+    jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
+#endif
         // ARMv7 clobbers metadataTable register. Thus we need to restore them back here.
         if (is32Bit())
             JIT::emitMaterializeMetadataAndConstantPoolRegisters(jit);
@@ -4507,7 +4533,7 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
             if (!canUseMegamorphicGetById(vm(), identifier.uid()))
                 allAreSimpleLoadOrMiss = false;
 
-            if (allAreSimpleLoadOrMiss && !is32Bit())
+            if (allAreSimpleLoadOrMiss && is64Bit())
                 return AccessCase::create(vm(), codeBlock, AccessCase::LoadMegamorphic, useHandlerIC() ? nullptr : identifier);
             return nullptr;
         }
@@ -4529,7 +4555,7 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
                 }
             }
 
-            if (allAreSimpleLoadOrMiss && !is32Bit())
+            if (allAreSimpleLoadOrMiss && is64Bit())
                 return AccessCase::create(vm(), codeBlock, AccessCase::IndexedMegamorphicLoad, nullptr);
             return nullptr;
         }
@@ -4560,7 +4586,7 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
             if (!canUseMegamorphicPutById(vm(), identifier.uid()))
                 allAreSimpleReplaceOrTransition = false;
 
-            if (allAreSimpleReplaceOrTransition && !is32Bit())
+            if (allAreSimpleReplaceOrTransition && is64Bit())
                 return AccessCase::create(vm(), codeBlock, AccessCase::StoreMegamorphic, useHandlerIC() ? nullptr : identifier);
             return nullptr;
         }
@@ -4585,7 +4611,7 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
                     break;
                 }
             }
-            if (allAreSimpleReplaceOrTransition && !is32Bit())
+            if (allAreSimpleReplaceOrTransition && is64Bit())
                 return AccessCase::create(vm(), codeBlock, AccessCase::IndexedMegamorphicStore, nullptr);
             return nullptr;
         }
@@ -4611,7 +4637,7 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
             if (!canUseMegamorphicInById(vm(), identifier.uid()))
                 allAreSimpleHitOrMiss = false;
 
-            if (allAreSimpleHitOrMiss && !is32Bit())
+            if (allAreSimpleHitOrMiss && is64Bit())
                 return AccessCase::create(vm(), codeBlock, AccessCase::InMegamorphic, useHandlerIC() ? nullptr : identifier);
             return nullptr;
         }
@@ -4632,7 +4658,7 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
                 }
             }
 
-            if (allAreSimpleHitOrMiss && !is32Bit())
+            if (allAreSimpleHitOrMiss && is64Bit())
                 return AccessCase::create(vm(), codeBlock, AccessCase::IndexedMegamorphicIn, nullptr);
             return nullptr;
         }
@@ -5202,6 +5228,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdCustomValueHandler(VM& vm)
 
 static void getterHandlerImpl(VM&, CCallHelpers& jit, JSValueRegs baseJSR, JSValueRegs resultJSR, GPRReg stubInfoGPR, GPRReg scratch1GPR, GPRReg scratch2GPR)
 {
+    ASSERT(noOverlap(baseJSR, stubInfoGPR, scratch1GPR, scratch2GPR, GPRInfo::handlerGPR));
 #if USE(JSVALUE64)
     JSValueRegs scratch1JSR(scratch1GPR);
 #else
@@ -5257,12 +5284,16 @@ static void getterHandlerImpl(VM&, CCallHelpers& jit, JSValueRegs baseJSR, JSVal
 
     // handlerGPR can be the same to BaselineJITRegisters::Call::calleeJSR.
     if constexpr (GPRInfo::handlerGPR == BaselineJITRegisters::Call::calleeJSR.payloadGPR()) {
+        ASSERT(noOverlap(scratch1GPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR()));
         jit.swap(scratch1GPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
         jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos()), scratch1GPR, BaselineJITRegisters::Call::callLinkInfoGPR);
     } else {
         jit.move(scratch1GPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
         jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos()), GPRInfo::handlerGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
     }
+#if USE(JSVALUE32_64)
+    jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
+#endif
     CallLinkInfo::emitDataICFastPath(jit);
     jit.setupResults(resultJSR);
 
@@ -5361,6 +5392,9 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdProxyObjectLoadHandler(VM&)
         jit.move(scratch1GPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
         jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos()), GPRInfo::handlerGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
     }
+#if USE(JSVALUE32_64)
+    jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
+#endif
     CallLinkInfo::emitDataICFastPath(jit);
     jit.setupResults(resultJSR);
 
@@ -5613,6 +5647,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> putByIdTransitionReallocatingOutOfLineHand
 template<bool isAccessor>
 static void customSetterHandlerImpl(VM& vm, CCallHelpers& jit, JSValueRegs baseJSR, JSValueRegs valueJSR, GPRReg stubInfoGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR)
 {
+    ASSERT(noOverlap(baseJSR, valueJSR, scratch1GPR, scratch2GPR, scratch3GPR, GPRInfo::handlerGPR));
     if constexpr (!isAccessor) {
         jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfHolder()), scratch3GPR);
         jit.moveConditionallyPtr(CCallHelpers::Equal, scratch3GPR, CCallHelpers::TrustedImm32(0), baseJSR.payloadGPR(), scratch3GPR, baseJSR.payloadGPR());
@@ -5686,6 +5721,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> putByIdCustomValueHandler(VM& vm)
 template<bool isStrict>
 static void setterHandlerImpl(VM&, CCallHelpers& jit, JSValueRegs baseJSR, JSValueRegs valueJSR, GPRReg stubInfoGPR, GPRReg scratch1GPR, GPRReg scratch2GPR)
 {
+    ASSERT(noOverlap(baseJSR, valueJSR, stubInfoGPR, scratch1GPR, scratch2GPR, GPRInfo::handlerGPR));
 #if USE(JSVALUE64)
     JSValueRegs tempRegs(scratch1GPR);
 #else
@@ -5742,12 +5778,16 @@ static void setterHandlerImpl(VM&, CCallHelpers& jit, JSValueRegs baseJSR, JSVal
 
     // handlerGPR can be the same to BaselineJITRegisters::Call::calleeJSR.
     if constexpr (GPRInfo::handlerGPR == BaselineJITRegisters::Call::calleeJSR.payloadGPR()) {
+        ASSERT(noOverlap(scratch1GPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR()));
         jit.swap(scratch1GPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
         jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos()), scratch1GPR, BaselineJITRegisters::Call::callLinkInfoGPR);
     } else {
         jit.move(scratch1GPR, BaselineJITRegisters::Call::calleeJSR.payloadGPR());
         jit.addPtr(CCallHelpers::TrustedImm32(InlineCacheHandler::offsetOfCallLinkInfos()), GPRInfo::handlerGPR, BaselineJITRegisters::Call::callLinkInfoGPR);
     }
+#if USE(JSVALUE32_64)
+    jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
+#endif
     CallLinkInfo::emitDataICFastPath(jit);
 
     jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), scratch1GPR);

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -734,6 +734,9 @@ static InlineCacheAction tryCacheArrayGetByVal(JSGlobalObject* globalObject, Cod
     {
         GCSafeConcurrentJSLocker locker(codeBlock->m_lock, globalObject->vm());
 
+        if (forceICFailure(globalObject))
+            return GiveUpOnCache;
+
         JSCell* base = baseValue.asCell();
 
         RefPtr<AccessCase> newCase;
@@ -1281,6 +1284,9 @@ static InlineCacheAction tryCacheArrayPutByVal(JSGlobalObject* globalObject, Cod
 
     {
         GCSafeConcurrentJSLocker locker(codeBlock->m_lock, globalObject->vm());
+
+        if (forceICFailure(globalObject))
+            return GiveUpOnCache;
 
         JSCell* base = baseValue.asCell();
 
@@ -1883,6 +1889,8 @@ static InlineCacheAction tryCacheArrayInByVal(JSGlobalObject* globalObject, Code
 
     {
         GCSafeConcurrentJSLocker locker(codeBlock->m_lock, globalObject->vm());
+        if (forceICFailure(globalObject))
+            return GiveUpOnCache;
 
         JSCell* base = baseValue.asCell();
 

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -5565,14 +5565,12 @@ void ByteCodeParser::handleGetById(
                 return;
             }
         }
-#if USE(JSVALUE64)
-        if (type == AccessType::GetById) {
+        if (type == AccessType::GetById && is64Bit()) {
             if (getByStatus.isMegamorphic() && canUseMegamorphicGetById(*m_vm, identifier.uid())) {
                 set(destination, addToGraph(GetByIdMegamorphic, OpInfo(data), OpInfo(prediction), base));
                 return;
             }
         }
-#endif
     }
 
     // Special path for custom accessors since custom's offset does not have any meaning.
@@ -5977,7 +5975,7 @@ void ByteCodeParser::handleInById(VirtualRegister destination, Node* base, Cache
             return;
     }
 
-    if (status.isMegamorphic() && canUseMegamorphicInById(*m_vm, identifier.uid())) {
+    if (status.isMegamorphic() && canUseMegamorphicInById(*m_vm, identifier.uid()) && is64Bit()) {
         set(destination, addToGraph(InByIdMegamorphic, OpInfo(identifier), base));
         return;
     }
@@ -6007,7 +6005,7 @@ void ByteCodeParser::emitPutById(
     if (isDirect)
         addToGraph(PutByIdDirect, OpInfo(identifier), OpInfo(ecmaMode), base, value);
     else
-        addToGraph((putByStatus.isMegamorphic() && canUseMegamorphicPutById(*m_vm, identifier.uid())) ? PutByIdMegamorphic : putByStatus.makesCalls() ? PutByIdFlush : PutById, OpInfo(identifier), OpInfo(ecmaMode), base, value);
+        addToGraph((putByStatus.isMegamorphic() && canUseMegamorphicPutById(*m_vm, identifier.uid()) && is64Bit()) ? PutByIdMegamorphic : putByStatus.makesCalls() ? PutByIdFlush : PutById, OpInfo(identifier), OpInfo(ecmaMode), base, value);
 }
 
 void ByteCodeParser::handlePutById(
@@ -7565,7 +7563,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
                 addVarArgChild(base);
                 addVarArgChild(property);
                 addVarArgChild(nullptr); // Leave room for property storage.
-                Node* getByVal = addToGraph(Node::VarArg, getByStatus.isMegamorphic() ? GetByValMegamorphic : GetByVal, OpInfo(arrayMode.asWord()), OpInfo(prediction));
+                Node* getByVal = addToGraph(Node::VarArg, (getByStatus.isMegamorphic() && is64Bit()) ? GetByValMegamorphic : GetByVal, OpInfo(arrayMode.asWord()), OpInfo(prediction));
                 m_exitOK = false; // GetByVal must be treated as if it clobbers exit state, since FixupPhase may make it generic.
                 set(bytecode.m_dst, getByVal);
                 if (!getByStatus.isMegamorphic() && getByStatus.observedStructureStubInfoSlowPath())
@@ -7584,7 +7582,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
             Node* property = get(bytecode.m_property);
 
             GetByStatus getByStatus = GetByStatus::computeFor(m_inlineStackTop->m_profiledBlock, m_inlineStackTop->m_baselineMap, m_icContextStack, currentCodeOrigin());
-            Node* getByValWithThis = addToGraph(getByStatus.isMegamorphic() ? GetByValWithThisMegamorphic : GetByValWithThis, OpInfo(), OpInfo(prediction), base, thisValue, property);
+            Node* getByValWithThis = addToGraph((getByStatus.isMegamorphic() && is64Bit()) ? GetByValWithThisMegamorphic : GetByValWithThis, OpInfo(), OpInfo(prediction), base, thisValue, property);
             set(bytecode.m_dst, getByValWithThis);
 
             NEXT_OPCODE(op_get_by_val_with_this);
@@ -7840,7 +7838,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
             GetByStatus getByStatus = GetByStatus::computeFor(m_inlineStackTop->m_profiledBlock, m_inlineStackTop->m_baselineMap, m_icContextStack, currentCodeOrigin());
 
             auto* data = m_graph.m_getByIdData.add(GetByIdData { CacheableIdentifier::createFromIdentifierOwnedByCodeBlock(m_inlineStackTop->m_profiledBlock, uid), CacheType::GetByIdSelf });
-            set(bytecode.m_dst, addToGraph(getByStatus.isMegamorphic() && canUseMegamorphicGetById(*m_vm, uid) ? GetByIdWithThisMegamorphic : GetByIdWithThis, OpInfo(data), OpInfo(prediction), base, thisValue));
+            set(bytecode.m_dst, addToGraph((getByStatus.isMegamorphic() && canUseMegamorphicGetById(*m_vm, uid) && is64Bit()) ? GetByIdWithThisMegamorphic : GetByIdWithThis, OpInfo(data), OpInfo(prediction), base, thisValue));
 
             NEXT_OPCODE(op_get_by_id_with_this);
         }
@@ -9668,7 +9666,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
                     }
                 }
                 ArrayMode arrayMode = getArrayMode(bytecode.metadata(codeBlock).m_arrayProfile, Array::Read);
-                set(bytecode.m_dst, addToGraph(status.isMegamorphic() ? InByValMegamorphic : InByVal, OpInfo(arrayMode.asWord()), base, property));
+                set(bytecode.m_dst, addToGraph((status.isMegamorphic() && is64Bit()) ? InByValMegamorphic : InByVal, OpInfo(arrayMode.asWord()), base, property));
             }
             NEXT_OPCODE(op_in_by_val);
         }
@@ -9818,7 +9816,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
             }
 
             GetByStatus getByStatus = GetByStatus::computeFor(m_inlineStackTop->m_profiledBlock, m_inlineStackTop->m_baselineMap, m_icContextStack, currentCodeOrigin());
-            if (getByStatus.isMegamorphic()) {
+            if (getByStatus.isMegamorphic() && is64Bit()) {
                 SpeculatedType prediction = getPrediction();
                 addVarArgChild(base);
                 addVarArgChild(propertyName);
@@ -9880,7 +9878,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
             Node* property = get(bytecode.m_propertyName);
 
             InByStatus inByStatus = InByStatus::computeFor(m_inlineStackTop->m_profiledBlock, m_inlineStackTop->m_baselineMap, m_icContextStack, currentCodeOrigin());
-            if (inByStatus.isMegamorphic()) {
+            if (inByStatus.isMegamorphic() && is64Bit()) {
                 set(bytecode.m_dst, addToGraph(InByValMegamorphic, OpInfo(arrayMode.asWord()), base, property));
                 NEXT_OPCODE(op_enumerator_in_by_val);
             }
@@ -9955,7 +9953,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
 
             // FIXME: Checking for a BadConstantValue causes us to always use the Generic variant if we switched from IndexedMode -> IndexedMode + OwnStructureMode even though that might be fine.
             PutByStatus putByStatus = PutByStatus::computeFor(m_inlineStackTop->m_profiledBlock, m_inlineStackTop->m_baselineMap, m_icContextStack, currentCodeOrigin());
-            if (putByStatus.isMegamorphic()) {
+            if (putByStatus.isMegamorphic() && is64Bit()) {
                 addVarArgChild(base);
                 addVarArgChild(propertyName);
                 addVarArgChild(value);
@@ -10361,7 +10359,7 @@ void ByteCodeParser::handlePutByVal(Bytecode bytecode, BytecodeIndex osrExitInde
     addVarArgChild(value);
     addVarArgChild(nullptr); // Leave room for property storage.
     addVarArgChild(nullptr); // Leave room for length.
-    Node* putByVal = addToGraph(Node::VarArg, isDirect ? PutByValDirect : status.isMegamorphic() ? PutByValMegamorphic : PutByVal, OpInfo(arrayMode.asWord()), OpInfo(bytecode.m_ecmaMode));
+    Node* putByVal = addToGraph(Node::VarArg, isDirect ? PutByValDirect : (status.isMegamorphic() && is64Bit()) ? PutByValMegamorphic : PutByVal, OpInfo(arrayMode.asWord()), OpInfo(bytecode.m_ecmaMode));
     m_exitOK = false; // PutByVal and PutByValDirect must be treated as if they clobber exit state, since FixupPhase may make them generic.
     if (!status.isMegamorphic() && status.observedStructureStubInfoSlowPath())
         m_graph.m_slowPutByVal.add(putByVal);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1200,7 +1200,7 @@ public:
 
     void prepareForExternalCall()
     {
-#if !defined(NDEBUG) && !CPU(ARM_THUMB2)
+#if ASSERT_ENABLED
         // We're about to call out to a "native" helper function. The helper
         // function is expected to set topCallFrame itself with the CallFrame
         // that is passed to it.

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -7879,7 +7879,7 @@ void SpeculativeJIT::compileGetByIdMegamorphic(Node* node)
     GPRReg scratch3GPR = scratch3.gpr();
 
     UniquedStringImpl* uid = node->cacheableIdentifier().uid();
-    JumpList slowCases = loadMegamorphicProperty(vm(), baseGPR, InvalidGPRReg, uid, scratch3GPR, scratch1GPR, scratch2GPR, scratch3GPR);
+    JumpList slowCases = loadMegamorphicProperty(vm(), baseGPR, InvalidGPRReg, uid, JSValueRegs(scratch3GPR), scratch1GPR, scratch2GPR, scratch3GPR);
     addSlowPathGenerator(slowPathCall(slowCases, this, operationGetByIdMegamorphicGeneric, scratch3GPR, LinkableConstant::globalObject(*this, node), baseGPR, node->cacheableIdentifier().rawBits()));
     jsValueResult(scratch3GPR, node);
 }
@@ -7899,7 +7899,7 @@ void SpeculativeJIT::compileGetByIdWithThisMegamorphic(Node* node)
     GPRReg scratch3GPR = scratch3.gpr();
 
     UniquedStringImpl* uid = node->cacheableIdentifier().uid();
-    JumpList slowCases = loadMegamorphicProperty(vm(), baseGPR, InvalidGPRReg, uid, scratch3GPR, scratch1GPR, scratch2GPR, scratch3GPR);
+    JumpList slowCases = loadMegamorphicProperty(vm(), baseGPR, InvalidGPRReg, uid, JSValueRegs(scratch3GPR), scratch1GPR, scratch2GPR, scratch3GPR);
     addSlowPathGenerator(slowPathCall(slowCases, this, operationGetByIdWithThisMegamorphicGeneric, scratch3GPR, LinkableConstant::globalObject(*this, node), baseGPR, thisValueRegs, node->cacheableIdentifier().rawBits()));
     jsValueResult(scratch3GPR, node);
 }
@@ -7929,7 +7929,7 @@ void SpeculativeJIT::compileGetByValMegamorphic(Node* node)
     slowCases.append(branchIfRopeStringImpl(scratch4GPR));
     slowCases.append(branchTest32(Zero, Address(scratch4GPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIsAtom())));
 
-    slowCases.append(loadMegamorphicProperty(vm(), baseGPR, scratch4GPR, nullptr, scratch3GPR, scratch1GPR, scratch2GPR, scratch3GPR));
+    slowCases.append(loadMegamorphicProperty(vm(), baseGPR, scratch4GPR, nullptr, JSValueRegs(scratch3GPR), scratch1GPR, scratch2GPR, scratch3GPR));
     addSlowPathGenerator(slowPathCall(slowCases, this, operationGetByValMegamorphicGeneric, scratch3GPR, LinkableConstant::globalObject(*this, node), baseGPR, subscriptGPR));
     jsValueResult(scratch3GPR, node);
 }
@@ -7960,7 +7960,7 @@ void SpeculativeJIT::compileGetByValWithThisMegamorphic(Node* node)
     slowCases.append(branchIfRopeStringImpl(scratch4GPR));
     slowCases.append(branchTest32(Zero, Address(scratch4GPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIsAtom())));
 
-    slowCases.append(loadMegamorphicProperty(vm(), baseGPR, scratch4GPR, nullptr, scratch3GPR, scratch1GPR, scratch2GPR, scratch3GPR));
+    slowCases.append(loadMegamorphicProperty(vm(), baseGPR, scratch4GPR, nullptr, JSValueRegs(scratch3GPR), scratch1GPR, scratch2GPR, scratch3GPR));
     addSlowPathGenerator(slowPathCall(slowCases, this, operationGetByValWithThisMegamorphicGeneric, scratch3GPR, LinkableConstant::globalObject(*this, node), baseGPR, subscriptRegs, thisValueRegs));
     jsValueResult(scratch3GPR, node);
 }
@@ -7978,7 +7978,7 @@ void SpeculativeJIT::compileInByIdMegamorphic(Node* node)
     GPRReg scratch3GPR = scratch3.gpr();
 
     UniquedStringImpl* uid = node->cacheableIdentifier().uid();
-    JumpList slowCases = hasMegamorphicProperty(vm(), baseGPR, InvalidGPRReg, uid, scratch3GPR, scratch1GPR, scratch2GPR, scratch3GPR);
+    JumpList slowCases = hasMegamorphicProperty(vm(), baseGPR, InvalidGPRReg, uid, JSValueRegs(scratch3GPR), scratch1GPR, scratch2GPR, scratch3GPR);
     addSlowPathGenerator(slowPathCall(slowCases, this, operationInByIdMegamorphicGeneric, scratch3GPR, LinkableConstant::globalObject(*this, node), baseGPR, node->cacheableIdentifier().rawBits()));
     jsValueResult(scratch3GPR, node);
 }
@@ -8007,7 +8007,7 @@ void SpeculativeJIT::compileInByValMegamorphic(Node* node)
     slowCases.append(branchIfRopeStringImpl(scratch4GPR));
     slowCases.append(branchTest32(Zero, Address(scratch4GPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIsAtom())));
 
-    slowCases.append(hasMegamorphicProperty(vm(), baseGPR, scratch4GPR, nullptr, scratch3GPR, scratch1GPR, scratch2GPR, scratch3GPR));
+    slowCases.append(hasMegamorphicProperty(vm(), baseGPR, scratch4GPR, nullptr, JSValueRegs(scratch3GPR), scratch1GPR, scratch2GPR, scratch3GPR));
     addSlowPathGenerator(slowPathCall(slowCases, this, operationInByValMegamorphicGeneric, scratch3GPR, LinkableConstant::globalObject(*this, node), baseGPR, subscriptGPR));
     jsValueResult(scratch3GPR, node);
 }
@@ -8232,10 +8232,10 @@ void SpeculativeJIT::compilePutByIdMegamorphic(Node* node)
     GPRReg scratch3GPR = scratch3.gpr();
 
     UniquedStringImpl* uid = node->cacheableIdentifier().uid();
-    auto [slow, reallocating] = storeMegamorphicProperty(vm(), baseGPR, InvalidGPRReg, uid, valueRegs.payloadGPR(), scratch1GPR, scratch2GPR, scratch3GPR);
+    auto [slow, reallocating, storeEntryGPR] = storeMegamorphicProperty(vm(), baseGPR, { uid }, valueRegs, scratch1GPR, scratch2GPR, scratch3GPR);
 
     addSlowPathGenerator(slowPathCall(slow, this, node->ecmaMode().isStrict() ? operationPutByIdStrictMegamorphicGeneric : operationPutByIdSloppyMegamorphicGeneric, NoResult, LinkableConstant::globalObject(*this, node), valueRegs, baseGPR, node->cacheableIdentifier().rawBits()));
-    addSlowPathGenerator(slowPathCall(reallocating, this, operationPutByMegamorphicReallocating, NoResult, TrustedImmPtr(&vm()), baseGPR, valueRegs, scratch3GPR));
+    addSlowPathGenerator(slowPathCall(reallocating, this, operationPutByMegamorphicReallocating, NoResult, TrustedImmPtr(&vm()), baseGPR, valueRegs, storeEntryGPR));
     noResult(node);
 }
 
@@ -8265,11 +8265,11 @@ void SpeculativeJIT::compilePutByValMegamorphic(Node* node)
     slowCases.append(branchIfRopeStringImpl(scratch4GPR));
     slowCases.append(branchTest32(Zero, Address(scratch4GPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIsAtom())));
 
-    auto [slow, reallocating] = storeMegamorphicProperty(vm(), baseGPR, scratch4GPR, nullptr, valueRegs.payloadGPR(), scratch1GPR, scratch2GPR, scratch3GPR);
+    auto [slow, reallocating, storeEntryGPR] = storeMegamorphicProperty(vm(), baseGPR, { scratch4GPR }, valueRegs, scratch1GPR, scratch2GPR, scratch3GPR);
     slowCases.append(WTFMove(slow));
 
     addSlowPathGenerator(slowPathCall(slowCases, this, node->ecmaMode().isStrict() ? operationPutByValStrictMegamorphicGeneric : operationPutByValSloppyMegamorphicGeneric, NoResult, LinkableConstant::globalObject(*this, node), baseGPR, subscriptGPR, valueRegs));
-    addSlowPathGenerator(slowPathCall(reallocating, this, operationPutByMegamorphicReallocating, NoResult, TrustedImmPtr(&vm()), baseGPR, valueRegs, scratch3GPR));
+    addSlowPathGenerator(slowPathCall(reallocating, this, operationPutByMegamorphicReallocating, NoResult, TrustedImmPtr(&vm()), baseGPR, valueRegs, storeEntryGPR));
     noResult(node);
 }
 

--- a/Source/JavaScriptCore/disassembler/CapstoneDisassembler.cpp
+++ b/Source/JavaScriptCore/disassembler/CapstoneDisassembler.cpp
@@ -47,6 +47,8 @@ bool tryToDisassemble(const CodePtr<DisassemblyPtrTag>& codePtr, size_t size, vo
         return false;
     if (cs_option(handle, CS_OPT_SYNTAX, CS_OPT_SYNTAX_NOREGNAME) != CS_ERR_OK)
         return false;
+    if (cs_option(handle, CS_OPT_SKIPDATA, CS_OPT_ON) != CS_ERR_OK)
+        return false;
 #elif CPU(ARM64)
     if (cs_open(CS_ARCH_ARM64, CS_MODE_ARM, &handle) != CS_ERR_OK)
         return false;

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -4217,7 +4217,7 @@ private:
             GPRReg scratch2GPR = params.gpScratch(1);
             GPRReg scratch3GPR = params.gpScratch(2);
 
-            CCallHelpers::JumpList slowCases = jit.loadMegamorphicProperty(state->vm(), baseGPR, InvalidGPRReg, uid, resultGPR, scratch1GPR, scratch2GPR, scratch3GPR);
+            CCallHelpers::JumpList slowCases = jit.loadMegamorphicProperty(state->vm(), baseGPR, InvalidGPRReg, uid, JSValueRegs(resultGPR), scratch1GPR, scratch2GPR, scratch3GPR);
             CCallHelpers::Label doneForSlow = jit.label();
 
             params.addLatePath([=](CCallHelpers& jit) {
@@ -4281,7 +4281,7 @@ private:
             slowCases.append(jit.branchIfRopeStringImpl(scratch4GPR));
             slowCases.append(jit.branchTest32(CCallHelpers::Zero, CCallHelpers::Address(scratch4GPR, StringImpl::flagsOffset()), CCallHelpers::TrustedImm32(StringImpl::flagIsAtom())));
 
-            slowCases.append(jit.loadMegamorphicProperty(state->vm(), baseGPR, scratch4GPR, nullptr, resultGPR, scratch1GPR, scratch2GPR, scratch3GPR));
+            slowCases.append(jit.loadMegamorphicProperty(state->vm(), baseGPR, scratch4GPR, nullptr, JSValueRegs(resultGPR), scratch1GPR, scratch2GPR, scratch3GPR));
             CCallHelpers::Label doneForSlow = jit.label();
 
             params.addLatePath([=](CCallHelpers& jit) {
@@ -4378,7 +4378,7 @@ private:
             GPRReg scratch2GPR = params.gpScratch(1);
             GPRReg scratch3GPR = params.gpScratch(2);
 
-            CCallHelpers::JumpList slowCases = jit.loadMegamorphicProperty(state->vm(), baseGPR, InvalidGPRReg, uid, resultGPR, scratch1GPR, scratch2GPR, scratch3GPR);
+            CCallHelpers::JumpList slowCases = jit.loadMegamorphicProperty(state->vm(), baseGPR, InvalidGPRReg, uid, JSValueRegs(resultGPR), scratch1GPR, scratch2GPR, scratch3GPR);
             CCallHelpers::Label doneForSlow = jit.label();
 
             params.addLatePath([=](CCallHelpers& jit) {
@@ -4552,7 +4552,7 @@ private:
             slowCases.append(jit.branchIfRopeStringImpl(scratch4GPR));
             slowCases.append(jit.branchTest32(CCallHelpers::Zero, CCallHelpers::Address(scratch4GPR, StringImpl::flagsOffset()), CCallHelpers::TrustedImm32(StringImpl::flagIsAtom())));
 
-            slowCases.append(jit.loadMegamorphicProperty(state->vm(), baseGPR, scratch4GPR, nullptr, resultGPR, scratch1GPR, scratch2GPR, scratch3GPR));
+            slowCases.append(jit.loadMegamorphicProperty(state->vm(), baseGPR, scratch4GPR, nullptr, JSValueRegs(resultGPR), scratch1GPR, scratch2GPR, scratch3GPR));
             CCallHelpers::Label doneForSlow = jit.label();
 
             params.addLatePath([=](CCallHelpers& jit) {
@@ -4888,7 +4888,8 @@ private:
             slowCases.append(jit.branchTest32(CCallHelpers::Zero, CCallHelpers::Address(scratch4GPR, StringImpl::flagsOffset()), CCallHelpers::TrustedImm32(StringImpl::flagIsAtom())));
 
             CCallHelpers::JumpList slow, reallocating;
-            std::tie(slow, reallocating) = jit.storeMegamorphicProperty(state->vm(), baseGPR, scratch4GPR, nullptr, valueGPR, scratch1GPR, scratch2GPR, scratch3GPR);
+            GPRReg storeEntryGPR;
+            std::tie(slow, reallocating, storeEntryGPR) = jit.storeMegamorphicProperty(state->vm(), baseGPR, { scratch4GPR }, JSValueRegs(valueGPR), scratch1GPR, scratch2GPR, scratch3GPR);
             slowCases.append(WTFMove(slow));
             CCallHelpers::Label doneForSlow = jit.label();
 
@@ -4905,7 +4906,7 @@ private:
                 callOperation(
                     *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
                     exceptions.get(), operationPutByMegamorphicReallocating, InvalidGPRReg,
-                    CCallHelpers::TrustedImmPtr(&state->vm()), baseGPR, valueGPR, scratch3GPR).call();
+                    CCallHelpers::TrustedImmPtr(&state->vm()), baseGPR, valueGPR, storeEntryGPR).call();
                 jit.jump().linkTo(doneForSlow, &jit);
             });
         });
@@ -5434,7 +5435,8 @@ private:
             GPRReg scratch3GPR = params.gpScratch(2);
 
             CCallHelpers::JumpList slow, reallocating;
-            std::tie(slow, reallocating) = jit.storeMegamorphicProperty(state->vm(), baseGPR, InvalidGPRReg, uid, valueGPR, scratch1GPR, scratch2GPR, scratch3GPR);
+            GPRReg storeEntryGPR;
+            std::tie(slow, reallocating, storeEntryGPR) = jit.storeMegamorphicProperty(state->vm(), baseGPR, { uid }, JSValueRegs(valueGPR), scratch1GPR, scratch2GPR, scratch3GPR);
             CCallHelpers::Label doneForSlow = jit.label();
 
             params.addLatePath([=](CCallHelpers& jit) {
@@ -5451,7 +5453,7 @@ private:
                 callOperation(
                     *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
                     exceptions.get(), operationPutByMegamorphicReallocating, InvalidGPRReg,
-                    CCallHelpers::TrustedImmPtr(&state->vm()), baseGPR, valueGPR, scratch3GPR).call();
+                    CCallHelpers::TrustedImmPtr(&state->vm()), baseGPR, valueGPR, storeEntryGPR).call();
                 jit.jump().linkTo(doneForSlow, &jit);
             });
         });
@@ -14815,7 +14817,7 @@ IGNORE_CLANG_WARNINGS_END
             GPRReg scratch2GPR = params.gpScratch(1);
             GPRReg scratch3GPR = params.gpScratch(2);
 
-            CCallHelpers::JumpList slowCases = jit.hasMegamorphicProperty(state->vm(), baseGPR, InvalidGPRReg, uid, resultGPR, scratch1GPR, scratch2GPR, scratch3GPR);
+            CCallHelpers::JumpList slowCases = jit.hasMegamorphicProperty(state->vm(), baseGPR, InvalidGPRReg, uid, JSValueRegs(resultGPR), scratch1GPR, scratch2GPR, scratch3GPR);
             CCallHelpers::Label doneForSlow = jit.label();
 
             params.addLatePath([=](CCallHelpers& jit) {
@@ -14879,7 +14881,7 @@ IGNORE_CLANG_WARNINGS_END
             slowCases.append(jit.branchIfRopeStringImpl(scratch4GPR));
             slowCases.append(jit.branchTest32(CCallHelpers::Zero, CCallHelpers::Address(scratch4GPR, StringImpl::flagsOffset()), CCallHelpers::TrustedImm32(StringImpl::flagIsAtom())));
 
-            slowCases.append(jit.hasMegamorphicProperty(state->vm(), baseGPR, scratch4GPR, nullptr, resultGPR, scratch1GPR, scratch2GPR, scratch3GPR));
+            slowCases.append(jit.hasMegamorphicProperty(state->vm(), baseGPR, scratch4GPR, nullptr, JSValueRegs(resultGPR), scratch1GPR, scratch2GPR, scratch3GPR));
             CCallHelpers::Label doneForSlow = jit.label();
 
             params.addLatePath([=](CCallHelpers& jit) {

--- a/Source/JavaScriptCore/interpreter/CachedCall.h
+++ b/Source/JavaScriptCore/interpreter/CachedCall.h
@@ -138,6 +138,8 @@ public:
 
 #if CPU(ARM64) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
         constexpr unsigned argumentCountIncludingThis = 1 + sizeof...(args);
+        ASSERT(m_valid);
+        ASSERT(argumentCountIncludingThis == static_cast<size_t>(m_protoCallFrame.argumentCount()));
         if constexpr (argumentCountIncludingThis <= 4) {
             if (LIKELY(m_numParameters <= argumentCountIncludingThis)) {
                 JSValue result = m_vm.interpreter.tryCallWithArguments(*this, thisValue, args...);

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -430,6 +430,7 @@ void AssemblyHelpers::emitStoreStructureWithTypeInfo(AssemblyHelpers& jit, Trust
 void AssemblyHelpers::loadProperty(GPRReg object, GPRReg offset, JSValueRegs result)
 {
     ASSERT(noOverlap(offset, result));
+    ASSERT(result.payloadGPR() != InvalidGPRReg);
     Jump isInline = branch32(LessThan, offset, TrustedImm32(firstOutOfLineOffset));
 
     loadPtr(Address(object, JSObject::butterflyOffset()), result.payloadGPR());
@@ -474,10 +475,12 @@ void AssemblyHelpers::storeProperty(JSValueRegs value, GPRReg object, GPRReg off
     ready.link(this);
 
     storeValue(value, BaseIndex(scratch, offset, TimesEight, (firstOutOfLineOffset - 2) * sizeof(EncodedJSValue)));
+#if ASSERT_ENABLED
+    move(TrustedImm32(0xBEEF), scratch);
+#endif
 }
 
-#if USE(JSVALUE64)
-AssemblyHelpers::JumpList AssemblyHelpers::loadMegamorphicProperty(VM& vm, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl* uid, GPRReg resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR)
+AssemblyHelpers::JumpList AssemblyHelpers::loadMegamorphicProperty(VM& vm, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl* uid, JSValueRegs resultJSR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR)
 {
     // uidGPR can be InvalidGPRReg if uid is non-nullptr.
 
@@ -535,9 +538,9 @@ AssemblyHelpers::JumpList AssemblyHelpers::loadMegamorphicProperty(VM& vm, GPRRe
     Label cacheHit = label();
     loadPtr(Address(scratch3GPR, MegamorphicCache::LoadEntry::offsetOfHolder()), scratch2GPR);
     auto missed = branchTestPtr(Zero, scratch2GPR);
-    moveConditionally64(Equal, scratch2GPR, TrustedImm32(std::bit_cast<uintptr_t>(JSCell::seenMultipleCalleeObjects())), baseGPR, scratch2GPR, scratch1GPR);
+    moveConditionallyPtr(Equal, scratch2GPR, TrustedImm32(std::bit_cast<uintptr_t>(JSCell::seenMultipleCalleeObjects())), baseGPR, scratch2GPR, scratch1GPR);
     load16(Address(scratch3GPR, MegamorphicCache::LoadEntry::offsetOfOffset()), scratch2GPR);
-    loadProperty(scratch1GPR, scratch2GPR, JSValueRegs { resultGPR });
+    loadProperty(scratch1GPR, scratch2GPR, resultJSR);
     auto done = jump();
 
     // Secondary cache lookup. Now,
@@ -565,19 +568,23 @@ AssemblyHelpers::JumpList AssemblyHelpers::loadMegamorphicProperty(VM& vm, GPRRe
     jump().linkTo(cacheHit, this);
 
     missed.link(this);
-    moveTrustedValue(jsUndefined(), JSValueRegs { resultGPR });
+    moveTrustedValue(jsUndefined(), JSValueRegs { resultJSR });
 
     done.link(this);
 
     return slowCases;
 }
 
-std::tuple<AssemblyHelpers::JumpList, AssemblyHelpers::JumpList> AssemblyHelpers::storeMegamorphicProperty(VM& vm, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl* uid, GPRReg valueGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR)
+std::tuple<AssemblyHelpers::JumpList, AssemblyHelpers::JumpList, GPRReg> AssemblyHelpers::storeMegamorphicProperty(VM& vm, GPRReg baseGPR, std::variant<GPRReg, UniquedStringImpl*> uid, JSValueRegs valueJSR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR)
 {
-    // uidGPR can be InvalidGPRReg if uid is non-nullptr.
-
-    if (!uid)
-        ASSERT(uidGPR != InvalidGPRReg);
+    std::visit(WTF::makeVisitor(
+        [&](auto* uid) {
+            ASSERT_UNUSED(uid, uid);
+        },
+        [&](GPRReg uidGPR) {
+            ASSERT_UNUSED(uidGPR, uidGPR != InvalidGPRReg);
+        }
+    ), uid);
 
     JumpList primaryFail;
     JumpList slowCases;
@@ -593,19 +600,22 @@ std::tuple<AssemblyHelpers::JumpList, AssemblyHelpers::JumpList> AssemblyHelpers
     xor32(scratch2GPR, scratch3GPR);
 #endif
 
-    if (uid)
-        add32(TrustedImm32(uid->hash()), scratch3GPR);
-    else {
-        // Note that we don't test if the hash is zero here. AtomStringImpl's can't have a zero
-        // hash, however, a SymbolImpl may. But, because this is a cache, we don't care. We only
-        // ever load the result from the cache if the cache entry matches what we are querying for.
-        // So we either get super lucky and use zero for the hash and somehow collide with the entity
-        // we're looking for, or we realize we're comparing against another entity, and go to the
-        // slow path anyways.
-        load32(Address(uidGPR, UniquedStringImpl::flagsOffset()), scratch2GPR);
-        urshift32(TrustedImm32(StringImpl::s_flagCount), scratch2GPR);
-        add32(scratch2GPR, scratch3GPR);
-    }
+    std::visit(WTF::makeVisitor(
+        [&](auto* uid) {
+            add32(TrustedImm32(uid->hash()), scratch3GPR);
+        },
+        [&](GPRReg uidGPR) {
+            // Note that we don't test if the hash is zero here. AtomStringImpl's can't have a zero
+            // hash, however, a SymbolImpl may. But, because this is a cache, we don't care. We only
+            // ever load the result from the cache if the cache entry matches what we are querying for.
+            // So we either get super lucky and use zero for the hash and somehow collide with the entity
+            // we're looking for, or we realize we're comparing against another entity, and go to the
+            // slow path anyways.
+            load32(Address(uidGPR, UniquedStringImpl::flagsOffset()), scratch2GPR);
+            urshift32(TrustedImm32(StringImpl::s_flagCount), scratch2GPR);
+            add32(scratch2GPR, scratch3GPR);
+        }
+    ), uid);
 
     and32(TrustedImm32(MegamorphicCache::storeCachePrimaryMask), scratch3GPR);
     if (hasOneBitSet(sizeof(MegamorphicCache::StoreEntry))) // is a power of 2
@@ -620,10 +630,14 @@ std::tuple<AssemblyHelpers::JumpList, AssemblyHelpers::JumpList> AssemblyHelpers
     load16(Address(scratch2GPR, MegamorphicCache::offsetOfEpoch()), scratch2GPR);
 
     primaryFail.append(branch32(NotEqual, scratch1GPR, Address(scratch3GPR, MegamorphicCache::StoreEntry::offsetOfOldStructureID())));
-    if (uid)
-        primaryFail.append(branchPtr(NotEqual, Address(scratch3GPR, MegamorphicCache::StoreEntry::offsetOfUid()), TrustedImmPtr(uid)));
-    else
-        primaryFail.append(branchPtr(NotEqual, Address(scratch3GPR, MegamorphicCache::StoreEntry::offsetOfUid()), uidGPR));
+    std::visit(WTF::makeVisitor(
+        [&](auto* uid) {
+            primaryFail.append(branchPtr(NotEqual, Address(scratch3GPR, MegamorphicCache::StoreEntry::offsetOfUid()), TrustedImmPtr(uid)));
+        },
+        [&](GPRReg uidGPR) {
+            primaryFail.append(branchPtr(NotEqual, Address(scratch3GPR, MegamorphicCache::StoreEntry::offsetOfUid()), uidGPR));
+        }
+    ), uid);
     // We already hit StructureID and uid. And we get stale epoch for this entry.
     // Since all entries in the secondary cache has stale epoch for this StructureID and uid pair, we should just go to the slow case.
     slowCases.append(branch32WithMemory16(NotEqual, Address(scratch3GPR, MegamorphicCache::StoreEntry::offsetOfEpoch()), scratch2GPR));
@@ -639,15 +653,19 @@ std::tuple<AssemblyHelpers::JumpList, AssemblyHelpers::JumpList> AssemblyHelpers
     store32(scratch2GPR, Address(baseGPR, JSCell::structureIDOffset()));
 
     replaceCase.link(this);
-    storeProperty(JSValueRegs { valueGPR }, baseGPR, scratch3GPR, scratch1GPR);
+    storeProperty(valueJSR, baseGPR, scratch3GPR, scratch1GPR);
     auto done = jump();
 
     // Secondary cache lookup
     primaryFail.link(this);
-    if (uid)
-        add32(TrustedImm32(static_cast<uint32_t>(std::bit_cast<uintptr_t>(uid))), scratch1GPR, scratch3GPR);
-    else
-        add32(uidGPR, scratch1GPR, scratch3GPR);
+    std::visit(WTF::makeVisitor(
+        [&](auto* uid) {
+            add32(TrustedImm32(static_cast<uint32_t>(std::bit_cast<uintptr_t>(uid))), scratch1GPR, scratch3GPR);
+        },
+        [&](GPRReg uidGPR) {
+            add32(uidGPR, scratch1GPR, scratch3GPR);
+        }
+    ), uid);
     addUnsignedRightShift32(scratch3GPR, scratch3GPR, TrustedImm32(MegamorphicCache::structureIDHashShift5), scratch3GPR);
     and32(TrustedImm32(MegamorphicCache::storeCacheSecondaryMask), scratch3GPR);
     if constexpr (hasOneBitSet(sizeof(MegamorphicCache::StoreEntry))) // is a power of 2
@@ -657,19 +675,23 @@ std::tuple<AssemblyHelpers::JumpList, AssemblyHelpers::JumpList> AssemblyHelpers
     addPtr(TrustedImmPtr(std::bit_cast<uint8_t*>(&cache) + MegamorphicCache::offsetOfStoreCacheSecondaryEntries()), scratch3GPR);
 
     slowCases.append(branch32(NotEqual, scratch1GPR, Address(scratch3GPR, MegamorphicCache::StoreEntry::offsetOfOldStructureID())));
-    if (uid)
-        slowCases.append(branchPtr(NotEqual, Address(scratch3GPR, MegamorphicCache::StoreEntry::offsetOfUid()), TrustedImmPtr(uid)));
-    else
-        slowCases.append(branchPtr(NotEqual, Address(scratch3GPR, MegamorphicCache::StoreEntry::offsetOfUid()), uidGPR));
+    std::visit(WTF::makeVisitor(
+        [&](auto* uid) {
+            slowCases.append(branchPtr(NotEqual, Address(scratch3GPR, MegamorphicCache::StoreEntry::offsetOfUid()), TrustedImmPtr(uid)));
+        },
+        [&](GPRReg uidGPR) {
+            slowCases.append(branchPtr(NotEqual, Address(scratch3GPR, MegamorphicCache::StoreEntry::offsetOfUid()), uidGPR));
+        }
+    ), uid);
     slowCases.append(branch32WithMemory16(NotEqual, Address(scratch3GPR, MegamorphicCache::StoreEntry::offsetOfEpoch()), scratch2GPR));
     jump().linkTo(cacheHit, this);
 
     done.link(this);
 
-    return std::tuple { slowCases, reallocatingCases };
+    return std::tuple { slowCases, reallocatingCases, scratch3GPR };
 }
 
-AssemblyHelpers::JumpList AssemblyHelpers::hasMegamorphicProperty(VM& vm, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl* uid, GPRReg resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR)
+AssemblyHelpers::JumpList AssemblyHelpers::hasMegamorphicProperty(VM& vm, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl* uid, JSValueRegs resultJSR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR)
 {
     // uidGPR can be InvalidGPRReg if uid is non-nullptr.
 
@@ -726,7 +748,7 @@ AssemblyHelpers::JumpList AssemblyHelpers::hasMegamorphicProperty(VM& vm, GPRReg
     // Cache hit!
     Label cacheHit = label();
     load16(Address(scratch3GPR, MegamorphicCache::HasEntry::offsetOfResult()), scratch2GPR);
-    boxBoolean(scratch2GPR, JSValueRegs { resultGPR });
+    boxBoolean(scratch2GPR, resultJSR);
     auto done = jump();
 
     // Secondary cache lookup. Now,
@@ -757,7 +779,6 @@ AssemblyHelpers::JumpList AssemblyHelpers::hasMegamorphicProperty(VM& vm, GPRReg
 
     return slowCases;
 }
-#endif
 
 void AssemblyHelpers::emitNonNullDecodeZeroExtendedStructureID(RegisterID source, RegisterID dest)
 {

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -270,7 +270,10 @@ public:
         load64(address, regs.gpr());
 #else
         static_assert(!PayloadOffset && TagOffset == 4, "Assumes little-endian system");
-        loadPair32(address, regs.payloadGPR(), regs.tagGPR());
+        if (regs.tagGPR() == InvalidGPRReg)
+            load32(address, regs.payloadGPR());
+        else
+            loadPair32(address, regs.payloadGPR(), regs.tagGPR());
 #endif
     }
     
@@ -280,7 +283,11 @@ public:
         load64(address, regs.gpr());
 #else
         static_assert(!PayloadOffset && TagOffset == 4, "Assumes little-endian system");
-        loadPair32(address, regs.payloadGPR(), regs.tagGPR());
+        ASSERT(regs.payloadGPR() != InvalidGPRReg);
+        if (regs.tagGPR() == InvalidGPRReg)
+            load32(address, regs.payloadGPR());
+        else
+            loadPair32(address, regs.payloadGPR(), regs.tagGPR());
 #endif
     }
 
@@ -289,17 +296,20 @@ public:
 #if USE(JSVALUE64)
         load64(address, regs.gpr());
 #else
-        loadPair32(AbsoluteAddress(address), regs.payloadGPR(), regs.tagGPR());
+        if (regs.tagGPR() == InvalidGPRReg)
+            load32(address, regs.payloadGPR());
+        else
+            loadPair32(AbsoluteAddress(address), regs.payloadGPR(), regs.tagGPR());
 #endif
     }
-    
+
     // Note that these clobber offset.
     void loadProperty(GPRReg object, GPRReg offset, JSValueRegs result);
     void storeProperty(JSValueRegs value, GPRReg object, GPRReg offset, GPRReg scratch);
 
-    JumpList loadMegamorphicProperty(VM&, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl*, GPRReg resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR);
-    std::tuple<JumpList, JumpList> storeMegamorphicProperty(VM&, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl*, GPRReg valueGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR);
-    JumpList hasMegamorphicProperty(VM&, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl*, GPRReg resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR);
+    JumpList loadMegamorphicProperty(VM&, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl*, JSValueRegs resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR);
+    std::tuple<JumpList, JumpList, GPRReg> storeMegamorphicProperty(VM&, GPRReg baseGPR, std::variant<GPRReg, UniquedStringImpl*> uid, JSValueRegs valueJSR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR);
+    JumpList hasMegamorphicProperty(VM&, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl*, JSValueRegs resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR);
 
     void moveValueRegs(JSValueRegs srcRegs, JSValueRegs destRegs)
     {

--- a/Source/JavaScriptCore/jit/BaselineJITRegisters.h
+++ b/Source/JavaScriptCore/jit/BaselineJITRegisters.h
@@ -174,15 +174,12 @@ namespace GetByVal {
     static_assert(noOverlap(baseJSR, propertyJSR, stubInfoGPR, profileGPR), "Required for DataIC");
     static constexpr auto scratchRegisters = allocatedScratchRegisters<GPRInfo, baseJSR, propertyJSR, stubInfoGPR, profileGPR, GPRInfo::handlerGPR>;
     static constexpr GPRReg scratch1GPR { scratchRegisters[0] };
-#if USE(JSVALUE64)
     static constexpr GPRReg scratch2GPR { scratchRegisters[1] };
     static constexpr GPRReg scratch3GPR { scratchRegisters[2] };
     static_assert(noOverlap(baseJSR, propertyJSR, stubInfoGPR, profileGPR, scratch1GPR, scratch2GPR, scratch3GPR), "Required for DataIC");
-#endif
     static_assert(noOverlap(resultJSR, stubInfoGPR));
 }
 
-#if USE(JSVALUE64)
 namespace EnumeratorGetByVal {
     // We rely on using the same registers when linking a CodeBlock and initializing registers
     // for a GetByVal StubInfo.
@@ -197,9 +194,7 @@ namespace EnumeratorGetByVal {
     static_assert(noOverlap(baseJSR, propertyJSR, stubInfoGPR, profileGPR, scratch1GPR, scratch2GPR, scratch3GPR));
     static_assert(noOverlap(resultJSR, stubInfoGPR));
 }
-#endif
 
-#if USE(JSVALUE64)
 namespace GetByValWithThis {
     // Registers used on both Fast and Slow paths
     using SlowOperation = decltype(operationGetByValWithThisOptimize);
@@ -215,7 +210,6 @@ namespace GetByValWithThis {
     static_assert(noOverlap(baseJSR, propertyJSR, thisJSR, stubInfoGPR, profileGPR, GPRInfo::handlerGPR, scratch1GPR), "Required for call to slow operation");
     static_assert(noOverlap(resultJSR, stubInfoGPR));
 }
-#endif
 
 namespace PutById {
     // Registers used on both Fast and Slow paths
@@ -229,12 +223,10 @@ namespace PutById {
     static_assert(noOverlap(baseJSR, valueJSR, stubInfoGPR, scratch1GPR), "Required for DataIC");
     static_assert(noOverlap(baseJSR, valueJSR, stubInfoGPR, GPRInfo::handlerGPR, scratch1GPR), "Required for call to slow operation");
 
-#if USE(JSVALUE64)
     static constexpr GPRReg scratch2GPR { scratchRegisters[1] };
     static constexpr GPRReg scratch3GPR { scratchRegisters[2] };
     static constexpr GPRReg scratch4GPR { scratchRegisters[3] };
     static_assert(noOverlap(baseJSR, valueJSR, stubInfoGPR, GPRInfo::handlerGPR, scratch1GPR, scratch2GPR, scratch3GPR, scratch4GPR), "Required for HandlerIC");
-#endif
 }
 
 namespace PutByVal {
@@ -244,19 +236,17 @@ namespace PutByVal {
     static constexpr JSValueRegs valueJSR { preferredArgumentJSR<SlowOperation, 2>() };
     static constexpr GPRReg stubInfoGPR { preferredArgumentGPR<SlowOperation, 3>() };
     static constexpr GPRReg profileGPR { preferredArgumentGPR<SlowOperation, 4>() };
-#if USE(JSVALUE64)
     static constexpr auto scratchRegisters = allocatedScratchRegisters<GPRInfo, baseJSR, propertyJSR, valueJSR, stubInfoGPR, profileGPR, GPRInfo::handlerGPR>;
     static constexpr GPRReg scratch1GPR { scratchRegisters[0] };
-    static constexpr GPRReg scratch2GPR { scratchRegisters[1] };
-    static_assert(noOverlap(baseJSR, propertyJSR, valueJSR, stubInfoGPR, profileGPR, scratch1GPR, GPRInfo::handlerGPR), "Required for call to slow operation");
-    static_assert(noOverlap(baseJSR, propertyJSR, valueJSR, stubInfoGPR, profileGPR, scratch1GPR, scratch2GPR), "Required for HandlerIC");
+#if CPU(ARM_THUMB2)
+    static constexpr GPRReg scratch2GPR { propertyJSR.tagGPR() };
 #else
-    static constexpr auto scratchRegisters = allocatedScratchRegisters<GPRInfo, baseJSR, propertyJSR, valueJSR, stubInfoGPR, profileGPR>;
-    static constexpr GPRReg scratch1GPR { scratchRegisters[0] };
+    static constexpr GPRReg scratch2GPR { scratchRegisters[1] };
 #endif
+    static_assert(noOverlap(baseJSR, propertyJSR.payloadGPR(), valueJSR, stubInfoGPR, profileGPR, scratch1GPR, GPRInfo::handlerGPR), "Required for call to slow operation");
+    static_assert(noOverlap(baseJSR, propertyJSR.payloadGPR(), valueJSR, stubInfoGPR, profileGPR, scratch1GPR, scratch2GPR), "Required for HandlerIC");
 }
 
-#if USE(JSVALUE64)
 namespace EnumeratorPutByVal {
     // We rely on using the same registers when linking a CodeBlock and initializing registers
     // for a PutByVal StubInfo.
@@ -268,7 +258,6 @@ namespace EnumeratorPutByVal {
     using PutByVal::scratch1GPR;
     using PutByVal::scratch2GPR;
 }
-#endif
 
 namespace InById {
     using GetById::resultJSR;

--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -510,9 +510,8 @@ public:
     static constexpr GPRReg nonPreservedNonReturnGPR = ARMRegisters::r5;
     static constexpr GPRReg nonPreservedNonArgumentGPR0 = ARMRegisters::r5;
     static constexpr GPRReg nonPreservedNonArgumentGPR1 = ARMRegisters::r4;
-    static constexpr GPRReg nonPreservedNonArgumentGPR2 = ARMRegisters::r9;
 
-    static constexpr GPRReg handlerGPR = GPRInfo::nonPreservedNonArgumentGPR2;
+    static constexpr GPRReg handlerGPR = regCS0;
 
     static constexpr GPRReg wasmScratchGPR0 = regT5;
     static constexpr GPRReg wasmScratchGPR1 = regT6;
@@ -534,11 +533,11 @@ public:
         return registerForIndex[index];
     }
 
-    static unsigned toIndex(GPRReg reg)
+    static constexpr unsigned toIndex(GPRReg reg)
     {
-        ASSERT(reg != InvalidGPRReg);
-        ASSERT(static_cast<int>(reg) < 16);
-        static const unsigned indexForRegister[16] =
+        ASSERT_UNDER_CONSTEXPR_CONTEXT(reg != InvalidGPRReg);
+        ASSERT_UNDER_CONSTEXPR_CONTEXT(static_cast<int>(reg) < 16);
+        constexpr unsigned indexForRegister[16] =
             { 0, 1, 2, 3, 4, 5, InvalidIndex, InvalidIndex, 6, 7, 8, 9, InvalidIndex, InvalidIndex, InvalidIndex, InvalidIndex };
         unsigned result = indexForRegister[reg];
         return result;
@@ -1140,7 +1139,7 @@ struct StaticScratchRegisterAllocator {
         unsigned resultIndex = 0;
         for (unsigned index = 0; index < RegisterBank::numberOfRegisters; ++index) {
             auto reg = RegisterBank::toRegister(index);
-            if (noOverlap(registers..., reg))
+            if (resultIndex < size && noOverlap(registers..., reg))
                 array[resultIndex++] = reg;
         }
         return array;

--- a/Source/JavaScriptCore/jit/ICStats.h
+++ b/Source/JavaScriptCore/jit/ICStats.h
@@ -106,7 +106,7 @@ public:
     ICEvent(VM& vm, Kind kind, const ClassInfo* classInfo, PropertyName propertyName)
         : m_kind(kind)
         , m_classInfo(classInfo)
-        , m_propertyName(Identifier::fromUid(vm, propertyName.uid()))
+        , m_propertyName(propertyName.uid() ? Identifier::fromUid(vm, propertyName.uid()) : Identifier())
         , m_propertyLocation(Unknown)
     {
     }

--- a/Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp
@@ -65,7 +65,7 @@ void ScratchRegisterAllocator::lock(JSValueRegs regs)
 }
 
 template<typename BankInfo>
-typename BankInfo::RegisterType ScratchRegisterAllocator::allocateScratch()
+typename BankInfo::RegisterType ScratchRegisterAllocator::tryAllocateScratch()
 {
     // First try to allocate a register that is totally free.
     for (unsigned i = 0; i < BankInfo::numberOfRegisters; ++i) {
@@ -88,15 +88,22 @@ typename BankInfo::RegisterType ScratchRegisterAllocator::allocateScratch()
             return reg;
         }
     }
-        
-    // We failed.
-    CRASH();
-    // Make some silly compilers happy.
     return static_cast<typename BankInfo::RegisterType>(-1);
 }
 
+template<typename BankInfo>
+typename BankInfo::RegisterType ScratchRegisterAllocator::allocateScratch()
+{
+    auto result = tryAllocateScratch<BankInfo>();
+    if (result == static_cast<typename BankInfo::RegisterType>(-1))
+        CRASH();
+    return result;
+}
+
 GPRReg ScratchRegisterAllocator::allocateScratchGPR() { return allocateScratch<GPRInfo>(); }
+GPRReg ScratchRegisterAllocator::tryAllocateScratchGPR() { return allocateScratch<GPRInfo>(); }
 FPRReg ScratchRegisterAllocator::allocateScratchFPR() { return allocateScratch<FPRInfo>(); }
+FPRReg ScratchRegisterAllocator::tryAllocateScratchFPR() { return allocateScratch<FPRInfo>(); }
 
 ScratchRegisterAllocator::PreservedState ScratchRegisterAllocator::preserveReusedRegistersByPushing(AssemblyHelpers& jit, ExtraStackSpace extraStackSpace)
 {

--- a/Source/JavaScriptCore/jit/ScratchRegisterAllocator.h
+++ b/Source/JavaScriptCore/jit/ScratchRegisterAllocator.h
@@ -46,13 +46,18 @@ public:
     void lock(GPRReg);
     void lock(FPRReg);
     void lock(JSValueRegs);
-    
+
+    template<typename BankInfo>
+    typename BankInfo::RegisterType tryAllocateScratch();
+
     template<typename BankInfo>
     typename BankInfo::RegisterType allocateScratch();
-    
+
     GPRReg allocateScratchGPR();
+    GPRReg tryAllocateScratchGPR();
     FPRReg allocateScratchFPR();
-    
+    FPRReg tryAllocateScratchFPR();
+
     bool didReuseRegisters() const
     {
         return !!m_numberOfReusedRegisters;

--- a/Source/JavaScriptCore/runtime/MapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/MapPrototype.cpp
@@ -223,7 +223,7 @@ JSC_DEFINE_HOST_FUNCTION(mapProtoFuncGetOrInsertComputed, (JSGlobalObject* globa
         ASSERT(callData.type != CallData::Type::None);
 
         if (LIKELY(callData.type == CallData::Type::JS)) {
-            CachedCall cachedCall(globalObject, jsCast<JSFunction*>(valueCallback), 2);
+            CachedCall cachedCall(globalObject, jsCast<JSFunction*>(valueCallback), 1);
             RETURN_IF_EXCEPTION(scope, JSValue());
 
             return cachedCall.callWithArguments(globalObject, jsUndefined(), key);

--- a/Source/JavaScriptCore/runtime/MegamorphicCache.cpp
+++ b/Source/JavaScriptCore/runtime/MegamorphicCache.cpp
@@ -83,4 +83,28 @@ void MegamorphicCache::clearEntries()
     m_epoch = 1;
 }
 
+void MegamorphicCache::StoreEntry::dump(PrintStream& out) const
+{
+    if (m_epoch == MegamorphicCache::invalidEpoch) {
+        out.print("<invalid epoch>");
+        return;
+    }
+    out.print("Case: ", m_uid, " ", *m_oldStructureID.decode(), " ", *m_newStructureID.decode(), " ", m_offset, " reallocating: ", m_reallocating);
+}
+
+void MegamorphicCache::dump(PrintStream& out) const
+{
+    for (auto& entry : m_storeCachePrimaryEntries) {
+        if (entry.m_epoch != m_epoch)
+            continue;
+        out.println(RawPointer(&entry), ": ", entry);
+    }
+    out.println("secondary:");
+    for (auto& entry : m_storeCacheSecondaryEntries) {
+        if (entry.m_epoch != m_epoch)
+            continue;
+        out.println(RawPointer(&entry), ": ", entry);
+    }
+}
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/MegamorphicCache.h
+++ b/Source/JavaScriptCore/runtime/MegamorphicCache.h
@@ -110,6 +110,8 @@ public:
             m_reallocating = reallocating;
         }
 
+        void dump(PrintStream& out) const;
+
         RefPtr<UniquedStringImpl> m_uid;
         StructureID m_oldStructureID { };
         StructureID m_newStructureID { };
@@ -279,6 +281,8 @@ public:
         if (UNLIKELY(m_epoch == invalidEpoch))
             clearEntries();
     }
+
+    void dump(PrintStream& out) const;
 
 private:
     JS_EXPORT_PRIVATE void clearEntries();

--- a/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
@@ -199,7 +199,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakMapGetOrInsertComputed, (JSGlobalObject* g
             ASSERT(callData.type != CallData::Type::None);
 
             if (LIKELY(callData.type == CallData::Type::JS)) {
-                CachedCall cachedCall(globalObject, jsCast<JSFunction*>(valueCallback), 2);
+                CachedCall cachedCall(globalObject, jsCast<JSFunction*>(valueCallback), 1);
                 RETURN_IF_EXCEPTION(scope, { });
 
                 value = cachedCall.callWithArguments(globalObject, jsUndefined(), key);

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -5260,7 +5260,7 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
     for (unsigned i = lastPatchArg; i < params.size(); ++i) {
         auto arg = params[i];
         if (arg.isStack()) {
-            unsigned scratch = -1;
+            int scratch = -1;
             for (unsigned i = 0; i < tailCallPatchpointScratchCount; ++i) {
                 if (!stackPatchArg[i]) {
                     scratch = i;

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -1372,7 +1372,7 @@ inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::asa
     if (!buffer())
         return;
 
-    RELEASE_ASSERT_WITH_MESSAGE(newSize <= capacity(), "Attempt to expand size (%lu) beyond current capacity (%lu)", newSize, capacity());
+    RELEASE_ASSERT_WITH_MESSAGE(newSize <= capacity(), "Attempt to expand size (%zu) beyond current capacity (%zu)", newSize, capacity());
 
     // Change allowed range.
     __sanitizer_annotate_contiguous_container(buffer(), endOfBuffer(), buffer() + size(), buffer() + newSize);


### PR DESCRIPTION
#### 6227edecd88fbf63e3a9a003fc33521e657c87db
<pre>
[ARMv7] Refactor to support cached calls and future handlerIC work.
<a href="https://bugs.webkit.org/show_bug.cgi?id=285756">https://bugs.webkit.org/show_bug.cgi?id=285756</a>

Reviewed by NOBODY (OOPS!).

In preparation for follow-up work to port over handlerIC and the
megamorphic cache to ARMv7, this patch includes some refactorings
and debugging improvements:

- Fix the DUMP_CODE option so that it works on ARMv7
- Add some additional forceICFailure checks
- Allow dumping the megamorphic cache
- Turn off DFG inlining for some nodes on armv7 (although the ICs are
    not yet implemented anyway).
- Refactor storeMegamorphicProperty and kin to be less confusing;
    a subsequent patch will introduce alternate versions that use fewer
    registers.
- Skip data when dumping disassembly
- Add some new asssertions re: scratch registers
- Fail to compile if toIndex can&apos;t produce a register (when
    statically-allocating baseline registers).
- Fix cachedCall on ARM; Darwin doesn&apos;t validate the second parameter.

* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
(JSC::LinkBuffer::copyCompactAndLinkCode):
(JSC::LinkBuffer::dumpCode):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::moveConditionallyPtr):
* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h:
(JSC::MacroAssemblerARMv7::moveConditionallyPtr):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::moveConditionallyPtr):
* Source/JavaScriptCore/assembler/ProbeContext.h:
(JSC::Probe::Context::jsr const):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp:
* Source/JavaScriptCore/bytecode/CallLinkInfo.cpp:
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheHandler::dump const):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheArrayGetByVal):
(JSC::tryCacheArrayPutByVal):
(JSC::tryCacheArrayInByVal):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleGetById):
(JSC::DFG::ByteCodeParser::handleInById):
(JSC::DFG::ByteCodeParser::emitPutById):
(JSC::DFG::ByteCodeParser::parseBlock):
(JSC::DFG::ByteCodeParser::handlePutByVal):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
(JSC::DFG::SpeculativeJIT::prepareForExternalCall):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileGetByIdMegamorphic):
(JSC::DFG::SpeculativeJIT::compileGetByIdWithThisMegamorphic):
(JSC::DFG::SpeculativeJIT::compileGetByValMegamorphic):
(JSC::DFG::SpeculativeJIT::compileGetByValWithThisMegamorphic):
(JSC::DFG::SpeculativeJIT::compileInByIdMegamorphic):
(JSC::DFG::SpeculativeJIT::compileInByValMegamorphic):
(JSC::DFG::SpeculativeJIT::compilePutByIdMegamorphic):
(JSC::DFG::SpeculativeJIT::compilePutByValMegamorphic):
* Source/JavaScriptCore/disassembler/CapstoneDisassembler.cpp:
(JSC::tryToDisassemble):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileGetByIdMegamorphic):
(JSC::FTL::DFG::LowerDFGToB3::compileGetByValMegamorphic):
(JSC::FTL::DFG::LowerDFGToB3::compileGetByIdWithThisMegamorphic):
(JSC::FTL::DFG::LowerDFGToB3::compileGetByValWithThisMegamorphic):
(JSC::FTL::DFG::LowerDFGToB3::compilePutByValMegamorphic):
(JSC::FTL::DFG::LowerDFGToB3::compilePutByIdMegamorphic):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/interpreter/CachedCall.h:
(JSC::CachedCall::callWithArguments):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::loadProperty):
(JSC::AssemblyHelpers::storeProperty):
(JSC::AssemblyHelpers::loadMegamorphicProperty):
(JSC::AssemblyHelpers::storeMegamorphicProperty):
(JSC::AssemblyHelpers::hasMegamorphicProperty):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::loadValue):
* Source/JavaScriptCore/jit/GPRInfo.h:
(JSC::GPRInfo::toIndex):
(JSC::StaticScratchRegisterAllocator::constructScratchRegisters):
* Source/JavaScriptCore/jit/ICStats.h:
(JSC::ICEvent::ICEvent):
* Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp:
(JSC::ScratchRegisterAllocator::tryAllocateScratch):
(JSC::ScratchRegisterAllocator::allocateScratch):
(JSC::ScratchRegisterAllocator::tryAllocateScratchGPR):
(JSC::ScratchRegisterAllocator::tryAllocateScratchFPR):
* Source/JavaScriptCore/jit/ScratchRegisterAllocator.h:
* Source/JavaScriptCore/runtime/MapPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/MegamorphicCache.cpp:
(JSC::MegamorphicCache::StoreEntry::dump const):
(JSC::MegamorphicCache::dump const):
* Source/JavaScriptCore/runtime/MegamorphicCache.h:
* Source/JavaScriptCore/runtime/WeakMapPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::prepareForTailCallImpl):
* Source/WTF/wtf/Vector.h:
(WTF::Malloc&gt;::asanBufferSizeWillChangeTo):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0424b4e43c2786441e6f0b1372b28aef5a8d31ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/84312 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/3935 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/38617 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89390 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/35321 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/4022 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/11911 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/89390 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/35321 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/87358 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/4022 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/38617 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89390 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/4022 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/38617 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/34370 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/77276 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/4022 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/38617 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/90771 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/83329 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/11579 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/11911 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/90771 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/11806 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/38617 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/90771 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/38617 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2944 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/11531 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17007 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/105748 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/11380 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/105748 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/14856 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/13153 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->