### PR TITLE
[GStreamer] imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-mimetype.html fails

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1172,7 +1172,6 @@ webkit.org/b/285595 media/video-seek-after-end-play.html [ Skip ]
 
 webkit.org/b/213699 http/wpt/mediarecorder/mute-tracks.html [ Timeout Pass ]
 webkit.org/b/213699 http/wpt/mediarecorder/video-rotation.html [ Failure ]
-webkit.org/b/213699 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-mimetype.html [ Pass Timeout ]
 webkit.org/b/213699 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-no-sink.https.html [ Failure ]
 webkit.org/b/213699 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-peerconnection.https.html [ Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/set-srcObject-MediaStream-Blob.html [ Pass Failure ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-mimetype-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-mimetype-expected.txt
@@ -32,7 +32,7 @@ PASS MediaRecorder mimeType is not set before 'onstart' for audio/video
 PASS MediaRecorder doesn't fire 'onstart' multiple times for audio
 PASS MediaRecorder doesn't fire 'onstart' multiple times for video
 PASS MediaRecorder doesn't fire 'onstart' multiple times for audio/video
-FAIL MediaRecorder formats mimeType well after 'start' for audio assert_regexp_match: mimeType has one codec a expected object "/^[a-z]+\/[a-z]+;[ ]*codecs=[^,]+$/" but got "audio/mp4"
-FAIL MediaRecorder formats mimeType well after 'start' for video assert_regexp_match: mimeType has one codec a expected object "/^[a-z]+\/[a-z]+;[ ]*codecs=[^,]+$/" but got "video/mp4"
-FAIL MediaRecorder formats mimeType well after 'start' for audio/video assert_regexp_match: mimeType has two codecs expected object "/^[a-z]+\/[a-z]+;[ ]*codecs=[^,]+,[^,]+$/" but got "video/mp4"
+PASS MediaRecorder formats mimeType well after 'start' for audio
+PASS MediaRecorder formats mimeType well after 'start' for video
+PASS MediaRecorder formats mimeType well after 'start' for audio/video
 

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -813,6 +813,8 @@ webkit.org/b/257624 webrtc/canvas-to-peer-connection-2d.html [ Failure Pass Time
 # Fails on WPE EWS, likely when checking the video pixels. Unable to reproduce this failure locally.
 webrtc/video-h264.html [ Failure ]
 
+webkit.org/b/285752 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-mimetype.html [ Pass Crash ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # 6. SLOW TESTS
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
@@ -49,9 +49,11 @@ std::pair<const char*, const char*> GStreamerCodecUtilities::parseH264ProfileAnd
 {
     ensureDebugCategoryInitialized();
 
+    uint64_t spsAsInteger = 0;
     auto components = codec.split('.');
+    if (components.size() > 1)
+        spsAsInteger = parseInteger<uint64_t>(components[1], 16).value_or(0);
 
-    auto spsAsInteger = parseInteger<uint64_t>(components[1], 16).value_or(0);
     std::array<uint8_t, 3> sps;
     sps[0] = spsAsInteger >> 16;
     sps[1] = (spsAsInteger >> 8) & 0xff;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -134,8 +134,12 @@ MediaRecorderPrivateBackend::MediaRecorderPrivateBackend(MediaStreamPrivate& str
         }
     } else {
         containerType = selectedTracks.videoTrack ? "video/mp4"_s : "audio/mp4"_s;
-        if (codecs.isEmpty() && selectedTracks.audioTrack && !selectedTracks.videoTrack)
-            codecs.append("mp4a"_s);
+        if (codecs.isEmpty()) {
+            if (selectedTracks.videoTrack)
+                codecs.append("avc1.4d002a"_s);
+            if (selectedTracks.audioTrack)
+                codecs.append("mp4a"_s);
+        }
     }
 
     StringBuilder builder;


### PR DESCRIPTION
#### bac54852496eb150b5542a1e258c3344b65372b6
<pre>
[GStreamer] imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-mimetype.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=285758">https://bugs.webkit.org/show_bug.cgi?id=285758</a>

Reviewed by Xabier Rodriguez-Calvar.

Set default codecs for the mp4 container and driving-by, fix a potential buffer overflow in the
GStreamer avc codec string parser.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-mimetype-expected.txt:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
(WebCore::MediaRecorderPrivateBackend::MediaRecorderPrivateBackend):

Canonical link: <a href="https://commits.webkit.org/288859@main">https://commits.webkit.org/288859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a725331b8b940fc98d9219ade936d271087c62e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89307 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35240 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65518 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23354 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76539 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45811 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2910 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30769 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34289 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90689 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11498 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8349 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73967 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73169 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18167 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17489 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15930 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2863 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11450 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16926 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11299 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14775 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13072 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->