### PR TITLE
[ Sequoia ] fast/table/col-and-colgroup-offsets.html is a constant failure.

### DIFF
--- a/LayoutTests/platform/mac-sonoma/fast/table/col-and-colgroup-offsets-expected.txt
+++ b/LayoutTests/platform/mac-sonoma/fast/table/col-and-colgroup-offsets-expected.txt
@@ -37,13 +37,13 @@ PASS document.getElementById("hasP").offsetWidth is 46
 PASS document.getElementById("columnThatShouldNotBeRendered").offsetWidth is 0
 
 Tests for offsetHeight:
-FAIL document.getElementById("productNo").parentNode.offsetHeight should be 108. Was 116.
-FAIL document.getElementById("productNo").offsetHeight should be 108. Was 116.
-FAIL document.getElementById("productName").offsetHeight should be 108. Was 116.
-FAIL document.getElementById("hasMAndHasNAndHasO").offsetHeight should be 108. Was 116.
-FAIL document.getElementById("hasMAndHasN").offsetHeight should be 108. Was 116.
-FAIL document.getElementById("hasO").offsetHeight should be 108. Was 116.
-FAIL document.getElementById("hasP").offsetHeight should be 108. Was 116.
+FAIL document.getElementById("productNo").parentNode.offsetHeight should be 111. Was 119.
+FAIL document.getElementById("productNo").offsetHeight should be 111. Was 119.
+FAIL document.getElementById("productName").offsetHeight should be 111. Was 119.
+FAIL document.getElementById("hasMAndHasNAndHasO").offsetHeight should be 111. Was 119.
+FAIL document.getElementById("hasMAndHasN").offsetHeight should be 111. Was 119.
+FAIL document.getElementById("hasO").offsetHeight should be 111. Was 119.
+FAIL document.getElementById("hasP").offsetHeight should be 111. Was 119.
 PASS document.getElementById("columnThatShouldNotBeRendered").offsetHeight is 0
 
 When borderCollapse == "collapse"
@@ -79,13 +79,13 @@ PASS document.getElementById("hasP").offsetWidth is 44
 PASS document.getElementById("columnThatShouldNotBeRendered").offsetWidth is 0
 
 Tests for offsetHeight:
-PASS document.getElementById("productNo").parentNode.offsetHeight is 88
-PASS document.getElementById("productNo").offsetHeight is 88
-PASS document.getElementById("productName").offsetHeight is 88
-PASS document.getElementById("hasMAndHasNAndHasO").offsetHeight is 88
-PASS document.getElementById("hasMAndHasN").offsetHeight is 88
-PASS document.getElementById("hasO").offsetHeight is 88
-PASS document.getElementById("hasP").offsetHeight is 88
+PASS document.getElementById("productNo").parentNode.offsetHeight is 91
+PASS document.getElementById("productNo").offsetHeight is 91
+PASS document.getElementById("productName").offsetHeight is 91
+PASS document.getElementById("hasMAndHasNAndHasO").offsetHeight is 91
+PASS document.getElementById("hasMAndHasN").offsetHeight is 91
+PASS document.getElementById("hasO").offsetHeight is 91
+PASS document.getElementById("hasP").offsetHeight is 91
 PASS document.getElementById("columnThatShouldNotBeRendered").offsetHeight is 0
 PASS successfullyParsed is true
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2443,9 +2443,6 @@ http/tests/media/fairplay/fps-mse-multi-key-renewal.html [ Pass Failure ]
 # Ventura doesn't support resampling when encoding to Opus, causing the test to fail.
 [ Ventura ] imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.html [ Failure ]
 
-# webkit.org/b/280424 [ Sequoia ] fast/table/col-and-colgroup-offsets.html is a constant failure.
-[ Sequoia+ ] fast/table/col-and-colgroup-offsets.html [ Failure ]
-
 webkit.org/b/257011 imported/w3c/web-platform-tests/css/css-text/hyphens/hyphenate-character-002.html [ ImageOnlyFailure ]
 
 # webkit.org/b/280646 [macOS Debug EWS] media/video-webkit-playsinline.html is a flaky crash


### PR DESCRIPTION
#### f97e84989be4a7e059b1130377129150870f13ca
<pre>
[ Sequoia ] fast/table/col-and-colgroup-offsets.html is a constant failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=280424">https://bugs.webkit.org/show_bug.cgi?id=280424</a>
<a href="https://rdar.apple.com/136772789">rdar://136772789</a>

Unreviewed rebaseline.

* LayoutTests/platform/mac-sonoma/fast/table/col-and-colgroup-offsets-expected.txt: Copied from LayoutTests/platform/mac/fast/table/col-and-colgroup-offsets-expected.txt.
* LayoutTests/platform/mac/TestExpectations: Remove expectation.
* LayoutTests/platform/mac/fast/table/col-and-colgroup-offsets-expected.txt:

Canonical link: <a href="https://commits.webkit.org/288816@main">https://commits.webkit.org/288816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5053b5584761a24f250a520c8dbcf9bae0a3da5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38817 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35523 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12123 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/89594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/23565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87558 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/76780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/3139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/31012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34571 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/31786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/90975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/11779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/90975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/12007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/72604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/90975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/16162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3217 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13085 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/11731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/11580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/15056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/13353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->