### PR TITLE
[WebAudio] Implement AudioContext::outputLatency

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/idlharness.https.window-expected.txt
@@ -48,7 +48,7 @@ PASS AudioContext interface: existence and properties of interface prototype obj
 PASS AudioContext interface: existence and properties of interface prototype object's "constructor" property
 PASS AudioContext interface: existence and properties of interface prototype object's @@unscopables property
 PASS AudioContext interface: attribute baseLatency
-FAIL AudioContext interface: attribute outputLatency assert_true: The prototype object must have a property "outputLatency" expected true got false
+PASS AudioContext interface: attribute outputLatency
 PASS AudioContext interface: operation getOutputTimestamp()
 PASS AudioContext interface: operation resume()
 PASS AudioContext interface: operation suspend()
@@ -60,7 +60,7 @@ PASS AudioContext interface: operation createMediaStreamDestination()
 PASS AudioContext must be primary interface of context
 PASS Stringification of context
 PASS AudioContext interface: context must inherit property "baseLatency" with the proper type
-FAIL AudioContext interface: context must inherit property "outputLatency" with the proper type assert_inherits: property "outputLatency" not found in prototype chain
+PASS AudioContext interface: context must inherit property "outputLatency" with the proper type
 PASS AudioContext interface: context must inherit property "getOutputTimestamp()" with the proper type
 PASS AudioContext interface: context must inherit property "resume()" with the proper type
 PASS AudioContext interface: context must inherit property "suspend()" with the proper type

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -44,6 +44,7 @@
 #include "Performance.h"
 #include "PlatformMediaSessionManager.h"
 #include "Quirks.h"
+#include <wtf/MediaTime.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(MEDIA_STREAM)
@@ -185,6 +186,18 @@ double AudioContext::baseLatency()
     lazyInitialize();
 
     return static_cast<double>(destination().framesPerBuffer()) / sampleRate();
+}
+
+double AudioContext::outputLatency()
+{
+    lazyInitialize();
+
+    if (!isPlaying())
+        return 0;
+    if (noiseInjectionPolicies())
+        return 512 / sampleRate(); // A fixed, but reasonable value for most platforms.
+
+    return destination().outputLatency().toDouble();
 }
 
 AudioTimestamp AudioContext::getOutputTimestamp()

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -66,6 +66,7 @@ public:
     const DefaultAudioDestinationNode& destination() const final { return m_destinationNode.get(); }
 
     double baseLatency();
+    double outputLatency();
 
     AudioTimestamp getOutputTimestamp();
 

--- a/Source/WebCore/Modules/webaudio/AudioContext.idl
+++ b/Source/WebCore/Modules/webaudio/AudioContext.idl
@@ -34,9 +34,7 @@
     [CallWith=CurrentDocument] constructor(optional AudioContextOptions contextOptions);
 
     readonly attribute double baseLatency;
-
-    // FIXME: Add support.
-    // readonly attribute double outputLatency;
+    readonly attribute double outputLatency;
 
     AudioTimestamp getOutputTimestamp();
 

--- a/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp
@@ -40,6 +40,7 @@
 #include "ScriptExecutionContext.h"
 #include "WorkerRunLoop.h"
 #include <wtf/MainThread.h>
+#include <wtf/MediaTime.h>
 #include <wtf/TZoneMallocInlines.h>
 
 constexpr unsigned EnabledInputChannels = 2;
@@ -247,6 +248,11 @@ ExceptionOr<void> DefaultAudioDestinationNode::setChannelCount(unsigned channelC
 unsigned DefaultAudioDestinationNode::framesPerBuffer() const
 {
     return m_destination ? m_destination->framesPerBuffer() : 0;
+}
+
+MediaTime DefaultAudioDestinationNode::outputLatency() const
+{
+    return m_destination ? m_destination->outputLatency() : MediaTime::zeroTime();
 }
 
 void DefaultAudioDestinationNode::render(AudioBus*, AudioBus* destinationBus, size_t numberOfFrames, const AudioIOPosition& outputPosition)

--- a/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.h
+++ b/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.h
@@ -28,6 +28,10 @@
 #include "AudioDestinationNode.h"
 #include "AudioIOCallback.h"
 
+namespace WTF {
+class MediaTime;
+}
+
 namespace WebCore {
 
 class AudioContext;
@@ -43,7 +47,8 @@ public:
     const AudioContext& context() const;
 
     unsigned framesPerBuffer() const;
-    
+    WTF::MediaTime outputLatency() const;
+
     void startRendering(CompletionHandler<void(std::optional<Exception>&&)>&&) final;
     void resume(CompletionHandler<void(std::optional<Exception>&&)>&&);
     void suspend(CompletionHandler<void(std::optional<Exception>&&)>&&);

--- a/Source/WebCore/platform/audio/AudioDestination.h
+++ b/Source/WebCore/platform/audio/AudioDestination.h
@@ -35,6 +35,7 @@
 #include <wtf/AbstractRefCounted.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Lock.h>
+#include <wtf/MediaTime.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>
 
@@ -63,6 +64,7 @@ public:
     WEBCORE_EXPORT static float hardwareSampleRate();
 
     virtual unsigned framesPerBuffer() const = 0;
+    virtual WTF::MediaTime outputLatency() const { return MediaTime::zeroTime(); }
 
     // maxChannelCount() returns the total number of output channels of the audio hardware.
     // A value of 0 indicates that the number of channels cannot be configured and

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -139,6 +139,8 @@ public:
     virtual size_t preferredBufferSize() const;
     virtual void setPreferredBufferSize(size_t);
 
+    virtual size_t outputLatency() const { return 0; }
+
     virtual void addConfigurationChangeObserver(AudioSessionConfigurationChangeObserver&);
     virtual void removeConfigurationChangeObserver(AudioSessionConfigurationChangeObserver&);
 

--- a/Source/WebCore/platform/audio/SharedAudioDestination.cpp
+++ b/Source/WebCore/platform/audio/SharedAudioDestination.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEB_AUDIO)
 
 #include "AudioUtilities.h"
+#include <wtf/MediaTime.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/WTFSemaphore.h>
 #include <wtf/WeakPtr.h>
@@ -51,6 +52,11 @@ public:
         return m_workBus->length();
     }
 
+    MediaTime outputLatency() const
+    {
+        return protectedDestination()->outputLatency();
+    }
+
 private:
     using AdapterKey = std::tuple<unsigned, float>;
     using AdapterMap = UncheckedKeyHashMap<AdapterKey, ThreadSafeWeakPtr<SharedAudioDestinationAdapter>>;
@@ -63,7 +69,7 @@ private:
 
     void configureRenderThread(CompletionHandler<void(bool)>&&);
 
-    Ref<AudioDestination> protectedDestination() { return m_destination; }
+    Ref<AudioDestination> protectedDestination() const { return m_destination; }
     Ref<AudioBus> protectedWorkBus() { return m_workBus; }
 
     unsigned m_numberOfOutputChannels;
@@ -259,6 +265,11 @@ unsigned SharedAudioDestination::framesPerBuffer() const
     return m_outputAdapter->framesPerBuffer();
 }
 
+MediaTime SharedAudioDestination::outputLatency() const
+{
+    return protectedOutputAdapter()->outputLatency();
+}
+
 void SharedAudioDestination::setIsPlaying(bool isPlaying)
 {
     ASSERT(isMainThread());
@@ -295,7 +306,7 @@ void SharedAudioDestination::sharedRender(AudioBus* sourceBus, AudioBus* destina
     }
 }
 
-Ref<SharedAudioDestinationAdapter> SharedAudioDestination::protectedOutputAdapter()
+Ref<SharedAudioDestinationAdapter> SharedAudioDestination::protectedOutputAdapter() const
 {
     return m_outputAdapter;
 }

--- a/Source/WebCore/platform/audio/SharedAudioDestination.h
+++ b/Source/WebCore/platform/audio/SharedAudioDestination.h
@@ -52,10 +52,11 @@ private:
     void stop(CompletionHandler<void(bool)>&&) final;
     bool isPlaying() final { return m_isPlaying; }
     unsigned framesPerBuffer() const final;
+    MediaTime outputLatency() const final;
 
     void setIsPlaying(bool);
 
-    Ref<SharedAudioDestinationAdapter> protectedOutputAdapter();
+    Ref<SharedAudioDestinationAdapter> protectedOutputAdapter() const;
 
     Lock m_dispatchToRenderThreadLock;
     Function<void(Function<void()>&&)> m_dispatchToRenderThread WTF_GUARDED_BY_LOCK(m_dispatchToRenderThreadLock);

--- a/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp
@@ -126,6 +126,11 @@ OSStatus AudioDestinationCocoa::render(double sampleTime, uint64_t hostTime, UIn
     return success ? noErr : -1;
 }
 
+MediaTime AudioDestinationCocoa::outputLatency() const
+{
+    return MediaTime { static_cast<int64_t>(m_audioOutputUnitAdaptor.outputLatency()), static_cast<uint32_t>(sampleRate()) } + MediaTime { static_cast<int64_t>(AudioSession::protectedSharedSession()->outputLatency()), static_cast<uint32_t>(AudioSession::protectedSharedSession()->sampleRate()) };
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.h
@@ -60,6 +60,7 @@ private:
 
     void startRendering(CompletionHandler<void(bool)>&&) override;
     void stopRendering(CompletionHandler<void(bool)>&&) override;
+    MediaTime outputLatency() const final;
 
     AudioOutputUnitAdaptor m_audioOutputUnitAdaptor;
 

--- a/Source/WebCore/platform/audio/cocoa/AudioOutputUnitAdaptor.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioOutputUnitAdaptor.cpp
@@ -71,6 +71,15 @@ OSStatus AudioOutputUnitAdaptor::inputProc(void* userData, AudioUnitRenderAction
     return adaptor->m_audioUnitRenderer.render(sampleTime, hostTime, numberOfFrames, ioData);
 }
 
+size_t AudioOutputUnitAdaptor::outputLatency() const
+{
+    Float64 latency = 0;
+    UInt32 size = sizeof(latency);
+    if (PAL::AudioUnitGetProperty(m_outputUnit, kAudioUnitProperty_Latency, kAudioUnitScope_Global, 0, &latency, &size) == noErr)
+        return latency;
+    return 0;
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/cocoa/AudioOutputUnitAdaptor.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioOutputUnitAdaptor.h
@@ -46,6 +46,8 @@ public:
     WEBCORE_EXPORT OSStatus start();
     WEBCORE_EXPORT OSStatus stop();
 
+    WEBCORE_EXPORT size_t outputLatency() const;
+
 private:
     static OSStatus inputProc(void* userData, AudioUnitRenderActionFlags*, const AudioTimeStamp*, UInt32 busNumber, UInt32 numberOfFrames, AudioBufferList* ioData);
 

--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
@@ -65,6 +65,7 @@ private:
     String routingContextUID() const final;
     size_t preferredBufferSize() const final;
     void setPreferredBufferSize(size_t) final;
+    size_t outputLatency() const final;
     bool isMuted() const final;
     void handleMutedStateChange() final;
 

--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
@@ -377,6 +377,12 @@ void AudioSessionIOS::setPreferredBufferSize(size_t bufferSize)
     ASSERT(!error);
 }
 
+size_t AudioSessionIOS::outputLatency() const
+{
+    auto latency = [[PAL::getAVAudioSessionClass() sharedInstance] outputLatency];
+    return latency * sampleRate();
+}
+
 bool AudioSessionIOS::isMuted() const
 {
     return false;

--- a/Source/WebCore/platform/audio/mac/AudioSessionMac.h
+++ b/Source/WebCore/platform/audio/mac/AudioSessionMac.h
@@ -80,6 +80,7 @@ private:
     String routingContextUID() const final;
     size_t preferredBufferSize() const final;
     void setPreferredBufferSize(size_t) final;
+    size_t outputLatency() const final;
     bool isMuted() const final;
     void handleMutedStateChange() final;
     void addConfigurationChangeObserver(AudioSessionConfigurationChangeObserver&) final;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
@@ -73,9 +73,9 @@ public:
 private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 
-    void createAudioDestination(RemoteAudioDestinationIdentifier, const String& inputDeviceId, uint32_t numberOfInputChannels, uint32_t numberOfOutputChannels, float sampleRate, float hardwareSampleRate, IPC::Semaphore&& renderSemaphore, WebCore::SharedMemoryHandle&&);
+    void createAudioDestination(RemoteAudioDestinationIdentifier, const String& inputDeviceId, uint32_t numberOfInputChannels, uint32_t numberOfOutputChannels, float sampleRate, float hardwareSampleRate, IPC::Semaphore&& renderSemaphore, WebCore::SharedMemoryHandle&&, CompletionHandler<void(size_t)>&&);
     void deleteAudioDestination(RemoteAudioDestinationIdentifier);
-    void startAudioDestination(RemoteAudioDestinationIdentifier, CompletionHandler<void(bool)>&&);
+    void startAudioDestination(RemoteAudioDestinationIdentifier, CompletionHandler<void(bool, size_t)>&&);
     void stopAudioDestination(RemoteAudioDestinationIdentifier, CompletionHandler<void(bool)>&&);
 #if PLATFORM(COCOA)
     void audioSamplesStorageChanged(RemoteAudioDestinationIdentifier, ConsumerSharedCARingBuffer::Handle&&);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in
@@ -29,10 +29,10 @@
     EnabledBy=WebAudioEnabled
 ]
 messages -> RemoteAudioDestinationManager {
-    CreateAudioDestination(WebKit::RemoteAudioDestinationIdentifier identifier, String inputDeviceId, uint32_t numberOfInputChannels, uint32_t numberOfOutputChannels, float sampleRate, float hardwareSampleRate, IPC::Semaphore renderSemaphore, WebCore::SharedMemory::Handle frameCount)
+    CreateAudioDestination(WebKit::RemoteAudioDestinationIdentifier identifier, String inputDeviceId, uint32_t numberOfInputChannels, uint32_t numberOfOutputChannels, float sampleRate, float hardwareSampleRate, IPC::Semaphore renderSemaphore, WebCore::SharedMemory::Handle frameCount) -> (size_t audioUnitLatency)
     DeleteAudioDestination(WebKit::RemoteAudioDestinationIdentifier identifier)
 
-    StartAudioDestination(WebKit::RemoteAudioDestinationIdentifier identifier) -> (bool isPlaying)
+    StartAudioDestination(WebKit::RemoteAudioDestinationIdentifier identifier) -> (bool isPlaying, size_t audioUnitLatency)
     StopAudioDestination(WebKit::RemoteAudioDestinationIdentifier identifier) -> (bool isPlaying)
 #if PLATFORM(COCOA)
     AudioSamplesStorageChanged(WebKit::RemoteAudioDestinationIdentifier identifier, struct WebKit::ConsumerSharedCARingBufferHandle storageHandle)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -73,6 +73,7 @@ RemoteAudioSessionConfiguration RemoteAudioSessionProxy::configuration()
         session->numberOfOutputChannels(),
         session->maximumNumberOfOutputChannels(),
         session->preferredBufferSize(),
+        session->outputLatency(),
         session->isMuted(),
         m_active,
         m_sceneIdentifier,

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
@@ -64,6 +64,7 @@ public:
 private:
     void startRendering(CompletionHandler<void(bool)>&&) override;
     void stopRendering(CompletionHandler<void(bool)>&&) override;
+    MediaTime outputLatency() const final;
 
     void startRenderingThread();
     void stopRenderingThread();
@@ -93,6 +94,7 @@ private:
     String m_inputDeviceId;
     unsigned m_numberOfInputChannels;
     float m_remoteSampleRate;
+    size_t m_audioUnitLatency;
 
     RefPtr<Thread> m_renderThread;
     RefPtr<WebCore::SharedMemory> m_frameCount;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -80,6 +80,7 @@ private:
     size_t bufferSize() const final { return configuration().bufferSize; }
     size_t numberOfOutputChannels() const final { return configuration().numberOfOutputChannels; }
     size_t maximumNumberOfOutputChannels() const final { return configuration().maximumNumberOfOutputChannels; }
+    size_t outputLatency() const final { return configuration().outputLatency; }
 
     bool tryToSetActiveInternal(bool) final;
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.h
@@ -38,6 +38,7 @@ struct RemoteAudioSessionConfiguration {
     size_t numberOfOutputChannels { 0 };
     size_t maximumNumberOfOutputChannels { 0 };
     size_t preferredBufferSize { 0 };
+    size_t outputLatency { 0 };
     bool isMuted { false };
     bool isActive { false };
     String sceneIdentifier;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in
@@ -29,12 +29,13 @@ struct WebKit::RemoteAudioSessionConfiguration {
     size_t numberOfOutputChannels;
     size_t maximumNumberOfOutputChannels;
     size_t preferredBufferSize;
+    size_t outputLatency;
     bool isMuted;
     bool isActive;
     String sceneIdentifier;
     WebCore::AudioSessionSoundStageSize soundStageSize;
 };
-    
+
 #endif
 
 #if ENABLE(GPU_PROCESS) && PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 420f89a0d4b8256194c08f5e6f7ab3e9288e61ae
<pre>
[WebAudio] Implement AudioContext::outputLatency
<a href="https://bugs.webkit.org/show_bug.cgi?id=285826">https://bugs.webkit.org/show_bug.cgi?id=285826</a>
<a href="https://rdar.apple.com/142794341">rdar://142794341</a>

Reviewed by Youenn Fablet.

Add implementation for Cocoa platforms, other platforms will return 0 for now.

* LayoutTests/imported/w3c/web-platform-tests/webaudio/idlharness.https.window-expected.txt:
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::outputLatency):
* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/Modules/webaudio/AudioContext.idl:
* Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp:
(WebCore::DefaultAudioDestinationNode::outputLatency const):
* Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.h:
* Source/WebCore/platform/audio/AudioDestination.h:
(WebCore::AudioDestination::outputLatency const):
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/platform/audio/SharedAudioDestination.cpp:
(WebCore::SharedAudioDestinationAdapter::outputLatency const):
(WebCore::SharedAudioDestinationAdapter::protectedDestination const):
(WebCore::SharedAudioDestination::outputLatency const):
(WebCore::SharedAudioDestination::protectedOutputAdapter const):
(WebCore::SharedAudioDestinationAdapter::protectedDestination): Deleted.
(WebCore::SharedAudioDestination::protectedOutputAdapter): Deleted.
* Source/WebCore/platform/audio/SharedAudioDestination.h:
* Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp:
(WebCore::AudioDestinationCocoa::outputLatency const):
* Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.h:
* Source/WebCore/platform/audio/cocoa/AudioOutputUnitAdaptor.cpp:
(WebCore::AudioOutputUnitAdaptor::outputLatency const):
* Source/WebCore/platform/audio/cocoa/AudioOutputUnitAdaptor.h:
* Source/WebCore/platform/audio/ios/AudioSessionIOS.h:
* Source/WebCore/platform/audio/ios/AudioSessionIOS.mm:
(WebCore::AudioSessionIOS::outputLatency const):
* Source/WebCore/platform/audio/mac/AudioSessionMac.h:
* Source/WebCore/platform/audio/mac/AudioSessionMac.mm:
(WebCore::AudioSessionMac::outputLatency const):
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp:
(WebKit::RemoteAudioDestinationManager::createAudioDestination):
(WebKit::RemoteAudioDestinationManager::startAudioDestination):
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::configuration):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::connection):
(WebKit::RemoteAudioDestinationProxy::startRendering):
(WebKit::RemoteAudioDestinationProxy::outputLatency const):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in:

Canonical link: <a href="https://commits.webkit.org/288904@main">https://commits.webkit.org/288904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a575fca536bfff9268bb62f4c7fb95721b2aebe8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84739 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89878 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/35791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12439 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/35791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87784 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3453 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77009 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/46216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3332 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31228 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34865 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91254 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12078 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72820 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73548 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18193 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17924 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/16367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/3526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12030 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11864 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15358 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/13610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->