### PR TITLE
e2e3: expose crypto.subtle.generateUserKey() and add feature flag

### DIFF
--- a/LayoutTests/http/wpt/crypto/setE2EEncryptedEmailEnabled.https-expected.txt
+++ b/LayoutTests/http/wpt/crypto/setE2EEncryptedEmailEnabled.https-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: Test finished.
+

--- a/LayoutTests/http/wpt/crypto/setE2EEncryptedEmailEnabled.https.html
+++ b/LayoutTests/http/wpt/crypto/setE2EEncryptedEmailEnabled.https.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>
+        Check that parts of the Digital Credentials API exposure
+        is controlled via preference.
+    </title>
+</head>
+<script>
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    async function runTest() {
+        checkWindowObject();
+
+        window.internals.settings.setE2EEncryptedEmailEnabled(false);
+
+        try {
+            await checkIFrame();
+        } catch (err) {
+            console.log(err);
+        } finally {
+            testRunner.notifyDone();
+        }
+        console.log("Test finished.");
+    }
+
+    function checkWindowObject() {
+        // on by default, because it's testable in the preferences .yaml file
+        if (window.crypto.subtle.generateUserKey === undefined) {
+            console.log(
+                "FAIL: generateUserKey() must be exposed as a function. Was enabled by pref."
+            );
+        }
+    }
+
+    async function checkIFrame() {
+        const iframe = document.querySelector("iframe");
+        await new Promise((r) => {
+            iframe.onload = r;
+            iframe.src = "about:blank";
+        });
+        const iframeWindow = iframe.contentWindow;
+        if ("generateUserKey" in iframeWindow.crypto.subtle) {
+            console.log("FAIL: generateUserKey() is disabled by preference.");
+        }
+    }
+</script>
+
+<body onload="runTest()">
+    <iframe></iframe>
+</body>
+
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2766,6 +2766,23 @@ DynamicSiteInterventionsEnabled:
     WebCore:
       default: false
 
+E2EEncryptedEmailEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "E2E Encrypted Email"
+  humanReadableDescription: "End-to-end encrypted email support"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  disableInLockdownMode: true
+  sharedPreferenceForWebProcess: true
+  richJavaScript: true
+
 EditableLinkBehavior:
   type: uint32_t
   refinedType: WebCore::EditableLinkBehavior

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -939,6 +939,7 @@ set(WebCore_NON_SVG_IDL_FILES
     crypto/JsonWebKey.idl
     crypto/RsaOtherPrimesInfo.idl
     crypto/SubtleCrypto.idl
+    crypto/UserCryptoKeyParams.idl
 
     crypto/keys/CryptoAesKeyAlgorithm.idl
     crypto/keys/CryptoEcKeyAlgorithm.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1233,6 +1233,7 @@ $(PROJECT_DIR)/crypto/CryptoKeyUsage.idl
 $(PROJECT_DIR)/crypto/JsonWebKey.idl
 $(PROJECT_DIR)/crypto/RsaOtherPrimesInfo.idl
 $(PROJECT_DIR)/crypto/SubtleCrypto.idl
+$(PROJECT_DIR)/crypto/UserCryptoKeyParams.idl
 $(PROJECT_DIR)/crypto/keys/CryptoAesKeyAlgorithm.idl
 $(PROJECT_DIR)/crypto/keys/CryptoEcKeyAlgorithm.idl
 $(PROJECT_DIR)/crypto/keys/CryptoHmacKeyAlgorithm.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -3090,6 +3090,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUnknownCredentialOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUnknownCredentialOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUserActivation.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUserActivation.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUserCryptoKeyParams.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUserCryptoKeyParams.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUserMessageHandler.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUserMessageHandler.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUserMessageHandlersNamespace.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -955,6 +955,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/crypto/JsonWebKey.idl \
     $(WebCore)/crypto/RsaOtherPrimesInfo.idl \
     $(WebCore)/crypto/SubtleCrypto.idl \
+    $(WebCore)/crypto/UserCryptoKeyParams.idl \
     $(WebCore)/crypto/keys/CryptoAesKeyAlgorithm.idl \
     $(WebCore)/crypto/keys/CryptoEcKeyAlgorithm.idl \
     $(WebCore)/crypto/keys/CryptoHmacKeyAlgorithm.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -882,6 +882,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     crypto/JsonWebKey.h
     crypto/RsaOtherPrimesInfo.h
     crypto/SerializedCryptoKeyWrap.h
+    crypto/UserCryptoKeyParams.h
     crypto/WrappedCryptoKey.h
 
     crypto/keys/CryptoAesKeyAlgorithm.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4782,6 +4782,7 @@ JSUserActivation.cpp
 JSUndoItem.cpp
 JSUndoManager.cpp
 JSUnknownCredentialOptions.cpp
+JSUserCryptoKeyParams.cpp
 JSUserMessageHandler.cpp
 JSUserMessageHandlersNamespace.cpp
 JSUserVerificationRequirement.cpp

--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -1303,4 +1303,9 @@ void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, Buffe
     unwrapAlgorithm->decrypt(*unwrapParams, unwrappingKey, WTFMove(wrappedKey), WTFMove(callback), WTFMove(exceptionCallback), *scriptExecutionContext(), m_workQueue);
 }
 
+void SubtleCrypto::generateUserKey(SubtleCrypto::AlgorithmIdentifier&&, Vector<CryptoKeyUsage>&&, Ref<DeferredPromise>&& promise)
+{
+    promise->reject(Exception { ExceptionCode::NotSupportedError });
+}
+
 } // namespace WebCore

--- a/Source/WebCore/crypto/SubtleCrypto.h
+++ b/Source/WebCore/crypto/SubtleCrypto.h
@@ -73,6 +73,7 @@ public:
     void exportKey(KeyFormat, CryptoKey&, Ref<DeferredPromise>&&);
     void wrapKey(JSC::JSGlobalObject&, KeyFormat, CryptoKey&, CryptoKey& wrappingKey, AlgorithmIdentifier&& wrapAlgorithm, Ref<DeferredPromise>&&);
     void unwrapKey(JSC::JSGlobalObject&, KeyFormat, BufferSource&& wrappedKey, CryptoKey& unwrappingKey, AlgorithmIdentifier&& unwrapAlgorithm, AlgorithmIdentifier&& unwrappedKeyAlgorithm, bool extractable, Vector<CryptoKeyUsage>&&, Ref<DeferredPromise>&&);
+    void generateUserKey(AlgorithmIdentifier&&, Vector<CryptoKeyUsage>&&, Ref<DeferredPromise>&&);
 
 private:
     explicit SubtleCrypto(ScriptExecutionContext*);

--- a/Source/WebCore/crypto/SubtleCrypto.idl
+++ b/Source/WebCore/crypto/SubtleCrypto.idl
@@ -44,4 +44,5 @@ typedef (object or DOMString) AlgorithmIdentifier;
     Promise<any> exportKey(KeyFormat format, CryptoKey key);
     [CallWith=CurrentGlobalObject] Promise<any> wrapKey(KeyFormat format, CryptoKey key, CryptoKey wrappingKey, AlgorithmIdentifier wrapAlgorithm);
     [CallWith=CurrentGlobalObject] Promise<CryptoKey> unwrapKey(KeyFormat format, BufferSource wrappedKey, CryptoKey unwrappingKey, AlgorithmIdentifier unwrapAlgorithm, AlgorithmIdentifier unwrappedKeyAlgorithm, boolean extractable, sequence<CryptoKeyUsage> keyUsages);
+    [EnabledBySetting=E2EEncryptedEmailEnabled] Promise<any> generateUserKey(AlgorithmIdentifier algorithm, sequence<CryptoKeyUsage> keyUsages);
 };

--- a/Source/WebCore/crypto/UserCryptoKeyParams.h
+++ b/Source/WebCore/crypto/UserCryptoKeyParams.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+struct UserCryptoKeyParams {
+    String userIdentifier;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/UserCryptoKeyParams.idl
+++ b/Source/WebCore/crypto/UserCryptoKeyParams.idl
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+dictionary UserCryptoKeyParams {
+  required DOMString userIdentifier;
+};

--- a/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
@@ -953,6 +953,16 @@ bool WKPreferencesGetEncodingDetectorEnabled(WKPreferencesRef preferencesRef)
     return toImpl(preferencesRef)->usesEncodingDetector();
 }
 
+void WKPreferencesSetE2EEncryptedEmailEnabled(WKPreferencesRef preferencesRef, bool enabled)
+{
+    toImpl(preferencesRef)->setE2EEncryptedEmailEnabled(enabled);
+}
+
+bool WKPreferencesGetE2EEncryptedEmailEnabled(WKPreferencesRef preferencesRef)
+{
+    return toImpl(preferencesRef)->e2EEncryptedEmailEnabled();
+}
+
 void WKPreferencesSetTextAutosizingEnabled(WKPreferencesRef preferencesRef, bool textAutosizingEnabled)
 {
     toImpl(preferencesRef)->setTextAutosizingEnabled(textAutosizingEnabled);

--- a/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
@@ -430,6 +430,10 @@ WK_EXPORT void WKPreferencesSetWebAuthenticationEnabled(WKPreferencesRef, bool f
 WK_EXPORT bool WKPreferencesGetWebAuthenticationEnabled(WKPreferencesRef);
 
 // Defaults to false
+WK_EXPORT void WKPreferencesSetE2EEncryptedEmailEnabled(WKPreferencesRef, bool flag);
+WK_EXPORT bool WKPreferencesGetE2EEncryptedEmailEnabled(WKPreferencesRef);
+
+// Defaults to false
 WK_EXPORT void WKPreferencesSetDigitalCredentialsEnabled(WKPreferencesRef, bool flag);
 WK_EXPORT bool WKPreferencesGetDigitalCredentialsEnabled(WKPreferencesRef);
 


### PR DESCRIPTION
#### 69d9cef9e72c84ad34ad2051fcc9341a7fd9c9d0
<pre>
e2e3: Implement feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=285875">https://bugs.webkit.org/show_bug.cgi?id=285875</a>
<a href="https://rdar.apple.com/142837102">rdar://142837102</a>

Reviewed by NOBODY (OOPS!).

Implement feature flag for e2e3 and exposes crypto.generateUserKey() method from:
<a href="https://github.com/WebKit/explainers/tree/main/remote-cryptokeys">https://github.com/WebKit/explainers/tree/main/remote-cryptokeys</a>

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/8517205c81e60b9237480731977c3f6c6ad08640">https://github.com/web-platform-tests/wpt/commit/8517205c81e60b9237480731977c3f6c6ad08640</a>

* LayoutTests/http/wpt/crypto/setE2EEncryptedEmailEnabled.https-expected.txt: Added.
* LayoutTests/http/wpt/crypto/setE2EEncryptedEmailEnabled.https.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::SubtleCrypto::generateUserKey):
* Source/WebCore/crypto/SubtleCrypto.h:
* Source/WebCore/crypto/SubtleCrypto.idl:
* Source/WebCore/crypto/UserCryptoKeyParams.h: Added.
* Source/WebCore/crypto/UserCryptoKeyParams.idl: Added.
* Source/WebKit/UIProcess/API/C/WKPreferences.cpp:
(WKPreferencesSetE2EEncryptedEmailEnabled):
(WKPreferencesGetE2EEncryptedEmailEnabled):
* Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69d9cef9e72c84ad34ad2051fcc9341a7fd9c9d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98295 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43822 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71300 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28694 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51633 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9554 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2023 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43136 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86006 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79840 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100326 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91962 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80321 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79636 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24180 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1512 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13468 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20332 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25509 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114612 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20019 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33055 "Found 11 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.bytecode-cache, microbenchmarks/memcpy-wasm-medium.js.default, microbenchmarks/memcpy-wasm-small.js.dfg-eager, microbenchmarks/memcpy-wasm-small.js.no-llint, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-collect-continuously, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-collect-continuously, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-slow-memory, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager, wasm.yaml/wasm/stress/repro_1289.js.wasm-collect-continuously, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch.js.wasm-slow-memory ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21760 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->