### PR TITLE
Unify macros used for CSS and Style value types

### DIFF
--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -43,8 +43,29 @@ namespace WebCore {
 template<typename> inline constexpr ASCIILiteral SerializationSeparator = ""_s;
 
 // Helper to define a simple `get()` implementation for a single value `name`.
-#define DEFINE_TYPE_WRAPPER(t, name) \
+#define DEFINE_TYPE_WRAPPER_GET(t, name) \
     template<size_t> const auto& get(const t& value) { return value.name; }
+
+// Helper to define a tuple-like conformance for a type with `numberOfArguments` arguments.
+#define DEFINE_TUPLE_LIKE_CONFORMANCE(t, numberOfArguments) \
+    namespace std { \
+        template<> class tuple_size<t> : public std::integral_constant<size_t, numberOfArguments> { }; \
+        template<size_t I> class tuple_element<I, t> { \
+        public: \
+            using type = decltype(get<I>(std::declval<t>())); \
+        }; \
+    } \
+    template<> inline constexpr bool WebCore::TreatAsTupleLike<t> = true;
+
+// Helper to define a tuple-like conformance and that the type should be serialized as space separated.
+#define DEFINE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(t, numberOfArguments) \
+    DEFINE_TUPLE_LIKE_CONFORMANCE(t, numberOfArguments) \
+    template<> inline constexpr ASCIILiteral WebCore::SerializationSeparator<t> = " "_s;
+
+// Helper to define a tuple-like conformance and that the type should be serialized as comma separated.
+#define DEFINE_COMMA_SEPARATED_TUPLE_LIKE_CONFORMANCE(t, numberOfArguments) \
+    DEFINE_TUPLE_LIKE_CONFORMANCE(t, numberOfArguments) \
+    template<> inline constexpr ASCIILiteral WebCore::SerializationSeparator<t> = ", "_s;
 
 // MARK: - Conforming Existing Types
 

--- a/Source/WebCore/css/values/CSSValueTypes.h
+++ b/Source/WebCore/css/values/CSSValueTypes.h
@@ -34,28 +34,6 @@ class CSSValue;
 
 namespace CSS {
 
-// Helper for declaring types in the CSS namespace as Tuple-Like.
-#define CSS_TUPLE_LIKE_CONFORMANCE(t, numberOfArguments) \
-    namespace std { \
-        template<> class tuple_size<WebCore::CSS::t> : public std::integral_constant<size_t, numberOfArguments> { }; \
-        template<size_t I> class tuple_element<I, WebCore::CSS::t> { \
-        public: \
-            using type = decltype(WebCore::CSS::get<I>(std::declval<WebCore::CSS::t>())); \
-        }; \
-    } \
-    template<> inline constexpr bool WebCore::TreatAsTupleLike<WebCore::CSS::t> = true; \
-\
-
-#define CSS_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(t, numberOfArguments) \
-    CSS_TUPLE_LIKE_CONFORMANCE(t, numberOfArguments) \
-    template<> inline constexpr ASCIILiteral WebCore::SerializationSeparator<WebCore::CSS::t> = " "_s; \
-\
-
-#define CSS_COMMA_SEPARATED_TUPLE_LIKE_CONFORMANCE(t, numberOfArguments) \
-    CSS_TUPLE_LIKE_CONFORMANCE(t, numberOfArguments) \
-    template<> inline constexpr ASCIILiteral WebCore::SerializationSeparator<WebCore::CSS::t> = ", "_s; \
-\
-
 // MARK: - Serialization
 
 // All leaf types must implement the following conversions:

--- a/Source/WebCore/css/values/backgrounds/CSSBorderRadius.h
+++ b/Source/WebCore/css/values/backgrounds/CSSBorderRadius.h
@@ -73,4 +73,4 @@ template<> struct Serialize<BorderRadius> { void operator()(StringBuilder&, cons
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(BorderRadius, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::BorderRadius, 2)

--- a/Source/WebCore/css/values/backgrounds/CSSBoxShadow.h
+++ b/Source/WebCore/css/values/backgrounds/CSSBoxShadow.h
@@ -60,4 +60,4 @@ template<size_t I> const auto& get(const BoxShadow& value)
 } // namespace CSS
 } // namespace WebCore
 
-CSS_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(BoxShadow, 5)
+DEFINE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::BoxShadow, 5)

--- a/Source/WebCore/css/values/color-adjust/CSSColorScheme.h
+++ b/Source/WebCore/css/values/color-adjust/CSSColorScheme.h
@@ -61,6 +61,6 @@ template<size_t I> const auto& get(const ColorScheme& colorScheme)
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(ColorScheme, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::ColorScheme, 2)
 
 #endif

--- a/Source/WebCore/css/values/easing/CSSCubicBezierEasingFunction.h
+++ b/Source/WebCore/css/values/easing/CSSCubicBezierEasingFunction.h
@@ -43,9 +43,9 @@ struct CubicBezierEasingParameters {
 };
 using CubicBezierEasingFunction = FunctionNotation<CSSValueCubicBezier, CubicBezierEasingParameters>;
 
-DEFINE_TYPE_WRAPPER(CubicBezierEasingParameters, value);
+DEFINE_TYPE_WRAPPER_GET(CubicBezierEasingParameters, value);
 
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(CubicBezierEasingParameters, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::CubicBezierEasingParameters, 1)

--- a/Source/WebCore/css/values/easing/CSSLinearEasingFunction.h
+++ b/Source/WebCore/css/values/easing/CSSLinearEasingFunction.h
@@ -52,7 +52,7 @@ struct LinearEasingParameters {
 };
 using LinearEasingFunction = FunctionNotation<CSSValueLinear, LinearEasingParameters>;
 
-DEFINE_TYPE_WRAPPER(LinearEasingParameters, stops);
+DEFINE_TYPE_WRAPPER_GET(LinearEasingParameters, stops);
 
 template<size_t I> const auto& get(const LinearEasingParameters::Stop& value)
 {
@@ -73,6 +73,6 @@ template<size_t I> const auto& get(const LinearEasingParameters::Stop::Length& v
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(LinearEasingParameters, 1)
-CSS_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(LinearEasingParameters::Stop, 2)
-CSS_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(LinearEasingParameters::Stop::Length, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::LinearEasingParameters, 1)
+DEFINE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::LinearEasingParameters::Stop, 2)
+DEFINE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::LinearEasingParameters::Stop::Length, 2)

--- a/Source/WebCore/css/values/easing/CSSSpringEasingFunction.h
+++ b/Source/WebCore/css/values/easing/CSSSpringEasingFunction.h
@@ -63,4 +63,4 @@ template<size_t I> const auto& get(const SpringEasingParameters& value)
 } // namespace CSS
 } // namespace WebCore
 
-CSS_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(SpringEasingParameters, 4)
+DEFINE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::SpringEasingParameters, 4)

--- a/Source/WebCore/css/values/easing/CSSStepsEasingFunction.h
+++ b/Source/WebCore/css/values/easing/CSSStepsEasingFunction.h
@@ -72,7 +72,7 @@ struct StepsEasingParameters {
 };
 using StepsEasingFunction = FunctionNotation<CSSValueSteps, StepsEasingParameters>;
 
-DEFINE_TYPE_WRAPPER(StepsEasingParameters, value);
+DEFINE_TYPE_WRAPPER_GET(StepsEasingParameters, value);
 
 template<size_t I, typename T, typename K, auto shouldSerializeKeyword> const auto& get(const StepsEasingParameters::Kind<T, K, shouldSerializeKeyword>& value)
 {
@@ -93,7 +93,7 @@ template<typename T, typename K, auto shouldSerializeKeyword> struct Serialize<S
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(StepsEasingParameters, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::StepsEasingParameters, 1)
 
 namespace std {
 

--- a/Source/WebCore/css/values/filter-effects/CSSBlurFunction.h
+++ b/Source/WebCore/css/values/filter-effects/CSSBlurFunction.h
@@ -40,9 +40,9 @@ struct Blur {
 };
 using BlurFunction = FunctionNotation<CSSValueBlur, Blur>;
 
-DEFINE_TYPE_WRAPPER(Blur, value);
+DEFINE_TYPE_WRAPPER_GET(Blur, value);
 
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(Blur, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Blur, 1)

--- a/Source/WebCore/css/values/filter-effects/CSSBrightnessFunction.h
+++ b/Source/WebCore/css/values/filter-effects/CSSBrightnessFunction.h
@@ -40,9 +40,9 @@ struct Brightness {
 };
 using BrightnessFunction = FunctionNotation<CSSValueBrightness, Brightness>;
 
-DEFINE_TYPE_WRAPPER(Brightness, value);
+DEFINE_TYPE_WRAPPER_GET(Brightness, value);
 
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(Brightness, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Brightness, 1)

--- a/Source/WebCore/css/values/filter-effects/CSSContrastFunction.h
+++ b/Source/WebCore/css/values/filter-effects/CSSContrastFunction.h
@@ -40,9 +40,9 @@ struct Contrast {
 };
 using ContrastFunction = FunctionNotation<CSSValueContrast, Contrast>;
 
-DEFINE_TYPE_WRAPPER(Contrast, value);
+DEFINE_TYPE_WRAPPER_GET(Contrast, value);
 
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(Contrast, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Contrast, 1)

--- a/Source/WebCore/css/values/filter-effects/CSSDropShadowFunction.h
+++ b/Source/WebCore/css/values/filter-effects/CSSDropShadowFunction.h
@@ -54,4 +54,4 @@ template<size_t I> const auto& get(const DropShadow& value)
 } // namespace CSS
 } // namespace WebCore
 
-CSS_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(DropShadow, 3)
+DEFINE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::DropShadow, 3)

--- a/Source/WebCore/css/values/filter-effects/CSSGrayscaleFunction.h
+++ b/Source/WebCore/css/values/filter-effects/CSSGrayscaleFunction.h
@@ -40,9 +40,9 @@ struct Grayscale {
 };
 using GrayscaleFunction = FunctionNotation<CSSValueGrayscale, Grayscale>;
 
-DEFINE_TYPE_WRAPPER(Grayscale, value);
+DEFINE_TYPE_WRAPPER_GET(Grayscale, value);
 
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(Grayscale, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Grayscale, 1)

--- a/Source/WebCore/css/values/filter-effects/CSSHueRotateFunction.h
+++ b/Source/WebCore/css/values/filter-effects/CSSHueRotateFunction.h
@@ -41,9 +41,9 @@ struct HueRotate {
 };
 using HueRotateFunction = FunctionNotation<CSSValueHueRotate, HueRotate>;
 
-DEFINE_TYPE_WRAPPER(HueRotate, value);
+DEFINE_TYPE_WRAPPER_GET(HueRotate, value);
 
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(HueRotate, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::HueRotate, 1)

--- a/Source/WebCore/css/values/filter-effects/CSSInvertFunction.h
+++ b/Source/WebCore/css/values/filter-effects/CSSInvertFunction.h
@@ -40,9 +40,9 @@ struct Invert {
 };
 using InvertFunction = FunctionNotation<CSSValueInvert, Invert>;
 
-DEFINE_TYPE_WRAPPER(Invert, value);
+DEFINE_TYPE_WRAPPER_GET(Invert, value);
 
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(Invert, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Invert, 1)

--- a/Source/WebCore/css/values/filter-effects/CSSOpacityFunction.h
+++ b/Source/WebCore/css/values/filter-effects/CSSOpacityFunction.h
@@ -40,9 +40,9 @@ struct Opacity {
 };
 using OpacityFunction = FunctionNotation<CSSValueOpacity, Opacity>;
 
-DEFINE_TYPE_WRAPPER(Opacity, value);
+DEFINE_TYPE_WRAPPER_GET(Opacity, value);
 
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(Opacity, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Opacity, 1)

--- a/Source/WebCore/css/values/filter-effects/CSSSaturateFunction.h
+++ b/Source/WebCore/css/values/filter-effects/CSSSaturateFunction.h
@@ -40,9 +40,9 @@ struct Saturate {
 };
 using SaturateFunction = FunctionNotation<CSSValueSaturate, Saturate>;
 
-DEFINE_TYPE_WRAPPER(Saturate, value);
+DEFINE_TYPE_WRAPPER_GET(Saturate, value);
 
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(Saturate, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Saturate, 1)

--- a/Source/WebCore/css/values/filter-effects/CSSSepiaFunction.h
+++ b/Source/WebCore/css/values/filter-effects/CSSSepiaFunction.h
@@ -40,9 +40,9 @@ struct Sepia {
 };
 using SepiaFunction = FunctionNotation<CSSValueSepia, Sepia>;
 
-DEFINE_TYPE_WRAPPER(Sepia, value);
+DEFINE_TYPE_WRAPPER_GET(Sepia, value);
 
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(Sepia, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Sepia, 1)

--- a/Source/WebCore/css/values/images/CSSGradient.h
+++ b/Source/WebCore/css/values/images/CSSGradient.h
@@ -393,19 +393,19 @@ using Gradient = std::variant<
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(LinearGradient, 3)
-CSS_TUPLE_LIKE_CONFORMANCE(PrefixedLinearGradient, 3)
-CSS_TUPLE_LIKE_CONFORMANCE(DeprecatedLinearGradient, 3)
-CSS_TUPLE_LIKE_CONFORMANCE(RadialGradient::Ellipse, 2)
-CSS_TUPLE_LIKE_CONFORMANCE(RadialGradient::Circle, 2)
-CSS_TUPLE_LIKE_CONFORMANCE(RadialGradient, 3)
-CSS_TUPLE_LIKE_CONFORMANCE(PrefixedRadialGradient::Ellipse, 2)
-CSS_TUPLE_LIKE_CONFORMANCE(PrefixedRadialGradient::Circle, 2)
-CSS_TUPLE_LIKE_CONFORMANCE(PrefixedRadialGradient, 3)
-CSS_TUPLE_LIKE_CONFORMANCE(DeprecatedRadialGradient::GradientBox, 4)
-CSS_TUPLE_LIKE_CONFORMANCE(DeprecatedRadialGradient, 3)
-CSS_TUPLE_LIKE_CONFORMANCE(ConicGradient::GradientBox, 2)
-CSS_TUPLE_LIKE_CONFORMANCE(ConicGradient, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::LinearGradient, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::PrefixedLinearGradient, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::DeprecatedLinearGradient, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::RadialGradient::Ellipse, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::RadialGradient::Circle, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::RadialGradient, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::PrefixedRadialGradient::Ellipse, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::PrefixedRadialGradient::Circle, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::PrefixedRadialGradient, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::DeprecatedRadialGradient::GradientBox, 4)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::DeprecatedRadialGradient, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::ConicGradient::GradientBox, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::ConicGradient, 3)
 
 template<typename C, typename P> inline constexpr bool WebCore::TreatAsTupleLike<WebCore::CSS::GradientColorStop<C, P>> = true;
 

--- a/Source/WebCore/css/values/motion/CSSRayFunction.h
+++ b/Source/WebCore/css/values/motion/CSSRayFunction.h
@@ -62,4 +62,4 @@ template<> struct Serialize<Ray> { void operator()(StringBuilder&, const Ray&); 
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(Ray, 4)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Ray, 4)

--- a/Source/WebCore/css/values/primitives/CSSPosition.h
+++ b/Source/WebCore/css/values/primitives/CSSPosition.h
@@ -34,14 +34,14 @@ struct TwoComponentPositionHorizontal {
 
     bool operator==(const TwoComponentPositionHorizontal&) const = default;
 };
-DEFINE_TYPE_WRAPPER(TwoComponentPositionHorizontal, offset);
+DEFINE_TYPE_WRAPPER_GET(TwoComponentPositionHorizontal, offset);
 
 struct TwoComponentPositionVertical {
     std::variant<Keyword::Top, Keyword::Bottom, Keyword::Center, LengthPercentage<>> offset;
 
     bool operator==(const TwoComponentPositionVertical&) const = default;
 };
-DEFINE_TYPE_WRAPPER(TwoComponentPositionVertical, offset);
+DEFINE_TYPE_WRAPPER_GET(TwoComponentPositionVertical, offset);
 
 using TwoComponentPosition              = SpaceSeparatedTuple<TwoComponentPositionHorizontal, TwoComponentPositionVertical>;
 
@@ -84,13 +84,13 @@ struct Position {
 
     std::variant<TwoComponentPosition, FourComponentPosition> value;
 };
-DEFINE_TYPE_WRAPPER(Position, value);
+DEFINE_TYPE_WRAPPER_GET(Position, value);
 
 bool isCenterPosition(const Position&);
 
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(TwoComponentPositionHorizontal, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(TwoComponentPositionVertical, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(Position, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::TwoComponentPositionHorizontal, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::TwoComponentPositionVertical, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Position, 1)

--- a/Source/WebCore/css/values/shapes/CSSCircleFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSCircleFunction.h
@@ -59,4 +59,4 @@ template<> struct Serialize<Circle> { void operator()(StringBuilder&, const Circ
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(Circle, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Circle, 2)

--- a/Source/WebCore/css/values/shapes/CSSEllipseFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSEllipseFunction.h
@@ -59,4 +59,4 @@ template<> struct Serialize<Ellipse> { void operator()(StringBuilder&, const Ell
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(Ellipse, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Ellipse, 2)

--- a/Source/WebCore/css/values/shapes/CSSInsetFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSInsetFunction.h
@@ -55,4 +55,4 @@ template<> struct Serialize<Inset> { void operator()(StringBuilder&, const Inset
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(Inset, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Inset, 2)

--- a/Source/WebCore/css/values/shapes/CSSPathFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSPathFunction.h
@@ -63,4 +63,4 @@ template<> struct CSSValueChildrenVisitor<Path::Data> { IterationStatus operator
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(Path, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Path, 2)

--- a/Source/WebCore/css/values/shapes/CSSPolygonFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSPolygonFunction.h
@@ -57,4 +57,4 @@ template<> struct Serialize<Polygon> { void operator()(StringBuilder&, const Pol
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(Polygon, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Polygon, 2)

--- a/Source/WebCore/css/values/shapes/CSSRectFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSRectFunction.h
@@ -56,4 +56,4 @@ template<> struct Serialize<Rect> { void operator()(StringBuilder&, const Rect&)
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(Rect, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Rect, 2)

--- a/Source/WebCore/css/values/shapes/CSSShapeFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSShapeFunction.h
@@ -56,7 +56,7 @@ struct ToPosition {
 
     bool operator==(const ToPosition&) const = default;
 };
-DEFINE_TYPE_WRAPPER(ToPosition, offset);
+DEFINE_TYPE_WRAPPER_GET(ToPosition, offset);
 
 template<> struct Serialize<ToPosition> { void operator()(StringBuilder&, const ToPosition&); };
 
@@ -68,7 +68,7 @@ struct ByCoordinatePair {
 
     bool operator==(const ByCoordinatePair&) const = default;
 };
-DEFINE_TYPE_WRAPPER(ByCoordinatePair, offset);
+DEFINE_TYPE_WRAPPER_GET(ByCoordinatePair, offset);
 
 template<> struct Serialize<ByCoordinatePair> { void operator()(StringBuilder&, const ByCoordinatePair&); };
 
@@ -121,7 +121,7 @@ struct MoveCommand {
 
     bool operator==(const MoveCommand&) const = default;
 };
-DEFINE_TYPE_WRAPPER(MoveCommand, toBy);
+DEFINE_TYPE_WRAPPER_GET(MoveCommand, toBy);
 
 template<> struct Serialize<MoveCommand> { void operator()(StringBuilder&, const MoveCommand&); };
 
@@ -136,7 +136,7 @@ struct LineCommand {
 
     bool operator==(const LineCommand&) const = default;
 };
-DEFINE_TYPE_WRAPPER(LineCommand, toBy);
+DEFINE_TYPE_WRAPPER_GET(LineCommand, toBy);
 
 template<> struct Serialize<LineCommand> { void operator()(StringBuilder&, const LineCommand&); };
 
@@ -164,9 +164,9 @@ struct HLineCommand {
 
     bool operator==(const HLineCommand&) const = default;
 };
-DEFINE_TYPE_WRAPPER(HLineCommand::By, offset);
-DEFINE_TYPE_WRAPPER(HLineCommand::To, offset);
-DEFINE_TYPE_WRAPPER(HLineCommand, toBy);
+DEFINE_TYPE_WRAPPER_GET(HLineCommand::By, offset);
+DEFINE_TYPE_WRAPPER_GET(HLineCommand::To, offset);
+DEFINE_TYPE_WRAPPER_GET(HLineCommand, toBy);
 
 template<> struct Serialize<HLineCommand::To> { void operator()(StringBuilder&, const HLineCommand::To&); };
 template<> struct Serialize<HLineCommand::By> { void operator()(StringBuilder&, const HLineCommand::By&); };
@@ -195,9 +195,9 @@ struct VLineCommand {
 
     bool operator==(const VLineCommand&) const = default;
 };
-DEFINE_TYPE_WRAPPER(VLineCommand::By, offset);
-DEFINE_TYPE_WRAPPER(VLineCommand::To, offset);
-DEFINE_TYPE_WRAPPER(VLineCommand, toBy);
+DEFINE_TYPE_WRAPPER_GET(VLineCommand::By, offset);
+DEFINE_TYPE_WRAPPER_GET(VLineCommand::To, offset);
+DEFINE_TYPE_WRAPPER_GET(VLineCommand, toBy);
 
 template<> struct Serialize<VLineCommand::To> { void operator()(StringBuilder&, const VLineCommand::To&); };
 template<> struct Serialize<VLineCommand::By> { void operator()(StringBuilder&, const VLineCommand::By&); };
@@ -249,7 +249,7 @@ template<size_t I> const auto& get(const CurveCommand::By& value)
     if constexpr (I == 2)
         return value.controlPoint2;
 }
-DEFINE_TYPE_WRAPPER(CurveCommand, toBy);
+DEFINE_TYPE_WRAPPER_GET(CurveCommand, toBy);
 
 template<> struct Serialize<CurveCommand::To> { void operator()(StringBuilder&, const CurveCommand::To&); };
 template<> struct Serialize<CurveCommand::By> { void operator()(StringBuilder&, const CurveCommand::By&); };
@@ -295,7 +295,7 @@ template<size_t I> const auto& get(const SmoothCommand::By& value)
     if constexpr (I == 1)
         return value.controlPoint;
 }
-DEFINE_TYPE_WRAPPER(SmoothCommand, toBy);
+DEFINE_TYPE_WRAPPER_GET(SmoothCommand, toBy);
 
 template<> struct Serialize<SmoothCommand::To> { void operator()(StringBuilder&, const SmoothCommand::To&); };
 template<> struct Serialize<SmoothCommand::By> { void operator()(StringBuilder&, const SmoothCommand::By&); };
@@ -371,23 +371,23 @@ template<> struct Serialize<Shape> { void operator()(StringBuilder&, const Shape
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(ToPosition, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(ByCoordinatePair, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(RelativeControlPoint, 2)
-CSS_TUPLE_LIKE_CONFORMANCE(AbsoluteControlPoint, 2)
-CSS_TUPLE_LIKE_CONFORMANCE(MoveCommand, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(LineCommand, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(HLineCommand::To, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(HLineCommand::By, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(HLineCommand, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(VLineCommand::To, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(VLineCommand::By, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(VLineCommand, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(CurveCommand::To, 3)
-CSS_TUPLE_LIKE_CONFORMANCE(CurveCommand::By, 3)
-CSS_TUPLE_LIKE_CONFORMANCE(CurveCommand, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(SmoothCommand::To, 2)
-CSS_TUPLE_LIKE_CONFORMANCE(SmoothCommand::By, 2)
-CSS_TUPLE_LIKE_CONFORMANCE(SmoothCommand, 1)
-CSS_TUPLE_LIKE_CONFORMANCE(ArcCommand, 5)
-CSS_TUPLE_LIKE_CONFORMANCE(Shape, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::ToPosition, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::ByCoordinatePair, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::RelativeControlPoint, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::AbsoluteControlPoint, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::MoveCommand, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::LineCommand, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::HLineCommand::To, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::HLineCommand::By, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::HLineCommand, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::VLineCommand::To, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::VLineCommand::By, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::VLineCommand, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::CurveCommand::To, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::CurveCommand::By, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::CurveCommand, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::SmoothCommand::To, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::SmoothCommand::By, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::SmoothCommand, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::ArcCommand, 5)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Shape, 3)

--- a/Source/WebCore/css/values/shapes/CSSXywhFunction.h
+++ b/Source/WebCore/css/values/shapes/CSSXywhFunction.h
@@ -59,4 +59,4 @@ template<> struct Serialize<Xywh> { void operator()(StringBuilder&, const Xywh&)
 } // namespace CSS
 } // namespace WebCore
 
-CSS_TUPLE_LIKE_CONFORMANCE(Xywh, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::Xywh, 3)

--- a/Source/WebCore/css/values/text-decoration/CSSTextShadow.h
+++ b/Source/WebCore/css/values/text-decoration/CSSTextShadow.h
@@ -53,4 +53,4 @@ template<size_t I> const auto& get(const TextShadow& value)
 } // namespace CSS
 } // namespace WebCore
 
-CSS_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(TextShadow, 3)
+DEFINE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(WebCore::CSS::TextShadow, 3)

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -43,28 +43,6 @@ namespace Style {
 
 class BuilderState;
 
-// Helper for declaring types in the Style namespace as Tuple-Like.
-#define STYLE_TUPLE_LIKE_CONFORMANCE(t, numberOfArguments) \
-    namespace std { \
-        template<> class tuple_size<WebCore::Style::t> : public std::integral_constant<size_t, numberOfArguments> { }; \
-        template<size_t I> class tuple_element<I, WebCore::Style::t> { \
-        public: \
-            using type = decltype(WebCore::Style::get<I>(std::declval<WebCore::Style::t>())); \
-        }; \
-    } \
-    template<> inline constexpr bool WebCore::TreatAsTupleLike<WebCore::Style::t> = true; \
-\
-
-#define STYLE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(t, numberOfArguments) \
-    STYLE_TUPLE_LIKE_CONFORMANCE(t, numberOfArguments) \
-    template<> inline constexpr ASCIILiteral WebCore::SerializationSeparator<WebCore::Style::t> = " "_s; \
-\
-
-#define STYLE_COMMA_SEPARATED_TUPLE_LIKE_CONFORMANCE(t, numberOfArguments) \
-    STYLE_TUPLE_LIKE_CONFORMANCE(t, numberOfArguments) \
-    template<> inline constexpr ASCIILiteral WebCore::SerializationSeparator<WebCore::Style::t> = ", "_s; \
-\
-
 // Types can specialize this and set the value to true to be treated as "non-converting"
 // for css to style / style to css conversion algorithms. This means the type is identical
 // for both CSS and Style systems (e.g. a constant value or an enum).

--- a/Source/WebCore/style/values/backgrounds/StyleBorderRadius.h
+++ b/Source/WebCore/style/values/backgrounds/StyleBorderRadius.h
@@ -64,4 +64,4 @@ FloatRoundedRect::Radii evaluate(const BorderRadius&, FloatSize referenceBox);
 } // namespace Style
 } // namespace WebCore
 
-STYLE_TUPLE_LIKE_CONFORMANCE(BorderRadius, 4)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::BorderRadius, 4)

--- a/Source/WebCore/style/values/backgrounds/StyleBoxShadow.h
+++ b/Source/WebCore/style/values/backgrounds/StyleBoxShadow.h
@@ -67,4 +67,4 @@ template<> struct Blending<BoxShadow> {
 } // namespace Style
 } // namespace WebCore
 
-STYLE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(BoxShadow, 5)
+DEFINE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(WebCore::Style::BoxShadow, 5)

--- a/Source/WebCore/style/values/color-adjust/StyleColorScheme.h
+++ b/Source/WebCore/style/values/color-adjust/StyleColorScheme.h
@@ -65,6 +65,6 @@ TextStream& operator<<(TextStream&, const ColorScheme&);
 } // namespace Style
 } // namespace WebCore
 
-STYLE_TUPLE_LIKE_CONFORMANCE(ColorScheme, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::ColorScheme, 2)
 
 #endif

--- a/Source/WebCore/style/values/images/StyleGradient.h
+++ b/Source/WebCore/style/values/images/StyleGradient.h
@@ -398,19 +398,19 @@ bool isOpaque(const Gradient&, const RenderStyle&);
 } // namespace Style
 } // namespace WebCore
 
-STYLE_TUPLE_LIKE_CONFORMANCE(LinearGradient, 3)
-STYLE_TUPLE_LIKE_CONFORMANCE(PrefixedLinearGradient, 3)
-STYLE_TUPLE_LIKE_CONFORMANCE(DeprecatedLinearGradient, 3)
-STYLE_TUPLE_LIKE_CONFORMANCE(RadialGradient::Ellipse, 2)
-STYLE_TUPLE_LIKE_CONFORMANCE(RadialGradient::Circle, 2)
-STYLE_TUPLE_LIKE_CONFORMANCE(RadialGradient, 3)
-STYLE_TUPLE_LIKE_CONFORMANCE(PrefixedRadialGradient::Ellipse, 2)
-STYLE_TUPLE_LIKE_CONFORMANCE(PrefixedRadialGradient::Circle, 2)
-STYLE_TUPLE_LIKE_CONFORMANCE(PrefixedRadialGradient, 3)
-STYLE_TUPLE_LIKE_CONFORMANCE(DeprecatedRadialGradient::GradientBox, 4)
-STYLE_TUPLE_LIKE_CONFORMANCE(DeprecatedRadialGradient, 3)
-STYLE_TUPLE_LIKE_CONFORMANCE(ConicGradient::GradientBox, 2)
-STYLE_TUPLE_LIKE_CONFORMANCE(ConicGradient, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::LinearGradient, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::PrefixedLinearGradient, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::DeprecatedLinearGradient, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::RadialGradient::Ellipse, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::RadialGradient::Circle, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::RadialGradient, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::PrefixedRadialGradient::Ellipse, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::PrefixedRadialGradient::Circle, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::PrefixedRadialGradient, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::DeprecatedRadialGradient::GradientBox, 4)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::DeprecatedRadialGradient, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::ConicGradient::GradientBox, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::ConicGradient, 3)
 
 template<typename C, typename P> inline constexpr bool WebCore::TreatAsTupleLike<WebCore::Style::GradientColorStop<C, P>> = true;
 

--- a/Source/WebCore/style/values/motion/StyleRayFunction.h
+++ b/Source/WebCore/style/values/motion/StyleRayFunction.h
@@ -66,4 +66,4 @@ DEFINE_TYPE_MAPPING(CSS::Ray, Ray)
 } // namespace Style
 } // namespace WebCore
 
-STYLE_TUPLE_LIKE_CONFORMANCE(Ray, 4)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::Ray, 4)

--- a/Source/WebCore/style/values/primitives/StylePosition.h
+++ b/Source/WebCore/style/values/primitives/StylePosition.h
@@ -35,14 +35,14 @@ struct TwoComponentPositionHorizontal {
 
     bool operator==(const TwoComponentPositionHorizontal&) const = default;
 };
-DEFINE_TYPE_WRAPPER(TwoComponentPositionHorizontal, offset);
+DEFINE_TYPE_WRAPPER_GET(TwoComponentPositionHorizontal, offset);
 
 struct TwoComponentPositionVertical {
     LengthPercentage<> offset;
 
     bool operator==(const TwoComponentPositionVertical&) const = default;
 };
-DEFINE_TYPE_WRAPPER(TwoComponentPositionVertical, offset);
+DEFINE_TYPE_WRAPPER_GET(TwoComponentPositionVertical, offset);
 
 struct Position  {
     Position(TwoComponentPositionHorizontal&& x, TwoComponentPositionVertical&& y)
@@ -99,6 +99,6 @@ float evaluate(const TwoComponentPositionVertical&, float referenceHeight);
 } // namespace Style
 } // namespace WebCore
 
-STYLE_TUPLE_LIKE_CONFORMANCE(TwoComponentPositionHorizontal, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(TwoComponentPositionVertical, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(Position, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::TwoComponentPositionHorizontal, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::TwoComponentPositionVertical, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::Position, 2)

--- a/Source/WebCore/style/values/shapes/StyleCircleFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleCircleFunction.h
@@ -68,4 +68,4 @@ template<> struct Blending<Circle> {
 } // namespace Style
 } // namespace WebCore
 
-STYLE_TUPLE_LIKE_CONFORMANCE(Circle, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::Circle, 2)

--- a/Source/WebCore/style/values/shapes/StyleEllipseFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleEllipseFunction.h
@@ -68,4 +68,4 @@ template<> struct Blending<Ellipse> {
 } // namespace Style
 } // namespace WebCore
 
-STYLE_TUPLE_LIKE_CONFORMANCE(Ellipse, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::Ellipse, 2)

--- a/Source/WebCore/style/values/shapes/StyleInsetFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleInsetFunction.h
@@ -60,4 +60,4 @@ template<> struct PathComputation<Inset> { WebCore::Path operator()(const Inset&
 } // namespace Style
 } // namespace WebCore
 
-STYLE_TUPLE_LIKE_CONFORMANCE(Inset, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::Inset, 2)

--- a/Source/WebCore/style/values/shapes/StylePathFunction.h
+++ b/Source/WebCore/style/values/shapes/StylePathFunction.h
@@ -83,4 +83,4 @@ template<> struct Blending<Path> {
 } // namespace Style
 } // namespace WebCore
 
-STYLE_TUPLE_LIKE_CONFORMANCE(Path, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::Path, 2)

--- a/Source/WebCore/style/values/shapes/StylePolygonFunction.h
+++ b/Source/WebCore/style/values/shapes/StylePolygonFunction.h
@@ -67,4 +67,4 @@ template<> struct Blending<Polygon> {
 } // namespace Style
 } // namespace WebCore
 
-STYLE_TUPLE_LIKE_CONFORMANCE(Polygon, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::Polygon, 2)

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.h
@@ -54,7 +54,7 @@ struct ToPosition {
 
     bool operator==(const ToPosition&) const = default;
 };
-DEFINE_TYPE_WRAPPER(ToPosition, offset);
+DEFINE_TYPE_WRAPPER_GET(ToPosition, offset);
 DEFINE_TYPE_MAPPING(CSS::ToPosition, ToPosition)
 
 // <by-coordinate-pair> = by <coordinate-pair>
@@ -65,7 +65,7 @@ struct ByCoordinatePair {
 
     bool operator==(const ByCoordinatePair&) const = default;
 };
-DEFINE_TYPE_WRAPPER(ByCoordinatePair, offset);
+DEFINE_TYPE_WRAPPER_GET(ByCoordinatePair, offset);
 DEFINE_TYPE_MAPPING(CSS::ByCoordinatePair, ByCoordinatePair)
 
 // <relative-control-point> = [<coordinate-pair> [from [start | end | origin]]?]
@@ -131,7 +131,7 @@ struct MoveCommand {
 
     bool operator==(const MoveCommand&) const = default;
 };
-DEFINE_TYPE_WRAPPER(MoveCommand, toBy);
+DEFINE_TYPE_WRAPPER_GET(MoveCommand, toBy);
 DEFINE_TYPE_MAPPING(CSS::MoveCommand, MoveCommand)
 
 // MARK: - Line Command
@@ -147,7 +147,7 @@ struct LineCommand {
 
     bool operator==(const LineCommand&) const = default;
 };
-DEFINE_TYPE_WRAPPER(LineCommand, toBy);
+DEFINE_TYPE_WRAPPER_GET(LineCommand, toBy);
 DEFINE_TYPE_MAPPING(CSS::LineCommand, LineCommand)
 
 // MARK: - HLine Command
@@ -175,9 +175,9 @@ struct HLineCommand {
 
     bool operator==(const HLineCommand&) const = default;
 };
-DEFINE_TYPE_WRAPPER(HLineCommand::By, offset);
-DEFINE_TYPE_WRAPPER(HLineCommand::To, offset);
-DEFINE_TYPE_WRAPPER(HLineCommand, toBy);
+DEFINE_TYPE_WRAPPER_GET(HLineCommand::By, offset);
+DEFINE_TYPE_WRAPPER_GET(HLineCommand::To, offset);
+DEFINE_TYPE_WRAPPER_GET(HLineCommand, toBy);
 DEFINE_TYPE_MAPPING(CSS::HLineCommand::To, HLineCommand::To)
 DEFINE_TYPE_MAPPING(CSS::HLineCommand::By, HLineCommand::By)
 DEFINE_TYPE_MAPPING(CSS::HLineCommand, HLineCommand)
@@ -207,9 +207,9 @@ struct VLineCommand {
 
     bool operator==(const VLineCommand&) const = default;
 };
-DEFINE_TYPE_WRAPPER(VLineCommand::By, offset);
-DEFINE_TYPE_WRAPPER(VLineCommand::To, offset);
-DEFINE_TYPE_WRAPPER(VLineCommand, toBy);
+DEFINE_TYPE_WRAPPER_GET(VLineCommand::By, offset);
+DEFINE_TYPE_WRAPPER_GET(VLineCommand::To, offset);
+DEFINE_TYPE_WRAPPER_GET(VLineCommand, toBy);
 DEFINE_TYPE_MAPPING(CSS::VLineCommand::To, VLineCommand::To)
 DEFINE_TYPE_MAPPING(CSS::VLineCommand::By, VLineCommand::By)
 DEFINE_TYPE_MAPPING(CSS::VLineCommand, VLineCommand)
@@ -262,7 +262,7 @@ template<size_t I> const auto& get(const CurveCommand::By& value)
     if constexpr (I == 2)
         return value.controlPoint2;
 }
-DEFINE_TYPE_WRAPPER(CurveCommand, toBy);
+DEFINE_TYPE_WRAPPER_GET(CurveCommand, toBy);
 
 DEFINE_TYPE_MAPPING(CSS::CurveCommand, CurveCommand)
 DEFINE_TYPE_MAPPING(CSS::CurveCommand::To, CurveCommand::To)
@@ -310,7 +310,7 @@ template<size_t I> const auto& get(const SmoothCommand::By& value)
     if constexpr (I == 1)
         return value.controlPoint;
 }
-DEFINE_TYPE_WRAPPER(SmoothCommand, toBy);
+DEFINE_TYPE_WRAPPER_GET(SmoothCommand, toBy);
 
 DEFINE_TYPE_MAPPING(CSS::SmoothCommand, SmoothCommand)
 DEFINE_TYPE_MAPPING(CSS::SmoothCommand::To, SmoothCommand::To)
@@ -415,23 +415,23 @@ std::optional<Shape> makeShapeFromPath(const Path&);
 } // namespace Style
 } // namespace WebCore
 
-STYLE_TUPLE_LIKE_CONFORMANCE(ToPosition, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(ByCoordinatePair, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(RelativeControlPoint, 2)
-STYLE_TUPLE_LIKE_CONFORMANCE(AbsoluteControlPoint, 2)
-STYLE_TUPLE_LIKE_CONFORMANCE(MoveCommand, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(LineCommand, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(HLineCommand::To, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(HLineCommand::By, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(HLineCommand, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(VLineCommand::To, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(VLineCommand::By, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(VLineCommand, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(CurveCommand::To, 3)
-STYLE_TUPLE_LIKE_CONFORMANCE(CurveCommand::By, 3)
-STYLE_TUPLE_LIKE_CONFORMANCE(CurveCommand, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(SmoothCommand::To, 2)
-STYLE_TUPLE_LIKE_CONFORMANCE(SmoothCommand::By, 2)
-STYLE_TUPLE_LIKE_CONFORMANCE(SmoothCommand, 1)
-STYLE_TUPLE_LIKE_CONFORMANCE(ArcCommand, 5)
-STYLE_TUPLE_LIKE_CONFORMANCE(Shape, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::ToPosition, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::ByCoordinatePair, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::RelativeControlPoint, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::AbsoluteControlPoint, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::MoveCommand, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::LineCommand, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::HLineCommand::To, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::HLineCommand::By, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::HLineCommand, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::VLineCommand::To, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::VLineCommand::By, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::VLineCommand, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::CurveCommand::To, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::CurveCommand::By, 3)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::CurveCommand, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::SmoothCommand::To, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::SmoothCommand::By, 2)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::SmoothCommand, 1)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::ArcCommand, 5)
+DEFINE_TUPLE_LIKE_CONFORMANCE(WebCore::Style::Shape, 3)

--- a/Source/WebCore/style/values/text-decoration/StyleTextShadow.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextShadow.h
@@ -60,4 +60,4 @@ template<> struct Blending<TextShadow> {
 } // namespace Style
 } // namespace WebCore
 
-STYLE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(TextShadow, 3)
+DEFINE_SPACE_SEPARATED_TUPLE_LIKE_CONFORMANCE(WebCore::Style::TextShadow, 3)


### PR DESCRIPTION
#### f52f517e1e1302a0d9ccd41f7b2c7c79547e4936
<pre>
Unify macros used for CSS and Style value types
<a href="https://bugs.webkit.org/show_bug.cgi?id=285818">https://bugs.webkit.org/show_bug.cgi?id=285818</a>

Reviewed by Tim Nguyen.

- Replaces CSS and Style specific macros with ones that take a fully
  qualified type.
- Consistently prefixes macros with DEFINE_*.
- Renames DEFINE_TYPE_WRAPPER to DEFINE_TYPE_WRAPPER_GET to clarify its
  behavior and free up DEFINE_TYPE_WRAPPER for the future.

* Source/WebCore/css/values/CSSValueAggregates.h:
* Source/WebCore/css/values/CSSValueTypes.h:
* Source/WebCore/css/values/backgrounds/CSSBorderRadius.h:
* Source/WebCore/css/values/backgrounds/CSSBoxShadow.h:
* Source/WebCore/css/values/color-adjust/CSSColorScheme.h:
* Source/WebCore/css/values/easing/CSSCubicBezierEasingFunction.h:
* Source/WebCore/css/values/easing/CSSLinearEasingFunction.h:
* Source/WebCore/css/values/easing/CSSSpringEasingFunction.h:
* Source/WebCore/css/values/easing/CSSStepsEasingFunction.h:
* Source/WebCore/css/values/filter-effects/CSSBlurFunction.h:
* Source/WebCore/css/values/filter-effects/CSSBrightnessFunction.h:
* Source/WebCore/css/values/filter-effects/CSSContrastFunction.h:
* Source/WebCore/css/values/filter-effects/CSSDropShadowFunction.h:
* Source/WebCore/css/values/filter-effects/CSSGrayscaleFunction.h:
* Source/WebCore/css/values/filter-effects/CSSHueRotateFunction.h:
* Source/WebCore/css/values/filter-effects/CSSInvertFunction.h:
* Source/WebCore/css/values/filter-effects/CSSOpacityFunction.h:
* Source/WebCore/css/values/filter-effects/CSSSaturateFunction.h:
* Source/WebCore/css/values/filter-effects/CSSSepiaFunction.h:
* Source/WebCore/css/values/images/CSSGradient.h:
* Source/WebCore/css/values/motion/CSSRayFunction.h:
* Source/WebCore/css/values/primitives/CSSPosition.h:
* Source/WebCore/css/values/shapes/CSSCircleFunction.h:
* Source/WebCore/css/values/shapes/CSSEllipseFunction.h:
* Source/WebCore/css/values/shapes/CSSInsetFunction.h:
* Source/WebCore/css/values/shapes/CSSPathFunction.h:
* Source/WebCore/css/values/shapes/CSSPolygonFunction.h:
* Source/WebCore/css/values/shapes/CSSRectFunction.h:
* Source/WebCore/css/values/shapes/CSSShapeFunction.h:
* Source/WebCore/css/values/shapes/CSSXywhFunction.h:
* Source/WebCore/css/values/text-decoration/CSSTextShadow.h:
* Source/WebCore/style/values/StyleValueTypes.h:
* Source/WebCore/style/values/backgrounds/StyleBorderRadius.h:
* Source/WebCore/style/values/backgrounds/StyleBoxShadow.h:
* Source/WebCore/style/values/color-adjust/StyleColorScheme.h:
* Source/WebCore/style/values/images/StyleGradient.h:
* Source/WebCore/style/values/motion/StyleRayFunction.h:
* Source/WebCore/style/values/primitives/StylePosition.h:
* Source/WebCore/style/values/shapes/StyleCircleFunction.h:
* Source/WebCore/style/values/shapes/StyleEllipseFunction.h:
* Source/WebCore/style/values/shapes/StyleInsetFunction.h:
* Source/WebCore/style/values/shapes/StylePathFunction.h:
* Source/WebCore/style/values/shapes/StylePolygonFunction.h:
* Source/WebCore/style/values/shapes/StyleShapeFunction.h:
* Source/WebCore/style/values/text-decoration/StyleTextShadow.h:

Canonical link: <a href="https://commits.webkit.org/288776@main">https://commits.webkit.org/288776@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc0f33bf59ed597ae8b1b9e2738e792b303ba7e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89473 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35403 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86478 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/11996 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65628 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/23470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3085 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/76675 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45922 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30906 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34451 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90854 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11660 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8483 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11887 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72499 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18128 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17617 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16061 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3055 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11612 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17088 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11461 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14937 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->