### PR TITLE
SVG text with gradient fill is rendered very slow

### DIFF
--- a/LayoutTests/imported/blink/svg/text/obb-paintserver.html
+++ b/LayoutTests/imported/blink/svg/text/obb-paintserver.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-12500" />
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-13003" />
 <svg width="200" height="400">
   <linearGradient id="gradient" x1="0" x2="0" y1="0" y2="1">
     <stop offset="0" stop-color="green"/>

--- a/LayoutTests/imported/mozilla/svg/text-scale-02.svg
+++ b/LayoutTests/imported/mozilla/svg/text-scale-02.svg
@@ -3,7 +3,7 @@
      http://creativecommons.org/publicdomain/zero/1.0/
 -->
 <svg xmlns="http://www.w3.org/2000/svg">
-  <meta name="fuzzy" content="maxDifference=0-2;totalPixels=67000-105000" />
+  <meta name="fuzzy" content="maxDifference=0-2; totalPixels=67000-111217" />
   <style>
     @font-face {
       font-family: Ahem;

--- a/LayoutTests/imported/mozilla/svg/text/simple-fill-gradient.svg
+++ b/LayoutTests/imported/mozilla/svg/text/simple-fill-gradient.svg
@@ -3,7 +3,7 @@
      http://creativecommons.org/publicdomain/zero/1.0/
 -->
 <svg xmlns="http://www.w3.org/2000/svg" width="700" height="200" viewBox="0 0 700 200">
-  <meta name="fuzzy" content="maxDifference=0-2;totalPixels=120-135" />
+  <meta name="fuzzy" content="maxDifference=0-2;totalPixels=120-137" />
   <style>
     @font-face {
       font-family: Ahem;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
@@ -3,7 +3,7 @@
  * Copyright (C) 2007 Rob Buis <buis@kde.org>
  * Copyright (C) 2008 Dirk Schulze <krit@webkit.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -264,7 +264,7 @@ void LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidationIfNeeded
     }
 }
 
-void LegacyRenderSVGResource::fillAndStrokePathOrShape(GraphicsContext& context, OptionSet<RenderSVGResourceMode> resourceMode, const Path* path, const RenderElement* shape) const
+void LegacyRenderSVGResource::fillAndStrokePathOrShape(GraphicsContext& context, OptionSet<RenderSVGResourceMode> resourceMode, const Path* path, const RenderElement* shape)
 {
     if (shape) {
         ASSERT(shape->isRenderOrLegacyRenderSVGShape());

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) Research In Motion Limited 2009-2010. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -83,8 +84,7 @@ public:
     static void markForLayoutAndParentResourceInvalidation(RenderObject&, bool needsLayout = true);
     static void markForLayoutAndParentResourceInvalidationIfNeeded(RenderObject&, bool needsLayout, SingleThreadWeakHashSet<RenderObject>* visitedRenderers);
 
-protected:
-    void fillAndStrokePathOrShape(GraphicsContext&, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement* shape) const;
+    static void fillAndStrokePathOrShape(GraphicsContext&, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement* shape);
 };
 
 constexpr bool resourceWasApplied(OptionSet<LegacyRenderSVGResource::ApplyResult> result)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
@@ -3,7 +3,7 @@
  * Copyright (C) 2008 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2008 Dirk Schulze <krit@webkit.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -56,65 +56,6 @@ void LegacyRenderSVGResourceGradient::removeClientFromCache(RenderElement& clien
     markClientForInvalidation(client, markForInvalidation ? RepaintInvalidation : ParentOnlyInvalidation);
 }
 
-#if USE(CG)
-static inline bool createMaskAndSwapContextForTextGradient(GraphicsContext*& context, GraphicsContext*& savedContext, RefPtr<ImageBuffer>& imageBuffer, RenderElement& renderer)
-{
-    auto* textRootBlock = RenderSVGText::locateRenderSVGTextAncestor(renderer);
-    ASSERT(textRootBlock);
-
-    AffineTransform absoluteTransform = SVGRenderingContext::calculateTransformationToOutermostCoordinateSystem(*textRootBlock);
-    // FIXME: This needs to be bounding box and should not use repaint rect.
-    // https://bugs.webkit.org/show_bug.cgi?id=278551
-    FloatRect repaintRect = textRootBlock->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate);
-
-    // Ignore 2D rotation, as it doesn't affect the size of the mask.
-    FloatSize scale(absoluteTransform.xScale(), absoluteTransform.yScale());
-
-    // Determine scale factor for the clipper. The size of intermediate ImageBuffers shouldn't be bigger than kMaxFilterSize.
-    ImageBuffer::sizeNeedsClamping(repaintRect.size(), scale);
-
-    auto maskImage = context->createScaledImageBuffer(repaintRect, scale);
-    if (!maskImage)
-        return false;
-
-    GraphicsContext& maskImageContext = maskImage->context();
-    ASSERT(maskImage);
-    savedContext = context;
-    context = &maskImageContext;
-    imageBuffer = WTFMove(maskImage);
-    return true;
-}
-
-static inline AffineTransform clipToTextMask(GraphicsContext& context, RefPtr<ImageBuffer>& imageBuffer, FloatRect& targetRect, RenderElement& renderer, bool boundingBoxMode, const AffineTransform& gradientTransform)
-{
-    auto* textRootBlock = RenderSVGText::locateRenderSVGTextAncestor(renderer);
-    ASSERT(textRootBlock);
-
-    AffineTransform absoluteTransform = SVGRenderingContext::calculateTransformationToOutermostCoordinateSystem(*textRootBlock);
-
-    // FIXME: This needs to be bounding box and should not use repaint rect.
-    // https://bugs.webkit.org/show_bug.cgi?id=278551
-    targetRect = textRootBlock->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate);
-    
-    // Ignore 2D rotation, as it doesn't affect the size of the mask.
-    FloatSize scale(absoluteTransform.xScale(), absoluteTransform.yScale());
-
-    // Determine scale factor for the clipper. The size of intermediate ImageBuffers shouldn't be bigger than kMaxFilterSize.
-    ImageBuffer::sizeNeedsClamping(targetRect.size(), scale);
-
-    SVGRenderingContext::clipToImageBuffer(context, targetRect, scale, imageBuffer, false);
-
-    AffineTransform matrix;
-    if (boundingBoxMode) {
-        FloatRect maskBoundingBox = textRootBlock->objectBoundingBox();
-        matrix.translate(maskBoundingBox.location());
-        matrix.scale(maskBoundingBox.size());
-    }
-    matrix *= gradientTransform;
-    return matrix;
-}
-#endif
-
 GradientData::Inputs LegacyRenderSVGResourceGradient::computeInputs(RenderElement& renderer, OptionSet<RenderSVGResourceMode> resourceMode)
 {
     std::optional<FloatRect> objectBoundingBox;
@@ -128,11 +69,8 @@ GradientData::Inputs LegacyRenderSVGResourceGradient::computeInputs(RenderElemen
     return { objectBoundingBox, textPaintingScale };
 }
 
-auto LegacyRenderSVGResourceGradient::applyResource(RenderElement& renderer, const RenderStyle& style, GraphicsContext*& context, OptionSet<RenderSVGResourceMode> resourceMode) -> OptionSet<ApplyResult>
+GradientData* LegacyRenderSVGResourceGradient::gradientDataForRenderer(RenderElement& renderer, const RenderStyle& style, OptionSet<RenderSVGResourceMode> resourceMode)
 {
-    ASSERT(context);
-    ASSERT(!resourceMode.isEmpty());
-
     // Be sure to synchronize all SVG properties on the gradientElement _before_ processing any further.
     // Otherwhise the call to collectGradientAttributes() in createTileImage(), may cause the SVG DOM property
     // synchronization to kick in, which causes removeAllClientsFromCache() to be called, which in turn deletes our
@@ -140,7 +78,7 @@ auto LegacyRenderSVGResourceGradient::applyResource(RenderElement& renderer, con
     if (m_shouldCollectGradientAttributes) {
         gradientElement().synchronizeAllAttributes();
         if (!collectGradientAttributes())
-            return { };
+            return nullptr;
 
         m_shouldCollectGradientAttributes = false;
     }
@@ -149,9 +87,7 @@ auto LegacyRenderSVGResourceGradient::applyResource(RenderElement& renderer, con
     // then the given effect (e.g. a gradient or a filter) will be ignored.
     auto inputs = computeInputs(renderer, resourceMode);
     if (inputs.objectBoundingBox && inputs.objectBoundingBox->isEmpty())
-        return { };
-
-    bool isPaintingText = resourceMode.contains(RenderSVGResourceMode::ApplyToText);
+        return nullptr;
 
     auto& gradientData = *m_gradientMap.ensure(&renderer, [&]() {
         return makeUnique<GradientData>();
@@ -166,7 +102,7 @@ auto LegacyRenderSVGResourceGradient::applyResource(RenderElement& renderer, con
         // box applied to the gradient space transform now, so the gradient shader can use it.
         if (gradientData.inputs.objectBoundingBox
 #if USE(CG)
-            && !isPaintingText
+            && !resourceMode.contains(RenderSVGResourceMode::ApplyToText)
 #endif
         ) {
             gradientData.userspaceTransform.translate(gradientData.inputs.objectBoundingBox->location());
@@ -181,32 +117,217 @@ auto LegacyRenderSVGResourceGradient::applyResource(RenderElement& renderer, con
             gradientData.userspaceTransform.scale(gradientData.inputs.textPaintingScale);
     }
 
-    // Draw gradient
-    context->save();
+    return &gradientData;
+}
 
-    if (isPaintingText) {
-#if USE(CG)
-        if (!createMaskAndSwapContextForTextGradient(context, m_savedContext, m_imageBuffer, renderer)) {
-            context->restore();
-            return { };
-        }
-#endif
-        context->setTextDrawingMode(resourceMode.contains(RenderSVGResourceMode::ApplyToFill) ? TextDrawingMode::Fill : TextDrawingMode::Stroke);
-    }
+static inline void applyGradientResource(RenderElement& renderer, const RenderStyle& style, GraphicsContext& context, const GradientData& gradientData, OptionSet<RenderSVGResourceMode> resourceMode)
+{
+    if (resourceMode.contains(RenderSVGResourceMode::ApplyToText))
+        context.setTextDrawingMode(resourceMode.contains(RenderSVGResourceMode::ApplyToFill) ? TextDrawingMode::Fill : TextDrawingMode::Stroke);
 
     auto& svgStyle = style.svgStyle();
     auto userspaceTransform = gradientData.userspaceTransform;
 
     if (resourceMode.contains(RenderSVGResourceMode::ApplyToFill)) {
-        context->setAlpha(svgStyle.fillOpacity());
-        context->setFillGradient(*gradientData.gradient, userspaceTransform);
-        context->setFillRule(svgStyle.fillRule());
+        context.setAlpha(svgStyle.fillOpacity());
+        context.setFillGradient(*gradientData.gradient, userspaceTransform);
+        context.setFillRule(svgStyle.fillRule());
     } else if (resourceMode.contains(RenderSVGResourceMode::ApplyToStroke)) {
         if (svgStyle.vectorEffect() == VectorEffect::NonScalingStroke)
-            userspaceTransform = transformOnNonScalingStroke(&renderer, gradientData.userspaceTransform);
-        context->setAlpha(svgStyle.strokeOpacity());
-        context->setStrokeGradient(*gradientData.gradient, userspaceTransform);
-        SVGRenderSupport::applyStrokeStyleToContext(*context, style, renderer);
+            userspaceTransform = LegacyRenderSVGResourceContainer::transformOnNonScalingStroke(&renderer, gradientData.userspaceTransform);
+        context.setAlpha(svgStyle.strokeOpacity());
+        context.setStrokeGradient(*gradientData.gradient, userspaceTransform);
+        SVGRenderSupport::applyStrokeStyleToContext(context, style, renderer);
+    }
+}
+
+class PathOrShapeGradientApplier : public GradientApplier {
+    WTF_MAKE_TZONE_ALLOCATED(PathOrShapeGradientApplier);
+    WTF_MAKE_NONCOPYABLE(PathOrShapeGradientApplier);
+public:
+    PathOrShapeGradientApplier() = default;
+
+private:
+    bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, const GradientData&, OptionSet<RenderSVGResourceMode>) final;
+    void postApplyResource(RenderElement&, GraphicsContext*&, const GradientData&, SVGUnitTypes::SVGUnitType gradientUnits, const AffineTransform& gradientTransform, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement*) final;
+};
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PathOrShapeGradientApplier);
+
+bool PathOrShapeGradientApplier::applyResource(RenderElement& renderer, const RenderStyle& style, GraphicsContext*& context, const GradientData& gradientData, OptionSet<RenderSVGResourceMode> resourceMode)
+{
+    context->save();
+    applyGradientResource(renderer, style, *context, gradientData, resourceMode);
+    return true;
+}
+
+void PathOrShapeGradientApplier::postApplyResource(RenderElement&, GraphicsContext*& context, const GradientData&, SVGUnitTypes::SVGUnitType, const AffineTransform&, OptionSet<RenderSVGResourceMode> resourceMode, const Path* path, const RenderElement* shape)
+{
+    LegacyRenderSVGResource::fillAndStrokePathOrShape(*context, resourceMode, path, shape);
+    context->restore();
+}
+
+#if USE(CG)
+class TextGradientClipper : public GradientApplier {
+    WTF_MAKE_TZONE_ALLOCATED(TextGradientClipper);
+    WTF_MAKE_NONCOPYABLE(TextGradientClipper);
+public:
+    TextGradientClipper() = default;
+
+private:
+    bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, const GradientData&, OptionSet<RenderSVGResourceMode>) final;
+    void postApplyResource(RenderElement&, GraphicsContext*&, const GradientData&, SVGUnitTypes::SVGUnitType gradientUnits, const AffineTransform& gradientTransform, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement*) final;
+
+    GraphicsContext* m_savedContext { nullptr };
+    RefPtr<ImageBuffer> m_imageBuffer;
+};
+
+static inline std::tuple<FloatRect, FloatSize> calculateGradientGeometry(RenderElement& renderer)
+{
+    auto* textRootBlock = RenderSVGText::locateRenderSVGTextAncestor(renderer);
+    ASSERT(textRootBlock);
+
+    // FIXME: This needs to be bounding box and should not use repaint rect.
+    // https://bugs.webkit.org/show_bug.cgi?id=278551
+    FloatRect repaintRect = textRootBlock->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate);
+
+    AffineTransform absoluteTransform = SVGRenderingContext::calculateTransformationToOutermostCoordinateSystem(*textRootBlock);
+
+    // Ignore 2D rotation, as it doesn't affect the size of the target.
+    FloatSize scale(absoluteTransform.xScale(), absoluteTransform.yScale());
+
+    return { repaintRect, scale };
+}
+
+static inline AffineTransform calculateGradientUserspaceTransform(RenderElement& renderer, SVGUnitTypes::SVGUnitType gradientUnits, const AffineTransform& gradientTransform)
+{
+    if (gradientUnits != SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX)
+        return gradientTransform;
+
+    auto* textRootBlock = RenderSVGText::locateRenderSVGTextAncestor(renderer);
+    ASSERT(textRootBlock);
+
+    auto boundingBox = textRootBlock->objectBoundingBox();
+
+    AffineTransform userspaceTransform;
+    userspaceTransform.translate(boundingBox.location());
+    userspaceTransform.scale(boundingBox.size());
+    userspaceTransform *= gradientTransform;
+
+    return userspaceTransform;
+}
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextGradientClipper);
+
+bool TextGradientClipper::applyResource(RenderElement& renderer, const RenderStyle& style, GraphicsContext*& context, const GradientData& gradientData, OptionSet<RenderSVGResourceMode> resourceMode)
+{
+    ASSERT(resourceMode.contains(RenderSVGResourceMode::ApplyToText));
+
+    auto [targetRect, scale] = calculateGradientGeometry(renderer);
+    ImageBuffer::sizeNeedsClamping(targetRect.size(), scale);
+
+    m_imageBuffer = context->createScaledImageBuffer(targetRect, scale);
+    if (!m_imageBuffer)
+        return false;
+
+    m_savedContext = context;
+    context = &m_imageBuffer->context();
+
+    applyGradientResource(renderer, style, *context, gradientData, resourceMode);
+    return true;
+}
+
+void TextGradientClipper::postApplyResource(RenderElement& renderer, GraphicsContext*& context, const GradientData& gradientData, SVGUnitTypes::SVGUnitType gradientUnits, const AffineTransform& gradientTransform, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement*)
+{
+    if (!m_savedContext)
+        return;
+
+    auto [targetRect, scale] = calculateGradientGeometry(renderer);
+    ImageBuffer::sizeNeedsClamping(targetRect.size(), scale);
+
+    Ref gradient = *gradientData.gradient;
+    auto userspaceTransform = calculateGradientUserspaceTransform(renderer, gradientUnits, gradientTransform);
+
+    // Restore on-screen drawing context
+    context = std::exchange(m_savedContext, nullptr);
+
+    GraphicsContextStateSaver stateSaver(*context);
+
+    SVGRenderingContext::clipToImageBuffer(*context, targetRect, scale, m_imageBuffer, false);
+
+    context->setFillGradient(WTFMove(gradient), userspaceTransform);
+    context->fillRect(targetRect);
+
+    m_imageBuffer = nullptr;
+}
+
+class TextGradientCompositor : public GradientApplier {
+    WTF_MAKE_TZONE_ALLOCATED(TextGradientCompositor);
+    WTF_MAKE_NONCOPYABLE(TextGradientCompositor);
+public:
+    TextGradientCompositor() = default;
+
+private:
+    bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, const GradientData&, OptionSet<RenderSVGResourceMode>) final;
+    void postApplyResource(RenderElement&, GraphicsContext*&, const GradientData&, SVGUnitTypes::SVGUnitType gradientUnits, const AffineTransform& gradientTransform, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement*) final;
+};
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(TextGradientCompositor);
+
+bool TextGradientCompositor::applyResource(RenderElement&, const RenderStyle&, GraphicsContext*& context, const GradientData&, OptionSet<RenderSVGResourceMode>)
+{
+    context->save();
+
+    context->beginTransparencyLayer(1);
+    return true;
+}
+
+void TextGradientCompositor::postApplyResource(RenderElement& renderer, GraphicsContext*& context, const GradientData& gradientData, SVGUnitTypes::SVGUnitType gradientUnits, const AffineTransform& gradientTransform, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement*)
+{
+    context->setCompositeOperation(CompositeOperator::SourceIn);
+    context->beginTransparencyLayer(1);
+    context->setCompositeOperation(CompositeOperator::SourceOver);
+
+    [[maybe_unused]] auto [targetRect, scale] = calculateGradientGeometry(renderer);
+
+    Ref gradient = *gradientData.gradient;
+    auto userspaceTransform = calculateGradientUserspaceTransform(renderer, gradientUnits, gradientTransform);
+
+    context->setFillGradient(WTFMove(gradient), userspaceTransform);
+    context->fillRect(targetRect);
+
+    context->endTransparencyLayer();
+    context->endTransparencyLayer();
+
+    context->restore();
+}
+#endif
+
+auto LegacyRenderSVGResourceGradient::applyResource(RenderElement& renderer, const RenderStyle& style, GraphicsContext*& context, OptionSet<RenderSVGResourceMode> resourceMode) -> OptionSet<ApplyResult>
+{
+    ASSERT(context);
+    ASSERT(!resourceMode.isEmpty());
+
+    auto gradientData = gradientDataForRenderer(renderer, style, resourceMode);
+    if (!gradientData)
+        return { };
+
+#if USE(CG)
+    if (resourceMode.contains(RenderSVGResourceMode::ApplyToText)) {
+        // PDF does not support some CompositeOperation
+        if (context->renderingMode() == RenderingMode::PDFDocument)
+            m_gradientApplier = makeUnique<TextGradientClipper>();
+        else
+            m_gradientApplier = makeUnique<TextGradientCompositor>();
+    }
+#endif
+
+    if (!m_gradientApplier)
+        m_gradientApplier = makeUnique<PathOrShapeGradientApplier>();
+
+    if (!m_gradientApplier->applyResource(renderer, style, context, *gradientData, resourceMode)) {
+        m_gradientApplier = nullptr;
+        return { };
     }
 
     return { ApplyResult::ResourceApplied };
@@ -217,33 +338,14 @@ void LegacyRenderSVGResourceGradient::postApplyResource(RenderElement& renderer,
     ASSERT(context);
     ASSERT(!resourceMode.isEmpty());
 
-    if (resourceMode.contains(RenderSVGResourceMode::ApplyToText)) {
-#if USE(CG)
-        // CG requires special handling for gradient on text
-        if (m_savedContext) {
-            auto gradientData = m_gradientMap.find(&renderer);
-            if (gradientData != m_gradientMap.end()) {
-                Ref gradient = *gradientData->value->gradient;
+    if (!m_gradientApplier)
+        return;
 
-                // Restore on-screen drawing context
-                context = std::exchange(m_savedContext, nullptr);
+    auto gradientData = m_gradientMap.find(&renderer);
+    if (gradientData != m_gradientMap.end())
+        m_gradientApplier->postApplyResource(renderer, context, *gradientData->value, gradientUnits(), gradientTransform(), resourceMode, path, shape);
 
-                FloatRect targetRect;
-                AffineTransform userspaceTransform = clipToTextMask(*context, m_imageBuffer, targetRect, renderer, gradientUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX, gradientTransform());
-
-                context->setFillGradient(WTFMove(gradient), userspaceTransform);
-                context->fillRect(targetRect);
-
-                m_imageBuffer = nullptr;
-            }
-        }
-#else
-        UNUSED_PARAM(renderer);
-#endif
-    } else
-        fillAndStrokePathOrShape(*context, resourceMode, path, shape);
-
-    context->restore();
+    m_gradientApplier = nullptr;
 }
 
 GradientColorStops LegacyRenderSVGResourceGradient::stopsByApplyingColorFilter(const GradientColorStops& stops, const RenderStyle& style)
@@ -270,4 +372,4 @@ GradientSpreadMethod LegacyRenderSVGResourceGradient::platformSpreadMethodFromSV
     return GradientSpreadMethod::Pad;
 }
 
-}
+} // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h
@@ -2,6 +2,7 @@
  * Copyright (C) 2006 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2008 Eric Seidel <eric@webkit.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -56,6 +57,15 @@ struct GradientData {
     Inputs inputs;
 };
 
+class GradientApplier {
+public:
+    GradientApplier() = default;
+    virtual ~GradientApplier() = default;
+
+    virtual bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, const GradientData&, OptionSet<RenderSVGResourceMode>) = 0;
+    virtual void postApplyResource(RenderElement&, GraphicsContext*&, const GradientData&, SVGUnitTypes::SVGUnitType gradientUnits, const AffineTransform& gradientTransform, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement*) = 0;
+};
+
 class LegacyRenderSVGResourceGradient : public LegacyRenderSVGResourceContainer {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(LegacyRenderSVGResourceGradient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGResourceGradient);
@@ -81,6 +91,7 @@ private:
     void element() const = delete;
 
     GradientData::Inputs computeInputs(RenderElement&, OptionSet<RenderSVGResourceMode>);
+    GradientData* gradientDataForRenderer(RenderElement&, const RenderStyle&, OptionSet<RenderSVGResourceMode>);
 
     virtual SVGUnitTypes::SVGUnitType gradientUnits() const = 0;
     virtual AffineTransform gradientTransform() const = 0;
@@ -89,11 +100,7 @@ private:
 
     UncheckedKeyHashMap<RenderObject*, std::unique_ptr<GradientData>> m_gradientMap;
 
-#if USE(CG)
-    GraphicsContext* m_savedContext { nullptr };
-    RefPtr<ImageBuffer> m_imageBuffer;
-#endif
-
+    std::unique_ptr<GradientApplier> m_gradientApplier;
     bool m_shouldCollectGradientAttributes { true };
 };
 


### PR DESCRIPTION
#### 19fb3bc3aa27a28183dbc388d1ba5df1cbb2feb6
<pre>
SVG text with gradient fill is rendered very slow
<a href="https://bugs.webkit.org/show_bug.cgi?id=285799#">https://bugs.webkit.org/show_bug.cgi?id=285799#</a>
<a href="https://rdar.apple.com/73203473">rdar://73203473</a>

Reviewed by Simon Fraser.

Refactor applying the SVG gradient resource into two appliers: one for text
(TextGradientClipper) and the other for PathOrShape (PathOrShapeGradientApplier).

TextGradientClipper draws the text into a mask ImageBuffer. Then GraphicsContext
is clipped to this ImageBuffer before the targetRect is filled with gradient.

PathOrShapeGradientApplier fills or strokes the path (or the shape) with the
gradient resource.

Add the new text applier TextGradientCompositor which draws the text into a
transparency layer with SourceIn. Then it fills the targetRect with the gradient
into another transparency layer with SourceOver. Then these two layers are
composited to GraphicsContext.

TextGradientCompositor will be used for all cases except when rendering to a
PDFDocument because PDF context does not support some CompositeOperation. In this
case TextGradientClipper will be used to draw the text.

* LayoutTests/imported/blink/svg/text/obb-paintserver.html:
* LayoutTests/imported/mozilla/svg/text-scale-02.svg:
* LayoutTests/imported/mozilla/svg/text/simple-fill-gradient.svg:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp:
(WebCore::LegacyRenderSVGResource::fillAndStrokePathOrShape):
(WebCore::LegacyRenderSVGResource::fillAndStrokePathOrShape const): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp:
(WebCore::LegacyRenderSVGResourceGradient::gradientDataForRenderer):
(WebCore::applyGradientResource):
(WebCore::PathOrShapeGradientApplier::applyResource):
(WebCore::PathOrShapeGradientApplier::postApplyResource):
(WebCore::calculateGradientGeometry):
(WebCore::calculateGradientUserspaceTransform):
(WebCore::TextGradientClipper::applyResource):
(WebCore::TextGradientClipper::postApplyResource):
(WebCore::TextGradientCompositor::applyResource):
(WebCore::TextGradientCompositor::postApplyResource):
(WebCore::LegacyRenderSVGResourceGradient::applyResource):
(WebCore::LegacyRenderSVGResourceGradient::postApplyResource):
(WebCore::createMaskAndSwapContextForTextGradient): Deleted.
(WebCore::clipToTextMask): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h:

Canonical link: <a href="https://commits.webkit.org/288788@main">https://commits.webkit.org/288788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e130ef2cf60ce83598514600060e71c46a054489

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89418 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35348 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86424 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65592 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23431 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76629 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45886 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/2991 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30859 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34397 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73881 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90798 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8471 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74040 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72454 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73239 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18141 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17572 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16016 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2974 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11558 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17034 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11407 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14883 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->