### PR TITLE
Reduce WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in Source/WebCore/platform/cocoa

### DIFF
--- a/Source/WebCore/platform/cocoa/CoreVideoSoftLink.h
+++ b/Source/WebCore/platform/cocoa/CoreVideoSoftLink.h
@@ -27,6 +27,7 @@
 
 #include <CoreVideo/CoreVideo.h>
 #include <wtf/SoftLinking.h>
+#include <wtf/StdLibExtras.h>
 
 typedef struct __IOSurface* IOSurfaceRef;
 
@@ -165,3 +166,16 @@ SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CoreVideo, CVPixelBufferCreateWithBytes, 
 #define CVPixelBufferCreateWithBytes softLink_CoreVideo_CVPixelBufferCreateWithBytes
 SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CoreVideo, CVPixelBufferCreateWithIOSurface, CVReturn, (CFAllocatorRef allocator, IOSurfaceRef surface, CFDictionaryRef pixelBufferAttributes, CVPixelBufferRef * pixelBufferOut), (allocator, surface, pixelBufferAttributes, pixelBufferOut))
 #define CVPixelBufferCreateWithIOSurface softLink_CoreVideo_CVPixelBufferCreateWithIOSurface
+
+namespace WebCore {
+inline std::span<uint8_t> CVPixelBufferGetSpanOfPlane(CVPixelBufferRef pixelBuffer, size_t planeIndex)
+{
+    auto* baseAddress = static_cast<uint8_t*>(WebCore::CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, planeIndex));
+    if (!baseAddress)
+        return { };
+
+    auto bytesPerRow = WebCore::CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, planeIndex);
+    auto height = WebCore::CVPixelBufferGetHeightOfPlane(pixelBuffer, planeIndex);
+    return unsafeMakeSpan(baseAddress, bytesPerRow * height);
+}
+}

--- a/Source/WebCore/platform/cocoa/DragImageCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragImageCocoa.mm
@@ -52,8 +52,6 @@
 SOFT_LINK_PRIVATE_FRAMEWORK_OPTIONAL(LinkPresentation)
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 IntSize dragImageSize(RetainPtr<NSImage> image)
@@ -218,11 +216,11 @@ LinkImageLayout::LinkImageLayout(URL& url, const String& titleString)
     CGFloat maximumUsedTextWidth = 0;
 
     auto buildLines = [this, maximumAvailableWidth, &maximumUsedTextWidth, &currentY] (NSString *text, NSColor *color, NSFont *font, CFIndex maximumLines, CTLineBreakMode lineBreakMode) {
-        CTParagraphStyleSetting paragraphStyleSettings[1];
-        paragraphStyleSettings[0].spec = kCTParagraphStyleSpecifierLineBreakMode;
-        paragraphStyleSettings[0].valueSize = sizeof(CTLineBreakMode);
-        paragraphStyleSettings[0].value = &lineBreakMode;
-        RetainPtr<CTParagraphStyleRef> paragraphStyle = adoptCF(CTParagraphStyleCreate(paragraphStyleSettings, 1));
+        CTParagraphStyleSetting paragraphStyleSettings;
+        paragraphStyleSettings.spec = kCTParagraphStyleSpecifierLineBreakMode;
+        paragraphStyleSettings.valueSize = sizeof(CTLineBreakMode);
+        paragraphStyleSettings.value = &lineBreakMode;
+        RetainPtr<CTParagraphStyleRef> paragraphStyle = adoptCF(CTParagraphStyleCreate(&paragraphStyleSettings, 1));
 
         NSDictionary *textAttributes = @{
             (id)kCTFontAttributeName: font,
@@ -336,7 +334,5 @@ DragImageRef createDragImageForColor(const Color& color, const FloatRect&, float
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(DRAG_SUPPORT) && PLATFORM(MAC)

--- a/Source/WebCore/platform/cocoa/SharedBufferCocoa.mm
+++ b/Source/WebCore/platform/cocoa/SharedBufferCocoa.mm
@@ -29,13 +29,13 @@
 #import "WebCoreJITOperations.h"
 #import "WebCoreObjCExtras.h"
 #import <JavaScriptCore/InitializeThreading.h>
-#import <pal/cf/CoreMediaSoftLink.h>
 #import <string.h>
 #import <wtf/MainThread.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#import <pal/cf/CoreMediaSoftLink.h>
 
 @interface WebCoreSharedBufferData : NSData
 - (instancetype)initWithDataSegment:(const WebCore::DataSegment&)dataSegment position:(NSUInteger)position size:(NSUInteger)size;
@@ -178,7 +178,7 @@ RetainPtr<NSData> DataSegment::createNSData() const
 void DataSegment::iterate(CFDataRef data, const Function<void(std::span<const uint8_t>)>& apply) const
 {
     [(__bridge NSData *)data enumerateByteRangesUsingBlock:^(const void *bytes, NSRange byteRange, BOOL *) {
-        apply({ static_cast<const uint8_t*>(bytes), byteRange.length });
+        apply(unsafeMakeSpan(static_cast<const uint8_t*>(bytes), byteRange.length));
     }];
 }
 
@@ -188,5 +188,3 @@ RetainPtr<NSData> SharedBufferDataView::createNSData() const
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/graphics/cv/CVUtilities.mm
+++ b/Source/WebCore/platform/graphics/cv/CVUtilities.mm
@@ -32,6 +32,7 @@
 #import "RealtimeVideoUtilities.h"
 #import <wtf/StdLibExtras.h>
 #import <wtf/cf/TypeCastsCF.h>
+
 #import "CoreVideoSoftLink.h"
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -189,15 +190,15 @@ RetainPtr<CVPixelBufferRef> createBlackPixelBuffer(size_t width, size_t height, 
     status = CVPixelBufferLockBaseAddress(pixelBuffer, 0);
     ASSERT(status == noErr);
 
-    auto* yPlane = static_cast<uint8_t*>(CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 0));
+    auto yPlane = CVPixelBufferGetSpanOfPlane(pixelBuffer, 0);
     size_t yStride = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 0);
     for (unsigned i = 0; i < height; ++i)
-        memset(&yPlane[i * yStride], 0, width);
+        zeroSpan(yPlane.subspan(i * yStride, width));
 
-    auto* uvPlane = static_cast<uint8_t*>(CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 1));
+    auto uvPlane = CVPixelBufferGetSpanOfPlane(pixelBuffer, 1);
     size_t uvStride = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 1);
     for (unsigned i = 0; i < height / 2; ++i)
-        memset(&uvPlane[i * uvStride], 128, width);
+        memsetSpan(uvPlane.subspan(i * uvStride, width), 128);
 
     status = CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
     ASSERT(!status);


### PR DESCRIPTION
#### b9c2462cf0d1997bf3a7bc7382c62cf8a265c359
<pre>
Reduce WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in Source/WebCore/platform/cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=285897">https://bugs.webkit.org/show_bug.cgi?id=285897</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/platform/cocoa/CoreVideoSoftLink.h:
(WebCore::CVPixelBufferGetSpanOfPlane):
* Source/WebCore/platform/cocoa/DragImageCocoa.mm:
* Source/WebCore/platform/cocoa/SharedBufferCocoa.mm:
(WebCore::DataSegment::iterate const):
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm:
(WebCore::copyToCVPixelBufferPlane):
(WebCore::SharedVideoFrameInfo::writePixelBuffer):
* Source/WebCore/platform/graphics/cv/CVUtilities.mm:
(WebCore::createBlackPixelBuffer):
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::copyToCVPixelBufferPlane):
(WebCore::VideoFrame::createNV12):
(WebCore::VideoFrame::createRGBA):
(WebCore::VideoFrame::createBGRA):
(WebCore::copyRGBData):
(WebCore::copyNV12):
(WebCore::copyI420OrI420A):

Canonical link: <a href="https://commits.webkit.org/288853@main">https://commits.webkit.org/288853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5df9972146177460dbec2fc0e76bdc2a1d12d541

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89780 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35692 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65881 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23709 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3384 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46152 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3263 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31135 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34767 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91155 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8746 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74353 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73479 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17848 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16287 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3427 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13183 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17372 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11766 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15260 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13512 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->