### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE usage for StringParsingBuffer::setPosition()

### DIFF
--- a/Source/WTF/wtf/text/StringParsingBuffer.h
+++ b/Source/WTF/wtf/text/StringParsingBuffer.h
@@ -51,15 +51,12 @@ public:
 
     constexpr size_t lengthRemaining() const { return m_data.size(); }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    constexpr void setPosition(const CharacterType* position)
+    constexpr void setPosition(std::span<const CharacterType> position)
     {
-        ASSERT(position <= std::to_address(m_data.end()));
-        // FIXME: This can be used to rewind to a position *before* the beginning
-        // of the span, preventing us from doing bounds validation at the moment.
-        m_data = { position, static_cast<size_t>(std::to_address(m_data.end()) - position) };
+        ASSERT(position.data() <= std::to_address(m_data.end()));
+        ASSERT(std::to_address(position.end()) <= std::to_address(m_data.end()));
+        m_data = position;
     }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     StringView stringViewOfCharactersRemaining() const LIFETIME_BOUND { return span(); }
 

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -511,14 +511,14 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             auto* it = SIMD::findInterleaved(start, vectorMatch, scalarMatch);
             cursor = start.subspan(it - start.data());
         }
-        m_parsingBuffer.setPosition(cursor.data());
+        m_parsingBuffer.setPosition(cursor);
 
         if (!cursor.empty()) {
             if (UNLIKELY(cursor[0] == '\0'))
                 return didFail(HTMLFastPathResult::FailedContainsNull, String());
 
             if (cursor[0] == '&' || cursor[0] == '\r') {
-                m_parsingBuffer.setPosition(start.data());
+                m_parsingBuffer.setPosition(start);
                 return scanEscapedText();
             }
         }
@@ -565,7 +565,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         if (m_parsingBuffer.atEnd() || !isCharAfterTagNameOrAttribute(*m_parsingBuffer)) {
             // Try parsing a case-insensitive tagName.
             m_charBuffer.shrink(0);
-            m_parsingBuffer.setPosition(start.data());
+            m_parsingBuffer.setPosition(start);
             while (m_parsingBuffer.hasCharactersRemaining()) {
                 auto c = *m_parsingBuffer;
                 if (isASCIIUpper(c))
@@ -599,7 +599,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         if (UNLIKELY(isValidAttributeNameChar(*m_parsingBuffer))) {
             // At this point name does not contain lowercase. It may contain upper-case,
             // which requires mapping. Assume it does.
-            m_parsingBuffer.setPosition(start.data());
+            m_parsingBuffer.setPosition(start);
             m_charBuffer.shrink(0);
             // isValidAttributeNameChar() returns false if end of input is reached.
             do {
@@ -682,12 +682,12 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             length = cursor.data() - start.data();
             if (UNLIKELY(cursor[0] != quoteChar)) {
                 if (LIKELY(cursor[0] == '&' || cursor[0] == '\r')) {
-                    m_parsingBuffer.setPosition(quoteStart.data());
+                    m_parsingBuffer.setPosition(quoteStart);
                     return scanEscapedAttributeValue();
                 }
                 return didFail(HTMLFastPathResult::FailedParsingQuotedAttributeValue, emptyAtom());
             }
-            m_parsingBuffer.setPosition(cursor.subspan(1).data());
+            m_parsingBuffer.setPosition(cursor.subspan(1));
         } else {
             skipWhile<isValidUnquotedAttributeValueChar>(m_parsingBuffer);
             length = m_parsingBuffer.position() - start.data();

--- a/Source/WebCore/html/parser/HTMLEntityParser.cpp
+++ b/Source/WebCore/html/parser/HTMLEntityParser.cpp
@@ -125,8 +125,8 @@ public:
     static bool isEmpty() { return false; }
     UChar currentCharacter() const { return m_source.atEnd() ? 0 : *m_source; }
     void advance() { m_source.advance(); }
-    void pushEverythingBack() { m_source.setPosition(m_startPosition.data()); }
-    void pushBackButKeep(unsigned keepCount) { m_source.setPosition(m_startPosition.subspan(keepCount).data()); }
+    void pushEverythingBack() { m_source.setPosition(m_startPosition); }
+    void pushBackButKeep(unsigned keepCount) { m_source.setPosition(m_startPosition.subspan(keepCount)); }
 
 private:
     StringParsingBuffer<CharacterType>& m_source;


### PR DESCRIPTION
#### aa8175730947eb09933fd38f2a3bbf9795fefb08
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE usage for StringParsingBuffer::setPosition()
<a href="https://bugs.webkit.org/show_bug.cgi?id=285894">https://bugs.webkit.org/show_bug.cgi?id=285894</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/text/StringParsingBuffer.h:
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::scanText):
(WebCore::HTMLFastPathParser::scanTagName):
(WebCore::HTMLFastPathParser::scanAttributeName):
(WebCore::HTMLFastPathParser::scanAttributeValue):
* Source/WebCore/html/parser/HTMLEntityParser.cpp:
(WebCore::StringParsingBufferSource::pushEverythingBack):
(WebCore::StringParsingBufferSource::pushBackButKeep):

Canonical link: <a href="https://commits.webkit.org/288844@main">https://commits.webkit.org/288844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d80cfa7464178b50133b866608924578b5d5396

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89742 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35654 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65851 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23677 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76887 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46123 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3226 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31099 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34729 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77566 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91116 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83645 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8709 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74321 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12169 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73444 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17811 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16251 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3381 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13176 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11894 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17334 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106038 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11728 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25598 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15222 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13474 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->