### PR TITLE
Remove RefPtr<LocalFrame> from Editor::Command

### DIFF
--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -331,10 +331,11 @@ public:
         WEBCORE_EXPORT bool allowExecutionWhenDisabled() const;
 
     private:
+        RefPtr<LocalFrame> frame() const;
+
         const EditorInternalCommand* m_command { nullptr };
         EditorCommandSource m_source;
         RefPtr<Document> m_document;
-        RefPtr<LocalFrame> m_frame;
     };
     WEBCORE_EXPORT Command command(const String& commandName); // Command source is EditorCommandSource::MenuOrKeyBinding.
     Command command(const String& commandName, EditorCommandSource);

--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -1896,9 +1896,13 @@ Editor::Command::Command(const EditorInternalCommand* command, EditorCommandSour
     : m_command(command)
     , m_source(source)
     , m_document(command ? &document : nullptr)
-    , m_frame(command ? document.frame() : nullptr)
 {
     ASSERT(command || !m_document);
+}
+
+RefPtr<LocalFrame> Editor::Command::frame() const
+{
+    return m_document ? m_document->frame() : nullptr;
 }
 
 bool Editor::Command::execute(const String& parameter, Event* triggeringEvent) const
@@ -1910,10 +1914,13 @@ bool Editor::Command::execute(const String& parameter, Event* triggeringEvent) c
     }
 
     m_document->updateLayoutIgnorePendingStylesheets();
-    if (m_document->frame() != m_frame)
+    RefPtr frame = this->frame();
+    if (m_document->frame() != frame.get())
+        return false;
+    if (!frame)
         return false;
 
-    return m_command->execute(*m_frame, triggeringEvent, m_source, parameter);
+    return m_command->execute(*frame, triggeringEvent, m_source, parameter);
 }
 
 bool Editor::Command::execute(Event* triggeringEvent) const
@@ -1930,7 +1937,8 @@ bool Editor::Command::isSupported() const
         return true;
     case EditorCommandSource::DOM:
     case EditorCommandSource::DOMWithUserInterface:
-        return m_command->isSupportedFromDOM(m_frame.get());
+        RefPtr frame = this->frame();
+        return m_command->isSupportedFromDOM(frame.get());
     }
     ASSERT_NOT_REACHED();
     return false;
@@ -1938,25 +1946,28 @@ bool Editor::Command::isSupported() const
 
 bool Editor::Command::isEnabled(Event* triggeringEvent) const
 {
-    if (!isSupported() || !m_frame)
+    RefPtr frame = this->frame();
+    if (!isSupported() || !frame)
         return false;
-    return m_command->isEnabled(*m_frame, triggeringEvent, m_source);
+    return m_command->isEnabled(*frame, triggeringEvent, m_source);
 }
 
 TriState Editor::Command::state(Event* triggeringEvent) const
 {
-    if (!isSupported() || !m_frame)
+    RefPtr frame = this->frame();
+    if (!isSupported() || !frame)
         return TriState::False;
-    return m_command->state(*m_frame, triggeringEvent);
+    return m_command->state(*frame, triggeringEvent);
 }
 
 String Editor::Command::value(Event* triggeringEvent) const
 {
-    if (!isSupported() || !m_frame)
+    RefPtr frame = this->frame();
+    if (!isSupported() || !frame)
         return String();
     if (m_command->value == valueNull && m_command->state != stateNone)
-        return m_command->state(*m_frame, triggeringEvent) == TriState::True ? "true"_s : "false"_s;
-    return m_command->value(*m_frame, triggeringEvent);
+        return m_command->state(*frame, triggeringEvent) == TriState::True ? "true"_s : "false"_s;
+    return m_command->value(*frame, triggeringEvent);
 }
 
 bool Editor::Command::isTextInsertion() const
@@ -1966,9 +1977,10 @@ bool Editor::Command::isTextInsertion() const
 
 bool Editor::Command::allowExecutionWhenDisabled() const
 {
-    if (!isSupported() || !m_frame)
+    RefPtr frame = this->frame();
+    if (!isSupported() || !frame)
         return false;
-    return m_command->allowExecutionWhenDisabled(*m_frame, m_source);
+    return m_command->allowExecutionWhenDisabled(*frame, m_source);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 2b37780921fbbde3970c73f477b41a8966bec6e1
<pre>
Remove RefPtr&lt;LocalFrame&gt; from Editor::Command
<a href="https://bugs.webkit.org/show_bug.cgi?id=285860">https://bugs.webkit.org/show_bug.cgi?id=285860</a>
<a href="https://rdar.apple.com/142821974">rdar://142821974</a>

Reviewed by Ryosuke Niwa.

The Editor::Command does not need to prevent the LocalFrame
from being destroyed.  If the LocalFrame is destroyed, I added
some null checks and we shouldn&apos;t interact with the LocalFrame.

* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::Editor::Command::Command):
(WebCore::Editor::Command::frame const):
(WebCore::Editor::Command::execute const):
(WebCore::Editor::Command::isSupported const):
(WebCore::Editor::Command::isEnabled const):
(WebCore::Editor::Command::state const):
(WebCore::Editor::Command::value const):
(WebCore::Editor::Command::allowExecutionWhenDisabled const):

Canonical link: <a href="https://commits.webkit.org/289096@main">https://commits.webkit.org/289096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fafd8b6a928ff018b7041ab190ddf2b05dd6b25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89561 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35490 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12089 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65722 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23542 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87525 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3345 "Found 3 new test failures: fast/files/blob-stream-frame.html http/tests/websocket/tests/hybi/no-subprotocol.html http/wpt/cache-storage/quota-third-party.https.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76751 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45992 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30982 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34538 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90942 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11746 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74150 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73352 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17691 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16137 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3181 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13304 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11698 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17174 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11547 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15023 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13320 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->