### PR TITLE
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/graphics

### DIFF
--- a/Source/WebCore/platform/graphics/FontSelectionAlgorithm.h
+++ b/Source/WebCore/platform/graphics/FontSelectionAlgorithm.h
@@ -433,8 +433,8 @@ public:
 private:
     using DistanceFunction = DistanceResult (FontSelectionAlgorithm::*)(Capabilities) const;
     using CapabilitiesRange = FontSelectionRange Capabilities::*;
-    FontSelectionValue bestValue(const bool eliminated[], DistanceFunction) const;
-    void filterCapability(bool eliminated[], DistanceFunction, CapabilitiesRange);
+    FontSelectionValue bestValue(std::span<const bool> eliminated, DistanceFunction) const;
+    void filterCapability(std::span<bool> eliminated, DistanceFunction, CapabilitiesRange);
 
     FontSelectionRequest m_request;
     Capabilities m_capabilitiesBounds;

--- a/Source/WebCore/platform/graphics/FontTaggedSettings.h
+++ b/Source/WebCore/platform/graphics/FontTaggedSettings.h
@@ -33,8 +33,6 @@
 #include <wtf/Hasher.h>
 #include <wtf/Vector.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 class TextStream;
 }
@@ -43,7 +41,11 @@ namespace WebCore {
 
 using FontTag = std::array<char, 4>;
 
-inline FontTag fontFeatureTag(const char characters[4]) { return {{ characters[0], characters[1], characters[2], characters[3] }}; }
+inline FontTag fontFeatureTag(std::span<const char, 5> nullTerminatedString)
+{
+    ASSERT(nullTerminatedString[4] == '\0');
+    return { nullTerminatedString[0], nullTerminatedString[1], nullTerminatedString[2], nullTerminatedString[3] };
+}
 
 inline void add(Hasher& hasher, std::array<char, 4> array)
 {
@@ -146,5 +148,3 @@ TextStream& operator<<(TextStream&, const FontTaggedSettings<int>&);
 TextStream& operator<<(TextStream&, const FontTaggedSettings<float>&);
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/FourCC.cpp
+++ b/Source/WebCore/platform/graphics/FourCC.cpp
@@ -32,13 +32,15 @@ std::optional<FourCC> FourCC::fromString(StringView string)
 {
     if (string.length() != 4 || !string.containsOnlyASCII())
         return std::nullopt;
-    return { { {
+
+    std::array<char, 5> code {
         static_cast<char>(string[0]),
         static_cast<char>(string[1]),
         static_cast<char>(string[2]),
         static_cast<char>(string[3]),
         '\0'
-    } } };
+    };
+    return FourCC { std::span { code } };
 }
 
 }

--- a/Source/WebCore/platform/graphics/FourCC.h
+++ b/Source/WebCore/platform/graphics/FourCC.h
@@ -27,14 +27,12 @@
 
 #include <wtf/text/WTFString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 struct FourCC {
     constexpr FourCC() = default;
     constexpr FourCC(uint32_t value) : value { value } { }
-    constexpr FourCC(const char (&nullTerminatedString)[5]);
+    constexpr FourCC(std::span<const char, 5> nullTerminatedString);
     constexpr std::array<char, 5> string() const;
     static std::optional<FourCC> fromString(StringView);
     friend constexpr bool operator==(FourCC, FourCC) = default;
@@ -42,7 +40,7 @@ struct FourCC {
     uint32_t value { 0 };
 };
 
-constexpr FourCC::FourCC(const char (&data)[5])
+constexpr FourCC::FourCC(std::span<const char, 5> data)
     : value(data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3])
 {
     ASSERT_UNDER_CONSTEXPR_CONTEXT(isASCII(data[0]));
@@ -74,5 +72,3 @@ template<> struct LogArgument<WebCore::FourCC> {
 };
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -38,8 +38,6 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/Vector.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 static const constexpr GlyphBufferGlyph deletedGlyph = 0xFFFF;
@@ -282,5 +280,3 @@ private:
 };
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/GlyphPage.h
+++ b/Source/WebCore/platform/graphics/GlyphPage.h
@@ -38,8 +38,6 @@
 #include <wtf/RefCounted.h>
 #include <wtf/Ref.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 // Holds the glyph index and the corresponding Font information for a given
@@ -137,12 +135,10 @@ private:
     }
 
     SingleThreadWeakPtr<const Font> m_font;
-    Glyph m_glyphs[size] { };
+    std::array<Glyph, size> m_glyphs { };
     WTF::BitSet<size> m_isColor;
 
     WEBCORE_EXPORT static unsigned s_count;
 };
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/GraphicsTypes.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsTypes.cpp
@@ -33,11 +33,9 @@
 #include <wtf/text/TextStream.h>
 #include <wtf/text/WTFString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
-static constexpr ASCIILiteral compositeOperatorNames[] = {
+static constexpr std::array compositeOperatorNames {
     "clear"_s,
     "copy"_s,
     "source-over"_s,
@@ -54,7 +52,7 @@ static constexpr ASCIILiteral compositeOperatorNames[] = {
     "difference"_s
 };
 
-static constexpr ASCIILiteral blendOperatorNames[] = {
+static constexpr std::array blendOperatorNames {
     "normal"_s,
     "multiply"_s,
     "screen"_s,
@@ -268,5 +266,3 @@ TextStream& operator<<(TextStream& ts, TextDrawingMode textDrawingMode)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/HEVCUtilities.cpp
+++ b/Source/WebCore/platform/graphics/HEVCUtilities.cpp
@@ -242,9 +242,9 @@ std::optional<HEVCParameters> parseHEVCDecoderConfigurationRecord(FourCC codecCo
         return std::nullopt;
 
     HEVCParameters parameters;
-    if (codecCode == "hev1")
+    if (codecCode == std::span { "hev1" })
         parameters.codec = HEVCParameters::Codec::Hev1;
-    else if (codecCode == "hvc1")
+    else if (codecCode == std::span { "hvc1" })
         parameters.codec = HEVCParameters::Codec::Hvc1;
     else
         return std::nullopt;

--- a/Source/WebCore/platform/graphics/Latin1TextIterator.h
+++ b/Source/WebCore/platform/graphics/Latin1TextIterator.h
@@ -23,8 +23,6 @@
 
 #include <wtf/text/WTFString.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 class Latin1TextIterator {
@@ -32,7 +30,7 @@ public:
     // The passed in LChar pointer starts at 'currentIndex'. The iterator operates on the range [currentIndex, lastIndex].
     // 'endCharacter' denotes the maximum length of the UChar array, which might exceed 'lastIndex'.
     Latin1TextIterator(std::span<const LChar> characters, unsigned currentIndex, unsigned lastIndex)
-        : m_characters(characters.data())
+        : m_characters(characters)
         , m_currentIndex(currentIndex)
         , m_originalIndex(currentIndex)
         , m_lastIndex(lastIndex)
@@ -62,22 +60,20 @@ public:
         m_currentIndex = index;
     }
 
-    const LChar* remainingCharacters() const
+    std::span<const LChar> remainingCharacters() const
     {
         auto relativeIndex = m_currentIndex - m_originalIndex;
-        return m_characters + relativeIndex;
+        return m_characters.subspan(relativeIndex);
     }
 
     unsigned currentIndex() const { return m_currentIndex; }
-    const LChar* characters() const { return m_characters; }
+    std::span<const LChar> characters() const { return m_characters; }
 
 private:
-    const LChar* const m_characters;
+    std::span<const LChar> m_characters;
     unsigned m_currentIndex;
     const unsigned m_originalIndex;
     const unsigned m_lastIndex;
 };
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/MIMESniffer.cpp
+++ b/Source/WebCore/platform/graphics/MIMESniffer.cpp
@@ -27,8 +27,7 @@
 #include "MIMESniffer.h"
 
 #include <array>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
@@ -37,7 +36,7 @@ namespace MIMESniffer {
 template<std::size_t N>
 constexpr auto span8(const char(&p)[N])
 {
-    return std::span<const uint8_t, N - 1>(byteCast<uint8_t>(&p[0]), N - 1);
+    return unsafeMakeSpan<const uint8_t, N - 1>(byteCast<uint8_t>(static_cast<const char*>(p)), N - 1);
 }
 
 static bool hasSignatureForMP4(std::span<const uint8_t> sequence)
@@ -347,5 +346,3 @@ String getMIMETypeFromContent(std::span<const uint8_t> sequence)
 } // namespace MIMESniffer
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -103,8 +103,6 @@
 #include "MediaPlayerPrivateHolePunch.h"
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaPlayer);
@@ -2033,7 +2031,7 @@ const Logger& MediaPlayer::mediaPlayerLogger()
 
 String convertEnumerationToString(MediaPlayer::ReadyState enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 5> values {
         MAKE_STATIC_STRING_IMPL("HaveNothing"),
         MAKE_STATIC_STRING_IMPL("HaveMetadata"),
         MAKE_STATIC_STRING_IMPL("HaveCurrentData"),
@@ -2051,7 +2049,7 @@ String convertEnumerationToString(MediaPlayer::ReadyState enumerationValue)
 
 String convertEnumerationToString(MediaPlayer::NetworkState enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 7> values {
         MAKE_STATIC_STRING_IMPL("Empty"),
         MAKE_STATIC_STRING_IMPL("Idle"),
         MAKE_STATIC_STRING_IMPL("Loading"),
@@ -2073,7 +2071,7 @@ String convertEnumerationToString(MediaPlayer::NetworkState enumerationValue)
 
 String convertEnumerationToString(MediaPlayer::Preload enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 3> values {
         MAKE_STATIC_STRING_IMPL("None"),
         MAKE_STATIC_STRING_IMPL("MetaData"),
         MAKE_STATIC_STRING_IMPL("Auto"),
@@ -2087,7 +2085,7 @@ String convertEnumerationToString(MediaPlayer::Preload enumerationValue)
 
 String convertEnumerationToString(MediaPlayer::SupportsType enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 3> values {
         MAKE_STATIC_STRING_IMPL("IsNotSupported"),
         MAKE_STATIC_STRING_IMPL("IsSupported"),
         MAKE_STATIC_STRING_IMPL("MayBeSupported"),
@@ -2117,7 +2115,7 @@ WTF::TextStream& operator<<(TextStream& ts, MediaPlayerEnums::VideoGravity gravi
 
 String convertEnumerationToString(MediaPlayer::BufferingPolicy enumerationValue)
 {
-    static const NeverDestroyed<String> values[] = {
+    static const std::array<NeverDestroyed<String>, 4> values {
         MAKE_STATIC_STRING_IMPL("Default"),
         MAKE_STATIC_STRING_IMPL("LimitReadAhead"),
         MAKE_STATIC_STRING_IMPL("MakeResourcesPurgeable"),
@@ -2152,7 +2150,5 @@ String convertSpatialVideoMetadataToString(const SpatialVideoMetadata& metadata)
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
@@ -70,10 +70,10 @@ static WTFLogChannel& logChannel() { return LogEME; }
 const Vector<FourCC>& CDMPrivateFairPlayStreaming::validFairPlayStreamingSchemes()
 {
     static NeverDestroyed<Vector<FourCC>> validSchemes = Vector<FourCC>({
-        "cbcs",
-        "cbc2",
-        "cbc1",
-        "cenc",
+        std::span { "cbcs" },
+        std::span { "cbc2" },
+        std::span { "cbc1" },
+        std::span { "cenc" }
     });
 
     return validSchemes;

--- a/Source/WebCore/platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.h
+++ b/Source/WebCore/platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.h
@@ -36,7 +36,7 @@ public:
     ISOFairPlayStreamingInfoBox(ISOFairPlayStreamingInfoBox&&);
     WEBCORE_EXPORT ~ISOFairPlayStreamingInfoBox();
 
-    static FourCC boxTypeName() { return "fpsi"; }
+    static FourCC boxTypeName() { return std::span { "fpsi" }; }
 
     FourCC scheme() const { return m_scheme; }
 
@@ -51,7 +51,7 @@ public:
     WEBCORE_EXPORT ISOFairPlayStreamingKeyRequestInfoBox();
     WEBCORE_EXPORT ~ISOFairPlayStreamingKeyRequestInfoBox();
 
-    static FourCC boxTypeName() { return "fkri"; }
+    static FourCC boxTypeName() { return std::span { "fkri" }; }
 
     using KeyID = Vector<uint8_t, 16>;
     const KeyID& keyID() const { return m_keyID; }
@@ -72,7 +72,7 @@ public:
     ISOFairPlayStreamingKeyAssetIdBox& operator=(const ISOFairPlayStreamingKeyAssetIdBox&) = default;
     ISOFairPlayStreamingKeyAssetIdBox& operator=(ISOFairPlayStreamingKeyAssetIdBox&&) = default;
 
-    static FourCC boxTypeName() { return "fkai"; }
+    static FourCC boxTypeName() { return std::span { "fkai" }; }
     const Vector<uint8_t> data() const { return m_data; }
 
     WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
@@ -91,7 +91,7 @@ public:
     ISOFairPlayStreamingKeyContextBox& operator=(const ISOFairPlayStreamingKeyContextBox&) = default;
     ISOFairPlayStreamingKeyContextBox& operator=(ISOFairPlayStreamingKeyContextBox&&) = default;
 
-    static FourCC boxTypeName() { return "fkcx"; }
+    static FourCC boxTypeName() { return std::span { "fkcx" }; }
     const Vector<uint8_t> data() const { return m_data; }
 
     WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
@@ -110,7 +110,7 @@ public:
     ISOFairPlayStreamingKeyVersionListBox& operator=(const ISOFairPlayStreamingKeyVersionListBox&) = default;
     ISOFairPlayStreamingKeyVersionListBox& operator=(ISOFairPlayStreamingKeyVersionListBox&&) = default;
 
-    static FourCC boxTypeName() { return "fkvl"; }
+    static FourCC boxTypeName() { return std::span { "fkvl" }; }
     const Vector<uint8_t> versions() const { return m_versions; }
 
     WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
@@ -126,7 +126,7 @@ public:
     ISOFairPlayStreamingKeyRequestBox(ISOFairPlayStreamingKeyRequestBox&&) = default;
     WEBCORE_EXPORT ~ISOFairPlayStreamingKeyRequestBox();
 
-    static FourCC boxTypeName() { return "fpsk"; }
+    static FourCC boxTypeName() { return std::span { "fpsk" }; }
 
     const ISOFairPlayStreamingKeyRequestInfoBox& requestInfo() const { return m_requestInfo; }
     const std::optional<ISOFairPlayStreamingKeyAssetIdBox>& assetID() const { return m_assetID; }
@@ -147,7 +147,7 @@ public:
     WEBCORE_EXPORT ISOFairPlayStreamingInitDataBox();
     WEBCORE_EXPORT ~ISOFairPlayStreamingInitDataBox();
 
-    static FourCC boxTypeName() { return "fpsd"; }
+    static FourCC boxTypeName() { return std::span { "fpsd" }; }
 
     const ISOFairPlayStreamingInfoBox& info() const { return m_info; }
     const Vector<ISOFairPlayStreamingKeyRequestBox>& requests() const { return m_requests; }

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -624,9 +624,9 @@ String ImageDecoderCG::decodeUTI(CGImageSourceRef imageSource, const SharedBuffe
         return uti;
     }
 
-    static constexpr auto ftypSignature = FourCC("ftyp");
-    static constexpr auto avifBrand = FourCC("avif");
-    static constexpr auto avisBrand = FourCC("avis");
+    static const FourCC ftypSignature = std::span { "ftyp" };
+    static const FourCC avifBrand = std::span { "avif" };
+    static const FourCC avisBrand = std::span { "avis" };
 
     auto boxUnsigned = [span = data.span()](unsigned index) -> unsigned {
         constexpr bool isLittleEndian = false;

--- a/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
+++ b/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
@@ -191,8 +191,10 @@ static Vector<hb_feature_t, 4> fontFeatures(const FontCascade& font, const FontP
     //    font-feature-settings descriptor in the @font-face rule.
     auto* fcPattern = fontPlatformData.fcPattern();
     FcChar8* fcFontFeature;
-    for (int i = 0; FcPatternGetString(fcPattern, FC_FONT_FEATURES, i, &fcFontFeature) == FcResultMatch; ++i)
-        featuresToBeApplied.set(fontFeatureTag(reinterpret_cast<char*>(fcFontFeature)), 1);
+    for (int i = 0; FcPatternGetString(fcPattern, FC_FONT_FEATURES, i, &fcFontFeature) == FcResultMatch; ++i) {
+        auto fcFontFeatureSpan = spanIncludingNullTerminator(reinterpret_cast<char*>(fcFontFeature)).subspan<0, 5>();
+        featuresToBeApplied.set(fontFeatureTag(fcFontFeatureSpan), 1);
+    }
 
     // 3. Font features implied by the value of the ‘font-variant’ property, the related ‘font-variant’
     //    subproperties and any other CSS property that uses OpenType features.

--- a/Source/WebCore/platform/graphics/iso/ISOBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOBox.cpp
@@ -94,7 +94,7 @@ bool ISOBox::parse(DataView& view, unsigned& offset)
     else if (!m_size)
         m_size = maximumPossibleSize;
 
-    if (m_boxType == "uuid") {
+    if (m_boxType == std::span { "uuid" }) {
         struct ExtendedType {
             uint8_t value[16];
         } extendedTypeStruct;

--- a/Source/WebCore/platform/graphics/iso/ISOOriginalFormatBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOOriginalFormatBox.h
@@ -34,7 +34,7 @@ public:
     ISOOriginalFormatBox();
     ~ISOOriginalFormatBox();
 
-    static FourCC boxTypeName() { return "frma"; }
+    static FourCC boxTypeName() { return std::span { "frma" }; }
 
     FourCC dataFormat() const { return m_dataFormat; }
 

--- a/Source/WebCore/platform/graphics/iso/ISOProtectionSchemeInfoBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOProtectionSchemeInfoBox.h
@@ -37,7 +37,7 @@ public:
     ISOProtectionSchemeInfoBox();
     ~ISOProtectionSchemeInfoBox();
 
-    static FourCC boxTypeName() { return "sinf"; }
+    static FourCC boxTypeName() { return std::span { "sinf" }; }
 
     const ISOOriginalFormatBox& originalFormatBox() const { return m_originalFormatBox; }
     const ISOSchemeTypeBox* schemeTypeBox() const { return m_schemeTypeBox.get(); }

--- a/Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.h
@@ -38,7 +38,7 @@ public:
     ISOProtectionSystemSpecificHeaderBox();
     ~ISOProtectionSystemSpecificHeaderBox();
 
-    static FourCC boxTypeName() { return "pssh"; }
+    static FourCC boxTypeName() { return std::span { "pssh" }; }
 
     static std::optional<Vector<uint8_t>> peekSystemID(JSC::DataView&, unsigned offset);
 

--- a/Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.h
@@ -34,7 +34,7 @@ public:
     ISOSchemeInformationBox();
     ~ISOSchemeInformationBox();
 
-    static FourCC boxTypeName() { return "schi"; }
+    static FourCC boxTypeName() { return std::span { "schi" }; }
 
     const ISOBox* schemeSpecificData() const { return m_schemeSpecificData.get(); }
 

--- a/Source/WebCore/platform/graphics/iso/ISOSchemeTypeBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOSchemeTypeBox.h
@@ -34,7 +34,7 @@ public:
     ISOSchemeTypeBox();
     ~ISOSchemeTypeBox();
 
-    static FourCC boxTypeName() { return "schm"; }
+    static FourCC boxTypeName() { return std::span { "schm" }; }
 
     FourCC schemeType() const { return m_schemeType; }
     uint32_t schemeVersion() const { return m_schemeVersion; }

--- a/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.h
@@ -34,7 +34,7 @@ public:
     ISOTrackEncryptionBox();
     ~ISOTrackEncryptionBox();
 
-    static FourCC boxTypeName() { return "tenc"; }
+    static FourCC boxTypeName() { return std::span { "tenc" }; }
 
     std::optional<int8_t> defaultCryptByteBlock() const { return m_defaultCryptByteBlock; }
     std::optional<int8_t> defaultSkipByteBlock() const { return m_defaultSkipByteBlock; }

--- a/Source/WebCore/platform/graphics/iso/ISOVTTCue.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOVTTCue.cpp
@@ -72,11 +72,11 @@ private:
     String m_contents;
 };
 
-static FourCC vttIdBoxType() { return "iden"; }
-static FourCC vttSettingsBoxType() { return "sttg"; }
-static FourCC vttPayloadBoxType() { return "payl"; }
-static FourCC vttCurrentTimeBoxType() { return "ctim"; }
-static FourCC vttCueSourceIDBoxType() { return "vsid"; }
+static FourCC vttIdBoxType() { return std::span { "iden" }; }
+static FourCC vttSettingsBoxType() { return std::span { "sttg" }; }
+static FourCC vttPayloadBoxType() { return std::span { "payl" }; }
+static FourCC vttCurrentTimeBoxType() { return std::span { "ctim" }; }
+static FourCC vttCueSourceIDBoxType() { return std::span { "vsid" }; }
 
 ISOWebVTTCue::ISOWebVTTCue(const MediaTime& presentationTime, const MediaTime& duration)
     : m_presentationTime(presentationTime)

--- a/Source/WebCore/platform/graphics/iso/ISOVTTCue.h
+++ b/Source/WebCore/platform/graphics/iso/ISOVTTCue.h
@@ -51,7 +51,7 @@ public:
     ISOWebVTTCue& operator=(const ISOWebVTTCue&) = default;
     ISOWebVTTCue& operator=(ISOWebVTTCue&&) = default;
 
-    static FourCC boxTypeName() { return "vttc"; }
+    static FourCC boxTypeName() { return std::span { "vttc" }; }
 
     const MediaTime& presentationTime() const { return m_presentationTime; }
     const MediaTime& duration() const { return m_duration; }


### PR DESCRIPTION
#### 21753b6e53c734d6b8969a631e2429ac41c3e219
<pre>
Further reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WebCore/platform/graphics
<a href="https://bugs.webkit.org/show_bug.cgi?id=285810">https://bugs.webkit.org/show_bug.cgi?id=285810</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/platform/graphics/FontSelectionAlgorithm.cpp:
(WebCore::FontSelectionAlgorithm::bestValue const):
(WebCore::FontSelectionAlgorithm::filterCapability):
(WebCore::FontSelectionAlgorithm::indexOfBestCapabilities):
* Source/WebCore/platform/graphics/FontSelectionAlgorithm.h:
* Source/WebCore/platform/graphics/FontTaggedSettings.h:
(WebCore::fontFeatureTag):
* Source/WebCore/platform/graphics/FourCC.cpp:
(WebCore::FourCC::fromString):
* Source/WebCore/platform/graphics/FourCC.h:
(WebCore::FourCC::FourCC):
* Source/WebCore/platform/graphics/GlyphBuffer.h:
* Source/WebCore/platform/graphics/GlyphPage.h:
* Source/WebCore/platform/graphics/GraphicsTypes.cpp:
* Source/WebCore/platform/graphics/HEVCUtilities.cpp:
(WebCore::parseHEVCDecoderConfigurationRecord):
* Source/WebCore/platform/graphics/Latin1TextIterator.h:
(WebCore::Latin1TextIterator::Latin1TextIterator):
(WebCore::Latin1TextIterator::remainingCharacters const):
(WebCore::Latin1TextIterator::characters const):
* Source/WebCore/platform/graphics/MIMESniffer.cpp:
(WebCore::MIMESniffer::mimeTypeFromSnifferEntries):
(WebCore::MIMESniffer::span8): Deleted.
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp:
(WebCore::CDMPrivateFairPlayStreaming::validFairPlayStreamingSchemes):
* Source/WebCore/platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.h:
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::ImageDecoderCG::decodeUTI):
* Source/WebCore/platform/graphics/iso/ISOBox.cpp:
(WebCore::ISOBox::parse):
* Source/WebCore/platform/graphics/iso/ISOOriginalFormatBox.h:
* Source/WebCore/platform/graphics/iso/ISOProtectionSchemeInfoBox.h:
* Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.h:
* Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.h:
* Source/WebCore/platform/graphics/iso/ISOSchemeTypeBox.h:
* Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.h:
* Source/WebCore/platform/graphics/iso/ISOVTTCue.cpp:
(WebCore::vttIdBoxType):
(WebCore::vttSettingsBoxType):
(WebCore::vttPayloadBoxType):
(WebCore::vttCurrentTimeBoxType):
(WebCore::vttCueSourceIDBoxType):
* Source/WebCore/platform/graphics/iso/ISOVTTCue.h:

Canonical link: <a href="https://commits.webkit.org/288807@main">https://commits.webkit.org/288807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c7b733cf01dad68f2183a6029aa25a5135ad3b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84391 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89471 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35401 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65626 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23468 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3086 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45920 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3037 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30905 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34449 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73927 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90852 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74077 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11885 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72498 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73277 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17616 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16060 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3053 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13079 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11610 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17086 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11459 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14935 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->