### PR TITLE
HTML parser: inline SVG tag name adjustment

### DIFF
--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -947,30 +947,12 @@ sub printTagNameHeaderFile
     print F "#if ASSERT_ENABLED\n";
     print F "TagName findTagName(const String&);\n";
     print F "#endif\n";
-    for my $namespace (sort keys %namespacesWithTagsRequiringAdjustment) {
-        print F "TagName adjust${namespace}TagName(TagName);\n";
-    }
     print F "\n";
     print F "inline const AtomString& tagNameAsString(TagName tagName)\n";
     print F "{\n";
     print F "    return tagNameStrings.get()[tagName];\n";
     print F "}\n";
     print F "\n";
-    for my $namespace (sort keys %namespacesWithTagsRequiringAdjustment) {
-        print F "inline TagName adjust${namespace}TagName(TagName tagName)\n";
-        print F "{\n";
-        print F "    switch (tagName) {\n";
-        for my $elementKey (sort byElementNameOrder keys %allElements) {
-            next if $allElements{$elementKey}{namespace} ne $namespace || $allElements{$elementKey}{unadjustedTagEnumValue} eq "";
-            print F "    case TagName::$allElements{$elementKey}{unadjustedTagEnumValue}:\n";
-            print F "        return TagName::$allElements{$elementKey}{tagEnumValue};\n";
-        }
-        print F "    default:\n";
-        print F "        return tagName;\n";
-        print F "    }\n";
-        print F "}\n";
-        print F "\n";
-    }
     print F "} // namespace WebCore\n";
     close F;
 }

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -474,6 +474,88 @@ template <bool shouldClose(const HTMLStackItem&)> void HTMLTreeBuilder::processC
     m_tree.insertHTMLElement(WTFMove(token));
 }
 
+static TagName adjustSVGTagName(TagName tagName)
+{
+    switch (tagName) {
+    case TagName::altglyphCaseUnadjusted:
+        return TagName::altGlyph;
+    case TagName::altglyphdefCaseUnadjusted:
+        return TagName::altGlyphDef;
+    case TagName::altglyphitemCaseUnadjusted:
+        return TagName::altGlyphItem;
+    case TagName::animatecolorCaseUnadjusted:
+        return TagName::animateColor;
+    case TagName::animatemotionCaseUnadjusted:
+        return TagName::animateMotion;
+    case TagName::animatetransformCaseUnadjusted:
+        return TagName::animateTransform;
+    case TagName::clippathCaseUnadjusted:
+        return TagName::clipPath;
+    case TagName::feblendCaseUnadjusted:
+        return TagName::feBlend;
+    case TagName::fecolormatrixCaseUnadjusted:
+        return TagName::feColorMatrix;
+    case TagName::fecomponenttransferCaseUnadjusted:
+        return TagName::feComponentTransfer;
+    case TagName::fecompositeCaseUnadjusted:
+        return TagName::feComposite;
+    case TagName::feconvolvematrixCaseUnadjusted:
+        return TagName::feConvolveMatrix;
+    case TagName::fediffuselightingCaseUnadjusted:
+        return TagName::feDiffuseLighting;
+    case TagName::fedisplacementmapCaseUnadjusted:
+        return TagName::feDisplacementMap;
+    case TagName::fedistantlightCaseUnadjusted:
+        return TagName::feDistantLight;
+    case TagName::fedropshadowCaseUnadjusted:
+        return TagName::feDropShadow;
+    case TagName::fefloodCaseUnadjusted:
+        return TagName::feFlood;
+    case TagName::fefuncaCaseUnadjusted:
+        return TagName::feFuncA;
+    case TagName::fefuncbCaseUnadjusted:
+        return TagName::feFuncB;
+    case TagName::fefuncgCaseUnadjusted:
+        return TagName::feFuncG;
+    case TagName::fefuncrCaseUnadjusted:
+        return TagName::feFuncR;
+    case TagName::fegaussianblurCaseUnadjusted:
+        return TagName::feGaussianBlur;
+    case TagName::feimageCaseUnadjusted:
+        return TagName::feImage;
+    case TagName::femergeCaseUnadjusted:
+        return TagName::feMerge;
+    case TagName::femergenodeCaseUnadjusted:
+        return TagName::feMergeNode;
+    case TagName::femorphologyCaseUnadjusted:
+        return TagName::feMorphology;
+    case TagName::feoffsetCaseUnadjusted:
+        return TagName::feOffset;
+    case TagName::fepointlightCaseUnadjusted:
+        return TagName::fePointLight;
+    case TagName::fespecularlightingCaseUnadjusted:
+        return TagName::feSpecularLighting;
+    case TagName::fespotlightCaseUnadjusted:
+        return TagName::feSpotLight;
+    case TagName::fetileCaseUnadjusted:
+        return TagName::feTile;
+    case TagName::feturbulenceCaseUnadjusted:
+        return TagName::feTurbulence;
+    case TagName::foreignobjectCaseUnadjusted:
+        return TagName::foreignObject;
+    case TagName::glyphrefCaseUnadjusted:
+        return TagName::glyphRef;
+    case TagName::lineargradientCaseUnadjusted:
+        return TagName::linearGradient;
+    case TagName::radialgradientCaseUnadjusted:
+        return TagName::radialGradient;
+    case TagName::textpathCaseUnadjusted:
+        return TagName::textPath;
+    default:
+        return tagName;
+    }
+}
+
 static void adjustSVGTagNameCase(AtomHTMLToken& token)
 {
     if (auto currentTagName = token.tagName(); currentTagName != TagName::Unknown)


### PR DESCRIPTION
#### 90b355436236763065bfd7d5478af15837674462
<pre>
HTML parser: inline SVG tag name adjustment
<a href="https://bugs.webkit.org/show_bug.cgi?id=254881">https://bugs.webkit.org/show_bug.cgi?id=254881</a>
<a href="https://rdar.apple.com/107802125">rdar://107802125</a>

Reviewed by NOBODY (OOPS!).

This is supposed to be a static list that does not change when we add
or remove elements. Inlining it more directly enforces that design.

* Source/WebCore/dom/make_names.pl:
(printTagNameHeaderFile):
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::adjustSVGTagName):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90b355436236763065bfd7d5478af15837674462

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89788 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35700 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12347 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65890 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23719 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46161 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31145 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34775 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91163 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74359 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12215 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73485 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17858 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16297 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3436 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11940 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17380 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11774 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15268 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->