### PR TITLE
ResouceLoader should have a weak reference to its LocalFrame

### DIFF
--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -78,8 +78,8 @@
 #endif
 
 #undef RESOURCELOADER_RELEASE_LOG
-#define PAGE_ID (frame() && frame()->pageID() ? frame()->pageID()->toUInt64() : 0)
-#define FRAME_ID (frame() ? frame()->frameID().object().toUInt64() : 0)
+#define PAGE_ID (this->frame() && this->frame()->pageID() ? this->frame()->pageID()->toUInt64() : 0)
+#define FRAME_ID (this->frame() ? this->frame()->frameID().object().toUInt64() : 0)
 #define RESOURCELOADER_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", frameLoader=%p, resourceID=%" PRIu64 "] ResourceLoader::" fmt, this, PAGE_ID, FRAME_ID, frameLoader(), identifier() ? identifier()->toUInt64() : 0, ##__VA_ARGS__)
 #define RESOURCELOADER_RELEASE_LOG_FORWARDABLE(fmt, ...) RELEASE_LOG_FORWARDABLE(Network, fmt, PAGE_ID, FRAME_ID, identifier() ? identifier()->toUInt64() : 0, ##__VA_ARGS__)
 
@@ -154,25 +154,28 @@ void ResourceLoader::init(ResourceRequest&& clientRequest, CompletionHandler<voi
     
     m_loadTiming.markStartTime();
 
-    m_defersLoading = m_options.defersLoadingPolicy == DefersLoadingPolicy::AllowDefersLoading && m_frame->page()->defersLoading();
+    RefPtr frame = m_frame.get();
+    if (!frame)
+        return completionHandler(false);
+    m_defersLoading = m_options.defersLoadingPolicy == DefersLoadingPolicy::AllowDefersLoading && frame->page()->defersLoading();
 
-    if (m_options.securityCheck == SecurityCheckPolicy::DoSecurityCheck && !m_frame->document()->protectedSecurityOrigin()->canDisplay(clientRequest.url(), OriginAccessPatternsForWebProcess::singleton())) {
+    if (m_options.securityCheck == SecurityCheckPolicy::DoSecurityCheck && !frame->document()->protectedSecurityOrigin()->canDisplay(clientRequest.url(), OriginAccessPatternsForWebProcess::singleton())) {
         RESOURCELOADER_RELEASE_LOG("init: Cancelling load because it violates security policy.");
-        FrameLoader::reportLocalLoadFailed(protectedFrame().get(), clientRequest.url().string());
+        FrameLoader::reportLocalLoadFailed(frame.get(), clientRequest.url().string());
         releaseResources();
         return completionHandler(false);
     }
 
     if (!portAllowed(clientRequest.url())) {
         RESOURCELOADER_RELEASE_LOG("init: Cancelling load to a blocked port.");
-        FrameLoader::reportBlockedLoadFailed(*protectedFrame(), clientRequest.url());
+        FrameLoader::reportBlockedLoadFailed(*frame, clientRequest.url());
         releaseResources();
         return completionHandler(false);
     }
 
     if (isIPAddressDisallowed(clientRequest.url())) {
         RESOURCELOADER_RELEASE_LOG("init: Cancelling load to disallowed IP address.");
-        FrameLoader::reportBlockedLoadFailed(*protectedFrame(), clientRequest.url());
+        FrameLoader::reportBlockedLoadFailed(*frame, clientRequest.url());
         releaseResources();
         return completionHandler(false);
     }
@@ -183,10 +186,10 @@ void ResourceLoader::init(ResourceRequest&& clientRequest, CompletionHandler<voi
     // to pipe through that method, we need to make sure there is always both a 1st party for cookies set and
     // Same-Site info. See <https://bugs.webkit.org/show_bug.cgi?id=26391>.
     if (clientRequest.firstPartyForCookies().isNull()) {
-        if (RefPtr document = m_frame->document())
+        if (RefPtr document = frame->document())
             clientRequest.setFirstPartyForCookies(document->firstPartyForCookies());
     }
-    FrameLoader::addSameSiteInfoToRequestIfNeeded(clientRequest, m_frame->protectedDocument().get());
+    FrameLoader::addSameSiteInfoToRequestIfNeeded(clientRequest, frame->protectedDocument().get());
 
     willSendRequestInternal(WTFMove(clientRequest), ResourceResponse(), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](ResourceRequest&& request) mutable {
 
@@ -300,9 +303,10 @@ void ResourceLoader::setDefersLoading(bool defers)
 
 FrameLoader* ResourceLoader::frameLoader() const
 {
-    if (!m_frame)
+    RefPtr frame = m_frame.get();
+    if (!frame)
         return nullptr;
-    return &m_frame->loader();
+    return &frame->loader();
 }
 
 RefPtr<DocumentLoader> ResourceLoader::protectedDocumentLoader() const
@@ -316,14 +320,15 @@ void ResourceLoader::loadDataURL()
     ASSERT(url.protocolIsData());
 
     auto shouldValidatePadding = DataURLDecoder::ShouldValidatePadding::Yes;
-    if (RefPtr document = m_frame ? m_frame->document() : nullptr) {
+    RefPtr frame = m_frame.get();
+    if (RefPtr document = frame ? frame->document() : nullptr) {
         if (document->quirks().shouldDisableDataURLPaddingValidation())
             shouldValidatePadding = DataURLDecoder::ShouldValidatePadding::No;
     }
 
     DataURLDecoder::ScheduleContext scheduleContext;
 #if USE(COCOA_EVENT_LOOP)
-    if (RefPtr page = m_frame->page())
+    if (RefPtr page = frame ? frame->page() : nullptr)
         scheduleContext.scheduledPairs = *page->scheduledRunLoopPairs();
 #endif
     DataURLDecoder::decode(url, scheduleContext, shouldValidatePadding, [this, protectedThis = Ref { *this }, url](auto decodeResult) mutable {
@@ -473,9 +478,8 @@ void ResourceLoader::willSendRequestInternal(ResourceRequest&& request, const Re
 #endif
 
         protectedFrameLoader()->notifier().willSendRequest(this, request, redirectResponse);
-    }
-    else
-        InspectorInstrumentation::willSendRequest(protectedFrame().get(), *m_identifier, m_frame->loader().protectedDocumentLoader().get(), request, redirectResponse, protectedCachedResource().get(), this);
+    } else if (RefPtr frame = m_frame.get())
+        InspectorInstrumentation::willSendRequest(frame.get(), *m_identifier, frame->loader().protectedDocumentLoader().get(), request, redirectResponse, protectedCachedResource().get(), this);
 
 #if USE(QUICK_LOOK)
     if (m_documentLoader) {
@@ -557,9 +561,10 @@ bool ResourceLoader::shouldAllowResourceToAskForCredentials() const
 {
     if (m_canCrossOriginRequestsAskUserForCredentials)
         return true;
-    if (!m_frame)
+    RefPtr frame = m_frame.get();
+    if (!frame)
         return false;
-    RefPtr topFrame = dynamicDowncast<LocalFrame>(m_frame->tree().top());
+    RefPtr topFrame = dynamicDowncast<LocalFrame>(frame->tree().top());
     if (!topFrame)
         return false;
     RefPtr topDocument = topFrame->document();
@@ -576,8 +581,9 @@ void ResourceLoader::didBlockAuthenticationChallenge()
     m_wasAuthenticationChallengeBlocked = true;
     if (m_options.clientCredentialPolicy == ClientCredentialPolicy::CannotAskClientForCredentials)
         return;
-    if (m_frame && !shouldAllowResourceToAskForCredentials())
-        m_frame->protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Blocked "_s, m_request.url().stringCenterEllipsizedToLength(), " from asking for credentials because it is a cross-origin request."_s));
+    RefPtr frame = m_frame.get();
+    if (frame && !shouldAllowResourceToAskForCredentials())
+        frame->protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Blocked "_s, m_request.url().stringCenterEllipsizedToLength(), " from asking for credentials because it is a cross-origin request."_s));
 }
 
 void ResourceLoader::didReceiveResponse(const ResourceResponse& r, CompletionHandler<void()>&& policyCompletionHandler)
@@ -589,8 +595,9 @@ void ResourceLoader::didReceiveResponse(const ResourceResponse& r, CompletionHan
     // anything including possibly derefing this; one example of this is Radar 3266216.
     Ref protectedThis { *this };
 
-    if (r.usedLegacyTLS() && m_frame) {
-        if (RefPtr document = m_frame->document()) {
+    RefPtr frame = m_frame.get();
+    if (r.usedLegacyTLS() && frame) {
+        if (RefPtr document = frame->document()) {
             if (!document->usedLegacyTLS()) {
                 if (RefPtr page = document->page()) {
                     RESOURCELOADER_RELEASE_LOG("usedLegacyTLS:");
@@ -601,14 +608,14 @@ void ResourceLoader::didReceiveResponse(const ResourceResponse& r, CompletionHan
         }
     }
 
-    if (r.wasPrivateRelayed() && m_frame) {
-        if (RefPtr document = m_frame->document()) {
+    if (r.wasPrivateRelayed() && frame) {
+        if (RefPtr document = frame->document()) {
             if (!document->wasPrivateRelayed())
                 document->setWasPrivateRelayed(true);
         }
     }
 
-    logResourceResponseSource(protectedFrame().get(), r.source());
+    logResourceResponseSource(frame.get(), r.source());
 
     m_response = r;
 
@@ -643,7 +650,8 @@ void ResourceLoader::didReceiveBuffer(const FragmentedSharedBuffer& buffer, long
     // FIXME: If we get a resource with more than 2B bytes, this code won't do the right thing.
     // However, with today's computers and networking speeds, this won't happen in practice.
     // Could be an issue with a giant local file.
-    if (m_options.sendLoadCallbacks == SendCallbackPolicy::SendCallbacks && m_frame)
+    RefPtr frame = m_frame.get();
+    if (m_options.sendLoadCallbacks == SendCallbackPolicy::SendCallbacks && frame)
         protectedFrameLoader()->notifier().didReceiveData(this, buffer.makeContiguous(), static_cast<int>(encodedDataLength));
 
 #if ENABLE(CONTENT_EXTENSIONS)
@@ -703,8 +711,10 @@ void ResourceLoader::cleanupForError(const ResourceError& error)
     if (m_notifiedLoadComplete)
         return;
     m_notifiedLoadComplete = true;
-    if (m_options.sendLoadCallbacks == SendCallbackPolicy::SendCallbacks && m_identifier)
-        protectedFrameLoader()->notifier().didFailToLoad(this, error);
+    if (m_options.sendLoadCallbacks == SendCallbackPolicy::SendCallbacks && m_identifier) {
+        if (RefPtr frameLoader = this->frameLoader())
+            frameLoader->notifier().didFailToLoad(this, error);
+    }
 }
 
 void ResourceLoader::cancel()
@@ -853,7 +863,8 @@ bool ResourceLoader::shouldUseCredentialStorage()
     if (m_options.storedCredentialsPolicy != StoredCredentialsPolicy::Use)
         return false;
 
-    if (RefPtr page = m_frame->page()) {
+    RefPtr frame = m_frame.get();
+    if (RefPtr page = frame ? frame->page() : nullptr) {
         if (!page->canUseCredentialStorage())
             return false;
     }
@@ -868,7 +879,8 @@ bool ResourceLoader::isAllowedToAskUserForCredentials() const
         return false;
     if (!shouldAllowResourceToAskForCredentials())
         return false;
-    return m_options.credentials == FetchOptions::Credentials::Include || (m_options.credentials == FetchOptions::Credentials::SameOrigin && m_frame->document()->protectedSecurityOrigin()->canRequest(originalRequest().url(), OriginAccessPatternsForWebProcess::singleton()));
+    RefPtr frame = m_frame.get();
+    return m_options.credentials == FetchOptions::Credentials::Include || (m_options.credentials == FetchOptions::Credentials::SameOrigin && frame && frame->document()->protectedSecurityOrigin()->canRequest(originalRequest().url(), OriginAccessPatternsForWebProcess::singleton()));
 }
 
 bool ResourceLoader::shouldIncludeCertificateInfo() const
@@ -957,7 +969,8 @@ bool ResourceLoader::isPDFJSResourceLoad() const
     if (!m_request.url().protocolIs("webkit-pdfjs-viewer"_s))
         return false;
 
-    RefPtr document = frame() && frame()->ownerElement() ? &frame()->ownerElement()->document() : nullptr;
+    RefPtr frame = m_frame.get();
+    RefPtr document = frame && frame->ownerElement() ? &frame->ownerElement()->document() : nullptr;
     return document ? document->isPDFDocument() : false;
 #else
     return false;
@@ -966,13 +979,19 @@ bool ResourceLoader::isPDFJSResourceLoad() const
 
 RefPtr<LocalFrame> ResourceLoader::protectedFrame() const
 {
-    return m_frame;
+    return m_frame.get();
+}
+
+LocalFrame* ResourceLoader::frame() const
+{
+    return m_frame.get();
 }
 
 #if ENABLE(CONTENT_EXTENSIONS)
 ResourceMonitor* ResourceLoader::resourceMonitorIfExists()
 {
-    if (RefPtr document = m_frame ? m_frame->document() : nullptr)
+    RefPtr frame = m_frame.get();
+    if (RefPtr document = frame ? frame->document() : nullptr)
         return document->resourceMonitorIfExists();
     return nullptr;
 }

--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -164,7 +164,7 @@ public:
     void unschedule(WTF::SchedulePair&);
 #endif
 
-    LocalFrame* frame() const { return m_frame.get(); }
+    WEBCORE_EXPORT LocalFrame* frame() const;
     RefPtr<LocalFrame> protectedFrame() const;
 
     const ResourceLoaderOptions& options() const { return m_options; }
@@ -192,7 +192,7 @@ protected:
     virtual void willSendRequestInternal(ResourceRequest&&, const ResourceResponse& redirectResponse, CompletionHandler<void(ResourceRequest&&)>&&);
 
     RefPtr<ResourceHandle> m_handle;
-    RefPtr<LocalFrame> m_frame;
+    WeakPtr<LocalFrame> m_frame;
     RefPtr<DocumentLoader> m_documentLoader;
     ResourceResponse m_response;
     ResourceLoadTiming m_loadTiming;

--- a/Source/WebCore/loader/SubresourceIntegrity.cpp
+++ b/Source/WebCore/loader/SubresourceIntegrity.cpp
@@ -211,10 +211,16 @@ static std::optional<ResourceCryptographicDigest::Algorithm> findStrongestAlgori
 
 void reportHashesIfNeeded(const CachedResource& resource)
 {
-    if (!resource.loader() || !resource.loader()->frame() || !resource.loader()->frame()->document())
+    RefPtr loader = resource.loader();
+    if (!loader)
+        return;
+    RefPtr frame = loader->frame();
+    if (!frame)
+        return;
+    RefPtr document = frame->document();
+    if (!document)
         return;
 
-    RefPtr document = resource.loader()->frame()->document();
     auto csp = document->checkedContentSecurityPolicy();
     URL documentURL = document->url();
 

--- a/Source/WebCore/loader/cache/CachedFont.cpp
+++ b/Source/WebCore/loader/cache/CachedFont.cpp
@@ -73,10 +73,15 @@ void CachedFont::didAddClient(CachedResourceClient& client)
 
 FontParsingPolicy CachedFont::policyForCustomFont(const Ref<SharedBuffer>& data)
 {
-    if (!m_loader || !m_loader->frame())
+    RefPtr loader = m_loader;
+    if (!loader)
         return FontParsingPolicy::Deny;
 
-    return fontBinaryParsingPolicy(data->span(), m_loader->frame()->settings().downloadableBinaryFontTrustedTypes());
+    RefPtr frame = loader->frame();
+    if (!frame)
+        return FontParsingPolicy::Deny;
+
+    return fontBinaryParsingPolicy(data->span(), frame->settings().downloadableBinaryFontTrustedTypes());
 }
 
 void CachedFont::finishLoading(const FragmentedSharedBuffer* data, const NetworkLoadMetrics& metrics)


### PR DESCRIPTION
#### fa3e4b9a0f97e02aabb703c771847ab45b089ed5
<pre>
ResouceLoader should have a weak reference to its LocalFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=285780">https://bugs.webkit.org/show_bug.cgi?id=285780</a>
<a href="https://rdar.apple.com/142712762">rdar://142712762</a>

Reviewed by Pascoe.

There are occasional crashes caused by a ResourceLoader dropping the last
strong reference to a Frame, especially with site isolation enabled.
A ResourceLoader does not need to prevent a LocalFrame from being destroyed,
it was just written before WeakPtr and it needs a weak reference to the
LocalFrame.  It&apos;s ok if the LocalFrame is destroyed.  I added strong references
on the stack when using it, and null checks to fail gracefully if the
LocalFrame does not exist any more.

* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::init):
(WebCore::ResourceLoader::frameLoader const):
(WebCore::ResourceLoader::loadDataURL):
(WebCore::ResourceLoader::willSendRequestInternal):
(WebCore::ResourceLoader::shouldAllowResourceToAskForCredentials const):
(WebCore::ResourceLoader::didBlockAuthenticationChallenge):
(WebCore::ResourceLoader::didReceiveResponse):
(WebCore::ResourceLoader::didReceiveBuffer):
(WebCore::ResourceLoader::cleanupForError):
(WebCore::ResourceLoader::shouldUseCredentialStorage):
(WebCore::ResourceLoader::isAllowedToAskUserForCredentials const):
(WebCore::ResourceLoader::isPDFJSResourceLoad const):
(WebCore::ResourceLoader::protectedFrame const):
(WebCore::ResourceLoader::frame const):
(WebCore::ResourceLoader::resourceMonitorIfExists):
* Source/WebCore/loader/ResourceLoader.h:
(WebCore::ResourceLoader::frame const): Deleted.
* Source/WebCore/loader/SubresourceIntegrity.cpp:
(WebCore::reportHashesIfNeeded):
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::willSendRequestInternal):
(WebCore::SubresourceLoader::didReceiveResponse):
(WebCore::SubresourceLoader::didFail):
* Source/WebCore/loader/cache/CachedFont.cpp:
(WebCore::CachedFont::policyForCustomFont):

Canonical link: <a href="https://commits.webkit.org/288750@main">https://commits.webkit.org/288750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1ad7370df00bd4517328cde6db1cc71ad88eb64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89364 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35295 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86371 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65562 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23390 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30820 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34344 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90744 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74005 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11780 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72415 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73207 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17530 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15977 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2918 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13047 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11505 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16981 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11354 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14830 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13127 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->