### PR TITLE
iOS Safari "click" events have the "mouse" pointerType when triggered from touch

### DIFF
--- a/LayoutTests/pointerevents/ios/pointer-type-attribute-on-stylus-tap-expected.txt
+++ b/LayoutTests/pointerevents/ios/pointer-type-attribute-on-stylus-tap-expected.txt
@@ -1,0 +1,15 @@
+Verifies the expected PointerEvent.pointerType attribute when stylus tapping on an element. This test requires WebKitTestRunner
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS receivedDown became true
+PASS receivedUp became true
+PASS receivedClick became true
+Received 'pointerdown' event with pointerType: 'pen'
+Received 'pointerup' event with pointerType: 'pen'
+Received 'click' event with pointerType: 'pen'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Tap here

--- a/LayoutTests/pointerevents/ios/pointer-type-attribute-on-stylus-tap.html
+++ b/LayoutTests/pointerevents/ios/pointer-type-attribute-on-stylus-tap.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    font-family: system-ui;
+    font-size: 16px;
+}
+
+.container {
+    width: 200px;
+    height: 200px;
+    text-align: center;
+    line-height: 200px;
+    background: teal;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+receivedDown = false;
+receivedUp = false;
+receivedClick = false;
+
+var downType;
+var upType;
+var clickType;
+
+addEventListener("load", async () => {
+    description("Verifies the expected PointerEvent.pointerType attribute when stylus tapping on an element. This test requires WebKitTestRunner");
+
+    const div = document.querySelector("#div");
+
+    div.addEventListener("pointerdown", (event) => {
+        event.preventDefault();
+        receivedDown = true;
+        downType = event.pointerType;
+    });
+
+    div.addEventListener("pointerup", (event) => {
+        event.preventDefault();
+        receivedUp = true;
+        upType = event.pointerType;
+    });
+
+    div.addEventListener("click", (event) => {
+        event.preventDefault();
+        receivedClick = true;
+        clickType = event.pointerType;
+    });
+
+    await UIHelper.stylusTapOnElement(div);
+
+    await shouldBecomeEqual("receivedDown", "true");
+    await shouldBecomeEqual("receivedUp", "true");
+    await shouldBecomeEqual("receivedClick", "true");
+
+    debug("Received 'pointerdown' event with pointerType: '" + downType + "'");
+    debug("Received 'pointerup' event with pointerType: '" + upType + "'");
+    debug("Received 'click' event with pointerType: '" + clickType + "'");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="container" id="div">Tap here</div>
+</body>
+</html>

--- a/LayoutTests/pointerevents/ios/pointer-type-attribute-on-touch-tap-expected.txt
+++ b/LayoutTests/pointerevents/ios/pointer-type-attribute-on-touch-tap-expected.txt
@@ -1,0 +1,15 @@
+Verifies the expected PointerEvent.pointerType attribute when touch tapping on an element. This test requires WebKitTestRunner
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS receivedDown became true
+PASS receivedUp became true
+PASS receivedClick became true
+Received 'pointerdown' event with pointerType: 'touch'
+Received 'pointerup' event with pointerType: 'touch'
+Received 'click' event with pointerType: 'touch'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Tap here

--- a/LayoutTests/pointerevents/ios/pointer-type-attribute-on-touch-tap.html
+++ b/LayoutTests/pointerevents/ios/pointer-type-attribute-on-touch-tap.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    font-family: system-ui;
+    font-size: 16px;
+}
+
+.container {
+    width: 200px;
+    height: 200px;
+    text-align: center;
+    line-height: 200px;
+    background: teal;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+receivedDown = false;
+receivedUp = false;
+receivedClick = false;
+
+var downType;
+var upType;
+var clickType;
+
+addEventListener("load", async () => {
+    description("Verifies the expected PointerEvent.pointerType attribute when touch tapping on an element. This test requires WebKitTestRunner");
+
+    const div = document.querySelector("#div");
+
+    div.addEventListener("pointerdown", (event) => {
+        event.preventDefault();
+        receivedDown = true;
+        downType = event.pointerType;
+    });
+
+    div.addEventListener("pointerup", (event) => {
+        event.preventDefault();
+        receivedUp = true;
+        upType = event.pointerType;
+    });
+
+    div.addEventListener("click", (event) => {
+        event.preventDefault();
+        receivedClick = true;
+        clickType = event.pointerType;
+    });
+
+    await UIHelper.tapElement(div);
+
+    await shouldBecomeEqual("receivedDown", "true");
+    await shouldBecomeEqual("receivedUp", "true");
+    await shouldBecomeEqual("receivedClick", "true");
+
+    debug("Received 'pointerdown' event with pointerType: '" + downType + "'");
+    debug("Received 'pointerup' event with pointerType: '" + upType + "'");
+    debug("Received 'click' event with pointerType: '" + clickType + "'");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="container" id="div">Tap here</div>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1482,6 +1482,13 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static stylusTapOnElement(element, modifiers=[])
+    {
+        const x = element.offsetLeft + element.offsetWidth / 2;
+        const y = element.offsetTop + element.offsetHeight / 2;
+        return UIHelper.stylusTapAt(x, y, modifiers);
+    }
+
     static attachmentInfo(attachmentIdentifier)
     {
         if (!this.isWebKit2())

--- a/Source/WebCore/dom/PointerEventTypeNames.h
+++ b/Source/WebCore/dom/PointerEventTypeNames.h
@@ -31,6 +31,6 @@ namespace WebCore {
 
 WEBCORE_EXPORT const String& mousePointerEventType();
 WEBCORE_EXPORT const String& penPointerEventType();
-const String& touchPointerEventType();
+WEBCORE_EXPORT const String& touchPointerEventType();
 
 } // namespace WebCore

--- a/Source/WebCore/platform/PlatformMouseEvent.h
+++ b/Source/WebCore/platform/PlatformMouseEvent.h
@@ -52,7 +52,7 @@ public:
     {
     }
 
-    PlatformMouseEvent(const IntPoint& position, const IntPoint& globalPosition, MouseButton button, PlatformEvent::Type type, int clickCount, OptionSet<PlatformEvent::Modifier> modifiers, WallTime timestamp, double force, SyntheticClickType syntheticClickType, PointerID pointerId = mousePointerID)
+    PlatformMouseEvent(const IntPoint& position, const IntPoint& globalPosition, MouseButton button, PlatformEvent::Type type, int clickCount, OptionSet<PlatformEvent::Modifier> modifiers, WallTime timestamp, double force, SyntheticClickType syntheticClickType, String pointerType = mousePointerEventType(), PointerID pointerId = mousePointerID)
         : PlatformEvent(type, modifiers, timestamp)
         , m_button(button)
         , m_syntheticClickType(syntheticClickType)
@@ -60,6 +60,7 @@ public:
         , m_globalPosition(globalPosition)
         , m_force(force)
         , m_pointerId(pointerId)
+        , m_pointerType(pointerType)
         , m_clickCount(clickCount)
     {
     }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1787,7 +1787,7 @@ public:
     bool mainFramePluginHandlesPageScaleGesture() const { return m_mainFramePluginHandlesPageScaleGesture; }
 
     void potentialTapAtPosition(const WebCore::FloatPoint&, bool shouldRequestMagnificationInformation, TapIdentifier requestID);
-    void commitPotentialTap(OptionSet<WebEventModifier>, TransactionID layerTreeTransactionIdAtLastTouchStart, WebCore::PointerID);
+    void commitPotentialTap(OptionSet<WebEventModifier>, TransactionID layerTreeTransactionIdAtLastTouchStart, WebCore::PointerID, const String& pointerType);
     void cancelPotentialTap();
     void tapHighlightAtPosition(const WebCore::FloatPoint&, TapIdentifier requestID);
     void attemptSyntheticClick(const WebCore::FloatPoint&, OptionSet<WebEventModifier>, TransactionID layerTreeTransactionIdAtLastTouchStart);

--- a/Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.h
+++ b/Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.h
@@ -39,6 +39,7 @@
 - (void)setResetTarget:(id)target action:(SEL)action;
 @property (nonatomic, weak) WKTouchEventsGestureRecognizer *supportingTouchEventsGestureRecognizer;
 @property (nonatomic, readonly) NSNumber *lastActiveTouchIdentifier;
+@property (nonatomic, readonly) std::optional<UITouchType> lastActiveTouchType;
 @end
 
 #endif

--- a/Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.mm
@@ -41,6 +41,7 @@
     __weak id _resetTarget;
     SEL _resetAction;
     RetainPtr<NSNumber> _lastActiveTouchIdentifier;
+    std::optional<UITouchType> _lastActiveTouchType;
 }
 
 - (void)setGestureIdentifiedTarget:(id)target action:(SEL)action
@@ -76,6 +77,7 @@
 
     [_resetTarget performSelector:_resetAction withObject:self];
     _lastActiveTouchIdentifier = nil;
+    _lastActiveTouchType = std::nullopt;
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
@@ -89,6 +91,7 @@
         UITouch *touch = [activeTouches objectForKey:touchIdentifier];
         if ([touch.gestureRecognizers containsObject:self]) {
             _lastActiveTouchIdentifier = touchIdentifier;
+            _lastActiveTouchType = touch.type;
             break;
         }
     }
@@ -97,6 +100,11 @@
 - (NSNumber*)lastActiveTouchIdentifier
 {
     return _lastActiveTouchIdentifier.get();
+}
+
+- (std::optional<UITouchType>)lastActiveTouchType
+{
+    return _lastActiveTouchType;
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -809,9 +809,9 @@ void WebPageProxy::potentialTapAtPosition(const WebCore::FloatPoint& position, b
     legacyMainFrameProcess().send(Messages::WebPage::PotentialTapAtPosition(requestID, position, shouldRequestMagnificationInformation), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::commitPotentialTap(OptionSet<WebEventModifier> modifiers, TransactionID layerTreeTransactionIdAtLastTouchStart, WebCore::PointerID pointerId)
+void WebPageProxy::commitPotentialTap(OptionSet<WebEventModifier> modifiers, TransactionID layerTreeTransactionIdAtLastTouchStart, WebCore::PointerID pointerId, const String& pointerType)
 {
-    legacyMainFrameProcess().send(Messages::WebPage::CommitPotentialTap(modifiers, layerTreeTransactionIdAtLastTouchStart, pointerId), webPageIDInMainFrameProcess());
+    legacyMainFrameProcess().send(Messages::WebPage::CommitPotentialTap(modifiers, layerTreeTransactionIdAtLastTouchStart, pointerId, pointerType), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::cancelPotentialTap()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -10175,7 +10175,7 @@ void WebPage::simulateClickOverFirstMatchingTextInViewportWithUserInteraction(co
 
     auto locationInWindow = view->contentsToWindow(location);
     auto makeSyntheticEvent = [&](PlatformEvent::Type type) -> PlatformMouseEvent {
-        return { locationInWindow, locationInWindow, MouseButton::Left, type, 1, { }, WallTime::now(), ForceAtClick, SyntheticClickType::OneFingerTap, mousePointerID };
+        return { locationInWindow, locationInWindow, MouseButton::Left, type, 1, { }, WallTime::now(), ForceAtClick, SyntheticClickType::OneFingerTap, mousePointerEventType(), mousePointerID };
     };
 
     WEBPAGE_RELEASE_LOG(MouseHandling, "Simulating click - dispatching events");

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -48,6 +48,7 @@
 #include <WebCore/PlaybackTargetClientContextIdentifier.h>
 #include <WebCore/PluginData.h>
 #include <WebCore/PointerCharacteristics.h>
+#include <WebCore/PointerEventTypeNames.h>
 #include <WebCore/PointerID.h>
 #include <WebCore/RectEdges.h>
 #include <WebCore/RegistrableDomain.h>
@@ -1003,7 +1004,7 @@ public:
 
     void attemptSyntheticClick(const WebCore::IntPoint&, OptionSet<WebKit::WebEventModifier>, TransactionID lastLayerTreeTransactionId);
     void potentialTapAtPosition(WebKit::TapIdentifier, const WebCore::FloatPoint&, bool shouldRequestMagnificationInformation);
-    void commitPotentialTap(OptionSet<WebKit::WebEventModifier>, TransactionID lastLayerTreeTransactionId, WebCore::PointerID);
+    void commitPotentialTap(OptionSet<WebKit::WebEventModifier>, TransactionID lastLayerTreeTransactionId, WebCore::PointerID, const String& pointerType);
     void commitPotentialTapFailed();
     void didHandleTapAsHover();
     void cancelPotentialTap();
@@ -1969,8 +1970,8 @@ private:
 #if PLATFORM(IOS_FAMILY)
     std::optional<FocusedElementInformation> focusedElementInformation();
     void generateSyntheticEditingCommand(SyntheticEditingCommandType);
-    void handleSyntheticClick(WebCore::Node& nodeRespondingToClick, const WebCore::FloatPoint& location, OptionSet<WebKit::WebEventModifier>, WebCore::PointerID = WebCore::mousePointerID);
-    void completeSyntheticClick(WebCore::Node& nodeRespondingToClick, const WebCore::FloatPoint& location, OptionSet<WebKit::WebEventModifier>, WebCore::SyntheticClickType, WebCore::PointerID = WebCore::mousePointerID);
+    void handleSyntheticClick(WebCore::Node& nodeRespondingToClick, const WebCore::FloatPoint& location, OptionSet<WebKit::WebEventModifier>, WebCore::PointerID = WebCore::mousePointerID, const String& pointerType = WebCore::mousePointerEventType());
+    void completeSyntheticClick(WebCore::Node& nodeRespondingToClick, const WebCore::FloatPoint& location, OptionSet<WebKit::WebEventModifier>, WebCore::SyntheticClickType, WebCore::PointerID = WebCore::mousePointerID, const String& pointerType = WebCore::mousePointerEventType());
     void sendTapHighlightForNodeIfNecessary(WebKit::TapIdentifier, WebCore::Node*, WebCore::FloatPoint);
     WebCore::VisiblePosition visiblePositionInFocusedNodeForPoint(const WebCore::LocalFrame&, const WebCore::IntPoint&, bool isInteractingWithFocusedElement);
     std::optional<WebCore::SimpleRange> rangeForGranularityAtPoint(WebCore::LocalFrame&, const WebCore::IntPoint&, WebCore::TextGranularity, bool isInteractingWithFocusedElement);
@@ -2827,6 +2828,7 @@ private:
     WebCore::FloatRect m_previousExposedContentRect;
     OptionSet<WebKit::WebEventModifier> m_pendingSyntheticClickModifiers;
     WebCore::PointerID m_pendingSyntheticClickPointerId { 0 };
+    String m_pendingSyntheticClickPointerType { WebCore::mousePointerEventType() };
     std::optional<DynamicViewportSizeUpdateID> m_pendingDynamicViewportSizeUpdateID;
     double m_lastTransactionPageScaleFactor { 0 };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -70,7 +70,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     AttemptSyntheticClick(WebCore::IntPoint point, OptionSet<WebKit::WebEventModifier> modifiers, WebKit::TransactionID lastLayerTreeTransactionId)
     PotentialTapAtPosition(WebKit::TapIdentifier requestID, WebCore::FloatPoint point, bool shouldRequestMagnificationInformation)
-    CommitPotentialTap(OptionSet<WebKit::WebEventModifier> modifiers, WebKit::TransactionID lastLayerTreeTransactionId, WebCore::PointerID pointerId)
+    CommitPotentialTap(OptionSet<WebKit::WebEventModifier> modifiers, WebKit::TransactionID lastLayerTreeTransactionId, WebCore::PointerID pointerId, String pointerType)
     CancelPotentialTap()
     TapHighlightAtPosition(WebKit::TapIdentifier requestID, WebCore::FloatPoint point)
     DidRecognizeLongPress()


### PR DESCRIPTION
#### d1f55d9bf83bf3a7c7d5df42efdbd9b3c6ec37d0
<pre>
iOS Safari &quot;click&quot; events have the &quot;mouse&quot; pointerType when triggered from touch
<a href="https://bugs.webkit.org/show_bug.cgi?id=282988">https://bugs.webkit.org/show_bug.cgi?id=282988</a>
<a href="https://rdar.apple.com/139828481">rdar://139828481</a>

Reviewed by Tim Horton.

282524@main made `click` a PointerEvent, but also introduced a small
PointerEvent spec incompliance, since the spec mandates that &quot;If the
events are generated by a pointing device, their pointerId and
pointerType MUST be the same as the PointerEvents that caused these
events.&quot;

As it pertains to touch interactions, we dispatch resulting `click`
events when the single tap gesture recognizer makes the web page commit
a potential tap (and handling the associated synthetic click). Before
this commit, we blindly assumed that the `click` events being dispatched
had the &quot;mouse&quot; pointer type. This resulted in the titled bug.

However, the synthetic tap GR, which tracks the last active touch, also
knows what the last active touch type (i.e. UITouchType) was. This type
maps reasonably well to the pointer types in question (direct --&gt; touch,
stylus --&gt; pen, others --&gt; mouse). These types are then plumbed through
the GR&apos;s action to the rest of WebKit&apos;s tap/synthetic click handling
code.

* LayoutTests/pointerevents/ios/pointer-type-attribute-on-stylus-tap-expected.txt: Added.
* LayoutTests/pointerevents/ios/pointer-type-attribute-on-stylus-tap.html: Added.
* LayoutTests/pointerevents/ios/pointer-type-attribute-on-touch-tap-expected.txt: Added.
* LayoutTests/pointerevents/ios/pointer-type-attribute-on-touch-tap.html: Added.
  Tests to check whether touch tap / stylus tap on an element generates
  the correct set of events (and PointerType attributes).
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.stylusTapOnElement):
* Source/WebCore/dom/PointerEventTypeNames.h:
* Source/WebCore/platform/PlatformMouseEvent.h:
(WebCore::PlatformMouseEvent::PlatformMouseEvent):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _singleTapRecognized:]):
* Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.h:
* Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.mm:
(-[WKSyntheticTapGestureRecognizer reset]):
(-[WKSyntheticTapGestureRecognizer touchesEnded:withEvent:]):
(-[WKSyntheticTapGestureRecognizer lastActiveTouchType]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::commitPotentialTap):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::dispatchSyntheticMouseMove):
(WebKit::WebPage::handleSyntheticClick):
(WebKit::WebPage::didFinishContentChangeObserving):
(WebKit::WebPage::completeSyntheticClick):
(WebKit::WebPage::potentialTapAtPosition):
(WebKit::WebPage::commitPotentialTap):

Canonical link: <a href="https://commits.webkit.org/288873@main">https://commits.webkit.org/288873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67141ebd4ea511a7b669e00f46aac5a056209539

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12324 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65867 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23696 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46138 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3249 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31121 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34752 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91140 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11965 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8729 "Found 1 new test failure: storage/indexeddb/same-name-index-added-after-rename-transaction-abort.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74340 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72713 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73466 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18176 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17834 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16273 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3405 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11917 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17357 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11751 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15245 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13497 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->