### PR TITLE
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in audio code

### DIFF
--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
@@ -30,7 +30,9 @@
 
 #include <CoreAudio/CoreAudioTypes.h>
 #include <pal/spi/cf/CoreMediaSPI.h>
+#include <span>
 #include <wtf/SoftLinking.h>
+#include <wtf/StdLibExtras.h>
 
 #if PLATFORM(WATCHOS)
 #define SOFTLINK_AVKIT_FRAMEWORK() SOFT_LINK_PRIVATE_FRAMEWORK_OPTIONAL(AVKit)
@@ -408,6 +410,19 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, CoreMedia, kCMFormatDescriptionExten
 #define kCMFormatDescriptionExtension_ProjectionKind get_CoreMedia_kCMFormatDescriptionExtension_ProjectionKind()
 SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, CoreMedia, kCMFormatDescriptionProjectionKind_Rectilinear, CFStringRef)
 #define kCMFormatDescriptionProjectionKind_Rectilinear get_CoreMedia_kCMFormatDescriptionProjectionKind_Rectilinear()
+
+namespace PAL {
+
+inline std::span<uint8_t> CMBlockBufferGetDataSpan(CMBlockBufferRef theBuffer, size_t offset = 0)
+{
+    char* data = nullptr;
+    size_t lengthAtOffset = 0;
+    if (auto error = PAL::CMBlockBufferGetDataPointer(theBuffer, offset, &lengthAtOffset, nullptr, &data))
+        return { };
+    return unsafeMakeSpan(byteCast<uint8_t>(data), lengthAtOffset);
+}
+
+} // namespace PAL
 
 #if PLATFORM(MAC)
 

--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -33,6 +33,7 @@
 #include "TextIteratorBehavior.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
+#include <wtf/text/StringCommon.h>
 
 namespace WebCore {
 
@@ -76,7 +77,7 @@ private:
 
 class TextIteratorCopyableText {
 public:
-    StringView text() const { return m_singleCharacter ? StringView(span(m_singleCharacter)) : StringView(m_string).substring(m_offset, m_length); }
+    StringView text() const { return m_singleCharacter ? StringView(WTF::span(m_singleCharacter)) : StringView(m_string).substring(m_offset, m_length); }
     void appendToStringBuilder(StringBuilder&) const;
 
     void reset();

--- a/Source/WebCore/platform/audio/DirectConvolver.cpp
+++ b/Source/WebCore/platform/audio/DirectConvolver.cpp
@@ -70,15 +70,14 @@ void DirectConvolver::process(AudioFloatArray* convolutionKernel, std::span<cons
     if (!isCopyGood)
         return;
 
-    auto inputP = m_buffer.span().subspan(m_inputBlockSize);
+    auto inputBuffer = m_buffer.span();
+    auto inputP = inputBuffer.subspan(m_inputBlockSize);
 
     // Copy samples to 2nd half of input buffer.
     memcpySpan(inputP, source);
 
 #if USE(ACCELERATE)
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    vDSP_conv(inputP.data() - kernelSize + 1, 1, kernelP.subspan(kernelSize - 1).data(), -1, destination.data(), 1, source.size(), kernelSize);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    vDSP_conv(inputBuffer.subspan(inputP.data() - inputBuffer.data() - kernelSize + 1).data(), 1, kernelP.subspan(kernelSize - 1).data(), -1, destination.data(), 1, source.size(), kernelSize);
 #else
     // FIXME: The macro can be further optimized to avoid pipeline stalls. One possibility is to maintain 4 separate sums and change the macro to CONVOLVE_FOUR_SAMPLES.
 #define CONVOLVE_ONE_SAMPLE             \

--- a/Source/WebCore/platform/audio/SincResampler.cpp
+++ b/Source/WebCore/platform/audio/SincResampler.cpp
@@ -34,6 +34,7 @@
 
 #include "AudioBus.h"
 #include "AudioUtilities.h"
+#include "VectorMath.h"
 #include <wtf/Algorithms.h>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -265,7 +266,7 @@ void SincResampler::process(std::span<float> destination, size_t framesToProcess
             // Figure out how much to weight each kernel's "convolution".
             double kernelInterpolationFactor = virtualOffsetIndex - offsetIndex;
 
-            destination[destinationIndex++] = convolve(inputP.data(), k1.data(), k2.data(), kernelInterpolationFactor);
+            destination[destinationIndex++] = convolve(inputP, k1, k2, kernelInterpolationFactor);
 
             // Advance the virtual index.
             m_virtualSourceIndex += m_scaleFactor;
@@ -293,15 +294,11 @@ void SincResampler::process(std::span<float> destination, size_t framesToProcess
     }
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-float SincResampler::convolve(const float* inputP, const float* k1, const float* k2, float kernelInterpolationFactor)
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+float SincResampler::convolve(std::span<const float> inputP, std::span<const float> k1, std::span<const float> k2, float kernelInterpolationFactor)
 {
 #if USE(ACCELERATE)
-    float sum1;
-    float sum2;
-    vDSP_dotpr(inputP, 1, k1, 1, &sum1, kernelSize);
-    vDSP_dotpr(inputP, 1, k2, 1, &sum2, kernelSize);
+    float sum1 = VectorMath::dotProduct(inputP.first(kernelSize), k1.first(kernelSize));
+    float sum2 = VectorMath::dotProduct(inputP.first(kernelSize), k2.first(kernelSize));
 
     // Linearly interpolate the two "convolutions".
     return (1.0f - kernelInterpolationFactor) * sum1 + kernelInterpolationFactor * sum2;
@@ -311,17 +308,17 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     __m128 m_sums2 = _mm_setzero_ps();
 
     // Based on |inputP| alignment, we need to use loadu or load.
-    if (reinterpret_cast<uintptr_t>(inputP) & 0x0F) {
+    if (reinterpret_cast<uintptr_t>(inputP.data()) & 0x0F) {
         for (unsigned i = 0; i < kernelSize; i += 4) {
-            m_input = _mm_loadu_ps(inputP + i);
-            m_sums1 = _mm_add_ps(m_sums1, _mm_mul_ps(m_input, _mm_load_ps(k1 + i)));
-            m_sums2 = _mm_add_ps(m_sums2, _mm_mul_ps(m_input, _mm_load_ps(k2 + i)));
+            m_input = _mm_loadu_ps(inputP.subspan(i).data());
+            m_sums1 = _mm_add_ps(m_sums1, _mm_mul_ps(m_input, _mm_load_ps(k1.subspan(i).data())));
+            m_sums2 = _mm_add_ps(m_sums2, _mm_mul_ps(m_input, _mm_load_ps(k2.subspan(i).data())));
         }
     } else {
         for (unsigned i = 0; i < kernelSize; i += 4) {
-            m_input = _mm_load_ps(inputP + i);
-            m_sums1 = _mm_add_ps(m_sums1, _mm_mul_ps(m_input, _mm_load_ps(k1 + i)));
-            m_sums2 = _mm_add_ps(m_sums2, _mm_mul_ps(m_input, _mm_load_ps(k2 + i)));
+            m_input = _mm_load_ps(inputP.subspan(i).data());
+            m_sums1 = _mm_add_ps(m_sums1, _mm_mul_ps(m_input, _mm_load_ps(k1.subspan(i).data())));
+            m_sums2 = _mm_add_ps(m_sums2, _mm_mul_ps(m_input, _mm_load_ps(k2.subspan(i).data())));
         }
     }
 
@@ -340,15 +337,14 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     float32x4_t m_input;
     float32x4_t m_sums1 = vmovq_n_f32(0);
     float32x4_t m_sums2 = vmovq_n_f32(0);
-
-    const float* upper = inputP + kernelSize;
-    for (; inputP < upper; ) {
-        m_input = vld1q_f32(inputP);
-        inputP += 4;
-        m_sums1 = vmlaq_f32(m_sums1, m_input, vld1q_f32(k1));
-        k1 += 4;
-        m_sums2 = vmlaq_f32(m_sums2, m_input, vld1q_f32(k2));
-        k2 += 4;
+    inputP = inputP.first(kernelSize);
+    while (!input.empty()) {
+        m_input = vld1q_f32(inputP.data());
+        skip(inputP, 4);
+        m_sums1 = vmlaq_f32(m_sums1, m_input, vld1q_f32(k1.data()));
+        skip(k1, 4);
+        m_sums2 = vmlaq_f32(m_sums2, m_input, vld1q_f32(k2.data()));
+        skip(k2, 4);
     }
 
     // Linearly interpolate the two "convolutions".
@@ -362,10 +358,9 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     float sum2 = 0;
 
     // Generate a single output sample.
-    int n = kernelSize;
-    while (n--) {
-        sum1 += *inputP * *k1++;
-        sum2 += *inputP++ * *k2++;
+    for (size_t i = 0; i < kernelSize; ++i) {
+        sum1 += inputP[i] * k1[i];
+        sum2 += inputP[i] * k2[i];
     }
 
     // Linearly interpolate the two "convolutions".

--- a/Source/WebCore/platform/audio/SincResampler.h
+++ b/Source/WebCore/platform/audio/SincResampler.h
@@ -59,7 +59,7 @@ private:
     void initializeKernel();
     void updateRegions(bool isSecondLoad);
 
-    float convolve(const float* inputP, const float* k1, const float* k2, float kernelInterpolationFactor);
+    float convolve(std::span<const float> inputP, std::span<const float> k1, std::span<const float> k2, float kernelInterpolationFactor);
     
     double m_scaleFactor;
 

--- a/Source/WebCore/platform/audio/UpSampler.cpp
+++ b/Source/WebCore/platform/audio/UpSampler.cpp
@@ -101,14 +101,14 @@ void UpSampler::process(std::span<const float> source, std::span<float> destinat
     if (!isInputBufferGood)
         return;
 
-    auto inputP = m_inputBuffer.span().subspan(source.size());
+    auto inputBuffer = m_inputBuffer.span();
+    auto inputP = inputBuffer.subspan(source.size());
     memcpySpan(inputP, source);
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // Copy even sample-frames 0,2,4,6... (delayed by the linear phase delay) directly into destination.
+    auto inputPMinusHalfSize = inputBuffer.subspan(inputP.data() - inputBuffer.data() - halfSize);
     for (size_t i = 0; i < source.size(); ++i)
-        destination[i * 2] = *((inputP.data() - halfSize) + i);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        destination[i * 2] = inputPMinusHalfSize[i];
 
     // Compute odd sample-frames 1,3,5,7...
     auto oddSamplesP = m_tempBuffer.span();

--- a/Source/WebCore/platform/audio/VectorMath.cpp
+++ b/Source/WebCore/platform/audio/VectorMath.cpp
@@ -174,6 +174,14 @@ void add(std::span<const double> inputVector1, std::span<const double> inputVect
     vDSP_vaddD(inputVector1.data(), 1, inputVector2.data(), 1, outputVector.data(), 1, inputVector1.size());
 }
 
+float dotProduct(std::span<const float> inputVector1, std::span<const float> inputVector2)
+{
+    RELEASE_ASSERT(inputVector1.size() == inputVector2.size());
+    float result = 0;
+    vDSP_dotpr(inputVector1.data(), 1, inputVector2.data(), 1, &result, inputVector1.size());
+    return result;
+}
+
 #else
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib/Win port
@@ -927,6 +935,15 @@ void add(std::span<const double> inputVector1, std::span<const double> inputVect
     RELEASE_ASSERT(outputVector.size() >= inputVector1.size());
     for (size_t i = 0; i < inputVector1.size(); ++i)
         outputVector[i] = inputVector1[i] + inputVector2[i];
+}
+
+float dotProduct(std::span<const float> inputVector1, std::span<const float> inputVector2)
+{
+    RELEASE_ASSERT(inputVector1.size() == inputVector2.size());
+    float result = 0;
+    for (size_t i = 0; i < inputVector1.size(); ++i)
+        result += inputVector1[i] * inputVector2[i];
+    return result;
 }
 
 #endif // USE(ACCELERATE)

--- a/Source/WebCore/platform/audio/VectorMath.h
+++ b/Source/WebCore/platform/audio/VectorMath.h
@@ -52,6 +52,9 @@ void add(std::span<const int> inputVector1, std::span<const int> inputVector2, s
 void add(std::span<const float> inputVector1, std::span<const float> inputVector2, std::span<float> outputVector);
 void add(std::span<const double> inputVector1, std::span<const double> inputVector2, std::span<double> outputVector);
 
+// result = sum(inputVector1[n] * inputVector2[n], 0 <= n < inputVector1.size());
+float dotProduct(std::span<const float> inputVector1, std::span<const float> inputVector2);
+
 // Finds the maximum magnitude of a float vector.
 float maximumMagnitude(std::span<const float> inputVector);
 

--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp
@@ -138,14 +138,14 @@ RetainPtr<CMBlockBufferRef> WebAudioBufferList::setSampleCountWithBlockBuffer(si
     }
     RetainPtr block = adoptCF(blockBuffer);
 
-    char* data = { };
-    if (auto error = PAL::CMBlockBufferGetDataPointer(blockBuffer, 0, nullptr, nullptr, &data)) {
-        RELEASE_LOG_ERROR(Media, "WebAudioBufferList::setSampleCountWithBlockBuffer CMBlockBufferGetDataPointer failed with: %d", static_cast<int>(error));
+    auto data = PAL::CMBlockBufferGetDataSpan(blockBuffer);
+    if (!data.data()) {
+        RELEASE_LOG_ERROR(Media, "WebAudioBufferList::setSampleCountWithBlockBuffer CMBlockBufferGetDataSpan failed.");
         return { };
     }
     m_blockBuffer = WTFMove(block);
 
-    initializeList(unsafeMakeSpan(reinterpret_cast<uint8_t*>(data), bufferSizes->second), bufferSizes->first);
+    initializeList(data.first(bufferSizes->second), bufferSizes->first);
 
     return m_blockBuffer;
 }

--- a/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h
+++ b/Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "PlatformAudioData.h"
+#include "SpanCoreAudio.h"
 #include <CoreAudio/CoreAudioTypes.h>
 #include <wtf/IteratorRange.h>
 #include <wtf/RetainPtr.h>
@@ -64,11 +65,10 @@ public:
     template <typename T = uint8_t>
     std::span<T> bufferAsSpan(uint32_t index) const
     {
-        ASSERT(index < m_list->mNumberBuffers);
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        if (index < m_list->mNumberBuffers)
-            return unsafeMakeSpan(static_cast<T*>(m_list->mBuffers[index].mData), m_list->mBuffers[index].mDataByteSize / sizeof(T));
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        auto buffers = span(*m_list);
+        ASSERT(index < buffers.size());
+        if (index < buffers.size())
+            return mutableSpan<T>(buffers[index]);
         return { };
     }
 

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -540,11 +540,7 @@ Ref<SharedBuffer> sharedBufferFromCMBlockBuffer(CMBlockBufferRef blockBuffer)
         [blockBuffer = ensureContiguousBlockBuffer(blockBuffer)]() -> std::span<const uint8_t> {
             if (!blockBuffer)
                 return { };
-            size_t lengthAtOffset = 0;
-            char* data = nullptr;
-            if (auto status = PAL::CMBlockBufferGetDataPointer(blockBuffer.get(), 0, &lengthAtOffset, nullptr, &data))
-                return { };
-            return unsafeMakeSpan(reinterpret_cast<uint8_t*>(data), lengthAtOffset);
+            return PAL::CMBlockBufferGetDataSpan(blockBuffer.get());
         }
     });
 }

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
@@ -418,11 +418,10 @@ Ref<WebCoreDecompressionSession::DecodingPromise> WebCoreDecompressionSession::d
                         return DecodingPromise::createAndReject(status);
                     buffer = adoptCF(contiguousBuffer);
                 }
-                auto size = PAL::CMBlockBufferGetDataLength(buffer.get());
-                char* data = nullptr;
-                if (auto status = PAL::CMBlockBufferGetDataPointer(buffer.get(), 0, nullptr, nullptr, &data); status != noErr)
-                    return DecodingPromise::createAndReject(status);
-                promises.append(videoDecoder->decode({ { byteCast<uint8_t>(data), size }, true, presentationTimestamp.toMicroseconds(), 0 }));
+                auto data = PAL::CMBlockBufferGetDataSpan(buffer.get());
+                if (!data.data())
+                    return DecodingPromise::createAndReject(-1);
+                promises.append(videoDecoder->decode({ data, true, presentationTimestamp.toMicroseconds(), 0 }));
             }
             DecodingPromise::Producer producer;
             auto promise = producer.promise();


### PR DESCRIPTION
#### 8b7ffa2d969a68ef098e98bc34ba1955b83c9bff
<pre>
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in audio code
<a href="https://bugs.webkit.org/show_bug.cgi?id=285795">https://bugs.webkit.org/show_bug.cgi?id=285795</a>

Reviewed by Darin Adler.

* Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h:
(PAL::CMBlockBufferGetDataSpan):
* Source/WebCore/platform/audio/DirectConvolver.cpp:
(WebCore::DirectConvolver::process):
* Source/WebCore/platform/audio/DownSampler.cpp:
(WebCore::DownSampler::process):
* Source/WebCore/platform/audio/SincResampler.cpp:
(WebCore::SincResampler::process):
(WebCore::SincResampler::convolve):
* Source/WebCore/platform/audio/SincResampler.h:
* Source/WebCore/platform/audio/UpSampler.cpp:
(WebCore::UpSampler::process):
* Source/WebCore/platform/audio/VectorMath.cpp:
(WebCore::VectorMath::dotProduct):
* Source/WebCore/platform/audio/VectorMath.h:
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::passthroughInputDataCallback):
(WebCore::AudioFileReader::decodeWebMData const):
* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.cpp:
(WebCore::WebAudioBufferList::setSampleCountWithBlockBuffer):
* Source/WebCore/platform/audio/cocoa/WebAudioBufferList.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::sharedBufferFromCMBlockBuffer):
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::decodeSampleInternal):

Canonical link: <a href="https://commits.webkit.org/288768@main">https://commits.webkit.org/288768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ce0295061830988b25aadae4ba81224dd0c3fbe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35357 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65600 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23437 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45894 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2999 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30867 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34406 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73889 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90808 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11615 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74050 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72461 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73250 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17579 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16023 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2990 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13062 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11567 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17043 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11416 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14892 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->