### PR TITLE
Reduce WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in WebCore/platform

### DIFF
--- a/Source/WebCore/platform/calc/CalculationExecutor.h
+++ b/Source/WebCore/platform/calc/CalculationExecutor.h
@@ -30,8 +30,6 @@
 #include <wtf/Forward.h>
 #include <wtf/MathExtras.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 namespace Calculation {
 
@@ -53,7 +51,10 @@ public:
     }
 
     struct const_iterator {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         const_iterator& operator++() { ++it; return *this; }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
         auto operator*() const { return transform(*it); }
 
         bool operator==(const const_iterator& other) const { return it == other.it; }
@@ -515,5 +516,3 @@ template<> struct OperatorExecutor<Random> {
 
 } // namespace Calculation
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/platform/cf/KeyedDecoderCF.cpp
+++ b/Source/WebCore/platform/cf/KeyedDecoderCF.cpp
@@ -28,9 +28,8 @@
 
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/cf/TypeCastsCF.h>
+#include <wtf/cf/VectorCF.h>
 #include <wtf/text/WTFString.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WebCore {
 
@@ -67,7 +66,7 @@ bool KeyedDecoderCF::decodeBytes(const String& key, std::span<const uint8_t>& by
     if (!data)
         return false;
 
-    bytes = { CFDataGetBytePtr(data), static_cast<size_t>(CFDataGetLength(data)) };
+    bytes = span(data);
     return true;
 }
 
@@ -191,5 +190,3 @@ void KeyedDecoderCF::endArray()
 }
 
 } // namespace WebCore
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### b9ab6bfb9ee2ff72ab008f27b7729f1bc23a0be7
<pre>
Reduce WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in WebCore/platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=285916">https://bugs.webkit.org/show_bug.cgi?id=285916</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/platform/calc/CalculationExecutor.h:
* Source/WebCore/platform/cf/KeyedDecoderCF.cpp:
(WebCore::KeyedDecoderCF::decodeBytes):

Canonical link: <a href="https://commits.webkit.org/288892@main">https://commits.webkit.org/288892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdce02fe18f374956a909b7f26a25fc7c238b455

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89793 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35705 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65892 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23721 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3394 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76932 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46163 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31144 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34780 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91168 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11993 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8760 "Found 2 new test failures: fast/selectors/text-field-selection-stroke-color.html imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-replaced.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74366 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12220 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73492 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17857 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16296 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3441 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13197 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11945 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17385 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11779 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15273 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13525 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->