### PR TITLE
[scroll-animations] JS override for animation-range should be per property

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Animation API call rangeStart overrides animation-range-start assert_approx_equals: values do not match for "animation's start time after first set of range updates" expected 16.666666666666668 +/- 0.125 but got 0
-FAIL Animation API call rangeEnd overrides animation-range-end assert_approx_equals: values do not match for "iteration duration after first style change" expected 50 +/- 0.125 but got 16.666667938232422
+PASS Animation API call rangeStart overrides animation-range-start
+PASS Animation API call rangeEnd overrides animation-range-end
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored.html
@@ -144,7 +144,7 @@
       assert_percents_equal(
           anim.currentTime, 100/6,
           'animation\'s current time after bumping scroll position');
-      assert_equals(getComputedStyle(target).marginLeft, '50px');
+      assert_approx_equals(parseFloat(getComputedStyle(target).marginLeft), 50, 0.125);
 
       // Step 3: Try to update the range start via CSS.  This change must be
       // ignored since previously set programmatically.
@@ -154,8 +154,7 @@
       assert_percents_equal(
           anim.currentTime, 100/6,
           'Current time unchanged after change to ignored CSS property');
-      assert_equals(
-          getComputedStyle(target).marginLeft, '50px',
+      assert_approx_equals(parseFloat(getComputedStyle(target).marginLeft), 50, 0.125,
           'Margin-left unaffected by change to ignored CSS property');
 
     }, 'Animation API call rangeStart overrides animation-range-start');
@@ -214,7 +213,7 @@
       assert_percents_equal(
           anim.currentTime, 100/6,
           'animation\'s current time after bumping scroll position');
-      assert_equals(getComputedStyle(target).marginLeft, "50px");
+      assert_approx_equals(parseFloat(getComputedStyle(target).marginLeft), 50, 0.125);
 
       // Step 3: Try to update the range end via CSS. This change must be
       // ignored since previously set programmatically.
@@ -224,8 +223,7 @@
       assert_percents_equal(
           anim.currentTime, 100/6,
           'Current time unchanged after change to ignored CSS property');
-      assert_equals(
-          getComputedStyle(target).marginLeft, '50px',
+      assert_approx_equals(parseFloat(getComputedStyle(target).marginLeft), 50, 0.125,
           'Margin-left unaffected by change to ignored CSS property');
 
     }, 'Animation API call rangeEnd overrides animation-range-end');

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -145,8 +145,10 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
         );
     }
 
-    if (!m_overriddenProperties.contains(Property::Range))
-        setRange(animation.range());
+    if (!m_overriddenProperties.contains(Property::RangeStart))
+        setRangeStart(animation.range().start);
+    if (!m_overriddenProperties.contains(Property::RangeEnd))
+        setRangeEnd(animation.range().end);
 
     effectTimingDidChange();
 
@@ -175,13 +177,13 @@ void CSSAnimation::setBindingsTimeline(RefPtr<AnimationTimeline>&& timeline)
 
 void CSSAnimation::setBindingsRangeStart(TimelineRangeValue&& range)
 {
-    m_overriddenProperties.add(Property::Range);
+    m_overriddenProperties.add(Property::RangeStart);
     StyleOriginatedAnimation::setBindingsRangeStart(WTFMove(range));
 }
 
 void CSSAnimation::setBindingsRangeEnd(TimelineRangeValue&& range)
 {
-    m_overriddenProperties.add(Property::Range);
+    m_overriddenProperties.add(Property::RangeEnd);
     StyleOriginatedAnimation::setBindingsRangeEnd(WTFMove(range));
 }
 

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -78,7 +78,8 @@ private:
         Keyframes = 1 << 8,
         CompositeOperation = 1 << 9,
         Timeline = 1 << 10,
-        Range = 1 << 11
+        RangeStart = 1 << 11,
+        RangeEnd = 1 << 12,
     };
 
     String m_animationName;

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1913,12 +1913,22 @@ void WebAnimation::setBindingsRangeEnd(TimelineRangeValue&& rangeEndValue)
         effect->animationRangeDidChange();
 }
 
-void WebAnimation::setRange(TimelineRange range)
+void WebAnimation::setRangeStart(SingleTimelineRange rangeStart)
 {
-    if (m_timelineRange == range)
+    if (m_timelineRange.start == rangeStart)
         return;
 
-    m_timelineRange = range;
+    m_timelineRange.start = rangeStart;
+    if (RefPtr effect = this->effect())
+        effect->animationRangeDidChange();
+}
+
+void WebAnimation::setRangeEnd(SingleTimelineRange rangeEnd)
+{
+    if (m_timelineRange.end == rangeEnd)
+        return;
+
+    m_timelineRange.end = rangeEnd;
     if (RefPtr effect = this->effect())
         effect->animationRangeDidChange();
 }

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -144,7 +144,8 @@ public:
     TimelineRangeValue bindingsRangeEnd() const { return m_timelineRange.end.serialize(); }
     virtual void setBindingsRangeStart(TimelineRangeValue&&);
     virtual void setBindingsRangeEnd(TimelineRangeValue&&);
-    void setRange(TimelineRange);
+    void setRangeStart(SingleTimelineRange);
+    void setRangeEnd(SingleTimelineRange);
     const TimelineRange& range() const { return m_timelineRange; }
 
     bool needsTick() const;


### PR DESCRIPTION
#### c16514b883b241c4b56e47dee2837cd982a94354
<pre>
[scroll-animations] JS override for animation-range should be per property
<a href="https://bugs.webkit.org/show_bug.cgi?id=285883">https://bugs.webkit.org/show_bug.cgi?id=285883</a>
<a href="https://rdar.apple.com/142841187">rdar://142841187</a>

Reviewed by Antoine Quint.

Setting animation-range via JS should override only on the property set (ie setting animation-range-start
via JS API should only override animation-range-start and not animation-range-end as well).

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored.html:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):
(WebCore::CSSAnimation::setBindingsRangeStart):
(WebCore::CSSAnimation::setBindingsRangeEnd):
* Source/WebCore/animation/CSSAnimation.h:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::intervalForAttachmentRange const):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setRangeStart):
(WebCore::WebAnimation::setRangeEnd):
(WebCore::WebAnimation::setRange): Deleted.
* Source/WebCore/animation/WebAnimation.h:

Canonical link: <a href="https://commits.webkit.org/288973@main">https://commits.webkit.org/288973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77e064307d235271d171609ad93f8badced1424d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90036 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35945 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12594 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66065 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23880 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87937 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3595 "Found 1 new test failure: fast/forms/ios/file-upload-panel.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77152 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46335 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31379 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35018 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91409 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12231 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8935 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74546 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12461 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72964 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73670 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18056 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16509 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13233 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12183 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12018 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13763 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->