### PR TITLE
AX: Expose accessibilityRowRange for the first child of list items

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/list-item-row-range-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/list-item-row-range-expected.txt
@@ -1,0 +1,47 @@
+This test ensures we expose accessibilityRowRange correctly for list items.
+
+ListMarker
+PASS: current.description === "AXLabel: 1"
+PASS: current.rowIndexRange() === "{9223372036854775807, 0}"
+StaticText
+PASS: current.description === "AXLabel: Foo"
+PASS: current.rowIndexRange() === "{0, 3}"
+ListMarker
+PASS: current.description === "AXLabel: 2"
+PASS: current.rowIndexRange() === "{9223372036854775807, 0}"
+StaticText
+PASS: current.description === "AXLabel: Bar"
+PASS: current.rowIndexRange() === "{1, 3}"
+ListMarker
+PASS: current.description === "AXLabel: a"
+PASS: current.rowIndexRange() === "{9223372036854775807, 0}"
+StaticText
+PASS: current.description === "AXLabel: Bar the second"
+PASS: current.rowIndexRange() === "{0, 2}"
+Button
+PASS: current.description === "AXLabel: Press"
+PASS: current.rowIndexRange() === "{9223372036854775807, 0}"
+StaticText
+PASS: current.description === "AXLabel: Last text"
+PASS: current.rowIndexRange() === "{9223372036854775807, 0}"
+ListMarker
+PASS: current.description === "AXLabel: b"
+PASS: current.rowIndexRange() === "{9223372036854775807, 0}"
+StaticText
+PASS: current.description === "AXLabel: Bar the third"
+PASS: current.rowIndexRange() === "{1, 2}"
+ListMarker
+PASS: current.description === "AXLabel: 3"
+PASS: current.rowIndexRange() === "{9223372036854775807, 0}"
+StaticText
+PASS: current.description === "AXLabel: Baz"
+PASS: current.rowIndexRange() === "{2, 3}"
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Foo
+Bar
+Bar the second PressLast text
+Bar the third
+Baz

--- a/LayoutTests/accessibility/ios-simulator/list-item-row-range.html
+++ b/LayoutTests/accessibility/ios-simulator/list-item-row-range.html
@@ -1,0 +1,65 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<ol>
+    <li>Foo</li>
+    <li>
+        Bar
+        <ol type="a">
+            <li>Bar the second <button>Press</button>Last text</li>
+            <li>Bar the third</li>
+        </ol>
+    </li>
+    <li>Baz</li>
+</ol>
+
+<script>
+var output = "This test ensures we expose accessibilityRowRange correctly for list items.\n\n";
+
+var webArea;
+var current;
+function moveToNextAndExpect(description, rowRange) {
+    current = webArea.uiElementForSearchPredicate(current, true, "AXAnyTypeSearchKey", "", false);
+    if (!current)
+        return;
+
+    const role = current.role;
+    output += `${current.role}\n`;
+    output += expect("current.description", `"AXLabel: ${description}"`);
+    output += expect("current.rowIndexRange()", `"${rowRange}"`);
+}
+
+const notFoundRange = "{9223372036854775807, 0}";
+if (window.accessibilityController) {
+    webArea = accessibilityController.rootElement.childAtIndex(0);
+    current = webArea;
+
+    moveToNextAndExpect("1", notFoundRange);
+    moveToNextAndExpect("Foo", "{0, 3}");
+
+    moveToNextAndExpect("2", notFoundRange);
+    moveToNextAndExpect("Bar", "{1, 3}");
+
+    moveToNextAndExpect("a", notFoundRange);
+    moveToNextAndExpect("Bar the second", "{0, 2}");
+    // Only expect the row range to be exposed for the first child in a list item.
+    moveToNextAndExpect("Press", notFoundRange);
+    moveToNextAndExpect("Last text", notFoundRange);
+
+    moveToNextAndExpect("b", notFoundRange);
+    moveToNextAndExpect("Bar the third", "{1, 2}");
+
+    moveToNextAndExpect("3", notFoundRange);
+    moveToNextAndExpect("Baz", "{2, 3}");
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
#### c47810c96653e409246f47ca21e5d8dcd548b9e2
<pre>
AX: Expose accessibilityRowRange for the first child of list items
<a href="https://bugs.webkit.org/show_bug.cgi?id=285762">https://bugs.webkit.org/show_bug.cgi?id=285762</a>
<a href="https://rdar.apple.com/142699051">rdar://142699051</a>

Reviewed by Chris Fleizach.

This allows assistive technologies to provide positional information for list items (e.g. &quot;foo, 1 of 3&quot;), matching macOS.
Only expose a valid row range for the first child of a list item so that ATs don&apos;t repeatedly output this information
when there are lots of things packed into the list item.

* LayoutTests/accessibility/ios-simulator/list-item-row-range-expected.txt: Added.
* LayoutTests/accessibility/ios-simulator/list-item-row-range.html: Added.
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper tableCellParent]):
(-[WebAccessibilityObjectWrapper accessibilityRowRange]):

Canonical link: <a href="https://commits.webkit.org/288767@main">https://commits.webkit.org/288767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff872d23fb8abc347d73cf84d82b906cdc671f4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89312 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35245 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65516 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23359 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45809 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2909 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30773 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34294 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90694 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11503 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8354 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73982 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73172 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18123 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17488 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15934 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2868 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11455 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16931 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11304 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14780 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->