### PR TITLE
Use correct SPI selector capitalization for ASDInstallWebAttributionService SPI

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/AppStoreDaemonSPI.h
+++ b/Source/WebKit/NetworkProcess/cocoa/AppStoreDaemonSPI.h
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_END
 #if HAVE(AD_ATTRIBUTION_KIT_PRIVATE_BROWSING)
 NS_ASSUME_NONNULL_BEGIN
 @interface ASDInstallWebAttributionService (Staging_for_137446922)
-- (void)removeInstallWebAttributionParamsFromPrivateBrowsingSessionId:(NSUUID *)sessionId completionHandler:(nullable void (^)(NSError *__nullable error))completionHandler;
+- (void)removeInstallWebAttributionParamsFromPrivateBrowsingSessionID:(NSUUID *)sessionId completionHandler:(nullable void (^)(NSError *__nullable error))completionHandler;
 @end
 @interface ASDInstallWebAttributionParamsConfig (Staging_for_137446922)
 @property (nullable, nonatomic, strong) NSUUID *privateBrowsingSessionId;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1546,8 +1546,8 @@ void NetworkSessionCocoa::notifyAdAttributionKitOfSessionTermination()
 #if HAVE(AD_ATTRIBUTION_KIT_PRIVATE_BROWSING)
     if (m_donatedEphemeralImpressionSessionID) {
         // FIXME: Remove this respondsToSelector check in 2026 or so.
-        if ([ASDInstallWebAttributionService.sharedInstance respondsToSelector:@selector(removeInstallWebAttributionParamsFromPrivateBrowsingSessionId:completionHandler:)])
-            [ASDInstallWebAttributionService.sharedInstance removeInstallWebAttributionParamsFromPrivateBrowsingSessionId:*m_donatedEphemeralImpressionSessionID completionHandler:^(NSError *) { }];
+        if ([ASDInstallWebAttributionService.sharedInstance respondsToSelector:@selector(removeInstallWebAttributionParamsFromPrivateBrowsingSessionID:completionHandler:)])
+            [ASDInstallWebAttributionService.sharedInstance removeInstallWebAttributionParamsFromPrivateBrowsingSessionID:*m_donatedEphemeralImpressionSessionID completionHandler:^(NSError *) { }];
     }
 #endif
 }


### PR DESCRIPTION
#### ad2b40f8006382be306502719b52434489c54aa7
<pre>
Use correct SPI selector capitalization for ASDInstallWebAttributionService SPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=285922">https://bugs.webkit.org/show_bug.cgi?id=285922</a>
<a href="https://rdar.apple.com/142636092">rdar://142636092</a>

Reviewed by Aditya Keerthi.

They use ID with a capital D.

* Source/WebKit/NetworkProcess/cocoa/AppStoreDaemonSPI.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::notifyAdAttributionKitOfSessionTermination):

Canonical link: <a href="https://commits.webkit.org/288880@main">https://commits.webkit.org/288880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9a0ab2018a5f1988632463cdaf180289fc43611

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89799 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35711 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12358 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65897 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23726 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46169 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3278 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34786 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91174 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/11999 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8767 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74375 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73495 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17865 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16305 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3447 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13190 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11951 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17391 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11785 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15279 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13531 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->