### PR TITLE
Don't propagate bbox for empty `text` to ancestors

### DIFF
--- a/LayoutTests/svg/text/text-bbox-empty-expected.txt
+++ b/LayoutTests/svg/text/text-bbox-empty-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Empty <text> does not contribute to ancestor bounding boxes.
+

--- a/LayoutTests/svg/text/text-bbox-empty.html
+++ b/LayoutTests/svg/text/text-bbox-empty.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<svg height="0" font-size="100">
+  <svg id="container1">
+    <rect x="200" y="300" width="100" height="400"/>
+    <g id="container2">
+      <text transform="translate(1000, 1000)"></text>
+    </g>
+    <text> </text>
+  </svg>
+</svg>
+<script>
+test(function() {
+  var bbox = document.querySelector('#container1').getBBox();
+  assert_array_equals([bbox.x, bbox.y, bbox.width, bbox.height], [200, 300, 100, 400]);
+  var bbox = document.querySelector('#container2').getBBox();
+  assert_array_equals([bbox.x, bbox.y, bbox.width, bbox.height], [0, 0, 0, 0]);
+}, 'Empty <text> does not contribute to ancestor bounding boxes.');
+</script>

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Alexander Kellett <lypanov@kde.org>
  * Copyright (C) 2006 Oliver Hunt <ojh16@student.canterbury.ac.nz>
  * Copyright (C) 2007 Nikolas Zimmermann <zimmermann@kde.org>
@@ -1011,5 +1011,10 @@ SVGRootInlineBox* RenderSVGText::legacyRootBox() const
     return downcast<SVGRootInlineBox>(RenderSVGBlock::legacyRootBox());
 }
 
+bool RenderSVGText::isObjectBoundingBoxValid() const
+{
+    // If we don't have any line boxes, then consider the bbox invalid.
+    return legacyRootBox();
+}
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2006-2023 Apple Inc.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2016 Google Inc. All rights reserved.
  * Copyright (C) 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) Research In Motion Limited 2010-2012. All rights reserved.
  *
@@ -69,6 +70,7 @@ public:
 
     FloatRect objectBoundingBox() const final { return m_objectBoundingBox; }
     FloatRect strokeBoundingBox() const final;
+    bool isObjectBoundingBoxValid() const;
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final;
 
     LayoutRect visualOverflowRectEquivalent() const { return SVGBoundingBoxComputation::computeVisualOverflowRect(*this); }

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -2,11 +2,11 @@
  * Copyright (C) 2007, 2008 Rob Buis <buis@kde.org>
  * Copyright (C) 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2007 Eric Seidel <eric@webkit.org>
- * Copyright (C) 2009 Google, Inc.  All rights reserved.
+ * Copyright (C) 2009-2016 Google, Inc.  All rights reserved.
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
  * Copyright (C) Research In Motion Limited 2009-2010. All rights reserved.
  * Copyright (C) 2018 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -164,6 +164,9 @@ void SVGRenderSupport::computeContainerBoundingBoxes(const RenderElement& contai
 
         // Don't include elements in the union that do not render.
         if (auto* shape = dynamicDowncast<LegacyRenderSVGShape>(current.ptr()); shape && shape->isRenderingDisabled())
+            continue;
+
+        if (auto* text = dynamicDowncast<RenderSVGText>(current.ptr()); (text && !text->isObjectBoundingBoxValid()))
             continue;
 
         const AffineTransform& transform = current->localToParentTransform();


### PR DESCRIPTION
#### af13560660544215afd576e1649975f14f7828e2
<pre>
Don&apos;t propagate bbox for empty `text` to ancestors

<a href="https://bugs.webkit.org/show_bug.cgi?id=261062">https://bugs.webkit.org/show_bug.cgi?id=261062</a>
<a href="https://rdar.apple.com/115217040">rdar://115217040</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/9960fef706fbd5429e65360e3ebeecce63c8c8f0">https://chromium.googlesource.com/chromium/src.git/+/9960fef706fbd5429e65360e3ebeecce63c8c8f0</a>

If we have a &lt;text&gt; element which is &quot;empty&quot; (essentially has no text
content after collapsing spaces), then its bounding box would be empty,
but would still be propagated to the bounding boxes of the ancestors -
which could span them out to be bigger than expected. Similarly they
could be subject to their userspace transform with a similar effect.

Skip propagation of empty &lt;text&gt; element - where &quot;empty&quot; is defined as
&quot;has no line boxes&quot;.

* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::isObjectBoundingBoxValid const):
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::computeContainerBoundingBoxes):
* LayoutTests/svg/text/text-bbox-empty.html: Add Test Case
* LayoutTests/svg/text/text-bbox-empty-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/289394@main">https://commits.webkit.org/289394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e6cbcb2ca2140ab35620a318a9ab5a72ea4bb03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91668 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37552 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67109 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24883 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89823 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78580 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47428 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4806 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32938 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36670 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75311 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93561 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13973 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10136 "Found 2 new test failures: accessibility/mac/scrolling-in-pdf-crash.html http/tests/workers/service/page-caching.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75909 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74426 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75104 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18470 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19427 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17838 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/6772 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13996 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/19256 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13734 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17179 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15519 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->