### PR TITLE
[TexMap] Make sure the damage is not propagated at any level when disabled

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -398,6 +398,8 @@ void TextureMapperLayer::collectDamageRecursive(TextureMapperPaintOptions& optio
 
 void TextureMapperLayer::collectDamageSelf(TextureMapperPaintOptions& options, Damage& damage)
 {
+    ASSERT(m_damagePropagation);
+
     if (!m_state.visible || !m_state.contentsVisible)
         return;
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -119,6 +119,7 @@ public:
     void addChild(TextureMapperLayer*);
 
 #if ENABLE(DAMAGE_TRACKING)
+    void setDamagePropagation(bool enabled) { m_damagePropagation = enabled; }
     void setDamage(const Damage&);
     void collectDamage(TextureMapper&, Damage&);
 #endif
@@ -185,7 +186,7 @@ private:
     void collect3DRenderingContextLayers(Vector<TextureMapperLayer*>&);
 
 #if ENABLE(DAMAGE_TRACKING)
-    bool canInferDamage() const { return !m_damage.isInvalid(); }
+    bool canInferDamage() const { return m_damagePropagation && !m_damage.isInvalid(); }
     void collectDamageRecursive(TextureMapperPaintOptions&, Damage&);
     void collectDamageSelf(TextureMapperPaintOptions&, Damage&);
     void damageWholeLayerDueToTransformChange(const TransformationMatrix& beforeChange, const TransformationMatrix& afterChange);
@@ -281,6 +282,7 @@ private:
     bool m_isReplica { false };
 
 #if ENABLE(DAMAGE_TRACKING)
+    bool m_damagePropagation { false };
     Damage m_damage;
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -96,8 +96,12 @@ GraphicsLayerCoordinated* CoordinatedPlatformLayer::owner() const
 TextureMapperLayer& CoordinatedPlatformLayer::ensureTarget()
 {
     ASSERT(!isMainThread());
-    if (!m_target)
+    if (!m_target) {
         m_target = makeUnique<TextureMapperLayer>();
+#if ENABLE(DAMAGE_TRACKING)
+        m_target->setDamagePropagation(m_damagePropagation);
+#endif
+    }
     return *m_target;
 }
 
@@ -876,7 +880,7 @@ void CoordinatedPlatformLayer::flushCompositingState(TextureMapper& textureMappe
             layer.setDamage(m_damage);
     }
 
-    if (m_pendingChanges.isEmpty()) {
+    if (m_damagePropagation && m_pendingChanges.isEmpty()) {
         // If there are no changes to the layer and yet m_backingStoreProxy || m_contentsBuffer
         // we must damage the whole layer for now to handle cases such as e.g. scrollbars.
         Damage fullLayerDamage;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -94,6 +94,11 @@ public:
     TextureMapperLayer* target() const;
     void invalidateTarget();
 
+#if ENABLE(DAMAGE_TRACKING)
+    void setDamagePropagation(bool enabled) { m_damagePropagation = enabled; }
+    bool damagePropagation() const { return m_damagePropagation; }
+#endif
+
     void setPosition(FloatPoint&&);
     enum class ForcePositionSync : bool { No, Yes };
     void setPositionForScrolling(const FloatPoint&, ForcePositionSync = ForcePositionSync::No);
@@ -230,6 +235,10 @@ private:
     std::unique_ptr<TextureMapperLayer> m_target;
     bool m_pendingTilesCreation { false };
     bool m_needsTilesUpdate { false };
+
+#if ENABLE(DAMAGE_TRACKING)
+    bool m_damagePropagation { false };
+#endif
 
     Lock m_lock;
     OptionSet<Change> m_pendingChanges WTF_GUARDED_BY_LOCK(m_lock);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -839,6 +839,9 @@ void GraphicsLayerCoordinated::updateVisibleRect(const FloatRect& rect)
 #if ENABLE(DAMAGE_TRACKING)
 void GraphicsLayerCoordinated::updateDamage()
 {
+    if (!m_platformLayer->damagePropagation())
+        return;
+
     Damage damage;
     if (m_damagedRectsAreUnreliable)
         damage.invalidate();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -86,6 +86,9 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage, WebCore::PlatformDisplayID displa
 {
     {
         auto& rootLayer = m_sceneState->rootLayer();
+#if ENABLE(DAMAGE_TRACKING)
+        rootLayer.setDamagePropagation(webPage.corePage()->settings().propagateDamagingInformation());
+#endif
         Locker locker { rootLayer.lock() };
         rootLayer.setAnchorPoint(FloatPoint3D(0, 0, 0));
         rootLayer.setSize(m_webPage.size());
@@ -377,6 +380,9 @@ void LayerTreeHost::backgroundColorDidChange()
 
 void LayerTreeHost::attachLayer(CoordinatedPlatformLayer& layer)
 {
+#if ENABLE(DAMAGE_TRACKING)
+    layer.setDamagePropagation(webPage().corePage()->settings().propagateDamagingInformation());
+#endif
     m_sceneState->addLayer(layer);
 }
 


### PR DESCRIPTION
#### 44c74277d5c32f0de52fcadf6cb431e4f5f3e105
<pre>
[TexMap] Make sure the damage is not propagated at any level when disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=285844">https://bugs.webkit.org/show_bug.cgi?id=285844</a>

Reviewed by Carlos Garcia Campos.

This change disables damage propagation:
- in the main thread
- in the compositor thread - before the damage is collected
thus improving performance and memory consumption when damage propagation runtime preference is disabled.

* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::collectDamageSelf):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
(WebCore::TextureMapperLayer::setDamagePropagation):
(WebCore::TextureMapperLayer::canInferDamage const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::ensureTarget):
(WebCore::CoordinatedPlatformLayer::flushCompositingState):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
(WebCore::CoordinatedPlatformLayer::setDamagePropagation):
(WebCore::CoordinatedPlatformLayer::damagePropagation const):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::updateDamage):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
(WebKit::LayerTreeHost::attachLayer):

Canonical link: <a href="https://commits.webkit.org/288995@main">https://commits.webkit.org/288995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3ed380c85006fc48516c4d7119d2f46a56ec3b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89964 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35877 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12527 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66008 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23829 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46283 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31303 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34951 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91340 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74489 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12391 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73615 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18248 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17994 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16437 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3612 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12116 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17566 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11950 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15444 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13696 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->