### PR TITLE
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/graphics

### DIFF
--- a/Source/WebCore/platform/graphics/Region.h
+++ b/Source/WebCore/platform/graphics/Region.h
@@ -91,13 +91,8 @@ public:
         bool isRect() const { return m_spans.size() <= 2 && m_segments.size() <= 2; }
         unsigned gridSize() const { return m_spans.size() * m_segments.size(); }
 
-        typedef const Span* SpanIterator;
-        SpanIterator spans_begin() const;
-        SpanIterator spans_end() const;
-
-        typedef const int* SegmentIterator;
-        SegmentIterator segments_begin(SpanIterator) const;
-        SegmentIterator segments_end(SpanIterator) const;
+        std::span<const Span> spans() const { return m_spans.span(); }
+        std::span<const int> segments(std::span<const Span>) const;
 
         static Shape unionShapes(const Shape& shape1, const Shape& shape2);
         static Shape intersectShapes(const Shape& shape1, const Shape& shape2);
@@ -125,10 +120,10 @@ public:
         static Shape shapeOperation(const Shape& shape1, const Shape& shape2);
 
         void appendSpan(int y);
-        void appendSpan(int y, SegmentIterator begin, SegmentIterator end);
-        void appendSpans(const Shape&, SpanIterator begin, SpanIterator end);
+        void appendSpan(int y, std::span<const int> segments);
+        void appendSpans(const Shape&, std::span<const Span> spans);
 
-        bool canCoalesce(SegmentIterator begin, SegmentIterator end);
+        bool canCoalesce(std::span<const int> segments);
 
         Vector<int, 32> m_segments;
         Vector<Span, 16> m_spans;

--- a/Source/WebCore/platform/graphics/SurrogatePairAwareTextIterator.h
+++ b/Source/WebCore/platform/graphics/SurrogatePairAwareTextIterator.h
@@ -23,8 +23,6 @@
 #include <unicode/utf16.h>
 #include <wtf/text/WTFString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 class SurrogatePairAwareTextIterator {
@@ -32,7 +30,7 @@ public:
     // The passed in UChar pointer starts at 'currentIndex'. The iterator operates on the range [currentIndex, lastIndex].
     // 'endIndex' denotes the maximum length of the UChar array, which might exceed 'lastIndex'.
     SurrogatePairAwareTextIterator(std::span<const UChar> characters, unsigned currentIndex, unsigned lastIndex)
-        : m_characters(characters.data())
+        : m_characters(characters)
         , m_currentIndex(currentIndex)
         , m_originalIndex(currentIndex)
         , m_lastIndex(lastIndex)
@@ -47,7 +45,8 @@ public:
 
         auto relativeIndex = m_currentIndex - m_originalIndex;
         clusterLength = 0;
-        U16_NEXT(&m_characters[relativeIndex], clusterLength, m_endIndex - m_currentIndex, character);
+        auto spanAtRelativeIndex = m_characters.subspan(relativeIndex);
+        U16_NEXT(spanAtRelativeIndex, clusterLength, m_endIndex - m_currentIndex, character);
         return true;
     }
 
@@ -63,17 +62,17 @@ public:
         m_currentIndex = index;
     }
 
-    const UChar* remainingCharacters() const
+    std::span<const UChar> remainingCharacters() const
     {
         auto relativeIndex = m_currentIndex - m_originalIndex;
-        return m_characters + relativeIndex;
+        return m_characters.subspan(relativeIndex);
     }
 
     unsigned currentIndex() const { return m_currentIndex; }
-    const UChar* characters() const { return m_characters; }
+    std::span<const UChar> characters() const { return m_characters; }
 
 private:
-    const UChar* const m_characters { nullptr };
+    std::span<const UChar> m_characters;
     unsigned m_currentIndex { 0 };
     const unsigned m_originalIndex { 0 };
     const unsigned m_lastIndex { 0 };
@@ -81,5 +80,3 @@ private:
 };
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/UnitBezier.h
+++ b/Source/WebCore/platform/graphics/UnitBezier.h
@@ -28,8 +28,6 @@
 
 #include <math.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
     struct UnitBezier {
@@ -180,10 +178,8 @@ namespace WebCore {
         double startGradient;
         double endGradient;
 
-        double splineSamples[CUBIC_BEZIER_SPLINE_SAMPLES];
+        std::array<double, CUBIC_BEZIER_SPLINE_SAMPLES> splineSamples;
     };
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WebCore/platform/graphics/VelocityData.cpp
+++ b/Source/WebCore/platform/graphics/VelocityData.cpp
@@ -29,8 +29,6 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HistoricalVelocityData);
@@ -88,5 +86,3 @@ TextStream& operator<<(TextStream& ts, const VelocityData& velocityData)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/VelocityData.h
+++ b/Source/WebCore/platform/graphics/VelocityData.h
@@ -83,7 +83,8 @@ private:
         MonotonicTime timestamp;
         FloatPoint position;
         double scale;
-    } m_positionHistory[maxHistoryDepth];
+    };
+    std::array<Data, maxHistoryDepth> m_positionHistory;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 04745f32fe682525984a6ccc94dddad7a490decb
<pre>
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/graphics
<a href="https://bugs.webkit.org/show_bug.cgi?id=285781">https://bugs.webkit.org/show_bug.cgi?id=285781</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/graphics/Region.cpp:
(WebCore::Region::rects const):
(WebCore::Region::contains const):
(WebCore::Region::Shape::compareShapes):
(WebCore::Region::Shape::canCoalesce):
(WebCore::Region::Shape::appendSpan):
(WebCore::Region::Shape::appendSpans):
(WebCore::Region::Shape::segments const):
(WebCore::operator&lt;&lt;):
(WebCore::Region::Shape::bounds const):
(WebCore::Region::Shape::shapeOperation):
(WebCore::Region::Shape::spans_begin const): Deleted.
(WebCore::Region::Shape::spans_end const): Deleted.
(WebCore::Region::Shape::segments_begin const): Deleted.
(WebCore::Region::Shape::segments_end const): Deleted.
* Source/WebCore/platform/graphics/Region.h:
(WebCore::Region::Shape::spans const):
* Source/WebCore/platform/graphics/SurrogatePairAwareTextIterator.h:
(WebCore::SurrogatePairAwareTextIterator::SurrogatePairAwareTextIterator):
(WebCore::SurrogatePairAwareTextIterator::consume):
(WebCore::SurrogatePairAwareTextIterator::remainingCharacters const):
(WebCore::SurrogatePairAwareTextIterator::characters const):
* Source/WebCore/platform/graphics/UnitBezier.h:
* Source/WebCore/platform/graphics/VelocityData.cpp:
* Source/WebCore/platform/graphics/VelocityData.h:

Canonical link: <a href="https://commits.webkit.org/288756@main">https://commits.webkit.org/288756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99e584962b60afce8f6787b279c07b4519d756ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89401 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35332 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11922 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65581 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23415 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3025 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/76613 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45874 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30843 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34381 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90782 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11590 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74030 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11817 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72438 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73228 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17557 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16000 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2955 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13053 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11542 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17018 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11391 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14867 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->