### PR TITLE
Make CheckedPtr / CheckedRef dereferencing safer

### DIFF
--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -110,12 +110,12 @@ public:
     ALWAYS_INLINE explicit operator bool() const { return PtrTraits::unwrap(m_ptr); }
 
     ALWAYS_INLINE T* get() const { return PtrTraits::unwrap(m_ptr); }
-    ALWAYS_INLINE T& operator*() const { ASSERT(m_ptr); return *get(); }
-    ALWAYS_INLINE T* operator->() const { return get(); }
+    ALWAYS_INLINE T& operator*() const { RELEASE_ASSERT(m_ptr); return *get(); }
+    ALWAYS_INLINE T* operator->() const { RELEASE_ASSERT(m_ptr); return get(); }
 
     CheckedRef<T> releaseNonNull()
     {
-        ASSERT(m_ptr);
+        RELEASE_ASSERT(m_ptr);
         auto& ptr = *PtrTraits::unwrap(std::exchange(m_ptr, nullptr));
         return CheckedRef { ptr, CheckedRef<T>::Adopt };
     }

--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -113,14 +113,18 @@ public:
 
     ALWAYS_INLINE T& get() const
     {
-        ASSERT(ptr());
+        RELEASE_ASSERT(m_ptr);
         return *ptr();
     }
 
-    ALWAYS_INLINE T* operator->() const { return ptr(); }
+    ALWAYS_INLINE T* operator->() const
+    {
+        RELEASE_ASSERT(m_ptr);
+        return ptr();
+    }
 
     ALWAYS_INLINE operator T&() const { return get(); }
-    ALWAYS_INLINE explicit operator bool() const { return get(); }
+    ALWAYS_INLINE explicit operator bool() const { return ptr(); }
 
     CheckedRef& operator=(T& reference)
     {


### PR DESCRIPTION
#### 00b2154f40135973fbf8bf313beb56797a5eeab7
<pre>
Make CheckedPtr / CheckedRef dereferencing safer
<a href="https://bugs.webkit.org/show_bug.cgi?id=285788">https://bugs.webkit.org/show_bug.cgi?id=285788</a>

Reviewed by Darin Adler.

Make CheckedPtr / CheckedRef dereferencing safer by RELEASE_ASSERT()
that the pointer is not null. This is important since null
dereferencing is undefined behavior.

This tested as performance neutral on Speedometer and JetStream.

* Source/WTF/wtf/CheckedPtr.h:
(WTF::CheckedPtr::operator* const):
* Source/WTF/wtf/CheckedRef.h:
(WTF::CheckedRef::get const):
(WTF::CheckedRef::operator-&gt; const):
(WTF::CheckedRef::operator bool const):

Canonical link: <a href="https://commits.webkit.org/288764@main">https://commits.webkit.org/288764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/944c35f6d951649351edfbf5072363aff674e004

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89400 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35331 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65582 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23418 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3026 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/76635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45875 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2977 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30845 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34380 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77286 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73871 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31613 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90781 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83339 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11589 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8416 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74031 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73229 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17558 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16002 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2954 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13059 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11541 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17017 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105758 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11390 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25529 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14866 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->