### PR TITLE
Support long-lived images of WebGL backbuffers

### DIFF
--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -325,6 +325,7 @@ list(APPEND WebCore_SOURCES
     platform/graphics/cocoa/GraphicsContextGLCocoa.mm
     platform/graphics/cocoa/IntRectCocoa.mm
     platform/graphics/cocoa/IOSurface.mm
+    platform/graphics/cocoa/IOSurfaceDrawingBuffer.cpp
     platform/graphics/cocoa/IOSurfacePoolCocoa.mm
     platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
     platform/graphics/cocoa/WebActionDisablingCALayerDelegate.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -161,7 +161,6 @@ platform/encryptedmedia/CDMProxy.cpp
 platform/encryptedmedia/clearkey/CDMClearKey.cpp
 platform/graphics/FontCascadeFonts.cpp
 platform/graphics/SourceBufferPrivate.cpp
-platform/graphics/angle/GraphicsContextGLANGLE.cpp
 platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
 platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -451,6 +451,7 @@ platform/graphics/cocoa/FontPlatformDataCocoa.mm
 platform/graphics/cocoa/GraphicsContextCocoa.mm
 platform/graphics/cocoa/HEVCUtilitiesCocoa.mm
 platform/graphics/cocoa/IOSurface.mm
+platform/graphics/cocoa/IOSurfaceDrawingBuffer.cpp
 platform/graphics/cocoa/IOSurfacePoolCocoa.mm
 platform/graphics/cocoa/IconCocoa.mm
 platform/graphics/cocoa/IntRectCocoa.mm

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -350,7 +350,7 @@ public:
 
     RefPtr<PixelBuffer> readRenderingResultsForPainting();
 
-    virtual void withBufferAsNativeImage(SurfaceBuffer, Function<void(NativeImage&)>);
+    virtual RefPtr<NativeImage> bufferAsNativeImage(SurfaceBuffer);
 
     // Returns the span of valid data read on success.
     bool getBufferSubDataWithStatus(GCGLenum target, GCGLintptr offset, std::span<uint8_t> data);
@@ -415,6 +415,8 @@ protected:
     GCGLenum adjustWebGL1TextureInternalFormat(GCGLenum internalformat, GCGLenum format, GCGLenum type);
     void setPackParameters(GCGLint alignment, GCGLint rowLength, GCGLboolean reverseRowOrder);
     bool validateClearBufferv(GCGLenum buffer, size_t valuesSize);
+    void prepareForDrawingBufferWriteIfBound();
+    virtual void prepareForDrawingBufferWrite();
 
     UncheckedKeyHashSet<String> m_availableExtensions;
     UncheckedKeyHashSet<String> m_requestableExtensions;

--- a/Source/WebCore/platform/graphics/cocoa/IOSurfaceDrawingBuffer.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurfaceDrawingBuffer.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if HAVE(IOSURFACE)
+#include "IOSurfaceDrawingBuffer.h"
+
+#include <CoreGraphics/CoreGraphics.h>
+#include <pal/spi/cg/CoreGraphicsSPI.h>
+
+#include <pal/cg/CoreGraphicsSoftLink.h>
+
+namespace WebCore {
+
+RefPtr<NativeImage> IOSurfaceDrawingBuffer::copyNativeImage() const
+{
+    if (!m_surface)
+        return nullptr;
+    if (!m_copyOnWriteContext) {
+        m_copyOnWriteContext = m_surface->createPlatformContext();
+        if (!m_copyOnWriteContext)
+            return nullptr;
+    }
+    m_needCopy = true;
+    return NativeImage::create(m_surface->createImage(m_copyOnWriteContext.get()));
+}
+
+void IOSurfaceDrawingBuffer::forceCopy()
+{
+    m_needCopy = false;
+    // See https://webkit.org/b/157966 and https://webkit.org/b/228682 for more context.
+    if (PAL::canLoad_CoreGraphics_CGIOSurfaceContextInvalidateSurface())
+        PAL::softLink_CoreGraphics_CGIOSurfaceContextInvalidateSurface(m_copyOnWriteContext.get());
+    else
+        CGContextFillRect(m_copyOnWriteContext.get(), CGRect { });
+}
+
+}
+
+#endif

--- a/Source/WebCore/platform/graphics/cocoa/IOSurfaceDrawingBuffer.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurfaceDrawingBuffer.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(IOSURFACE)
+
+#include "IOSurface.h"
+#include "NativeImage.h"
+
+namespace WebCore {
+
+// Move-only value type holding a IOSurface that will be used in by drawing to it
+// as well as reading from it via CG.
+// Important subtle expected behavior is to migrate the existing CGImages from
+// IOSurfaces to main memory when the drawing buffer instance is destroyed. This
+// is to prevent long-lived images reserving IOSurfaces.
+class IOSurfaceDrawingBuffer {
+public:
+    IOSurfaceDrawingBuffer() = default;
+    IOSurfaceDrawingBuffer(IOSurfaceDrawingBuffer&&);
+    explicit IOSurfaceDrawingBuffer(std::unique_ptr<IOSurface>&&);
+    IOSurfaceDrawingBuffer& operator=(IOSurfaceDrawingBuffer&&);
+    operator bool() const { return !!m_surface; }
+    IOSurface* surface() const { return m_surface.get(); }
+
+    IntSize size() const;
+
+    // Returns true if surface cannot be modified because it's in
+    // cross-process use, and copy-on-write would not work.
+    bool isInUse() const;
+
+    // Should be called always when writing to the surface.
+    void prepareForWrite();
+
+    // Creates a copy of current contents.
+    RefPtr<NativeImage> copyNativeImage() const;
+private:
+    void forceCopy();
+    std::unique_ptr<IOSurface> m_surface;
+    mutable RetainPtr<CGContextRef> m_copyOnWriteContext;
+    mutable bool m_needCopy { false };
+};
+
+inline IOSurfaceDrawingBuffer::IOSurfaceDrawingBuffer(IOSurfaceDrawingBuffer&& other)
+    : m_surface(WTFMove(other.m_surface))
+    , m_copyOnWriteContext(WTFMove(other.m_copyOnWriteContext))
+    , m_needCopy(std::exchange(other.m_needCopy, false))
+{
+}
+
+inline IOSurfaceDrawingBuffer::IOSurfaceDrawingBuffer(std::unique_ptr<IOSurface>&& surface)
+    : m_surface(WTFMove(surface))
+{
+}
+
+inline IOSurfaceDrawingBuffer& IOSurfaceDrawingBuffer::operator=(IOSurfaceDrawingBuffer&& other)
+{
+    m_surface = WTFMove(other.m_surface);
+    m_copyOnWriteContext = WTFMove(other.m_copyOnWriteContext);
+    m_needCopy = std::exchange(other.m_needCopy, false);
+    return *this;
+}
+
+inline void IOSurfaceDrawingBuffer::prepareForWrite()
+{
+    if (m_needCopy)
+        forceCopy();
+}
+
+inline bool IOSurfaceDrawingBuffer::isInUse() const
+{
+    if (!m_surface)
+        return false;
+    return m_surface->isInUse();
+}
+
+inline IntSize IOSurfaceDrawingBuffer::size() const
+{
+    if (!m_surface)
+        return { };
+    return m_surface->size();
+}
+
+}
+
+#endif

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -203,9 +203,8 @@ void RemoteGraphicsContextGL::ensureExtensionEnabled(String&& extension)
 void RemoteGraphicsContextGL::drawSurfaceBufferToImageBuffer(WebCore::GraphicsContextGL::SurfaceBuffer buffer, WebCore::RenderingResourceIdentifier imageBufferIdentifier, CompletionHandler<void()>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->withBufferAsNativeImage(buffer, [&](NativeImage& image) {
-        paintNativeImageToImageBuffer(image, imageBufferIdentifier);
-    });
+    if (RefPtr image = protectedContext()->bufferAsNativeImage(buffer))
+        paintNativeImageToImageBuffer(*image, imageBufferIdentifier);
     completionHandler();
 }
 

--- a/Tools/TestWebKitAPI/GraphicsTestUtilities.cpp
+++ b/Tools/TestWebKitAPI/GraphicsTestUtilities.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GraphicsTestUtilities.h"
+
+#include "WebCoreTestUtilities.h"
+#include <WebCore/GraphicsContext.h>
+#include <WebCore/Image.h>
+#include <WebCore/ImageBuffer.h>
+#include <WebCore/NativeImage.h>
+#include <WebCore/PixelBuffer.h>
+
+namespace TestWebKitAPI {
+using namespace WebCore;
+
+::testing::AssertionResult imageBufferPixelIs(Color expected, const ImageBuffer& imageBuffer, FloatPoint point)
+{
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, DestinationColorSpace::SRGB() };
+    auto pixelBuffer = imageBuffer.getPixelBuffer(format, enclosingIntRect(FloatRect { point, FloatSize { 1, 1 } }));
+    auto got = Color { SRGBA<uint8_t> { pixelBuffer->item(0), pixelBuffer->item(1), pixelBuffer->item(2), pixelBuffer->item(3) } };
+    if (got != expected) {
+        // Use this to debug the contents in the browser.
+        // WTFLogAlways("%s", imageBuffer.toDataURL("image/png"_s).latin1().data());
+        return ::testing::AssertionFailure() << "color is not expected at " << point << ". Got: " << got << ", expected: " << expected << ".";
+    }
+    return ::testing::AssertionSuccess();
+}
+
+::testing::AssertionResult imagePixelIs(Color expected, Image& image, FloatPoint point)
+{
+    RefPtr buffer = ImageBuffer::create({ 1, 1 }, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1.0f, DestinationColorSpace::SRGB(),ImageBufferPixelFormat::BGRA8); // NOLINT
+    if (!buffer)
+        return ::testing::AssertionFailure() << "failed to allocate temp buffer";
+    buffer->context().drawImage(image, { 0, 0, 1, 1 }, { point, FloatSize { 1, 1 } });
+    return imageBufferPixelIs(expected, *buffer, { 0, 0 });
+}
+
+::testing::AssertionResult imagePixelIs(Color expected, NativeImage& image, FloatPoint point)
+{
+    RefPtr buffer = ImageBuffer::create({ 1, 1 }, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1.0f, DestinationColorSpace::SRGB(),ImageBufferPixelFormat::BGRA8); // NOLINT
+    if (!buffer)
+        return ::testing::AssertionFailure() << "failed to allocate temp buffer";
+    buffer->context().drawNativeImage(image, { 0, 0, 1, 1 }, { point, FloatSize { 1, 1 } });
+    return imageBufferPixelIs(expected, *buffer, { 0, 0 });
+}
+
+
+}

--- a/Tools/TestWebKitAPI/GraphicsTestUtilities.h
+++ b/Tools/TestWebKitAPI/GraphicsTestUtilities.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Test.h"
+#include <WebCore/Color.h>
+#include <WebCore/FloatPoint.h>
+
+namespace WebCore {
+class Image;
+class ImageBuffer;
+class NativeImage;
+
+}
+
+namespace TestWebKitAPI {
+
+::testing::AssertionResult imageBufferPixelIs(WebCore::Color expected, const WebCore::ImageBuffer&, WebCore::FloatPoint);
+::testing::AssertionResult imagePixelIs(WebCore::Color expected, WebCore::Image&, WebCore::FloatPoint);
+::testing::AssertionResult imagePixelIs(WebCore::Color expected, WebCore::NativeImage&, WebCore::FloatPoint);
+
+}

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -378,6 +378,7 @@
 		7B397C0828BE394B00239202 /* UtilitiesCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7C83E0391D0A602700FEBCF3 /* UtilitiesCocoa.mm */; };
 		7B52E86C2A2A1A2200A3251F /* ThreadSafeObjectHeapTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B52E8642A2A1A2200A3251F /* ThreadSafeObjectHeapTests.cpp */; };
 		7B636FC229700F0700F3670F /* StreamConnectionWorkQueueTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B636FC129700F0700F3670F /* StreamConnectionWorkQueueTests.cpp */; };
+		7B66CFD82D3194B900BD6CB5 /* GraphicsTestUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B66CFD72D3194B900BD6CB5 /* GraphicsTestUtilities.cpp */; };
 		7B6FF89728C22D9400CA76B0 /* WebKit.framework in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 2B648DBA28C1C1F700791F2B /* WebKit.framework */; };
 		7B7392E928F849EC007297FC /* MessageSenderTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B7392E128F849EC007297FC /* MessageSenderTests.cpp */; };
 		7B7392EC28F84BD3007297FC /* IPCTestUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B7392EB28F84BD2007297FC /* IPCTestUtilities.cpp */; };
@@ -3032,6 +3033,8 @@
 		7B41A8302D08CD9400CE56F9 /* RestoreSessionStorage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RestoreSessionStorage.mm; sourceTree = "<group>"; };
 		7B52E8642A2A1A2200A3251F /* ThreadSafeObjectHeapTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThreadSafeObjectHeapTests.cpp; sourceTree = "<group>"; };
 		7B636FC129700F0700F3670F /* StreamConnectionWorkQueueTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamConnectionWorkQueueTests.cpp; sourceTree = "<group>"; };
+		7B66CFD62D3194B900BD6CB5 /* GraphicsTestUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GraphicsTestUtilities.h; sourceTree = "<group>"; };
+		7B66CFD72D3194B900BD6CB5 /* GraphicsTestUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GraphicsTestUtilities.cpp; sourceTree = "<group>"; };
 		7B7392E128F849EC007297FC /* MessageSenderTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MessageSenderTests.cpp; sourceTree = "<group>"; };
 		7B7392EA28F849F3007297FC /* IPCTestUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPCTestUtilities.h; sourceTree = "<group>"; };
 		7B7392EB28F84BD2007297FC /* IPCTestUtilities.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IPCTestUtilities.cpp; sourceTree = "<group>"; };
@@ -4079,6 +4082,8 @@
 				5CABDBEC2735CB4D00B88BCB /* DeprecatedGlobalValues.cpp */,
 				5CABDBED2735CB4D00B88BCB /* DeprecatedGlobalValues.h */,
 				5CABDBF02735DDA100B88BCB /* DeprecatedGlobalValues.mm */,
+				7B66CFD72D3194B900BD6CB5 /* GraphicsTestUtilities.cpp */,
+				7B66CFD62D3194B900BD6CB5 /* GraphicsTestUtilities.h */,
 				C0ADBE7A12FCA4D000D2C129 /* JavaScriptTest.cpp */,
 				C0ADBE7B12FCA4D000D2C129 /* JavaScriptTest.h */,
 				BC575BBF126F5752006F0F12 /* PlatformUtilities.cpp */,
@@ -7072,6 +7077,7 @@
 				510A921424D615B400BFD89C /* GoogleStadia.mm in Sources */,
 				E394AE6F23F2303E005B4936 /* GrantAccessToMobileAssets.mm in Sources */,
 				2D09CF0026A68297009C43C0 /* GraphicsContextCGTests.mm in Sources */,
+				7B66CFD82D3194B900BD6CB5 /* GraphicsTestUtilities.cpp in Sources */,
 				8E4A85371E1D1AB200F53B0F /* GridPosition.cpp in Sources */,
 				51EB125924C68592000CB030 /* HIDGamepads.mm in Sources */,
 				7CCE7EFA1A411AE600447C4C /* HitTestResultNodeHandle.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
@@ -27,6 +27,7 @@
 #import "Test.h"
 
 #if PLATFORM(COCOA) && ENABLE(WEBGL)
+#import "GraphicsTestUtilities.h"
 #import "WebCoreTestUtilities.h"
 #import <Metal/Metal.h>
 #import <WebCore/Color.h>
@@ -39,9 +40,11 @@
 
 namespace TestWebKitAPI {
 
+using namespace WebCore;
+
 namespace {
 
-class MockGraphicsContextGLClient final : public WebCore::GraphicsContextGL::Client {
+class MockGraphicsContextGLClient final : public GraphicsContextGL::Client {
 public:
     void forceContextLost() final { ++m_contextLostCalls; }
     void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const String&) final { }
@@ -51,19 +54,19 @@ private:
     int m_contextLostCalls { 0 };
 };
 
-class TestedGraphicsContextGLCocoa : public WebCore::GraphicsContextGLCocoa {
+class TestedGraphicsContextGLCocoa : public GraphicsContextGLCocoa {
 public:
-    static RefPtr<TestedGraphicsContextGLCocoa> create(WebCore::GraphicsContextGLAttributes&& attributes)
+    static RefPtr<TestedGraphicsContextGLCocoa> create(GraphicsContextGLAttributes&& attributes)
     {
         auto context = adoptRef(*new TestedGraphicsContextGLCocoa(WTFMove(attributes)));
         if (!context->initialize())
             return nullptr;
         return context;
     }
-    RefPtr<WebCore::GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() final { return nullptr; }
+    RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() final { return nullptr; }
 private:
-    TestedGraphicsContextGLCocoa(WebCore::GraphicsContextGLAttributes attributes)
-        : WebCore::GraphicsContextGLCocoa(WTFMove(attributes), { })
+    TestedGraphicsContextGLCocoa(GraphicsContextGLAttributes attributes)
+        : GraphicsContextGLCocoa(WTFMove(attributes), { })
     {
     }
 };
@@ -86,8 +89,8 @@ class AnyContextAttributeTest : public testing::TestWithParam<std::tuple<bool, b
 protected:
     bool antialias() const { return std::get<0>(GetParam()); }
     bool preserveDrawingBuffer() const { return std::get<1>(GetParam()); }
-    WebCore::GraphicsContextGLAttributes attributes();
-    RefPtr<TestedGraphicsContextGLCocoa> createTestContext(WebCore::IntSize contextSize);
+    GraphicsContextGLAttributes attributes();
+    RefPtr<TestedGraphicsContextGLCocoa> createTestContext(IntSize contextSize);
 
     void SetUp() override // NOLINT
     {
@@ -102,9 +105,9 @@ private:
     std::optional<ScopedSetAuxiliaryProcessTypeForTesting> m_scopedProcessType;
 };
 
-WebCore::GraphicsContextGLAttributes AnyContextAttributeTest::attributes()
+GraphicsContextGLAttributes AnyContextAttributeTest::attributes()
 {
-    WebCore::GraphicsContextGLAttributes attributes;
+    GraphicsContextGLAttributes attributes;
     attributes.antialias = antialias();
     attributes.depth = false;
     attributes.stencil = false;
@@ -113,7 +116,7 @@ WebCore::GraphicsContextGLAttributes AnyContextAttributeTest::attributes()
     return attributes;
 }
 
-RefPtr<TestedGraphicsContextGLCocoa> AnyContextAttributeTest::createTestContext(WebCore::IntSize contextSize)
+RefPtr<TestedGraphicsContextGLCocoa> AnyContextAttributeTest::createTestContext(IntSize contextSize)
 {
     auto context = TestedGraphicsContextGLCocoa::create(attributes());
     if (!context)
@@ -128,16 +131,16 @@ static const int expectedDisplayBufferPoolSize = 3;
 
 static ::testing::AssertionResult changeContextContents(TestedGraphicsContextGLCocoa& context, int iteration)
 {
-    WebCore::Color expected { iteration % 2 ? WebCore::Color::green : WebCore::Color::yellow };
-    auto [r, g, b, a] = expected.toColorTypeLossy<WebCore::SRGBA<float>>().resolved();
+    Color expected { iteration % 2 ? Color::green : Color::yellow };
+    auto [r, g, b, a] = expected.toColorTypeLossy<SRGBA<float>>().resolved();
     context.clearColor(r, g, b, a);
-    context.clear(WebCore::GraphicsContextGL::COLOR_BUFFER_BIT);
+    context.clear(GraphicsContextGL::COLOR_BUFFER_BIT);
     uint8_t gotValues[4] = { };
     auto sampleAt = context.getInternalFramebufferSize();
     sampleAt.contract(2, 3);
     sampleAt.clampNegativeToZero();
-    context.readPixels({ sampleAt.width(), sampleAt.height(), 1, 1 }, WebCore::GraphicsContextGL::RGBA, WebCore::GraphicsContextGL::UNSIGNED_BYTE, gotValues, 4, 0, false);
-    WebCore::Color got { WebCore::SRGBA<uint8_t> { gotValues[0], gotValues[1], gotValues[2], gotValues[3] } };
+    context.readPixels({ sampleAt.width(), sampleAt.height(), 1, 1 }, GraphicsContextGL::RGBA, GraphicsContextGL::UNSIGNED_BYTE, gotValues, 4, 0, false);
+    Color got { SRGBA<uint8_t> { gotValues[0], gotValues[1], gotValues[2], gotValues[3] } };
     if (got != expected)
         return ::testing::AssertionFailure() << "Failed to verify draw to context. Got: " << got << ", expected: " << expected << ".";
     return ::testing::AssertionSuccess();
@@ -193,21 +196,21 @@ TEST_F(GraphicsContextGLCocoaTest, MultipleGPUsDifferentPowerPreferenceMetal)
 {
     if (!hasMultipleGPUs())
         return;
-    WebCore::GraphicsContextGLAttributes attributes;
-    EXPECT_EQ(attributes.powerPreference, WebCore::GraphicsContextGLPowerPreference::Default);
-    auto defaultContext = TestedGraphicsContextGLCocoa::create(WebCore::GraphicsContextGLAttributes { attributes });
+    GraphicsContextGLAttributes attributes;
+    EXPECT_EQ(attributes.powerPreference, GraphicsContextGLPowerPreference::Default);
+    auto defaultContext = TestedGraphicsContextGLCocoa::create(GraphicsContextGLAttributes { attributes });
     ASSERT_NE(defaultContext, nullptr);
 
-    attributes.powerPreference = WebCore::GraphicsContextGLPowerPreference::LowPower;
-    auto lowPowerContext = TestedGraphicsContextGLCocoa::create(WebCore::GraphicsContextGLAttributes { attributes });
+    attributes.powerPreference = GraphicsContextGLPowerPreference::LowPower;
+    auto lowPowerContext = TestedGraphicsContextGLCocoa::create(GraphicsContextGLAttributes { attributes });
     ASSERT_NE(lowPowerContext, nullptr);
 
-    attributes.powerPreference = WebCore::GraphicsContextGLPowerPreference::HighPerformance;
-    auto highPerformanceContext = TestedGraphicsContextGLCocoa::create(WebCore::GraphicsContextGLAttributes { attributes });
+    attributes.powerPreference = GraphicsContextGLPowerPreference::HighPerformance;
+    auto highPerformanceContext = TestedGraphicsContextGLCocoa::create(GraphicsContextGLAttributes { attributes });
     ASSERT_NE(highPerformanceContext, nullptr);
 
-    EXPECT_NE(lowPowerContext->getString(WebCore::GraphicsContextGL::RENDERER), highPerformanceContext->getString(WebCore::GraphicsContextGL::RENDERER));
-    EXPECT_EQ(defaultContext->getString(WebCore::GraphicsContextGL::RENDERER), lowPowerContext->getString(WebCore::GraphicsContextGL::RENDERER));
+    EXPECT_NE(lowPowerContext->getString(GraphicsContextGL::RENDERER), highPerformanceContext->getString(GraphicsContextGL::RENDERER));
+    EXPECT_EQ(defaultContext->getString(GraphicsContextGL::RENDERER), lowPowerContext->getString(GraphicsContextGL::RENDERER));
 }
 #endif
 
@@ -219,24 +222,24 @@ TEST_F(GraphicsContextGLCocoaTest, MultipleGPUsExplicitLowPowerDeviceMetal)
 {
     if (!hasMultipleGPUs())
         return;
-    WebCore::GraphicsContextGLAttributes attributes1;
-    attributes1.powerPreference = WebCore::GraphicsContextGLPowerPreference::LowPower;
-    auto lowPowerContext = TestedGraphicsContextGLCocoa::create(WebCore::GraphicsContextGLAttributes { attributes1 });
+    GraphicsContextGLAttributes attributes1;
+    attributes1.powerPreference = GraphicsContextGLPowerPreference::LowPower;
+    auto lowPowerContext = TestedGraphicsContextGLCocoa::create(GraphicsContextGLAttributes { attributes1 });
     ASSERT_NE(lowPowerContext, nullptr);
 
-    WebCore::GraphicsContextGLAttributes attributes2;
+    GraphicsContextGLAttributes attributes2;
     attributes2.windowGPUID = [lowPowerDevice() registryID];
-    auto explicitDeviceContext = TestedGraphicsContextGLCocoa::create(WebCore::GraphicsContextGLAttributes { attributes2 });
+    auto explicitDeviceContext = TestedGraphicsContextGLCocoa::create(GraphicsContextGLAttributes { attributes2 });
     ASSERT_NE(explicitDeviceContext.get(), nullptr);
 
     // Context with windowGPUID from low power device results to same thing as requesting default low power context.
-    EXPECT_EQ(lowPowerContext->getString(WebCore::GraphicsContextGL::RENDERER), explicitDeviceContext->getString(WebCore::GraphicsContextGL::RENDERER));
+    EXPECT_EQ(lowPowerContext->getString(GraphicsContextGL::RENDERER), explicitDeviceContext->getString(GraphicsContextGL::RENDERER));
 
     // High performance request on a low power explicit device as windowGPUID respects the high performance request.
-    attributes2.powerPreference = WebCore::GraphicsContextGLPowerPreference::HighPerformance;
-    auto highPerformanceExplicitDeviceContext = TestedGraphicsContextGLCocoa::create(WebCore::GraphicsContextGLAttributes { attributes2 });
+    attributes2.powerPreference = GraphicsContextGLPowerPreference::HighPerformance;
+    auto highPerformanceExplicitDeviceContext = TestedGraphicsContextGLCocoa::create(GraphicsContextGLAttributes { attributes2 });
     ASSERT_NE(highPerformanceExplicitDeviceContext.get(), nullptr);
-    EXPECT_NE(highPerformanceExplicitDeviceContext->getString(WebCore::GraphicsContextGL::RENDERER), explicitDeviceContext->getString(WebCore::GraphicsContextGL::RENDERER));
+    EXPECT_NE(highPerformanceExplicitDeviceContext->getString(GraphicsContextGL::RENDERER), explicitDeviceContext->getString(GraphicsContextGL::RENDERER));
 }
 
 // Tests that requesting context with windowGPUID from high performance device results to same thing
@@ -247,24 +250,24 @@ TEST_F(GraphicsContextGLCocoaTest, MultipleGPUsExplicitHighPerformanceDeviceMeta
 {
     if (!hasMultipleGPUs())
         return;
-    WebCore::GraphicsContextGLAttributes attributes1;
-    attributes1.powerPreference = WebCore::GraphicsContextGLPowerPreference::HighPerformance;
-    auto highPerformanceContext = TestedGraphicsContextGLCocoa::create(WebCore::GraphicsContextGLAttributes { attributes1 });
+    GraphicsContextGLAttributes attributes1;
+    attributes1.powerPreference = GraphicsContextGLPowerPreference::HighPerformance;
+    auto highPerformanceContext = TestedGraphicsContextGLCocoa::create(GraphicsContextGLAttributes { attributes1 });
     ASSERT_NE(highPerformanceContext, nullptr);
 
-    WebCore::GraphicsContextGLAttributes attributes2;
+    GraphicsContextGLAttributes attributes2;
     attributes2.windowGPUID = [highPerformanceDevice() registryID];
-    auto explicitDeviceContext = TestedGraphicsContextGLCocoa::create(WebCore::GraphicsContextGLAttributes { attributes2 });
+    auto explicitDeviceContext = TestedGraphicsContextGLCocoa::create(GraphicsContextGLAttributes { attributes2 });
     ASSERT_NE(explicitDeviceContext.get(), nullptr);
 
     // Context with windowGPUID from high performance device results to same thing as requesting default high performance context.
-    EXPECT_EQ(highPerformanceContext->getString(WebCore::GraphicsContextGL::RENDERER), explicitDeviceContext->getString(WebCore::GraphicsContextGL::RENDERER));
+    EXPECT_EQ(highPerformanceContext->getString(GraphicsContextGL::RENDERER), explicitDeviceContext->getString(GraphicsContextGL::RENDERER));
 
     // Low power request on a high performance explicit device as windowGPUID ignores the low power request.
-    attributes2.powerPreference = WebCore::GraphicsContextGLPowerPreference::LowPower;
-    auto lowPowerExplicitDeviceContext = TestedGraphicsContextGLCocoa::create(WebCore::GraphicsContextGLAttributes { attributes2 });
+    attributes2.powerPreference = GraphicsContextGLPowerPreference::LowPower;
+    auto lowPowerExplicitDeviceContext = TestedGraphicsContextGLCocoa::create(GraphicsContextGLAttributes { attributes2 });
     ASSERT_NE(lowPowerExplicitDeviceContext.get(), nullptr);
-    EXPECT_EQ(lowPowerExplicitDeviceContext->getString(WebCore::GraphicsContextGL::RENDERER), explicitDeviceContext->getString(WebCore::GraphicsContextGL::RENDERER));
+    EXPECT_EQ(lowPowerExplicitDeviceContext->getString(GraphicsContextGL::RENDERER), explicitDeviceContext->getString(GraphicsContextGL::RENDERER));
 }
 
 // Tests that requesting GraphicsContextGL instances with different devices results in different underlying
@@ -276,9 +279,9 @@ TEST_F(GraphicsContextGLCocoaTest, MultipleGPUsDifferentGPUIDsMetal)
     Vector<Ref<TestedGraphicsContextGLCocoa>> contexts;
     auto devices = allDevices();
     for (id<MTLDevice> device in devices.get()) {
-        WebCore::GraphicsContextGLAttributes attributes;
+        GraphicsContextGLAttributes attributes;
         attributes.windowGPUID = [device registryID];
-        auto context = TestedGraphicsContextGLCocoa::create(WebCore::GraphicsContextGLAttributes { attributes });
+        auto context = TestedGraphicsContextGLCocoa::create(GraphicsContextGLAttributes { attributes });
         EXPECT_NE(context.get(), nullptr);
         if (!context)
             continue;
@@ -296,8 +299,8 @@ TEST_F(GraphicsContextGLCocoaTest, MultipleGPUsDifferentGPUIDsMetal)
 
 TEST_F(GraphicsContextGLCocoaTest, ClearBufferIncorrectSizes)
 {
-    using GL = WebCore::GraphicsContextGL;
-    WebCore::GraphicsContextGLAttributes attributes;
+    using GL = GraphicsContextGL;
+    GraphicsContextGLAttributes attributes;
     attributes.isWebGL2 = true;
     attributes.depth = true;
     attributes.stencil = true;
@@ -384,7 +387,7 @@ TEST_F(GraphicsContextGLCocoaTest, ClearBufferIncorrectSizes)
 // than the underlying OpenGL context of destroyed context.
 TEST_F(GraphicsContextGLCocoaTest, DestroyWithoutMakingCurrent)
 {
-    WebCore::GraphicsContextGLAttributes attributes;
+    GraphicsContextGLAttributes attributes;
     attributes.isWebGL2 = true;
     attributes.depth = true;
     attributes.stencil = true;
@@ -402,12 +405,12 @@ TEST_F(GraphicsContextGLCocoaTest, DestroyWithoutMakingCurrent)
 
 TEST_F(GraphicsContextGLCocoaTest, TwoLinks)
 {
-    WebCore::GraphicsContextGLAttributes attributes;
+    GraphicsContextGLAttributes attributes;
     auto gl = TestedGraphicsContextGLCocoa::create(WTFMove(attributes));
-    auto vs = gl->createShader(WebCore::GraphicsContextGL::VERTEX_SHADER);
+    auto vs = gl->createShader(GraphicsContextGL::VERTEX_SHADER);
     gl->shaderSource(vs, "void main() { }"_s);
     gl->compileShader(vs);
-    auto fs = gl->createShader(WebCore::GraphicsContextGL::FRAGMENT_SHADER);
+    auto fs = gl->createShader(GraphicsContextGL::FRAGMENT_SHADER);
     gl->shaderSource(fs, "void main() { }"_s);
     gl->compileShader(fs);
     auto program = gl->createProgram();
@@ -418,6 +421,65 @@ TEST_F(GraphicsContextGLCocoaTest, TwoLinks)
     gl->linkProgram(program);
     EXPECT_TRUE(gl->getErrors().isEmpty());
     gl = nullptr;
+}
+
+TEST_F(GraphicsContextGLCocoaTest, BufferAsImageNoDrawingBufferReturnsNullptr)
+{
+    using GL = GraphicsContextGL;
+    auto gl = TestedGraphicsContextGLCocoa::create({ });
+    RefPtr drawingImage = gl->bufferAsNativeImage(GL::SurfaceBuffer::DrawingBuffer);
+    RefPtr displayImage = gl->bufferAsNativeImage(GL::SurfaceBuffer::DisplayBuffer);
+    EXPECT_EQ(drawingImage, nullptr);
+    EXPECT_EQ(displayImage, nullptr);
+}
+
+
+TEST_F(GraphicsContextGLCocoaTest, BufferAsImageAfterReshape)
+{
+    using GL = GraphicsContextGL;
+    auto gl = TestedGraphicsContextGLCocoa::create({ });
+    gl->reshape(10, 10);
+    RefPtr drawingImage = gl->bufferAsNativeImage(GL::SurfaceBuffer::DrawingBuffer);
+    RefPtr displayImage = gl->bufferAsNativeImage(GL::SurfaceBuffer::DisplayBuffer);
+    EXPECT_NE(drawingImage, nullptr);
+    EXPECT_EQ(displayImage, nullptr);
+    EXPECT_EQ(drawingImage->size(), FloatSize(10, 10));
+    EXPECT_TRUE(imagePixelIs(Color::transparentBlack, *drawingImage, FloatPoint(5, 5)));
+}
+
+// Test copying images and mutating the drawing buffer.
+// The mutations should only be visible in the new buffers, and not the old ones.
+TEST_F(GraphicsContextGLCocoaTest, CopyImageAndMutateDrawingBuffer)
+{
+    using GL = GraphicsContextGL;
+    auto gl = TestedGraphicsContextGLCocoa::create({ });
+    gl->reshape(10, 10);
+    RefPtr drawingImage0 = gl->bufferAsNativeImage(GL::SurfaceBuffer::DrawingBuffer);
+    ASSERT_NE(drawingImage0, nullptr);
+    EXPECT_TRUE(imagePixelIs(Color::transparentBlack, *drawingImage0, FloatPoint(5, 5)));
+    gl->clearColor(0.f, 1.f, 0.f, 1.f);
+    gl->clear(GL::COLOR_BUFFER_BIT);
+    RefPtr drawingImage1 = gl->bufferAsNativeImage(GL::SurfaceBuffer::DrawingBuffer);
+    ASSERT_NE(drawingImage1, nullptr);
+    EXPECT_TRUE(imagePixelIs(Color::transparentBlack, *drawingImage0, FloatPoint(5, 5)));
+    EXPECT_TRUE(imagePixelIs(Color::green, *drawingImage1, FloatPoint(5, 5)));
+
+    gl->clearColor(0.f, 0.f, 1.f, 1.f);
+    gl->clear(GL::COLOR_BUFFER_BIT);
+    EXPECT_TRUE(imagePixelIs(Color::transparentBlack, *drawingImage0, FloatPoint(5, 5)));
+    EXPECT_TRUE(imagePixelIs(Color::green, *drawingImage1, FloatPoint(5, 5)));
+    RefPtr drawingImage2 = gl->bufferAsNativeImage(GL::SurfaceBuffer::DrawingBuffer);
+    ASSERT_NE(drawingImage2, nullptr);
+    EXPECT_TRUE(imagePixelIs(Color::transparentBlack, *drawingImage0, FloatPoint(5, 5)));
+    EXPECT_TRUE(imagePixelIs(Color::green, *drawingImage1, FloatPoint(5, 5)));
+    EXPECT_TRUE(imagePixelIs(Color::blue, *drawingImage2, FloatPoint(5, 5)));
+    gl->prepareForDisplay();
+    RefPtr displayImage = gl->bufferAsNativeImage(GL::SurfaceBuffer::DisplayBuffer);
+    ASSERT_NE(displayImage, nullptr);
+    EXPECT_TRUE(imagePixelIs(Color::transparentBlack, *drawingImage0, FloatPoint(5, 5)));
+    EXPECT_TRUE(imagePixelIs(Color::green, *drawingImage1, FloatPoint(5, 5)));
+    EXPECT_TRUE(imagePixelIs(Color::blue, *drawingImage2, FloatPoint(5, 5)));
+    EXPECT_TRUE(imagePixelIs(Color::blue, *displayImage, FloatPoint(5, 5)));
 }
 
 TEST_P(AnyContextAttributeTest, DisplayBuffersAreRecycled)
@@ -504,7 +566,7 @@ TEST_P(AnyContextAttributeTest, PrepareFailureWorks)
     EXPECT_TRUE(context->getErrors().isEmpty());
     ASSERT_TRUE(changeContextContents(*context, 0));
     EXPECT_TRUE(context->getErrors().isEmpty());
-    context->simulateEventForTesting(WebCore::GraphicsContextGLSimulatedEventForTesting::DisplayBufferAllocationFailure);
+    context->simulateEventForTesting(GraphicsContextGLSimulatedEventForTesting::DisplayBufferAllocationFailure);
     context->prepareForDisplay();
     EXPECT_NE(context->displayBufferSurface(), nullptr);
     EXPECT_EQ(1, client.contextLostCalls());
@@ -523,7 +585,7 @@ TEST_P(AnyContextAttributeTest, PrepareFailureWorks)
     } else {
         ASSERT_FALSE(changeContextContents(*context, 1));
         uint32_t gotValue = 0;
-        context->readPixels({ 0, 0, 1, 1 }, WebCore::GraphicsContextGL::RGBA, WebCore::GraphicsContextGL::UNSIGNED_BYTE, { reinterpret_cast<uint8_t*>(&gotValue), 4 }, 4, 0, false);
+        context->readPixels({ 0, 0, 1, 1 }, GraphicsContextGL::RGBA, GraphicsContextGL::UNSIGNED_BYTE, { reinterpret_cast<uint8_t*>(&gotValue), 4 }, 4, 0, false);
         EXPECT_EQ(0u, gotValue);
         EXPECT_EQ(GCGLErrorCode::InvalidFramebufferOperation, context->getErrors());
     }
@@ -540,7 +602,7 @@ TEST_P(AnyContextAttributeTest, FinishIsSignaled)
     auto context = createTestContext({ 2048, 2048 });
     ASSERT_NE(context, nullptr);
     context->clearColor(0.f, 1.f, 0.f, 1.f);
-    context->clear(WebCore::GraphicsContextGL::COLOR_BUFFER_BIT);
+    context->clear(GraphicsContextGL::COLOR_BUFFER_BIT);
     std::atomic<bool> signalled = false;
     std::atomic<uint32_t> signalThreadUID = 0;
     context->prepareForDisplayWithFinishedSignal([&signalled, &signalThreadUID] {

--- a/Tools/TestWebKitAPI/WebCoreTestUtilities.h
+++ b/Tools/TestWebKitAPI/WebCoreTestUtilities.h
@@ -77,4 +77,32 @@ inline std::ostream& operator<<(std::ostream& os, const WebCore::FloatRect& valu
     return os << s.release();
 }
 
+inline std::ostream& operator<<(std::ostream& os, const WebCore::FloatPoint& value)
+{
+    TextStream s { TextStream::LineMode::SingleLine };
+    s << value;
+    return os << s.release();
+}
+
+inline std::ostream& operator<<(std::ostream& os, const WebCore::IntRect& value)
+{
+    TextStream s { TextStream::LineMode::SingleLine };
+    s << value;
+    return os << s.release();
+}
+
+inline std::ostream& operator<<(std::ostream& os, const WebCore::IntSize& value)
+{
+    TextStream s { TextStream::LineMode::SingleLine };
+    s << value;
+    return os << s.release();
+}
+
+inline std::ostream& operator<<(std::ostream& os, const WebCore::IntPoint& value)
+{
+    TextStream s { TextStream::LineMode::SingleLine };
+    s << value;
+    return os << s.release();
+}
+
 }


### PR DESCRIPTION
#### 99889a50c5762026c26d6665c88dc28d7c5ee991
<pre>
Support long-lived images of WebGL backbuffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=285834">https://bugs.webkit.org/show_bug.cgi?id=285834</a>
<a href="https://rdar.apple.com/142803884">rdar://142803884</a>

Reviewed by Dan Glastonbury.

Add the ability to hold on to WebGL drawing and display buffer images
long term.

Construct the buffers out of held CGIOSurfaceContexts. When the IOSurface
is being modified, notify the CGIOSurfaceContext. This will migrate
the possible CGImage reference to malloc-backed memory.

Write to the backbuffer is detected by notifying about the write for
any GraphicsContextGL function that might modify the default
framebuffer.

This will be used to solve the deadlock case where the WebGL image is
drawn to a ImageBuffer (for example for 2D context interop)
synchronously across threads. The long term image can be snapshot and
held without needing to guarantee the end-of-use. Thus the image
creation can be done in RemoteGraphicsContextGL timeline and the image
use will be posted in RemoteRenderingBackend timeline. This part of
the work will be made in the subsequent commits.

* Source/WebCore/PlatformMac.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::resolveMultisamplingIfNecessary):
(WebCore::GraphicsContextGLANGLE::prepareTexture):
(WebCore::GraphicsContextGLANGLE::clear):
(WebCore::GraphicsContextGLANGLE::drawArrays):
(WebCore::GraphicsContextGLANGLE::drawElements):
(WebCore::GraphicsContextGLANGLE::drawArraysInstanced):
(WebCore::GraphicsContextGLANGLE::drawElementsInstanced):
(WebCore::GraphicsContextGLANGLE::invalidateFramebuffer):
(WebCore::GraphicsContextGLANGLE::invalidateSubFramebuffer):
(WebCore::GraphicsContextGLANGLE::drawRangeElements):
(WebCore::GraphicsContextGLANGLE::drawBuffers):
(WebCore::GraphicsContextGLANGLE::clearBufferiv):
(WebCore::GraphicsContextGLANGLE::clearBufferuiv):
(WebCore::GraphicsContextGLANGLE::clearBufferfv):
(WebCore::GraphicsContextGLANGLE::multiDrawArraysInstancedANGLE):
(WebCore::GraphicsContextGLANGLE::multiDrawElementsANGLE):
(WebCore::GraphicsContextGLANGLE::multiDrawElementsInstancedANGLE):
(WebCore::GraphicsContextGLANGLE::drawArraysInstancedBaseInstanceANGLE):
(WebCore::GraphicsContextGLANGLE::drawElementsInstancedBaseVertexBaseInstanceANGLE):
(WebCore::GraphicsContextGLANGLE::multiDrawArraysInstancedBaseInstanceANGLE):
(WebCore::GraphicsContextGLANGLE::multiDrawElementsInstancedBaseVertexBaseInstanceANGLE):
(WebCore::GraphicsContextGLANGLE::drawSurfaceBufferToImageBuffer):
(WebCore::GraphicsContextGLANGLE::bufferAsNativeImage):
(WebCore::GraphicsContextGLANGLE::prepareForDrawingBufferWriteIfBound):
(WebCore::GraphicsContextGLANGLE::prepareForDrawingBufferWrite):
(WebCore::GraphicsContextGLANGLE::withBufferAsNativeImage): Deleted.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
(WebCore::IOSurfacePbuffer::pbuffer const):
(WebCore::IOSurfacePbuffer::IOSurfacePbuffer):
(WebCore::IOSurfacePbuffer::operator=):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::displayBufferSurface):
(WebCore::GraphicsContextGLCocoa::drawingBuffer):
(WebCore::GraphicsContextGLCocoa::displayBuffer):
(WebCore::GraphicsContextGLCocoa::surfaceBuffer):
(WebCore::GraphicsContextGLCocoa::bindNextDrawingBuffer):
(WebCore::GraphicsContextGLCocoa::freeDrawingBuffers):
(WebCore::GraphicsContextGLCocoa::readCompositedResults):
(WebCore::GraphicsContextGLCocoa::surfaceBufferToVideoFrame):
(WebCore::GraphicsContextGLCocoa::bufferAsNativeImage):
(WebCore::GraphicsContextGLCocoa::prepareForDrawingBufferWrite):
(WebCore::GraphicsContextGLCocoa::withBufferAsNativeImage): Deleted.
* Source/WebCore/platform/graphics/cocoa/IOSurfaceDrawingBuffer.cpp: Added.
(WebCore::IOSurfaceDrawingBuffer::copyNativeImage const):
(WebCore::IOSurfaceDrawingBuffer::forceCopy):
* Source/WebCore/platform/graphics/cocoa/IOSurfaceDrawingBuffer.h: Added.
(WebCore::IOSurfaceDrawingBuffer::operator bool const):
(WebCore::IOSurfaceDrawingBuffer::surface const):
(WebCore::IOSurfaceDrawingBuffer::IOSurfaceDrawingBuffer):
(WebCore::IOSurfaceDrawingBuffer::operator=):
(WebCore::IOSurfaceDrawingBuffer::prepareForWrite):
(WebCore::IOSurfaceDrawingBuffer::isInUse const):
(WebCore::IOSurfaceDrawingBuffer::size const):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::drawSurfaceBufferToImageBuffer):
* Tools/TestWebKitAPI/GraphicsTestUtilities.cpp: Added.
(TestWebKitAPI::imageBufferPixelIs):
(TestWebKitAPI::imagePixelIs):
* Tools/TestWebKitAPI/GraphicsTestUtilities.h: Copied from Tools/TestWebKitAPI/WebCoreTestUtilities.h.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp:
(TestWebKitAPI::hasTestPattern):
(TestWebKitAPI::TEST(ImageBufferTests, ImageBufferSubPixelDrawing)):
(TestWebKitAPI::TEST(ImageBufferTests, DISABLED_DrawImageBufferDoesNotReferenceExtraMemory)):
(TestWebKitAPI::imageBufferPixelIs): Deleted.
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm:
(TestWebKitAPI::WebCore::TestedGraphicsContextGLCocoa::create):
(TestWebKitAPI::WebCore::TestedGraphicsContextGLCocoa::TestedGraphicsContextGLCocoa):
(TestWebKitAPI::WebCore::AnyContextAttributeTest::attributes):
(TestWebKitAPI::WebCore::AnyContextAttributeTest::createTestContext):
(TestWebKitAPI::changeContextContents):
(TestWebKitAPI::TEST_F(GraphicsContextGLCocoaTest, MultipleGPUsDifferentPowerPreferenceMetal)):
(TestWebKitAPI::TEST_F(GraphicsContextGLCocoaTest, MultipleGPUsExplicitLowPowerDeviceMetal)):
(TestWebKitAPI::TEST_F(GraphicsContextGLCocoaTest, MultipleGPUsExplicitHighPerformanceDeviceMetal)):
(TestWebKitAPI::TEST_F(GraphicsContextGLCocoaTest, MultipleGPUsDifferentGPUIDsMetal)):
(TestWebKitAPI::TEST_F(GraphicsContextGLCocoaTest, ClearBufferIncorrectSizes)):
(TestWebKitAPI::TEST_F(GraphicsContextGLCocoaTest, DestroyWithoutMakingCurrent)):
(TestWebKitAPI::TEST_F(GraphicsContextGLCocoaTest, TwoLinks)):
(TestWebKitAPI::TEST_F(GraphicsContextGLCocoaTest, BufferAsImageNoDrawingBufferReturnsNullptr)):
(TestWebKitAPI::TEST_F(GraphicsContextGLCocoaTest, BufferAsImageAfterReshape)):
(TestWebKitAPI::TEST_F(GraphicsContextGLCocoaTest, CopyImageAndMutateDrawingBuffer)):
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/WebCoreTestUtilities.h:
(WebCore::operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/289054@main">https://commits.webkit.org/289054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/faf8770b28da39b4069e70b39dc1c333ce333124

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90355 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36268 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66262 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24080 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77412 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46536 "Found 2 new API test failures: /WPE/TestSSL:/webkit/WebKitWebView/web-socket-client-side-certificate, /WPE/TestSSL:/webkit/WebKitWebView/web-socket-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3729 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31673 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35336 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91800 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12575 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9160 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12804 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73920 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18285 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18319 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16747 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4567 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12518 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12348 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15841 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14099 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->