### PR TITLE
[Cleanup] Remove & in InlineLine to match neighboring style.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
@@ -377,7 +377,7 @@ void Line::appendTextContent(const InlineTextItem& inlineTextItem, const RenderS
         if (m_runs.isEmpty())
             return true;
         auto& lastRun = m_runs.last();
-        if (&lastRun.layoutBox() != &inlineTextItem.layoutBox())
+        if (lastRun.layoutBox() != inlineTextItem.layoutBox())
             return true;
         if (lastRun.bidiLevel() != inlineTextItem.bidiLevel())
             return true;
@@ -499,7 +499,7 @@ void Line::appendTextFast(const InlineTextItem& inlineTextItem, const RenderStyl
         auto& lastRun = m_runs.last();
         if (lastRun.hasCollapsedTrailingWhitespace())
             return true;
-        if (&lastRun.layoutBox() != &inlineTextItem.layoutBox())
+        if (lastRun.layoutBox() != inlineTextItem.layoutBox())
             return true;
         if (inlineTextItem.isZeroWidthSpaceSeparator())
             return true;


### PR DESCRIPTION
#### 92606fe7388bf6a502af9b7ebb7104a2e01b64ee
<pre>
[Cleanup] Remove &amp; in InlineLine to match neighboring style.
<a href="https://bugs.webkit.org/show_bug.cgi?id=285861">https://bugs.webkit.org/show_bug.cgi?id=285861</a>
&lt;<a href="https://rdar.apple.com/142759226">rdar://142759226</a>&gt;

This is a purely stylistic change and is somewhat pedantic.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92606fe7388bf6a502af9b7ebb7104a2e01b64ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84494 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4119 "Hash 92606fe7 for PR 38944 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38799 "Hash 92606fe7 for PR 38944 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89576 "Hash 92606fe7 for PR 38944 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35505 "Hash 92606fe7 for PR 38944 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86579 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4204 "Hash 92606fe7 for PR 38944 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12104 "Hash 92606fe7 for PR 38944 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/89576 "Hash 92606fe7 for PR 38944 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/35505 "Hash 92606fe7 for PR 38944 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87540 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/4204 "Hash 92606fe7 for PR 38944 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/38799 "Hash 92606fe7 for PR 38944 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/89576 "Hash 92606fe7 for PR 38944 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/4204 "Hash 92606fe7 for PR 38944 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/38799 "Hash 92606fe7 for PR 38944 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34553 "Hash 92606fe7 for PR 38944 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/4204 "Hash 92606fe7 for PR 38944 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/38799 "Hash 92606fe7 for PR 38944 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90957 "Hash 92606fe7 for PR 38944 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11761 "Hash 92606fe7 for PR 38944 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/12104 "Hash 92606fe7 for PR 38944 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/90957 "Hash 92606fe7 for PR 38944 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/11988 "Hash 92606fe7 for PR 38944 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/38799 "Hash 92606fe7 for PR 38944 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/90957 "Hash 92606fe7 for PR 38944 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/38799 "Hash 92606fe7 for PR 38944 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/3196 "The change is no longer eligible for processing.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11713 "Hash 92606fe7 for PR 38944 does not build (failure)") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11562 "Hash 92606fe7 for PR 38944 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15038 "Hash 92606fe7 for PR 38944 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13335 "Hash 92606fe7 for PR 38944 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->