### PR TITLE
[WGSL] Struct padding calculation can overflow

### DIFF
--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -366,7 +366,7 @@ void AttributeValidator::visit(AST::Structure& structure)
         size = offset;
         size += *fieldSize;
         if (UNLIKELY(size.hasOverflowed()))
-            size = currentSize;
+            size = std::numeric_limits<unsigned>::max();
 
         if (previousMember)
             previousMember->m_padding = offset - previousSize;

--- a/Source/WebGPU/WGSL/tests/invalid/large-struct.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/large-struct.wgsl
@@ -1,0 +1,13 @@
+// RUN: %not %metal main 2>&1 | %check
+
+struct Data {
+    @size(2147483647) a: bool,
+    @size(2147483647) b: bool,
+    @size(2147483647) c: bool,
+}
+
+@compute @workgroup_size(1)
+fn main() {
+    // CHECK-L:The combined byte size of all variables in this function exceeds 8192 bytes
+    var d : Data;
+}


### PR DESCRIPTION
#### 01ece4a19daeb1fa6b3657f37b860538e073cdb3
<pre>
[WGSL] Struct padding calculation can overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=285842">https://bugs.webkit.org/show_bug.cgi?id=285842</a>
<a href="https://rdar.apple.com/142550450">rdar://142550450</a>

Reviewed by Mike Wyrzykowski.

When size overflowed it was incorrectly set to the previous size, instead of
UINT_MAX, which made it possible to overflow while calculating padding since
size could be smaller than offset.

* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
* Source/WebGPU/WGSL/tests/invalid/large-struct.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/288953@main">https://commits.webkit.org/288953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6a873be3e839c41fdbd216747ee08aca6147ebf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89533 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35462 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65676 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23520 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87497 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3137 "Found 4 new test failures: fast/files/blob-stream-frame.html http/tests/app-privacy-report/app-attribution-post-request.html http/tests/websocket/tests/hybi/no-subprotocol.html http/wpt/cache-storage/quota-third-party.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45970 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3087 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30957 "Build is in progress. Recent messages:") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34510 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/73974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90913 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8537 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74130 "Found 17 new test failures: imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-descendant-text-mutated-001.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-character.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vs-float-clearance-002.html imported/w3c/web-platform-tests/css/css-transforms/animation/transform-non-invertible-discrete-interpolation.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-offscreen-new.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-new.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-exit.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-view-transition-group.html imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-002.html imported/w3c/web-platform-tests/html/canvas/offscreen/text/canvas.2d.fontStretch.condensed.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73332 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18227 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17668 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16112 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3148 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11670 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17146 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11519 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/14995 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13292 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->