### PR TITLE
Avoid scanning for GC roots in environment

### DIFF
--- a/Source/WTF/wtf/StackBounds.cpp
+++ b/Source/WTF/wtf/StackBounds.cpp
@@ -50,6 +50,8 @@
 
 namespace WTF {
 
+thread_local void* StackBounds::m_origin_limit = nullptr;
+
 #if OS(DARWIN)
 
 StackBounds StackBounds::newThreadStackBounds(PlatformThreadHandle thread)

--- a/Source/WTF/wtf/StackBounds.h
+++ b/Source/WTF/wtf/StackBounds.h
@@ -66,9 +66,17 @@ public:
         return result;
     }
 
+    static void setCurrentThreadStackOriginLimit(void* limit)
+    {
+        RELEASE_ASSERT(m_origin_limit == nullptr);
+        m_origin_limit = limit;
+    }
+
     void* origin() const
     {
         ASSERT(m_origin);
+        if (m_origin_limit != nullptr)
+            return m_origin_limit;
         return m_origin;
     }
 
@@ -153,6 +161,8 @@ private:
 
     void* m_origin;
     void* m_bound;
+
+    static thread_local void* m_origin_limit;
 
     friend class StackStats;
 };

--- a/Source/WTF/wtf/glib/RunLoopGLib.cpp
+++ b/Source/WTF/wtf/glib/RunLoopGLib.cpp
@@ -96,6 +96,15 @@ RunLoop::~RunLoop()
 
 void RunLoop::run()
 {
+    // On 32-bit armv7/linux we run into an issue where the environment strings
+    // located at the bottom of the stack are interpreted as cells pointing
+    // into the heap, keeping actually dead objects alive.
+    //
+    // Set the thread stack origin limit here to avoid scanning for roots
+    // beyond this frame.
+    int stackOrigin;
+    StackBounds::setCurrentThreadStackOriginLimit(&stackOrigin);
+
     Ref runLoop = RunLoop::current();
     GMainContext* mainContext = runLoop->m_mainContext.get();
 


### PR DESCRIPTION
#### a3628ef5257607b769e23d5e314e09389f76396e
<pre>
Avoid scanning for GC roots in environment
<a href="https://bugs.webkit.org/show_bug.cgi?id=285840">https://bugs.webkit.org/show_bug.cgi?id=285840</a>

Reviewed by NOBODY (OOPS!).

On 32-bit armv7/linux we run into an issue where the environment strings
located at the bottom of the stack are interpreted as cells pointing
into the heap, keeping actually dead objects alive.

This sets a thread stack origin limit to avoid scanning for roots
beyond the runloop frame.

* Source/WTF/wtf/StackBounds.cpp:
* Source/WTF/wtf/StackBounds.h:
(WTF::StackBounds::setCurrentThreadStackOriginLimit):
(WTF::StackBounds::origin const):
* Source/WTF/wtf/glib/RunLoopGLib.cpp:
(WTF::RunLoop::run):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3628ef5257607b769e23d5e314e09389f76396e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89531 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35460 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12058 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65677 "Failure limit exceed. At least found 497 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23521 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87495 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3135 "Found 4 new test failures: fast/files/blob-stream-frame.html http/tests/app-privacy-report/app-attribution-post-request.html http/tests/websocket/tests/hybi/no-subprotocol.html http/wpt/cache-storage/quota-third-party.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76724 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45971 "Found 3 new API test failures: /WPE/TestConsoleMessage:/webkit/WebKitConsoleMessage/security-error, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3085 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30955 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34508 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77413 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73972 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90911 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83466 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8535 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74128 "Failure limit exceed. At least found 494 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/accessibility-node-memory-management.html accessibility/accessibility-node-reparent.html accessibility/accessibility-object-detached.html accessibility/accessibility-object-update-during-style-resolution-crash.html accessibility/activation-of-input-field-inside-other-element.html accessibility/active-descendant-changes-result-in-focus-changes.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72548 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73330 "Found 19 new API test failures: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive, /WebKitGTK/TestResources:/webkit/WebKitWebResource/mime-type, /WebKitGTK/TestResources:/webkit/WebKitWebResource/active-uri, /WebKitGTK/TestResources:/webkit/WebKitWebResource/loading, /WebKitGTK/TestResources:/webkit/WebKitWebView/history-cache, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/user-agent, /WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-error, /WebKitGTK/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-script, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/load-gresource, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/title ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17666 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16110 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3145 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11668 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17144 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/105885 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11517 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25551 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14993 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13290 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->