### PR TITLE
[iOS] [SelectionHonorsOverflowScrolling] Selection shows up in the wrong place in RTL horizontally scrollable containers

### DIFF
--- a/LayoutTests/editing/selection/ios/select-text-in-horizontal-rtl-scroller-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-text-in-horizontal-rtl-scroller-expected.txt
@@ -1,0 +1,15 @@
+عنوان بريدي الإلكتروني هو select@this.text. أرسل لي تحديثًا عند وصولك إلى المطار
+
+Verifies that the text selection shows up in the correct place inside a right-to-left overflow scrolling container
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS selectionRects.length is 1
+PASS selectionRects[0].top is >= 1
+PASS selectionRects[0].left is >= 1
+PASS selectionRects[0].width is >= 1
+PASS selectionRects[0].height is >= 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/select-text-in-horizontal-rtl-scroller.html
+++ b/LayoutTests/editing/selection/ios/select-text-in-horizontal-rtl-scroller.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true SelectionHonorsOverflowScrolling=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    font-size: 20px;
+    font-family: system-ui;
+}
+
+.scrollable {
+    width: 300px;
+    height: 300px;
+    border: solid 1px lightgray;
+    border-radius: 4px;
+    box-sizing: border-box;
+    overflow-x: scroll;
+    overflow-y: hidden;
+    line-height: 1.5em;
+    outline: none;
+    padding: 1em;
+    direction: rtl;
+}
+
+.target {
+    border: 1px solid tomato;
+    padding: 3px;
+}
+
+.horizontal-space {
+    width: 2000px;
+    height: 10px;
+    background-color: tomato;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the text selection shows up in the correct place inside a right-to-left overflow scrolling container");
+
+    await UIHelper.longPressElement(document.querySelector(".target"));
+    selectionRects = await UIHelper.waitForSelectionToAppear();
+
+    shouldBe("selectionRects.length", "1");
+    shouldBeGreaterThanOrEqual("selectionRects[0].top", "1");
+    shouldBeGreaterThanOrEqual("selectionRects[0].left", "1");
+    shouldBeGreaterThanOrEqual("selectionRects[0].width", "1");
+    shouldBeGreaterThanOrEqual("selectionRects[0].height", "1");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="scrollable">
+        <p>عنوان بريدي الإلكتروني هو <span class="target">select</span>@this.text. أرسل لي تحديثًا عند وصولك إلى المطار</p>
+        <div class="horizontal-space"></div>
+    </div>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5970,7 +5970,7 @@ void WebPage::computeEnclosingLayerID(EditorState& state, const VisibleSelection
         if (!scrollingNodeID)
             return { };
 
-        return { scrollableArea->scrollPosition(), WTFMove(scrollingNodeID) };
+        return { scrollableArea->scrollOrigin() + scrollableArea->scrollPosition(), WTFMove(scrollingNodeID) };
     };
 
     CheckedPtr<RenderLayer> scrollableLayer;


### PR DESCRIPTION
#### ac295b7e2a8ba630a79bcca7aba2b4b802119771
<pre>
[iOS] [SelectionHonorsOverflowScrolling] Selection shows up in the wrong place in RTL horizontally scrollable containers
<a href="https://bugs.webkit.org/show_bug.cgi?id=285855">https://bugs.webkit.org/show_bug.cgi?id=285855</a>
<a href="https://rdar.apple.com/142818910">rdar://142818910</a>

Reviewed by Megan Gardner and Abrar Rahman Protyasha.

The logic introduced in 286537@main currently fails to account for the case where the enclosing
scroller that contains the selection is right-to-left. In this case, `scrollPosition()` initially
returns `(0, 0)`, but the corresponding `-[WKChildScrollView contentOffset]` is in physical
coordinates — that is, `(max horizontal extent, 0)` initially.

As a result, logic that attempts to reconcile stale scroll positions upon arrival of `EditorState`
in the UI process (incorrectly) believes the scroll position must be adjusted, and ends up moving
selection rects offscreen.

To fix this, account for `scrollOrigin()` when computing `enclosingScrollPosition`. Note that the
`scrollPosition()` starts at `(0, 0)` and *decreases* as you scroll to the physical left (logical
right) direction, so the sum of `scrollOrigin()` and `scrollPosition()` gives us the actual physical
scroll position, consistent with `-contentOffset`.

* LayoutTests/editing/selection/ios/select-text-in-horizontal-rtl-scroller-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-text-in-horizontal-rtl-scroller.html: Added.
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::computeEnclosingLayerID const):

Canonical link: <a href="https://commits.webkit.org/288814@main">https://commits.webkit.org/288814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26a3464c2e78e7941eeab61cc0c36a9c44e5f637

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89569 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35498 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12097 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65701 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23550 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87533 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76756 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/45996 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/30987 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34546 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90950 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8568 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74158 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11981 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73359 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18151 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17706 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/16141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3189 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11706 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17182 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11555 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13328 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->