### PR TITLE
Fix GPU process painting of form controls in sideways-lr writing mode

### DIFF
--- a/Source/WebCore/platform/graphics/adwaita/MenuListAdwaita.cpp
+++ b/Source/WebCore/platform/graphics/adwaita/MenuListAdwaita.cpp
@@ -50,7 +50,7 @@ void MenuListAdwaita::draw(GraphicsContext& graphicsContext, const FloatRoundedR
     auto zoomedArrowSize = menuListButtonArrowSize * style.zoomFactor;
     FloatRect fieldRect = borderRect.rect();
     fieldRect.inflate(menuListButtonBorderSize);
-    if (style.states.contains(ControlStyle::State::RightToLeft))
+    if (style.states.contains(ControlStyle::State::InlineFlippedWritingMode))
         fieldRect.move(menuListButtonPadding, 0);
     else
         fieldRect.move(fieldRect.width() - (zoomedArrowSize + menuListButtonPadding), 0);

--- a/Source/WebCore/platform/graphics/adwaita/ProgressBarAdwaita.cpp
+++ b/Source/WebCore/platform/graphics/adwaita/ProgressBarAdwaita.cpp
@@ -72,7 +72,7 @@ void ProgressBarAdwaita::draw(GraphicsContext& graphicsContext, const FloatRound
     bool isDeterminate = progressBarPart.position() >= 0;
     if (isDeterminate) {
         auto progressWidth = fieldRect.width() * progressBarPart.position();
-        if (style.states.contains(ControlStyle::State::RightToLeft))
+        if (style.states.contains(ControlStyle::State::InlineFlippedWritingMode))
             fieldRect.move(fieldRect.width() - progressWidth, 0);
         fieldRect.setWidth(progressWidth);
     } else {

--- a/Source/WebCore/platform/graphics/adwaita/SliderTrackAdwaita.cpp
+++ b/Source/WebCore/platform/graphics/adwaita/SliderTrackAdwaita.cpp
@@ -79,7 +79,7 @@ void SliderTrackAdwaita::draw(GraphicsContext& graphicsContext, const FloatRound
     FloatRoundedRect::Radii corners;
     if (isHorizontal) {
         float offset = rangeRect.width() * sliderTrackPart.thumbPosition();
-        if (style.states.contains(ControlStyle::State::RightToLeft)) {
+        if (style.states.contains(ControlStyle::State::InlineFlippedWritingMode)) {
             rangeRect.move(rangeRect.width() - offset, 0);
             rangeRect.setWidth(offset);
             corners.setTopRight(corner);

--- a/Source/WebCore/platform/graphics/adwaita/TextFieldAdwaita.cpp
+++ b/Source/WebCore/platform/graphics/adwaita/TextFieldAdwaita.cpp
@@ -87,7 +87,7 @@ void TextFieldAdwaita::draw(GraphicsContext& graphicsContext, const FloatRounded
     if (style.states.contains(ControlStyle::State::ListButton)) {
         auto zoomedArrowSize = menuListButtonArrowSize * style.zoomFactor;
         FloatRect arrowRect = borderRect.rect();
-        if (style.states.contains(ControlStyle::State::RightToLeft))
+        if (style.states.contains(ControlStyle::State::InlineFlippedWritingMode))
             arrowRect.move(textFieldBorderSize * 2, 0);
         else
             arrowRect.move(arrowRect.width() - (zoomedArrowSize + textFieldBorderSize * 2), 0);

--- a/Source/WebCore/platform/graphics/controls/ControlStyle.cpp
+++ b/Source/WebCore/platform/graphics/controls/ControlStyle.cpp
@@ -69,8 +69,8 @@ TextStream& operator<<(TextStream& ts, ControlStyle::State state)
     case ControlStyle::State::DarkAppearance:
         ts << "dark-appearance";
         break;
-    case ControlStyle::State::RightToLeft:
-        ts << "right-to-left";
+    case ControlStyle::State::InlineFlippedWritingMode:
+        ts << "inline-flipped-writing-mode";
         break;
     case ControlStyle::State::LargeControls:
         ts << "large-controls";

--- a/Source/WebCore/platform/graphics/controls/ControlStyle.h
+++ b/Source/WebCore/platform/graphics/controls/ControlStyle.h
@@ -36,24 +36,24 @@ namespace WebCore {
 
 struct ControlStyle {
     enum class State {
-        Hovered             = 1 << 0,
-        Pressed             = 1 << 1,
-        Focused             = 1 << 2,
-        Enabled             = 1 << 3,
-        Checked             = 1 << 4,
-        Default             = 1 << 5,
-        WindowActive        = 1 << 6,
-        Indeterminate       = 1 << 7,
-        SpinUp              = 1 << 8, // Sub-state for HoverState and PressedState.
-        Presenting          = 1 << 9,
-        FormSemanticContext = 1 << 10,
-        DarkAppearance      = 1 << 11,
-        RightToLeft         = 1 << 12,
-        LargeControls       = 1 << 13,
-        ReadOnly            = 1 << 14,
-        ListButton          = 1 << 15,
-        ListButtonPressed   = 1 << 16,
-        VerticalWritingMode = 1 << 17,
+        Hovered                  = 1 << 0,
+        Pressed                  = 1 << 1,
+        Focused                  = 1 << 2,
+        Enabled                  = 1 << 3,
+        Checked                  = 1 << 4,
+        Default                  = 1 << 5,
+        WindowActive             = 1 << 6,
+        Indeterminate            = 1 << 7,
+        SpinUp                   = 1 << 8, // Sub-state for HoverState and PressedState.
+        Presenting               = 1 << 9,
+        FormSemanticContext      = 1 << 10,
+        DarkAppearance           = 1 << 11,
+        InlineFlippedWritingMode = 1 << 12,
+        LargeControls            = 1 << 13,
+        ReadOnly                 = 1 << 14,
+        ListButton               = 1 << 15,
+        ListButtonPressed        = 1 << 16,
+        VerticalWritingMode      = 1 << 17,
     };
     OptionSet<State> states;
     float fontSize { 12 };

--- a/Source/WebCore/platform/graphics/controls/SliderTrackPart.cpp
+++ b/Source/WebCore/platform/graphics/controls/SliderTrackPart.cpp
@@ -89,8 +89,8 @@ void SliderTrackPart::drawTicks(GraphicsContext& context, const FloatRect& rect,
     context.setFillColor(style.textColor);
 
     bool isVerticalWritingMode = style.states.contains(ControlStyle::State::VerticalWritingMode);
-    bool isRightToLeft = style.states.contains(ControlStyle::State::RightToLeft);
-    bool isInlineFlipped = (!isHorizontal && !isVerticalWritingMode) || isRightToLeft;
+    bool isInlineFlippedWritingMode = style.states.contains(ControlStyle::State::InlineFlippedWritingMode);
+    bool isInlineFlipped = (!isHorizontal && !isVerticalWritingMode) || isInlineFlippedWritingMode;
 
     for (auto tickRatio : m_tickRatios) {
         double value = isInlineFlipped ? 1.0 - tickRatio : tickRatio;

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -430,7 +430,7 @@ void ControlMac::drawListButton(GraphicsContext& context, const FloatRect& rect,
 
     FloatPoint listButtonLocation;
     float listButtonLogicalTop = logicalRect.center().y() - desiredComboBoxButtonLogicalSize.height() / 2;
-    if (style.states.contains(ControlStyle::State::RightToLeft))
+    if (style.states.contains(ControlStyle::State::InlineFlippedWritingMode))
         listButtonLocation = { logicalRect.x() + desiredComboBoxInset, listButtonLogicalTop };
     else
         listButtonLocation = { logicalRect.maxX() - desiredComboBoxButtonLogicalSize.width() - desiredComboBoxInset, listButtonLogicalTop };

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
@@ -184,10 +184,10 @@ void MenuListButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& b
     if (bounds.width() < arrowWidth + arrowPaddingBefore * style.zoomFactor)
         return;
 
-    bool isRightToLeft = style.states.contains(ControlStyle::State::RightToLeft);
+    bool isInlineFlipped = style.states.contains(ControlStyle::State::InlineFlippedWritingMode);
 
     float leftEdge;
-    if (isRightToLeft)
+    if (isInlineFlipped)
         leftEdge = logicalBounds.x() + arrowPaddingAfter * style.zoomFactor;
     else
         leftEdge = logicalBounds.maxX() - arrowPaddingAfter * style.zoomFactor - arrowWidth;

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm
@@ -72,7 +72,7 @@ void MenuListMac::updateCellStates(const FloatRect& rect, const ControlStyle& st
 {
     ControlMac::updateCellStates(rect, style);
 
-    auto direction = style.states.contains(ControlStyle::State::RightToLeft) ? NSUserInterfaceLayoutDirectionRightToLeft : NSUserInterfaceLayoutDirectionLeftToRight;
+    auto direction = style.states.contains(ControlStyle::State::InlineFlippedWritingMode) ? NSUserInterfaceLayoutDirectionRightToLeft : NSUserInterfaceLayoutDirectionLeftToRight;
     [m_popUpButtonCell setUserInterfaceLayoutDirection:direction];
 
     // Update the various states we respond to.

--- a/Source/WebCore/platform/graphics/mac/controls/MeterMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MeterMac.mm
@@ -52,7 +52,7 @@ void MeterMac::updateCellStates(const FloatRect& rect, const ControlStyle& style
 
     ControlMac::updateCellStates(rect, style);
 
-    [m_levelIndicatorCell setUserInterfaceLayoutDirection:style.states.contains(ControlStyle::State::RightToLeft) ? NSUserInterfaceLayoutDirectionRightToLeft : NSUserInterfaceLayoutDirectionLeftToRight];
+    [m_levelIndicatorCell setUserInterfaceLayoutDirection:style.states.contains(ControlStyle::State::InlineFlippedWritingMode) ? NSUserInterfaceLayoutDirectionRightToLeft : NSUserInterfaceLayoutDirectionLeftToRight];
 
     auto& meterPart = owningMeterPart();
     

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
@@ -152,7 +152,7 @@ void ProgressBarMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
         context.translate(-inflatedRect.location());
     }
 
-    if (style.states.contains(ControlStyle::State::RightToLeft)) {
+    if (style.states.contains(ControlStyle::State::InlineFlippedWritingMode)) {
         context.translate(2 * inflatedRect.x() + inflatedRect.width(), 0);
         context.scale(FloatSize(-1, 1));
     }

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
@@ -69,7 +69,7 @@ void SwitchThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
     GraphicsContextStateSaver stateSaver(context);
 
     auto isOn = owningPart().isOn();
-    auto isRTL = style.states.contains(ControlStyle::State::RightToLeft);
+    auto isInlineFlipped = style.states.contains(ControlStyle::State::InlineFlippedWritingMode);
     auto isVertical = style.states.contains(ControlStyle::State::VerticalWritingMode);
     auto isEnabled = style.states.contains(ControlStyle::State::Enabled);
     auto isPressed = style.states.contains(ControlStyle::State::Pressed);
@@ -99,7 +99,7 @@ void SwitchThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
         context.scale(style.zoomFactor);
     }
 
-    auto drawingThumbIsLogicallyLeft = (!isRTL && !isOn) || (isRTL && isOn);
+    auto drawingThumbIsLogicallyLeft = (!isInlineFlipped && !isOn) || (isInlineFlipped && isOn);
     auto drawingThumbLogicalXAxis = inflatedTrackRect.width() - inflatedThumbRect.width();
     auto drawingThumbLogicalXAxisProgress = drawingThumbLogicalXAxis * progress;
     auto drawingThumbLogicalX = drawingThumbIsLogicallyLeft ? drawingThumbLogicalXAxis - drawingThumbLogicalXAxisProgress : drawingThumbLogicalXAxisProgress;
@@ -107,7 +107,7 @@ void SwitchThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
 
     auto coreUISize = SwitchMacUtilities::coreUISizeForControlSize(controlSize);
 
-    auto maskImage = SwitchMacUtilities::trackMaskImage(context, inflatedTrackRect.size(), deviceScaleFactor, isRTL, coreUISize);
+    auto maskImage = SwitchMacUtilities::trackMaskImage(context, inflatedTrackRect.size(), deviceScaleFactor, isInlineFlipped, coreUISize);
     if (!maskImage)
         return;
 
@@ -127,7 +127,7 @@ void SwitchThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
             (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchKnob,
             (__bridge NSString *)kCUIStateKey: (__bridge NSString *)(!isEnabled ? kCUIStateDisabled : isPressed ? kCUIStatePressed : kCUIStateActive),
             (__bridge NSString *)kCUISizeKey: SwitchMacUtilities::coreUISizeForControlSize(controlSize),
-            (__bridge NSString *)kCUIUserInterfaceLayoutDirectionKey: (__bridge NSString *)(isRTL ? kCUIUserInterfaceLayoutDirectionRightToLeft : kCUIUserInterfaceLayoutDirectionLeftToRight),
+            (__bridge NSString *)kCUIUserInterfaceLayoutDirectionKey: (__bridge NSString *)(isInlineFlipped ? kCUIUserInterfaceLayoutDirectionRightToLeft : kCUIUserInterfaceLayoutDirectionLeftToRight),
             (__bridge NSString *)kCUIScaleKey: @(deviceScaleFactor),
         }];
     }

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -714,8 +714,8 @@ OptionSet<ControlStyle::State> RenderTheme::extractControlStyleStatesForRenderer
         states.add(ControlStyle::State::FormSemanticContext);
     if (renderer.useDarkAppearance())
         states.add(ControlStyle::State::DarkAppearance);
-    if (!renderer.style().isLeftToRightDirection())
-        states.add(ControlStyle::State::RightToLeft);
+    if (renderer.writingMode().isInlineFlipped())
+        states.add(ControlStyle::State::InlineFlippedWritingMode);
     if (supportsLargeFormControls())
         states.add(ControlStyle::State::LargeControls);
     if (isReadOnlyControl(renderer))

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3672,7 +3672,7 @@ enum class WebCore::FetchHeadersGuard : uint8_t {
     Presenting,
     FormSemanticContext,
     DarkAppearance,
-    RightToLeft,
+    InlineFlippedWritingMode,
     LargeControls,
     ReadOnly,
     ListButton,


### PR DESCRIPTION
#### e127e21c8292880e78e35c10bdf13c277b56580d
<pre>
Fix GPU process painting of form controls in sideways-lr writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=285793">https://bugs.webkit.org/show_bug.cgi?id=285793</a>
<a href="https://rdar.apple.com/142725048">rdar://142725048</a>

Reviewed by Aditya Keerthi.

Pass `writingMode().isInlineFlipped()` instead of `style().isRightToLeftDirection()`, in order to paint
in the correct direction in sideways-lr writing mode.

* Source/WebCore/platform/graphics/adwaita/MenuListAdwaita.cpp:
(WebCore::MenuListAdwaita::draw):
* Source/WebCore/platform/graphics/adwaita/ProgressBarAdwaita.cpp:
(WebCore::ProgressBarAdwaita::draw):
* Source/WebCore/platform/graphics/adwaita/SliderTrackAdwaita.cpp:
(WebCore::SliderTrackAdwaita::draw):
* Source/WebCore/platform/graphics/adwaita/TextFieldAdwaita.cpp:
(WebCore::TextFieldAdwaita::draw):
* Source/WebCore/platform/graphics/controls/ControlStyle.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/controls/ControlStyle.h:
* Source/WebCore/platform/graphics/controls/SliderTrackPart.cpp:
(WebCore::SliderTrackPart::drawTicks const):
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::ControlMac::drawListButton):
* Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm:
(WebCore::MenuListButtonMac::draw):
* Source/WebCore/platform/graphics/mac/controls/MenuListMac.mm:
(WebCore::MenuListMac::updateCellStates):
* Source/WebCore/platform/graphics/mac/controls/MeterMac.mm:
(WebCore::MeterMac::updateCellStates):
* Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm:
(WebCore::ProgressBarMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm:
(WebCore::SwitchThumbMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm:
(WebCore::SwitchTrackMac::draw):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::extractControlStyleStatesForRendererInternal const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/288766@main">https://commits.webkit.org/288766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3997e7ada02d476f59a0781391d440ddb22aca5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38659 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35363 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11956 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/89433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/23440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87400 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/76642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/3003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/30872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34412 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/31641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90814 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11621 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11848 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/72466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/17584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/16028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2997 "Failed to checkout and rebase branch from PR 38889") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13061 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11573 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17049 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11422 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14898 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->