### PR TITLE
[ Sequoia wk2 ] two accessibility/mac/ pdf tests are a consistent timeout

### DIFF
--- a/LayoutTests/accessibility/mac/basic-embed-pdf-accessibility-expected.txt
+++ b/LayoutTests/accessibility/mac/basic-embed-pdf-accessibility-expected.txt
@@ -7,14 +7,12 @@ PASS: pdfEmbedElement.childrenCount === 1
 PASS: pdfAxObject.stringAttributeValue('AXSubrole') === 'AXPDFPluginSubrole'
 PASS: pdfAxObject.childrenCount === 1
 PASS: pdfAxObject.parentElement().domIdentifier === 'pdfEmbed'
-PASS: pdfLayerController.stringAttributeValue('AXRole') === 'AXGroup'
-PASS: pdfLayerController.stringAttributeValue('AXDescription') === 'document'
+PASS: pdfPageObject.role === 'AXRole: AXPage'
 PASS: pdfTextNode.stringAttributeValue('AXRole') === 'AXStaticText'
-PASS: pdfTextNode.stringAttributeValue('AXValue').trimEnd() === 'Welcome to the website for the WebKit Open Source Project!'
+PASS: pdfTextNode.stringValue.split(' ')[1] === 'Welcome'
 PASS: hitTestResult.stringAttributeValue('AXRole') === 'AXGroup'
-PASS: hitTestResult.stringAttributeValue('AXDescription') === 'document'
 PASS: pdfTextNode.stringAttributeValue('AXRole') === 'AXStaticText'
-PASS: pdfTextNode.stringAttributeValue('AXValue').trimEnd() === 'Welcome to the website for the WebKit Open Source Project!'
+PASS: pdfTextNode.stringValue.split(' ')[1] === 'Welcome'
 PASS: searchResultElement.stringAttributeValue('AXSubrole') === 'AXPDFPluginSubrole'
 
 PASS successfullyParsed is true

--- a/LayoutTests/accessibility/mac/basic-embed-pdf-accessibility.html
+++ b/LayoutTests/accessibility/mac/basic-embed-pdf-accessibility.html
@@ -3,6 +3,7 @@
 <head>
 <script src="../../resources/js-test.js"></script>
 <script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/ui-helper.js"></script>
 </head>
 <body>
 
@@ -11,94 +12,75 @@
 </div>
 
 <script>
-    let output = "This test ensures PDFs loaded in embed tags are exposed in the accessibility tree.\n\n";
+let output = "This test ensures PDFs loaded in embed tags are exposed in the accessibility tree.\n\n";
 
-    async function traverseChildrenWithPath(startObject, traversalPath) {
-        let currentObject = startObject;
-        for (let index of traversalPath) {
-            await waitFor(() => {
-                return currentObject.childAtIndex(index);
-            });
-            currentObject = currentObject.childAtIndex(index);
-        }
-        return currentObject;
-    }
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
 
-    if (window.accessibilityController) {
-        window.jsTestIsAsync = true;
-
-        var hitTestResult, pdfAxObject, pdfEmbedElement, pdfLayerController, searchResultElement;
-        requestAnimationFrame(async function() {
-            await new Promise((resolve) => setTimeout(resolve, 0)); // Wait for the embed plugin to load after style update.
-
-            // First, ensure the <embed> and the PDF inside the <embed> are completely initialized.
-            // It would be nice if we could listen for an <embed> load event to be fired, but WebKit erroneously
-            // doesn't fire those for <embed>s: https://bugs.webkit.org/show_bug.cgi?id=230054
-            await waitFor(() => {
-                embedContainer = accessibilityController.accessibleElementById("embedContainer");
-                return embedContainer && embedContainer.childrenCount >= 1;
-            });
-            await waitFor(() => {
-                pdfEmbedElement = accessibilityController.accessibleElementById("pdfEmbed");
-                return pdfEmbedElement && pdfEmbedElement.children.length >= 1;
-            });
-            await waitFor(() => {
-                pdfAxObject = pdfEmbedElement.childAtIndex(0);
-                return pdfAxObject && pdfAxObject.children.length >= 1;
-            });
-            await waitFor(() => {
-                pdfLayerController = pdfAxObject.childAtIndex(0);
-                return pdfLayerController && pdfLayerController.children.length >= 1;
-            });
-
-            output += expect("pdfEmbedElement.domIdentifier", "'pdfEmbed'");
-            output += expect("pdfEmbedElement.role", "'AXRole: AXGroup'");
-            // Verify the group that contains the PDF AX object isn't considered empty via an AXEmptyGroup subrole.
-            output += expect("pdfEmbedElement.subrole", "'AXSubrole: AXApplicationGroup'");
-            output += expect("pdfEmbedElement.childrenCount", "1");
-
-            output += expect("pdfAxObject.stringAttributeValue('AXSubrole')", "'AXPDFPluginSubrole'");
-            output += expect("pdfAxObject.childrenCount", "1");
-            // Ensure the PDF accessibility object considers the embed element to be its parent.
-            output += expect("pdfAxObject.parentElement().domIdentifier", "'pdfEmbed'");
-
-            output += expect("pdfLayerController.stringAttributeValue('AXRole')", "'AXGroup'");
-            output += expect("pdfLayerController.stringAttributeValue('AXDescription')", "'document'");
-
-            traversalPathToTextNode = [0, 0, 0, 0, 1, 0, 0];
-            pdfTextNode = await traverseChildrenWithPath(pdfLayerController, traversalPathToTextNode);
-            output += expect("pdfTextNode.stringAttributeValue('AXRole')", "'AXStaticText'");
-            output += expect("pdfTextNode.stringAttributeValue('AXValue').trimEnd()", "'Welcome to the website for the WebKit Open Source Project!'");
-
-            // Ensure we can hit test onto the PDF.
-            await waitFor(() => {
-                domPdfEmbedElement = document.getElementById("pdfEmbed");
-                if (!domPdfEmbedElement)
-                    return false;
-
-                hitTestResult = accessibilityController.elementAtPoint(
-                    domPdfEmbedElement.offsetLeft + (domPdfEmbedElement.offsetWidth / 2),
-                    domPdfEmbedElement.offsetTop + (domPdfEmbedElement.offsetHeight / 2),
-                );
-                return hitTestResult;
-            });
-            output += expect("hitTestResult.stringAttributeValue('AXRole')", "'AXGroup'");
-            output += expect("hitTestResult.stringAttributeValue('AXDescription')", "'document'");
-            pdfTextNode = await traverseChildrenWithPath(hitTestResult, traversalPathToTextNode);
-            output += expect("pdfTextNode.stringAttributeValue('AXRole')", "'AXStaticText'");
-            output += expect("pdfTextNode.stringAttributeValue('AXValue').trimEnd()", "'Welcome to the website for the WebKit Open Source Project!'");
-
-            // Ensure a search from the embed element returns the PDF accessibility object.
-            await waitFor(() => {
-                searchResultElement = pdfEmbedElement.uiElementForSearchPredicate(null, true, "AXAnyTypeSearchKey", "", false);
-                return searchResultElement;
-            });
-            output += expect("searchResultElement.stringAttributeValue('AXSubrole')", "'AXPDFPluginSubrole'");
-
-            debug(output);
-            finishJSTest();
+    var hitTestResult, pdfAxObject, pdfEmbedElement, pdfPageObject, searchResultElement;
+    setTimeout(async function() {
+        await waitFor(() => {
+            embedContainer = accessibilityController.accessibleElementById("embedContainer");
+            return embedContainer && embedContainer.childrenCount >= 1;
         });
-    }
+        await waitFor(() => {
+            pdfEmbedElement = accessibilityController.accessibleElementById("pdfEmbed");
+            return pdfEmbedElement && pdfEmbedElement.childrenCount >= 1;
+        });
+        await waitFor(() => {
+            pdfAxObject = pdfEmbedElement.childAtIndex(0);
+            return pdfAxObject && pdfAxObject.childrenCount >= 1;
+        });
+        await waitFor(() => {
+            pdfPageObject = findFirstPageDescendant(pdfAxObject);
+            return pdfPageObject && pdfPageObject.childrenCount >= 1;
+        });
+
+        output += expect("pdfEmbedElement.domIdentifier", "'pdfEmbed'");
+        output += expect("pdfEmbedElement.role", "'AXRole: AXGroup'");
+        // Verify the group that contains the PDF AX object isn't considered empty via an AXEmptyGroup subrole.
+        output += expect("pdfEmbedElement.subrole", "'AXSubrole: AXApplicationGroup'");
+        output += expect("pdfEmbedElement.childrenCount", "1");
+
+        output += expect("pdfAxObject.stringAttributeValue('AXSubrole')", "'AXPDFPluginSubrole'");
+        output += expect("pdfAxObject.childrenCount", "1");
+        // Ensure the PDF accessibility object considers the embed element to be its parent.
+        output += expect("pdfAxObject.parentElement().domIdentifier", "'pdfEmbed'");
+
+        output += expect("pdfPageObject.role", "'AXRole: AXPage'");
+        await waitFor(() => {
+            pdfTextNode = traverseChildrenToFirstStaticText(pdfPageObject);
+            return pdfTextNode;
+        });
+
+        output += expect("pdfTextNode.stringAttributeValue('AXRole')", "'AXStaticText'");
+        // Get the first word in the string, since the hierarchy can differ for different OS versions.
+        output += expect("pdfTextNode.stringValue.split(' ')[1]", "'Welcome'");
+
+        let domPdfEmbedElement = document.getElementById("pdfEmbed");
+        hitTestResult = accessibilityController.elementAtPoint(
+            domPdfEmbedElement.offsetLeft + (domPdfEmbedElement.offsetWidth / 2),
+            domPdfEmbedElement.offsetTop + (domPdfEmbedElement.offsetHeight / 2),
+        );
+        output += expect("hitTestResult.stringAttributeValue('AXRole')", "'AXGroup'");
+        await waitFor(() => {
+            pdfTextNode = traverseChildrenToFirstStaticText(hitTestResult);
+            return pdfTextNode;
+        })
+        output += expect("pdfTextNode.stringAttributeValue('AXRole')", "'AXStaticText'");
+        output += expect("pdfTextNode.stringValue.split(' ')[1]", "'Welcome'");
+
+        // Ensure a search from the embed element returns the PDF accessibility object.
+        await waitFor(() => {
+            searchResultElement = pdfEmbedElement.uiElementForSearchPredicate(null, true, "AXAnyTypeSearchKey", "", false);
+            return searchResultElement;
+        });
+        output += expect("searchResultElement.stringAttributeValue('AXSubrole')", "'AXPDFPluginSubrole'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/accessibility/mac/iframe-pdf-expected.txt
+++ b/LayoutTests/accessibility/mac/iframe-pdf-expected.txt
@@ -1,24 +1,9 @@
 This test ensures PDFs loaded in iframes are exposed in the accessibility tree.
 
-Traversal path to text node inside PDF:
 
-At index 0, got AXRole: AXScrollArea
-At index 0, got AXRole: AXWebArea
-At index 0, got AXRole: AXGroup
-At index 0, got AXRole: AXGroup
-At index 0, got AXRole: AXGroup
-At index 0, got AXRole: AXPage
-At index 0, got AXRole: AXGroup
-At index 0, got AXRole: AXGroup
-At index 0, got AXRole: AXGroup
-At index 1, got AXRole: AXGroup
-At index 0, got AXRole: AXGroup
-At index 0, got AXRole: AXStaticText
-
-Found object:
+Found text object:
 AXRole: AXStaticText
-AXValue: Welcome to the website for the WebKit Open Source Project!
-
+First word: Welcome
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/mac/iframe-pdf.html
+++ b/LayoutTests/accessibility/mac/iframe-pdf.html
@@ -13,37 +13,23 @@
 <script>
     var testOutput = "This test ensures PDFs loaded in iframes are exposed in the accessibility tree.\n\n";
 
-    function traverseChildrenWithPath(startObject, traversalPath) {
-        if (!startObject)
-            return [];
-
-        let traversalString = "";
-        let currentObject = startObject;
-        for (let index of traversalPath) {
-            currentObject = currentObject.childAtIndex(index);
-            if (!currentObject)
-                return [];
-            traversalString += `At index ${index}, got ${currentObject.role}\n`;
-        }
-        return [traversalString, currentObject];
-    }
-
     if (window.accessibilityController) {
-        var textNode, traversalString;
+        var textNode, traversalString, pageObject;
         setTimeout(async function() {
             // This test is async because we may need to try the traversal a few times before the iframe
             // and the PDF inside the iframe are fully loaded.
             await waitFor(() => {
-                let container = accessibilityController.accessibleElementById("container");
-                [traversalString, textNode] = traverseChildrenWithPath(container, [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0]);
+                pageObject = findFirstPageDescendant(accessibilityController.accessibleElementById("container"));
+                if (!pageObject)
+                    return false;
+
+                textNode = traverseChildrenToFirstStaticText(pageObject);
                 return textNode;
             });
-            testOutput += "Traversal path to text node inside PDF:\n\n";
-            testOutput += traversalString;
 
-            testOutput += "\nFound object:\n";
+            testOutput += "\nFound text object:\n";
             testOutput += `${textNode.role}\n`;
-            testOutput += `${textNode.stringValue.trimEnd()}\n`;
+            testOutput += `First word: ${textNode.stringValue.split(" ")[1]}`; // Get first word (omit 'AXValue')
 
             debug(testOutput);
             finishJSTest();

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1880,9 +1880,6 @@ imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-
 # webkit.org/b/277908 [ iOS macOS Debug wk2 ] imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator-with-window-tracks.https.html is a flaky text failure
 [ Debug ] imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator-with-window-tracks.https.html [ Pass Failure ]
 
-webkit.org/b/281531 [ Sequoia+ ] accessibility/mac/basic-embed-pdf-accessibility.html [ Timeout ]
-webkit.org/b/281531 [ Sequoia+ ] accessibility/mac/iframe-pdf.html [ Timeout ]
-
 # webkit.org/b/282046 REGRESSION(285592@main): [ macOS iOS wk2 ] http/tests/site-isolation/l oad-event.html are near constant failures.
 http/tests/site-isolation/load-event.html [ Pass Failure ]
 

--- a/LayoutTests/resources/accessibility-helper.js
+++ b/LayoutTests/resources/accessibility-helper.js
@@ -371,3 +371,28 @@ function resetActiveElementAndSelectedChildren(id) {
         child.removeAttribute("aria-selected");
     });
 }
+
+function findFirstPageDescendant(startObject) {
+    if (!startObject || startObject.role == "AXRole: AXPage")
+        return startObject;
+
+    for (let i = 0; i < startObject.childrenCount; i++) {
+        let result = findFirstPageDescendant(startObject.childAtIndex(i));
+        if (result)
+            return result;
+    }
+
+    return null;
+}
+
+function traverseChildrenToFirstStaticText(startObject) {
+    if (!startObject || startObject.role == "AXRole: AXStaticText")
+        return startObject;
+
+    for (let i = 0; i < startObject.childrenCount; i++) {
+        let result = traverseChildrenToFirstStaticText(startObject.childAtIndex(i));
+        if (result)
+            return result;
+    }
+    return null;
+}


### PR DESCRIPTION
#### 85e2ede7862a7216edda0e6eac8e29e97ec01f78
<pre>
[ Sequoia wk2 ] two accessibility/mac/ pdf tests are a consistent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=281531">https://bugs.webkit.org/show_bug.cgi?id=281531</a>
<a href="https://rdar.apple.com/137996591">rdar://137996591</a>

Reviewed by Tyler Wilcock.

These PDF tests assumed that the accessibility hierarchy that is vended from PDFKit
does not change. But, between Sonoma and Sequoia, the structure had changed, causing
these tests with pre-defined paths to fail (specifically, when finding the AXPage and
AXStaticText elements).

These are now updated to use a &quot;search&quot; approach to find elements, rather than
a specific path, to avoid hierarchy assumptions and to increase their resilliency
against future changes.

* LayoutTests/accessibility/mac/basic-embed-pdf-accessibility-expected.txt:
* LayoutTests/accessibility/mac/basic-embed-pdf-accessibility.html:
* LayoutTests/accessibility/mac/iframe-pdf-expected.txt:
* LayoutTests/accessibility/mac/iframe-pdf.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/resources/accessibility-helper.js:

Canonical link: <a href="https://commits.webkit.org/288850@main">https://commits.webkit.org/288850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6a0aeb7874ec325d98caa94b23e093d602d8aae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89736 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35648 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12293 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65855 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23670 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76882 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46115 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3222 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31094 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34723 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74102 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91110 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11936 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74316 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73438 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18163 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17809 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16246 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3375 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11888 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11722 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15216 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13468 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->