### PR TITLE
REGRESSION (284795@main): [iOS] Find on Page buttons do not move to next result on pdfbooksworld.com

### DIFF
--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2683,7 +2683,7 @@ void FrameSelection::revealSelection(SelectionRevealMode revealMode, const Scrol
     // FIXME: This code only handles scrolling the startContainer's layer, but
     // the selection rect could intersect more than just that.
     // See <rdar://problem/4799899>.
-    m_document->frame()->view()->setWasScrolledByUser(true);
+    m_document->frame()->view()->setLastUserScrollType(LocalFrameView::UserScrollType::Implicit);
     LocalFrameView::scrollRectToVisible(rect, *start.deprecatedNode()->renderer(), insideFixed, { revealMode, alignment, alignment, ShouldAllowCrossOriginScrolling::Yes, scrollBehavior });
     updateAppearance();
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2654,7 +2654,7 @@ void FrameLoader::open(CachedFrameBase& cachedFrame)
     // When navigating to a CachedFrame its FrameView should never be null.  If it is we'll crash in creative ways downstream.
     ASSERT(view);
     if (RefPtr localView = dynamicDowncast<LocalFrameView>(view.get()))
-        localView->setWasScrolledByUser(false);
+        localView->setLastUserScrollType(std::nullopt);
 
     Ref frame = m_frame.get();
     std::optional<IntRect> previousViewFrameRect = frame->view() ?  frame->view()->frameRect() : std::optional<IntRect>(std::nullopt);
@@ -4297,7 +4297,7 @@ void FrameLoader::loadSameDocumentItem(HistoryItem& item)
     // FIXME: Does form state need to be saved here too?
     history->saveScrollPositionAndViewStateToItem(history->protectedCurrentItem().get());
     if (RefPtr view = frame->view())
-        view->setWasScrolledByUser(false);
+        view->setLastUserScrollType(std::nullopt);
 
     history->setCurrentItem(item);
         

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -621,7 +621,7 @@ void HistoryController::recursiveUpdateForCommit()
         saveScrollPositionAndViewStateToItem(protectedCurrentItem().get());
 
         if (RefPtr view = m_frame->view())
-            view->setWasScrolledByUser(false);
+            view->setLastUserScrollType(std::nullopt);
 
         // Now commit the provisional item
         if (RefPtr provisionalItem = m_provisionalItem) {

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4976,7 +4976,7 @@ void EventHandler::scheduleScrollEvent()
 void EventHandler::setFrameWasScrolledByUser()
 {
     if (RefPtr view = m_frame->view())
-        view->setWasScrolledByUser(true);
+        view->setLastUserScrollType(LocalFrameView::UserScrollType::Explicit);
 }
 
 bool EventHandler::passMousePressEventToScrollbar(MouseEventWithHitTestResults& mouseEventAndResult, Scrollbar* scrollbar)

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -392,7 +392,9 @@ public:
     WEBCORE_EXPORT void updateControlTints();
 
     WEBCORE_EXPORT bool wasScrolledByUser() const;
-    WEBCORE_EXPORT void setWasScrolledByUser(bool);
+
+    enum class UserScrollType : uint8_t { Explicit, Implicit };
+    WEBCORE_EXPORT void setLastUserScrollType(std::optional<UserScrollType>);
 
     bool safeToPropagateScrollToParent() const;
 
@@ -1044,6 +1046,8 @@ private:
 
     std::unique_ptr<ScrollAnchoringController> m_scrollAnchoringController;
 
+    std::optional<UserScrollType> m_lastUserScrollType;
+
     bool m_shouldUpdateWhileOffscreen { true };
     bool m_canHaveScrollbars { true };
     bool m_cannotBlitToWindow { false };
@@ -1057,7 +1061,6 @@ private:
 #endif
 
     bool m_isTrackingRepaints { false }; // Used for testing.
-    bool m_wasScrolledByUser { false };
     bool m_shouldScrollToFocusedElement { false };
 
     bool m_isPainting { false };

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1830,7 +1830,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
 {
     ASSERT(WebThreadIsLockedOrDisabled());
     if (auto* view = _private->coreFrame->view())
-        view->setWasScrolledByUser(true);
+        view->setLastUserScrollType(WebCore::LocalFrameView::UserScrollType::Explicit);
 }
 
 - (NSString *)stringByEvaluatingJavaScriptFromString:(NSString *)string forceUserGesture:(BOOL)forceUserGesture

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm
@@ -890,6 +890,20 @@ TEST(WebKit, ScrollToFoundRangeAtTopWithObscuredContentInsets)
     EXPECT_TRUE(CGPointEqualToPoint([webView scrollView].contentOffset, initialContentOffset));
 }
 
+TEST(WebKit, ScrollToFoundRangeInNonScrollableIframe)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 400)]);
+    [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width,initial-scale=1'><iframe id='frame' scrolling='no' srcdoc='<style> p { margin-bottom: 800px; } </style><p>Top</p><p>Bottom</p>'></iframe>"];
+
+    EXPECT_WK_STREQ("0", [webView stringByEvaluatingJavaScript:@"document.getElementById('frame').contentWindow.scrollY"]);
+
+    RetainPtr ranges = textRangesForQueryString(webView.get(), @"Bottom");
+    [webView scrollRangeToVisible:[ranges firstObject] inDocument:nil];
+
+    TestWebKitAPI::Util::runFor(500_ms);
+    EXPECT_WK_STREQ("771", [webView stringByEvaluatingJavaScript:@"document.getElementById('frame').contentWindow.scrollY"]);
+}
+
 TEST(WebKit, CannotHaveMultipleFindOverlays)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);


### PR DESCRIPTION
#### 4a615c7a8d08c08f33cfecb389b06619ecb36fd8
<pre>
REGRESSION (284795@main): [iOS] Find on Page buttons do not move to next result on pdfbooksworld.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=285777">https://bugs.webkit.org/show_bug.cgi?id=285777</a>
<a href="https://rdar.apple.com/142585912">rdar://142585912</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

284795@main marked scrolling due to selection revealing as a &quot;user scroll&quot;, to
avoid jumpiness on back navigation, when the user has made a selection.

However, simply marking selection revealing as a user scroll breaks scrolling
to reveal found matches in &lt;iframe&gt;s with scrolling=&quot;no&quot;. This is due to an
early return in `LocalFrameView::scrollRectToVisibleInChildView`, since the
user cannot actually scroll the frame through interaction, when scrolling=&quot;no&quot;.

To preserve the fix in 284795@main, without breaking find on page, split user
scrolls into explicit (driven by interaction) and implicit (as the result of
performing another action). Then, `scrollRectToVisibleInChildView` is only
made to bail early if the last user scroll was explicit. This ensures that
&lt;iframe&gt;s with scrolling=&quot;no&quot; can continue to be scrolled for the purposes of
revealing found matches.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::revealSelection):

Scrolling due to selection revealing continue to be marked as user scrolls
for the purpose of preserving the fix in 284795@main. However, they are
marked &quot;implicit&quot;, since the user is not scrolling via interaction.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::open):
(WebCore::FrameLoader::loadSameDocumentItem):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::recursiveUpdateForCommit):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::setFrameWasScrolledByUser):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::reset):
(WebCore::LocalFrameView::scrollRectToVisibleInChildView):

Only ignore scrolls due to user interaction when scrolling=&quot;no&quot;.

(WebCore::LocalFrameView::enableSpeculativeTilingIfNeeded):
(WebCore::LocalFrameView::show):
(WebCore::LocalFrameView::wasScrolledByUser const):
(WebCore::LocalFrameView::setLastUserScrollType):
(WebCore::LocalFrameView::setWasScrolledByUser): Deleted.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _userScrolled]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(TEST(WebKit, ScrollToFoundRangeInNonScrollableIframe)):

Canonical link: <a href="https://commits.webkit.org/288765@main">https://commits.webkit.org/288765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fe957a4d57339ca7a77d2f292f9c4838d970b5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89360 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35291 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65552 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23386 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/2996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76582 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45845 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2947 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30812 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34340 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90740 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8426 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74004 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11776 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73206 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17526 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15969 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2914 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13060 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11501 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16977 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11350 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14826 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->