### PR TITLE
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/graphics

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2500,12 +2500,12 @@ RefPtr<ByteArrayPixelBuffer> CanvasRenderingContext2DBase::cacheImageDataIfPossi
     ConstPixelBufferConversionView source {
         .format = { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, colorSpace },
         .bytesPerRow = bytesPerRow,
-        .rows = imageData.data().asUint8ClampedArray()->data(),
+        .rows = imageData.data().asUint8ClampedArray()->span(),
     };
     PixelBufferConversionView destination {
         .format = cachedFormat,
         .bytesPerRow = bytesPerRow,
-        .rows = cachedBuffer->data().data(),
+        .rows = cachedBuffer->data().mutableSpan(),
     };
     convertImagePixels(source, destination, size);
     m_cachedContents.emplace<CachedContentsImageData>(*this, *cachedBuffer);
@@ -2538,12 +2538,12 @@ RefPtr<ImageData> CanvasRenderingContext2DBase::makeImageDataIfContentsCached(co
     ConstPixelBufferConversionView source {
         .format = pixelBuffer->format(),
         .bytesPerRow = bytesPerRow,
-        .rows = data->data(),
+        .rows = data->span(),
     };
     PixelBufferConversionView destination {
         .format = { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, pixelBuffer->format().colorSpace },
         .bytesPerRow = bytesPerRow,
-        .rows = data->data(),
+        .rows = data->mutableSpan(),
     };
     convertImagePixels(source, destination, size);
     return ImageData::create(size, WTFMove(data), m_settings.colorSpace);

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -98,7 +98,7 @@ void ImageBufferBackend::convertToLuminanceMask()
     putPixelBuffer(*pixelBuffer, sourceRect, IntPoint::zero(), AlphaPremultiplication::Premultiplied);
 }
 
-void ImageBufferBackend::getPixelBuffer(const IntRect& sourceRect, const uint8_t* sourceData, PixelBuffer& destinationPixelBuffer)
+void ImageBufferBackend::getPixelBuffer(const IntRect& sourceRect, std::span<const uint8_t> sourceData, PixelBuffer& destinationPixelBuffer)
 {
     IntRect backendRect { { }, size() };
     auto sourceRectClipped = intersection(backendRect, sourceRect);
@@ -117,19 +117,23 @@ void ImageBufferBackend::getPixelBuffer(const IntRect& sourceRect, const uint8_t
     ConstPixelBufferConversionView source {
         { AlphaPremultiplication::Premultiplied, convertToPixelFormat(pixelFormat()), colorSpace() },
         sourceBytesPerRow,
-        sourceData + sourceRectClipped.y() * sourceBytesPerRow + sourceRectClipped.x() * 4
+        sourceData.subspan(sourceRectClipped.y() * sourceBytesPerRow + sourceRectClipped.x() * 4)
     };
     unsigned destinationBytesPerRow = static_cast<unsigned>(4u * sourceRect.width());
+    size_t offset = destinationRect.y() * destinationBytesPerRow + destinationRect.x() * 4;
+    if (offset > destinationPixelBuffer.bytes().size())
+        return;
+
     PixelBufferConversionView destination {
         destinationPixelBuffer.format(),
         destinationBytesPerRow,
-        destinationPixelBuffer.bytes().data() + destinationRect.y() * destinationBytesPerRow + destinationRect.x() * 4
+        destinationPixelBuffer.bytes().subspan(offset)
     };
 
     convertImagePixels(source, destination, destinationRect.size());
 }
 
-void ImageBufferBackend::putPixelBuffer(const PixelBuffer& sourcePixelBuffer, const IntRect& sourceRect, const IntPoint& destinationPoint, AlphaPremultiplication destinationAlphaFormat, uint8_t* destinationData)
+void ImageBufferBackend::putPixelBuffer(const PixelBuffer& sourcePixelBuffer, const IntRect& sourceRect, const IntPoint& destinationPoint, AlphaPremultiplication destinationAlphaFormat, std::span<uint8_t> destinationData)
 {
     IntRect backendRect { { }, size() };
     auto sourceRectClipped = intersection({ IntPoint::zero(), sourcePixelBuffer.size() }, sourceRect);
@@ -149,13 +153,13 @@ void ImageBufferBackend::putPixelBuffer(const PixelBuffer& sourcePixelBuffer, co
     ConstPixelBufferConversionView source {
         sourcePixelBuffer.format(),
         sourceBytesPerRow,
-        sourcePixelBuffer.bytes().data() + sourceRectClipped.y() * sourceBytesPerRow + sourceRectClipped.x() * 4
+        sourcePixelBuffer.bytes().subspan(sourceRectClipped.y() * sourceBytesPerRow + sourceRectClipped.x() * 4)
     };
     unsigned destinationBytesPerRow = bytesPerRow();
     PixelBufferConversionView destination {
         { destinationAlphaFormat, convertToPixelFormat(pixelFormat()), colorSpace() },
         destinationBytesPerRow,
-        destinationData + destinationRect.y() * destinationBytesPerRow + destinationRect.x() * 4
+        destinationData.subspan(destinationRect.y() * destinationBytesPerRow + destinationRect.x() * 4)
     };
 
     convertImagePixels(source, destination, destinationRect.size());

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -185,8 +185,8 @@ protected:
     const DestinationColorSpace& colorSpace() const { return m_parameters.colorSpace; }
     ImageBufferPixelFormat pixelFormat() const { return m_parameters.pixelFormat; }
 
-    WEBCORE_EXPORT void getPixelBuffer(const IntRect& srcRect, const uint8_t* data, PixelBuffer& destination);
-    WEBCORE_EXPORT void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat, uint8_t* destination);
+    WEBCORE_EXPORT void getPixelBuffer(const IntRect& srcRect, std::span<const uint8_t> data, PixelBuffer& destination);
+    WEBCORE_EXPORT void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat, std::span<uint8_t> destination);
 
     Parameters m_parameters;
 };

--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -32,10 +32,9 @@
 #include "PathStream.h"
 #include "PathTraversalState.h"
 #include "PlatformPathImpl.h"
+#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -593,10 +592,10 @@ bool Path::strokeContains(const FloatPoint& point, const Function<void(GraphicsC
 
 bool Path::hasSubpaths() const
 {
-    if (auto segment = asSingle())
-        return PathStream::computeHasSubpaths({ segment, 1 });
+    if (auto* segment = asSingle())
+        return PathStream::computeHasSubpaths(singleElementSpan(*segment));
 
-    if (auto impl = asImpl())
+    if (auto* impl = asImpl())
         return impl->hasSubpaths();
 
     return false;
@@ -604,10 +603,10 @@ bool Path::hasSubpaths() const
 
 FloatRect Path::fastBoundingRect() const
 {
-    if (auto segment = asSingle())
-        return PathStream::computeFastBoundingRect({ segment, 1 });
+    if (auto* segment = asSingle())
+        return PathStream::computeFastBoundingRect(singleElementSpan(*segment));
 
-    if (auto impl = asImpl())
+    if (auto* impl = asImpl())
         return impl->fastBoundingRect();
 
     return { };
@@ -615,10 +614,10 @@ FloatRect Path::fastBoundingRect() const
 
 FloatRect Path::boundingRect() const
 {
-    if (auto segment = asSingle())
-        return PathStream::computeBoundingRect({ segment, 1 });
+    if (auto* segment = asSingle())
+        return PathStream::computeBoundingRect(singleElementSpan(*segment));
 
-    if (auto impl = asImpl())
+    if (auto* impl = asImpl())
         return impl->boundingRect();
 
     return { };
@@ -643,5 +642,3 @@ TextStream& operator<<(TextStream& ts, const Path& path)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/PathImpl.cpp
+++ b/Source/WebCore/platform/graphics/PathImpl.cpp
@@ -27,8 +27,6 @@
 #include "PathImpl.h"
 #include <wtf/TZoneMallocInlines.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PathImpl);
@@ -139,5 +137,3 @@ bool PathImpl::hasSubpaths() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/PathTraversalState.cpp
+++ b/Source/WebCore/platform/graphics/PathTraversalState.cpp
@@ -25,8 +25,6 @@
 #include <wtf/MathExtras.h>
 #include <wtf/Vector.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static const float kPathSegmentLengthTolerance = 0.00001f;
@@ -267,5 +265,3 @@ bool PathTraversalState::processPathElement(PathElement::Type type, std::span<co
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/PixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/PixelBuffer.cpp
@@ -30,8 +30,6 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/TextStream.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 bool PixelBuffer::supportedPixelFormat(PixelFormat pixelFormat)
@@ -135,5 +133,3 @@ void PixelBuffer::set(size_t index, double value)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -30,6 +30,8 @@
 #include "DestinationColorSpace.h"
 #include "IntSize.h"
 #include "PixelFormat.h"
+#include <wtf/StdLibExtras.h>
+#include <wtf/text/ParsingUtilities.h>
 
 #if USE(ACCELERATE) && USE(CG)
 #include <Accelerate/Accelerate.h>
@@ -38,8 +40,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkPixmap.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -96,7 +96,7 @@ template<typename View> static vImage_Buffer makeVImageBuffer(const View& view, 
     result.height = static_cast<vImagePixelCount>(size.height());
     result.width = static_cast<vImagePixelCount>(size.width());
     result.rowBytes = view.bytesPerRow;
-    result.data = const_cast<uint8_t*>(view.rows);
+    result.data = const_cast<uint8_t*>(view.rows.data());
 
     return result;
 }
@@ -182,7 +182,7 @@ static void convertImagePixelsSkia(const ConstPixelBufferConversionView& source,
         source.format.colorSpace.platformColorSpace()
     );
     // Utilize SkPixmap which is a raw bytes wrapper capable of performing conversions.
-    SkPixmap sourcePixmap(sourceImageInfo, source.rows, source.bytesPerRow);
+    SkPixmap sourcePixmap(sourceImageInfo, source.rows.data(), source.bytesPerRow);
     SkImageInfo destinationImageInfo = SkImageInfo::Make(
         destinationSize.width(),
         destinationSize.height(),
@@ -191,7 +191,7 @@ static void convertImagePixelsSkia(const ConstPixelBufferConversionView& source,
         destination.format.colorSpace.platformColorSpace()
     );
     // Read pixels from source to destination and convert pixels if necessary.
-    sourcePixmap.readPixels(destinationImageInfo, destination.rows, destination.bytesPerRow);
+    sourcePixmap.readPixels(destinationImageInfo, destination.rows.data(), destination.bytesPerRow);
 }
 
 #endif
@@ -199,16 +199,16 @@ static void convertImagePixelsSkia(const ConstPixelBufferConversionView& source,
 enum class PixelFormatConversion { None, Permute };
 
 template<PixelFormatConversion pixelFormatConversion>
-static void convertSinglePixelPremultipliedToPremultiplied(const uint8_t* sourcePixel, uint8_t* destinationPixel)
+static void convertSinglePixelPremultipliedToPremultiplied(std::span<const uint8_t, 4> sourcePixel, std::span<uint8_t, 4> destinationPixel)
 {
     uint8_t alpha = sourcePixel[3];
     if (!alpha) {
-        reinterpret_cast<uint32_t*>(destinationPixel)[0] = 0;
+        reinterpretCastSpanStartTo<uint32_t>(destinationPixel) = 0;
         return;
     }
 
     if constexpr (pixelFormatConversion == PixelFormatConversion::None)
-        reinterpret_cast<uint32_t*>(destinationPixel)[0] = reinterpret_cast<const uint32_t*>(sourcePixel)[0];
+        reinterpretCastSpanStartTo<uint32_t>(destinationPixel) = reinterpretCastSpanStartTo<const uint32_t>(sourcePixel);
     else {
         // Swap pixel channels BGRA <-> RGBA.
         destinationPixel[0] = sourcePixel[2];
@@ -219,7 +219,7 @@ static void convertSinglePixelPremultipliedToPremultiplied(const uint8_t* source
 }
 
 template<PixelFormatConversion pixelFormatConversion>
-static void convertSinglePixelPremultipliedToUnpremultiplied(const uint8_t* sourcePixel, uint8_t* destinationPixel)
+static void convertSinglePixelPremultipliedToUnpremultiplied(std::span<const uint8_t, 4> sourcePixel, std::span<uint8_t, 4> destinationPixel)
 {
     uint8_t alpha = sourcePixel[3];
     if (!alpha || alpha == 255) {
@@ -242,7 +242,7 @@ static void convertSinglePixelPremultipliedToUnpremultiplied(const uint8_t* sour
 }
 
 template<PixelFormatConversion pixelFormatConversion>
-static void convertSinglePixelUnpremultipliedToPremultiplied(const uint8_t* sourcePixel, uint8_t* destinationPixel)
+static void convertSinglePixelUnpremultipliedToPremultiplied(std::span<const uint8_t, 4> sourcePixel, std::span<uint8_t, 4> destinationPixel)
 {
     uint8_t alpha = sourcePixel[3];
     if (!alpha || alpha == 255) {
@@ -265,10 +265,10 @@ static void convertSinglePixelUnpremultipliedToPremultiplied(const uint8_t* sour
 }
 
 template<PixelFormatConversion pixelFormatConversion>
-static void convertSinglePixelUnpremultipliedToUnpremultiplied(const uint8_t* sourcePixel, uint8_t* destinationPixel)
+static void convertSinglePixelUnpremultipliedToUnpremultiplied(std::span<const uint8_t, 4> sourcePixel, std::span<uint8_t, 4> destinationPixel)
 {
     if constexpr (pixelFormatConversion == PixelFormatConversion::None)
-        reinterpret_cast<uint32_t*>(destinationPixel)[0] = reinterpret_cast<const uint32_t*>(sourcePixel)[0];
+        reinterpretCastSpanStartTo<uint32_t>(destinationPixel) = reinterpretCastSpanStartTo<const uint32_t>(sourcePixel);
     else {
         // Swap pixel channels BGRA <-> RGBA.
         destinationPixel[0] = sourcePixel[2];
@@ -278,18 +278,16 @@ static void convertSinglePixelUnpremultipliedToUnpremultiplied(const uint8_t* so
     }
 }
 
-template<void (*convertFunctor)(const uint8_t*, uint8_t*)>
+template<void (*convertFunctor)(std::span<const uint8_t, 4>, std::span<uint8_t, 4>)>
 static void convertImagePixelsUnaccelerated(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
 {
-    const uint8_t* sourceRows = source.rows;
-    uint8_t* destinationRows = destination.rows;
+    auto sourceRows = source.rows;
+    auto destinationRows = destination.rows;
 
     size_t bytesPerRow = destinationSize.width() * 4;
-    for (int y = 0; y < destinationSize.height(); ++y) {
+    for (int y = 0; y < destinationSize.height(); ++y, skip(sourceRows, source.bytesPerRow), skip(destinationRows, destination.bytesPerRow)) {
         for (size_t x = 0; x < bytesPerRow; x += 4)
-            convertFunctor(&sourceRows[x], &destinationRows[x]);
-        sourceRows += source.bytesPerRow;
-        destinationRows += destination.bytesPerRow;
+            convertFunctor(sourceRows.subspan(x).subspan<0, 4>(), destinationRows.subspan(x).subspan<0, 4>());
     }
 }
 
@@ -310,7 +308,7 @@ void convertImagePixels(const ConstPixelBufferConversionView& source, const Pixe
         convertImagePixelsAccelerated(source, destination, destinationSize);
 #elif USE(SKIA)
     if (source.format.alphaFormat == destination.format.alphaFormat && source.format.pixelFormat == destination.format.pixelFormat && source.format.colorSpace == destination.format.colorSpace)
-        memcpy(destination.rows, source.rows, source.bytesPerRow * destinationSize.height());
+        memcpySpan(destination.rows, source.rows.first(source.bytesPerRow * destinationSize.height()));
     else
         convertImagePixelsSkia(source, destination, destinationSize);
 #else
@@ -319,7 +317,7 @@ void convertImagePixels(const ConstPixelBufferConversionView& source, const Pixe
     ASSERT(source.format.colorSpace == destination.format.colorSpace);
 
     if (source.format.alphaFormat == destination.format.alphaFormat && source.format.pixelFormat == destination.format.pixelFormat) {
-        memcpy(destination.rows, source.rows, source.bytesPerRow * destinationSize.height());
+        memcpySpan(destination.rows, source.rows.first(source.bytesPerRow * destinationSize.height()));
         return;
     }
 
@@ -353,19 +351,19 @@ void convertImagePixels(const ConstPixelBufferConversionView& source, const Pixe
 #endif
 }
 
-void copyRows(unsigned sourceBytesPerRow, const uint8_t* source, unsigned destinationBytesPerRow, uint8_t* destination, unsigned rows, unsigned copyBytesPerRow)
+void copyRowsInternal(unsigned sourceBytesPerRow, std::span<const uint8_t> source, unsigned destinationBytesPerRow, std::span<uint8_t> destination, unsigned rows, unsigned copyBytesPerRow)
 {
     if (sourceBytesPerRow == destinationBytesPerRow && copyBytesPerRow == sourceBytesPerRow)
-        std::copy(source, source + copyBytesPerRow * rows, destination);
+        memcpySpan(destination, source.first(copyBytesPerRow * rows));
     else {
         for (unsigned row = 0; row < rows; ++row) {
-            std::copy(source, source + copyBytesPerRow, destination);
-            source += sourceBytesPerRow;
-            destination += destinationBytesPerRow;
+            memcpySpan(destination, source.first(copyBytesPerRow));
+            if (sourceBytesPerRow > source.size() || destinationBytesPerRow > destination.size())
+                break;
+            skip(source, sourceBytesPerRow);
+            skip(destination, destinationBytesPerRow);
         }
     }
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.h
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.h
@@ -35,18 +35,18 @@ class IntSize;
 struct PixelBufferConversionView {
     PixelBufferFormat format;
     unsigned bytesPerRow;
-    uint8_t* rows;
+    std::span<uint8_t> rows;
 };
 
 struct ConstPixelBufferConversionView {
     PixelBufferFormat format;
     unsigned bytesPerRow;
-    const uint8_t* rows;
+    std::span<const uint8_t> rows;
 };
 
 void convertImagePixels(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize&);
 
-WEBCORE_EXPORT void copyRows(unsigned sourceBytesPerRow, const uint8_t* source, unsigned destinationBytesPerRow, uint8_t* destination, unsigned rows, unsigned copyBytesPerRow);
+WEBCORE_EXPORT void copyRowsInternal(unsigned sourceBytesPerRow, std::span<const uint8_t> source, unsigned destinationBytesPerRow, std::span<uint8_t> destination, unsigned rows, unsigned copyBytesPerRow);
 
 inline void copyRows(unsigned sourceBytesPerRow, std::span<const uint8_t> source, unsigned destinationBytesPerRow, std::span<uint8_t> destination, unsigned rows, unsigned copyBytesPerRow)
 {
@@ -66,7 +66,7 @@ inline void copyRows(unsigned sourceBytesPerRow, std::span<const uint8_t> source
         ASSERT_NOT_REACHED();
         return;
     }
-    copyRows(sourceBytesPerRow, source.data(), destinationBytesPerRow, destination.data(), rows, copyBytesPerRow);
+    copyRowsInternal(sourceBytesPerRow, source, destinationBytesPerRow, destination, rows, copyBytesPerRow);
 }
 
 }

--- a/Source/WebCore/platform/graphics/ShadowBlur.cpp
+++ b/Source/WebCore/platform/graphics/ShadowBlur.cpp
@@ -46,8 +46,6 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/ParsingUtilities.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 enum {
@@ -245,7 +243,7 @@ void ShadowBlur::updateShadowBlurValues()
 static const int blurSumShift = 15;
 
 // Takes a two dimensional array with three rows and two columns for the lobes.
-static void calculateLobes(int lobes[][2], float blurRadius, bool shadowsIgnoreTransforms)
+static void calculateLobes(std::array<std::array<int, 2>, 3>& lobes, float blurRadius, bool shadowsIgnoreTransforms)
 {
     int diameter;
     if (shadowsIgnoreTransforms)
@@ -295,9 +293,9 @@ void ShadowBlur::clear()
 
 void ShadowBlur::blurLayerImage(std::span<uint8_t> imageData, const IntSize& size, int rowStride)
 {
-    const int channels[4] = { 3, 0, 1, 3 };
+    constexpr std::array channels { 3, 0, 1, 3 };
 
-    int lobes[3][2]; // indexed by pass, and left/right lobe
+    std::array<std::array<int, 2>, 3> lobes; // indexed by pass, and left/right lobe
     calculateLobes(lobes, m_blurRadius.width(), m_shadowsIgnoreTransforms);
 
     // First pass is horizontal.
@@ -949,5 +947,3 @@ void ShadowBlur::drawShadowLayer(const AffineTransform& transform, const IntRect
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
@@ -80,15 +80,15 @@ std::unique_ptr<ImageBufferCGBitmapBackend> ImageBufferCGBitmapBackend::create(c
         fastFree(const_cast<void*>(data));
     }));
 
-    return std::unique_ptr<ImageBufferCGBitmapBackend>(new ImageBufferCGBitmapBackend(parameters, data.leakSpan().data(), WTFMove(dataProvider), WTFMove(context)));
+    return std::unique_ptr<ImageBufferCGBitmapBackend>(new ImageBufferCGBitmapBackend(parameters, data.leakSpan(), WTFMove(dataProvider), WTFMove(context)));
 }
 
-ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend(const Parameters& parameters, uint8_t* data, RetainPtr<CGDataProviderRef>&& dataProvider, std::unique_ptr<GraphicsContextCG>&& context)
+ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend(const Parameters& parameters, std::span<uint8_t> data, RetainPtr<CGDataProviderRef>&& dataProvider, std::unique_ptr<GraphicsContextCG>&& context)
     : ImageBufferCGBackend(parameters, WTFMove(context))
     , m_data(data)
     , m_dataProvider(WTFMove(dataProvider))
 {
-    ASSERT(m_data);
+    ASSERT(m_data.data());
     ASSERT(m_dataProvider);
     ASSERT(m_context);
     applyBaseTransform(*m_context);

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h
@@ -46,7 +46,7 @@ public:
     GraphicsContext& context() final;
 
 private:
-    ImageBufferCGBitmapBackend(const Parameters&, uint8_t* data, RetainPtr<CGDataProviderRef>&&, std::unique_ptr<GraphicsContextCG>&&);
+    ImageBufferCGBitmapBackend(const Parameters&, std::span<uint8_t> data, RetainPtr<CGDataProviderRef>&&, std::unique_ptr<GraphicsContextCG>&&);
 
     unsigned bytesPerRow() const final;
 
@@ -56,7 +56,7 @@ private:
     void getPixelBuffer(const IntRect&, PixelBuffer&) final;
     void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) final;
 
-    uint8_t* m_data;
+    std::span<uint8_t> m_data;
     RetainPtr<CGDataProviderRef> m_dataProvider;
 };
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -191,14 +191,14 @@ void ImageBufferIOSurfaceBackend::getPixelBuffer(const IntRect& srcRect, PixelBu
 {
     const_cast<ImageBufferIOSurfaceBackend*>(this)->prepareForExternalRead();
     if (auto lock = m_surface->lock<IOSurface::AccessMode::ReadOnly>())
-        ImageBufferBackend::getPixelBuffer(srcRect, static_cast<const uint8_t*>(lock->surfaceBaseAddress()), destination);
+        ImageBufferBackend::getPixelBuffer(srcRect, lock->surfaceSpan(), destination);
 }
 
 void ImageBufferIOSurfaceBackend::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
 {
     prepareForExternalWrite();
     if (auto lock = m_surface->lock<IOSurface::AccessMode::ReadWrite>())
-        ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, static_cast<uint8_t*>(lock->surfaceBaseAddress()));
+        ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, lock->surfaceSpan());
 }
 
 bool ImageBufferIOSurfaceBackend::canMapBackingStore() const

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -118,6 +118,16 @@ public:
             return IOSurfaceGetBaseAddress(m_surface.get());
         }
 
+        std::span<uint8_t> surfaceSpan()
+        {
+            return unsafeMakeSpan(static_cast<uint8_t*>(IOSurfaceGetBaseAddress(m_surface.get())), IOSurfaceGetAllocSize(m_surface.get()));
+        }
+
+        std::span<const uint8_t> surfaceSpan() const
+        {
+            return unsafeMakeSpan(static_cast<const uint8_t*>(IOSurfaceGetBaseAddress(m_surface.get())), IOSurfaceGetAllocSize(m_surface.get()));
+        }
+
     private:
         explicit Locker(RetainPtr<IOSurfaceRef> surface)
             : m_surface(WTFMove(surface))

--- a/Source/WebCore/platform/graphics/filters/FilterImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.cpp
@@ -146,8 +146,8 @@ static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& de
     if (UNLIKELY(rowBytes.hasOverflowed()))
         return;
 
-    ConstPixelBufferConversionView source { sourcePixelBuffer.format(), rowBytes, sourcePixelBuffer.bytes().data() };
-    PixelBufferConversionView destination { destinationPixelBuffer.format(), rowBytes, destinationPixelBuffer.bytes().data() };
+    ConstPixelBufferConversionView source { sourcePixelBuffer.format(), rowBytes, sourcePixelBuffer.bytes() };
+    PixelBufferConversionView destination { destinationPixelBuffer.format(), rowBytes, destinationPixelBuffer.bytes() };
 
     convertImagePixels(source, destination, destinationSize);
 }

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
@@ -78,18 +78,28 @@ RefPtr<NativeImage> ImageBufferSkiaUnacceleratedBackend::createNativeImageRefere
     return nullptr;
 }
 
+static std::span<const uint8_t> span(const SkPixmap& pixmap)
+{
+    return unsafeMakeSpan(static_cast<const uint8_t*>(pixmap.addr()), pixmap.computeByteSize());
+}
+
+static std::span<uint8_t> mutableSpan(SkPixmap& pixmap)
+{
+    return unsafeMakeSpan(static_cast<uint8_t*>(pixmap.writable_addr()), pixmap.computeByteSize());
+}
+
 void ImageBufferSkiaUnacceleratedBackend::getPixelBuffer(const IntRect& srcRect, PixelBuffer& destination)
 {
     SkPixmap pixmap;
     if (m_surface->peekPixels(&pixmap))
-        ImageBufferBackend::getPixelBuffer(srcRect, static_cast<const uint8_t*>(pixmap.writable_addr()), destination);
+        ImageBufferBackend::getPixelBuffer(srcRect, span(pixmap), destination);
 }
 
 void ImageBufferSkiaUnacceleratedBackend::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
 {
     SkPixmap pixmap;
     if (m_surface->peekPixels(&pixmap))
-        ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, static_cast<uint8_t*>(pixmap.writable_addr()));
+        ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, mutableSpan(pixmap));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.h
+++ b/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.h
@@ -90,7 +90,7 @@ private:
 
     void clearColorTransform();
     void prepareColorTransform();
-    void maybePerformColorSpaceConversion(void* inputBuffer, void* outputBuffer, unsigned numberOfPixels);
+    void maybePerformColorSpaceConversion(std::span<uint8_t> inputBuffer, std::span<uint8_t> outputBuffer, unsigned numberOfPixels);
 #if USE(LCMS)
     LCMSProfilePtr tryDecodeICCColorProfile();
 #elif USE(CG)

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
@@ -154,12 +154,12 @@ RefPtr<NativeImage> ImageBufferShareableBitmapBackend::createNativeImageReferenc
 
 void ImageBufferShareableBitmapBackend::getPixelBuffer(const IntRect& srcRect, PixelBuffer& destination)
 {
-    ImageBufferBackend::getPixelBuffer(srcRect, m_bitmap->span().data(), destination);
+    ImageBufferBackend::getPixelBuffer(srcRect, m_bitmap->span(), destination);
 }
 
 void ImageBufferShareableBitmapBackend::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
 {
-    ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, m_bitmap->mutableSpan().data());
+    ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, m_bitmap->mutableSpan());
 }
 
 String ImageBufferShareableBitmapBackend::debugDescription() const


### PR DESCRIPTION
#### b24251f27e415a48a7d97b755794dafcbd3439b7
<pre>
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/graphics
<a href="https://bugs.webkit.org/show_bug.cgi?id=285805">https://bugs.webkit.org/show_bug.cgi?id=285805</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::cacheImageDataIfPossible):
(WebCore::CanvasRenderingContext2DBase::makeImageDataIfContentsCached const):
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::getPixelBuffer):
(WebCore::ImageBufferBackend::putPixelBuffer):
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::hasSubpaths const):
(WebCore::Path::fastBoundingRect const):
(WebCore::Path::boundingRect const):
* Source/WebCore/platform/graphics/PathImpl.cpp:
* Source/WebCore/platform/graphics/PathTraversalState.cpp:
* Source/WebCore/platform/graphics/PixelBuffer.cpp:
* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::makeVImageBuffer):
(WebCore::convertSinglePixelPremultipliedToPremultiplied):
(WebCore::convertSinglePixelPremultipliedToUnpremultiplied):
(WebCore::convertSinglePixelUnpremultipliedToPremultiplied):
(WebCore::convertSinglePixelUnpremultipliedToUnpremultiplied):
(WebCore::convertFunctor):
(WebCore::copyRowsInternal):
(WebCore::copyRows): Deleted.
* Source/WebCore/platform/graphics/PixelBufferConversion.h:
(WebCore::copyRows):
* Source/WebCore/platform/graphics/ShadowBlur.cpp:
(WebCore::calculateLobes):
(WebCore::ShadowBlur::blurLayerImage):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp:
(WebCore::ImageBufferCGBitmapBackend::create):
(WebCore::ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::getPixelBuffer):
(WebCore::ImageBufferIOSurfaceBackend::putPixelBuffer):
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/filters/FilterImage.cpp:
(WebCore::copyImageBytes):

Canonical link: <a href="https://commits.webkit.org/288806@main">https://commits.webkit.org/288806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a899697d5efe968590c04ae8613877cda8547a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35415 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65639 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23482 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87451 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3103 "Found 3 new test failures: fast/files/blob-stream-frame.html http/tests/websocket/tests/hybi/no-subprotocol.html http/wpt/cache-storage/quota-third-party.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45933 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30918 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34463 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90867 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11672 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74096 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11899 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73291 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17629 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16073 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3071 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13078 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11624 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17100 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11473 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14949 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->