### PR TITLE
[Cocoa][MSE] Seeking to the end of X.com videos will never complete

### DIFF
--- a/LayoutTests/media/media-source/media-source-seek-past-end-expected.txt
+++ b/LayoutTests/media/media-source/media-source-seek-past-end-expected.txt
@@ -1,0 +1,29 @@
+This tests that when seeking and play into unbuffered time, currentTime doesn't appear to go backward.
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(videoSourceBuffer = source.addSourceBuffer(videoLoader.type()))
+RUN(audioSourceBuffer = source.addSourceBuffer(audioLoader.type()))
+-
+Load video sourceBuffer
+RUN(videoSourceBuffer.appendBuffer(videoLoader.initSegment()))
+RUN(videoSourceBuffer.appendBuffer(videoLoader.mediaSegment(0)))
+-
+Load audio sourceBuffer
+RUN(audioSourceBuffer.appendBuffer(audioLoader.initSegment()))
+RUN(audioSourceBuffer.appendBuffer(audioLoader.mediaSegment(0)))
+-
+Ensure video sourceBuffer is shorter
+RUN(minBuffered = Math.min(videoSourceBuffer.buffered.end(0), audioSourceBuffer.buffered.end(0)))
+RUN(audioSourceBuffer.remove(minBuffered, video.duration))
+RUN(videoSourceBuffer.remove(minBuffered - 0.01, video.duration))
+-
+Seek into the unbuffered video range; should timeout
+RUN(video.currentTime = video.duration)
+EXPECTED (video.seeking == 'true') OK
+-
+End loading; should cause seeked event to fire
+RUN(source.endOfStream())
+EVENT(seeked)
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-seek-past-end.html
+++ b/LayoutTests/media/media-source/media-source-seek-past-end.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-seek-past-end</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var loader;
+    var source;
+    var videoSourceBuffer;
+    var audioSourceBuffer;
+    var minBuffered;
+    var seekPromise;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    async function runTest() {
+        videoLoader = new MediaSourceLoader('content/test-fragmented-manifest.json');
+        await loaderPromise(videoLoader);
+
+        audioLoader = new MediaSourceLoader('content/test-48khz-manifest.json');
+        await loaderPromise(audioLoader);
+
+        findMediaElement();
+
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+        run('videoSourceBuffer = source.addSourceBuffer(videoLoader.type())');
+        run('audioSourceBuffer = source.addSourceBuffer(audioLoader.type())');
+        waitFor(video, 'error').then(failTest);
+
+        consoleWrite('-');
+        consoleWrite('Load video sourceBuffer');
+        run('videoSourceBuffer.appendBuffer(videoLoader.initSegment())');
+        await waitFor(videoSourceBuffer, 'update', true);
+        run('videoSourceBuffer.appendBuffer(videoLoader.mediaSegment(0))');
+        await waitFor(videoSourceBuffer, 'update', true);
+
+        consoleWrite('-');
+        consoleWrite('Load audio sourceBuffer');
+        run('audioSourceBuffer.appendBuffer(audioLoader.initSegment())');
+        await waitFor(audioSourceBuffer, 'update', true);
+        run('audioSourceBuffer.appendBuffer(audioLoader.mediaSegment(0))');
+        await waitFor(audioSourceBuffer, 'update', true);
+
+        consoleWrite('-');
+        consoleWrite('Ensure video sourceBuffer is shorter');
+        run('minBuffered = Math.min(videoSourceBuffer.buffered.end(0), audioSourceBuffer.buffered.end(0))');
+        run('audioSourceBuffer.remove(minBuffered, video.duration)');
+        await waitFor(audioSourceBuffer, 'update', true);
+        run('videoSourceBuffer.remove(minBuffered - 0.01, video.duration)');
+        await waitFor(videoSourceBuffer, 'update', true);
+
+        consoleWrite('-');
+        consoleWrite('Seek into the unbuffered video range; should timeout');
+        run('video.currentTime = video.duration');
+        seekPromise = waitFor(video, 'seeked');
+        await sleepFor(250);
+        testExpected('video.seeking', true);
+
+        consoleWrite('-');
+        consoleWrite('End loading; should cause seeked event to fire');
+        run('source.endOfStream()');
+        await seekPromise;
+
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    })
+    </script>
+</head>
+<body>
+    <div>
+        This tests that when seeking and play into unbuffered time, currentTime doesn't appear to go backward.
+    </div>
+    <video controls muted></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4258,6 +4258,8 @@ webkit.org/b/213783 webanimations/accelerated-animation-with-easing.html [ Failu
 
 webkit.org/b/216763 webrtc/captureCanvas-webrtc-software-h264-high.html [ Skip ] # Timeout
 
+webkit.org/b/285921 media/media-source/media-source-seek-past-end.html [ Failure ]
+
 # End: Common failures between GTK and WPE.
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -347,7 +347,10 @@ void SourceBufferPrivate::reenqueueMediaForTime(TrackBuffer& trackBuffer, TrackI
 {
     if (needsFlush == NeedsFlush::Yes)
         flush(trackID);
-    if (trackBuffer.reenqueueMediaForTime(time, timeFudgeFactor()))
+    bool isEnded = false;
+    if (RefPtr mediaSource = m_mediaSource.get())
+        isEnded = mediaSource->isEnded();
+    if (trackBuffer.reenqueueMediaForTime(time, timeFudgeFactor(), isEnded))
         provideMediaData(trackBuffer, trackID);
 }
 

--- a/Source/WebCore/platform/graphics/TrackBuffer.h
+++ b/Source/WebCore/platform/graphics/TrackBuffer.h
@@ -55,7 +55,7 @@ public:
     
     bool updateMinimumUpcomingPresentationTime();
     
-    bool reenqueueMediaForTime(const MediaTime&, const MediaTime& timeFudgeFactor);
+    bool reenqueueMediaForTime(const MediaTime&, const MediaTime& timeFudgeFactor, bool isEnded = false);
     MediaTime findSeekTimeForTargetTime(const MediaTime& targetTime, const MediaTime& negativeThreshold, const MediaTime& positiveThreshold);
     int64_t removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime);
     PlatformTimeRanges removeSamples(const DecodeOrderSampleMap::MapType&, ASCIILiteral);


### PR DESCRIPTION
#### e3ec66bc9646bfbd69446c491205765c530e8989
<pre>
[Cocoa][MSE] Seeking to the end of X.com videos will never complete
<a href="https://bugs.webkit.org/show_bug.cgi?id=285776">https://bugs.webkit.org/show_bug.cgi?id=285776</a>
<a href="https://rdar.apple.com/136845120">rdar://136845120</a>

Reviewed by Jean-Yves Avenard.

We already allow selections immediately before a buffered range to succeed; also
apply the same &quot;fudge factor&quot; to allow seeking just past the end of a buffered range.

* LayoutTests/media/media-source-seek-past-end-expected.txt: Added.
* LayoutTests/media/media-source-seek-past-end.html: Added.
* Source/WebCore/platform/graphics/TrackBuffer.cpp:

Canonical link: <a href="https://commits.webkit.org/288962@main">https://commits.webkit.org/288962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/912e52172e5fdede08fd90a4fcdcb5b6b554e759

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35742 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65916 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23744 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76968 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46189 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3305 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31180 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 22 flakes 2 failures; Uploaded test results; 21 flakes 3 failures; Compiled WebKit (warnings); layout-tests; Passed layout tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34817 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31985 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91206 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74392 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12257 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73517 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18234 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17888 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16331 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3478 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11982 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17422 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11816 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15310 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->