### PR TITLE
Build fix: [WebKit] Avoid running "Generate Derived Sources" in installhdrs phases

### DIFF
--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -1,3 +1,5 @@
+#include <TargetConditionals.h>
+
 framework module WebKit_Private [system] {
   umbrella header "WebKitPrivate.h"
   export *
@@ -2129,7 +2131,9 @@ framework module WebKit_Private [system] {
     export *
   }
 
-#if ENABLE(IOS_TOUCH_EVENTS)
+  // Inlined spelling of ENABLE(IOS_TOUCH_EVENTS), so that this file can be preprocessed without
+  // needing WTF headers installed.
+#if TARGET_OS_IPHONE && __has_include(<CoreFoundation/CFPriv.h>)
   explicit module WebEventRegion {
     header "WebEventRegion.h"
     export *

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -19279,7 +19279,6 @@
 		DD6BF6292D2F4DC200B9A084 /* Unifdef module.private.modulemap */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
-			dependencyFile = "$(DERIVED_FILES_DIR)/$(WK_MODULEMAP_PRIVATE_FILE:file).d";
 			files = (
 			);
 			inputFileListPaths = (
@@ -19295,7 +19294,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "xcrun clang -E -P -w -include wtf/Platform.h -I \"${BUILT_PRODUCTS_DIR}/${WK_LIBRARY_HEADERS_FOLDER_PATH}\" -I \"${SDK_DIR}${SYSTEM_PREFIX}${WK_LIBRARY_HEADERS_FOLDER_PATH}\" -MMD -MF \"${DERIVED_FILES_DIR}/$(basename \"${SCRIPT_INPUT_FILE_0}\").d\" - < \"${SCRIPT_INPUT_FILE_0}\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = "xcrun clang -E -P -w -target ${ARCHS%% *}-${LLVM_TARGET_TRIPLE_VENDOR}-${LLVM_TARGET_TRIPLE_OS_VERSION}${LLVM_TARGET_TRIPLE_SUFFIX} - < \"${SCRIPT_INPUT_FILE_0}\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 		};
 		DDC907B5298B2DE800ECA4D6 /* Migrate WebCore and WebKitLegacy Headers */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
#### e2deac204edc265c3c3c86598a1fb73f24edbeb3
<pre>
Build fix: [WebKit] Avoid running &quot;Generate Derived Sources&quot; in installhdrs phases
<a href="https://bugs.webkit.org/show_bug.cgi?id=285641">https://bugs.webkit.org/show_bug.cgi?id=285641</a>
<a href="https://rdar.apple.com/142713320">rdar://142713320</a>

Unreviewed.

The added script phase that runs WebKit&apos;s modulemap through the
preprocessor was not passing a -target argument. So, the preprocessor
was using the default target, which caused ENABLE(IOS_TOUCH_EVENTS) to
be false for Catalyst. Fix by passing this argument.

To go a step further, inline the ENABLE(IOS_TOUCH_EVENTS) definition, so
that the modulemap doesn&apos;t depend on wtf/Platform.h at all. This avoids
an installhdrs dependency on WTF altogether.

* Source/WebKit/Modules/iOS_Private.modulemap:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/288747@main">https://commits.webkit.org/288747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0168a743b2131999432139b1d140b53557217cfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89381 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35312 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11901 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/23400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87349 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3009 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76598 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/45861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2960 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34361 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90761 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11570 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74014 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11797 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72423 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18116 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17541 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/15985 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/2935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11522 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/16998 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11371 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14847 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13144 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->