### PR TITLE
Opt WebKit processes into requiring a per boot seed for TZoneHeapManager.

### DIFF
--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -46,6 +46,10 @@
 #import <wtf/spi/darwin/XPCSPI.h>
 #import <wtf/text/MakeString.h>
 
+#if USE(TZONE_MALLOC)
+#import <bmalloc/TZoneHeapManager.h>
+#endif
+
 #if __has_include(<WebKitAdditions/DyldCallbackAdditions.h>)
 #import <WebKitAdditions/DyldCallbackAdditions.h>
 #endif
@@ -127,6 +131,9 @@ static bool s_isWebProcess = false;
 
 void XPCServiceEventHandler(xpc_connection_t peer)
 {
+#if USE(TZONE_MALLOC)
+    bmalloc::api::TZoneHeapManager::requirePerBootSeed();
+#endif
     OSObjectPtr<xpc_connection_t> retainedPeerConnection(peer);
 
     xpc_connection_set_target_queue(peer, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0));

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.h
@@ -130,6 +130,7 @@ public:
     TZoneHeapManager(TZoneHeapManager &other) = delete;
     void operator=(const TZoneHeapManager &) = delete;
 
+    BEXPORT static void requirePerBootSeed();
     BEXPORT static void setBucketParams(unsigned smallSizeCount, unsigned largeSizeCount = 0, unsigned smallSizeLimit = 0);
 
     BEXPORT static bool isReady();
@@ -177,7 +178,7 @@ private:
     inline unsigned tzoneBucketForKey(const TZoneSpecification&, unsigned bucketCountForSize, LockHolder&);
     TZoneTypeBuckets* populateBucketsForSizeClass(LockHolder&, SizeAndAlignment::Value);
 
-    static TZoneHeapManager::State m_state;
+    static TZoneHeapManager::State s_state;
     Mutex m_mutex;
     Mutex m_differentSizeMutex;
     uint64_t m_tzoneKeySeed;


### PR DESCRIPTION
#### 1d13510af04896b1d4420ea77ec73c9b6f23bb1f
<pre>
Opt WebKit processes into requiring a per boot seed for TZoneHeapManager.
<a href="https://bugs.webkit.org/show_bug.cgi?id=285804">https://bugs.webkit.org/show_bug.cgi?id=285804</a>
<a href="https://rdar.apple.com/142752165">rdar://142752165</a>

Reviewed by Keith Miller and Yusuke Suzuki.

In 288751@main, we removed a RELEASE_BASSERT that ensures that the TZoneHeapManager primodialSeed
is unique per boot to accommodate clients code that are not WebKit processes which may not have
access to kern.boottime.  However, we can restore this RELEASE_ASSERT for WebKit processes which
we do know have access.

This patch adds TZoneHeapManager::requirePerBootSeed() which allows a client to opt into enabling
that RELEASE_BASSERT, and requiring a unique per boot seed.

Also renamed m_state to s_state since it is a static field.
Also made bucketsForSmallSizes, bucketsForLargeSizes, and maxSmallSize static since the are only
accessed in TZoneHeapManager.cpp.

* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceEventHandler):
* Source/bmalloc/bmalloc/TZoneHeapManager.cpp:
(bmalloc::api::TZoneHeapManager::TZoneHeapManager):
(bmalloc::api::TZoneHeapManager::requirePerBootSeed):
(bmalloc::api::TZoneHeapManager::setBucketParams):
(bmalloc::api::TZoneHeapManager::init):
(bmalloc::api::TZoneHeapManager::isReady):
(bmalloc::api::TZoneHeapManager::dumpRegisteredTypes):
(bmalloc::api::TZoneHeapManager::populateBucketsForSizeClass):
(bmalloc::api::TZoneHeapManager::heapRefForTZoneType):
* Source/bmalloc/bmalloc/TZoneHeapManager.h:

Canonical link: <a href="https://commits.webkit.org/288777@main">https://commits.webkit.org/288777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca72dd46ccd72fc18681b81ecbfd124b56150fa6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/3975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89429 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35359 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65599 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23439 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87396 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3077 "Found 9 new test failures: fast/files/blob-stream-frame.html http/tests/IndexedDB/storage-limit-1.https.html http/tests/IndexedDB/storage-limit-2.https.html http/tests/websocket/tests/hybi/no-subprotocol.html http/wpt/background-fetch/background-fetch-persistency.window.html http/wpt/beacon/cors/crossorigin-arraybufferview-no-preflight.html http/wpt/cache-storage/quota-third-party.https.html http/wpt/service-workers/persistent-modules.html storage/indexeddb/modern/opendatabase-after-storage-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45893 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3028 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/html/cross-origin-opener-policy/iframe-popup-same-origin-to-unsafe-none.https.html?3-4 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/iframe-popup-same-origin-to-unsafe-none.https.html?5-6 imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30869 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34408 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77314 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73918 "Found 15 new API test failures: TestWebKitAPI.ProcessSwap.NavigatingCrossOriginFromCOOPAndCOEPSameOriginToCOOPSameOrigin, TestWebKitAPI.WebKit.NetworkProcessCrashWithPendingConnection, TestWebKitAPI.WKWebView.LocalStorageProcessCrashes, TestWebKitAPI.WebKit.NetworkProcessCrashNonPersistentDataStore, TestWebKitAPI.WKProcessPool.InitialWarmedProcessUsed, TestWebKitAPI.WebKit.DoLoadWithNonDefaultDataStoreAfterTerminatingNetworkProcess, TestWebKitAPI.ProcessSwap.NavigatingSameOriginFromCOOPAndCOEPSameOrigin, TestWebKitAPI.WebKit.ProxyAfterNetworkProcessCrash, TestWebKitAPI.NetworkProcess.BroadcastChannelCrashRecovery, TestWebKitAPI.WebKit.NetworkProcessCrashNonDefaultPersistentDataStore ... (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31638 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90810 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83367 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8484 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74051 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72463 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73251 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17581 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16025 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/2992 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13065 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11569 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17045 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105786 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11418 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25533 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13191 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->