### PR TITLE
Make type conversion explicit when using RectEdges

### DIFF
--- a/Source/WebCore/html/canvas/CanvasLayerContextSwitcher.cpp
+++ b/Source/WebCore/html/canvas/CanvasLayerContextSwitcher.cpp
@@ -71,7 +71,7 @@ GraphicsContext* CanvasLayerContextSwitcher::drawingContext() const
 
 FloatBoxExtent CanvasLayerContextSwitcher::outsets() const
 {
-    return protectedContext()->calculateFilterOutsets(m_bounds);
+    return toFloatBoxExtent(protectedContext()->calculateFilterOutsets(m_bounds));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -126,7 +126,7 @@ RefPtr<Filter> CanvasRenderingContext2D::createFilter(const FloatRect& bounds) c
 
     auto outsets = calculateFilterOutsets(bounds);
 
-    filter->setFilterRegion(bounds + outsets);
+    filter->setFilterRegion(bounds + toFloatBoxExtent(outsets));
     return filter;
 }
 

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -488,7 +488,7 @@ void InteractionRegionOverlay::drawSettings(GraphicsContext& context)
     for (unsigned i = 1; i < m_settings.size(); i++)
         rect.unite(rectForSettingAtIndex(i));
 
-    rect.expand(FloatBoxExtent { 4, 4, 4, 4 });
+    rect.expand(FloatBoxExtent { 4.0f, 4.0f, 4.0f, 4.0f });
 
     {
         GraphicsContextStateSaver stateSaver(context);

--- a/Source/WebCore/platform/FloatConversion.h
+++ b/Source/WebCore/platform/FloatConversion.h
@@ -49,6 +49,13 @@ namespace WebCore {
     {
         return static_cast<CGFloat>(number);
     }
+
+    template<typename T> constexpr float narrowPrecisionToFloatFromCGFloat(T);
+
+    template<> constexpr float narrowPrecisionToFloatFromCGFloat(CGFloat number)
+    {
+        return static_cast<CGFloat>(number);
+    }
 #endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/LengthBox.h
+++ b/Source/WebCore/platform/LengthBox.h
@@ -75,6 +75,16 @@ inline LayoutBoxExtent toLayoutBoxExtent(const IntBoxExtent& extent)
     return { extent.top(), extent.right(), extent.bottom(), extent.left() };
 }
 
+inline FloatBoxExtent toFloatBoxExtent(const IntBoxExtent& extent)
+{
+    return {
+        static_cast<float>(extent.top()),
+        static_cast<float>(extent.right()),
+        static_cast<float>(extent.bottom()),
+        static_cast<float>(extent.left()),
+    };
+}
+
 WTF::TextStream& operator<<(WTF::TextStream&, const LengthBox&);
 WTF::TextStream& operator<<(WTF::TextStream&, const IntBoxExtent&);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const FloatBoxExtent&);

--- a/Source/WebCore/platform/RectEdges.h
+++ b/Source/WebCore/platform/RectEdges.h
@@ -50,7 +50,7 @@ public:
 
     template<typename U>
     RectEdges(U&& top, U&& right, U&& bottom, U&& left)
-        : m_sides({ { std::forward<T>(top), std::forward<T>(right), std::forward<T>(bottom), std::forward<T>(left) } })
+        : m_sides({ { std::forward<U>(top), std::forward<U>(right), std::forward<U>(bottom), std::forward<U>(left) } })
     {
     }
 

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -120,7 +120,7 @@ bool SVGFEMorphologyElement::isIdentity() const
 IntOutsets SVGFEMorphologyElement::outsets(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits) const
 {
     auto radius = SVGFilter::calculateResolvedSize({ radiusX(), radiusY() }, targetBoundingBox, primitiveUnits);
-    return { radius.height(), radius.width(), radius.height(), radius.width() };
+    return { static_cast<int>(radius.height()), static_cast<int>(radius.width()), static_cast<int>(radius.height()), static_cast<int>(radius.width()) };
 }
 
 RefPtr<FilterEffect> SVGFEMorphologyElement::createFilterEffect(const FilterEffectVector&, const GraphicsContext&) const

--- a/Source/WebKit/Shared/gtk/PrintInfoGtk.cpp
+++ b/Source/WebKit/Shared/gtk/PrintInfoGtk.cpp
@@ -29,6 +29,7 @@
 #include <gtk/gtk.h>
 #if HAVE(GTK_UNIX_PRINTING)
 #include <gtk/gtkunixprint.h>
+#include <WebCore/FloatConversion.h>
 #endif
 
 namespace WebKit {
@@ -46,7 +47,7 @@ PrintInfo::PrintInfo(GtkPrintJob* job, PrintMode printMode)
     pageSetupScaleFactor = gtk_print_settings_get_scale(jobSettings.get()) / 100.0;
     availablePaperWidth = gtk_page_setup_get_paper_width(jobPageSetup.get(), GTK_UNIT_POINTS) - gtk_page_setup_get_left_margin(jobPageSetup.get(), GTK_UNIT_POINTS) - gtk_page_setup_get_right_margin(jobPageSetup.get(), GTK_UNIT_POINTS);
     availablePaperHeight = gtk_page_setup_get_paper_height(jobPageSetup.get(), GTK_UNIT_POINTS) - gtk_page_setup_get_top_margin(jobPageSetup.get(), GTK_UNIT_POINTS) - gtk_page_setup_get_bottom_margin(jobPageSetup.get(), GTK_UNIT_POINTS);
-    margin = { gtk_page_setup_get_top_margin(jobPageSetup.get(), GTK_UNIT_POINTS), gtk_page_setup_get_right_margin(jobPageSetup.get(), GTK_UNIT_POINTS), gtk_page_setup_get_bottom_margin(jobPageSetup.get(), GTK_UNIT_POINTS), gtk_page_setup_get_left_margin(jobPageSetup.get(), GTK_UNIT_POINTS) };
+    margin = { WebCore::narrowPrecisionToFloat(gtk_page_setup_get_top_margin(jobPageSetup.get(), GTK_UNIT_POINTS)), WebCore::narrowPrecisionToFloat(gtk_page_setup_get_right_margin(jobPageSetup.get(), GTK_UNIT_POINTS)), WebCore::narrowPrecisionToFloat(gtk_page_setup_get_bottom_margin(jobPageSetup.get(), GTK_UNIT_POINTS)), WebCore::narrowPrecisionToFloat(gtk_page_setup_get_left_margin(jobPageSetup.get(), GTK_UNIT_POINTS)) };
 
     pageSetup = WTFMove(jobPageSetup);
 

--- a/Source/WebKit/Shared/mac/PrintInfoMac.mm
+++ b/Source/WebKit/Shared/mac/PrintInfoMac.mm
@@ -28,13 +28,15 @@
 
 #if PLATFORM(MAC)
 
+#import <WebCore/FloatConversion.h>
+
 namespace WebKit {
 
 PrintInfo::PrintInfo(NSPrintInfo *printInfo)
     : pageSetupScaleFactor([[[printInfo dictionary] objectForKey:NSPrintScalingFactor] floatValue])
     , availablePaperWidth([printInfo paperSize].width - [printInfo leftMargin] - [printInfo rightMargin])
     , availablePaperHeight([printInfo paperSize].height - [printInfo topMargin] - [printInfo bottomMargin])
-    , margin([printInfo topMargin], [printInfo rightMargin], [printInfo bottomMargin], [printInfo leftMargin])
+    , margin(WebCore::narrowPrecisionToFloatFromCGFloat([printInfo topMargin]), WebCore::narrowPrecisionToFloatFromCGFloat([printInfo rightMargin]), WebCore::narrowPrecisionToFloatFromCGFloat([printInfo bottomMargin]), WebCore::narrowPrecisionToFloatFromCGFloat([printInfo leftMargin]))
 {
     ASSERT(printInfo);
 }

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -67,6 +67,7 @@
 #import "_WKWarningView.h"
 #import <WebCore/ColorCocoa.h>
 #import <WebCore/ContentsFormatCocoa.h>
+#import <WebCore/FloatConversion.h>
 #import <WebCore/GraphicsContextCG.h>
 #import <WebCore/IOSurfacePool.h>
 #import <WebCore/LocalCurrentTraitCollection.h>
@@ -4420,7 +4421,7 @@ static bool isLockdownModeWarningNeeded()
     CGRect unobscuredRectInContentCoordinates = [self convertRect:futureUnobscuredRectInSelfCoordinates toView:_contentView.get()];
 
     UIEdgeInsets unobscuredSafeAreaInsets = [self _computedUnobscuredSafeAreaInset];
-    WebCore::FloatBoxExtent unobscuredSafeAreaInsetsExtent(unobscuredSafeAreaInsets.top, unobscuredSafeAreaInsets.right, unobscuredSafeAreaInsets.bottom, unobscuredSafeAreaInsets.left);
+    WebCore::FloatBoxExtent unobscuredSafeAreaInsetsExtent { WebCore::narrowPrecisionToFloatFromCGFloat(unobscuredSafeAreaInsets.top), WebCore::narrowPrecisionToFloatFromCGFloat(unobscuredSafeAreaInsets.right), WebCore::narrowPrecisionToFloatFromCGFloat(unobscuredSafeAreaInsets.bottom), WebCore::narrowPrecisionToFloatFromCGFloat(unobscuredSafeAreaInsets.left) };
 
     _perProcessState.lastSentViewLayoutSize = newViewLayoutSize;
     _perProcessState.lastSentDeviceOrientation = newOrientation;

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -61,6 +61,7 @@
 #import "_WKWebViewPrintFormatterInternal.h"
 #import <CoreGraphics/CoreGraphics.h>
 #import <WebCore/AccessibilityObject.h>
+#import <WebCore/FloatConversion.h>
 #import <WebCore/FloatQuad.h>
 #import <WebCore/InspectorOverlay.h>
 #import <WebCore/LocalFrameView.h>
@@ -669,7 +670,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 static WebCore::FloatBoxExtent floatBoxExtent(UIEdgeInsets insets)
 {
-    return WebCore::FloatBoxExtent(insets.top, insets.right, insets.bottom, insets.left);
+    return { WebCore::narrowPrecisionToFloatFromCGFloat(insets.top), WebCore::narrowPrecisionToFloatFromCGFloat(insets.right), WebCore::narrowPrecisionToFloatFromCGFloat(insets.bottom), WebCore::narrowPrecisionToFloatFromCGFloat(insets.left) };
 }
 
 - (CGRect)_computeUnobscuredContentRectRespectingInputViewBounds:(CGRect)unobscuredContentRect inputViewBounds:(CGRect)inputViewBounds

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -39,6 +39,7 @@
 #import "WebFullScreenManagerProxy.h"
 #import "WebPageProxy.h"
 #import "WebPreferences.h"
+#import <WebCore/FloatConversion.h>
 #import <WebCore/LocalizedStrings.h>
 #import <WebCore/PlaybackSessionInterfaceAVKitLegacy.h>
 #import <WebCore/PlaybackSessionInterfaceTVOS.h>
@@ -948,7 +949,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     ASSERT(_valid);
     auto safeAreaInsets = self.view.safeAreaInsets;
-    WebCore::FloatBoxExtent insets { safeAreaInsets.top, safeAreaInsets.right, safeAreaInsets.bottom, safeAreaInsets.left };
+    WebCore::FloatBoxExtent insets { WebCore::narrowPrecisionToFloatFromCGFloat(safeAreaInsets.top), WebCore::narrowPrecisionToFloatFromCGFloat(safeAreaInsets.right), WebCore::narrowPrecisionToFloatFromCGFloat(safeAreaInsets.bottom), WebCore::narrowPrecisionToFloatFromCGFloat(safeAreaInsets.left) };
 
     CGRect cancelFrame = _cancelButton.get().frame;
     CGPoint maxXY = CGPointMake(CGRectGetMaxX(cancelFrame), CGRectGetMaxY(cancelFrame));

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5791,10 +5791,10 @@ static _WKRectEdge toWKRectEdge(WebCore::RectEdges<bool> edges)
 static WebCore::RectEdges<bool> toRectEdges(_WKRectEdge edges)
 {
     return {
-        edges & _WKRectEdgeTop,
-        edges & _WKRectEdgeRight,
-        edges & _WKRectEdgeBottom,
-        edges & _WKRectEdgeLeft
+        static_cast<bool>(edges & _WKRectEdgeTop),
+        static_cast<bool>(edges & _WKRectEdgeRight),
+        static_cast<bool>(edges & _WKRectEdgeBottom),
+        static_cast<bool>(edges & _WKRectEdgeLeft),
     };
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -161,6 +161,7 @@
 #import <WebCore/EmptyBadgeClient.h>
 #import <WebCore/Event.h>
 #import <WebCore/EventHandler.h>
+#import <WebCore/FloatConversion.h>
 #import <WebCore/FocusController.h>
 #import <WebCore/FontAttributes.h>
 #import <WebCore/FontCache.h>
@@ -4793,7 +4794,7 @@ IGNORE_WARNINGS_END
 - (void)_setUnobscuredSafeAreaInsets:(WebEdgeInsets)insets
 {
     if (auto page = _private->page)
-        page->setUnobscuredSafeAreaInsets(WebCore::FloatBoxExtent(insets.top, insets.right, insets.bottom, insets.left));
+        page->setUnobscuredSafeAreaInsets({ WebCore::narrowPrecisionToFloatFromCGFloat(insets.top), WebCore::narrowPrecisionToFloatFromCGFloat(insets.right), WebCore::narrowPrecisionToFloatFromCGFloat(insets.bottom), WebCore::narrowPrecisionToFloatFromCGFloat(insets.left) });
 }
 
 - (WebEdgeInsets)_unobscuredSafeAreaInsets


### PR DESCRIPTION
#### d4c07d7b0c8db793e13e563c3f917000eaa8e670
<pre>
Make type conversion explicit when using RectEdges
<a href="https://bugs.webkit.org/show_bug.cgi?id=285790">https://bugs.webkit.org/show_bug.cgi?id=285790</a>

Reviewed by Darin Adler.

Make RectEdges more consistent with other WebCore types by removing
implicit numeric conversions. Instead, require callers to explicitly
convert values as normal.

Originally motivated by needing to fix RectEdges forwarding constructor
to forward using the deduced type, which this change also addresses.

* Source/WebCore/html/canvas/CanvasLayerContextSwitcher.cpp:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
* Source/WebCore/page/DebugPageOverlays.cpp:
* Source/WebCore/platform/LengthBox.h:
* Source/WebCore/platform/RectEdges.h:
* Source/WebCore/svg/SVGFEMorphologyElement.cpp:
* Source/WebKit/Shared/gtk/PrintInfoGtk.cpp:
* Source/WebKit/Shared/mac/PrintInfoMac.mm:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
* Source/WebKitLegacy/mac/WebView/WebView.mm:

Canonical link: <a href="https://commits.webkit.org/288763@main">https://commits.webkit.org/288763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c78ddcace4009e335d491cfa3cff4db59815f3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84342 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89421 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35351 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11944 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65594 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23432 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3043 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/76632 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45888 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30863 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34400 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90802 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11609 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8437 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11836 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73243 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18122 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17575 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16019 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2979 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11561 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17037 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11410 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14886 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13183 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->