### PR TITLE
[GStreamer] Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in VideoEncoderPrivate

### DIFF
--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -797,8 +797,6 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
 
             g_value_init(&intValue, G_TYPE_INT);
 
-            WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
-
             switch (bitRateAllocation.scalabilityMode()) {
             case WebCore::VideoEncoderScalabilityMode::L1T1:
                 numberLayers = 1;
@@ -808,7 +806,7 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                     g_value_array_append(bitrates.get(), &intValue);
                 }
                 for (unsigned i = 0; i < 3; i++) {
-                    static const int decimatorValues[] = { 1, 1, 1 };
+                    static const std::array<int, 3> decimatorValues = { 1, 1, 1 };
                     g_value_set_int(&intValue, decimatorValues[i]);
                     g_value_array_append(decimators.get(), &intValue);
                 }
@@ -825,12 +823,12 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                     g_value_array_append(bitrates.get(), &intValue);
                 }
                 for (unsigned i = 0; i < 3; i++) {
-                    static const int decimatorValues[] = { 1, 1, 1 };
+                    static const std::array<int, 3> decimatorValues = { 1, 1, 1 };
                     g_value_set_int(&intValue, decimatorValues[i]);
                     g_value_array_append(decimators.get(), &intValue);
                 }
                 for (unsigned i = 0; i < 4; i++) {
-                    static const int layerIdValues[] = { 0, 1, 0, 1 };
+                    static const std::array<int, 4> layerIdValues = { 0, 1, 0, 1 };
                     g_value_set_int(&intValue, layerIdValues[i]);
                     g_value_array_append(layerIds.get(), &intValue);
                 }
@@ -862,12 +860,12 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                     g_value_array_append(bitrates.get(), &intValue);
                 }
                 for (unsigned i = 0; i < 3; i++) {
-                    static const int decimatorValues[] = { 4, 2, 1 };
+                    static const std::array<int, 3> decimatorValues = { 4, 2, 1 };
                     g_value_set_int(&intValue, decimatorValues[i]);
                     g_value_array_append(decimators.get(), &intValue);
                 }
                 for (unsigned i = 0; i < 4; i++) {
-                    static const int layerIdValues[] = { 0, 2, 1, 2 };
+                    static const std::array<int, 4> layerIdValues = { 0, 2, 1, 2 };
                     g_value_set_int(&intValue, layerIdValues[i]);
                     g_value_array_append(layerIds.get(), &intValue);
                 }
@@ -893,7 +891,6 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                 layerSyncFlags = { false, true, true, false, false, false, false, false };
                 break;
             }
-            WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             g_value_unset(&intValue);
 
             GST_DEBUG_OBJECT(encoder, "Configuring for %s scalability mode", scalabilityString.characters());

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h
@@ -63,9 +63,7 @@ public:
     {
         RELEASE_ASSERT(spatialLayerIndex < MaxSpatialLayers);
         RELEASE_ASSERT(temporalLayerIndex < MaxTemporalLayers);
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
         m_bitRates[spatialLayerIndex][temporalLayerIndex].emplace(bitRate);
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     std::optional<uint32_t> getBitRate(unsigned spatialLayerIndex, unsigned temporalLayerIndex) const
@@ -74,9 +72,7 @@ public:
             return std::nullopt;
         if (UNLIKELY(temporalLayerIndex >= MaxTemporalLayers))
             return std::nullopt;
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib port
         return m_bitRates[spatialLayerIndex][temporalLayerIndex];
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     WebCore::VideoEncoderScalabilityMode scalabilityMode() const { return m_scalabilityMode; }
@@ -87,7 +83,7 @@ private:
     { }
 
     WebCore::VideoEncoderScalabilityMode m_scalabilityMode;
-    std::optional<uint32_t> m_bitRates[MaxSpatialLayers][MaxTemporalLayers];
+    std::array<std::array<std::optional<uint32_t>, MaxSpatialLayers>, MaxTemporalLayers> m_bitRates;
 };
 
 bool videoEncoderSupportsCodec(WebKitVideoEncoder*, const String&);


### PR DESCRIPTION
#### 5136aa9003a3e39d6ac991abcc0acf2fe48c20fd
<pre>
[GStreamer] Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in VideoEncoderPrivate
<a href="https://bugs.webkit.org/show_bug.cgi?id=285816">https://bugs.webkit.org/show_bug.cgi?id=285816</a>

Reviewed by Xabier Rodriguez-Calvar.

Use std::array to store temporal and spatial bitrate allocations.

* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(webkit_video_encoder_class_init):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h:
(WebKitVideoEncoderBitRateAllocation::setBitRate):
(WebKitVideoEncoderBitRateAllocation::getBitRate const):

Canonical link: <a href="https://commits.webkit.org/288868@main">https://commits.webkit.org/288868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/629df30134641b847903f408e87f3a6cb4f9e79c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35391 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65618 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23460 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45912 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3027 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30897 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34439 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73917 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90842 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11648 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8473 "Found 1 new test failure: imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-coop-navigated-popup.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74070 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72490 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73270 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18170 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17608 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16052 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3036 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17076 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11449 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14925 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->