### PR TITLE
[Intelligence Effects] Remaining text doesn't shift down after proofreading if the line count changes

### DIFF
--- a/Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift
@@ -19,6 +19,7 @@ internal import UIKit_Private
 #endif
 
 import WebKitSwift
+internal import SwiftUI
 
 // MARK: Platform abstraction type aliases
 
@@ -31,6 +32,11 @@ typealias PlatformView = UIView
 typealias PlatformBounds = CGRect
 typealias PlatformTextPreview = UITargetedPreview
 #endif
+
+struct PlatformContentPreview {
+    let previewImage: CGImage?
+    let presentationFrame: CGRect
+}
 
 // MARK: Platform abstraction protocols
 
@@ -70,7 +76,7 @@ extension PlatformIntelligenceTextEffect {
     ///
     /// Clients must also take the responsibility of animating the remaining text away from the replaced text if needed, using
     /// the provided animation parameters.
-    func performReplacementAndGeneratePreview(for chunk: Chunk, effect: PlatformIntelligenceReplacementTextEffect<Chunk>, animation: PlatformIntelligenceReplacementTextEffect<Chunk>.AnimationParameters) async -> PlatformTextPreview?
+    func performReplacementAndGeneratePreview(for chunk: Chunk, effect: PlatformIntelligenceReplacementTextEffect<Chunk>) async -> (PlatformTextPreview?, remainder: PlatformContentPreview?)
 
     /// This function is invoked after preparing the replacement effect, but before the effect is added.
     func replacementEffectWillBegin(_ effect: PlatformIntelligenceReplacementTextEffect<Chunk>) async
@@ -187,7 +193,7 @@ private final class UIReplacementTextEffectTextChunkAdapter<Wrapped>: UITextEffe
     }
     
     func textPreview(for rect: CGRect) async -> _WTTextPreview? {
-        // FIXME: Implement this function so that subsequent text pieces animate out of the way if needed.
+        // This is implemented manually by the system instead of relying on the WTUI interface.
         nil
     }
 
@@ -315,13 +321,138 @@ struct PlatformIntelligenceTextEffectID: Hashable {
     }
 }
 
-/// A replacement effect, which essentially involves the original text fading away while at the same time the new text fades in right above it.
-@MainActor class PlatformIntelligenceReplacementTextEffect<Chunk>: PlatformIntelligenceTextEffect where Chunk: PlatformIntelligenceTextEffectChunk {
-    struct AnimationParameters {
-        let duration: TimeInterval
-        let delay: TimeInterval
+/// An effect which shifts the remaining text (the text after the currently replaced text) either up or down,
+/// depending on if the newly replaced text is taller than the source text.
+@MainActor class PlatformIntelligenceRemainderAffordanceTextEffect<Chunk>: PlatformIntelligenceTextEffect where Chunk: PlatformIntelligenceTextEffectChunk {
+    private enum AnimationKind {
+        case contract
+        case expand
     }
 
+    struct Previews {
+        let source: PlatformTextPreview
+        let destination: PlatformTextPreview
+        let remainder: PlatformContentPreview
+    }
+
+    let id = PlatformIntelligenceTextEffectID()
+    let chunk: Chunk
+    let previews: Previews
+
+    init(chunk: Chunk, previews: Previews) {
+        self.chunk = chunk
+        self.previews = previews
+    }
+
+    private static func animation(for kind: AnimationKind) -> SwiftUI.Animation {
+        // Empirically derived animation values, specifically ensuring that the text avoids being overlapped by the replacement animation.
+
+        switch kind {
+        case .contract: .easeInOut(duration: 0.4).delay(0.5)
+        case .expand: .bouncy(duration: 0.4).delay(0.2)
+        }
+    }
+
+    private func heightDelta() -> Double {
+#if canImport(UIKit)
+        let sourceRect = previews.source.size
+        let destRect = previews.destination.size
+
+        let delta = destRect.height - sourceRect.height
+#else
+        let sourceRect = previews.source
+            .map(\.presentationFrame)
+            .reduce(CGRect.zero) { $0.union($1) }
+
+        let destRect = previews.destination
+            .map(\.presentationFrame)
+            .reduce(CGRect.zero) { $0.union($1) }
+
+        let delta = destRect.size.height - sourceRect.size.height
+#endif
+
+        return delta
+    }
+
+    func _add<Source>(to view: PlatformIntelligenceTextEffectView<Source>) async where Source : PlatformIntelligenceTextEffectViewSource, Source.Chunk == Chunk {
+        guard let remainderPreviewImage = previews.remainder.previewImage else {
+            return
+        }
+
+        // Compute the difference in height between the original text and the replaced text.
+        let delta = heightDelta()
+
+        // Create two rects:
+        // 1. A source frame for the remainder of the text content before the text is replaced.
+        // 2. A destination frame for the remainder of the text content after the text is replaced.
+        //
+        // The y-coordinates are adjusted for AppKit to account for the origin being the bottom left instead of top left.
+
+        let remainderRect = previews.remainder.presentationFrame
+
+#if canImport(UIKit)
+        let remainderViewSourceFrameY = remainderRect.origin.y
+#else
+        // origin-y-coordinate is flipped in AppKit
+        let remainderViewSourceFrameY = view.frame.size.height - remainderRect.size.height - remainderRect.origin.y
+#endif
+
+        let remainderViewSourceFrame = CGRect(
+            x: remainderRect.origin.x,
+            y: remainderViewSourceFrameY,
+            width: remainderRect.size.width,
+            height: remainderRect.size.height
+        )
+
+#if canImport(UIKit)
+        // shift down if the replaced text is taller than the source text
+        let remainderViewDestFrameY = remainderViewSourceFrame.origin.y + delta
+#else
+        // shift down if the replaced text is taller than the source text
+        let remainderViewDestFrameY = remainderViewSourceFrame.origin.y - delta
+#endif
+
+        let remainderViewDestinationFrame = CGRect(
+            x: remainderViewSourceFrame.origin.x,
+            y: remainderViewDestFrameY,
+            width: remainderViewSourceFrame.size.width,
+            height: remainderViewSourceFrame.size.height
+        )
+
+        // Create an empty view with the source frame, and set its layer's contents to the image
+        // of the remaining text content.
+
+        let remainderView = PlatformView(frame: remainderViewSourceFrame)
+
+#if canImport(UIKit)
+        remainderView.layer.contents = remainderPreviewImage
+#else
+        remainderView.wantsLayer = true
+        remainderView.layer!.contents = remainderPreviewImage
+#endif
+
+        // Add the newly created view as a subview to the effect view.
+
+        view.addSubview(remainderView)
+
+        // Perform the animation to animate the frame to make room for the replaced text.
+        // This will run concurrently with the replacement effect, and it must not ever overlap with the effect.
+
+        let animation = Self.animation(for: delta > 0 ? .expand : .contract)
+        let changes = {
+            remainderView.frame = remainderViewDestinationFrame
+        }
+
+#if canImport(UIKit)
+        UIView.animate(animation, changes: changes)
+#else
+        NSAnimationContext.animate(animation, changes: changes)
+#endif
+    }
+}
+
+/// A replacement effect, which essentially involves the original text fading away while at the same time the new text fades in right above it.
+@MainActor class PlatformIntelligenceReplacementTextEffect<Chunk>: PlatformIntelligenceTextEffect where Chunk: PlatformIntelligenceTextEffectChunk {
     let id = PlatformIntelligenceTextEffectID()
     let chunk: Chunk
 
@@ -362,7 +493,9 @@ struct PlatformIntelligenceTextEffectID: Hashable {
 
         await view.source.updateTextChunkVisibility(self.chunk, visible: false)
 
-        guard let destinationPreview = await view.source.performReplacementAndGeneratePreview(for: self.chunk, effect: self, animation: .init(duration: 0, delay: 0)) else {
+        let (destinationPreview, remainderPreview) = await view.source.performReplacementAndGeneratePreview(for: self.chunk, effect: self)
+
+        guard let destinationPreview else {
             assertionFailure("Failed to generate destination text preview for replacement effect")
             return
         }
@@ -418,6 +551,14 @@ struct PlatformIntelligenceTextEffectID: Hashable {
         view.wrappedEffectIDToPlatformEffects[sourceEffectID] = self
         view.platformEffectIDToWrappedEffectIDs[self.id, default: []].insert(sourceEffectID)
 #endif
+
+        guard let remainderPreview else {
+            return
+        }
+
+        let previews = PlatformIntelligenceRemainderAffordanceTextEffect<Chunk>.Previews(source: sourcePreview, destination: destinationPreview, remainder: remainderPreview)
+        let remainderEffect = PlatformIntelligenceRemainderAffordanceTextEffect(chunk: chunk, previews: previews)
+        await remainderEffect._add(to: view)
     }
 }
 

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h
@@ -31,8 +31,9 @@
 #import <UIKit/UIKit.h>
 #else
 #import <AppKit/AppKit.h>
-#import <WebKit/_WKTextPreview.h>
 #endif
+
+#import <WebKit/_WKTextPreview.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -54,6 +55,8 @@ NS_SWIFT_UI_ACTOR
 #else
 - (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator textPreviewsForRange:(NSRange)range completion:(void (^)(NSArray<_WKTextPreview *> *))completion;
 #endif
+
+- (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator contentPreviewForRange:(NSRange)range completion:(void (^)(_WKTextPreview *))completion;
 
 - (void)intelligenceTextEffectCoordinator:(WKIntelligenceTextEffectCoordinator *)coordinator rectsForProofreadingSuggestionsInRange:(NSRange)range completion:(void (^)(NSArray<NSValue *> *))completion;
 


### PR DESCRIPTION
#### 1615acbb126895eb148ca2b625639a9c7c282399
<pre>
[Intelligence Effects] Remaining text doesn&apos;t shift down after proofreading if the line count changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=285789">https://bugs.webkit.org/show_bug.cgi?id=285789</a>
<a href="https://rdar.apple.com/142712429">rdar://142712429</a>

Reviewed by Wenson Hsieh.

If a Proofreading operation involves multiple &quot;chunks&quot;, the remaining text after each subsequent replacement
needs to be shifted vertically while the replacement animation is ongoing.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView intelligenceTextEffectCoordinator:contentPreviewForRange:completion:]):
* Source/WebKit/WebKitSwift/WritingTools/PlatformIntelligenceTextEffectView.swift:
(PlatformIntelligenceTextEffectViewSource.textPreview(for:)):
(PlatformIntelligenceTextEffectViewSource.performReplacementAndGeneratePreview(for:effect:animation:remainder:)):
(WTTextPreviewAsyncSourceAdapter.textPreview(for:)):
(Previews.heightDelta):
(PlatformIntelligenceTextEffectViewSource.performReplacementAndGeneratePreview(for:effect:animation:)): Deleted.
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.h:
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceTextEffectCoordinator.swift:
(requestReplacement(withProcessedRange:finished:characterDelta:operation:)):
(startReplacementAnimation(using:)):
(WKIntelligenceTextEffectCoordinator.textPreview(for:)):
(WKIntelligenceTextEffectCoordinator.performReplacementAndGeneratePreview(for:effect:animation:remainder:)):
(WKIntelligenceTextEffectCoordinator.replacementEffectWillBegin(_:)):
(platformTextPreview(from:)):
(WKIntelligenceTextEffectCoordinator.performReplacementAndGeneratePreview(for:effect:animation:)): Deleted.

Canonical link: <a href="https://commits.webkit.org/288781@main">https://commits.webkit.org/288781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6427ab63b3495b1b40d3040beea7cc4b2729b3bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89489 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35419 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12014 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/23486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87455 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/76690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/45935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/3051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/30921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34467 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/31691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90871 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11676 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74098 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11903 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/72514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/17631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/16076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/3076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13066 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11628 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11477 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14953 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13250 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->