### PR TITLE
[Cookie Store API] Ensure subdomains can set/get cookies for higher-level domains

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any.js
@@ -143,7 +143,7 @@ promise_test(async testCase => {
   assert_equals(cookie_attributes.name, 'cookie-name');
   assert_equals(cookie_attributes.value, 'cookie-value');
 
-  await cookieStore.delete(cookie_attributes);
+  await cookieStore.delete(cookie_attributes.name);
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie, null);
 }, 'cookieStore.delete with get result');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
@@ -40,7 +40,7 @@ PASS cookieStore.set with domain that is not equal current host
 PASS cookieStore.set with domain set to the current hostname
 PASS cookieStore.set with domain set to a subdomain of the current hostname
 PASS cookieStore.set with domain set to a non-domain-matching suffix of the current hostname
-FAIL cookieStore.set default domain is null and differs from current hostname assert_equals: expected 2 but got 1
+PASS cookieStore.set default domain is null and differs from current hostname
 PASS cookieStore.set with path set to the current directory
 PASS cookieStore.set with path set to a subdirectory of the current directory
 PASS cookieStore.set default path is /

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.js
@@ -307,7 +307,7 @@ promise_test(async testCase => {
   assert_equals(cookie_attributes.value, 'old-cookie-value');
 
   cookie_attributes.value = 'new-cookie-value';
-  await cookieStore.set(cookie_attributes);
+  await cookieStore.set(cookie_attributes.name, cookie_attributes.value);
   const cookie = await cookieStore.get('cookie-name');
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'new-cookie-value');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt
@@ -40,7 +40,7 @@ PASS cookieStore.set with domain that is not equal current host
 PASS cookieStore.set with domain set to the current hostname
 PASS cookieStore.set with domain set to a subdomain of the current hostname
 PASS cookieStore.set with domain set to a non-domain-matching suffix of the current hostname
-FAIL cookieStore.set default domain is null and differs from current hostname assert_equals: expected 2 but got 1
+PASS cookieStore.set default domain is null and differs from current hostname
 PASS cookieStore.set with path set to the current directory
 PASS cookieStore.set with path set to a subdirectory of the current directory
 PASS cookieStore.set default path is /

--- a/Source/WebCore/Modules/cookie-store/CookieListItem.h
+++ b/Source/WebCore/Modules/cookie-store/CookieListItem.h
@@ -54,6 +54,11 @@ struct CookieListItem {
             sameSite = CookieSameSite::None;
             break;
         }
+
+        // Due to how CFNetwork handles host-only cookies, we may need to prepend a '.' to the domain when
+        // setting a cookie (see CookieStore::set). So we must strip this '.' when returning the cookie.
+        if (domain.startsWith('.'))
+            domain = domain.substring(1, domain.length() - 1);
     }
 
     String name;

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -90,6 +90,7 @@ Tests/WebKitCocoa/ContentSecurityPolicyTestHelpers.mm
 Tests/WebKitCocoa/ContextMenus.mm
 Tests/WebKitCocoa/CookieAcceptPolicy.mm
 Tests/WebKitCocoa/CookiePrivateBrowsing.mm
+Tests/WebKitCocoa/CookieStoreAPI.mm
 Tests/WebKitCocoa/CopyHTML.mm
 Tests/WebKitCocoa/CopyRTF.mm
 Tests/WebKitCocoa/CopyURL.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3051,6 +3051,7 @@
 		7BC8628729B8B33500217CB5 /* DisplayListRecorderTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DisplayListRecorderTests.cpp; sourceTree = "<group>"; };
 		7BE875FB2919457B00B15289 /* AudioStreamDescriptionCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AudioStreamDescriptionCocoa.mm; sourceTree = "<group>"; };
 		7BE962542CF015FA00D7C11F /* RestoreLocalStorage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RestoreLocalStorage.mm; sourceTree = "<group>"; };
+		7BF2CC442D3786850018D13E /* CookieStoreAPI.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CookieStoreAPI.mm; sourceTree = "<group>"; };
 		7BF5017028E55F7A0008BB16 /* StackTraceTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StackTraceTest.cpp; sourceTree = "<group>"; };
 		7C1AF7931E8DCBAB002645B9 /* PrepareForMoveToWindow.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PrepareForMoveToWindow.mm; sourceTree = "<group>"; };
 		7C3965051CDD74F90094DBB8 /* ColorTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ColorTests.cpp; sourceTree = "<group>"; };
@@ -4305,6 +4306,7 @@
 				5C3B1D2522A74EA400BCF4D0 /* ContextMenus.mm */,
 				5C2936911D5BF63E00DEAB1E /* CookieAcceptPolicy.mm */,
 				5C19A5231FD0F32600EEA323 /* CookiePrivateBrowsing.mm */,
+				7BF2CC442D3786850018D13E /* CookieStoreAPI.mm */,
 				9B1056411F9045C700D5583F /* CopyHTML.mm */,
 				9999108A1F393C8B008AD455 /* Copying.mm */,
 				1C79201B234BDD9B001EAF23 /* CopyRTF.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieStoreAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieStoreAPI.mm
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "HTTPServer.h"
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestNavigationDelegate.h"
+#import "TestWKWebView.h"
+#import "Utilities.h"
+#import <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+TEST(WebKit, CookieStoreSetCookieForHigherLevelDomain)
+{
+    HTTPServer server({
+        { "/foo"_s, { "foo"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 300) configuration:configuration.get()]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://subdomain.example.com/foo"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    NSError *error;
+    [webView objectByCallingAsyncFunction:@"await cookieStore.set({ name: 'cookieName', value: 'cookieValue', domain: 'example.com' });" withArguments:nil error:&error];
+    EXPECT_NULL(error);
+
+    id result = [webView objectByCallingAsyncFunction:@"return (await cookieStore.get('cookieName')).value;" withArguments:nil error:&error];
+    EXPECT_NULL(error);
+    EXPECT_TRUE([result isKindOfClass:[NSString class]]);
+    EXPECT_TRUE([result isEqualToString:@"cookieValue"]);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 4413e221bc3419c996bc44b737d6af540908a0ca
<pre>
[Cookie Store API] Ensure subdomains can set/get cookies for higher-level domains
<a href="https://bugs.webkit.org/show_bug.cgi?id=285890">https://bugs.webkit.org/show_bug.cgi?id=285890</a>
<a href="https://rdar.apple.com/142427907">rdar://142427907</a>

Reviewed by Sihui Liu.

Step 9 in the Cookie Store API spec for setting a cookie (<a href="https://wicg.github.io/cookie-store/#set-a-cookie)">https://wicg.github.io/cookie-store/#set-a-cookie)</a>
says that if a non-null domain is passed in, then:

1. If domain starts with U+002E (.), then return failure.
2. If host does not equal domain and host does not end with U+002E (.)
   followed by domain, then return failure.

This means that on the test website (which has a host of static-safari.apple.com),
setting a cookie with the domain &quot;apple.com&quot; should work.

But currently, it does not.

More generally speaking, this means subdomains should be able to set/get cookies for higher level domains,
but currently are unable to.

The issue is that we&apos;re not following all the steps of setting a cookie. After the pre-processing steps
in the #set-a-cookie part of the spec linked above, the spec says to follow the steps here:
<a href="https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-14#name-storage-model">https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-14#name-storage-model</a>

Step 10 of this says:
If the domain-attribute is non-empty:
    If the canonicalized request-host does not domain-match the domain-attribute:
        Abort these steps and ignore the cookie entirely.
    Otherwise:
        Set the cookie&apos;s host-only-flag to false.
        Set the cookie&apos;s domain to the domain-attribute.
Otherwise:
    Set the cookie&apos;s host-only-flag to true.
    Set the cookie&apos;s domain to the canonicalized request-host.

A host-only cookie is one accessible only by the exact host/domain it was set by. (If you don&apos;t
specify a domain, the host will be used as the domain, so they&apos;ll be same).

The way host-only only works is a CFNetwork quirk and is explained in a comment in the
normalizeCookieProperties function in CFHTTPCookie.mm:
- If domain begins with a &apos;.&apos;, host-only is false, and so the cookie is accessible by subdomains
- If not, it&apos;s considered a host-only cookie (not accessible by subdomains).

Currently, we&apos;re setting all cookies without the &apos;.&apos; (so they are host-only). This patch
updates CookieStore::set to follow step 10. If the user passes in a non-null domain which
domain-matches the host, we will prepend a &apos;.&apos; to the domain (which sets host-only to false).

This allows subdomains to set/get cookies for higher level domains.

As noted at the bottom of the spec&apos;s section about querying cookies:
<a href="https://wicg.github.io/cookie-store/#query-cookies-algorithm">https://wicg.github.io/cookie-store/#query-cookies-algorithm</a>, the host-only property is not
exposed to script. And CFNetwork&apos;s quirk with the &apos;.&apos; should not be exposed to script either.
So this &apos;.&apos; is stripped when the cookie is returned by any getter of the Cookie Store API. How: get
operations always return a CookieListItem constructed from the Cookie. So upon construction from a
Cookie, we force CookieListItem to strip the beginning &apos;.&apos; from the domain if if exists.

Testing:
- Checking that subdomains can set/get cookies for higher-level domains (checking host-only is set
to false) is done by the new API test CookieStoreSetCookieForHigherLevelDomain in CookieStoreAPI.mm

- Checking that returning a cookie will not have a prepended &apos;.&apos; is already done by existing layout tests.
One of the tests in this file below sets a cookie by specifying a domain and checks the returned domain:
<a href="https://github.com/web-platform-tests/wpt/blob/master/cookie-store/cookieListItem_attributes.https.any.js">https://github.com/web-platform-tests/wpt/blob/master/cookie-store/cookieListItem_attributes.https.any.js</a>

Changes to WPT layout tests:
There is a test in cookieStore_delete_arguments.https.any.js that sets a cookie, gets the cookie, and
passes the result of the get into delete. This test was passing before this change but now fails to
delete the cookie. The issue is that the result of the get is a CookieListItem (which contains a
domain). When we set the cookie, we don&apos;t specify a domain, so the domain is set to &quot;localhost&quot;.
The returned result (which contains &quot;localhost&quot;) is passed to delete. Since the delete call recieves
a passed-in domain, it adds the &apos;.&apos; and tries to delete the cookie with domain &quot;.localhost&quot;. Of course,
there is no such cookie and so our original cookie doesn&apos;t get deleted.

But CookieListItem shouldn&apos;t contain domain at all--we don&apos;t want to expose this property. CookieListItem
should contain only name and value. So we change the test to rely only on the properties we actually
expose to script--so the test continues to pass now. Similar change in the other changed test. We&apos;ll
upstream these changes to WPT soon.

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt:
* Source/WebCore/Modules/cookie-store/CookieListItem.h:
(WebCore::CookieListItem::CookieListItem):
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::set):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CookieStoreAPI.mm: Added.
(TestWebKitAPI::TEST(WebKit, CookieStoreSetCookieForHigherLevelDomain)):

Canonical link: <a href="https://commits.webkit.org/288983@main">https://commits.webkit.org/288983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b66fad1c461210e3c09f8b72e709a5910d1df38e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39355 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/90108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/36015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12664 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/90108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/36015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88004 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/77207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/90108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/3525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/31434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/35088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/32242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91481 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12303 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12532 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/73017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/18105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/16556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13239 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12251 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/12087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/15583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13831 "Failed to checkout and rebase branch from PR 38972") | | | 
<!--EWS-Status-Bubble-End-->