### PR TITLE
Create a C++ implementation of WebExtensionSQLite classes

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2024 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebExtensionSQLiteDatabase.h"
+
+#include "APIError.h"
+#include "Logging.h"
+#include "WebExtensionSQLiteHelpers.h"
+#include <sqlite3.h>
+#include <wtf/FileSystem.h>
+#include <wtf/RefPtr.h>
+#include <wtf/TZoneMallocInlines.h>
+
+static constexpr auto WebExtensionSQLiteErrorDomain = "com.apple.WebKit.SQLite"_s;
+static constexpr auto WebExtensionSQLiteInMemoryDatabaseName = "file::memory:"_s;
+static constexpr auto WebExtensionSQLiteErrorMessageKey = "Message"_s;
+static constexpr auto WebExtensionSQLiteErrorSQLKey = "SQL"_s;
+
+using namespace WebKit;
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebExtensionSQLiteDatabase);
+
+WebExtensionSQLiteDatabase::WebExtensionSQLiteDatabase(const URL& url, Ref<WorkQueue>&& queue)
+    : m_queue(WTFMove(queue))
+{
+    ASSERT(url.protocolIsFile());
+
+    m_url = url;
+}
+
+void WebExtensionSQLiteDatabase::assertQueue()
+{
+    assertIsCurrent(m_queue.get());
+}
+
+int WebExtensionSQLiteDatabase::close()
+{
+    assertQueue();
+
+    int result = sqlite3_close_v2(m_db);
+    if (result != SQLITE_OK) {
+        RELEASE_LOG_ERROR(Extensions, "Failed to close database: %s (%d)", m_lastErrorMessage.data(), result);
+        return result;
+    }
+
+    m_db = nullptr;
+    return result;
+}
+
+void WebExtensionSQLiteDatabase::reportErrorWithCode(int errorCode, const String& query, RefPtr<API::Error> outError)
+{
+    assertQueue();
+    ASSERT(errorCode != SQLITE_OK);
+
+    if (outError)
+        outError = API::Error::create({ WebExtensionSQLiteErrorDomain, errorCode, m_url, emptyString() });
+    else
+        RELEASE_LOG_ERROR(Extensions, "Unhandled SQLite error: %d", errorCode);
+}
+
+void WebExtensionSQLiteDatabase::reportErrorWithCode(int errorCode, sqlite3_stmt* statement, RefPtr<API::Error> outError)
+{
+    assertQueue();
+    ASSERT(errorCode != SQLITE_OK);
+
+    if (statement) {
+        if (char* sql = sqlite3_expanded_sql(statement)) {
+            reportErrorWithCode(errorCode, String::fromUTF8(sql), outError);
+            sqlite3_free(sql);
+        }
+    }
+
+    reportErrorWithCode(errorCode, emptyString(), outError);
+}
+
+RefPtr<API::Error> WebExtensionSQLiteDatabase::errorWithSQLiteErrorCode(int errorCode)
+{
+    if (errorCode == SQLITE_OK)
+        return nullptr;
+
+    String errorMessage = String::fromUTF8(sqlite3_errstr(errorCode));
+    return API::Error::create({ WebExtensionSQLiteErrorDomain, errorCode, { }, emptyString() });
+}
+
+bool WebExtensionSQLiteDatabase::enableWAL(RefPtr<API::Error>& error)
+{
+    Ref<WebExtensionSQLiteDatabase> protectedThis(*this);
+
+    // SQLite docs: The synchronous NORMAL setting is a good choice for most applications running in WAL mode.
+    if (!SQLiteDatabaseExecuteAndReturnError(*this, error, "PRAGMA synchronous = NORMAL"_s))
+        return false;
+    return SQLiteDatabaseEnumerate(*this, error, "PRAGMA journal_mode = WAL"_s, std::tie(std::ignore));
+}
+
+bool WebExtensionSQLiteDatabase::openWithAccessType(AccessType accessType, ProtectionType protectionType, const String& vfs, RefPtr<API::Error> outError)
+{
+    int flags = SQLITE_OPEN_NOMUTEX;
+
+    switch (accessType) {
+    case AccessType::ReadOnly:
+        flags |= SQLITE_OPEN_READONLY;
+        break;
+    case AccessType::ReadWrite:
+        flags |= SQLITE_OPEN_READWRITE;
+        break;
+    case AccessType::ReadWriteCreate:
+        flags |= SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
+        break;
+    }
+
+#if PLATFORM(IOS_FAMILY)
+    switch (protectionType) {
+    case ProtectionType::Default:
+    case ProtectionType::CompleteUntilFirstUserAuthentication:
+        flags |= SQLITE_OPEN_FILEPROTECTION_COMPLETEUNTILFIRSTUSERAUTHENTICATION;
+        break;
+    case ProtectionType::CompleteUnlessOpen:
+        flags |= SQLITE_OPEN_FILEPROTECTION_COMPLETEUNLESSOPEN;
+        break;
+    case ProtectionType::Complete:
+        flags |= SQLITE_OPEN_FILEPROTECTION_COMPLETE;
+        break;
+    }
+#endif
+
+    assertQueue();
+    ASSERT(!m_db);
+
+    const char* databasePath;
+    if (m_url == inMemoryDatabaseURL())
+        databasePath = WebExtensionSQLiteInMemoryDatabaseName.span().data();
+    else if (m_url == privateOnDiskDatabaseURL())
+        databasePath = "";
+    else {
+        ASSERT(!m_url.isEmpty());
+
+        databasePath = m_url.fileSystemPath().utf8().data();
+        if (FileSystem::fileExists(m_url.truncatedForUseAsBase().fileSystemPath())) {
+            if (outError) {
+                RELEASE_LOG_ERROR(Extensions, "Unable to create parent folder for database at path: %s", m_url.fileSystemPath().utf8().data());
+                outError = errorWithSQLiteErrorCode(SQLITE_CANTOPEN);
+            }
+
+            return false;
+        }
+    }
+
+    int result = sqlite3_open_v2(databasePath, &m_db, flags, vfs.isEmpty() ? nullptr : vfs.utf8().data());
+    if (result == SQLITE_OK)
+        return true;
+
+    // SQLite may return a valid database handle even if an error occurred. sqlite3_close silently
+    // ignores calls with a null handle so we can call it here unconditionally.
+    sqlite3_close_v2(m_db);
+    m_db = nullptr;
+
+    if (result == SQLITE_CANTOPEN && !(flags & SQLITE_OPEN_CREATE))
+        return false;
+
+    if (outError)
+        outError = errorWithSQLiteErrorCode(result);
+
+    return false;
+}
+
+URL WebExtensionSQLiteDatabase::inMemoryDatabaseURL()
+{
+    return URL(WebExtensionSQLiteInMemoryDatabaseName);
+}
+
+URL WebExtensionSQLiteDatabase::privateOnDiskDatabaseURL()
+{
+    return URL("webkit::privateondisk"_s);
+}
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2024 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "APIError.h"
+#include <sqlite3.h>
+#include <wtf/Forward.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/RefPtr.h>
+#include <wtf/URL.h>
+#include <wtf/WorkQueue.h>
+
+struct sqlite3;
+
+namespace WebKit {
+
+class WebExtensionSQLiteStatement;
+class WebExtensionSQLiteStore;
+
+class WebExtensionSQLiteDatabase final : public RefCounted<WebExtensionSQLiteDatabase> {
+    WTF_MAKE_NONCOPYABLE(WebExtensionSQLiteDatabase);
+    WTF_MAKE_TZONE_ALLOCATED(WebExtensionSQLiteDatabase);
+
+    friend class WebExtensionSQLiteStatement;
+    friend class WebExtensionSQLiteStore;
+
+public:
+    template<typename... Args>
+    static Ref<WebExtensionSQLiteDatabase> create(Args&&... args)
+    {
+        return adoptRef(*new WebExtensionSQLiteDatabase(std::forward<Args>(args)...));
+    }
+
+    explicit WebExtensionSQLiteDatabase(const URL&, Ref<WorkQueue>&&);
+    ~WebExtensionSQLiteDatabase()
+    {
+        ASSERT(!m_db);
+    }
+
+    static URL inMemoryDatabaseURL();
+
+    enum class AccessType : uint8_t {
+        ReadOnly = 0,
+        ReadWrite,
+        ReadWriteCreate
+    };
+
+    // This enum is only applicable on iOS and has no effect on other platforms.
+    // ProtectionType::Default sets the protection to class C.
+    enum class ProtectionType : uint8_t {
+        Default = 0,
+        CompleteUntilFirstUserAuthentication,
+        CompleteUnlessOpen,
+        Complete
+    };
+
+    bool openWithAccessType(AccessType, ProtectionType = { }, const String& vfs = { }, RefPtr<API::Error> = nullptr);
+    bool enableWAL(RefPtr<API::Error>&);
+
+    void reportErrorWithCode(int, const String& query, RefPtr<API::Error> = nullptr);
+    void reportErrorWithCode(int, sqlite3_stmt* statement, RefPtr<API::Error> = nullptr);
+
+    int close();
+
+    sqlite3* sqlite3Handle() const { return m_db; };
+    void assertQueue();
+    Ref<WorkQueue> queue() const { return m_queue; };
+
+private:
+    RefPtr<API::Error> errorWithSQLiteErrorCode(int errorCode);
+    URL privateOnDiskDatabaseURL();
+
+    sqlite3* m_db { nullptr };
+    URL m_url;
+
+    int m_lastErrorCode;
+    CString m_lastErrorMessage;
+
+    Ref<WorkQueue> m_queue;
+};
+
+}; // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatatypeTraits.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatatypeTraits.h
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "APIData.h"
+#include "WebExtensionSQLiteDatabase.h"
+#include <sqlite3.h>
+#include <tuple>
+
+namespace WebKit {
+
+template<typename Type>
+class WebExtensionSQLiteDatatypeTraits {
+public:
+    static Type fetch(sqlite3_stmt* statement, int index);
+    static int bind(sqlite3_stmt* statement, int index, const Type&);
+};
+
+template<>
+class WebExtensionSQLiteDatatypeTraits<int> {
+public:
+    static inline int fetch(sqlite3_stmt* statement, int index)
+    {
+        return sqlite3_column_int(statement, index);
+    }
+
+    static inline int bind(sqlite3_stmt* statement, int index, int value)
+    {
+        return sqlite3_bind_int(statement, index, value);
+    }
+};
+
+template<>
+class WebExtensionSQLiteDatatypeTraits<int64_t> {
+public:
+    static inline int64_t fetch(sqlite3_stmt* statement, int index)
+    {
+        return sqlite3_column_int64(statement, index);
+    }
+
+    static inline int bind(sqlite3_stmt* statement, int index, int64_t value)
+    {
+        return sqlite3_bind_int64(statement, index, value);
+    }
+};
+
+template<>
+class WebExtensionSQLiteDatatypeTraits<double> {
+public:
+    static inline double fetch(sqlite3_stmt* statement, int index)
+    {
+        return sqlite3_column_double(statement, index);
+    }
+
+    static inline int bind(sqlite3_stmt* statement, int index, double value)
+    {
+        return sqlite3_bind_double(statement, index, value);
+    }
+};
+
+template<>
+class WebExtensionSQLiteDatatypeTraits<String> {
+public:
+    static String fetch(sqlite3_stmt* statement, int index)
+    {
+        if (sqlite3_column_type(statement, index) == SQLITE_NULL)
+            return emptyString();
+
+        return String::fromUTF8(reinterpret_cast<const char*>(sqlite3_column_text(statement, index)));
+    }
+
+    static inline int bind(sqlite3_stmt* statement, int index, const String& value)
+    {
+        if (!value)
+            return sqlite3_bind_null(statement, index);
+
+        return sqlite3_bind_text(statement, index, value.utf8().data(), -1, SQLITE_TRANSIENT);
+    }
+};
+
+template<>
+class WebExtensionSQLiteDatatypeTraits<RefPtr<API::Data>> {
+public:
+    static RefPtr<API::Data> fetch(sqlite3_stmt* statement, int index)
+    {
+        if (sqlite3_column_type(statement, index) == SQLITE_NULL)
+            return nullptr;
+
+        auto* blob = static_cast<const uint8_t*>(sqlite3_column_blob(statement, index));
+        if (!blob)
+            return nullptr;
+
+        int blobSize = sqlite3_column_bytes(statement, index);
+        if (blobSize <= 0)
+            return nullptr;
+
+        return API::Data::create(unsafeMakeSpan(blob, blobSize));
+    }
+
+    static inline int bind(sqlite3_stmt* statement, int index, RefPtr<API::Data> value)
+    {
+        if (!value)
+            return sqlite3_bind_null(statement, index);
+
+        return sqlite3_bind_blob64(statement, index, value->span().data(), value->span().size(), SQLITE_TRANSIENT);
+    }
+};
+
+template<>
+class WebExtensionSQLiteDatatypeTraits<std::nullptr_t> {
+public:
+    static inline std::nullptr_t fetch(sqlite3_stmt* statement, int index)
+    {
+        return std::nullptr_t();
+    }
+
+    static inline int bind(sqlite3_stmt* statement, int index, std::nullptr_t)
+    {
+        return sqlite3_bind_null(statement, index);
+    }
+};
+
+template<>
+class WebExtensionSQLiteDatatypeTraits<decltype(std::ignore)> {
+public:
+    static inline decltype(std::ignore) fetch(sqlite3_stmt* statement, int index)
+    {
+        return std::ignore;
+    }
+
+    static inline int bind(sqlite3_stmt* statement, int index, decltype(std::ignore))
+    {
+        return SQLITE_OK;
+    }
+};
+
+} // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteHelpers.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteHelpers.h
@@ -1,0 +1,341 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WebExtensionSQLiteDatabase.h"
+#include "WebExtensionSQLiteDatatypeTraits.h"
+#include "WebExtensionSQLiteStatement.h"
+
+#pragma GCC visibility push(hidden)
+
+namespace WebKit {
+
+// MARK: Interface
+
+template <typename... Parameters>
+void SQLiteStatementBindAllParameters(Ref<WebExtensionSQLiteDatabase>, Parameters&&...);
+
+template <typename... Parameters>
+int SQLiteDatabaseExecute(Ref<WebExtensionSQLiteDatabase>, const String& query, Parameters&&...);
+
+template <typename... Parameters>
+Ref<WebExtensionSQLiteRowEnumerator> SQLiteDatabaseFetch(Ref<WebExtensionSQLiteDatabase>, const String& query, Parameters&&...);
+
+bool SQLiteDatabaseEnumerate(Ref<WebExtensionSQLiteDatabase>, RefPtr<API::Error>&, const String& query, Function<void(RefPtr<WebExtensionSQLiteRow>, bool)>);
+
+template <typename... Parameters>
+bool SQLiteDatabaseEnumerateRows(Ref<WebExtensionSQLiteDatabase>, RefPtr<API::Error>&, const String& query, std::tuple<Parameters...>&&, Function<void(RefPtr<WebExtensionSQLiteRow>, bool)>);
+
+template <typename... Parameters>
+bool SQLiteDatabaseExecuteAndReturnError(Ref<WebExtensionSQLiteDatabase>, RefPtr<API::Error>&, const String& query, Parameters&&...);
+
+
+inline bool SQLiteIsExecutionError(int errorCode)
+{
+    return errorCode != SQLITE_OK && errorCode != SQLITE_ROW && errorCode != SQLITE_DONE;
+}
+
+// MARK: Implementation
+
+template <typename T>
+struct IsTuple : std::false_type { };
+template <typename... Args>
+struct IsTuple<std::tuple<Args...>> : std::true_type { };
+
+template <int currentParameterIndex, typename T, typename... Parameters>
+void SQLiteStatementBindAllParameters(RefPtr<WebExtensionSQLiteStatement>, T&&, Parameters&&...);
+template <int currentParameterIndex>
+void SQLiteStatementBindAllParameters(RefPtr<WebExtensionSQLiteStatement>);
+template <typename... Parameters>
+int SQLiteDatabaseExecuteAndReturnIntError(Ref<WebExtensionSQLiteDatabase>, RefPtr<API::Error> = nullptr, const String& query = { }, Parameters&&...);
+
+template <typename... Parameters>
+void SQLiteStatementBindAllParameters(RefPtr<WebExtensionSQLiteStatement> statement, Parameters&&... parameters)
+{
+    SQLiteStatementBindAllParameters<1>(statement, std::forward<Parameters>(parameters)...);
+}
+
+template <typename... Parameters>
+int SQLiteDatabaseExecute(Ref<WebExtensionSQLiteDatabase> database, const String& query, Parameters&&... parameters)
+{
+    return SQLiteDatabaseExecuteAndReturnIntError(database, nullptr, query, std::forward<Parameters>(parameters)...);
+}
+
+template <typename... Parameters>
+bool SQLiteDatabaseExecuteAndReturnError(Ref<WebExtensionSQLiteDatabase> database, RefPtr<API::Error>& error, const String& query, Parameters&&... parameters)
+{
+    int result = SQLiteDatabaseExecuteAndReturnIntError(database, error, query, std::forward<Parameters>(parameters)...);
+    return result == SQLITE_DONE || result == SQLITE_OK;
+}
+
+template <typename... Parameters>
+int SQLiteDatabaseExecuteAndReturnIntError(Ref<WebExtensionSQLiteDatabase> database, RefPtr<API::Error> error, const String& query, Parameters&&... parameters)
+{
+    RefPtr<API::Error> statementError;
+    RefPtr statement = WebExtensionSQLiteStatement::create(database, query, statementError);
+    if (!statement) {
+        if (error)
+            error = statementError;
+        return static_cast<int>(statementError->errorCode());
+    }
+
+    SQLiteStatementBindAllParameters(statement, std::forward<Parameters>(parameters)...);
+
+    int resultCode = statement->execute();
+    statement->invalidate();
+
+    if (SQLiteIsExecutionError(resultCode))
+        database->reportErrorWithCode(resultCode, statement->handle(), error);
+
+    return resultCode;
+}
+
+template <typename... Parameters>
+Ref<WebExtensionSQLiteRowEnumerator> SQLiteDatabaseFetch(Ref<WebExtensionSQLiteDatabase> database, const String& query, Parameters&&... parameters)
+{
+    RefPtr statement = WebExtensionSQLiteStatement::create(database, query, nullptr);
+    SQLiteStatementBindAllParameters(statement, std::forward<Parameters>(parameters)...);
+    return statement->fetch();
+}
+
+template <typename T>
+inline void SQLiteStatementBindParameter(RefPtr<WebExtensionSQLiteStatement> statement, int index, const T& object)
+{
+    statement->bind(object, index);
+}
+
+template <>
+inline void SQLiteStatementBindParameter<unsigned>(RefPtr<WebExtensionSQLiteStatement> statement, int index, const unsigned& object)
+{
+    ASSERT(object <= INT_MAX);
+    statement->bind(static_cast<int>(object), index);
+}
+
+template <>
+inline void SQLiteStatementBindParameter<uint64_t>(RefPtr<WebExtensionSQLiteStatement> statement, int index, const uint64_t& object)
+{
+    ASSERT(object <= INT64_MAX);
+    statement->bind(static_cast<int64_t>(object), index);
+}
+
+template <>
+inline void SQLiteStatementBindParameter<long>(RefPtr<WebExtensionSQLiteStatement> statement, int index, const long& object)
+{
+    SQLiteStatementBindParameter(statement, index, static_cast<int64_t>(object));
+}
+
+template <>
+inline void SQLiteStatementBindParameter<bool>(RefPtr<WebExtensionSQLiteStatement> statement, int index, const bool& object)
+{
+    statement->bind(!!object, index);
+}
+
+template <int currentParameterIndex, typename T, typename... Parameters>
+void SQLiteStatementBindAllParameters(RefPtr<WebExtensionSQLiteStatement> statement, T&& parameter, Parameters&&... parameters)
+{
+    SQLiteStatementBindParameter(statement, currentParameterIndex, std::forward<T>(parameter));
+    SQLiteStatementBindAllParameters<currentParameterIndex + 1>(statement, std::forward<Parameters>(parameters)...);
+}
+
+template <int currentParameterIndex>
+void SQLiteStatementBindAllParameters(RefPtr<WebExtensionSQLiteStatement>)
+{
+}
+
+template <typename Tuple, int index, int count>
+typename std::enable_if<index < count, void>::type SQLiteStatementBindTupleParameters(RefPtr<WebExtensionSQLiteStatement> statement, Tuple&& parameters)
+{
+    SQLiteStatementBindParameter(statement, index + 1, std::get<index>(parameters));
+    SQLiteStatementBindTupleParameters<Tuple, index + 1, count>(statement, std::forward(parameters));
+}
+
+template <typename ReturnType, typename BlockType, typename... Args>
+class SQLiteIteratorBlock {
+public:
+    typedef Function<ReturnType(Args...)> FunctionType;
+    typedef std::tuple<Args...> TupleType;
+
+public:
+    inline SQLiteIteratorBlock(BlockType)
+    {
+    }
+
+    template<int ...S>
+    inline ReturnType callBlockWithAllColumns(sqlite3_stmt* statement, FunctionType enumerationBlock, std::integer_sequence<int, S...>)
+    {
+        return enumerationBlock(WebExtensionSQLiteDatatypeTraits<typename std::tuple_element<S, TupleType>::type>::fetch(statement, S)...);
+    }
+
+    inline ReturnType callBlockWithAllColumns(sqlite3_stmt* statement, FunctionType enumerationBlock)
+    {
+        return callBlockWithAllColumns(statement, enumerationBlock, std::make_integer_sequence<int, std::tuple_size<TupleType>::value>());
+    }
+};
+
+template<typename R, typename... Args>
+typename std::enable_if<std::is_same<R, bool>::value, bool>::type StatementCallBlockWithAllColumns(sqlite3_stmt* statement, Function<R(Args...)> block)
+{
+    return SQLiteIteratorBlock<R, Args...>(block).callBlockWithAllColumns(statement, block);
+}
+
+template<typename R, typename... Args>
+typename std::enable_if<std::is_void<R>::value, bool>::type StatementCallBlockWithAllColumns(sqlite3_stmt* statement, Function<R(Args...)> block)
+{
+    SQLiteIteratorBlock<R, Args...>(block).callBlockWithAllColumns(statement, block);
+    return true;
+}
+
+template<typename TupleType, int ...S>
+bool WBSStatementFetchColumnsInTuple(sqlite3_stmt* statement, TupleType&& tuple, std::integer_sequence<int, S...>)
+{
+    tuple = std::make_tuple(WebExtensionSQLiteDatatypeTraits<typename std::remove_reference<typename std::tuple_element<S, TupleType>::type>::type>::fetch(statement, S)...);
+    return true;
+}
+
+template<typename TupleType>
+bool WBSStatementFetchColumnsInTuple(sqlite3_stmt* statement, TupleType&& tuple)
+{
+    return WBSStatementFetchColumnsInTuple(statement, std::forward<TupleType>(tuple), std::make_integer_sequence<int, std::tuple_size<TupleType>::value>());
+}
+
+template<int Index, int Count, typename TupleType>
+typename std::enable_if<Index >= Count && !IsTuple<typename std::tuple_element<Index, TupleType>::type>::value, bool>::type SQLiteStatementBindOrStep(Ref<WebExtensionSQLiteDatabase> database, sqlite3_stmt* statement, RefPtr<API::Error>& error, TupleType&& tuple)
+{
+    while (true) {
+        int resultCode = sqlite3_step(statement);
+        if (resultCode == SQLITE_DONE)
+            return true;
+
+        if (resultCode != SQLITE_ROW) {
+            database->reportErrorWithCode(resultCode, statement, error);
+            break;
+        }
+
+        if (!StatementCallBlockWithAllColumns(statement, std::get<Index>(tuple)))
+            break;
+    }
+
+    return false;
+}
+
+template<int Index, int Count, typename TupleType>
+typename std::enable_if<Index >= Count && IsTuple<typename std::tuple_element<Index, TupleType>::type>::value, bool>::type SQLiteStatementBindOrStep(Ref<WebExtensionSQLiteDatabase> database, sqlite3_stmt* statement, RefPtr<API::Error>& error, TupleType&& tuple)
+{
+    int resultCode = sqlite3_step(statement);
+    if (resultCode != SQLITE_ROW) {
+        database->reportErrorWithCode(resultCode, statement, error);
+        return false;
+    }
+
+    if (!WBSStatementFetchColumnsInTuple(statement, WTFMove(std::get<Index>(tuple))))
+        return false;
+
+    resultCode = sqlite3_step(statement);
+    if (resultCode != SQLITE_DONE) {
+        database->reportErrorWithCode(resultCode, statement, error);
+        return false;
+    }
+
+    return true;
+}
+
+template<int Index, int Count, typename TupleType>
+typename std::enable_if<Index < Count, bool>::type SQLiteStatementBindOrStep(Ref<WebExtensionSQLiteDatabase> database, sqlite3_stmt* statement, RefPtr<API::Error>& error, TupleType&& tuple)
+{
+    if (int resultCode = WebExtensionSQLiteDatatypeTraits<typename std::remove_const<typename std::remove_reference<typename std::tuple_element<Index, TupleType>::type>::type>::type>::bind(statement, Index + 1, std::get<Index>(tuple)) != SQLITE_OK) {
+        database->reportErrorWithCode(resultCode, statement, error);
+        return false;
+    }
+
+    return SQLiteStatementBindOrStep<Index + 1, Count, TupleType>(database, statement, error, std::forward<TupleType>(tuple));
+}
+
+template<int Index, int Count, typename TupleType>
+typename std::enable_if<Index >= Count, bool>::type SQLiteStatementBind(Ref<WebExtensionSQLiteDatabase> database, sqlite3_stmt* statement, RefPtr<API::Error>& error, TupleType&& tuple)
+{
+    return true;
+}
+
+template<int Index, int Count, typename TupleType>
+typename std::enable_if<Index < Count, bool>::type SQLiteStatementBind(Ref<WebExtensionSQLiteDatabase> database, sqlite3_stmt* statement, RefPtr<API::Error>& error, TupleType&& tuple)
+{
+    if (int resultCode = WebExtensionSQLiteDatatypeTraits<typename std::remove_const<typename std::remove_reference<typename std::tuple_element<Index, TupleType>::type>::type>::type>::bind(statement, Index + 1, std::get<Index>(tuple)) != SQLITE_OK) {
+        database->reportErrorWithCode(resultCode, statement, error);
+        return false;
+    }
+
+    return SQLiteStatementBind<Index + 1, Count, TupleType>(database, statement, error, std::forward<TupleType>(tuple));
+}
+
+template<typename... Args>
+bool SQLiteDatabaseEnumerate(Ref<WebExtensionSQLiteDatabase> database, RefPtr<API::Error>& error, const String& query, Args&&... args)
+{
+    RefPtr<API::Error> outError;
+    RefPtr<WebExtensionSQLiteStatement> statement = WebExtensionSQLiteStatement::create(database, query, outError);
+    error = outError;
+    if (outError)
+        return false;
+
+    bool result = SQLiteStatementBindOrStep<0, sizeof...(args) - 1, typename std::tuple<Args...>>(database, statement->handle(), error, std::forward_as_tuple(args...));
+    statement->invalidate();
+    return result;
+}
+
+template<typename... Args>
+bool SQLiteDatabaseEnumerate(RefPtr<WebExtensionSQLiteStatement> statement, RefPtr<API::Error>& error, Args&&... args)
+{
+    bool result = SQLiteStatementBindOrStep<0, sizeof...(args) - 1, typename std::tuple<Args...>>(statement->database(), statement->handle(), error, std::forward_as_tuple(args...));
+
+    statement->reset();
+    return result;
+}
+
+template<typename... Parameters>
+bool SQLiteDatabaseEnumerateRows(Ref<WebExtensionSQLiteDatabase> database, RefPtr<API::Error>& error, const String& query, std::tuple<Parameters...>&& parameters, Function<void(RefPtr<WebExtensionSQLiteRow>, bool)> enumerationBlock)
+{
+    RefPtr<API::Error> outError;
+    RefPtr<WebExtensionSQLiteStatement> statement = WebExtensionSQLiteStatement::create(database, query, outError);
+    error = outError;
+    if (outError)
+        return false;
+
+    SQLiteStatementBind<0, std::tuple_size<std::tuple<Parameters...>>::value, typename std::tuple<Parameters...>>(database, statement->handle(), error, WTFMove(parameters));
+
+    bool result = statement->fetchWithEnumerationCallback(enumerationBlock, error);
+    statement->invalidate();
+    return result;
+}
+
+} // namespace WebKit
+
+using WebKit::SQLiteDatabaseEnumerate;
+using WebKit::SQLiteDatabaseExecute;
+using WebKit::SQLiteDatabaseExecuteAndReturnError;
+using WebKit::SQLiteDatabaseFetch;
+using WebKit::SQLiteIsExecutionError;
+using WebKit::SQLiteStatementBindAllParameters;
+
+#pragma GCC visibility pop

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2024 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebExtensionSQLiteRow.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "WebExtensionSQLiteDatabase.h"
+#include "WebExtensionSQLiteStatement.h"
+#include <sqlite3.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebExtensionSQLiteRow);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebExtensionSQLiteRowEnumerator);
+
+WebExtensionSQLiteRow::WebExtensionSQLiteRow(Ref<WebExtensionSQLiteStatement> statement)
+    : m_statement(statement)
+    , m_handle(statement->handle())
+{
+    m_statement->database()->assertQueue();
+}
+
+String WebExtensionSQLiteRow::getString(int index)
+{
+    m_statement->database()->assertQueue();
+    if (isNullAtIndex(index))
+        return emptyString();
+
+    sqlite3_stmt* handle = m_handle;
+    return String::fromUTF8(reinterpret_cast<const char*>(sqlite3_column_text(handle, index)));
+}
+
+int WebExtensionSQLiteRow::getInt(int index)
+{
+    m_statement->database()->assertQueue();
+    return sqlite3_column_int(m_handle, index);
+}
+
+int64_t WebExtensionSQLiteRow::getInt64(int index)
+{
+    m_statement->database()->assertQueue();
+    return sqlite3_column_int64(m_handle, index);
+}
+
+double WebExtensionSQLiteRow::getDouble(int index)
+{
+    m_statement->database()->assertQueue();
+    return sqlite3_column_double(m_handle, index);
+}
+
+bool WebExtensionSQLiteRow::getBool(int index)
+{
+    return !!getInt(index);
+}
+
+RefPtr<API::Data> WebExtensionSQLiteRow::getData(int index)
+{
+    m_statement->database()->assertQueue();
+    if (isNullAtIndex(index))
+        return nullptr;
+
+    auto* blob = static_cast<const uint8_t*>(sqlite3_column_blob(m_handle, index));
+    if (!blob)
+        return nullptr;
+
+    int blobSize = sqlite3_column_bytes(m_handle, index);
+    if (blobSize <= 0)
+        return nullptr;
+
+    return API::Data::create(unsafeMakeSpan(blob, blobSize));
+}
+
+bool WebExtensionSQLiteRow::isNullAtIndex(int index)
+{
+    m_statement->database()->assertQueue();
+    return sqlite3_column_type(m_handle, index) == SQLITE_NULL;
+}
+
+WebExtensionSQLiteRowEnumerator::WebExtensionSQLiteRowEnumerator(Ref<WebExtensionSQLiteStatement> statement)
+    : m_statement(statement)
+{
+    m_statement->database()->assertQueue();
+}
+
+RefPtr<WebExtensionSQLiteRow> WebExtensionSQLiteRowEnumerator::next()
+{
+    m_statement->database()->assertQueue();
+    int lastResultCode = sqlite3_step(m_statement->handle());
+
+    switch (lastResultCode) {
+    case SQLITE_ROW:
+        if (!m_row)
+            m_row = WebExtensionSQLiteRow::create(m_statement);
+        return m_row;
+    case SQLITE_OK:
+    case SQLITE_DONE:
+        break;
+
+    default:
+        m_statement->database()->reportErrorWithCode(lastResultCode, m_statement->handle(), nullptr);
+        break;
+    }
+
+    return nullptr;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "APIData.h"
+#include "APIError.h"
+#include "WebExtensionSQLiteStatement.h"
+#include <sqlite3.h>
+#include <wtf/Forward.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/RefPtr.h>
+#include <wtf/URL.h>
+#include <wtf/WorkQueue.h>
+
+namespace WebKit {
+
+class WebExtensionSQLiteRow : public RefCounted<WebExtensionSQLiteRow> {
+    WTF_MAKE_NONCOPYABLE(WebExtensionSQLiteRow);
+    WTF_MAKE_TZONE_ALLOCATED(WebExtensionSQLiteRow);
+
+public:
+    template<typename... Args>
+    static Ref<WebExtensionSQLiteRow> create(Args&&... args)
+    {
+        return adoptRef(*new WebExtensionSQLiteRow(std::forward<Args>(args)...));
+    }
+    explicit WebExtensionSQLiteRow(Ref<WebExtensionSQLiteStatement>);
+
+    String getString(int index);
+    int getInt(int index);
+    int64_t getInt64(int index);
+    double getDouble(int index);
+    bool getBool(int index);
+    RefPtr<API::Data> getData(int index);
+
+private:
+    bool isNullAtIndex(int index);
+
+    Ref<WebExtensionSQLiteStatement> m_statement;
+    sqlite3_stmt* m_handle;
+};
+
+class WebExtensionSQLiteRowEnumerator : public RefCounted<WebExtensionSQLiteRowEnumerator> {
+    WTF_MAKE_NONCOPYABLE(WebExtensionSQLiteRowEnumerator);
+    WTF_MAKE_TZONE_ALLOCATED(WebExtensionSQLiteRowEnumerator);
+
+public:
+    template<typename... Args>
+    static Ref<WebExtensionSQLiteRowEnumerator> create(Args&&... args)
+    {
+        return adoptRef(*new WebExtensionSQLiteRowEnumerator(std::forward<Args>(args)...));
+    }
+
+    explicit WebExtensionSQLiteRowEnumerator(Ref<WebExtensionSQLiteStatement>);
+
+    RefPtr<WebExtensionSQLiteRow> next();
+    Ref<WebExtensionSQLiteStatement> statement() { return m_statement; };
+
+private:
+    Ref<WebExtensionSQLiteStatement> m_statement;
+    RefPtr<WebExtensionSQLiteRow> m_row;
+};
+
+}; // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.cpp
@@ -1,0 +1,266 @@
+/*
+ * Copyright (C) 2024 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebExtensionSQLiteStatement.h"
+
+#include "Logging.h"
+#include "WebExtensionSQLiteDatabase.h"
+#include "WebExtensionSQLiteHelpers.h"
+#include <sqlite3.h>
+#include <wtf/TZoneMallocInlines.h>
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebExtensionSQLiteStatement);
+
+WebExtensionSQLiteStatement::WebExtensionSQLiteStatement(Ref<WebExtensionSQLiteDatabase> database, const String& query, RefPtr<API::Error> outError)
+    : m_db(database)
+{
+    Ref db = m_db;
+
+    ASSERT(db->sqlite3Handle());
+
+    db->assertQueue();
+
+    int result = sqlite3_prepare_v2(db->sqlite3Handle(), query.utf8().data(), -1, &m_handle, 0);
+    if (result != SQLITE_OK) {
+        db->reportErrorWithCode(result, query, outError);
+        return;
+    }
+}
+
+WebExtensionSQLiteStatement::~WebExtensionSQLiteStatement()
+{
+    sqlite3_stmt* handle = m_handle;
+    if (!handle)
+        return;
+
+    database()->queue()->dispatch([database = Ref { database() }, handle = WTFMove(handle)]() mutable {
+        // The database might have closed already;
+        if (!database->sqlite3Handle())
+            return;
+
+        sqlite3_finalize(handle);
+    });
+}
+
+int WebExtensionSQLiteStatement::execute()
+{
+    database()->assertQueue();
+    ASSERT(isValid());
+
+    int resultCode = sqlite3_step(m_handle);
+    if (!SQLiteIsExecutionError(resultCode))
+        return resultCode;
+
+    return resultCode;
+}
+
+bool WebExtensionSQLiteStatement::execute(RefPtr<API::Error>& outError)
+{
+    Ref database = m_db;
+
+    database->assertQueue();
+    ASSERT(isValid());
+
+    int resultCode = sqlite3_step(m_handle);
+    if (!SQLiteIsExecutionError(resultCode))
+        return true;
+
+    database->reportErrorWithCode(resultCode, m_handle, outError);
+    return false;
+}
+
+Ref<WebExtensionSQLiteRowEnumerator> WebExtensionSQLiteStatement::fetch()
+{
+    m_db->assertQueue();
+    ASSERT(isValid());
+
+    Ref<WebExtensionSQLiteStatement> protectedThis(*this);
+    return WebExtensionSQLiteRowEnumerator::create(*this);
+}
+
+bool WebExtensionSQLiteStatement::fetchWithEnumerationCallback(Function<void(RefPtr<WebExtensionSQLiteRow>, bool)>& callback, RefPtr<API::Error>& outError)
+{
+    m_db->assertQueue();
+    ASSERT(isValid());
+
+    RefPtr<WebExtensionSQLiteRow> row;
+    Ref<WebExtensionSQLiteStatement> protectedThis(*this);
+
+    int result = SQLITE_OK;
+    bool stop = false;
+    while (!stop) {
+        result = sqlite3_step(m_handle);
+        if (result != SQLITE_ROW)
+            break;
+
+        if (!row)
+            row = WebExtensionSQLiteRow::create(*this);
+
+        callback(row, stop);
+    }
+
+    if (result == SQLITE_DONE)
+        return true;
+
+    return false;
+}
+
+void WebExtensionSQLiteStatement::reset()
+{
+    m_db->assertQueue();
+    ASSERT(isValid());
+
+    int result = sqlite3_reset(m_handle);
+    if (result != SQLITE_OK)
+        RELEASE_LOG_DEBUG(Extensions, "Could not reset statement: %s (%d)", m_db->m_lastErrorMessage.data(), result);
+}
+
+void WebExtensionSQLiteStatement::invalidate()
+{
+    m_db->assertQueue();
+    ASSERT(isValid());
+
+    int result = sqlite3_finalize(m_handle);
+    if (result != SQLITE_OK)
+        RELEASE_LOG_DEBUG(Extensions, "Could not finalize statement: %s (%d)", m_db->m_lastErrorMessage.data(), (int)result);
+    m_handle = nullptr;
+}
+
+void WebExtensionSQLiteStatement::bind(const String& string, int parameterIndex)
+{
+    m_db->assertQueue();
+    ASSERT(isValid());
+    ASSERT_ARG(parameterIndex, parameterIndex > 0);
+
+    int result = sqlite3_bind_text(m_handle, parameterIndex, string.utf8().data(), -1, SQLITE_TRANSIENT);
+    if (result != SQLITE_OK)
+        RELEASE_LOG_DEBUG(Extensions, "Could not bind string: %s (%d)", m_db->m_lastErrorMessage.data(), (int)result);
+}
+
+void WebExtensionSQLiteStatement::bind(const int& n, int parameterIndex)
+{
+    m_db->assertQueue();
+    ASSERT(isValid());
+    ASSERT_ARG(parameterIndex, parameterIndex > 0);
+
+    int result = sqlite3_bind_int(m_handle, parameterIndex, n);
+    if (result != SQLITE_OK)
+        RELEASE_LOG_DEBUG(Extensions, "Could not bind int: %s (%d)", m_db->m_lastErrorMessage.data(), (int)result);
+}
+
+void WebExtensionSQLiteStatement::bind(const int64_t& n, int parameterIndex)
+{
+    m_db->assertQueue();
+    ASSERT(isValid());
+    ASSERT_ARG(parameterIndex, parameterIndex > 0);
+
+    int result = sqlite3_bind_int64(m_handle, parameterIndex, n);
+    if (result != SQLITE_OK)
+        RELEASE_LOG_DEBUG(Extensions, "Could not bind integer: %s (%d)", m_db->m_lastErrorMessage.data(), (int)result);
+}
+
+void WebExtensionSQLiteStatement::bind(const double& n, int parameterIndex)
+{
+    m_db->assertQueue();
+    ASSERT(isValid());
+    ASSERT_ARG(parameterIndex, parameterIndex > 0);
+
+    int result = sqlite3_bind_double(m_handle, parameterIndex, n);
+    if (result != SQLITE_OK)
+        RELEASE_LOG_DEBUG(Extensions, "Could not bind int: %s (%d)", m_db->m_lastErrorMessage.data(), (int)result);
+}
+
+void WebExtensionSQLiteStatement::bind(const RefPtr<API::Data>& data, int parameterIndex)
+{
+    m_db->assertQueue();
+    ASSERT(isValid());
+    ASSERT_ARG(parameterIndex, parameterIndex > 0);
+
+    int result = sqlite3_bind_blob(m_handle, parameterIndex, data->span().data(), data->span().size(), SQLITE_TRANSIENT);
+    if (result != SQLITE_OK)
+        RELEASE_LOG_DEBUG(Extensions, "Could not bind blob: %s (%d)", m_db->m_lastErrorMessage.data(), (int)result);
+}
+
+void WebExtensionSQLiteStatement::bind(int parameterIndex)
+{
+    m_db->assertQueue();
+    ASSERT(isValid());
+    ASSERT_ARG(parameterIndex, parameterIndex > 0);
+
+    int result = sqlite3_bind_null(m_handle, parameterIndex);
+    if (result != SQLITE_OK)
+        RELEASE_LOG_DEBUG(Extensions, "Could not bind null: %s (%d)", m_db->m_lastErrorMessage.data(), (int)result);
+}
+
+HashMap<String, int> WebExtensionSQLiteStatement::columnNamesToIndicies()
+{
+    m_db->assertQueue();
+    ASSERT(isValid());
+
+    if (!m_columnNamesToIndicies.isEmpty())
+        return m_columnNamesToIndicies;
+
+    int columnCount = sqlite3_column_count(m_handle);
+    m_columnNamesToIndicies.reserveInitialCapacity(columnCount);
+
+    for (int i = 0; i < columnCount; i++) {
+        const char* columnName = sqlite3_column_name(m_handle, i);
+        ASSERT(columnName);
+
+        m_columnNamesToIndicies.add(String::fromUTF8(columnName), i);
+    }
+
+    return m_columnNamesToIndicies;
+}
+
+Vector<String> WebExtensionSQLiteStatement::columnNames()
+{
+    m_db->assertQueue();
+    ASSERT(isValid());
+
+    if (!m_columnNames.isEmpty())
+        return m_columnNames;
+
+    int columnCount = sqlite3_column_count(m_handle);
+    m_columnNames.reserveInitialCapacity(columnCount);
+
+    for (int i = 0; i < columnCount; i++) {
+        const char* columnName = sqlite3_column_name(m_handle, i);
+        ASSERT(columnName);
+
+        m_columnNames.append(String::fromUTF8(columnName));
+    }
+
+    return m_columnNames;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2024 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "APIData.h"
+#include "APIError.h"
+#include "WebExtensionSQLiteDatabase.h"
+#include <sqlite3.h>
+#include <wtf/Forward.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/RefPtr.h>
+#include <wtf/URL.h>
+#include <wtf/WorkQueue.h>
+
+namespace WebKit {
+
+class WebExtensionSQLiteRow;
+class WebExtensionSQLiteRowEnumerator;
+
+class WebExtensionSQLiteStatement : public RefCounted<WebExtensionSQLiteStatement> {
+    WTF_MAKE_NONCOPYABLE(WebExtensionSQLiteStatement);
+    WTF_MAKE_TZONE_ALLOCATED(WebExtensionSQLiteStatement);
+
+public:
+    template<typename... Args>
+    static Ref<WebExtensionSQLiteStatement> create(Args&&... args)
+    {
+        return adoptRef(*new WebExtensionSQLiteStatement(std::forward<Args>(args)...));
+    }
+
+    explicit WebExtensionSQLiteStatement(Ref<WebExtensionSQLiteDatabase>, const String& query, RefPtr<API::Error> outError = nullptr);
+
+    ~WebExtensionSQLiteStatement();
+
+    void bind(const String&, int parameterIndex);
+    void bind(const int&, int parameterIndex);
+    void bind(const int64_t&, int parameterIndex);
+    void bind(const double&, int parameterIndex);
+    void bind(const RefPtr<API::Data>&, int parameterIndex);
+    void bind(int parameterIndex);
+
+    int execute();
+    bool execute(RefPtr<API::Error>&);
+
+    Ref<WebExtensionSQLiteRowEnumerator> fetch();
+    bool fetchWithEnumerationCallback(Function<void(RefPtr<WebExtensionSQLiteRow>, bool)>&, RefPtr<API::Error>&);
+
+    void reset();
+    void invalidate();
+
+    Ref<WebExtensionSQLiteDatabase> database() { return m_db; };
+    sqlite3_stmt* handle() { return m_handle; };
+    bool isValid() { return !!m_handle; };
+
+    Vector<String> columnNames();
+    HashMap<String, int> columnNamesToIndicies();
+private:
+    sqlite3_stmt* m_handle;
+    Ref<WebExtensionSQLiteDatabase> m_db;
+
+    Vector<String> m_columnNames;
+    HashMap<String, int> m_columnNamesToIndicies;
+};
+
+}; // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.cpp
@@ -1,0 +1,397 @@
+/*
+ * Copyright (C) 2024 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebExtensionSQLiteStore.h"
+
+#include "WebExtensionSQLiteHelpers.h"
+#include <sqlite3.h>
+#include <wtf/MainThread.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/TZoneMallocInlines.h>
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebExtensionSQLiteStore);
+
+WebExtensionSQLiteStore::WebExtensionSQLiteStore(const String& uniqueIdentifier, const String& directory, bool useInMemoryDatabase)
+    : m_uniqueIdentifier(uniqueIdentifier)
+    , m_directory(URL(URL("file:"_s), directory))
+    , m_queue(WorkQueue::create("com.apple.WebKit.WKWebExtensionSQLiteStore"_s))
+    , m_useInMemoryDatabase(useInMemoryDatabase)
+{
+}
+
+void WebExtensionSQLiteStore::close()
+{
+    if (!database())
+        return;
+
+    if (isMainRunLoop()) {
+        queue()->dispatchSync([db = RefPtr { database() }] {
+            db->close();
+        });
+
+        return;
+    }
+
+    assertIsCurrent(queue());
+    database()->close();
+}
+
+void WebExtensionSQLiteStore::deleteDatabase(CompletionHandler<void(const String& errorMessage)>&& completionHandler)
+{
+    queue()->dispatch([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
+        auto deleteDatabaseErrorMessage = protectedThis->deleteDatabase();
+        WorkQueue::protectedMain()->dispatch([deleteDatabaseErrorMessage, completionHandler = WTFMove(completionHandler)]() mutable {
+            completionHandler(deleteDatabaseErrorMessage);
+        });
+    });
+}
+
+// MARK: Database Management
+
+void WebExtensionSQLiteStore::vacuum()
+{
+    assertIsCurrent(queue());
+    ASSERT(m_database);
+
+    DatabaseResult result = SQLiteDatabaseExecute(*m_database, "VACUUM"_s);
+    if (result != SQLITE_DONE)
+        RELEASE_LOG_ERROR(Extensions, "Failed to vacuum database for extension %s: %s (%d)", m_uniqueIdentifier.utf8().data(), m_database->m_lastErrorMessage.data(), result);
+}
+
+bool WebExtensionSQLiteStore::openDatabaseIfNecessary(String& outErrorMessage, bool createIfNecessary)
+{
+    assertIsCurrent(queue());
+
+    if (isDatabaseOpen()) {
+        outErrorMessage = nullString();
+        return true;
+    }
+
+    auto accessType = createIfNecessary ? WebExtensionSQLiteDatabase::AccessType::ReadWriteCreate : WebExtensionSQLiteDatabase::AccessType::ReadWrite;
+    outErrorMessage = openDatabase(databaseURL(), accessType, true);
+    return isDatabaseOpen();
+}
+
+String WebExtensionSQLiteStore::openDatabase(const URL& databaseURL, WebExtensionSQLiteDatabase::AccessType accessType, bool deleteDatabaseFileOnError)
+{
+    assertIsCurrent(queue());
+    ASSERT(!isDatabaseOpen());
+
+    bool usingDatabaseFile = !m_useInMemoryDatabase;
+
+    if (usingDatabaseFile) {
+        if (!FileSystem::makeAllDirectories(m_directory.fileSystemPath()) || FileSystem::fileType(m_directory.fileSystemPath()) != FileSystem::FileType::Directory) {
+            RELEASE_LOG_ERROR(Extensions, "Failed to create extension storage directory for extension %s", m_uniqueIdentifier.utf8().data());
+            return "Failed to create extension storage directory."_s;
+        }
+    }
+
+    m_database = WebExtensionSQLiteDatabase::create(databaseURL, m_queue.copyRef());
+
+    // FIXME: rdar://87898825 (unlimitedStorage: Allow the SQLite database to be opened as SQLiteDatabaseAccessTypeReadOnly if the request is to calculate storage size).
+    RefPtr<API::Error> error;
+    if (RefPtr db = m_database; !db->openWithAccessType(accessType, { }, { }, error)) {
+        if (!error && accessType != WebExtensionSQLiteDatabase::AccessType::ReadWriteCreate) {
+            // The file didn't exist and we were not asked to create it.
+            m_database = nullptr;
+            return nullString();
+        }
+
+        if (error)
+            RELEASE_LOG_ERROR(Extensions, "Failed to open database for extension %s: %s", m_uniqueIdentifier.utf8().data(), error->localizedDescription().utf8().data());
+
+        if (usingDatabaseFile && deleteDatabaseFileOnError)
+            return deleteDatabaseFileAtURL(databaseURL, true);
+
+        db->close();
+        m_database = nullptr;
+
+        return "Failed to open extension storage database."_s;
+    }
+
+    // Enable write-ahead logging to minimize the impact of SQLite's disk I/O.
+    if (RefPtr db = m_database; !db->enableWAL(error)) {
+        if (error)
+            RELEASE_LOG_ERROR(Extensions, "Failed to enable write-ahead logging on database for extension %s: %s", m_uniqueIdentifier.utf8().data(), error->localizedDescription().utf8().data());
+
+        if (usingDatabaseFile && deleteDatabaseFileOnError)
+            return deleteDatabaseFileAtURL(databaseURL, true);
+
+        db->close();
+        m_database = nullptr;
+
+        return "Failed to open extension storage database."_s;
+    }
+
+    return handleSchemaVersioning(deleteDatabaseFileOnError);
+}
+
+bool WebExtensionSQLiteStore::isDatabaseOpen()
+{
+    assertIsCurrent(queue());
+    return !!m_database;
+}
+
+String WebExtensionSQLiteStore::deleteDatabaseFileAtURL(const URL& databaseURL, bool reopenDatabase)
+{
+    assertIsCurrent(queue());
+    ASSERT(!m_useInMemoryDatabase);
+
+    String errorMessage;
+    if (isDatabaseOpen()) {
+        if (RefPtr db = database(); db->close() != SQLITE_OK)
+            errorMessage = "Failed to close extension storage database"_s;
+        m_database = nullptr;
+    }
+
+    String databaseFilePath = databaseURL.fileSystemPath();
+    static constexpr std::array<ASCIILiteral, 2> databaseFileSuffixes { "-shm"_s, "-wal"_s };
+
+    // -shm and -wal files may not exist, so don't report errors for those.
+    for (auto& suffix : databaseFileSuffixes)
+        FileSystem::deleteFile(makeString(databaseFilePath, suffix));
+
+    if (FileSystem::fileExists(databaseFilePath) && !FileSystem::deleteFile(databaseFilePath)) {
+        RELEASE_LOG_ERROR(Extensions, "Failed to delete database for extension %s", m_uniqueIdentifier.utf8().data());
+        return "Failed to delete extension storage database file."_s;
+    }
+
+    if (!reopenDatabase) {
+        m_database = nullptr;
+        return errorMessage;
+    }
+
+    // Only try to recover from errors opening the database by deleting the file once.
+    return openDatabase(databaseURL, WebExtensionSQLiteDatabase::AccessType::ReadWriteCreate, false);
+}
+
+String WebExtensionSQLiteStore::deleteDatabaseIfEmpty()
+{
+    assertIsCurrent(queue());
+    if (!isDatabaseEmpty())
+        return nullString();
+
+    return deleteDatabase();
+}
+
+String WebExtensionSQLiteStore::deleteDatabase()
+{
+    assertIsCurrent(queue());
+
+    String databaseCloseErrorMessage;
+    if (isDatabaseOpen()) {
+        if (RefPtr db = database(); db->close() != SQLITE_OK) {
+            RELEASE_LOG_ERROR(Extensions, "Failed to close storage database for extension %s", m_uniqueIdentifier.utf8().data());
+            databaseCloseErrorMessage = "Failed to close extension storage database."_s;
+        }
+        m_database = nullptr;
+    }
+
+    if (m_useInMemoryDatabase)
+        return databaseCloseErrorMessage;
+
+    String deleteDatabaseFileErrorMessage = deleteDatabaseFileAtURL(databaseURL(), false);
+
+    // An error from closing the database takes precedence over an error deleting the database file.
+    return databaseCloseErrorMessage.length() ? databaseCloseErrorMessage : deleteDatabaseFileErrorMessage;
+}
+
+String WebExtensionSQLiteStore::handleSchemaVersioning(bool deleteDatabaseFileOnError)
+{
+    SchemaVersion currentSchemaVersion = currentDatabaseSchemaVersion();
+    SchemaVersion schemaVersion = migrateToCurrentSchemaVersionIfNeeded();
+
+    if (schemaVersion != currentSchemaVersion) {
+        RELEASE_LOG_ERROR(Extensions, "Schema version (%d) does not match the supported schema version (%d) in database for extension %s", schemaVersion, currentSchemaVersion, m_uniqueIdentifier.utf8().data());
+
+        if (!m_useInMemoryDatabase && deleteDatabaseFileOnError)
+            return deleteDatabaseFileAtURL(databaseURL(), true);
+
+        RefPtr db = database();
+        db->close();
+
+        m_database = nullptr;
+
+        return "Failed to open extension storage database because of an invalid schema version."_s;
+    }
+
+    return nullString();
+}
+
+SchemaVersion WebExtensionSQLiteStore::migrateToCurrentSchemaVersionIfNeeded()
+{
+    assertIsCurrent(queue());
+
+    auto schemaVersion = databaseSchemaVersion();
+    auto currentSchemaVersion = currentDatabaseSchemaVersion();
+    if (schemaVersion == currentSchemaVersion)
+        return schemaVersion;
+
+    // The initial implementation of this class didn't store the schema version, which is indistinguishable from the database not existing at all.
+    // Because of this, we still need to do the migration when schemaVersion is 0, even though this is unnecessary if the database we just created,
+    // but we don't want to spam the log every time we create a new database.
+    if (!!schemaVersion)
+        RELEASE_LOG_INFO(Extensions, "Schema version (%d) does not match our supported schema version (%d) in database for extension %s, recreating database", schemaVersion, currentSchemaVersion, m_uniqueIdentifier.utf8().data());
+
+    // Someday we might migrate existing data from an older schema version, but we just start over for now.
+    if (resetDatabaseSchema() != SQLITE_DONE)
+        return 0;
+
+    if (setDatabaseSchemaVersion(0) != SQLITE_DONE)
+        return 0;
+
+    vacuum();
+
+    // We're dealing with a fresh database. Create the schema from scratch.
+    if (createFreshDatabaseSchema() != SQLITE_DONE)
+        return 0;
+
+    setDatabaseSchemaVersion(currentDatabaseSchemaVersion());
+
+    return currentDatabaseSchemaVersion();
+}
+
+SchemaVersion WebExtensionSQLiteStore::databaseSchemaVersion()
+{
+    assertIsCurrent(queue());
+    ASSERT(m_database);
+
+    SchemaVersion schemaVersion = 0;
+    Ref rows = SQLiteDatabaseFetch(*m_database, "PRAGMA user_version"_s);
+    if (RefPtr row = rows->next())
+        schemaVersion = row->getInt(0);
+    rows->statement()->invalidate();
+
+    return schemaVersion;
+}
+
+DatabaseResult WebExtensionSQLiteStore::setDatabaseSchemaVersion(SchemaVersion newVersion)
+{
+    assertIsCurrent(queue());
+    ASSERT(m_database);
+
+    DatabaseResult result = SQLiteDatabaseExecute(*m_database, makeString("PRAGMA user_version = "_s, newVersion));
+    if (result != SQLITE_DONE)
+        RELEASE_LOG_ERROR(Extensions, "Failed to set database version for extension %s: %s (%d)", m_uniqueIdentifier.utf8().data(), m_database->m_lastErrorMessage.data(), result);
+
+    return result;
+}
+
+String WebExtensionSQLiteStore::savepointNameFromUUID(const WTF::UUID& savepointIdentifier)
+{
+    return makeString("S"_s, makeStringByReplacingAll(savepointIdentifier.toString(), "-"_s, ""_s));
+}
+
+void WebExtensionSQLiteStore::createSavepoint(CompletionHandler<void(Markable<WTF::UUID> savepointIdentifier, const String& errorMessage)>&& completionHandler)
+{
+    UUID savepointIdentifier = UUID::createVersion4();
+
+    queue()->dispatch([protectedThis = Ref { *this }, savepointIdentifier = WTFMove(savepointIdentifier), completionHandler = WTFMove(completionHandler)]() mutable {
+        String errorMessage;
+        if (protectedThis->openDatabaseIfNecessary(errorMessage, false)) {
+            WorkQueue::protectedMain()->dispatch([errorMessage = WTFMove(errorMessage), completionHandler = WTFMove(completionHandler)]() mutable {
+                completionHandler({ }, errorMessage);
+            });
+
+            return;
+        }
+
+        ASSERT(!errorMessage.length());
+        ASSERT(protectedThis->m_database);
+
+        DatabaseResult result = SQLiteDatabaseExecute(*(protectedThis->m_database), makeString("SAVEPOINT "_s, protectedThis->savepointNameFromUUID(savepointIdentifier)));
+        if (result != SQLITE_DONE) {
+            RELEASE_LOG_ERROR(Extensions, "Failed to create storage savepoint for extension %s. %s (%d)", protectedThis->m_uniqueIdentifier.utf8().data(), protectedThis->m_database->m_lastErrorMessage.data(), result);
+            errorMessage = "Failed to create savepoint."_s;
+        }
+
+        WorkQueue::protectedMain()->dispatch([errorMessage = WTFMove(errorMessage), savepointIdentifier = WTFMove(savepointIdentifier), completionHandler = WTFMove(completionHandler)]() mutable {
+            completionHandler(!errorMessage.length() ? savepointIdentifier : WTF::UUID { UInt128 { 0 } }, errorMessage);
+        });
+    });
+}
+
+void WebExtensionSQLiteStore::commitSavepoint(WTF::UUID& savepointIdentifier, CompletionHandler<void(const String& errorMessage)>&& completionHandler)
+{
+    queue()->dispatch([protectedThis = Ref { *this }, savepointIdentifier = WTFMove(savepointIdentifier), completionHandler = WTFMove(completionHandler)]() mutable {
+        String errorMessage;
+        if (protectedThis->openDatabaseIfNecessary(errorMessage, false)) {
+            WorkQueue::protectedMain()->dispatch([errorMessage = WTFMove(errorMessage), completionHandler = WTFMove(completionHandler)]() mutable {
+                completionHandler(errorMessage);
+            });
+
+            return;
+        }
+
+        ASSERT(errorMessage.isEmpty());
+        ASSERT(protectedThis->m_database);
+
+        DatabaseResult result = SQLiteDatabaseExecute(*(protectedThis->m_database), makeString("RELEASE SAVEPOINT "_s, protectedThis->savepointNameFromUUID(savepointIdentifier)));
+        if (result != SQLITE_DONE) {
+            RELEASE_LOG_ERROR(Extensions, "Failed to release storage savepoint for extension %s. %s (%d)", protectedThis->m_uniqueIdentifier.utf8().data(), protectedThis->m_database->m_lastErrorMessage.data(), result);
+            errorMessage = "Failed to release savepoint."_s;
+        }
+
+        WorkQueue::protectedMain()->dispatch([errorMessage = WTFMove(errorMessage), completionHandler = WTFMove(completionHandler)]() mutable {
+            completionHandler(errorMessage);
+        });
+    });
+}
+
+void WebExtensionSQLiteStore::rollbackToSavepoint(WTF::UUID& savepointIdentifier, CompletionHandler<void(const String& errorMessage)>&& completionHandler)
+{
+    queue()->dispatch([protectedThis = Ref { *this }, savepointIdentifier = WTFMove(savepointIdentifier), completionHandler = WTFMove(completionHandler)]() mutable {
+        String errorMessage;
+        if (protectedThis->openDatabaseIfNecessary(errorMessage, false)) {
+            WorkQueue::protectedMain()->dispatch([errorMessage = WTFMove(errorMessage), completionHandler = WTFMove(completionHandler)]() mutable {
+                completionHandler(errorMessage);
+            });
+
+            return;
+        }
+
+        ASSERT(errorMessage.isEmpty());
+        ASSERT(protectedThis->m_database);
+
+        DatabaseResult result = SQLiteDatabaseExecute(*(protectedThis->m_database), makeString("ROLLBACK TO SAVEPOINT "_s, protectedThis->savepointNameFromUUID(savepointIdentifier)));
+        if (result != SQLITE_DONE) {
+            RELEASE_LOG_ERROR(Extensions, "Failed to rollback to storage savepoint for extension %s. %s (%d)", protectedThis->m_uniqueIdentifier.utf8().data(), protectedThis->m_database->m_lastErrorMessage.data(), result);
+            errorMessage = "Failed to rollback to savepoint."_s;
+        }
+
+        WorkQueue::protectedMain()->dispatch([errorMessage = WTFMove(errorMessage), completionHandler = WTFMove(completionHandler)]() mutable {
+            completionHandler(errorMessage);
+        });
+    });
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2024 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WebExtensionSQLiteDatabase.h"
+#include <wtf/CompletionHandler.h>
+#include <wtf/Forward.h>
+#include <wtf/Function.h>
+#include <wtf/Markable.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/UUID.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+typedef int SchemaVersion;
+typedef int DatabaseResult;
+using WTF::UUID;
+
+class WebExtensionSQLiteStore : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebExtensionSQLiteStore> {
+    WTF_MAKE_TZONE_ALLOCATED(WebExtensionSQLiteStore);
+    WTF_MAKE_NONCOPYABLE(WebExtensionSQLiteStore)
+
+public:
+    WebExtensionSQLiteStore(const String& uniqueIdentifier, const String& directory, bool useInMemoryDatabase);
+    virtual ~WebExtensionSQLiteStore() { close(); };
+
+    SchemaVersion databaseSchemaVersion();
+    bool useInMemoryDatabase() { return m_useInMemoryDatabase; };
+
+    bool openDatabaseIfNecessary(String& outErrorMessage, bool createIfNecessary);
+
+    void close();
+    void deleteDatabase(CompletionHandler<void(const String& errorMessage)>&&);
+    String deleteDatabaseIfEmpty();
+
+    void createSavepoint(CompletionHandler<void(Markable<WTF::UUID> savepointIdentifier, const String& errorMessage)>&&);
+    void commitSavepoint(WTF::UUID& savepointIdentifier, CompletionHandler<void(const String& errorMessage)>&&);
+    void rollbackToSavepoint(WTF::UUID& savepointIdentifier, CompletionHandler<void(const String& errorMessage)>&&);
+
+protected:
+    virtual DatabaseResult createFreshDatabaseSchema() = 0;
+    virtual DatabaseResult resetDatabaseSchema() = 0;
+    virtual bool isDatabaseEmpty() = 0;
+    virtual SchemaVersion currentDatabaseSchemaVersion() = 0;
+    virtual URL databaseURL() = 0;
+
+    DatabaseResult setDatabaseSchemaVersion(SchemaVersion newVersion);
+    SchemaVersion migrateToCurrentSchemaVersionIfNeeded();
+
+    Ref<WorkQueue> queue() { return m_queue; };
+    RefPtr<WebExtensionSQLiteDatabase> database() { return m_database; };
+    String uniqueIdentifier() { return m_uniqueIdentifier; };
+    CString lastErrorMessage() { return m_database->m_lastErrorMessage; };
+    URL directory() { return m_directory; };
+
+private:
+    void vacuum();
+    bool isDatabaseOpen();
+    String openDatabase(const URL& databaseURL, WebExtensionSQLiteDatabase::AccessType, bool deleteDatabaseFileOnError);
+    String deleteDatabaseFileAtURL(const URL& databaseURL, bool reopenDatabase);
+    String deleteDatabase();
+
+    String savepointNameFromUUID(const WTF::UUID& savepointIdentifier);
+
+    String handleSchemaVersioning(bool deleteDatabaseFileOnError);
+
+    String m_uniqueIdentifier;
+    URL m_directory;
+    RefPtr<WebExtensionSQLiteDatabase> m_database;
+    Ref<WorkQueue> m_queue;
+    bool m_useInMemoryDatabase;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -302,6 +302,10 @@ Shared/API/c/WKUserContentURLPattern.cpp
 Shared/Databases/IndexedDB/IDBUtilities.cpp
 
 Shared/Extensions/WebExtensionFrameIdentifier.cpp
+Shared/Extensions/WebExtensionSQLiteDatabase.cpp
+Shared/Extensions/WebExtensionSQLiteStatement.cpp
+Shared/Extensions/WebExtensionSQLiteRow.cpp
+Shared/Extensions/WebExtensionSQLiteStore.cpp
 Shared/Extensions/WebExtensionLocalization.cpp
 Shared/Extensions/WebExtensionPermission.cpp
 Shared/Extensions/WebExtensionUtilities.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -6649,6 +6649,16 @@
 		7CF47FF917275C57008ACB91 /* PageBanner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageBanner.h; sourceTree = "<group>"; };
 		7CF47FFC17276AE3008ACB91 /* WKBundlePageBannerMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKBundlePageBannerMac.mm; sourceTree = "<group>"; };
 		7CF47FFD17276AE3008ACB91 /* WKBundlePageBannerMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKBundlePageBannerMac.h; sourceTree = "<group>"; };
+		7D49D11F2D1AA1AE00C6855E /* WebExtensionSQLiteDatabase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionSQLiteDatabase.h; sourceTree = "<group>"; };
+		7D49D1202D1AA1AE00C6855E /* WebExtensionSQLiteDatabase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionSQLiteDatabase.cpp; sourceTree = "<group>"; };
+		7D49D1212D1AA1AE00C6855E /* WebExtensionSQLiteDatatypeTraits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionSQLiteDatatypeTraits.h; sourceTree = "<group>"; };
+		7D49D1222D1AA1AE00C6855E /* WebExtensionSQLiteHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionSQLiteHelpers.h; sourceTree = "<group>"; };
+		7D49D1232D1AA1AE00C6855E /* WebExtensionSQLiteRow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionSQLiteRow.h; sourceTree = "<group>"; };
+		7D49D1242D1AA1AE00C6855E /* WebExtensionSQLiteRow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionSQLiteRow.cpp; sourceTree = "<group>"; };
+		7D49D1252D1AA1AE00C6855E /* WebExtensionSQLiteStatement.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionSQLiteStatement.h; sourceTree = "<group>"; };
+		7D49D1262D1AA1AE00C6855E /* WebExtensionSQLiteStatement.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionSQLiteStatement.cpp; sourceTree = "<group>"; };
+		7D49D1272D1AA1AE00C6855E /* WebExtensionSQLiteStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionSQLiteStore.h; sourceTree = "<group>"; };
+		7D49D1282D1AA1AE00C6855E /* WebExtensionSQLiteStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionSQLiteStore.cpp; sourceTree = "<group>"; };
 		7D5151492CF818CA0035DD16 /* WebExtensionLocalization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionLocalization.h; sourceTree = "<group>"; };
 		7D51514A2CF818CA0035DD16 /* WebExtensionLocalization.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionLocalization.cpp; sourceTree = "<group>"; };
 		7D51514B2CF818CA0035DD16 /* WebExtensionUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionUtilities.cpp; sourceTree = "<group>"; };
@@ -13872,6 +13882,16 @@
 				B624FF1A2ABE503000F6EDF6 /* WebExtensionScriptInjectionResultParameters.h */,
 				0237F5E92C4B27F500AD23EF /* WebExtensionSidebarParameters.h */,
 				0237F5E82C4B27DC00AD23EF /* WebExtensionSidebarParameters.serialization.in */,
+				7D49D1202D1AA1AE00C6855E /* WebExtensionSQLiteDatabase.cpp */,
+				7D49D11F2D1AA1AE00C6855E /* WebExtensionSQLiteDatabase.h */,
+				7D49D1212D1AA1AE00C6855E /* WebExtensionSQLiteDatatypeTraits.h */,
+				7D49D1222D1AA1AE00C6855E /* WebExtensionSQLiteHelpers.h */,
+				7D49D1242D1AA1AE00C6855E /* WebExtensionSQLiteRow.cpp */,
+				7D49D1232D1AA1AE00C6855E /* WebExtensionSQLiteRow.h */,
+				7D49D1262D1AA1AE00C6855E /* WebExtensionSQLiteStatement.cpp */,
+				7D49D1252D1AA1AE00C6855E /* WebExtensionSQLiteStatement.h */,
+				7D49D1282D1AA1AE00C6855E /* WebExtensionSQLiteStore.cpp */,
+				7D49D1272D1AA1AE00C6855E /* WebExtensionSQLiteStore.h */,
 				B6B156592B5E1779004F9894 /* WebExtensionStorage.serialization.in */,
 				B6B1565A2B5E177A004F9894 /* WebExtensionStorageAccessLevel.h */,
 				1C4957A22A983E39007D0B64 /* WebExtensionTab.serialization.in */,
@@ -20327,9 +20347,7 @@
 		};
 		5C400E6A29DB8AB500446F6F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = 5C139DA129DB82E500D5117B /* WebContentCaptivePortalExtension */;
 			targetProxy = 5C400E6929DB8AB500446F6F /* PBXContainerItemProxy */;
 		};
@@ -20345,25 +20363,19 @@
 		};
 		5CE4B60729CEBB760038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = 5CA5A2C929CBBA1A000F1046 /* WebContentExtension */;
 			targetProxy = 5CE4B60629CEBB760038F565 /* PBXContainerItemProxy */;
 		};
 		5CE4B62329CF880B0038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = 5CE4B61529CF877F0038F565 /* GPUExtension */;
 			targetProxy = 5CE4B62229CF880B0038F565 /* PBXContainerItemProxy */;
 		};
 		5CE4B62529CF880B0038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = 5CE4B60829CF87680038F565 /* NetworkingExtension */;
 			targetProxy = 5CE4B62429CF880B0038F565 /* PBXContainerItemProxy */;
 		};

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -317,6 +317,10 @@ _PATH_RULES_SPECIFIER = [
      ["-build/include_order",
       "-readability/naming/underscores"]),
 
+    ([  # This file has >= symbols in templates, which looks like a closing bracket to the style checker
+     os.path.join('Source', 'WebKit', 'Shared', 'Extensions', 'WebExtensionSQLiteHelpers.h')],
+     ["-readability/naming/underscores"]),
+
     # For third-party code, keep only the following checks--
     #
     #   No tabs: to avoid having to set the SVN allow-tabs property.


### PR DESCRIPTION
#### 0d58f6b2b12f66664bdc7e052869a8d406967b21
<pre>
Create a C++ implementation of WebExtensionSQLite classes
<a href="https://webkit.org/b/285893">https://webkit.org/b/285893</a>

Reviewed by Timothy Hatcher.

This adds a new WebExtensionSQLite implementation, with the Database, Helpers, Row, Statements, and Store classes.
Currently, there is no usage of this implementation, as StorageSQLiteStore, RegisteredScriptsSQLiteStore, and DeclarativeNetRequestSQLiteStore should be ported separately.

* Source/WebKit/Scripts/generate-unified-sources.sh:
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.cpp: Added.
(WebExtensionSQLiteDatabase::WebExtensionSQLiteDatabase):
(WebExtensionSQLiteDatabase::assertQueue):
(WebExtensionSQLiteDatabase::close):
(WebExtensionSQLiteDatabase::reportErrorWithCode):
(WebExtensionSQLiteDatabase::errorWithSQLiteErrorCode):
(WebExtensionSQLiteDatabase::enableWAL):
(WebExtensionSQLiteDatabase::openWithAccessType):
(WebExtensionSQLiteDatabase::inMemoryDatabaseURL):
(WebExtensionSQLiteDatabase::privateOnDiskDatabaseURL):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h: Added.
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatatypeTraits.h: Added.
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;int&gt;::fetch):
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;int&gt;::bind):
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;int64_t&gt;::fetch):
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;int64_t&gt;::bind):
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;double&gt;::fetch):
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;double&gt;::bind):
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;String&gt;::fetch):
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;String&gt;::bind):
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;RefPtr&lt;API::Data&gt;&gt;::fetch):
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;RefPtr&lt;API::Data&gt;&gt;::bind):
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;std::nullptr_t&gt;::fetch):
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;std::nullptr_t&gt;::bind):
(WebKit::WebExtensionSQLiteDatatypeTraits&lt;decltype):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteHelpers.h: Added.
(WebKit::SQLiteIsExecutionError):
(WebKit::SQLiteDatabaseExecuteAndReturnIntError):
(WebKit::SQLiteStatementBindAllParameters):
(WebKit::SQLiteDatabaseExecute):
(WebKit::SQLiteDatabaseExecuteAndReturnError):
(WebKit::SQLiteDatabaseFetch):
(WebKit::SQLiteStatementBindParameter):
(WebKit::SQLiteStatementBindParameter&lt;unsigned&gt;):
(WebKit::SQLiteStatementBindParameter&lt;uint64_t&gt;):
(WebKit::SQLiteStatementBindParameter&lt;long&gt;):
(WebKit::SQLiteStatementBindParameter&lt;bool&gt;):
(WebKit::SQLiteStatementBindTupleParameters):
(WebKit::SQLiteIteratorBlock::SQLiteIteratorBlock):
(WebKit::SQLiteIteratorBlock::callBlockWithAllColumns):
(WebKit::StatementCallBlockWithAllColumns):
(WebKit::WBSStatementFetchColumnsInTuple):
(WebKit::SQLiteStatementBindOrStep):
(WebKit::SQLiteStatementBind):
(WebKit::SQLiteDatabaseEnumerate):
(WebKit::SQLiteDatabaseEnumerateRows):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.cpp: Added.
(WebKit::WebExtensionSQLiteRow::WebExtensionSQLiteRow):
(WebKit::WebExtensionSQLiteRow::getString):
(WebKit::WebExtensionSQLiteRow::getInt):
(WebKit::WebExtensionSQLiteRow::getInt64):
(WebKit::WebExtensionSQLiteRow::getDouble):
(WebKit::WebExtensionSQLiteRow::getBool):
(WebKit::WebExtensionSQLiteRow::getData):
(WebKit::WebExtensionSQLiteRow::isNullAtIndex):
(WebKit::WebExtensionSQLiteRowEnumerator::WebExtensionSQLiteRowEnumerator):
(WebKit::WebExtensionSQLiteRowEnumerator::next):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteRow.h: Added.
(WebKit::WebExtensionSQLiteRow::create):
(WebKit::WebExtensionSQLiteRowEnumerator::create):
(WebKit::WebExtensionSQLiteRowEnumerator::statement):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.cpp: Added.
(WebKit::WebExtensionSQLiteStatement::WebExtensionSQLiteStatement):
(WebKit::WebExtensionSQLiteStatement::~WebExtensionSQLiteStatement):
(WebKit::WebExtensionSQLiteStatement::execute):
(WebKit::WebExtensionSQLiteStatement::fetch):
(WebKit::WebExtensionSQLiteStatement::fetchWithEnumerationCallback):
(WebKit::WebExtensionSQLiteStatement::reset):
(WebKit::WebExtensionSQLiteStatement::invalidate):
(WebKit::WebExtensionSQLiteStatement::bind):
(WebKit::WebExtensionSQLiteStatement::columnNamesToIndicies):
(WebKit::WebExtensionSQLiteStatement::columnNames):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteStatement.h: Added.
(WebKit::WebExtensionSQLiteStatement::create):
(WebKit::WebExtensionSQLiteStatement::database):
(WebKit::WebExtensionSQLiteStatement::handle):
(WebKit::WebExtensionSQLiteStatement::isValid):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.cpp: Added.
(WebKit::WebExtensionSQLiteStore::WebExtensionSQLiteStore):
(WebKit::WebExtensionSQLiteStore::close):
(WebKit::WebExtensionSQLiteStore::deleteDatabase):
(WebKit::WebExtensionSQLiteStore::vacuum):
(WebKit::WebExtensionSQLiteStore::openDatabaseIfNecessary):
(WebKit::WebExtensionSQLiteStore::openDatabase):
(WebKit::WebExtensionSQLiteStore::isDatabaseOpen):
(WebKit::WebExtensionSQLiteStore::deleteDatabaseFileAtURL):
(WebKit::WebExtensionSQLiteStore::deleteDatabaseIfEmpty):
(WebKit::WebExtensionSQLiteStore::handleSchemaVersioning):
(WebKit::WebExtensionSQLiteStore::migrateToCurrentSchemaVersionIfNeeded):
(WebKit::WebExtensionSQLiteStore::databaseSchemaVersion):
(WebKit::WebExtensionSQLiteStore::setDatabaseSchemaVersion):
(WebKit::WebExtensionSQLiteStore::savepointNameFromUUID):
(WebKit::WebExtensionSQLiteStore::createSavepoint):
(WebKit::WebExtensionSQLiteStore::commitSavepoint):
(WebKit::WebExtensionSQLiteStore::rollbackToSavepoint):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteStore.h: Added.
(WebKit::WebExtensionSQLiteStore::~WebExtensionSQLiteStore):
(WebKit::WebExtensionSQLiteStore::useInMemoryDatabase):
(WebKit::WebExtensionSQLiteStore::queue):
(WebKit::WebExtensionSQLiteStore::database):
(WebKit::WebExtensionSQLiteStore::uniqueIdentifier):
(WebKit::WebExtensionSQLiteStore::lastErrorMessage):
(WebKit::WebExtensionSQLiteStore::directory):
* Source/WebKit/Sources.txt:
* Source/WebKit/UnifiedSources-output.xcfilelist:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/Scripts/webkitpy/style/checker.py:

Canonical link: <a href="https://commits.webkit.org/289200@main">https://commits.webkit.org/289200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/689b034fff04992619ded30d39f5f7f96727b719

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90470 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36384 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66343 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24158 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3937 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77519 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46625 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/84749 "webkitpy-tests (failure)") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31780 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35452 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74540 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32618 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91960 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74924 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12918 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74043 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18423 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16854 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4710 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13362 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12632 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18097 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12462 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15955 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14213 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->