### PR TITLE
[Mac] Unable to unpause video using "play/pause" keyboard key on Chess.com

### DIFF
--- a/LayoutTests/media/remote-control-command-paused-with-webaudio-expected.txt
+++ b/LayoutTests/media/remote-control-command-paused-with-webaudio-expected.txt
@@ -1,0 +1,31 @@
+Test that the "seekToPlaybackPosition" remote control command works.
+
+
+RUN(video.src = findMediaFile("video", "content/test"))
+EVENT(canplay)
+RUN(audio.src = findMediaFile("audio", "content/test"))
+EVENT(canplay)
+RUN(context = new AudioContext())
+-
+Start the AudioContext
+RUN(context.resume())
+Promise resolved OK
+-
+Play then pause the audio element
+RUN(audio.play())
+EVENT(playing)
+RUN(audio.pause())
+EVENT(pause)
+-
+Play then pause the video element
+RUN(video.play())
+EVENT(playing)
+RUN(video.pause())
+EVENT(pause)
+-
+Send a "play" remote control command
+RUN(internals.postRemoteControlCommand('play'))
+EVENT(play)
+EXPECTED (event.target === video == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/remote-control-command-paused-with-webaudio.html
+++ b/LayoutTests/media/remote-control-command-paused-with-webaudio.html
@@ -1,0 +1,64 @@
+<html>
+<head>
+    <script src="media-file.js"></script>
+    <script src="video-test.js"></script>
+    <script>
+    audio = null;
+    context = null;
+    event = null;
+
+    async function runTest()
+    {
+        if (!window.internals) {
+            failTest('This test requires window.internals.');
+            return;
+        }
+
+        findMediaElement();
+        run('video.src = findMediaFile("video", "content/test")');
+        await waitFor(video, 'canplay');
+
+        audio = document.querySelector('audio');
+        run('audio.src = findMediaFile("audio", "content/test")');
+        await waitFor(audio, 'canplay');
+
+        run('context = new AudioContext()');
+
+        consoleWrite('-');
+        consoleWrite('Start the AudioContext');
+        await shouldResolve(run('context.resume()'));
+
+        consoleWrite('-');
+        consoleWrite('Play then pause the audio element');
+        run('audio.play()');
+        await waitFor(audio, 'playing');
+        run('audio.pause()');
+        await waitFor(audio, 'pause');
+
+        consoleWrite('-')
+        consoleWrite('Play then pause the video element');
+        run('video.play()');
+        await waitFor(video, 'playing');
+        run('video.pause()');
+        await waitFor(video, 'pause');
+
+        consoleWrite('-');
+        consoleWrite('Send a "play" remote control command');
+        run("internals.postRemoteControlCommand('play')");
+        waitFor(audio, 'play').then(failTest);
+        event = await waitFor(video, 'play');
+        testExpected('event.target === video', true);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+
+<body>
+    <p>Test that the "seekToPlaybackPosition" remote control command works.</p>
+    <video muted controls></video>
+    <audio muted></audio>
+</body>
+</html>

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -238,6 +238,7 @@ private:
     virtual void updateSessionState() { }
 
     Vector<WeakPtr<PlatformMediaSession>> sessionsMatching(const Function<bool(const PlatformMediaSession&)>&) const;
+    WeakPtr<PlatformMediaSession> firstSessionMatching(const Function<bool(const PlatformMediaSession&)>&) const;
 
 #if !RELEASE_LOG_DISABLED
     void scheduleStateLog();


### PR DESCRIPTION
#### 94e09d11c6cdfb523a550b6a91388d8b30100cfc
<pre>
[Mac] Unable to unpause video using &quot;play/pause&quot; keyboard key on Chess.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=285787">https://bugs.webkit.org/show_bug.cgi?id=285787</a>
<a href="https://rdar.apple.com/138120620">rdar://138120620</a>

Reviewed by Jean-Yves Avenard.

When a media element moves from a playing to paused state, PlatformMediaSessionManager
re-orders its list of active sessions. If there are any other playing sessions, the newly
paused session is moved to the end of the list of active sessions.

Separately, when a remote control command is received, that command is dispatched to the
first session in the list of active sessions. If that session does not support remote control
commands, the command is dropped.

On Chess.com, there are &gt;16 active sessions when a video is playing. Many are WebAudio sessions,
but some are HTMLAudioElement sessions used for sound effects. After pausing the video on the
page, that video&apos;s session is moved to the end of the list of active sessions, below all the
playing WebAudio sessions as well as the paused HTMLAudioElement sessions. When a remote control
command is subsequently received, it&apos;s dispatched to the WebAudio session, which drops it.

This fix has two parts:
- When a session is paused, it is moved in the session list just after the last playing session,
  rather than to the end of the list.
- When a remote control command is received, it&apos;s sent to the first session in the list of
  active sessions which supports remote control commands.

* LayoutTests/media/remote-control-command-paused-with-webaudio-expected.txt: Added.
* LayoutTests/media/remote-control-command-paused-with-webaudio.html: Added.
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::sessionWillEndPlayback):
(WebCore::PlatformMediaSessionManager::processDidReceiveRemoteControlCommand):
(WebCore::PlatformMediaSessionManager::firstSessionMatching const):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:

Canonical link: <a href="https://commits.webkit.org/288808@main">https://commits.webkit.org/288808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ac25644e002c7e9dcb3351c70f3fc20ebccfb3e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89402 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35333 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86409 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65579 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23416 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45872 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2975 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30844 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34382 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73869 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31612 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90783 "Hash 0ac25644 for PR 38883 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8417 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/90783 "Hash 0ac25644 for PR 38883 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11818 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72439 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/90783 "Hash 0ac25644 for PR 38883 does not build (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18148 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17556 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16001 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2956 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11543 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17019 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11392 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14868 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13165 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->