### PR TITLE
Introduce the StageMode attribute to Model

### DIFF
--- a/LayoutTests/model-element/model-element-stagemode-expected.txt
+++ b/LayoutTests/model-element/model-element-stagemode-expected.txt
@@ -1,0 +1,2 @@
+PASS Setting stage mode persists after changing source on the same model element
+PASS Checking <model> stage mode value after updating

--- a/LayoutTests/model-element/model-element-stagemode.html
+++ b/LayoutTests/model-element/model-element-stagemode.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ModelElementEnabled=true ModelProcessEnabled=true ] -->
+<meta charset="utf-8">
+<title>&lt;model> stagemode attribute</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/model-element-test-utils.js"></script>
+<script src="resources/model-utils.js"></script>
+<body>
+<script>
+'use strict';
+
+promise_test(async t => {
+    const model = document.createElement("model");
+    const firstSource = model.appendChild(makeSource("resources/cube.usdz"));
+    await model.ready;
+
+    assert_equals(model.stageMode, "");
+    model.stageMode = "orbit";
+    assert_equals(model.stageMode, "orbit");
+
+    const secondSource = model.appendChild(makeSource("resources/heart.usdz"));
+    firstSource.remove();
+    assert_equals(model.currentSrc, secondSource.src);
+    await model.ready;
+
+    assert_equals(model.stageMode, "orbit");
+}, `Setting stage mode persists after changing source on the same model element`);
+
+promise_test(async t => {
+    const [model, source] = createModelAndSource(t, "resources/cube.usdz");
+    await model.ready;
+
+    assert_equals(model.stageMode, "");
+    model.stageMode = "orbit";
+    assert_equals(model.stageMode, "orbit");
+    model.stageMode = "none";
+    assert_equals(model.stageMode, "none");
+    model.stageMode = "Hello world!";
+    assert_equals(model.stageMode, "Hello world!");
+
+}, `Checking <model> stage mode value after updating`);
+
+</script>
+</body>

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -305,6 +305,7 @@ void HTMLModelElement::createModelPlayer()
     m_modelPlayer->setLoop(loop());
     m_modelPlayer->setPlaybackRate(m_playbackRate, [&](double) { });
     m_modelPlayer->setHasPortal(hasPortal());
+    m_modelPlayer->setStageMode(stageMode());
 #endif
 
     // FIXME: We need to tell the player if the size changes as well, so passing this
@@ -534,6 +535,8 @@ void HTMLModelElement::attributeChanged(const QualifiedName& name, const AtomStr
         updateLoop();
     else if (name == environmentmapAttr)
         updateEnvironmentMap();
+    else if (name == stagemodeAttr)
+        updateStageMode();
 #if PLATFORM(VISION)
     else if (document().settings().modelNoPortalAttributeEnabled() && name == noportalAttr)
         updateHasPortal();
@@ -707,6 +710,21 @@ void HTMLModelElement::updateAutoplay()
 {
     if (m_modelPlayer)
         m_modelPlayer->setAutoplay(autoplay());
+}
+
+WebCore::StageModeOperation HTMLModelElement::stageMode() const
+{
+    String attr = attributeWithoutSynchronization(HTMLNames::stagemodeAttr);
+    if (equalLettersIgnoringASCIICase(attr, "orbit"_s))
+        return WebCore::StageModeOperation::Orbit;
+
+    return WebCore::StageModeOperation::None;
+}
+
+void HTMLModelElement::updateStageMode()
+{
+    if (m_modelPlayer)
+        m_modelPlayer->setStageMode(stageMode());
 }
 
 bool HTMLModelElement::loop() const

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -42,6 +42,10 @@
 #include "SharedBuffer.h"
 #include <wtf/UniqueRef.h>
 
+#if ENABLE(MODEL_PROCESS)
+#include "StageModeOperations.h"
+#endif
+
 namespace WebCore {
 
 class DOMMatrixReadOnly;
@@ -147,7 +151,6 @@ public:
     void setPaused(bool, DOMPromiseDeferred<void>&&);
     double currentTime() const;
     void setCurrentTime(double);
-
     const URL& environmentMap() const;
     void setEnvironmentMap(const URL&);
 #endif
@@ -231,6 +234,8 @@ private:
     void environmentMapResourceFinished();
     bool hasPortal() const;
     void updateHasPortal();
+    WebCore::StageModeOperation stageMode() const;
+    void updateStageMode();
 #endif
     void modelResourceFinished();
 

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.idl
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.idl
@@ -53,6 +53,8 @@
     [Conditional=MODEL_PROCESS, EnabledBySetting=ModelProcessEnabled] Promise<undefined> play();
     [Conditional=MODEL_PROCESS, EnabledBySetting=ModelProcessEnabled] Promise<undefined> pause();
     [Conditional=MODEL_PROCESS, EnabledBySetting=ModelProcessEnabled] attribute double currentTime;
+    
+    [Conditional=MODEL_PROCESS, EnabledBySetting=ModelProcessEnabled, Reflect] attribute DOMString stageMode;
 
     [Conditional=MODEL_PROCESS, EnabledBySetting=ModelProcessEnabled, CEReactions=NotNeeded, Reflect, URL] attribute USVString environmentMap;
     [Conditional=MODEL_PROCESS, EnabledBySetting=ModelProcessEnabled] readonly attribute Promise<undefined> environmentMapReady;

--- a/Source/WebCore/Modules/model-element/ModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.cpp
@@ -30,6 +30,10 @@
 #include "TransformationMatrix.h"
 #include <wtf/TZoneMallocInlines.h>
 
+#if ENABLE(MODEL_PROCESS)
+#include <WebCore/StageModeOperations.h>
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ModelPlayer);
@@ -112,6 +116,10 @@ void ModelPlayer::setEnvironmentMap(Ref<SharedBuffer>&&)
 }
 
 void ModelPlayer::setHasPortal(bool)
+{
+}
+
+void ModelPlayer::setStageMode(WebCore::StageModeOperation)
 {
 }
 #endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -38,6 +38,7 @@
 
 #if ENABLE(MODEL_PROCESS)
 #include "ModelPlayerIdentifier.h"
+#include <WebCore/StageModeOperations.h>
 #endif
 
 namespace WebCore {
@@ -97,6 +98,7 @@ public:
     virtual void setCurrentTime(Seconds, CompletionHandler<void()>&&);
     virtual void setEnvironmentMap(Ref<SharedBuffer>&& data);
     virtual void setHasPortal(bool);
+    virtual void setStageMode(WebCore::StageModeOperation);
 #endif
 };
 

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -404,6 +404,7 @@ src
 srcdoc
 srclang
 srcset
+stagemode
 standby
 start
 step

--- a/Source/WebCore/page/StageModeOperations.h
+++ b/Source/WebCore/page/StageModeOperations.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2007-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(MODEL_PROCESS)
+namespace WebCore {
+
+enum class StageModeOperation : bool {
+    None,
+    Orbit,
+};
+
+} // namespace WebCore
+#endif
+

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -36,6 +36,7 @@
 #include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/ModelPlayer.h>
 #include <WebCore/ModelPlayerIdentifier.h>
+#include <WebCore/StageModeOperations.h>
 #include <WebKitAdditions/REPtr.h>
 #include <WebKitAdditions/REModelLoaderClient.h>
 #include <simd/simd.h>
@@ -132,6 +133,7 @@ public:
     void setCurrentTime(Seconds, CompletionHandler<void()>&&) final;
     void setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data) final;
     void setHasPortal(bool) final;
+    void setStageMode(WebCore::StageModeOperation) final;
 
     USING_CAN_MAKE_WEAKPTR(WebCore::REModelLoaderClient);
 
@@ -169,6 +171,8 @@ private:
 
     RefPtr<WebCore::SharedBuffer> m_transientEnvironmentMapData;
     bool m_hasPortal { true };
+
+    WebCore::StageModeOperation m_stageModeOperation { WebCore::StageModeOperation::None };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in
@@ -39,6 +39,7 @@ messages -> ModelProcessModelPlayerProxy {
     SetCurrentTime(Seconds currentTime) -> () Async
     SetEnvironmentMap(Ref<WebCore::SharedBuffer> data)
     SetHasPortal(bool hasPortal)
+    SetStageMode(enum:bool WebCore::StageModeOperation stagemodeOp)
 }
 
 #endif

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -748,6 +748,14 @@ void ModelProcessModelPlayerProxy::setHasPortal(bool hasPortal)
     updateTransform();
 }
 
+void ModelProcessModelPlayerProxy::setStageMode(WebCore::StageModeOperation stagemodeOp)
+{
+    if (m_stageModeOperation == stagemodeOp)
+        return;
+
+    m_stageModeOperation = stagemodeOp;
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1070,6 +1070,7 @@ def headers_for_type(type):
         'WebCore::ShouldSample': ['<WebCore/DiagnosticLoggingClient.h>'],
         'WebCore::SourceBufferAppendMode': ['<WebCore/SourceBufferPrivate.h>'],
         'WebCore::SourceBufferEvictionData': ['<WebCore/SourceBufferPrivateClient.h>'],
+        'WebCore::StageModeOperation': ['<WebCore/StageModeOperations.h>'],
         'WebCore::StorageAccessPromptWasShown': ['<WebCore/DocumentStorageAccess.h>'],
         'WebCore::StorageAccessScope': ['<WebCore/DocumentStorageAccess.h>'],
         'WebCore::StorageAccessWasGranted': ['<WebCore/DocumentStorageAccess.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8932,3 +8932,8 @@ header: <WebCore/DocumentClasses.h>
 #endif
     PDF
 };
+
+#if ENABLE(MODEL_PROCESS)
+header: <WebCore/StageModeOperations.h>
+enum class WebCore::StageModeOperation : bool;
+#endif

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -341,6 +341,16 @@ void ModelProcessModelPlayer::setHasPortal(bool hasPortal)
     m_hasPortal = hasPortal;
     send(Messages::ModelProcessModelPlayerProxy::SetHasPortal(m_hasPortal));
 }
+
+void ModelProcessModelPlayer::setStageMode(WebCore::StageModeOperation stagemodeOp)
+{
+    if (m_stageModeOperation == stagemodeOp)
+        return;
+
+    m_stageModeOperation = stagemodeOp;
+    send(Messages::ModelProcessModelPlayerProxy::SetStageMode(m_stageModeOperation));
+}
+
 }
 
 #endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -33,6 +33,7 @@
 #import <WebCore/ModelPlayer.h>
 #import <WebCore/ModelPlayerClient.h>
 #import <WebCore/ModelPlayerIdentifier.h>
+#import <WebCore/StageModeOperations.h>
 #import <wtf/Compiler.h>
 
 namespace WebKit {
@@ -104,6 +105,7 @@ private:
     void setCurrentTime(Seconds, CompletionHandler<void()>&&) final;
     void setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data) final;
     void setHasPortal(bool) final;
+    void setStageMode(WebCore::StageModeOperation) final;
 
     WebCore::ModelPlayerIdentifier m_id;
     WeakPtr<WebPage> m_page;
@@ -122,6 +124,7 @@ private:
     std::optional<MonotonicTime> m_clockTimestampOfLastCurrentTimeSet;
     std::optional<Seconds> m_lastCachedCurrentTime;
     std::optional<MonotonicTime> m_lastCachedClockTimestamp;
+    WebCore::StageModeOperation m_stageModeOperation { WebCore::StageModeOperation::None };
 };
 
 }


### PR DESCRIPTION
#### 9ad0659e5627046e8b8464ee1fc2310c49602d03
<pre>
Introduce the StageMode attribute to Model
<a href="https://bugs.webkit.org/show_bug.cgi?id=285899">https://bugs.webkit.org/show_bug.cgi?id=285899</a>
<a href="https://rdar.apple.com/142566328">rdar://142566328</a>

Reviewed by Ada Chan.

This is the first of three PRs used to introduce the stagemode attribute to model views, which will
be used to define and control the interaction of a model. The stagemode attribute takes a string and
determines how the model behaves based on user&apos;s gesture input on the view containing the model. In
particular, we currently support 2 types of stagemode behaviors: orbit, which will allow users to rotate
the model, and none, which will disable model interaction. Subsequent PRs will be made to use this
attribute to define model interaction.

* LayoutTests/model-element/model-element-stagemode-expected.txt: Added.
* LayoutTests/model-element/model-element-stagemode.html: Added.
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::createModelPlayer):
Updates the stagemode attribute when the source for the model element updates
(WebCore::HTMLModelElement::attributeChanged):
Updates the stagemode attribute when the attribute changes
(WebCore::HTMLModelElement::stageMode const):
Returns the enum corresponding to the stagemode attribute as defined by the user-defined string
(WebCore::HTMLModelElement::updateStageMode):
Updates the internal variable the model player uses to track the stagemode attribute
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/HTMLModelElement.idl:
* Source/WebCore/Modules/model-element/ModelPlayer.cpp:
(WebCore::ModelPlayer::setStageMode):
Virtual function to update the player based on the stagemode attribute
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLAttributeNames.in:
* Source/WebCore/page/StageModeOperations.h: Added.
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.messages.in:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::setStageMode):
Updates the internal variable correpsonding to the stagemode attribute
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::setStageMode):
Updates the internal variable correpsonding to the stagemode attribute
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:

Canonical link: <a href="https://commits.webkit.org/289830@main">https://commits.webkit.org/289830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3dbf9fdfbd59e851a5a2685244b6d7120302d2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42303 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92811 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38664 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89965 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15606 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67872 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25610 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5983 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48240 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/87411 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5763 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33952 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37771 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/76162 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94679 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/15082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/11099 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76721 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75401 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75959 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18716 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20347 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18770 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/8086 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/15100 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20401 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14842 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18287 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16624 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->