### PR TITLE
REGRESSION (283135@main): Headings using `background-clip: text` become rectangles when exported as PDF

### DIFF
--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1609,6 +1609,8 @@ webkit.org/b/174460 fast/canvas/canvas-blend-solid.html [ Failure ]
 
 webkit.org/b/175421 printing/width-overflow.html [ Failure ]
 
+webkit.org/b/285785 printing/background-clip-text.html [ ImageOnlyFailure ]
+
 webkit.org/b/176648 fast/repaint/inline-outline-repaint.html [ ImageOnlyFailure ]
 
 webkit.org/b/177294 platform/gtk/fonts/fontconfig-aliasing-settings.html [ Failure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -551,6 +551,8 @@ webkit.org/b/181767 fast/hidpi/filters-hue-rotate.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/206653 imported/w3c/web-platform-tests/clipboard-apis/async-navigator-clipboard-basics.https.html [ Failure ]
 
+webkit.org/b/285785 printing/background-clip-text.html [ ImageOnlyFailure ]
+
 # WPT css-fonts failures/passes unique to WPE
 
 webkit.org/b/208869 fast/images/inline-image-box-with-no-alt-should-collapse-no-quirks.html [ Failure ]

--- a/LayoutTests/printing/background-clip-text-expected.html
+++ b/LayoutTests/printing/background-clip-text-expected.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            font-size: 12pt;
+        }
+                
+        .exact {
+            print-color-adjust: exact;
+        }
+        .economy {
+            print-color-adjust: economy;
+        }
+
+        .container {
+            border: 4px solid black;
+            margin: 10px;
+            padding: 4px;
+            text-align: center;
+        }
+        
+        .blue-red {
+            color: blue;
+            background-color: red;
+            border-color: green;
+        }
+
+        .gradient {
+            color: blue;
+            background: linear-gradient(to bottom right, green, yellow);
+        }
+        
+        .background-clip {
+            background: linear-gradient(to bottom right, green, yellow);
+            background-clip: text;
+            color: transparent;
+        }
+        
+        .economy .gradient {
+            background: white;
+            color: blue;
+        }
+        
+        .economy .background-clip {
+            background: white;
+            color: black;
+        }
+    </style>
+    <script>
+        if (window.internals)
+            internals.setPrinting(600, 600);
+    </script>
+</head>
+<body>
+    <div class="exact grouping">
+        <h2><code>print-color-adjust: exact</code></h2>
+        <div class="container">
+            Black on white
+        </div>
+
+        <div class="container blue-red">
+            Blue on red
+        </div>
+
+        <div class="container gradient">
+            Gradient
+        </div>
+
+        <div class="container background-clip">
+            background-clip: text
+        </div>
+    </div>
+    
+    <div class="economy grouping">
+        <h2><code>print-color-adjust: economy</code></h2>
+        <div class="container">
+            Black on white
+        </div>
+
+        <div class="container blue-red">
+            Blue on red
+        </div>
+
+        <div class="container gradient">
+            Gradient
+        </div>
+
+        <div class="container background-clip">
+            background-clip: text
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/printing/background-clip-text.html
+++ b/LayoutTests/printing/background-clip-text.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            font-size: 12pt;
+        }
+                
+        .exact {
+            print-color-adjust: exact;
+        }
+        .economy {
+            print-color-adjust: economy;
+        }
+
+        .container {
+            border: 4px solid black;
+            margin: 10px;
+            padding: 4px;
+            text-align: center;
+        }
+        
+        .blue-red {
+            color: blue;
+            background-color: red;
+            border-color: green;
+        }
+
+        .gradient {
+            color: blue;
+            background: linear-gradient(to bottom right, green, yellow);
+        }
+        
+        .background-clip {
+            background: linear-gradient(to bottom right, green, yellow);
+            background-clip: text;
+            color: transparent;
+        }
+    </style>
+    <script>
+        if (window.internals)
+            internals.setPrinting(600, 600);
+    </script>
+</head>
+<body>
+    <div class="exact grouping">
+        <h2><code>print-color-adjust: exact</code></h2>
+        <div class="container">
+            Black on white
+        </div>
+
+        <div class="container blue-red">
+            Blue on red
+        </div>
+
+        <div class="container gradient">
+            Gradient
+        </div>
+
+        <div class="container background-clip">
+            background-clip: text
+        </div>
+    </div>
+    
+    <div class="economy grouping">
+        <h2><code>print-color-adjust: economy</code></h2>
+        <div class="container">
+            Black on white
+        </div>
+
+        <div class="container blue-red">
+            Blue on red
+        </div>
+
+        <div class="container gradient">
+            Gradient
+        </div>
+
+        <div class="container background-clip">
+            background-clip: text
+        </div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -144,7 +144,7 @@ StyledMarkedText::Style StyledMarkedText::computeStyleForUnmarkedMarkedText(cons
 {
     StyledMarkedText::Style style;
     style.textDecorationStyles = TextDecorationPainter::stylesForRenderer(renderer, lineStyle.textDecorationsInEffect(), isFirstLine, paintInfo.paintBehavior);
-    style.textStyles = computeTextPaintStyle(renderer.frame(), lineStyle, paintInfo);
+    style.textStyles = computeTextPaintStyle(renderer, lineStyle, paintInfo);
     style.textShadow = ShadowData::clone(paintInfo.forceTextColor() ? nullptr : lineStyle.textShadow());
     return style;
 }

--- a/Source/WebCore/rendering/TextPaintStyle.cpp
+++ b/Source/WebCore/rendering/TextPaintStyle.cpp
@@ -71,8 +71,9 @@ static Color adjustColorForVisibilityOnBackground(const Color& textColor, const 
     return textColor.lightened();
 }
 
-TextPaintStyle computeTextPaintStyle(const LocalFrame& frame, const RenderStyle& lineStyle, const PaintInfo& paintInfo)
+TextPaintStyle computeTextPaintStyle(const RenderText& renderer, const RenderStyle& lineStyle, const PaintInfo& paintInfo)
 {
+    auto& frame = renderer.frame();
     TextPaintStyle paintStyle;
     paintStyle.useDarkAppearance = frame.document() ? frame.document()->useDarkAppearance(&lineStyle) : false;
 
@@ -91,7 +92,7 @@ TextPaintStyle computeTextPaintStyle(const LocalFrame& frame, const RenderStyle&
     }
 
     if (lineStyle.insideDefaultButton()) {
-        Page* page = frame.page();
+        Page* page = renderer.frame().page();
         if (page && page->focusController().isActive()) {
             OptionSet<StyleColorOptions> options;
             if (page->settings().useSystemAppearance())
@@ -107,8 +108,14 @@ TextPaintStyle computeTextPaintStyle(const LocalFrame& frame, const RenderStyle&
     if (frame.document() && frame.document()->printing()) {
         if (lineStyle.printColorAdjust() == PrintColorAdjust::Economy)
             forceBackgroundToWhite = true;
+
         if (frame.settings().shouldPrintBackgrounds())
             forceBackgroundToWhite = false;
+
+        if (forceBackgroundToWhite) {
+            if (renderer.style().hasAnyBackgroundClipText())
+                paintStyle.fillColor = Color::black;
+        }
     }
 
     // Make the text fill color legible against a white background

--- a/Source/WebCore/rendering/TextPaintStyle.h
+++ b/Source/WebCore/rendering/TextPaintStyle.h
@@ -33,8 +33,8 @@ namespace WebCore {
 
 class GraphicsContext;
 class LocalFrame;
-class RenderText;
 class RenderStyle;
+class RenderText;
 class ShadowData;
 struct PaintInfo;
 
@@ -58,7 +58,7 @@ struct TextPaintStyle {
 };
 
 bool textColorIsLegibleAgainstBackgroundColor(const Color& textColor, const Color& backgroundColor);
-TextPaintStyle computeTextPaintStyle(const LocalFrame&, const RenderStyle&, const PaintInfo&);
+TextPaintStyle computeTextPaintStyle(const RenderText&, const RenderStyle&, const PaintInfo&);
 TextPaintStyle computeTextSelectionPaintStyle(const TextPaintStyle&, const RenderText&, const RenderStyle&, const PaintInfo&, std::optional<ShadowData>& selectionShadow);
 
 enum FillColorType { UseNormalFillColor, UseEmphasisMarkColor };

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2581,18 +2581,22 @@ RoundedRect RenderStyle::getRoundedInnerBorderFor(const LayoutRect& borderRect, 
     return roundedRect;
 }
 
-static bool allLayersAreFixed(const FillLayer& layers)
+bool RenderStyle::hasEntirelyFixedBackground() const
 {
-    for (auto* layer = &layers; layer; layer = layer->next()) {
+    for (auto* layer = &backgroundLayers(); layer; layer = layer->next()) {
         if (!(layer->image() && layer->attachment() == FillAttachment::FixedBackground))
             return false;
     }
     return true;
 }
 
-bool RenderStyle::hasEntirelyFixedBackground() const
+bool RenderStyle::hasAnyBackgroundClipText() const
 {
-    return allLayersAreFixed(backgroundLayers());
+    for (auto* layer = &backgroundLayers(); layer; layer = layer->next()) {
+        if (layer->clip() == FillBox::Text)
+            return true;
+    }
+    return false;
 }
 
 const CounterDirectiveMap& RenderStyle::counterDirectives() const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -401,6 +401,7 @@ public:
 
     inline bool hasBackgroundImage() const;
     inline bool hasAnyFixedBackground() const;
+    bool hasAnyBackgroundClipText() const;
 
     bool hasEntirelyFixedBackground() const;
     inline bool hasAnyLocalBackground() const;


### PR DESCRIPTION
#### 4d774bdad1260cf75c4b21611a52d14f2d5a3219
<pre>
REGRESSION (283135@main): Headings using `background-clip: text` become rectangles when exported as PDF
<a href="https://bugs.webkit.org/show_bug.cgi?id=285760">https://bugs.webkit.org/show_bug.cgi?id=285760</a>
<a href="https://rdar.apple.com/142698412">rdar://142698412</a>

Reviewed by Tim Horton.

There were a couple of issues with `background-clip: text` that affect printing. First, when printing
skips backgrounds (because of `print-color-adjust: economy` and the user unchecking the Print Backgrounds
checkbox in the print dialog), `background-clip: text` did not show at all because it&apos;s painted as a background.
Fix this by changing the `layerClip` from `FillBox::Text` to `FillBox::BorderBox` in `BackgroundPainter::paintFillLayer()`,
and making the text black in `computeTextPaintStyle()`; the spec[1] allows us to make these adjustments for `economy`.
This is tested by a layout test.

Second, when printing or generating a PDF when including backgrounds, i.e. for `print-color-adjust: exact` or with
the Print Backgrounds checkbox checked, the SourceIn blend mode is not supported, which resulted in a solid background
and missing text. Fix this by falling back to clipping to an image buffer for PDF contexts, in `BackgroundPainter::paintFillLayer()`.
This is tested by a new API test.

[1] <a href="https://drafts.csswg.org/css-color-adjust/#propdef-print-color-adjust">https://drafts.csswg.org/css-color-adjust/#propdef-print-color-adjust</a>

* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* LayoutTests/printing/background-clip-text-expected.html: Added.
* LayoutTests/printing/background-clip-text.html: Added.
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer const):
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::StyledMarkedText::computeStyleForUnmarkedMarkedText):
* Source/WebCore/rendering/TextPaintStyle.cpp:
(WebCore::computeTextPaintStyle):
* Source/WebCore/rendering/TextPaintStyle.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::hasEntirelyFixedBackground const):
(WebCore::RenderStyle::hasAnyBackgroundClipText const):
(WebCore::allLayersAreFixed): Deleted.
* Source/WebCore/rendering/style/RenderStyle.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DrawingToPDF.mm:
(TestWebKitAPI::TEST(DrawingToPDF, BackgroundClipText)):

Canonical link: <a href="https://commits.webkit.org/288753@main">https://commits.webkit.org/288753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/332f1e6ed00226b8b81046330d4563f58149c8de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89369 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35300 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65557 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23393 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76589 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45850 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2952 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30819 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34349 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90749 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8395 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74008 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73210 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18120 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17532 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15976 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2923 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11510 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16986 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11359 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13132 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->