### PR TITLE
Try out -Wunsafe-buffer-usage-in-libc-call on the Safer CPP bot

### DIFF
--- a/Configurations/CommonBase.xcconfig
+++ b/Configurations/CommonBase.xcconfig
@@ -44,7 +44,7 @@ WK_GCC_OPTIMIZATION_LEVEL_SANITIZER_OVERRIDE_NO = $(WK_DEFAULT_GCC_OPTIMIZATION_
 WK_GCC_OPTIMIZATION_LEVEL_SANITIZER_OVERRIDE_YES = $(WK_SANITIZER_GCC_OPTIMIZATION_LEVEL);
 
 WK_COMMON_OTHER_CFLAGS = $(WK_SANITIZER_OTHER_CFLAGS);
-OTHER_CFLAGS = $(inherited) $(WK_COMMON_OTHER_CFLAGS);
+OTHER_CFLAGS = $(inherited) $(WK_COMMON_OTHER_CFLAGS) -Wno-elaborated-enum-base;
 
 WK_COMMON_OTHER_CPLUSPLUSFLAGS = $(WK_LIBCPP_ASSERTIONS_CFLAGS) $(WK_SANITIZER_OTHER_CPLUSPLUSFLAGS);
 OTHER_CPLUSPLUSFLAGS = $(inherited) $(WK_COMMON_OTHER_CPLUSPLUSFLAGS);
@@ -64,7 +64,7 @@ GCC_WARN_NON_VIRTUAL_DESTRUCTOR = YES;
 WK_COMMON_WARNING_CFLAGS = -Wall -Wc99-designator -Wconditional-uninitialized -Wextra -Wdeprecated-enum-enum-conversion -Wdeprecated-enum-float-conversion -Wenum-float-conversion -Wfinal-dtor-non-final-class -Wformat=2 -Wmisleading-indentation -Wreorder-init-list -Wundef -Wvla;
 WARNING_CFLAGS = $(inherited) $(WK_COMMON_WARNING_CFLAGS) $(WK_SANITIZER_WARNING_CFLAGS);
 
-WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL = -Wno-unknown-warning-option -Wno-unsafe-buffer-usage-in-libc-call;
+WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL = -Wno-unknown-warning-option -Wunsafe-buffer-usage-in-libc-call;
 WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=macosx13*] = ;
 WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=macosx14*] = ;
 WK_NO_UNSAFE_BUFFER_USAGE_IN_LIBC_CALL[sdk=macosx15.0*] = ;

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -364,6 +364,7 @@ WebProcess::WebProcess()
 
 WebProcess::~WebProcess()
 {
+    /* dummy change to tickle the bot */
     ASSERT_NOT_REACHED();
 }
 


### PR DESCRIPTION
#### af3e503c46439d0106a715f6aebe48fabfa5725c
<pre>
Try out -Wunsafe-buffer-usage-in-libc-call on the Safer CPP bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=285881">https://bugs.webkit.org/show_bug.cgi?id=285881</a>
<a href="https://rdar.apple.com/142840182">rdar://142840182</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Configurations/CommonBase.xcconfig:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af3e503c46439d0106a715f6aebe48fabfa5725c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89737 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35649 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65845 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23671 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46117 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3225 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31098 "Build is in progress. Recent messages:") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34724 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74105 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91111 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74318 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72690 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73441 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17810 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16250 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3376 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11889 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17329 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11723 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15217 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13469 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->