### PR TITLE
Begin implementing fullscreen for site isolation

### DIFF
--- a/Source/WebKit/UIProcess/API/C/playstation/WKView.cpp
+++ b/Source/WebKit/UIProcess/API/C/playstation/WKView.cpp
@@ -110,7 +110,8 @@ void WKViewSetVisible(WKViewRef view, bool visible)
 void WKViewWillEnterFullScreen(WKViewRef view)
 {
 #if ENABLE(FULLSCREEN_API)
-    WebKit::toImpl(view)->willEnterFullScreen();
+    // FIXME: Replace this and WKViewSetViewClient's enterFullScreen with a listener object.
+    WebKit::toImpl(view)->willEnterFullScreen([] (bool) { });
 #endif
 }
 
@@ -168,11 +169,14 @@ void WKViewSetViewClient(WKViewRef view, const WKViewClientBase* client)
             m_client.setViewNeedsDisplay(WebKit::toAPI(&view), WebKit::toAPI(region.bounds()), m_client.base.clientInfo);
         }
 
-        void enterFullScreen(WebKit::PlayStationWebView& view)
+        void enterFullScreen(WebKit::PlayStationWebView& view, CompletionHandler<void(bool)>&& completionHandler)
         {
             if (!m_client.enterFullScreen)
-                return;
+                return completionHandler(false);
             m_client.enterFullScreen(WebKit::toAPI(&view), m_client.base.clientInfo);
+
+            // FIXME: Replace this and WKViewWillEnterFullScreen with a listener object.
+            completionHandler(false);
         }
         
         void exitFullScreen(WebKit::PlayStationWebView& view)

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -409,15 +409,15 @@ bool PageClientImpl::isFullScreen()
     return webkitWebViewBaseIsFullScreen(WEBKIT_WEB_VIEW_BASE(m_viewWidget));
 }
 
-void PageClientImpl::enterFullScreen()
+void PageClientImpl::enterFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
     if (!m_viewWidget)
-        return;
+        return completionHandler(false);
 
     if (isFullScreen())
-        return;
+        return completionHandler(false);
 
-    webkitWebViewBaseWillEnterFullScreen(WEBKIT_WEB_VIEW_BASE(m_viewWidget));
+    webkitWebViewBaseWillEnterFullScreen(WEBKIT_WEB_VIEW_BASE(m_viewWidget), WTFMove(completionHandler));
 
     if (!WEBKIT_IS_WEB_VIEW(m_viewWidget) || !webkitWebViewEnterFullScreen(WEBKIT_WEB_VIEW(m_viewWidget)))
         webkitWebViewBaseEnterFullScreen(WEBKIT_WEB_VIEW_BASE(m_viewWidget));

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
@@ -136,7 +136,7 @@ private:
     // WebFullScreenManagerProxyClient
     void closeFullScreenManager() override;
     bool isFullScreen() override;
-    void enterFullScreen() override;
+    void enterFullScreen(CompletionHandler<void(bool)>&&) override;
     void exitFullScreen() override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -2620,12 +2620,14 @@ static bool webkitWebViewBaseToplevelOnScreenWindowIsFullScreen(WebKitWebViewBas
     return priv->toplevelOnScreenWindow && priv->toplevelOnScreenWindow->isFullscreen();
 }
 
-void webkitWebViewBaseWillEnterFullScreen(WebKitWebViewBase* webkitWebViewBase)
+void webkitWebViewBaseWillEnterFullScreen(WebKitWebViewBase* webkitWebViewBase, CompletionHandler<void(bool)>&& completionHandler)
 {
     WebKitWebViewBasePrivate* priv = webkitWebViewBase->priv;
     ASSERT(priv->fullScreenState == WebFullScreenManagerProxy::FullscreenState::NotInFullscreen);
     if (auto* fullScreenManagerProxy = priv->pageProxy->fullScreenManager())
-        fullScreenManagerProxy->willEnterFullScreen();
+        fullScreenManagerProxy->willEnterFullScreen(WTFMove(completionHandler));
+    else
+        completionHandler(false);
     priv->fullScreenState = WebFullScreenManagerProxy::FullscreenState::EnteringFullscreen;
 }
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
@@ -57,7 +57,7 @@ void webkitWebViewBasePropagateKeyEvent(WebKitWebViewBase*, GdkEvent*);
 void webkitWebViewBasePropagateWheelEvent(WebKitWebViewBase*, GdkEvent*);
 void webkitWebViewBaseChildMoveResize(WebKitWebViewBase*, GtkWidget*, const WebCore::IntRect&);
 #if ENABLE(FULLSCREEN_API)
-void webkitWebViewBaseWillEnterFullScreen(WebKitWebViewBase*);
+void webkitWebViewBaseWillEnterFullScreen(WebKitWebViewBase*, CompletionHandler<void(bool)>&&);
 void webkitWebViewBaseEnterFullScreen(WebKitWebViewBase*);
 void webkitWebViewBaseWillExitFullScreen(WebKitWebViewBase*);
 void webkitWebViewBaseExitFullScreen(WebKitWebViewBase*);

--- a/Source/WebKit/UIProcess/API/playstation/APIViewClient.h
+++ b/Source/WebKit/UIProcess/API/playstation/APIViewClient.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/CompletionHandler.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -45,7 +46,7 @@ public:
     virtual ~ViewClient() = default;
 
     virtual void setViewNeedsDisplay(WebKit::PlayStationWebView&, const WebCore::Region&) { }
-    virtual void enterFullScreen(WebKit::PlayStationWebView&) { }
+    virtual void enterFullScreen(WebKit::PlayStationWebView&, CompletionHandler<void(bool)>&& completionHandler) { completionHandler(false); }
     virtual void exitFullScreen(WebKit::PlayStationWebView&) { }
     virtual void closeFullScreen(WebKit::PlayStationWebView&) { }
     virtual void beganEnterFullScreen(WebKit::PlayStationWebView&, const WebCore::IntRect&, const WebCore::IntRect&) { }

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -403,12 +403,12 @@ bool PageClientImpl::isFullScreen()
     return m_view.isFullScreen();
 }
 
-void PageClientImpl::enterFullScreen()
+void PageClientImpl::enterFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
     if (isFullScreen())
-        return;
+        return completionHandler(false);
 
-    m_view.willEnterFullScreen();
+    m_view.willEnterFullScreen(WTFMove(completionHandler));
 #if ENABLE(WPE_PLATFORM)
     if (m_view.wpeView()) {
         static_cast<WKWPE::ViewPlatform&>(m_view).enterFullScreen();

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -156,7 +156,7 @@ private:
 
     void closeFullScreenManager() override;
     bool isFullScreen() override;
-    void enterFullScreen() override;
+    void enterFullScreen(CompletionHandler<void(bool)>&&) override;
     void exitFullScreen() override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
@@ -150,11 +150,13 @@ bool View::isFullScreen() const
     return m_fullscreenState == WebFullScreenManagerProxy::FullscreenState::EnteringFullscreen || m_fullscreenState == WebFullScreenManagerProxy::FullscreenState::InFullscreen;
 }
 
-void View::willEnterFullScreen()
+void View::willEnterFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
     ASSERT(m_fullscreenState == WebFullScreenManagerProxy::FullscreenState::NotInFullscreen);
     if (auto* fullScreenManagerProxy = page().fullScreenManager())
-        fullScreenManagerProxy->willEnterFullScreen();
+        fullScreenManagerProxy->willEnterFullScreen(WTFMove(completionHandler));
+    else
+        completionHandler(false);
     m_fullscreenState = WebFullScreenManagerProxy::FullscreenState::EnteringFullscreen;
 }
 

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
@@ -76,7 +76,7 @@ public:
 
 #if ENABLE(FULLSCREEN_API)
     bool isFullScreen() const;
-    void willEnterFullScreen();
+    void willEnterFullScreen(CompletionHandler<void(bool)>&&);
     void willExitFullScreen();
 #endif
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -67,9 +67,9 @@ public:
     virtual void closeFullScreenManager() = 0;
     virtual bool isFullScreen() = 0;
 #if PLATFORM(IOS_FAMILY)
-    virtual void enterFullScreen(WebCore::FloatSize mediaDimensions) = 0;
+    virtual void enterFullScreen(WebCore::FloatSize mediaDimensions, CompletionHandler<void(bool)>&&) = 0;
 #else
-    virtual void enterFullScreen() = 0;
+    virtual void enterFullScreen(CompletionHandler<void(bool)>&&) = 0;
 #endif
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     virtual void updateImageSource() = 0;
@@ -113,7 +113,7 @@ public:
         ExitingFullscreen,
     };
     FullscreenState fullscreenState() const { return m_fullscreenState; }
-    void willEnterFullScreen(WebCore::HTMLMediaElementEnums::VideoFullscreenMode = WebCore::HTMLMediaElementEnums::VideoFullscreenModeStandard);
+    void willEnterFullScreen(CompletionHandler<void(bool)>&&);
     void didEnterFullScreen();
     void willExitFullScreen();
     void didExitFullScreen();
@@ -135,7 +135,7 @@ private:
     WebFullScreenManagerProxy(WebPageProxy&, WebFullScreenManagerProxyClient&);
 
     void supportsFullScreen(bool withKeyboard, CompletionHandler<void(bool)>&&);
-    void enterFullScreen(bool blocksReturnToFullscreenFromPictureInPicture, FullScreenMediaDetails&&);
+    void enterFullScreen(bool blocksReturnToFullscreenFromPictureInPicture, FullScreenMediaDetails&&, CompletionHandler<void(bool)>&&);
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     void updateImageSource(FullScreenMediaDetails&&);
 #endif

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
@@ -28,7 +28,7 @@
 ]
 messages -> WebFullScreenManagerProxy {
     SupportsFullScreen(bool withKeyboard) -> (bool supportsFullScreen) Synchronous
-    EnterFullScreen(bool blocksReturnToFullscreenFromPictureInPicture, struct WebKit::FullScreenMediaDetails mediaDetails)
+    EnterFullScreen(bool blocksReturnToFullscreenFromPictureInPicture, struct WebKit::FullScreenMediaDetails mediaDetails) -> (bool success)
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     UpdateImageSource(struct WebKit::FullScreenMediaDetails mediaDetails)
 #endif

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -248,7 +248,7 @@ private:
     // WebFullScreenManagerProxyClient
     void closeFullScreenManager() override;
     bool isFullScreen() override;
-    void enterFullScreen(WebCore::FloatSize mediaDimensions) override;
+    void enterFullScreen(WebCore::FloatSize mediaDimensions, CompletionHandler<void(bool)>&&) override;
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     void updateImageSource() override;
 #endif

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -785,9 +785,11 @@ bool PageClientImpl::isFullScreen()
     return [webView fullScreenWindowController].isFullScreen;
 }
 
-void PageClientImpl::enterFullScreen(FloatSize mediaDimensions)
+void PageClientImpl::enterFullScreen(FloatSize mediaDimensions, CompletionHandler<void(bool)>&& completionHandler)
 {
-    [[webView() fullScreenWindowController] enterFullScreen:mediaDimensions];
+    if (![webView() fullScreenWindowController])
+        return completionHandler(false);
+    [[webView() fullScreenWindowController] enterFullScreen:mediaDimensions completionHandler:WTFMove(completionHandler)];
 }
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
@@ -26,6 +26,7 @@
 #if ENABLE(FULLSCREEN_API) && PLATFORM(IOS_FAMILY)
 
 #import <UIKit/UIViewControllerTransitioning.h>
+#import <wtf/CompletionHandler.h>
 
 @class WKFullScreenViewController;
 @class WKWebView;
@@ -43,7 +44,7 @@
 #endif
 
 - (id)initWithWebView:(WKWebView *)webView;
-- (void)enterFullScreen:(CGSize)mediaDimensions;
+- (void)enterFullScreen:(CGSize)mediaDimensions completionHandler:(CompletionHandler<void(bool)>&&)completionHandler;
 #if ENABLE(QUICKLOOK_FULLSCREEN)
 - (void)updateImageSource;
 #endif

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -224,7 +224,7 @@ private:
     // WebFullScreenManagerProxyClient
     void closeFullScreenManager() override;
     bool isFullScreen() override;
-    void enterFullScreen() override;
+    void enterFullScreen(CompletionHandler<void(bool)>&&) override;
     void exitFullScreen() override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -809,9 +809,11 @@ bool PageClientImpl::isFullScreen()
     return m_impl->fullScreenWindowController().isFullScreen;
 }
 
-void PageClientImpl::enterFullScreen()
+void PageClientImpl::enterFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
-    [m_impl->fullScreenWindowController() enterFullScreen:nil];
+    if (!m_impl->fullScreenWindowController())
+        return completionHandler(false);
+    [m_impl->fullScreenWindowController() enterFullScreen:nil completionHandler:WTFMove(completionHandler)];
 }
 
 void PageClientImpl::exitFullScreen()

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
@@ -26,6 +26,7 @@
 #if ENABLE(FULLSCREEN_API) && PLATFORM(MAC)
 
 #import <AppKit/AppKit.h>
+#import <wtf/CompletionHandler.h>
 #import <wtf/NakedPtr.h>
 #import <wtf/NakedRef.h>
 #import <wtf/RetainPtr.h>
@@ -74,7 +75,7 @@ typedef enum FullScreenState : NSInteger FullScreenState;
 
 - (BOOL)isFullScreen;
 
-- (void)enterFullScreen:(NSScreen *)screen;
+- (void)enterFullScreen:(NSScreen *)screen completionHandler:(CompletionHandler<void(bool)>&&)completionHandler;
 - (void)exitFullScreen;
 - (void)exitFullScreenImmediately;
 - (void)requestExitFullScreen;

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -221,10 +221,10 @@ static RetainPtr<CGImageRef> createImageWithCopiedData(CGImageRef sourceImage)
     return adoptCF(CGImageCreate(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, colorSpace, bitmapInfo, provider.get(), 0, shouldInterpolate, intent));
 }
 
-- (void)enterFullScreen:(NSScreen *)screen
+- (void)enterFullScreen:(NSScreen *)screen completionHandler:(CompletionHandler<void(bool)>&&)completionHandler
 {
     if ([self isFullScreen])
-        return;
+        return completionHandler(false);
     _fullScreenState = WaitingToEnterFullScreen;
 
     if (!screen)
@@ -277,7 +277,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _savedScale = _page->pageScaleFactor();
     _page->scalePageRelativeToScrollPosition(1, { });
     [self _manager]->setAnimatingFullScreen(true);
-    [self _manager]->willEnterFullScreen();
+    [self _manager]->willEnterFullScreen(WTFMove(completionHandler));
 }
 
 - (void)beganEnterFullScreenWithInitialFrame:(NSRect)initialFrame finalFrame:(NSRect)finalFrame

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
@@ -252,9 +252,9 @@ bool PageClientImpl::isFullScreen()
     return m_view.isFullScreen();
 }
 
-void PageClientImpl::enterFullScreen()
+void PageClientImpl::enterFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
-    m_view.enterFullScreen();
+    m_view.enterFullScreen(WTFMove(completionHandler));
 }
 
 void PageClientImpl::exitFullScreen()

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.h
@@ -129,7 +129,7 @@ private:
 
     void closeFullScreenManager() override;
     bool isFullScreen() override;
-    void enterFullScreen() override;
+    void enterFullScreen(CompletionHandler<void(bool)>&&) override;
     void exitFullScreen() override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;

--- a/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
+++ b/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
@@ -115,10 +115,10 @@ void PlayStationWebView::setViewNeedsDisplay(const WebCore::Region& region)
 }
 
 #if ENABLE(FULLSCREEN_API)
-void PlayStationWebView::willEnterFullScreen()
+void PlayStationWebView::willEnterFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
     m_isFullScreen = true;
-    m_page->fullScreenManager()->willEnterFullScreen();
+    m_page->fullScreenManager()->willEnterFullScreen(WTFMove(completionHandler));
 }
 
 void PlayStationWebView::didEnterFullScreen()
@@ -155,10 +155,12 @@ bool PlayStationWebView::isFullScreen()
     return m_isFullScreen;
 }
 
-void PlayStationWebView::enterFullScreen()
+void PlayStationWebView::enterFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
     if (m_client && !isFullScreen())
-        m_client->enterFullScreen(*this);
+        m_client->enterFullScreen(*this, WTFMove(completionHandler));
+    else
+        completionHandler(false);
 }
 
 void PlayStationWebView::exitFullScreen()

--- a/Source/WebKit/UIProcess/playstation/PlayStationWebView.h
+++ b/Source/WebKit/UIProcess/playstation/PlayStationWebView.h
@@ -59,7 +59,7 @@ public:
 #endif
 
 #if ENABLE(FULLSCREEN_API)
-    void willEnterFullScreen();
+    void willEnterFullScreen(CompletionHandler<void(bool)>&&);
     void didEnterFullScreen();
     void willExitFullScreen();
     void didExitFullScreen();
@@ -71,7 +71,7 @@ public:
 #if ENABLE(FULLSCREEN_API)
     bool isFullScreen();
     void closeFullScreenManager();
-    void enterFullScreen();
+    void enterFullScreen(CompletionHandler<void(bool)>&&);
     void exitFullScreen();
     void beganEnterFullScreen(const WebCore::IntRect&, const WebCore::IntRect&);
     void beganExitFullScreen(const WebCore::IntRect&, const WebCore::IntRect&);

--- a/Source/WebKit/UIProcess/win/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.cpp
@@ -316,9 +316,10 @@ bool PageClientImpl::isFullScreen()
     return false;
 }
 
-void PageClientImpl::enterFullScreen()
+void PageClientImpl::enterFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
     notImplemented();
+    completionHandler(false);
 }
 
 void PageClientImpl::exitFullScreen()

--- a/Source/WebKit/UIProcess/win/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.h
@@ -128,7 +128,7 @@ private:
     // WebFullScreenManagerProxyClient
     void closeFullScreenManager() override;
     bool isFullScreen() override;
-    void enterFullScreen() override;
+    void enterFullScreen(CompletionHandler<void(bool)>&&) override;
     void exitFullScreen() override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -247,15 +247,11 @@ FullScreenMediaDetails WebFullScreenManager::getImageMediaDetails(CheckedPtr<Ren
 }
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
 
-void WebFullScreenManager::enterFullScreenForElement(WebCore::Element* element, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode)
+void WebFullScreenManager::enterFullScreenForElement(WebCore::Element& element, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
-    ASSERT(element);
-    if (!element)
-        return;
+    ALWAYS_LOG(LOGIDENTIFIER, "<", element.tagName(), " id=\"", element.getIdAttribute(), "\">");
 
-    ALWAYS_LOG(LOGIDENTIFIER, "<", element->tagName(), " id=\"", element->getIdAttribute(), "\">");
-
-    setElement(*element);
+    setElement(element);
 
 
     FullScreenMediaDetails mediaDetails;
@@ -286,7 +282,7 @@ void WebFullScreenManager::enterFullScreenForElement(WebCore::Element* element, 
 
         auto mainVideoElementSize = [&]() -> FloatSize {
 #if PLATFORM(VISION)
-            if (!fullscreenElementIsVideoElement && element->document().quirks().shouldDisableFullscreenVideoAspectRatioAdaptiveSizing())
+            if (!fullscreenElementIsVideoElement && element.document().quirks().shouldDisableFullscreenVideoAspectRatioAdaptiveSizing())
                 return { };
 #endif
             return FloatSize(m_mainVideoElement->videoWidth(), m_mainVideoElement->videoHeight());
@@ -300,7 +296,7 @@ void WebFullScreenManager::enterFullScreenForElement(WebCore::Element* element, 
 #endif
 
     m_page->prepareToEnterElementFullScreen();
-    m_page->injectedBundleFullScreenClient().enterFullScreenForElement(m_page.ptr(), element, m_element->document().quirks().blocksReturnToFullscreenFromPictureInPictureQuirk(), mode, WTFMove(mediaDetails));
+    m_page->injectedBundleFullScreenClient().enterFullScreenForElement(m_page.get(), element, m_element->document().quirks().blocksReturnToFullscreenFromPictureInPictureQuirk(), mode, WTFMove(mediaDetails));
 
     if (mode == WebCore::HTMLMediaElementEnums::VideoFullscreenModeInWindow) {
         willEnterFullScreen(mode);

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -66,7 +66,7 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 
     bool supportsFullScreenForElement(const WebCore::Element&, bool withKeyboard);
-    void enterFullScreenForElement(WebCore::Element*, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
+    void enterFullScreenForElement(WebCore::Element&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     void updateImageSource(WebCore::Element&);
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in
@@ -28,7 +28,6 @@
 messages -> WebFullScreenManager {
     RequestRestoreFullScreen() -> (bool succeeded) Async
     RequestExitFullScreen()
-    WillEnterFullScreen(WebCore::MediaPlayerEnums::VideoFullscreenMode mode);
     DidEnterFullScreen()
     WillExitFullScreen()
     DidExitFullScreen()

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -135,8 +135,8 @@ void WKBundlePageSetFullScreenClient(WKBundlePageRef pageRef, WKBundlePageFullSc
 void WKBundlePageWillEnterFullScreen(WKBundlePageRef pageRef)
 {
 #if ENABLE(FULLSCREEN_API)
-    WebKit::toImpl(pageRef)->fullScreenManager()->saveScrollPosition();
-    WebKit::toImpl(pageRef)->fullScreenManager()->willEnterFullScreen();
+    WebKit::toImpl(pageRef)->fullScreenManager().saveScrollPosition();
+    WebKit::toImpl(pageRef)->fullScreenManager().willEnterFullScreen();
 #else
     UNUSED_PARAM(pageRef);
 #endif
@@ -145,7 +145,7 @@ void WKBundlePageWillEnterFullScreen(WKBundlePageRef pageRef)
 void WKBundlePageDidEnterFullScreen(WKBundlePageRef pageRef)
 {
 #if ENABLE(FULLSCREEN_API)
-    WebKit::toImpl(pageRef)->fullScreenManager()->didEnterFullScreen();
+    WebKit::toImpl(pageRef)->fullScreenManager().didEnterFullScreen();
 #else
     UNUSED_PARAM(pageRef);
 #endif
@@ -154,7 +154,7 @@ void WKBundlePageDidEnterFullScreen(WKBundlePageRef pageRef)
 void WKBundlePageWillExitFullScreen(WKBundlePageRef pageRef)
 {
 #if ENABLE(FULLSCREEN_API)
-    WebKit::toImpl(pageRef)->fullScreenManager()->willExitFullScreen();
+    WebKit::toImpl(pageRef)->fullScreenManager().willExitFullScreen();
 #else
     UNUSED_PARAM(pageRef);
 #endif
@@ -163,8 +163,8 @@ void WKBundlePageWillExitFullScreen(WKBundlePageRef pageRef)
 void WKBundlePageDidExitFullScreen(WKBundlePageRef pageRef)
 {
 #if ENABLE(FULLSCREEN_API)
-    WebKit::toImpl(pageRef)->fullScreenManager()->didExitFullScreen();
-    WebKit::toImpl(pageRef)->fullScreenManager()->restoreScrollPosition();
+    WebKit::toImpl(pageRef)->fullScreenManager().didExitFullScreen();
+    WebKit::toImpl(pageRef)->fullScreenManager().restoreScrollPosition();
 #else
     UNUSED_PARAM(pageRef);
 #endif

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFullScreenClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFullScreenClient.h
@@ -54,7 +54,7 @@ class WebPage;
 class InjectedBundlePageFullScreenClient : public API::Client<WKBundlePageFullScreenClientBase> {
 public:
     bool supportsFullScreen(WebPage*, bool withKeyboard);
-    void enterFullScreenForElement(WebPage*, WebCore::Element*, bool blocksReturnToFullscreenFromPictureInPicture, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, FullScreenMediaDetails&&);
+    void enterFullScreenForElement(WebPage&, WebCore::Element&, bool blocksReturnToFullscreenFromPictureInPicture, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, FullScreenMediaDetails&&);
     void exitFullScreenForElement(WebPage*, WebCore::Element*, bool);
     void beganEnterFullScreen(WebPage*, WebCore::IntRect& initialFrame, WebCore::IntRect& finalFrame);
     void beganExitFullScreen(WebPage*, WebCore::IntRect& initialFrame, WebCore::IntRect& finalFrame);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1321,14 +1321,14 @@ void WebChromeClient::clearVideoFullscreenMode(HTMLVideoElement& videoElement, H
 
 bool WebChromeClient::supportsFullScreenForElement(const Element& element, bool withKeyboard)
 {
-    return protectedPage()->fullScreenManager()->supportsFullScreenForElement(element, withKeyboard);
+    return protectedPage()->fullScreenManager().supportsFullScreenForElement(element, withKeyboard);
 }
 
 void WebChromeClient::enterFullScreenForElement(Element& element, HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
-    protectedPage()->fullScreenManager()->enterFullScreenForElement(&element, mode);
+    protectedPage()->fullScreenManager().enterFullScreenForElement(element, mode);
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    if (RefPtr videoElement = dynamicDowncast<HTMLVideoElement>(&element); videoElement && mode == HTMLMediaElementEnums::VideoFullscreenModeInWindow)
+    if (RefPtr videoElement = dynamicDowncast<HTMLVideoElement>(element); videoElement && mode == HTMLMediaElementEnums::VideoFullscreenModeInWindow)
         setVideoFullscreenMode(*videoElement, mode);
 #endif
 }
@@ -1336,7 +1336,7 @@ void WebChromeClient::enterFullScreenForElement(Element& element, HTMLMediaEleme
 #if ENABLE(QUICKLOOK_FULLSCREEN)
 void WebChromeClient::updateImageSource(Element& element)
 {
-    protectedPage()->fullScreenManager()->updateImageSource(element);
+    protectedPage()->fullScreenManager().updateImageSource(element);
 }
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
 
@@ -1349,7 +1349,7 @@ void WebChromeClient::exitFullScreenForElement(Element* element)
             exitingInWindowFullscreen = videoElement->fullscreenMode() == HTMLMediaElementEnums::VideoFullscreenModeInWindow;
     }
 #endif
-    protectedPage()->fullScreenManager()->exitFullScreenForElement(element);
+    protectedPage()->fullScreenManager().exitFullScreenForElement(element);
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     if (exitingInWindowFullscreen)
         clearVideoFullscreenMode(*dynamicDowncast<HTMLVideoElement>(*element), HTMLMediaElementEnums::VideoFullscreenModeInWindow);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -558,7 +558,7 @@ void WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad()
 #if ENABLE(FULLSCREEN_API)
     auto* document = m_localFrame->document();
     if (document && document->fullscreenManager().fullscreenElement())
-        webPage->fullScreenManager()->exitFullScreenForElement(webPage->fullScreenManager()->element());
+        webPage->fullScreenManager().exitFullScreenForElement(webPage->fullScreenManager().element());
 #endif
 
     webPage->findController().hideFindUI();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5215,8 +5215,7 @@ Ref<VideoPresentationManager> WebPage::protectedVideoPresentationManager()
 void WebPage::videoControlsManagerDidChange()
 {
 #if ENABLE(FULLSCREEN_API)
-    if (auto* manager = fullScreenManager())
-        manager->videoControlsManagerDidChange();
+    fullScreenManager().videoControlsManagerDidChange();
 #endif
 }
 
@@ -5308,11 +5307,16 @@ void WebPage::setAllowsMediaDocumentInlinePlayback(bool allows)
 #endif
 
 #if ENABLE(FULLSCREEN_API)
-WebFullScreenManager* WebPage::fullScreenManager()
+WebFullScreenManager& WebPage::fullScreenManager()
 {
     if (!m_fullScreenManager)
         m_fullScreenManager = WebFullScreenManager::create(*this);
-    return m_fullScreenManager.get();
+    return *m_fullScreenManager;
+}
+
+Ref<WebFullScreenManager> WebPage::protectedFullscreenManager()
+{
+    return fullScreenManager();
 }
 
 void WebPage::isInFullscreenChanged(IsInFullscreenMode isInFullscreenMode)
@@ -6222,7 +6226,7 @@ bool WebPage::dispatchMessage(IPC::Connection& connection, IPC::Decoder& decoder
 
 #if ENABLE(FULLSCREEN_API)
     if (decoder.messageReceiverName() == Messages::WebFullScreenManager::messageReceiverName()) {
-        fullScreenManager()->didReceiveMessage(connection, decoder);
+        fullScreenManager().didReceiveMessage(connection, decoder);
         return true;
     }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -621,7 +621,8 @@ public:
 #endif
 
 #if ENABLE(FULLSCREEN_API)
-    WebFullScreenManager* fullScreenManager();
+    WebFullScreenManager& fullScreenManager();
+    Ref<WebFullScreenManager> protectedFullscreenManager();
 
     enum class IsInFullscreenMode : bool { No, Yes };
     void isInFullscreenChanged(IsInFullscreenMode);


### PR DESCRIPTION
#### 87ea7838ce18c3dae3f75121036b5c55443a36ac
<pre>
Begin implementing fullscreen for site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=285898">https://bugs.webkit.org/show_bug.cgi?id=285898</a>

Reviewed by Andy Estes.

This removes Messages::WebFullScreenManager::WillEnterFullScreen, which
was only ever sent to the main frame process, and replaces it with a
CompletionHandler that sends the equivalent signal to whichever process
sent Messages::WebFullScreenManagerProxy::EnterFullScreen, which now
is sent using sendWithAsyncReply.  To do this, I found that
WebFullScreenManagerProxy::willEnterFullScreen is only ever called as a
result of Messages::WebFullScreenManagerProxy::EnterFullScreen.  I also
found that WebPage::fullScreenManager only returns a non-null pointer,
and InjectedBundlePageFullScreenClient::enterFullScreenForElement only
ever receives non-null WebPage and Element pointers, so I changed them
to C++ references.

* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::willEnterFullScreen):
(WebKit::WebFullScreenManagerProxy::enterFullScreen):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::enterFullScreen):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController enterFullScreen:completionHandler:]):
(-[WKFullScreenWindowController _enterFullScreen:windowScene:completionHandler:]):
(-[WKFullScreenWindowController enterFullScreen:]): Deleted.
(-[WKFullScreenWindowController _enterFullScreen:windowScene:]): Deleted.
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::enterFullScreen):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h:
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController enterFullScreen:completionHandler:]):
(-[WKFullScreenWindowController enterFullScreen:]): Deleted.
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::enterFullScreenForElement):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageWillEnterFullScreen):
(WKBundlePageDidEnterFullScreen):
(WKBundlePageWillExitFullScreen):
(WKBundlePageDidExitFullScreen):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFullScreenClient.cpp:
(WebKit::InjectedBundlePageFullScreenClient::enterFullScreenForElement):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFullScreenClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::supportsFullScreenForElement):
(WebKit::WebChromeClient::enterFullScreenForElement):
(WebKit::WebChromeClient::updateImageSource):
(WebKit::WebChromeClient::exitFullScreenForElement):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::videoControlsManagerDidChange):
(WebKit::WebPage::fullScreenManager):
(WebKit::WebPage::dispatchMessage):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/288910@main">https://commits.webkit.org/288910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80ec3e586e4e240d4b3a6e8f61fcbe350b9d7361

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89832 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35744 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65917 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23747 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76971 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46190 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/web-socket-client-side-certificate (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3304 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34819 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91208 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12032 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8794 "Found 60 new test failures: fast/events/event-handler-detached-document.html fast/selectors/text-field-selection-stroke-color.html fast/table/multiple-captions-crash5.html fast/text/emoji-gender-2-4.html fonts/font-fallback-prefers-pictographs.html http/wpt/service-workers/basic-fetch-with-contentfilter.https.html imported/blink/fast/css/fixed-overlaps-absolute-in-clip.html imported/w3c/web-platform-tests/css/css-backgrounds/background-gradient-interpolation-001.html imported/w3c/web-platform-tests/css/css-backgrounds/background-gradient-interpolation-002.html imported/w3c/web-platform-tests/css/css-backgrounds/border-radius-clipping-with-transform-001.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74393 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12259 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72775 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73518 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17890 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16334 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3480 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13209 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11984 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17424 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11818 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15312 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13564 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->