### PR TITLE
Fix GNU/Hurd build by avoiding PATH_MAX usage

### DIFF
--- a/Source/JavaScriptCore/API/tests/testapi.c
+++ b/Source/JavaScriptCore/API/tests/testapi.c
@@ -1578,12 +1578,15 @@ int main(int argc, char* argv[])
     configureJSCForTesting();
 
 #if !OS(WINDOWS)
-    char resolvedPath[PATH_MAX];
-    if (!realpath(argv[0], resolvedPath))
-        fprintf(stdout, "Could not get the absolute pathname for: %s\n", argv[0]);
-    char* newCWD = dirname(resolvedPath);
-    if (chdir(newCWD))
-        fprintf(stdout, "Could not chdir to: %s\n", newCWD);
+    char *resolvedPath = realpath(argv[0], NULL);
+    if (!resolvedPath)
+        fprintf(stderr, "Could not get the absolute pathname for: %s\n", argv[0]);
+    else {
+        char *newCWD = dirname(resolvedPath);
+        if (chdir(newCWD))
+            fprintf(stderr, "Could not chdir to: %s\n", newCWD);
+        free(resolvedPath);
+    }
 #endif
 
     const char* filter = argc > 1 ? argv[1] : NULL;

--- a/Source/WTF/wtf/playstation/FileSystemPlayStation.cpp
+++ b/Source/WTF/wtf/playstation/FileSystemPlayStation.cpp
@@ -98,13 +98,9 @@ Vector<String> listDirectorySub(const String& path, bool fullPath)
             if (!strcmp(name, ".") || !strcmp(name, ".."))
                 continue;
             String newEntry;
-            if (fullPath) {
-                char filePath[PATH_MAX];
-                if (fullPath && static_cast<int>(sizeof(filePath) - 1) < snprintf(filePath, sizeof(filePath), "%s/%s", cpath.data(), name))
-                    continue; // buffer overflow
-
-                newEntry = stringFromFileSystemRepresentation(filePath);
-            } else
+            if (fullPath)
+                newEntry = makeString(path, '/', stringFromFileSystemRepresentation(name));
+            else
                 newEntry = stringFromFileSystemRepresentation(name);
 
             // Some file system representations cannot be represented as a UTF-16 string,
@@ -138,9 +134,8 @@ bool deleteNonEmptyDirectory(const String& path)
 String realPath(const String& filePath)
 {
     CString fsRep = fileSystemRepresentation(filePath);
-    char resolvedName[PATH_MAX];
-    const char* result = realpath(fsRep.data(), resolvedName);
-    return result ? String::fromUTF8(result) : filePath;
+    std::unique_ptr<char, decltype(free)*> resolvedPath(realpath(fsRep.data(), nullptr), free);
+    return resolvedPath ? String::fromUTF8(resolvedPath) : filePath;
 }
 
 

--- a/Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp
+++ b/Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp
@@ -75,12 +75,9 @@ static void scanDirectoryForDictionaries(const char* directoryPath, UncheckedKey
         if (locale.isEmpty())
             continue;
 
-        auto filePath = FileSystem::pathByAppendingComponent(directoryPathString, fileName);
-        char normalizedPath[PATH_MAX];
-        if (!realpath(FileSystem::fileSystemRepresentation(filePath).data(), normalizedPath))
-            continue;
+        auto fullPath = FileSystem::pathByAppendingComponent(directoryPathString, fileName);
+        auto filePath = FileSystem::realPath(fullPath);
 
-        filePath = FileSystem::stringFromFileSystemRepresentation(normalizedPath);
         availableLocales.add(locale, Vector<String>()).iterator->value.append(filePath);
 
         String localeReplacingUnderscores = makeStringByReplacingAll(locale, '_', '-');


### PR DESCRIPTION
#### 598f74dba3e992cdc11d1f3a8f5aa6f53c60fdd7
<pre>
Fix GNU/Hurd build by avoiding PATH_MAX usage
<a href="https://bugs.webkit.org/show_bug.cgi?id=285806">https://bugs.webkit.org/show_bug.cgi?id=285806</a>

Reviewed by Darin Adler.

This is a rework of the patch proposed on
<a href="https://bugs.webkit.org/show_bug.cgi?id=219572">https://bugs.webkit.org/show_bug.cgi?id=219572</a>

GNU/Hurd does not define an arbitrary PATH_MAX limitation.

- Constructed paths can be allocated as appropriate.

- For realpath() calls, since posix 2008 and since long on bsd/linux-like
OS, realpath() can be passed NULL.

* Source/JavaScriptCore/API/tests/testapi.c:
(main): Pass NULL to realpath().
* Source/WTF/wtf/playstation/FileSystemPlayStation.cpp:
(WTF::FileSystemImpl::listDirectorySub): Compute buffer size.
(WTF::FileSystemImpl::realPath): Pass nullptr to realpath().
* Source/WTF/wtf/posix/FileSystemPOSIX.cpp:
(WTF::FileSystemImpl::openTemporaryFile): Compute buffer size.
* Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp:
(WebCore::scanDirectoryForDictionaries): Use FileSystem::realPath().

Canonical link: <a href="https://commits.webkit.org/288943@main">https://commits.webkit.org/288943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e300477a9175937ff6a0ca868387a49d8fd28e3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89943 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35856 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65996 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23810 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46270 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31283 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34930 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77767 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91319 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83846 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8862 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74479 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12370 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72875 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73605 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18220 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17975 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16418 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/3591 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12095 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17535 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106239 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11929 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25640 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15423 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13675 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->