### PR TITLE
Add initial infrastructure for implementing fullscreen with site isolation

### DIFF
--- a/Source/WebKit/Scripts/generate-unified-sources.sh
+++ b/Source/WebKit/Scripts/generate-unified-sources.sh
@@ -18,7 +18,7 @@ if [ $# -eq 0 ]; then
     echo "Using unified source list files: Sources.txt, SourcesCocoa.txt, Platform/Sources.txt, Platform/SourcesCocoa.txt"
 fi
 
-UnifiedSourceCppFileCount=137
+UnifiedSourceCppFileCount=140
 UnifiedSourceCFileCount=0
 UnifiedSourceMmFileCount=80
 

--- a/Source/WebKit/Shared/NativeWebMouseEvent.h
+++ b/Source/WebKit/Shared/NativeWebMouseEvent.h
@@ -31,6 +31,7 @@
 #if USE(APPKIT)
 #include <wtf/RetainPtr.h>
 OBJC_CLASS NSView;
+OBJC_CLASS NSEvent;
 #endif
 
 #if PLATFORM(GTK)

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -404,6 +404,7 @@ UIProcess/ProcessThrottler.cpp
 UIProcess/ProvisionalFrameProxy.cpp
 UIProcess/ProvisionalPageProxy.cpp
 UIProcess/RemotePageDrawingAreaProxy.cpp
+UIProcess/RemotePageFullscreenManagerProxy.cpp
 UIProcess/RemotePageProxy.cpp
 UIProcess/ResponsivenessTimer.cpp
 UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp

--- a/Source/WebKit/UIProcess/RemotePageFullscreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageFullscreenManagerProxy.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemotePageFullscreenManagerProxy.h"
+
+#if ENABLE(FULLSCREEN_API)
+
+#include "WebFullScreenManagerProxy.h"
+#include "WebFullScreenManagerProxyMessages.h"
+
+namespace WebKit {
+
+Ref<RemotePageFullscreenManagerProxy> RemotePageFullscreenManagerProxy::create(WebCore::PageIdentifier identifier, WebFullScreenManagerProxy* manager, WebProcessProxy& process)
+{
+    return adoptRef(*new RemotePageFullscreenManagerProxy(identifier, manager, process));
+}
+
+RemotePageFullscreenManagerProxy::RemotePageFullscreenManagerProxy(WebCore::PageIdentifier identifier, WebFullScreenManagerProxy* manager, WebProcessProxy& process)
+    : m_identifier(identifier)
+    , m_manager(manager)
+    , m_process(process)
+{
+    process.addMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_identifier, *this);
+}
+
+RemotePageFullscreenManagerProxy::~RemotePageFullscreenManagerProxy()
+{
+    m_process->removeMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_identifier);
+}
+
+void RemotePageFullscreenManagerProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+{
+    if (RefPtr manager = m_manager.get())
+        manager->didReceiveMessage(connection, decoder);
+}
+
+bool RemotePageFullscreenManagerProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+{
+    if (RefPtr manager = m_manager.get())
+        return manager->didReceiveSyncMessage(connection, decoder, replyEncoder);
+    return false;
+}
+
+}
+#endif

--- a/Source/WebKit/UIProcess/RemotePageFullscreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageFullscreenManagerProxy.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(FULLSCREEN_API)
+
+#include "MessageReceiver.h"
+#include <WebCore/PageIdentifier.h>
+
+namespace WebKit {
+
+class WebFullScreenManagerProxy;
+class WebProcessProxy;
+
+class RemotePageFullscreenManagerProxy : public IPC::MessageReceiver, public RefCounted<RemotePageFullscreenManagerProxy> {
+public:
+    static Ref<RemotePageFullscreenManagerProxy> create(WebCore::PageIdentifier, WebFullScreenManagerProxy*, WebProcessProxy&);
+
+    ~RemotePageFullscreenManagerProxy();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+private:
+    RemotePageFullscreenManagerProxy(WebCore::PageIdentifier, WebFullScreenManagerProxy*, WebProcessProxy&);
+
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+
+    const WebCore::PageIdentifier m_identifier;
+    const WeakPtr<WebFullScreenManagerProxy> m_manager;
+    const Ref<WebProcessProxy> m_process;
+};
+
+}
+#endif

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -36,6 +36,7 @@
 #include "PageLoadState.h"
 #include "ProvisionalFrameProxy.h"
 #include "RemotePageDrawingAreaProxy.h"
+#include "RemotePageFullscreenManagerProxy.h"
 #include "RemotePageVisitedLinkStoreRegistration.h"
 #include "WebFrameProxy.h"
 #include "WebPageMessages.h"
@@ -87,6 +88,9 @@ void RemotePageProxy::injectPageIntoNewProcess()
     RELEASE_ASSERT(drawingArea);
 
     m_drawingArea = RemotePageDrawingAreaProxy::create(*drawingArea, m_process);
+#if ENABLE(FULLSCREEN_API)
+    m_fullscreenManager = RemotePageFullscreenManagerProxy::create(pageID(), page->fullScreenManager(), m_process);
+#endif
     m_visitedLinkStoreRegistration = makeUnique<RemotePageVisitedLinkStoreRegistration>(*page, m_process);
 
     m_process->send(
@@ -106,6 +110,9 @@ void RemotePageProxy::removePageFromProcess()
     if (!m_drawingArea)
         return;
     m_drawingArea = nullptr;
+#if ENABLE(FULLSCREEN_API)
+    m_fullscreenManager = nullptr;
+#endif
     m_visitedLinkStoreRegistration = nullptr;
     m_process->send(Messages::WebPage::Close(), m_webPageID);
 }

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -58,6 +58,7 @@ namespace WebKit {
 
 class NativeWebMouseEvent;
 class RemotePageDrawingAreaProxy;
+class RemotePageFullscreenManagerProxy;
 class RemotePageVisitedLinkStoreRegistration;
 class UserData;
 class WebFrameProxy;
@@ -113,12 +114,15 @@ private:
 
     const WebCore::PageIdentifier m_webPageID;
     const Ref<WebProcessProxy> m_process;
-    WeakPtr<WebPageProxy> m_page;
+    const WeakPtr<WebPageProxy> m_page;
     const WebCore::Site m_site;
+    const UniqueRef<WebProcessActivityState> m_processActivityState;
     RefPtr<RemotePageDrawingAreaProxy> m_drawingArea;
+#if ENABLE(FULLSCREEN_API)
+    RefPtr<RemotePageFullscreenManagerProxy> m_fullscreenManager;
+#endif
     std::unique_ptr<RemotePageVisitedLinkStoreRegistration> m_visitedLinkStoreRegistration;
     WebPageProxyMessageReceiverRegistration m_messageReceiverRegistration;
-    UniqueRef<WebProcessActivityState> m_processActivityState;
 };
 
 }

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -128,6 +128,9 @@ public:
     bool lockFullscreenOrientation(WebCore::ScreenOrientationType);
     void unlockFullscreenOrientation();
 
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+
 private:
     WebFullScreenManagerProxy(WebPageProxy&, WebFullScreenManagerProxyClient&);
 
@@ -140,9 +143,6 @@ private:
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame);
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame);
     void callCloseCompletionHandlers();
-
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }

--- a/Source/WebKit/UnifiedSources-output.xcfilelist
+++ b/Source/WebKit/UnifiedSources-output.xcfilelist
@@ -55,8 +55,11 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource134.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource135.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource136.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource137.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource138.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource139.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource14-mm.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource14.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource140.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource15-mm.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource15.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/unified-sources/UnifiedSource16-mm.mm

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2512,6 +2512,9 @@
 		FA4FE2662B75EB290016E671 /* CoreIPCNull.mm in Sources */ = {isa = PBXBuildFile; fileRef = FA4FE2642B75EAFF0016E671 /* CoreIPCNull.mm */; };
 		FAA4E3012A1575A5003F5E50 /* WebFrameLoaderClient.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA4E2FF2A1575A4003F5E50 /* WebFrameLoaderClient.h */; };
 		FAB955FB2B75E43D0060829C /* CoreIPCNull.h in Headers */ = {isa = PBXBuildFile; fileRef = FAB955F92B75E43D0060829C /* CoreIPCNull.h */; };
+		FABBBC842D35B59A00820017 /* UnifiedSource140.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FABBBC832D35B59A00820017 /* UnifiedSource140.cpp */; };
+		FABBBC852D35B59A00820017 /* UnifiedSource138.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FABBBC812D35B59A00820017 /* UnifiedSource138.cpp */; };
+		FABBBC862D35B59A00820017 /* UnifiedSource139.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FABBBC822D35B59A00820017 /* UnifiedSource139.cpp */; };
 		FABBDEA12B85557500EFAFC4 /* CoreIPCNSURLCredential.mm in Sources */ = {isa = PBXBuildFile; fileRef = FABBDE9E2B85550100EFAFC4 /* CoreIPCNSURLCredential.mm */; };
 		FAD2A1EE2BF6D51000953297 /* CoroutineUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = FAD2A1ED2BF6D4FD00953297 /* CoroutineUtilities.h */; };
 		FAE61CE62D0A5608000D238D /* UnifiedSource132.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAE61CDF2D0A5606000D238D /* UnifiedSource132.cpp */; };
@@ -8333,6 +8336,11 @@
 		FAB751D12BACB65D00AC26DB /* APIPageConfigurationCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = APIPageConfigurationCocoa.mm; sourceTree = "<group>"; };
 		FAB955F92B75E43D0060829C /* CoreIPCNull.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCNull.h; sourceTree = "<group>"; };
 		FAB955FA2B75E43D0060829C /* CoreIPCNull.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCNull.serialization.in; sourceTree = "<group>"; };
+		FABBBC7F2D35AC6800820017 /* RemotePageFullscreenManagerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemotePageFullscreenManagerProxy.h; sourceTree = "<group>"; };
+		FABBBC802D35AC6800820017 /* RemotePageFullscreenManagerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemotePageFullscreenManagerProxy.cpp; sourceTree = "<group>"; };
+		FABBBC812D35B59A00820017 /* UnifiedSource138.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource138.cpp; path = "UnifiedSource138.cpp"; sourceTree = "<group>"; };
+		FABBBC822D35B59A00820017 /* UnifiedSource139.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource139.cpp; path = "UnifiedSource139.cpp"; sourceTree = "<group>"; };
+		FABBBC832D35B59A00820017 /* UnifiedSource140.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource140.cpp; path = "UnifiedSource140.cpp"; sourceTree = "<group>"; };
 		FABBDE9D2B85550000EFAFC4 /* CoreIPCNSURLCredential.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCNSURLCredential.h; sourceTree = "<group>"; };
 		FABBDE9E2B85550100EFAFC4 /* CoreIPCNSURLCredential.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCNSURLCredential.mm; sourceTree = "<group>"; };
 		FAC3C3BA2A93E561001E2EB8 /* RemoteScrollingCoordinatorTransaction.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = RemoteScrollingCoordinatorTransaction.serialization.in; sourceTree = "<group>"; };
@@ -11056,6 +11064,9 @@
 				FAE61CE42D0A5607000D238D /* UnifiedSource135.cpp */,
 				FAE61CE12D0A5606000D238D /* UnifiedSource136.cpp */,
 				FAE61CE32D0A5607000D238D /* UnifiedSource137.cpp */,
+				FABBBC812D35B59A00820017 /* UnifiedSource138.cpp */,
+				FABBBC822D35B59A00820017 /* UnifiedSource139.cpp */,
+				FABBBC832D35B59A00820017 /* UnifiedSource140.cpp */,
 			);
 			path = "unified-sources";
 			sourceTree = "<group>";
@@ -14222,6 +14233,8 @@
 				1AEE57242409F142002005D6 /* QuickLookThumbnailLoader.mm */,
 				5CCB54DC2A4FEA6A0005FAA8 /* RemotePageDrawingAreaProxy.cpp */,
 				5CCB54DB2A4FEA6A0005FAA8 /* RemotePageDrawingAreaProxy.h */,
+				FABBBC802D35AC6800820017 /* RemotePageFullscreenManagerProxy.cpp */,
+				FABBBC7F2D35AC6800820017 /* RemotePageFullscreenManagerProxy.h */,
 				5C907E9A294D507100B3402D /* RemotePageProxy.cpp */,
 				5C907E99294D507100B3402D /* RemotePageProxy.h */,
 				5CEB40A22A534EE100563C91 /* RemotePageVisitedLinkStoreRegistration.h */,
@@ -20031,6 +20044,9 @@
 				FAE61CEB2D0A5608000D238D /* UnifiedSource135.cpp in Sources */,
 				FAE61CE82D0A5608000D238D /* UnifiedSource136.cpp in Sources */,
 				FAE61CEA2D0A5608000D238D /* UnifiedSource137.cpp in Sources */,
+				FABBBC852D35B59A00820017 /* UnifiedSource138.cpp in Sources */,
+				FABBBC862D35B59A00820017 /* UnifiedSource139.cpp in Sources */,
+				FABBBC842D35B59A00820017 /* UnifiedSource140.cpp in Sources */,
 				078B04442CF1149200B453A6 /* URLSchemeHandler.swift in Sources */,
 				078B04B62CF2B4D300B453A6 /* View+WebViewModifiers.swift in Sources */,
 				52CDC5C62731DA0D00A3E3EB /* VirtualAuthenticatorManager.cpp in Sources */,


### PR DESCRIPTION
#### 8bcb61bb1e0f746f0e58e8a0719a72196b796d15
<pre>
Add initial infrastructure for implementing fullscreen with site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=285873">https://bugs.webkit.org/show_bug.cgi?id=285873</a>
<a href="https://rdar.apple.com/142835496">rdar://142835496</a>

Reviewed by Charlie Wolfe.

InjectedBundlePageFullScreenClient::enterFullScreenForElement sends a message
Messages::WebFullScreenManagerProxy::EnterFullScreen to the UI process, but
with site isolation the WebFullScreenManagerProxy is only registered to listen
for IPC from the main frame process.  To have an object in the UI process
to communicate with, I follow a pattern similar to RemotePageDrawingAreaProxy
and create an object owned by the RemotePageProxy.  Initially, it does nothing
but forward IPC to the WebFullScreenManagerProxy.  I see fullscreen requests
proceeding further than they did before, but they still don&apos;t work quite right.
This is only the beginning piece.

* Source/WebKit/Scripts/generate-unified-sources.sh:
* Source/WebKit/Shared/NativeWebMouseEvent.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/RemotePageFullscreenManagerProxy.cpp: Added.
(WebKit::RemotePageFullscreenManagerProxy::create):
(WebKit::RemotePageFullscreenManagerProxy::RemotePageFullscreenManagerProxy):
(WebKit::RemotePageFullscreenManagerProxy::~RemotePageFullscreenManagerProxy):
(WebKit::RemotePageFullscreenManagerProxy::didReceiveMessage):
(WebKit::RemotePageFullscreenManagerProxy::didReceiveSyncMessage):
* Source/WebKit/UIProcess/RemotePageFullscreenManagerProxy.h: Added.
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::injectPageIntoNewProcess):
* Source/WebKit/UIProcess/RemotePageProxy.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UnifiedSources-output.xcfilelist:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/288830@main">https://commits.webkit.org/288830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89da53102415d2f43d4ffbc96707b8c39ef58c31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89735 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35647 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65844 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23674 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87641 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46116 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/84004 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3218 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34722 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91109 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11935 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74314 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72688 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17806 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/16248 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3374 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13166 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11887 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11721 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15215 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13467 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->