### PR TITLE
URLPattern constructor first parameter should be a URLPatternInput

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -200,7 +200,7 @@ PASS Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 PASS Pattern: ["/foo"] Inputs: undefined
 PASS Pattern: ["example.com/foo"] Inputs: undefined
 PASS Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"]
@@ -235,10 +235,10 @@ PASS Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"]
 PASS Pattern: ["(café)://foo"] Inputs: undefined
 PASS Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}]
 PASS Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"]
-FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
-FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
-FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
-FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
+PASS Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"]
+PASS Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"]
+PASS Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"]
+PASS Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
 PASS Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"]
@@ -248,7 +248,7 @@ PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@exam
 PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
-FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
+FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] assert_equals: compiled pattern property 'pathname' expected "/data\\:channel.html" but got "data\\:channel.html"
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Invalid input to canonicalize a URL host string.
@@ -331,11 +331,11 @@ PASS Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}]
 PASS Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
 PASS Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]
 PASS Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}]
-FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
+PASS Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]
 PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -200,7 +200,7 @@ PASS Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 PASS Pattern: ["/foo"] Inputs: undefined
 PASS Pattern: ["example.com/foo"] Inputs: undefined
 PASS Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"]
@@ -235,10 +235,10 @@ PASS Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"]
 PASS Pattern: ["(café)://foo"] Inputs: undefined
 PASS Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}]
 PASS Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"]
-FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
-FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
-FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
-FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
+PASS Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"]
+PASS Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"]
+PASS Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"]
+PASS Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
 PASS Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"]
@@ -248,7 +248,7 @@ PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@exam
 PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
-FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
+FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] assert_equals: compiled pattern property 'pathname' expected "/data\\:channel.html" but got "data\\:channel.html"
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Invalid input to canonicalize a URL host string.
@@ -331,11 +331,11 @@ PASS Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}]
 PASS Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
 PASS Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]
 PASS Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}]
-FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
+PASS Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]
 PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -200,7 +200,7 @@ PASS Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 PASS Pattern: ["/foo"] Inputs: undefined
 PASS Pattern: ["example.com/foo"] Inputs: undefined
 PASS Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"]
@@ -235,10 +235,10 @@ PASS Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"]
 PASS Pattern: ["(café)://foo"] Inputs: undefined
 PASS Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}]
 PASS Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"]
-FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
-FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
-FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
-FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
+PASS Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"]
+PASS Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"]
+PASS Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"]
+PASS Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
 PASS Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"]
@@ -248,7 +248,7 @@ PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@exam
 PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
-FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
+FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] assert_equals: compiled pattern property 'pathname' expected "/data\\:channel.html" but got "data\\:channel.html"
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Invalid input to canonicalize a URL host string.
@@ -331,11 +331,11 @@ PASS Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}]
 PASS Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
 PASS Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]
 PASS Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}]
-FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
+PASS Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]
 PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -200,7 +200,7 @@ PASS Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 PASS Pattern: ["/foo"] Inputs: undefined
 PASS Pattern: ["example.com/foo"] Inputs: undefined
 PASS Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"]
@@ -235,10 +235,10 @@ PASS Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"]
 PASS Pattern: ["(café)://foo"] Inputs: undefined
 PASS Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}]
 PASS Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"]
-FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
-FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
-FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
-FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
+PASS Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"]
+PASS Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"]
+PASS Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"]
+PASS Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
 PASS Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"]
@@ -248,7 +248,7 @@ PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@exam
 PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
-FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
+FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] assert_equals: compiled pattern property 'pathname' expected "/data\\:channel.html" but got "data\\:channel.html"
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Invalid input to canonicalize a URL host string.
@@ -331,11 +331,11 @@ PASS Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}]
 PASS Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
 PASS Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]
 PASS Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}]
-FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
+PASS Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]
 PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -200,7 +200,7 @@ PASS Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 PASS Pattern: ["/foo"] Inputs: undefined
 PASS Pattern: ["example.com/foo"] Inputs: undefined
 PASS Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"]
@@ -235,10 +235,10 @@ PASS Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"]
 PASS Pattern: ["(café)://foo"] Inputs: undefined
 PASS Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}]
 PASS Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"]
-FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
-FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
-FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
-FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
+PASS Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"]
+PASS Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"]
+PASS Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"]
+PASS Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
 PASS Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"]
@@ -248,7 +248,7 @@ PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@exam
 PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
-FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
+FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] assert_equals: compiled pattern property 'pathname' expected "/data\\:channel.html" but got "data\\:channel.html"
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Invalid input to canonicalize a URL host string.
@@ -331,11 +331,11 @@ PASS Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}]
 PASS Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
 PASS Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]
 PASS Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}]
-FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
+PASS Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]
 PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -200,7 +200,7 @@ PASS Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 PASS Pattern: ["/foo"] Inputs: undefined
 PASS Pattern: ["example.com/foo"] Inputs: undefined
 PASS Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"]
@@ -235,10 +235,10 @@ PASS Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"]
 PASS Pattern: ["(café)://foo"] Inputs: undefined
 PASS Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}]
 PASS Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"]
-FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
-FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
-FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
-FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
+PASS Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"]
+PASS Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"]
+PASS Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"]
+PASS Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
 PASS Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"]
@@ -248,7 +248,7 @@ PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@exam
 PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
-FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
+FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] assert_equals: compiled pattern property 'pathname' expected "/data\\:channel.html" but got "data\\:channel.html"
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Invalid input to canonicalize a URL host string.
@@ -331,11 +331,11 @@ PASS Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}]
 PASS Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
 PASS Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]
 PASS Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}]
-FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
+PASS Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]
 PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -200,7 +200,7 @@ PASS Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 PASS Pattern: ["/foo"] Inputs: undefined
 PASS Pattern: ["example.com/foo"] Inputs: undefined
 PASS Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"]
@@ -235,10 +235,10 @@ PASS Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"]
 PASS Pattern: ["(café)://foo"] Inputs: undefined
 PASS Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}]
 PASS Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"]
-FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
-FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
-FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
-FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
+PASS Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"]
+PASS Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"]
+PASS Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"]
+PASS Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
 PASS Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"]
@@ -248,7 +248,7 @@ PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@exam
 PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
-FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
+FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] assert_equals: compiled pattern property 'pathname' expected "/data\\:channel.html" but got "data\\:channel.html"
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Invalid input to canonicalize a URL host string.
@@ -331,11 +331,11 @@ PASS Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}]
 PASS Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
 PASS Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]
 PASS Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}]
-FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
+PASS Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]
 PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -200,7 +200,7 @@ PASS Pattern: [{"pathname":"var x = 1;"}] Inputs: [{"pathname":"var x = 1;"}]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: ["./foo/bar","https://example.com"]
 PASS Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"},"https://example.com"]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz","https://example.com:8080"] Inputs: [{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080"}]
 PASS Pattern: ["/foo"] Inputs: undefined
 PASS Pattern: ["example.com/foo"] Inputs: undefined
 PASS Pattern: ["http{s}?://{*.}?example.com/:product/:endpoint"] Inputs: ["https://sub.example.com/foo/bar"]
@@ -235,10 +235,10 @@ PASS Pattern: ["foo://bar"] Inputs: ["foo://bad_url_browser_interop"]
 PASS Pattern: ["(café)://foo"] Inputs: undefined
 PASS Pattern: ["https://example.com/foo?bar#baz"] Inputs: [{"protocol":"https:","search":"?bar","hash":"#baz","baseURL":"http://example.com/foo"}]
 PASS Pattern: [{"protocol":"http{s}?:","search":"?bar","hash":"#baz"}] Inputs: ["http://example.com/foo?bar#baz"]
-FAIL Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"] Type error
-FAIL Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"] Type error
-FAIL Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"] Type error
-FAIL Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"] Type error
+PASS Pattern: ["?bar#baz","https://example.com/foo"] Inputs: ["?bar#baz","https://example.com/foo"]
+PASS Pattern: ["?bar","https://example.com/foo#baz"] Inputs: ["?bar","https://example.com/foo#snafu"]
+PASS Pattern: ["#baz","https://example.com/foo?bar"] Inputs: ["#baz","https://example.com/foo?bar"]
+PASS Pattern: ["#baz","https://example.com/foo"] Inputs: ["#baz","https://example.com/foo"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","data:data-urls-cannot-be-base-urls"]
 PASS Pattern: [{"pathname":"*"}] Inputs: ["foo","not|a|valid|url"]
 PASS Pattern: ["https://foo\\:bar@example.com"] Inputs: ["https://foo:bar@example.com"]
@@ -248,7 +248,7 @@ PASS Pattern: ["https://:user::pass@example.com"] Inputs: ["https://foo:bar@exam
 PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.com"]
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 FAIL Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"] assert_equals: compiled pattern property 'username' expected "foo%3Abar" but got "foo\\:bar"
-FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] Type error
+FAIL Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"] assert_equals: compiled pattern property 'pathname' expected "/data\\:channel.html" but got "data\\:channel.html"
 FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.
 FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Invalid input to canonicalize a URL host string.
@@ -331,11 +331,11 @@ PASS Pattern: [{"pathname":"/:foo\\bar"}] Inputs: [{"pathname":"/bazbar"}]
 PASS Pattern: [{"pathname":"/foo/bar"},{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 PASS Pattern: [{"ignoreCase":true}] Inputs: [{"pathname":"/FOO/BAR"}]
 PASS Pattern: ["https://example.com:8080/foo?bar#baz",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
-FAIL Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}] Type error
+PASS Pattern: ["/foo?bar#baz","https://example.com:8080",{"ignoreCase":true}] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
 PASS Pattern: ["/foo?bar#baz",{"ignoreCase":true},"https://example.com:8080"] Inputs: [{"pathname":"/FOO","search":"BAR","hash":"BAZ","baseURL":"https://example.com:8080"}]
 PASS Pattern: [{"search":"foo","baseURL":"https://example.com/a/+/b"}] Inputs: [{"search":"foo","baseURL":"https://example.com/a/+/b"}]
 PASS Pattern: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}] Inputs: [{"hash":"foo","baseURL":"https://example.com/?q=*&v=?&hmm={}&umm=()"}]
-FAIL Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"] Type error
+PASS Pattern: ["#foo","https://example.com/?q=*&v=?&hmm={}&umm=()"] Inputs: ["https://example.com/?q=*&v=?&hmm={}&umm=()#foo"]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/a"}]
 PASS Pattern: [{"pathname":"/([[a-z]--a])"}] Inputs: [{"pathname":"/z"}]
 PASS Pattern: [{"pathname":"/([\\d&&[0-1]])"}] Inputs: [{"pathname":"/0"}]

--- a/Source/WebCore/Modules/url-pattern/URLPattern.idl
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.idl
@@ -34,7 +34,7 @@ typedef (USVString or URLPatternInit) URLPatternInput;
     EnabledBySetting=URLPatternAPIEnabled,
     Exposed=(Window,Worker)
 ] interface URLPattern {
-    [CallWith=CurrentScriptExecutionContext] constructor(URLPatternInit input, USVString baseURL, optional URLPatternOptions options);
+    [CallWith=CurrentScriptExecutionContext] constructor(URLPatternInput input, USVString baseURL, optional URLPatternOptions options);
     [CallWith=CurrentScriptExecutionContext] constructor(optional URLPatternInput input, optional URLPatternOptions options);
 
     [CallWith=CurrentScriptExecutionContext] boolean test(optional URLPatternInput input, optional USVString baseURL);


### PR DESCRIPTION
#### bab56b0eaa156009e1358e45f49e5fb5bbb38fb1
<pre>
URLPattern constructor first parameter should be a URLPatternInput
<a href="https://rdar.apple.com/142802023">rdar://142802023</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=285832">https://bugs.webkit.org/show_bug.cgi?id=285832</a>

Reviewed by Anne van Kesteren.

Align WebIDL definition to spec.

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* Source/WebCore/Modules/url-pattern/URLPattern.idl:

Canonical link: <a href="https://commits.webkit.org/288855@main">https://commits.webkit.org/288855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/761a0476bf3b7cf12d4412cf8348a86fb4f504fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35448 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65667 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23506 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87483 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3121 "Found 4 new test failures: fast/files/blob-stream-frame.html http/tests/app-privacy-report/user-attribution-post-request.html http/tests/websocket/tests/hybi/no-subprotocol.html http/wpt/cache-storage/quota-third-party.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45961 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3071 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30942 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34495 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73961 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90899 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8522 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74118 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72535 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73319 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18165 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17653 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16097 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3123 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11656 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17132 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11505 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14981 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13278 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->