### PR TITLE
Import more WPT tests into css-display

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/empty-text-baseline-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/empty-text-baseline-001-expected.txt
@@ -1,0 +1,7 @@
+x
+x
+
+PASS Empty second line in #inner does not generate baseline for #span
+PASS Empty second line in #inner does not generate baseline for #span with white-space: pre-line
+PASS Empty second line in #inner does not generate baseline for #span with white-space: pre
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/empty-text-baseline-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/empty-text-baseline-001.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: An Empty Text Node Should Not Generate a Baseline</title>
+<link rel="author" title="David Shin" href="mailto:dshin@mozilla.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#intro">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9606">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1855583">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+body {
+  margin: 0;
+}
+
+#container {
+  font-family: Ahem;
+}
+
+#inner {
+  display: inline-block;
+}
+</style>
+<div id="container"><div id="inner">x</div><span id="span">x</span></div>
+<script>
+const expected = span.offsetTop;
+
+// Force an empty text node on the second line of #inner
+inner.appendChild(document.createElement("br"));
+inner.appendChild(document.createTextNode(''));
+
+test(function() {
+  assert_equals(span.offsetTop, expected);
+}, "Empty second line in #inner does not generate baseline for #span");
+
+test(function() {
+  inner.style = "white-space: pre-line";
+  assert_equals(span.offsetTop, expected);
+}, "Empty second line in #inner does not generate baseline for #span with white-space: pre-line");
+
+test(function() {
+  inner.style = "white-space: pre";
+  assert_equals(span.offsetTop, expected);
+}, "Empty second line in #inner does not generate baseline for #span with white-space: pre");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/empty-text-baseline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/empty-text-baseline-002-expected.txt
@@ -1,0 +1,8 @@
+x
+x
+x
+x
+
+PASS Empty content pseudo-element does not generate baseline
+PASS Empty content pseudo-element does not generate baseline with white-space: pre
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/empty-text-baseline-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/empty-text-baseline-002.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: An Empty Text Node Should Not Generate a Baseline</title>
+<link rel="author" title="David Shin" href="mailto:dshin@mozilla.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#intro">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9606">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1855583">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+body {
+  margin: 0;
+}
+
+.ahem {
+  font-family: Ahem;
+}
+
+.with-pseudo::before, .with-pseudo::after {
+  content: "";
+  width: 4px;
+  height: 4px;
+  border: 2px solid;
+  background: orange;
+  display: inline-block;
+}
+
+.font-size::before, .font-size::after {
+  font-size: 100px;
+}
+
+.line-height::before, .line-height::after {
+  line-height: 10;
+}
+
+.empty-concat::before, .empty-concat::after {
+  content: "" "" "" "" "";
+}
+
+</style>
+<div id="reference" class="ahem">x</div>
+<div id="fs" class="ahem with-pseudo font-size">x</div>
+<div id="ba" class="ahem with-pseudo line-height">x</div>
+<div id="ec" class="ahem with-pseudo font-size empty-concat">x</div>
+<script>
+test(function() {
+  assert_equals(fs.offsetHeight, reference.offsetHeight);
+  assert_equals(ba.offsetHeight, reference.offsetHeight);
+  assert_equals(ec.offsetHeight, reference.offsetHeight);
+}, "Empty content pseudo-element does not generate baseline");
+
+test(function() {
+  const divs = [fs, ba, ec];
+  for (let d of divs) {
+    d.style = "white-space: pre";
+  }
+  assert_equals(fs.offsetHeight, reference.offsetHeight);
+  assert_equals(ba.offsetHeight, reference.offsetHeight);
+  assert_equals(ec.offsetHeight, reference.offsetHeight);
+}, "Empty content pseudo-element does not generate baseline with white-space: pre");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/w3c-import.log
@@ -15,6 +15,8 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-display/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/css/css-display/empty-text-baseline-001.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-display/empty-text-baseline-002.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-change-iframe-expected.xht
 /LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-change-iframe.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-change-object-iframe-expected.xht


### PR DESCRIPTION
#### e49c296a7f07372bb9cb7e534d97ce35b112c8a9
<pre>
Import more WPT tests into css-display
<a href="https://bugs.webkit.org/show_bug.cgi?id=285767">https://bugs.webkit.org/show_bug.cgi?id=285767</a>

Reviewed by Tim Nguyen.

Import more missing WPT tests into /web-platform-tests/css/css-display/

* LayoutTests/imported/w3c/web-platform-tests/css/css-display/empty-text-baseline-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/empty-text-baseline-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/empty-text-baseline-002-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/empty-text-baseline-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/288760@main">https://commits.webkit.org/288760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1e4e0c0362e775c5870f8861fe2909d7b380b91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89331 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35264 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65526 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23367 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45819 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30790 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34313 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73825 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31555 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90713 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11522 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8365 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-remove-from-document-networkState.html imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/73979 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11748 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73182 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17506 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15947 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2887 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13056 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11474 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11323 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14799 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->