### PR TITLE
Temporary extension resources are not deleted when it is unloaded.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -40,8 +40,6 @@
 #import "WebExtensionUtilities.h"
 #import <CoreFoundation/CFBundle.h>
 #import <WebCore/LocalizedStrings.h>
-#import <wtf/FileSystem.h>
-#import <wtf/Scope.h>
 #import <wtf/cf/TypeCastsCF.h>
 #import <wtf/text/MakeString.h>
 
@@ -63,94 +61,6 @@ namespace WebKit {
 
 static NSString * const generatedBackgroundPageFilename = @"_generated_background_page.html";
 static NSString * const generatedBackgroundServiceWorkerFilename = @"_generated_service_worker.js";
-
-static String convertChromeExtensionToTemporaryZipFile(const String& inputFilePath)
-{
-    // Converts a Chrome extension file to a temporary ZIP file by checking for a valid Chrome extension signature ('Cr24')
-    // and copying the contents starting from the ZIP signature ('PK\x03\x04'). Returns a null string if the signatures
-    // are not found or any file operations fail.
-
-    auto inputFileHandle = FileSystem::openFile(inputFilePath, FileSystem::FileOpenMode::Read);
-    if (!FileSystem::isHandleValid(inputFileHandle))
-        return nullString();
-
-    auto closeFile = makeScopeExit([&] {
-        FileSystem::unlockAndCloseFile(inputFileHandle);
-    });
-
-    static std::array<uint8_t, 4> expectedSignature = { 'C', 'r', '2', '4' };
-
-    // Verify Chrome extension magic signature.
-    std::array<uint8_t, 4> signature;
-    auto bytesRead = FileSystem::readFromFile(inputFileHandle, signature);
-    if (bytesRead != expectedSignature.size() || signature != expectedSignature)
-        return nullString();
-
-    // Create a temporary ZIP file.
-    auto [temporaryFilePath, temporaryFileHandle] = FileSystem::openTemporaryFile("WebKitExtension-"_s, ".zip"_s);
-    if (!FileSystem::isHandleValid(temporaryFileHandle))
-        return nullString();
-
-    auto closeTempFile = makeScopeExit([fileHandle = temporaryFileHandle] {
-        FileSystem::unlockAndCloseFile(fileHandle);
-    });
-
-    std::array<uint8_t, 4096> buffer;
-    bool signatureFound = false;
-
-    while (true) {
-        bytesRead = FileSystem::readFromFile(inputFileHandle, buffer);
-
-        // Error reading file.
-        if (bytesRead < 0)
-            return nullString();
-
-        // Done reading file.
-        if (!bytesRead)
-            break;
-
-        size_t bufferOffset = 0;
-        if (!signatureFound) {
-            // Not enough bytes for the signature.
-            if (bytesRead < 4)
-                return nullString();
-
-            // Search for the ZIP file magic signature in the buffer.
-            for (ssize_t i = 0; i < bytesRead - 3; ++i) {
-                if (buffer[i] == 'P' && buffer[i + 1] == 'K' && buffer[i + 2] == 0x03 && buffer[i + 3] == 0x04) {
-                    signatureFound = true;
-                    bufferOffset = i;
-                    break;
-                }
-            }
-
-            // Continue until the start of the ZIP file is found.
-            if (!signatureFound)
-                continue;
-        }
-
-        auto bytesToWrite = std::span(buffer).subspan(bufferOffset, bytesRead - bufferOffset);
-        auto bytesWritten = FileSystem::writeToFile(temporaryFileHandle, bytesToWrite);
-        if (bytesWritten != static_cast<int64_t>(bytesToWrite.size()))
-            return nullString();
-    }
-
-    return temporaryFilePath;
-}
-
-static String processFileAndExtractZipArchive(const String& path)
-{
-    // Check if the file is a Chrome extension archive and extract it.
-    auto temporaryZipFilePath = convertChromeExtensionToTemporaryZipFile(path);
-    if (!temporaryZipFilePath.isNull()) {
-        auto temporaryDirectory = FileSystem::extractTemporaryZipArchive(temporaryZipFilePath);
-        FileSystem::deleteFile(temporaryZipFilePath);
-        return temporaryDirectory;
-    }
-
-    // Assume the file is already a ZIP archive and try to extract it.
-    return FileSystem::extractTemporaryZipArchive(path);
-}
 
 WebExtension::WebExtension(NSBundle *appExtensionBundle, NSURL *resourceURL, RefPtr<API::Error>& outError)
     : m_bundle(appExtensionBundle)
@@ -177,6 +87,7 @@ WebExtension::WebExtension(NSBundle *appExtensionBundle, NSURL *resourceURL, Ref
 
             ASSERT(temporaryDirectory.right(1) != "/"_s);
             m_resourceBaseURL = URL::fileURLWithFileSystemPath(makeString(temporaryDirectory, '/'));
+            m_resourcesAreTemporary = true;
         }
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -3861,7 +3861,7 @@ void WebExtensionContext::performTasksAfterBackgroundContentLoads()
     scheduleBackgroundContentToUnload();
 }
 
-void WebExtensionContext::wakeUpBackgroundContentIfNecessary(CompletionHandler<void()>&& completionHandler)
+void WebExtensionContext::wakeUpBackgroundContentIfNecessary(Function<void()>&& completionHandler)
 {
     if (!protectedExtension()->hasBackgroundContent()) {
         completionHandler();
@@ -3882,7 +3882,7 @@ void WebExtensionContext::wakeUpBackgroundContentIfNecessary(CompletionHandler<v
     loadBackgroundWebViewIfNeeded();
 }
 
-void WebExtensionContext::wakeUpBackgroundContentIfNecessaryToFireEvents(EventListenerTypeSet&& types, CompletionHandler<void()>&& completionHandler)
+void WebExtensionContext::wakeUpBackgroundContentIfNecessaryToFireEvents(EventListenerTypeSet&& types, Function<void()>&& completionHandler)
 {
     RefPtr extension = m_extension;
     if (!extension->hasBackgroundContent()) {

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -76,7 +76,7 @@ public:
 
     explicit WebExtension(Resources&& = { });
 
-    ~WebExtension() { }
+    ~WebExtension();
 
     enum class CacheResult : bool { No, Yes };
     enum class SuppressNotFoundErrors : bool { No, Yes };
@@ -352,6 +352,8 @@ public:
 #endif
 
 private:
+    static String processFileAndExtractZipArchive(const String&);
+
     bool parseManifest(StringView);
 
     void parseWebAccessibleResourcesVersion3();
@@ -398,6 +400,7 @@ private:
 #endif
 
     URL m_resourceBaseURL;
+    bool m_resourcesAreTemporary { false };
     Ref<const JSON::Value> m_manifestJSON;
     Resources m_resources;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -187,7 +187,7 @@ public:
     using EventListenerTypeFrameMap = HashMap<WebExtensionEventListenerTypeWorldPair, WeakFrameCountedSet>;
     using EventListenerTypeSet = HashSet<WebExtensionEventListenerType>;
     using ContentWorldTypeSet = HashSet<WebExtensionContentWorldType>;
-    using VoidCompletionHandlerVector = Vector<CompletionHandler<void()>>;
+    using VoidFunctionVector = Vector<Function<void()>>;
 
     using WindowIdentifierMap = HashMap<WebExtensionWindowIdentifier, Ref<WebExtensionWindow>>;
     using WindowIdentifierVector = Vector<WebExtensionWindowIdentifier>;
@@ -582,8 +582,8 @@ public:
 
     void loadBackgroundContent(CompletionHandler<void(NSError *)>&&);
 
-    void wakeUpBackgroundContentIfNecessary(CompletionHandler<void()>&&);
-    void wakeUpBackgroundContentIfNecessaryToFireEvents(EventListenerTypeSet&&, CompletionHandler<void()>&&);
+    void wakeUpBackgroundContentIfNecessary(Function<void()>&&);
+    void wakeUpBackgroundContentIfNecessaryToFireEvents(EventListenerTypeSet&&, Function<void()>&&);
 
     HashSet<Ref<WebProcessProxy>> processes(WebExtensionEventListenerType type, WebExtensionContentWorldType contentWorldType) const
     {
@@ -991,7 +991,7 @@ private:
     bool m_requestedOptionalAccessToAllHosts { false };
     bool m_hasAccessToPrivateData { false };
 
-    VoidCompletionHandlerVector m_actionsToPerformAfterBackgroundContentLoads;
+    VoidFunctionVector m_actionsToPerformAfterBackgroundContentLoads;
     EventListenerTypeCountedSet m_backgroundContentEventListeners;
     EventListenerTypeFrameMap m_eventListenerFrames;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -596,8 +596,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, DynamicRules)
     storageDirectory = [storageDirectory stringByAppendingPathComponent:manager.get().context.uniqueIdentifier];
     EXPECT_TRUE([NSFileManager.defaultManager fileExistsAtPath:[storageDirectory stringByAppendingPathComponent:@"DeclarativeNetRequestContentRuleList.data"]]);
 
-    [manager.get().controller unloadExtensionContext:manager.get().context error:nullptr];
-
+    [manager unload];
     [manager loadAndRun];
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Load Tab");

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
@@ -1525,10 +1525,8 @@ TEST(WKWebExtensionAPIRuntime, StartupEvent)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Startup Event Fired");
 
-    [manager.get().controller unloadExtensionContext:manager.get().context error:nullptr];
-
+    [manager unload];
     [manager runForTimeInterval:5];
-
     [manager loadAndRun];
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Startup Event Did Not Fire");
@@ -1558,10 +1556,8 @@ TEST(WKWebExtensionAPIRuntime, InstalledEvent)
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Installed Event Fired");
 
-    [manager.get().controller unloadExtensionContext:manager.get().context error:nullptr];
-
+    [manager unload];
     [manager runForTimeInterval:1];
-
     [manager loadAndRun];
 
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Installed Event Fired");

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
@@ -1196,7 +1196,7 @@ TEST(WKWebExtensionAPIScripting, RegisteredScriptIsInjectedAfterContextReloads)
 
     EXPECT_TRUE(manager.get().context.hasInjectedContent);
 
-    [manager.get().controller unloadExtensionContext:manager.get().context error:nullptr];
+    [manager unload];
 
     EXPECT_FALSE(manager.get().context.hasInjectedContent);
 

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -73,11 +73,15 @@ using CocoaColor = UIColor;
 - (void)sendTestMessage:(NSString *)message;
 - (void)sendTestMessage:(NSString *)message withArgument:(id)argument;
 
+- (void)loadAndRun;
+
 - (void)load;
+- (void)unload;
+
 - (void)run;
 - (void)runForTimeInterval:(NSTimeInterval)interval;
 - (id)runUntilTestMessage:(NSString *)message;
-- (void)loadAndRun;
+
 - (void)done;
 
 @end

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -152,6 +152,11 @@
     return self;
 }
 
+- (void)dealloc
+{
+    [self unload];
+}
+
 - (BOOL)respondsToSelector:(SEL)selector
 {
     return [_controllerDelegate respondsToSelector:selector] || [super respondsToSelector:selector];
@@ -224,6 +229,13 @@
 {
     NSError *error;
     EXPECT_TRUE([_controller loadExtensionContext:_context error:&error]);
+    EXPECT_NULL(error);
+}
+
+- (void)unload
+{
+    NSError *error;
+    EXPECT_TRUE([_controller unloadExtensionContext:_context error:&error]);
     EXPECT_NULL(error);
 }
 


### PR DESCRIPTION
#### e82bb6d82140825672ab1494b74ca8467f854dd8
<pre>
Temporary extension resources are not deleted when it is unloaded.
<a href="https://webkit.org/b/285871">https://webkit.org/b/285871</a>
<a href="https://rdar.apple.com/142834398">rdar://142834398</a>

Reviewed by Brian Weinstein.

Delete the extension resources in ~WebExtension if they were extracted from a Zip archive
into a temporary directory.

Changed the test manager to unload extension contexts on dealloc, so the cleanup code paths get
exercised in testing. This uncovered a case where the extension can load and unload so quickly,
the background page loading completions handlers waiting for wakeup don&apos;t have time to be called,
so they hit the uncalled assertion. Changing these to Function fixes this, since they are not
guaranteed to be called.

Moved the Zip file code to the cross-platform WebExtension file, since it is not Cocoa specific.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::WebExtension):
(WebKit::convertChromeExtensionToTemporaryZipFile): Deleted.
(WebKit::processFileAndExtractZipArchive): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::wakeUpBackgroundContentIfNecessary): Use Function.
(WebKit::WebExtensionContext::wakeUpBackgroundContentIfNecessaryToFireEvents): Ditto.
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::~WebExtension): Added. Delete temp resources.
(WebKit::convertChromeExtensionToTemporaryZipFile): Added.
(WebKit::WebExtension::processFileAndExtractZipArchive): Added.
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
(WebKit::WebExtension::~WebExtension): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, DynamicRules)): Use unload on the manager.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, StartupEvent)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, InstalledEvent)): Ditto.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, RegisteredScriptIsInjectedAfterContextReloads)): Ditto.
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager dealloc]): Added.
(-[TestWebExtensionManager unload]): Added.

Canonical link: <a href="https://commits.webkit.org/288826@main">https://commits.webkit.org/288826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0d6738dcb54d579d9cf00263b38c2407647cb78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89607 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35536 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86610 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12136 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65728 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23570 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46021 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3145 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31018 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34584 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/90988 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11792 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74179 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12020 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73380 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17728 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16167 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3230 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13165 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11744 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11593 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15069 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13366 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->