### PR TITLE
Improve DisplayList logging to show some errors

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
@@ -232,5 +232,16 @@ TextStream& operator<<(TextStream& ts, const Item& item)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, StopReplayReason reason)
+{
+    switch (reason) {
+    case StopReplayReason::ReplayedAllItems: ts << "ReplayedAllItems"; break;
+    case StopReplayReason::MissingCachedResource: ts << "MissingCachedResource"; break;
+    case StopReplayReason::InvalidItemOrExtent: ts << "InvalidItemOrExtent"; break;
+    case StopReplayReason::OutOfMemory: ts << "OutOfMemory"; break;
+    }
+    return ts;
+}
+
 } // namespace DisplayList
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.h
@@ -232,6 +232,7 @@ bool shouldDumpItem(const Item&, OptionSet<AsTextFlag>);
 WEBCORE_EXPORT void dumpItem(TextStream&, const Item&, OptionSet<AsTextFlag>);
 
 WEBCORE_EXPORT TextStream& operator<<(TextStream&, const Item&);
+WEBCORE_EXPORT TextStream& operator<<(TextStream&, StopReplayReason);
 
 } // namespace DisplayList
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.cpp
@@ -68,6 +68,7 @@ ReplayResult Replayer::replay(const FloatRect& initialClip, bool trackReplayList
         if (applyResult.stopReason) {
             result.reasonForStopping = *applyResult.stopReason;
             result.missingCachedResourceIdentifier = WTFMove(applyResult.resourceIdentifier);
+            LOG_WITH_STREAM(DisplayLists, stream << " failed to replay for reason " << result.reasonForStopping << ". Resource " << result.missingCachedResourceIdentifier << " is missing");
             break;
         }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -595,8 +595,10 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(ImageBuffer& imageBuffer)
         return false;
     }
 
-    if (!renderingBackend->isCached(imageBuffer))
+    if (!renderingBackend->isCached(imageBuffer)) {
+        LOG_WITH_STREAM(DisplayLists, stream << "RemoteDisplayListRecorderProxy::recordResourceUse - failed to record use of image buffer " << imageBuffer.renderingResourceIdentifier());
         return false;
+    }
 
     renderingBackend->remoteResourceCacheProxy().recordImageBufferUse(imageBuffer);
     return true;


### PR DESCRIPTION
#### b739c3d3e7fd311c29301a22a42b77af4b4bae02
<pre>
Improve DisplayList logging to show some errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=285782">https://bugs.webkit.org/show_bug.cgi?id=285782</a>
<a href="https://rdar.apple.com/142715101">rdar://142715101</a>

Reviewed by Cameron McCormack.

Log when we fail to cache an ImageBuffer resource, and when replay fails.

* Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp:
(WebCore::DisplayList::operator&lt;&lt;):
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListReplayer.cpp:
(WebCore::DisplayList::Replayer::replay):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordResourceUse):

Canonical link: <a href="https://commits.webkit.org/288745@main">https://commits.webkit.org/288745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80d6457dd58fbaac9acf3b560ea40741374db6e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89367 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35298 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86374 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/3998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11887 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23389 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87335 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/2999 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76586 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2950 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30816 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34347 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90747 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11556 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74007 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72411 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18112 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17531 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15973 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11508 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16984 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11357 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14833 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13130 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->