### PR TITLE
Revert 288547@main: [Site Isolation] Avoid reusing the main frame after cross-site navigation

### DIFF
--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -158,14 +158,10 @@ Ref<FrameState> WebBackForwardListFrameItem::copyFrameStateWithChildren()
     return frameState;
 }
 
-bool WebBackForwardListFrameItem::sharesAncestor(WebBackForwardListFrameItem& frameItem) const
+bool WebBackForwardListFrameItem::hasAncestorFrame(FrameIdentifier frameID)
 {
-    HashSet<WebCore::BackForwardFrameItemIdentifier> currentAncestors;
-    for (RefPtr currentAncestor = m_parent.get(); currentAncestor; currentAncestor = currentAncestor->m_parent.get())
-        currentAncestors.add(currentAncestor->m_identifier);
-
-    for (RefPtr frameItemAncestor = frameItem.m_parent.get(); frameItemAncestor; frameItemAncestor = frameItemAncestor->m_parent.get()) {
-        if (currentAncestors.contains(frameItemAncestor->m_identifier))
+    for (RefPtr ancestor = m_parent.get(); ancestor; ancestor = ancestor->m_parent.get()) {
+        if (ancestor->frameID() == frameID)
             return true;
     }
     return false;

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -55,7 +55,7 @@ public:
     WebBackForwardListFrameItem* parent() const { return m_parent.get(); }
     RefPtr<WebBackForwardListFrameItem> protectedParent() const { return m_parent.get(); }
     void setParent(WebBackForwardListFrameItem* parent) { m_parent = parent; }
-    bool sharesAncestor(WebBackForwardListFrameItem&) const;
+    bool hasAncestorFrame(WebCore::FrameIdentifier);
 
     WebBackForwardListFrameItem& rootFrame();
     WebBackForwardListFrameItem& mainFrame();

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -117,19 +117,21 @@ void WebBackForwardList::addItem(Ref<WebBackForwardListItem>&& newItem)
             m_entries.removeLast();
         }
 
-        while (m_entries.size()) {
-            Ref lastEntry = m_entries.last();
-            if (!lastEntry->isRemoteFrameNavigation() || lastEntry->navigatedFrameItem().sharesAncestor(newItem->navigatedFrameItem()))
-                break;
-            didRemoveItem(lastEntry);
-            removedItems.append(WTFMove(lastEntry));
-            m_entries.removeLast();
+        if (auto frameID = newItem->navigatedFrameItem().frameID()) {
+            while (m_entries.size()) {
+                Ref lastEntry = m_entries.last();
+                if (!lastEntry->isRemoteFrameNavigation() || !lastEntry->navigatedFrameItem().hasAncestorFrame(*frameID))
+                    break;
+                didRemoveItem(lastEntry);
+                removedItems.append(WTFMove(lastEntry));
+                m_entries.removeLast();
 
-            if (m_entries.isEmpty()) {
-                m_currentIndex = std::nullopt;
-                m_provisionalIndex = std::nullopt;
-            } else
-                setProvisionalOrCurrentIndex(*provisionalOrCurrentIndex() - 1);
+                if (m_entries.isEmpty()) {
+                    m_currentIndex = std::nullopt;
+                    m_provisionalIndex = std::nullopt;
+                } else
+                    setProvisionalOrCurrentIndex(*provisionalOrCurrentIndex() - 1);
+            }
         }
 
         // Toss the first item if the list is getting too big, as long as we're not using it

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4941,7 +4941,7 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
     if (mainFrameInPreviousProcess && preferences->siteIsolationEnabled())
         mainFrameInPreviousProcess->removeChildFrames();
 
-    ASSERT(m_legacyMainFrameProcess.ptr() != &provisionalPage->process() || preferences->siteIsolationEnabled());
+    ASSERT(m_legacyMainFrameProcess.ptr() != &provisionalPage->process());
 
     auto shouldDelayClosingUntilFirstLayerFlush = ShouldDelayClosingUntilFirstLayerFlush::No;
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### e8e095063fd3e8c52891126f0500a40e8681e74c
<pre>
Revert 288547@main: [Site Isolation] Avoid reusing the main frame after cross-site navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=285829">https://bugs.webkit.org/show_bug.cgi?id=285829</a>
<a href="https://rdar.apple.com/142560425">rdar://142560425</a>

Unreviewed.

Caused an internal page load test to not complete.

* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::hasAncestorFrame):
(WebKit::WebBackForwardListFrameItem::sharesAncestor const): Deleted.
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::initializeWebPage):
(WebKit::ProvisionalPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::addItem):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::commitProvisionalPage):

Canonical link: <a href="https://commits.webkit.org/288809@main">https://commits.webkit.org/288809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9c6b00e8f2636256d2ea8e9e047752c01117a20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35440 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65662 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23501 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87475 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3116 "Found 4 new test failures: fast/files/blob-stream-frame.html http/tests/app-privacy-report/app-attribution-post-request.html http/tests/websocket/tests/hybi/no-subprotocol.html http/wpt/cache-storage/quota-third-party.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76707 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45956 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3066 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34487 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73956 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31708 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90891 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74113 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11923 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72531 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73314 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17647 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16093 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3115 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13080 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11648 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17124 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11497 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14973 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->