### PR TITLE
REGRESSION (287037@main): After calling -[WKWebView closeAllMediaPresentationsWithCompletionHandler:], subsequent attempts to enter fullscreen fail

### DIFF
--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -214,8 +214,14 @@ void WebFullScreenManagerProxy::setFullscreenAutoHideDuration(Seconds duration)
 
 void WebFullScreenManagerProxy::close()
 {
-    if (CheckedPtr client = std::exchange(m_client, nullptr))
+    if (CheckedPtr client = m_client)
         client->closeFullScreenManager();
+}
+
+void WebFullScreenManagerProxy::detachFromClient()
+{
+    close();
+    m_client = nullptr;
 }
 
 bool WebFullScreenManagerProxy::isFullScreen()

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -104,6 +104,7 @@ public:
     void prepareQuickLookImageURL(CompletionHandler<void(URL&&)>&&) const;
 #endif // QUICKLOOK_FULLSCREEN
     void close();
+    void detachFromClient();
 
     enum class FullscreenState : uint8_t {
         NotInFullscreen,

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10948,7 +10948,7 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
 
 #if ENABLE(FULLSCREEN_API)
     if (m_fullScreenManager) {
-        m_fullScreenManager->close();
+        m_fullScreenManager->detachFromClient();
         m_fullScreenManager = nullptr;
     }
 #endif


### PR DESCRIPTION
#### e43905574b5307066e3d9c4134a9dad75b04219c
<pre>
REGRESSION (287037@main): After calling -[WKWebView closeAllMediaPresentationsWithCompletionHandler:], subsequent attempts to enter fullscreen fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=285827">https://bugs.webkit.org/show_bug.cgi?id=285827</a>
<a href="https://rdar.apple.com/140306400">rdar://140306400</a>

Reviewed by Chris Dumez.

WebFullScreenManagerProxy::close() is called when a client calls
-[WKWebView closeAllMediaPresentationsWithCompletionHandler:]. After 287037@main, this results in
WebFullScreenManagerProxy::m_client being incorrectly set to null. As a result, subsequent attempts
to enter fullscreen fail since there is no longer a client when
WebFullScreenManagerProxy::enterFullScreen() is called.

Fixed this by adding WebFullScreenManagerProxy::detachFromClient(). This method explicitly clears
m_client and is called by WebPageProxy::resetState(). Restored WebFullScreenManagerProxy::close() to
its previous behavior.

Manually tested.

* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::close):
(WebKit::WebFullScreenManagerProxy::detachFromClient):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::resetState):

Canonical link: <a href="https://commits.webkit.org/288827@main">https://commits.webkit.org/288827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9863c312bf375f1a5410669fa54dab9c26476dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89507 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35437 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65659 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23500 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87472 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3112 "Found 4 new test failures: fast/files/blob-stream-frame.html http/tests/app-privacy-report/app-attribution-post-request.html http/tests/websocket/tests/hybi/no-subprotocol.html http/wpt/cache-storage/quota-third-party.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45953 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3062 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34484 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91084 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8512 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72526 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18153 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17644 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16088 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3107 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11645 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17121 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11494 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14970 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->