### PR TITLE
Rename topDocument() and make it return a pointer instead of a reference

### DIFF
--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -585,19 +585,37 @@ static constexpr bool unreachableForValue = false;
 
 #if ERROR_DISABLED
 #define LOG_ERROR(...) ((void)0)
+#define LOG_ERROR_ONCE(...) ((void)0)
 #else
 #define LOG_ERROR(...) WTFReportError(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, __VA_ARGS__)
+#define LOG_ERROR_ONCE(...) do { \
+    static std::once_flag onceFlag; \
+    std::call_once( \
+        onceFlag, \
+        [&] { \
+            LOG_ERROR(__VA_ARGS__); \
+        }); \
+} while (0)
 #endif
 
 /* LOG */
 
 #if LOG_DISABLED
 #define LOG(channel, ...) ((void)0)
+#define LOG_ONCE(channel, ...) ((void)0)
 #else
 #define LOG(channel, ...) do { \
         if (LOG_CHANNEL(channel).state != logChannelStateOff) \
             WTFLog(&LOG_CHANNEL(channel), __VA_ARGS__); \
     } while (0)
+#define LOG_ONCE(channel, ...) do { \
+    static std::once_flag onceFlag; \
+    std::call_once( \
+        onceFlag, \
+        [&] { \
+            LOG(channel, __VA_ARGS__); \
+        }); \
+} while (0)
 #endif
 
 /* LOG_VERBOSE */

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -90,7 +90,8 @@ static bool shouldDocumentAllowWebAudioToAutoPlay(const Document& document)
 {
     if (document.isCapturing())
         return true;
-    if (document.quirks().shouldAutoplayWebAudioForArbitraryUserGesture() && document.topDocument().hasHadUserInteraction())
+    RefPtr mainDocument = document.protectedMainFrameDocument();
+    if (document.quirks().shouldAutoplayWebAudioForArbitraryUserGesture() && mainDocument && mainDocument->hasHadUserInteraction())
         return true;
     RefPtr window = document.domWindow();
     return window && window->hasTransientActivation();
@@ -150,7 +151,8 @@ AudioContext::AudioContext(Document& document, const AudioContextOptions& contex
 void AudioContext::constructCommon()
 {
     ASSERT(document());
-    if (document()->topDocument().requiresUserGestureForAudioPlayback())
+    RefPtr mainFrameDocument = document()->mainFrameDocument();
+    if (!mainFrameDocument || mainFrameDocument->requiresUserGestureForAudioPlayback())
         addBehaviorRestriction(RequireUserGestureForAudioStartRestriction);
     else
         m_restrictions = NoRestrictions;

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -6,7 +6,6 @@ Modules/WebGPU/Implementation/WebGPUImpl.cpp
 Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp
 Modules/applepay/ApplePaySession.cpp
 Modules/applepay/ApplePaySetup.cpp
-Modules/applepay/PaymentSession.cpp
 Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
 Modules/applicationmanifest/ApplicationManifestParser.cpp
 Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1417,7 +1417,7 @@ Document* AccessibilityObject::topDocument() const
 {
     if (!document())
         return nullptr;
-    return &document()->topDocument();
+    return document()->mainFrameDocument();
 }
 
 RenderView* AccessibilityObject::topRenderer() const

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -1823,7 +1823,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     // Verify this is the top document. If not, we might need to go through the platform widget.
     auto* frameView = self.axBackingObject->documentFrameView();
     auto* document = self.axBackingObject->document();
-    if (document && frameView && document != &document->topDocument())
+    if (document && frameView && !document->isTopDocument())
         return frameView->platformWidget();
     
     // The top scroll view's parent is the web document view.

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1227,8 +1227,12 @@ public:
 
     WEBCORE_EXPORT Document* parentDocument() const;
     RefPtr<Document> protectedParentDocument() const { return parentDocument(); }
+
+    // topDocument temporarily left in to allow staging other related commits
     WEBCORE_EXPORT Document& topDocument() const;
     Ref<Document> protectedTopDocument() const { return topDocument(); }
+    WEBCORE_EXPORT Document* mainFrameDocument() const;
+    RefPtr<Document> protectedMainFrameDocument() const { return mainFrameDocument(); }
     WEBCORE_EXPORT bool isTopDocument() const;
 
     WEBCORE_EXPORT RefPtr<Document> localTopDocument() const;
@@ -2142,11 +2146,13 @@ private:
     void updateCaptureAccordingToMutedState();
     MediaProducerMediaStateFlags computeCaptureState() const;
 #endif
-    bool isTopDocumentLegacy() const { return &topDocument() == this; }
+    bool isTopDocumentLegacy() const { return mainFrameDocument() == this; }
     void securityOriginDidChange() final;
 
     Ref<DocumentSyncData> syncData() { return m_syncData.get(); }
     void populateDocumentSyncDataForNewlyConstructedDocument(ProcessSyncDataType);
+
+    bool mainFrameDocumentHasHadUserInteraction() const;
 
     const Ref<const Settings> m_settings;
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2928,8 +2928,12 @@ Node::InsertedIntoAncestorResult Element::insertedIntoAncestor(InsertionType ins
         }
         if (UNLIKELY(isDefinedCustomElement()))
             CustomElementReactionQueue::enqueueConnectedCallbackIfNeeded(*this);
-        if (shouldAutofocus(*this))
-            Ref { document().topDocument() }->appendAutofocusCandidate(*this);
+        if (shouldAutofocus(*this)) {
+            if (RefPtr mainFrameDocument = document().mainFrameDocument())
+                mainFrameDocument->appendAutofocusCandidate(*this);
+            else
+                LOG_ONCE(SiteIsolation, "Unable to properly perform Element::insertedIntoAncestor() without access to the main frame document ");
+        }
     }
 
     if (parentNode() == &parentOfInsertedTree) {

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -111,8 +111,8 @@ private:
     WTFLogChannel& logChannel() const;
 #endif
 
-    Document& topDocument() { return m_topDocument ? *m_topDocument : document().topDocument(); }
-    Ref<Document> protectedTopDocument();
+    Document* mainFrameDocument();
+    RefPtr<Document> protectedMainFrameDocument();
 
     void updatePageFullscreenStatusIfTopDocument();
 

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -205,8 +205,10 @@ void HTMLDialogElement::runFocusingSteps()
     if (!control->document().isSameOriginAsTopDocument())
         return;
 
-    Ref topDocument = control->document().topDocument();
-    topDocument->clearAutofocusCandidates();
+    if (RefPtr mainFrameDocument = control->document().mainFrameDocument())
+        mainFrameDocument->clearAutofocusCandidates();
+    else
+        LOG_ONCE(SiteIsolation, "Unable to fully perform HTMLDialogElement::runFocusingSteps() without access to the main frame document ");
     page->setAutofocusProcessed();
 }
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -74,6 +74,7 @@
 #include "LabelsNodeList.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
+#include "Logging.h"
 #include "MediaControlsHost.h"
 #include "MutableStyleProperties.h"
 #include "NodeName.h"
@@ -1069,8 +1070,10 @@ static void runPopoverFocusingSteps(HTMLElement& popover)
     if (!control->document().isSameOriginAsTopDocument())
         return;
 
-    Ref topDocument = control->document().topDocument();
-    topDocument->clearAutofocusCandidates();
+    if (RefPtr mainFrameDocument = control->document().mainFrameDocument())
+        mainFrameDocument->clearAutofocusCandidates();
+    else
+        LOG_ONCE(SiteIsolation, "Unable to fully perform runPopoverFocusingSteps() without access to the main frame document ");
     page->setAutofocusProcessed();
 }
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1288,8 +1288,8 @@ private:
     bool m_tracksAreReady : 1;
     bool m_haveVisibleTextTrack : 1;
     bool m_processingPreferenceChange : 1;
-    bool m_shouldAudioPlaybackRequireUserGesture : 1;
-    bool m_shouldVideoPlaybackRequireUserGesture : 1;
+    bool m_shouldAudioPlaybackRequireUserGesture : 1 { true };
+    bool m_shouldVideoPlaybackRequireUserGesture : 1 { true };
     bool m_volumeLocked : 1;
     bool m_cachedIsInVisibilityAdjustmentSubtree : 1 { false };
     bool m_requiresTextTrackRepresentation : 1 { false };

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -396,7 +396,10 @@ bool HTMLPlugInElement::setReplacement(PluginUnavailabilityReason reason, const 
 
 bool HTMLPlugInElement::isReplacementObscured()
 {
-    Ref topDocument = document().topDocument();
+    RefPtr topDocument = document().protectedMainFrameDocument();
+    if (!topDocument)
+        return false;
+
     RefPtr topFrameView = topDocument->view();
     if (!topFrameView)
         return false;
@@ -405,7 +408,7 @@ bool HTMLPlugInElement::isReplacementObscured()
 
     // Updating the layout may have detached this document from the top document.
     auto* renderView = topDocument->renderView();
-    if (!renderView || !document().view() || &document().topDocument() != topDocument.ptr())
+    if (!renderView || !document().view() || document().mainFrameDocument() != topDocument.get())
         return false;
 
     CheckedPtr pluginRenderer = dynamicDowncast<RenderEmbeddedObject>(renderer());

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3839,7 +3839,7 @@ bool EventHandler::keyEvent(const PlatformKeyboardEvent& keyEvent)
 {
     Ref frame = m_frame.get();
     RefPtr page = frame->protectedPage();
-    RefPtr topDocument = frame->document() ? &frame->document()->topDocument() : nullptr;
+    RefPtr mainFrameDocument = frame->document() ? frame->document()->protectedMainFrameDocument() : nullptr;
     MonotonicTime savedLastHandledUserGestureTimestamp;
     bool savedUserDidInteractWithPage = page ? page->userDidInteractWithPage() : false;
 
@@ -3849,12 +3849,12 @@ bool EventHandler::keyEvent(const PlatformKeyboardEvent& keyEvent)
     bool wasHandled = internalKeyEvent(keyEvent);
 
     // If the key event was not handled, do not treat it as user interaction with the page.
-    if (topDocument) {
+    if (mainFrameDocument) {
         if (!wasHandled) {
             if (page)
                 page->setUserDidInteractWithPage(savedUserDidInteractWithPage);
         } else
-            ResourceLoadObserver::shared().logUserInteractionWithReducedTimeResolution(*topDocument);
+            ResourceLoadObserver::shared().logUserInteractionWithReducedTimeResolution(*mainFrameDocument);
     }
 
     if (!wasHandled && frame->document())

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1961,7 +1961,7 @@ bool LocalDOMWindow::isSecureContext() const
 
 bool LocalDOMWindow::crossOriginIsolated() const
 {
-    ASSERT(ScriptExecutionContext::crossOriginMode() == CrossOriginMode::Shared || !document() || document()->topDocument().crossOriginOpenerPolicy().value == CrossOriginOpenerPolicyValue::SameOriginPlusCOEP);
+    ASSERT(ScriptExecutionContext::crossOriginMode() == CrossOriginMode::Shared || !document() || !document()->mainFrameDocument() || document()->mainFrameDocument()->crossOriginOpenerPolicy().value == CrossOriginOpenerPolicyValue::SameOriginPlusCOEP);
     return ScriptExecutionContext::crossOriginMode() == CrossOriginMode::Isolated;
 }
 
@@ -2228,7 +2228,7 @@ void LocalDOMWindow::failedToRegisterDeviceMotionEventListener()
 void LocalDOMWindow::incrementScrollEventListenersCount()
 {
     RefPtr document = this->document();
-    if (++m_scrollEventListenerCount == 1 && document == &document->topDocument()) {
+    if (++m_scrollEventListenerCount == 1 && document->isTopDocument()) {
         if (RefPtr frame = this->frame(); frame && frame->page())
             frame->protectedPage()->chrome().client().setNeedsScrollNotifications(*frame, true);
     }
@@ -2237,7 +2237,7 @@ void LocalDOMWindow::incrementScrollEventListenersCount()
 void LocalDOMWindow::decrementScrollEventListenersCount()
 {
     RefPtr document = this->document();
-    if (!--m_scrollEventListenerCount && document == &document->topDocument()) {
+    if (!--m_scrollEventListenerCount && document->isTopDocument()) {
         RefPtr frame = this->frame();
         if (frame && frame->page() && document->backForwardCacheState() == Document::NotInBackForwardCache)
             frame->protectedPage()->chrome().client().setNeedsScrollNotifications(*frame, false);

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -105,6 +105,13 @@ static inline OptionSet<AutoplayQuirk> allowedAutoplayQuirks(Document& document)
     return loader->allowedAutoplayQuirks();
 }
 
+static inline OptionSet<AutoplayQuirk> allowedAutoplayQuirks(Document* document)
+{
+    if (!document)
+        return { };
+    return allowedAutoplayQuirks(*document);
+}
+
 static HashMap<RegistrableDomain, String>& updatableStorageAccessUserAgentStringQuirks()
 {
     // FIXME: Make this a member of Quirks.
@@ -179,7 +186,7 @@ bool Quirks::needsAutoplayPlayPauseEvents() const
     if (allowedAutoplayQuirks(document).contains(AutoplayQuirk::SynthesizedPauseEvents))
         return true;
 
-    return allowedAutoplayQuirks(document->topDocument()).contains(AutoplayQuirk::SynthesizedPauseEvents);
+    return allowedAutoplayQuirks(document->mainFrameDocument()).contains(AutoplayQuirk::SynthesizedPauseEvents);
 }
 
 // netflix.com https://bugs.webkit.org/show_bug.cgi?id=173030
@@ -197,7 +204,7 @@ bool Quirks::needsPerDocumentAutoplayBehavior() const
 {
 #if PLATFORM(MAC)
     Ref document = *m_document;
-    ASSERT(document.ptr() == &document->topDocument());
+    ASSERT(document->isTopDocument());
     return needsQuirks() && allowedAutoplayQuirks(document).contains(AutoplayQuirk::PerDocumentAutoplayBehavior);
 #else
     return needsQuirks() && m_quirksData.isNetflix;

--- a/Source/WebCore/page/ios/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/ios/ContentChangeObserver.cpp
@@ -58,7 +58,13 @@ static bool isHiddenBehindFullscreenElement(const Node& descendantCandidate)
 {
     // Fullscreen status is propagated on the ancestor document chain all the way to the top document.
     auto& document = descendantCandidate.document();
-    CheckedPtr fullscreenManager = document.topDocument().fullscreenManagerIfExists();
+    RefPtr mainFrameDocument = document.protectedMainFrameDocument();
+    if (!mainFrameDocument) {
+        LOG_ONCE(SiteIsolation, "Unable to properly calculate isHiddenBehindFullscreenElement() without access to the main frame document ");
+        return false;
+    }
+
+    CheckedPtr fullscreenManager = mainFrameDocument->fullscreenManagerIfExists();
     if (!fullscreenManager)
         return false;
     auto* topMostFullScreenElement = fullscreenManager->fullscreenElement();

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -165,6 +165,7 @@ namespace WebCore {
     M(Services) \
     M(ServiceWorker) \
     M(SharedWorker) \
+    M(SiteIsolation) \
     M(SpellingAndGrammar) \
     M(SQLDatabase) \
     M(Storage) \

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -40,6 +40,7 @@
 #include "LegacyRenderSVGRoot.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
+#include "Logging.h"
 #include "NodeTraversal.h"
 #include "Page.h"
 #include "RenderBoxInlines.h"
@@ -1013,7 +1014,12 @@ RenderView::RepaintRegionAccumulator::RepaintRegionAccumulator(RenderView* view)
     if (!view)
         return;
 
-    auto* rootRenderView = view->document().topDocument().renderView();
+    RefPtr mainFrameDocument = view->document().protectedMainFrameDocument();
+    if (!mainFrameDocument) {
+        LOG_ONCE(SiteIsolation, "Unable to properly perform RenderView::RepaintRegionAccumulator::RepaintRegionAccumulator() without access to the main frame document ");
+        return;
+    }
+    auto* rootRenderView = mainFrameDocument->renderView();
     if (!rootRenderView)
         return;
 

--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -156,6 +156,7 @@ extern "C" {
     M(SessionState) \
     M(SharedDisplayLists) \
     M(SharedWorker) \
+    M(SiteIsolation) \
     M(Storage) \
     M(StorageAPI) \
     M(SystemPreview) \

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1238,7 +1238,13 @@ inline DocumentLoader* WebFrame::policySourceDocumentLoader() const
     if (!document)
         return nullptr;
 
-    RefPtr policySourceDocumentLoader = document->topDocument().loader();
+    RefPtr mainFrameDocument = document->protectedMainFrameDocument();
+    if (!mainFrameDocument) {
+        LOG_ONCE(SiteIsolation, "Unable to properly calculate WebFrame::policySourceDocumentLoader() without access to the main frame document ");
+        return nullptr;
+    }
+
+    RefPtr policySourceDocumentLoader = mainFrameDocument->loader();
     if (!policySourceDocumentLoader)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3253,13 +3253,18 @@ static inline bool isAssistableElement(Element& element)
 
 static inline bool isObscuredElement(Element& element)
 {
-    Ref topDocument = element.document().topDocument();
+    RefPtr mainFrameDocument = element.document().protectedMainFrameDocument();
+    if (!mainFrameDocument) {
+        LOG_ONCE(SiteIsolation, "Unable to properly perform isObscuredElement() without access to the main frame document ");
+        return false;
+    }
+
     auto elementRectInMainFrame = element.boundingBoxInRootViewCoordinates();
 
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowChildFrameContent, HitTestRequest::Type::DisallowUserAgentShadowContent, HitTestRequest::Type::IgnoreClipping };
     HitTestResult result(elementRectInMainFrame.center());
 
-    topDocument->hitTest(hitType, result);
+    mainFrameDocument->hitTest(hitType, result);
     result.setToNonUserAgentShadowAncestor();
 
     if (result.targetElement() == &element)


### PR DESCRIPTION
#### 18391053bff1f5c0ebc6597d9fc3e693e6168cdd
<pre>
Rename topDocument() and make it return a pointer instead of a reference
<a href="https://rdar.apple.com/142888352">rdar://142888352</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=285917">https://bugs.webkit.org/show_bug.cgi?id=285917</a>

Reviewed by Alex Christensen.

This accomplishes two things:
1 - Makes searching for true &quot;topDocument()&quot; uses in the codebase much easier since the phrase &quot;mainFrameDocument&quot; doesn&apos;t otherwise exist.
2 - Instead of always returning a Document&amp; even if it&apos;s actually wrong, this forces us to confront the reality that a mainFrameDocument
    often doesn&apos;t exist with site isolation enabled, so we have to handle each case reasonably.

* Source/WTF/wtf/Assertions.h:
* Source/WebCore/Modules/applepay/PaymentSession.cpp:
(WebCore::PaymentSession::canCreateSession):
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::shouldDocumentAllowWebAudioToAutoPlay):
(WebCore::AudioContext::constructCommon):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::topDocument const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityContainer]):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::~Document):
(WebCore::Document::topOrigin const):
(WebCore::Document::createRenderTree):
(WebCore::Document::destroyRenderTree):
(WebCore::Document::willBeRemovedFromFrame):
(WebCore::Document::clearAXObjectCache):
(WebCore::Document::existingAXObjectCacheSlow const):
(WebCore::Document::axObjectCache const):
(WebCore::Document::implicitClose):
(WebCore::Document::urlForBindings):
(WebCore::Document::flushAutofocusCandidates):
(WebCore::Document::referrerForBindings):
(WebCore::Document::mainFrameDocument const):
(WebCore::Document::shouldForceNoOpenerBasedOnCOOP const):
(WebCore::Document::mainFrameDocumentHasHadUserInteraction const):
(WebCore::Document::processingUserGestureForMedia const):
(WebCore::Document::deviceOrientationAndMotionAccessController):
(WebCore::Document::isRunningUserScripts const):
(WebCore::Document::setAsRunningUserScripts):
(WebCore::Document::crossOriginOpenerPolicy const):
(WebCore::Document::advancedPrivacyProtections const):
(WebCore::Document::topDocument const): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::protectedMainFrameDocument const):
(WebCore::Document::isTopDocumentLegacy const):
(WebCore::Document::protectedTopDocument const): Deleted.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::insertedIntoAncestor):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::mainFrameDocument):
(WebCore::FullscreenManager::protectedMainFrameDocument):
(WebCore::FullscreenManager::requestFullscreenForElement):
(WebCore::FullscreenManager::cancelFullscreen):
(WebCore::FullscreenManager::exitFullscreen):
(WebCore::FullscreenManager::didExitFullscreen):
(WebCore::FullscreenManager::protectedTopDocument): Deleted.
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/dom/UserGestureIndicator.cpp:
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::runFocusingSteps):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::runPopoverFocusingSteps):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::m_remote):
(WebCore::HTMLMediaElement::removeBehaviorRestrictionsAfterFirstUserGesture):
(WebCore::HTMLMediaElement::updateRateChangeRestrictions):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::isReplacementObscured):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::playbackStateChangePermitted const):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::keyEvent):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::crossOriginIsolated const):
(WebCore::LocalDOMWindow::incrementScrollEventListenersCount):
(WebCore::LocalDOMWindow::decrementScrollEventListenersCount):
* Source/WebCore/page/Quirks.cpp:
(WebCore::allowedAutoplayQuirks):
(WebCore::Quirks::needsAutoplayPlayPauseEvents const):
(WebCore::Quirks::needsPerDocumentAutoplayBehavior const):
* Source/WebCore/page/ios/ContentChangeObserver.cpp:
(WebCore::isHiddenBehindFullscreenElement):
* Source/WebCore/platform/Logging.h:
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::RepaintRegionAccumulator::RepaintRegionAccumulator):
* Source/WebKit/Platform/Logging.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::policySourceDocumentLoader const):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::isObscuredElement):

Canonical link: <a href="https://commits.webkit.org/288984@main">https://commits.webkit.org/288984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb4d7597b15577a661700f31c5203be4f4befb59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39330 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90089 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35997 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12642 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/66104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/23922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77196 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/46371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3511 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31423 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35069 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77914 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32231 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91468 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83983 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12279 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12509 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73712 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18244 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18094 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16544 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12231 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106375 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12066 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25677 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15569 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13817 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->