### PR TITLE
[css-anchor-position-1] Document::updateStyleIfNeeded: skip updating style if in the middle of anchor resolution

### DIFF
--- a/LayoutTests/fast/css/css-anchor-position/anchor-container-crash-expected.txt
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-container-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/css/css-anchor-position/anchor-container-crash.html
+++ b/LayoutTests/fast/css/css-anchor-position/anchor-container-crash.html
@@ -1,0 +1,39 @@
+<style>
+
+.anchor {
+  position: absolute;
+  anchor-name: --anchor;
+}
+
+.target {
+  position: fixed;
+  container-type: size;
+}
+
+.target-1 {
+  anchor-name: --target-1;
+  inset: anchor(--anchor outside);
+}
+
+.target-2 {
+  inset: anchor(--anchor inside);
+}
+
+.target-3 {
+  inset: anchor(--target-1 inside);
+}
+
+</style>
+
+<div class="anchor">This test passes if it does not crash.</div>
+
+<div class="target target-1"></div>
+<div class="target target-2"></div>
+<div class="target target-3"></div>
+
+<script>
+
+if (window.testRunner)
+  testRunner.dumpAsText();
+
+</script>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2733,7 +2733,7 @@ bool Document::updateStyleIfNeeded()
 {
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
-    if (isResolvingContainerQueriesForSelfOrAncestor())
+    if (isInStyleInterleavedLayoutForSelfOrAncestor())
         return false;
 
     RefPtr frameView = view();
@@ -3043,15 +3043,6 @@ void Document::setIsResolvingTreeStyle(bool value)
 {
     RELEASE_ASSERT(value != m_isResolvingTreeStyle);
     m_isResolvingTreeStyle = value;
-}
-
-bool Document::isResolvingContainerQueriesForSelfOrAncestor() const
-{
-    if (m_isResolvingContainerQueries)
-        return true;
-    if (RefPtr owner = ownerElement())
-        return owner->document().isResolvingContainerQueriesForSelfOrAncestor();
-    return false;
 }
 
 bool Document::isInStyleInterleavedLayoutForSelfOrAncestor() const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1551,7 +1551,6 @@ public:
     bool inStyleRecalc() const { return m_inStyleRecalc; }
     bool inRenderTreeUpdate() const { return m_inRenderTreeUpdate; }
     bool isResolvingContainerQueries() const { return m_isResolvingContainerQueries; }
-    bool isResolvingContainerQueriesForSelfOrAncestor() const;
     bool isInStyleInterleavedLayout() const { return m_isResolvingContainerQueries || m_isResolvingAnchorPositionedElements; };
     bool isInStyleInterleavedLayoutForSelfOrAncestor() const;
     bool isResolvingTreeStyle() const { return m_isResolvingTreeStyle; }


### PR DESCRIPTION
#### 8a4278966a12796bcd6c9643bb856d75fa7435dd
<pre>
[css-anchor-position-1] Document::updateStyleIfNeeded: skip updating style if in the middle of anchor resolution
<a href="https://rdar.apple.com/141735714">rdar://141735714</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=285895">https://bugs.webkit.org/show_bug.cgi?id=285895</a>

Reviewed by Antti Koivisto.

Document::updateStyleIfNeeded should skip updating style if it&apos;s in the middle
of style/layout interleaving. This includes the style/layout interleaving
of container query and anchor positioning resolution, however the code wasn&apos;t
updated to include the latter case.

* LayoutTests/fast/css/css-anchor-position/anchor-container-crash.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateStyleIfNeeded):
* Source/WebCore/dom/Document.h:
(WebCore::Document::isResolvingContainerQueries const):

Canonical link: <a href="https://commits.webkit.org/288907@main">https://commits.webkit.org/288907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ed989002af1f3f8bea6f87431cc3d5177024950

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/38999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89750 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35662 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65859 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23683 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76893 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46130 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31105 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34737 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74114 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91124 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74326 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73450 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18195 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17818 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16257 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3389 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11902 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17342 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11736 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13482 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->