### PR TITLE
Remove unnecessary flags from calc options

### DIFF
--- a/Source/WebCore/css/calc/CSSCalcTree+CalculationValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+CalculationValue.cpp
@@ -350,8 +350,6 @@ Tree fromCalculationValue(const CalculationValue& calculationValue, const Render
             .conversionData = std::nullopt,
             .symbolTable = { },
             .allowZeroValueLengthRemovalFromSum = true,
-            .allowUnresolvedUnits = false,
-            .allowNonMatchingUnits = false
         },
         .style = style,
     };
@@ -379,8 +377,6 @@ Ref<CalculationValue> toCalculationValue(const Tree& tree, const EvaluationOptio
         .conversionData = options.conversionData,
         .symbolTable = options.symbolTable,
         .allowZeroValueLengthRemovalFromSum = true,
-        .allowUnresolvedUnits = false,
-        .allowNonMatchingUnits = false
     };
     auto simplifiedTree = copyAndSimplify(tree, simplificationOptions);
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
@@ -135,10 +135,6 @@ std::optional<double> evaluate(const NonCanonicalDimension& root, const Evaluati
     if (auto canonical = canonicalize(root, options.conversionData))
         return evaluate(*canonical, options);
 
-    // FIXME: This is only needed while CSSToLengthConversionData is optional. Once all callers pass one in, this will go away.
-    if (options.allowUnresolvedUnits)
-        return root.value;
-
     return std::nullopt;
 }
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Evaluation.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Evaluation.h
@@ -48,12 +48,6 @@ struct EvaluationOptions {
 
     // `symbolTable` contains information needed to convert unresolved symbols into numeric values.
     const CSSCalcSymbolTable& symbolTable;
-
-    // `allowUnresolvedUnits` allows math operations to be evaluated even if the unit is not fully canonicalized. Only meaningful if `conversionData` cannot be supplied.
-    bool allowUnresolvedUnits = false;
-
-    // `allowNonMatchingUnits` allows math operations to be evaluated even if the units of its arguments don't match. Only meaningful if `conversionData` cannot be supplied.
-    bool allowNonMatchingUnits = false;
 };
 
 std::optional<double> evaluateDouble(const Tree&, const EvaluationOptions&);

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -936,8 +936,6 @@ static std::optional<TypedChild> consumeMediaProgress(CSSParserTokenRange& token
         .conversionData = state.simplificationOptions->conversionData,
         .symbolTable = state.simplificationOptions->symbolTable,
         .allowZeroValueLengthRemovalFromSum = state.simplificationOptions->allowZeroValueLengthRemovalFromSum,
-        .allowUnresolvedUnits = state.simplificationOptions->allowUnresolvedUnits,
-        .allowNonMatchingUnits = state.simplificationOptions->allowNonMatchingUnits,
     };
     if (state.simplificationOptions)
         nestedState.simplificationOptions = &nestedSimplificationOptions;
@@ -1041,8 +1039,6 @@ static std::optional<TypedChild> consumeContainerProgress(CSSParserTokenRange& t
         .conversionData = state.simplificationOptions->conversionData,
         .symbolTable = state.simplificationOptions->symbolTable,
         .allowZeroValueLengthRemovalFromSum = state.simplificationOptions->allowZeroValueLengthRemovalFromSum,
-        .allowUnresolvedUnits = state.simplificationOptions->allowUnresolvedUnits,
-        .allowNonMatchingUnits = state.simplificationOptions->allowNonMatchingUnits,
     };
     if (state.simplificationOptions)
         nestedState.simplificationOptions = &nestedSimplificationOptions;

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -121,9 +121,9 @@ static bool unitsMatch(const CanonicalDimension& a, const CanonicalDimension& b,
     return a.dimension == b.dimension;
 }
 
-static bool unitsMatch(const NonCanonicalDimension& a, const NonCanonicalDimension& b, const SimplificationOptions& options)
+static bool unitsMatch(const NonCanonicalDimension& a, const NonCanonicalDimension& b, const SimplificationOptions&)
 {
-    return a.unit == b.unit || options.allowNonMatchingUnits;
+    return a.unit == b.unit;
 }
 
 // MARK: Predicate: magnitudeComparable
@@ -165,9 +165,9 @@ constexpr bool fullyResolved(const CanonicalDimension&, const SimplificationOpti
     return true;
 }
 
-constexpr bool fullyResolved(const NonCanonicalDimension&, const SimplificationOptions& options)
+constexpr bool fullyResolved(const NonCanonicalDimension&, const SimplificationOptions&)
 {
-    return options.allowUnresolvedUnits;
+    return false;
 }
 
 std::optional<CanonicalDimension> canonicalize(NonCanonicalDimension root, const std::optional<CSSToLengthConversionData>& conversionData)

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.h
@@ -53,12 +53,6 @@ struct SimplificationOptions {
 
     // `allowZeroValueLengthRemovalFromSum` allows removal of 0 value lengths (px, em, etc.) from Sum operations.
     bool allowZeroValueLengthRemovalFromSum = false;
-
-    // `allowUnresolvedUnits` allows math operations to be evaluated even if the unit is not fully canonicalized. Only meaningful if `conversionData` cannot be supplied.
-    bool allowUnresolvedUnits = false;
-
-    // `allowNonMatchingUnits` allows math operations to be evaluated even if the units of its arguments don't match. Only meaningful if `conversionData` cannot be supplied.
-    bool allowNonMatchingUnits = false;
 };
 
 

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -69,8 +69,6 @@ RefPtr<CSSCalcValue> CSSCalcValue::parse(CSSParserTokenRange& tokens, const CSSP
         .conversionData = std::nullopt,
         .symbolTable = { },
         .allowZeroValueLengthRemovalFromSum = false,
-        .allowUnresolvedUnits = false,
-        .allowNonMatchingUnits = false
     };
 
     auto tree = CSSCalc::parseAndSimplify(tokens, context, parserOptions, simplificationOptions);
@@ -108,8 +106,6 @@ Ref<CSSCalcValue> CSSCalcValue::copySimplified(const CSSToLengthConversionData& 
         .conversionData = conversionData,
         .symbolTable = symbolTable,
         .allowZeroValueLengthRemovalFromSum = true,
-        .allowUnresolvedUnits = false,
-        .allowNonMatchingUnits = false
     };
 
     if (!canSimplify(m_tree, simplificationOptions))
@@ -131,8 +127,6 @@ Ref<CSSCalcValue> CSSCalcValue::copySimplified(NoConversionDataRequiredToken, co
         .conversionData = std::nullopt,
         .symbolTable = symbolTable,
         .allowZeroValueLengthRemovalFromSum = true,
-        .allowUnresolvedUnits = false,
-        .allowNonMatchingUnits = false
     };
 
     if (!canSimplify(m_tree, simplificationOptions))
@@ -260,8 +254,6 @@ double CSSCalcValue::doubleValue(NoConversionDataRequiredToken, const CSSCalcSym
         .range = m_range,
         .conversionData = std::nullopt,
         .symbolTable = symbolTable,
-        .allowUnresolvedUnits = true,
-        .allowNonMatchingUnits = true
     };
     return clampToPermittedRange(CSSCalc::evaluateDouble(m_tree, options).value_or(0));
 }

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -473,8 +473,6 @@ ExceptionOr<Ref<CSSNumericValue>> CSSNumericValue::parse(Document& document, Str
                 .conversionData = std::nullopt,
                 .symbolTable = { },
                 .allowZeroValueLengthRemovalFromSum = false,
-                .allowUnresolvedUnits = false,
-                .allowNonMatchingUnits = false
             };
             auto tree = CSSCalc::parseAndSimplify(componentValueRange, parserContext, parserOptions, simplificationOptions);
             if (!tree)


### PR DESCRIPTION
#### 07db089c750f164a7482f6e97139598b38f73310
<pre>
Remove unnecessary flags from calc options
<a href="https://bugs.webkit.org/show_bug.cgi?id=285926">https://bugs.webkit.org/show_bug.cgi?id=285926</a>

Reviewed by Darin Adler.

Remove special casing needed when first bringing up the new calc
implementation that is no longer required.

* Source/WebCore/css/calc/CSSCalcTree+CalculationValue.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Evaluation.h:
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.h:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
* Source/WebCore/css/typedom/CSSNumericValue.cpp:

Canonical link: <a href="https://commits.webkit.org/289039@main">https://commits.webkit.org/289039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b61c32f18a110fbfa250520a25464dbdc6805139

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90109 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36016 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66114 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23932 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46381 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3528 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31435 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35089 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74329 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91482 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12304 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9105 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74598 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12533 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73717 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18276 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18106 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16557 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4330 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12252 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17704 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12088 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15584 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->