### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF

### DIFF
--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -52,8 +52,6 @@
 #include <glib.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF {
 
 namespace FileSystemImpl {
@@ -378,5 +376,3 @@ String pathByAppendingComponents(StringView path, const Vector<StringView>& comp
 
 } // namespace FileSystemImpl
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -71,8 +71,6 @@
 #include <mach/thread_switch.h>
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #if OS(QNX)
 #define SA_RESTART 0
 #endif
@@ -701,7 +699,5 @@ void Thread::yield()
 }
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // USE(PTHREADS)

--- a/Source/WTF/wtf/spi/darwin/XPCSPI.h
+++ b/Source/WTF/wtf/spi/darwin/XPCSPI.h
@@ -28,6 +28,7 @@
 #include <dispatch/dispatch.h>
 #include <os/object.h>
 #include <span>
+#include <wtf/StdLibExtras.h>
 
 #if HAVE(XPC_API) || USE(APPLE_INTERNAL_SDK)
 #include <xpc/xpc.h>
@@ -259,7 +260,5 @@ inline std::span<const uint8_t> xpc_dictionary_get_data_span(xpc_object_t xdict,
 {
     size_t dataSize { 0 };
     auto* data = static_cast<const uint8_t*>(xpc_dictionary_get_data(xdict, key, &dataSize));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    return { data, dataSize };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    return unsafeMakeSpan(data, dataSize);
 }

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -26,8 +26,6 @@
 #include "config.h"
 #include <wtf/threads/Signals.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #if OS(UNIX)
 
 #if HAVE(MACH_EXCEPTIONS)
@@ -39,6 +37,7 @@ extern "C" {
 #include <cstdio>
 #include <mutex>
 #include <signal.h>
+#include <wtf/StdLibExtras.h>
 
 #if HAVE(MACH_EXCEPTIONS)
 #include <dispatch/dispatch.h>
@@ -230,7 +229,7 @@ inline ptrauth_generic_signature_t hashThreadState(const thread_state_t source)
 
     hash = ptrauth_sign_generic_data(hash, mach_thread_self());
 
-    const uintptr_t* srcPtr = reinterpret_cast<const uintptr_t*>(source);
+    auto srcPtr = unsafeMakeSpan(reinterpret_cast<const uintptr_t*>(source), threadStateSizeInPointers);
 
     // Exclude the __opaque_flags field which is reserved for OS use.
     // __opaque_flags is at the end of the payload.
@@ -263,6 +262,7 @@ kern_return_t catch_mach_exception_raise_state_identity(mach_port_t, mach_port_t
     return KERN_FAILURE;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 static kern_return_t runSignalHandlers(Signal signal, PlatformRegisters& registers, mach_msg_type_number_t dataCount, mach_exception_data_t exceptionData)
 {
     SigInfo info;
@@ -287,6 +287,7 @@ static kern_return_t runSignalHandlers(Signal signal, PlatformRegisters& registe
     });
     return didHandle ? KERN_SUCCESS : KERN_FAILURE;
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #if defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
 
@@ -538,7 +539,9 @@ static void jscSignalHandler(int sig, siginfo_t* info, void* ucontext)
     }
 
     unsigned oldActionIndex = static_cast<size_t>(signal) + (sig == SIGBUS);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     struct sigaction& oldAction = handlers.oldActions[static_cast<size_t>(oldActionIndex)];
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     if (signal == Signal::Usr) {
         if (oldAction.sa_sigaction)
             oldAction.sa_sigaction(sig, info, ucontext);
@@ -601,9 +604,11 @@ void SignalHandlers::finalize()
             RELEASE_ASSERT(!result);
             action.sa_flags = SA_SIGINFO;
             auto systemSignals = toSystemSignal(signal);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             result = sigaction(std::get<0>(systemSignals), &action, &handlers.oldActions[offsetForSystemSignal(std::get<0>(systemSignals))]);
             if (std::get<1>(systemSignals))
                 result |= sigaction(*std::get<1>(systemSignals), &action, &handlers.oldActions[offsetForSystemSignal(*std::get<1>(systemSignals))]);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             RELEASE_ASSERT(!result);
         }
     }
@@ -612,5 +617,3 @@ void SignalHandlers::finalize()
 } // namespace WTF
 
 #endif // OS(UNIX)
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/threads/Signals.h
+++ b/Source/WTF/wtf/threads/Signals.h
@@ -121,8 +121,8 @@ struct SignalHandlers {
     };
     InitState initState;
 
-    uint8_t numberOfHandlers[numberOfSignals];
-    SignalHandlerMemory handlers[numberOfSignals][maxNumberOfHandlers];
+    std::array<uint8_t, numberOfSignals> numberOfHandlers;
+    std::array<std::array<SignalHandlerMemory, maxNumberOfHandlers>, numberOfSignals> handlers;
 
 #if OS(UNIX)
     struct sigaction oldActions[numberOfSignals];

--- a/Source/WTF/wtf/unicode/UTF8Conversion.cpp
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.cpp
@@ -32,8 +32,6 @@
 #include <wtf/text/StringHasherInlines.h>
 #include <wtf/unicode/CharacterNames.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WTF::Unicode {
 
 static constexpr char32_t sentinelCodePoint = U_SENTINEL;
@@ -51,14 +49,18 @@ template<> char32_t next<Replacement::None, LChar>(std::span<const LChar> charac
 template<> char32_t next<Replacement::None, char8_t>(std::span<const char8_t> characters, size_t& offset)
 {
     char32_t character;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     U8_NEXT(characters, offset, characters.size(), character);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return U_IS_SURROGATE(character) ? sentinelCodePoint : character;
 }
 
 template<> char32_t next<Replacement::ReplaceInvalidSequences, char8_t>(std::span<const char8_t> characters, size_t& offset)
 {
     char32_t character;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     U8_NEXT_OR_FFFD(characters, offset, characters.size(), character);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return character;
 }
 
@@ -211,5 +213,3 @@ bool equal(std::span<const LChar> a, std::span<const char8_t> b)
 }
 
 } // namespace WTF::Unicode
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
+++ b/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
@@ -33,8 +33,6 @@
 
 #if !UCONFIG_NO_COLLATION
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 #include <mutex>
 #include <unicode/ucol.h>
 #include <wtf/Lock.h>
@@ -180,6 +178,7 @@ static UBool hasPreviousLatin1(UCharIterator* iterator)
     return iterator->index > iterator->start;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 static UChar32 currentLatin1(UCharIterator* iterator)
 {
     ASSERT(iterator->index >= iterator->start);
@@ -202,6 +201,7 @@ static UChar32 previousLatin1(UCharIterator* iterator)
         return U_SENTINEL;
     return static_cast<const LChar*>(iterator->context)[--iterator->index];
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static uint32_t getStateLatin1(const UCharIterator* iterator)
 {
@@ -273,7 +273,5 @@ int Collator::collate(const char8_t* a, const char8_t* b) const
 }
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif

--- a/Source/WTF/wtf/unicode/icu/ICUHelpers.cpp
+++ b/Source/WTF/wtf/unicode/icu/ICUHelpers.cpp
@@ -27,21 +27,20 @@
 #include <wtf/unicode/icu/ICUHelpers.h>
 
 #include <mutex>
+#include <span>
 #include <unicode/uvernum.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF {
 namespace ICU {
 
-static const UVersionInfo& version()
+static std::span<const uint8_t, U_MAX_VERSION_LENGTH> version()
 {
     static UVersionInfo versions { };
     static std::once_flag onceKey;
     std::call_once(onceKey, [&] {
         u_getVersion(versions);
     });
-    return versions;
+    return std::span { versions };
 }
 
 unsigned majorVersion()
@@ -57,5 +56,3 @@ unsigned minorVersion()
 }
 
 } } // namespace WTF::ICU
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtensionBridge.mm
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtensionBridge.mm
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import "config.h"
 #import "AuxiliaryProcessExtensionBridge.h"
 
 #import "ExtensionEventHandler.h"


### PR DESCRIPTION
#### 2be3693e4293226299385f4dbcb4ef52d145d80f
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=285822">https://bugs.webkit.org/show_bug.cgi?id=285822</a>

Reviewed by Geoffrey Garen.

* Source/WTF/wtf/posix/FileSystemPOSIX.cpp:
* Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp:
(WTF::OSAllocator::tryReserveAndCommit):
* Source/WTF/wtf/posix/ThreadingPOSIX.cpp:
* Source/WTF/wtf/spi/darwin/XPCSPI.h:
(xpc_dictionary_get_data_span):
* Source/WTF/wtf/text/StringParsingBuffer.h:
* Source/WTF/wtf/threads/Signals.cpp:
(WTF::hashThreadState):
(WTF::jscSignalHandler):
(WTF::SignalHandlers::finalize):
* Source/WTF/wtf/threads/Signals.h:
* Source/WTF/wtf/unicode/UTF8Conversion.cpp:
(WTF::Unicode::char8_t&gt;):
* Source/WTF/wtf/unicode/icu/CollatorICU.cpp:
* Source/WTF/wtf/unicode/icu/ICUHelpers.cpp:
(WTF::ICU::version):

Canonical link: <a href="https://commits.webkit.org/288815@main">https://commits.webkit.org/288815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f08c4f95754a58523e0d2c160dac527c2632023

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35493 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12092 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65713 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23554 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87528 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46008 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30991 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34541 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77446 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90945 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83499 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11749 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74155 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73357 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18150 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17702 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/16144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3184 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11701 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17177 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105918 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11550 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25555 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->