### PR TITLE
[GStreamer] Fix "pipeline and player states are not synchronized" assertion crash

### DIFF
--- a/LayoutTests/media/media-source/media-source-muted-scroll-and-seek-crash-expected.txt
+++ b/LayoutTests/media/media-source/media-source-muted-scroll-and-seek-crash-expected.txt
@@ -1,0 +1,4 @@
+
+No crash OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-muted-scroll-and-seek-crash.html
+++ b/LayoutTests/media/media-source/media-source-muted-scroll-and-seek-crash.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MediaSourceEnabled=true ] -->
+<html>
+<head>
+    <title>Test scrolling and seeking in an initially hidden and muted MSE video - it should not crash</title>
+    <link rel="author" title="Carlos Bentzen" href="cadubentzen@igalia.com">
+    <style>
+        .fullheight {
+            height: 100vh;
+        }
+    </style>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    const COUNT_ITERATIONS = 10;
+
+    function createObserver() {
+        let handleIntersect = (entries, observer) => {
+            entries.forEach((entry) => {
+                video.currentTime = 0;
+                video.play();
+            });
+        }
+        let options = {
+            root: null,
+            rootMargin: "0px",
+            threshold: [0],
+        };
+        let observer = new IntersectionObserver(handleIntersect, options);
+        observer.observe(video);
+    }
+
+    async function runTest() {
+        findMediaElement();
+        createObserver();
+
+        let source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen', true);
+
+        let loader = new MediaSourceLoader('content/test-fragmented-video-manifest.json');
+        await loader.load();
+        await loader.loadMediaData();
+
+        let sourceBuffer = source.addSourceBuffer(loader.type());
+        sourceBuffer.appendBuffer(loader.initSegment());
+        await waitFor(sourceBuffer, 'update', true);
+        sourceBuffer.appendBuffer(loader.mediaSegment(0));
+        await waitFor(sourceBuffer, 'update', true);
+        source.endOfStream();
+        video.play();
+
+        for (let numScrolled = 0; numScrolled < COUNT_ITERATIONS; ++numScrolled) {
+            await sleepFor(50);
+            const isVideoVisible = (numScrolled % 2 != 0);
+            const scrollTargetY = isVideoVisible ? 0 : window.innerHeight;
+            window.scrollTo(0, scrollTargetY);
+        }
+        source.removeSourceBuffer(sourceBuffer);
+        logResult(Success, 'No crash');
+        endTest();
+    }
+    </script>
+</head>
+<body onload="runTest()">
+    <div class="fullheight"></div>
+    <video muted></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -145,7 +145,7 @@ public:
     void setMuted(bool) final;
     MediaPlayer::NetworkState networkState() const final;
     MediaPlayer::ReadyState readyState() const final;
-    void setPageIsVisible(bool visible) final { m_visible = visible; }
+    void setPageIsVisible(bool visible) final { m_pageIsVisible = visible; }
     void setVisibleInViewport(bool isVisible) final;
     void setPresentationSize(const IntSize&) final;
     MediaTime duration() const override;
@@ -342,6 +342,8 @@ protected:
     bool m_didErrorOccur { false };
     mutable bool m_isEndReached { false };
     mutable std::optional<bool> m_isLiveStream;
+
+    // Must reflect whether the last successfull call to gst_element_set_state() was for PLAYING.
     bool m_isPipelinePlaying = false;
 
     // m_isPaused represents:
@@ -367,6 +369,9 @@ protected:
     SeekTarget m_seekTarget;
     GRefPtr<GstElement> m_source { nullptr };
     bool m_areVolumeAndMuteInitialized { false };
+
+    // Reflects whether the pipeline was paused due to the HTMLMediaElement being both muted and invisible in the viewport.
+    bool m_isPausedByViewport { false };
 
 #if USE(TEXTURE_MAPPER)
     OptionSet<TextureMapperFlags> m_textureMapperFlags;
@@ -564,7 +569,9 @@ private:
 #endif
 
     bool m_isMuted { false };
-    bool m_visible { false };
+
+    // Whether the page containing the HTMLMediaElement is visible, reflects: setPageIsVisible()
+    bool m_pageIsVisible { false };
 
     // playbin3 only:
     bool m_waitingForStreamsSelectedEvent { true };
@@ -620,7 +627,6 @@ private:
 
     bool m_didTryToRecoverPlayingState { false };
 
-    bool m_isVisibleInViewport { true };
     GstState m_invisiblePlayerState { GST_STATE_VOID_PENDING };
 
     // Specific to MediaStream playback.

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -418,7 +418,7 @@ void MediaPlayerPrivateGStreamerMSE::updateStates()
 {
     bool isWaitingPreroll = isPipelineWaitingPreroll();
     bool shouldUpdatePlaybackState = false;
-    bool shouldBePlaying = (!m_isPaused && readyState() >= MediaPlayer::ReadyState::HaveFutureData && m_playbackRatePausedState != PlaybackRatePausedState::RatePaused)
+    bool shouldBePlaying = (!m_isPaused && !m_isPausedByViewport && readyState() >= MediaPlayer::ReadyState::HaveFutureData && m_playbackRatePausedState != PlaybackRatePausedState::RatePaused)
         || m_playbackRatePausedState == PlaybackRatePausedState::ShouldMoveToPlaying;
     GST_DEBUG_OBJECT(pipeline(), "shouldBePlaying = %s, m_isPipelinePlaying = %s, is seeking %s", boolForPrinting(shouldBePlaying),
         boolForPrinting(m_isPipelinePlaying), boolForPrinting(isWaitingPreroll));


### PR DESCRIPTION
#### d65ff7e6d420dbf512df6f6da8c0948f9507e423
<pre>
[GStreamer] Fix &quot;pipeline and player states are not synchronized&quot; assertion crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=285850">https://bugs.webkit.org/show_bug.cgi?id=285850</a>

Reviewed by Philippe Normand.

WebKit pauses muted videos when scrolling to save resources. However,
when running in Debug, an assertion was failing inside
MediaPlayerPrivateGStreamer::paused() in the GStreamer ports:

&gt; ASSERTION FAILED: pipeline and player states are not synchronized

After some debugging, I found two problems that were causing the
assertion to fail:

(1) MediaPlayerPrivateGStreamerMSE::updateStates() didn&apos;t account for
this behavior, which could trigger unexpected state changes. The patch
adds it to the `shouldBePlaying` check.

(2) The assertion checks m_isPipelinePlaying against the actual state of
the pipeline. However, the code setting the pipeline to PAUSED when
scrolling away (see setVisibleInViewport()) didn&apos;t update this field.
Normally you use setPipelineState() instead which updates this field.

As drive-by fixes this patch also adds new logs and renames two fields
to have more useful names.

 * m_isVisibleInViewport is negated and renamed m_isPausedByViewport,
   reflecting its actual meaning (`m_isVisibleInViewport` was often true
   while the HTMLMediaElement was not visible in the viewport.

 * m_isVisible is renamed to m_pageIsVisible to both match other code and
   to reflect its actual meaning.

This patch adds back media-source-muted-scroll-and-seek-crash.html from
276798@main, which can be used to test the crash does not happen.  Note
however the same caveat from back then applies:

&gt; Currently, part of the code to trigger the crash isn&apos;t executed
&gt; due to WEBKIT_GST_ALLOW_PLAYBACK_OF_INVISIBLE_VIDEOS=1 being set in the test driver in
&gt; Tools/Scripts/webkitpy/port/glib.py (264017@main), which needs to be commented manually.
&gt; We should find a way to add a test preference for this code path to be enabled.

* LayoutTests/media/media-source/media-source-muted-scroll-and-seek-crash.html: Added.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::paused const):
(WebCore::MediaPlayerPrivateGStreamer::changePipelineState):
(WebCore::MediaPlayerPrivateGStreamer::setVisibleInViewport):
(WebCore::MediaPlayerPrivateGStreamer::paint):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::updateStates):

Canonical link: <a href="https://commits.webkit.org/288906@main">https://commits.webkit.org/288906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4b0699aee375b74880449d714e0d9f6e5cabd5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89782 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35694 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65882 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23713 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3386 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76925 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46153 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3265 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31137 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34769 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74137 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91157 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8749 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74354 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72729 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73480 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18194 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17850 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16289 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3430 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11934 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17374 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11768 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15262 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13514 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->