### PR TITLE
Import more WPT tests into css-anchor-position

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7520,6 +7520,7 @@ webkit.org/b/282024 fast/text/text-box-edge-with-margin-padding-border-simple.ht
 # -- Anchor Positioning -- #
 
 # general failures
+imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-003.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-003.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-003.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-003.tentative-expected.txt
@@ -1,0 +1,9 @@
+
+
+FAIL Initial scroll position assert_equals: e1 x expected 100 but got 0
+FAIL Scroll to 40,60 assert_equals: e1 x expected 100 but got 0
+FAIL Reattach at 40,60 assert_equals: e1 x expected 100 but got 0
+FAIL Redisplay at 40,60 assert_equals: e1 x expected 120 but got 0
+FAIL Scroll to 0,0 and relayout assert_equals: e1 x expected 120 but got 0
+FAIL Redisplay at 0,0 assert_equals: e1 x expected 100 but got 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-003.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-003.tentative.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<title>position-area to include current scroll position at first layout</title>
+<link rel="author" title="Morten Stenshorne" href="mailto:mstensho@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#scroll">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/test-common.js"></script>
+<iframe id="iframe" width="500" height="500" srcdoc='
+<style>
+  body {
+    overflow: hidden;
+    margin: 0;
+  }
+  .pos {
+    position: absolute;
+    box-sizing: border-box;
+    border: solid;
+    position-anchor: --anchor;
+    width: 50%;
+    height: 50%;
+    background: cyan;
+  }
+  #container.thicker > .pos {
+    border-width: thick;
+  }
+</style>
+<div style="width:1000px; height:1000px;">
+  <div id="container">
+    <div style="height:200px;"></div>
+    <div style="anchor-name:--anchor; margin-left:200px; width:100px; height:100px; background:gray;"></div>
+    <div id="e1" class="pos" style="position-area:top left;"></div>
+    <div id="e2" class="pos" style="position-area:top center;"></div>
+    <div id="e3" class="pos" style="position-area:top right;"></div>
+    <div id="e4" class="pos" style="position-area:center left;"></div>
+    <div id="e5" class="pos" style="position-area:center center;"></div>
+    <div id="e6" class="pos" style="position-area:center right;"></div>
+    <div id="e7" class="pos" style="position-area:bottom left;"></div>
+    <div id="e8" class="pos" style="position-area:bottom center;"></div>
+    <div id="e9" class="pos" style="position-area:bottom right;"></div>
+  </div>
+</div>
+'></iframe>
+<script>
+  // Wait for the iframe to load:
+  onload = function() {
+    const doc = iframe.contentWindow.document;
+    const container = doc.getElementById('container');
+    const e1 = doc.getElementById('e1');
+    const e2 = doc.getElementById('e2');
+    const e3 = doc.getElementById('e3');
+    const e4 = doc.getElementById('e4');
+    const e5 = doc.getElementById('e5');
+    const e6 = doc.getElementById('e6');
+    const e7 = doc.getElementById('e7');
+    const e8 = doc.getElementById('e8');
+    const e9 = doc.getElementById('e9');
+
+    function assert_rects_equal(elm, x, y, width, height) {
+      assert_equals(elm.offsetLeft, x, (elm.id + " x"));
+      assert_equals(elm.offsetTop, y, (elm.id + " y"));
+      assert_equals(elm.offsetWidth, width, (elm.id + " width"));
+      assert_equals(elm.offsetHeight, height, (elm.id + " height"));
+    }
+
+    function assert_at_initial() {
+      assert_rects_equal(e1, 100, 100, 100, 100);
+      assert_rects_equal(e2, 225, 100, 50, 100);
+      assert_rects_equal(e3, 300, 100, 100, 100);
+      assert_rects_equal(e4, 100, 225, 100, 50);
+      assert_rects_equal(e5, 225, 225, 50, 50);
+      assert_rects_equal(e6, 300, 225, 100, 50);
+      assert_rects_equal(e7, 100, 300, 100, 100);
+      assert_rects_equal(e8, 225, 300, 50, 100);
+      assert_rects_equal(e9, 300, 300, 100, 100);
+    }
+
+    function assert_at_40_60() {
+      assert_rects_equal(e1, 120, 130, 80, 70);
+      assert_rects_equal(e2, 225, 130, 50, 70);
+      assert_rects_equal(e3, 300, 130, 120, 70);
+      assert_rects_equal(e4, 120, 225, 80, 50);
+      assert_rects_equal(e5, 225, 225, 50, 50);
+      assert_rects_equal(e6, 300, 225, 120, 50);
+      assert_rects_equal(e7, 120, 300, 80, 130);
+      assert_rects_equal(e8, 225, 300, 50, 130);
+      assert_rects_equal(e9, 300, 300, 120, 130);
+    }
+
+    promise_test(async() => {
+      assert_at_initial();
+    }, "Initial scroll position");
+
+    promise_test(async() => {
+      await waitUntilNextAnimationFrame();
+      await waitUntilNextAnimationFrame();
+      iframe.contentWindow.scrollTo(40, 60);
+      await waitUntilNextAnimationFrame();
+      await waitUntilNextAnimationFrame();
+      assert_at_initial();
+    }, "Scroll to 40,60");
+
+    promise_test(async() => {
+      // As long as we're within the same animation frame (and therefore haven't
+      // run ResizeObserver events), there will be no anchor recalculation point.
+      container.style.display = "flow-root";
+      assert_at_initial();
+      container.style.display = "none";
+      document.body.offsetTop;
+      container.style.display = "block";
+      assert_at_initial();
+    }, "Reattach at 40,60");
+
+    promise_test(async() => {
+      container.style.display = "none";
+      await waitUntilNextAnimationFrame();
+      await waitUntilNextAnimationFrame();
+      container.style.display = "block";
+      await waitUntilNextAnimationFrame();
+      await waitUntilNextAnimationFrame();
+      assert_at_40_60();
+    }, "Redisplay at 40,60");
+
+    promise_test(async() => {
+      iframe.contentWindow.scrollTo(0, 0);
+      container.className = "thicker";
+      container.style.display = "block";
+      await waitUntilNextAnimationFrame();
+      await waitUntilNextAnimationFrame();
+      assert_at_40_60();
+    }, "Scroll to 0,0 and relayout");
+
+    promise_test(async() => {
+      container.style.display = "none";
+      await waitUntilNextAnimationFrame();
+      container.style.display = "block";
+      await waitUntilNextAnimationFrame();
+      await waitUntilNextAnimationFrame();
+      assert_at_initial();
+    }, "Redisplay at 0,0");
+  }
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/remove-anchor-dirty-layout-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/remove-anchor-dirty-layout-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Remove anchor
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/remove-anchor-dirty-layout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/remove-anchor-dirty-layout.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel="help" href="https://issues.chromium.org/issues/381362589">
+<style>
+  #anchor {
+    anchor-name: --a;
+  }
+  #target {
+    position: absolute;
+    top: anchor(top);
+    position-anchor: --a;
+  }
+</style>
+<div id="anchor"></div>
+<div id="target"></div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  promise_test(async t => {
+    await new Promise(resolve => requestAnimationFrame(resolve));
+    await new Promise(resolve => requestAnimationFrame(resolve));
+    await new Promise(resolve => step_timeout(resolve));
+    let element = document.getElementById("anchor");
+    element.remove();
+    await new Promise(resolve => requestAnimationFrame(resolve));
+  }, "Remove anchor");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/w3c-import.log
@@ -255,6 +255,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scroll-adjust-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scroll-adjust-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scroll-adjust.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-003.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-value.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-with-insets.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-wm-dir.html
@@ -350,6 +351,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/property-interpolations.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-anchor-dynamic.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/pseudo-element-anchor.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/remove-anchor-dirty-layout.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/sticky-anchor-position-invalid-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/sticky-anchor-position-invalid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-alignment.html


### PR DESCRIPTION
#### 40f8e98fa81decd01ec37f4b7a986dc20ffbe4ca
<pre>
Import more WPT tests into css-anchor-position
<a href="https://bugs.webkit.org/show_bug.cgi?id=285798">https://bugs.webkit.org/show_bug.cgi?id=285798</a>

Reviewed by Tim Nguyen.

Import more WPT tests into css-anchor-position

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-003.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-003.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/remove-anchor-dirty-layout-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/remove-anchor-dirty-layout.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/288761@main">https://commits.webkit.org/288761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08f518921c88b14fc98ce69a6aa654874f8350ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89407 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35337 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11928 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65585 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23420 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76619 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45878 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2979 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30849 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34386 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73873 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90787 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11595 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8421 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74033 "Found 23 new test failures: imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-descendant-text-mutated-001.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-character.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vs-float-clearance-002.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-non-invertible-discrete-interpolation.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-offscreen-new.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-new.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-exit.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-ident.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple-wildcard.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11822 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73231 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17562 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16006 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2960 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13057 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11547 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11396 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14872 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13169 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->