### PR TITLE
REGRESSION(288642@main): [GStreamer][Debug] Triggers ASSERT when running http/tests/inspector/gatherWebInspectorRTCLogs.html

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCLogSink.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCLogSink.cpp
@@ -69,9 +69,13 @@ void GStreamerWebRTCLogSink::start()
 #else
     if (!m_isGstDebugActive)
         gst_debug_remove_log_function(gst_debug_log_default);
-    gst_debug_add_log_function(static_cast<GstLogFunction>(+[](GstDebugCategory*, GstDebugLevel level, const char*, const char*, int, GObject*, GstDebugMessage* message, gpointer userData) G_GNUC_NO_INSTRUMENT {
+    gst_debug_add_log_function(static_cast<GstLogFunction>(+[](GstDebugCategory*, GstDebugLevel level, const char*, const char*, int, GObject*, GstDebugMessage* debugMessage, gpointer userData) G_GNUC_NO_INSTRUMENT {
+        const char* message = gst_debug_message_get(debugMessage);
+        if (!message)
+            return;
+
         auto self = reinterpret_cast<GStreamerWebRTCLogSink*>(userData);
-        self->m_callback(toWebRTCLogLevel(level), String::fromUTF8(gst_debug_message_get(message)));
+        self->m_callback(toWebRTCLogLevel(level), String::fromUTF8(message));
     }), this, nullptr);
 
     // Do not include webrtcstats in the list, because stats are logged using a different code path by the endpoint.


### PR DESCRIPTION
#### b409dbbfe5a2996ca45e441e0fc59b37e9ed600e
<pre>
REGRESSION(288642@main): [GStreamer][Debug] Triggers ASSERT when running http/tests/inspector/gatherWebInspectorRTCLogs.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=285814">https://bugs.webkit.org/show_bug.cgi?id=285814</a>

Reviewed by Xabier Rodriguez-Calvar.

The gst_debug_message_get() function returns nullptr when it fails to apply the format specifiers to
the debug message, so this needs to be accounted for and we now return early when this happens.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCLogSink.cpp:
(WebCore::GStreamerWebRTCLogSink::start):

Canonical link: <a href="https://commits.webkit.org/288860@main">https://commits.webkit.org/288860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79ead8d9e79569c9f6b73b4a93bdeb02ecf3af95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89458 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35389 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11982 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65616 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23458 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45910 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3025 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30894 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34437 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73915 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90839 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74067 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73267 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18168 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17605 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16049 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3032 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11598 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17074 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11447 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14923 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13220 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->