### PR TITLE
[WPE] WPE Platform: Initialize DRM scale factor from default value in WPESettings

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRM.cpp
@@ -67,14 +67,7 @@ WPEScreen* wpeScreenDRMCreate(std::unique_ptr<WPE::DRM::Crtc>&& crtc, const WPE:
     auto* priv = WPE_SCREEN_DRM(screen)->priv;
     priv->crtc = WTFMove(crtc);
 
-    double scale = 1;
-    if (const char* scaleString = getenv("WPE_DRM_SCALE"))
-        scale = g_ascii_strtod(scaleString, nullptr);
-
-    wpe_screen_set_position(screen, priv->crtc->x() / scale, priv->crtc->y() / scale);
-    wpe_screen_set_size(screen, priv->crtc->width() / scale, priv->crtc->height() / scale);
     wpe_screen_set_physical_size(screen, connector.widthMM(), connector.heightMM());
-    wpe_screen_set_scale(screen, scale);
 
     if (const auto& mode = priv->crtc->currentMode())
         priv->mode = mode.value();


### PR DESCRIPTION
#### de09004ea9459ad8622ed41c7eef4ecb7c6a84af
<pre>
[WPE] WPE Platform: Initialize DRM scale factor from default value in WPESettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=285820">https://bugs.webkit.org/show_bug.cgi?id=285820</a>

Reviewed by Carlos Garcia Campos.

Initialize the DRM scale factor from WPESettings within WPEDisplayDRM, after the WPEScreenDRM being created.

* Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp:
(wpeDisplayDRMSetup):
* Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRM.cpp:
(wpeScreenDRMCreate):

Canonical link: <a href="https://commits.webkit.org/289142@main">https://commits.webkit.org/289142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0949d38a3ed3a5c32058bc571b636e8ad3f41657

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85493 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5202 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90596 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36510 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13180 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66446 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24259 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77629 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46728 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3993 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35579 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74681 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92190 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9395 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75114 "Found 65 new test failures: compositing/blend-mode/non-separable-blend-modes.html compositing/layer-creation/will-change-layer-creation.html css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute.html editing/spelling/grammar-and-spelling-error-styling.html fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/css/focus-ring-exists-for-search-field.html fast/hidpi/hidpi-form-controls-drawing-size.html fast/inline/list-marker-inside-container-with-margin.html fast/inline/overflowing-content-with-hypens.html fast/multicol/columns-on-body.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13043 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73462 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74244 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18530 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16964 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4902 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13335 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12822 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18227 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12632 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16080 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->