### PR TITLE
[iPadOS/visionOS] YouTube media controls never dismiss after tapping to skip a preroll ad

### DIFF
--- a/LayoutTests/fast/events/touch/ios/content-observation/mousemove-after-synthetic-click-quirk-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/content-observation/mousemove-after-synthetic-click-quirk-expected.txt
@@ -1,0 +1,12 @@
+Verifies that mousemove is dispatched after a synthetic click
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS dispatchedMouseMoveOverTarget became true
+PASS Clicked target
+PASS dispatchedMouseMoveOverWrapper became true
+PASS dispatchedMouseOutOverWrapper became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/touch/ios/content-observation/mousemove-after-synthetic-click-quirk.html
+++ b/LayoutTests/fast/events/touch/ios/content-observation/mousemove-after-synthetic-click-quirk.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../../../resources/ui-helper.js"></script>
+<script src="../../../../../resources/js-test.js"></script>
+<style>
+#target {
+    width: 300px;
+    height: 300px;
+    border: 1px solid green;
+}
+
+#target-wrapper {
+    width: 320px;
+    height: 320px;
+    border: 1px solid blue;
+}
+
+#popup {
+    position: absolute;
+    top: 100px;
+    left: -1000px;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    transition: left 0ms ease-in-out 0ms;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+dispatchedMouseMoveOverTarget = false;
+dispatchedMouseOutOverWrapper = false;
+dispatchedMouseMoveOverWrapper = false;
+window.internals?.settings.setContentChangeObserverEnabled(true);
+window.internals?.setTopDocumentURLForQuirks("https://www.youtube.com");
+
+addEventListener("load", async () => {
+    description("Verifies that mousemove is dispatched after a synthetic click");
+
+    let targetContainer = document.getElementById("target-wrapper");
+    let target = document.getElementById("target");
+    let popup = document.getElementById("popup");
+
+    target.addEventListener("mousemove", event => {
+        popup.style.left = "10px";
+        dispatchedMouseMoveOverTarget = true;
+    });
+    target.addEventListener("click", event => {
+        testPassed("Clicked target");
+        target.remove();
+        targetContainer.addEventListener("mousemove", () => { dispatchedMouseMoveOverWrapper = true; });
+        targetContainer.addEventListener("mouseout", () => { dispatchedMouseOutOverWrapper = true; });
+    });
+    popup.addEventListener("click", () => testFailed("Unexpected click over popup"));
+
+    // First tap should trigger mouse hover.
+    await UIHelper.activateElement(target);
+    await shouldBecomeEqual("dispatchedMouseMoveOverTarget", "true");
+
+    // Second tap should complete the synthetic click.
+    await UIHelper.waitForDoubleTapDelay();
+    await UIHelper.activateElement(target);
+
+    await shouldBecomeEqual("dispatchedMouseMoveOverWrapper", "true");
+    await shouldBecomeEqual("dispatchedMouseOutOverWrapper", "true");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div id="target-wrapper">
+        <div id="target"></div>
+    </div>
+    <div id="popup"></div>
+    <pre id="description"></pre>
+    <pre id="console"></pre>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -992,8 +992,12 @@ void WebPage::completeSyntheticClick(Node& nodeRespondingToClick, const WebCore:
         auto& document = nodeRespondingToClick.document();
         // Dispatch mouseOut to dismiss tooltip content when tapping on the control bar buttons (cc, settings).
         if (document.quirks().needsYouTubeMouseOutQuirk()) {
-            if (auto* frame = document.frame())
-                frame->eventHandler().dispatchSyntheticMouseOut(PlatformMouseEvent(roundedAdjustedPoint, roundedAdjustedPoint, MouseButton::Left, PlatformEvent::Type::NoType, 0, platformModifiers, WallTime::now(), 0, WebCore::SyntheticClickType::NoTap, pointerId));
+            if (RefPtr frame = document.frame()) {
+                PlatformMouseEvent event { roundedAdjustedPoint, roundedAdjustedPoint, MouseButton::Left, PlatformEvent::Type::NoType, 0, platformModifiers, WallTime::now(), 0, WebCore::SyntheticClickType::NoTap, pointerId };
+                if (!nodeRespondingToClick.isConnected())
+                    frame->eventHandler().dispatchSyntheticMouseMove(event);
+                frame->eventHandler().dispatchSyntheticMouseOut(event);
+            }
         }
     }
 


### PR DESCRIPTION
#### 1fb3367b0a4fb304a289c0f59ac61b6c85ab4101
<pre>
[iPadOS/visionOS] YouTube media controls never dismiss after tapping to skip a preroll ad
<a href="https://bugs.webkit.org/show_bug.cgi?id=285821">https://bugs.webkit.org/show_bug.cgi?id=285821</a>
<a href="https://rdar.apple.com/108748685">rdar://108748685</a>

Reviewed by Abrar Rahman Protyasha and Richard Robinson.

On youtube.com in visionOS and iPadOS, tapping the Skip button when a preroll ad is playing causes
the video player to get into a state where media controls stay visible, until the user taps anywhere
in the video player again. This is because YouTube has JavaScript that listens for mouseover events
that occur over the Skip button, which keeps the controls presented until the next mousemove or
mouseover event over the video. When this bug reproduces, a `mousemove` isn&apos;t dispatched over the
video player when tapping Skip, which causes YouTube&apos;s JavaScript to be stuck in a state where it
believes the media controls should stay presented, since the mouse is still over custom controls (in
this case, the Skip button).

When using a mouse pointer on trackpad on iPad or on Mac, this isn&apos;t a problem in practice because
the user would likely move the mouse anywhere over the video, immediately after clicking Skip.
However, this subsequent movement doesn&apos;t happen when performing a synthetic click.

To fix this, we augment an existing quirk (added in <a href="https://commits.webkit.org/209926@main)">https://commits.webkit.org/209926@main)</a> which
dispatches a synthetic `mouseout` after completing synthetic click, such that it additionally
dispatches a synthetic `mousemove` in the case where the synthetic `click` event caused the target
node to become unparented (i.e. in the case of the Skip button, which removes itself when clicked).
In doing so, this effectively updates the node under the (synthetic) mouse location before sending
a `mouseout` when tapping.

* LayoutTests/fast/events/touch/ios/content-observation/mousemove-after-synthetic-click-quirk-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/content-observation/mousemove-after-synthetic-click-quirk.html: Added.

Add a layout test to exercise this quirk on YouTube.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::completeSyntheticClick):

See above for more details.

Canonical link: <a href="https://commits.webkit.org/288780@main">https://commits.webkit.org/288780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90738c7389eb0a3f0def1df87b5acbbe12aa86ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89483 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35413 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12008 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65637 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23480 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87449 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3095 "Found 4 new test failures: fast/files/blob-stream-frame.html http/tests/app-privacy-report/user-attribution-post-request.html http/tests/websocket/tests/hybi/no-subprotocol.html http/wpt/cache-storage/quota-third-party.https.html (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/76685 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45931 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/3046 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30916 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34461 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/73936 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90865 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8494 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74089 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72509 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73289 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18133 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17627 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16071 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3067 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11622 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17098 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11471 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14947 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13244 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->