### PR TITLE
Need to automatically initialize TZoneHeapManager for non-WebKit processes.

### DIFF
--- a/Source/bmalloc/bmalloc/TZoneHeap.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeap.cpp
@@ -55,6 +55,11 @@ void* tzoneAllocateNonCompactWithFastFallbackSlow(size_t requestedSize, const TZ
         if (tzoneMallocFallback == TZoneMallocFallback::ForceSpecifiedFallBack)
             return bmalloc_allocate_inline(requestedSize, pas_non_compact_allocation_mode);
 
+        if (BUNLIKELY(tzoneMallocFallback == TZoneMallocFallback::Undecided)) {
+            TZoneHeapManager::ensureSingleton();
+            return tzoneAllocateNonCompactWithFastFallbackSlow(requestedSize, spec);
+        }
+
         RELEASE_BASSERT(tzoneMallocFallback == TZoneMallocFallback::ForceDebugMalloc);
         IsoMallocFallback::MallocResult result = IsoMallocFallback::tryMalloc(requestedSize, CompactAllocationMode::NonCompact);
         BASSERT(result.didFallBack);
@@ -78,6 +83,11 @@ void* tzoneAllocateCompactWithFastFallbackSlow(size_t requestedSize, const TZone
     if (BUNLIKELY(tzoneMallocFallback != TZoneMallocFallback::DoNotFallBack)) {
         if (BLIKELY(tzoneMallocFallback == TZoneMallocFallback::ForceSpecifiedFallBack))
             return bmalloc_allocate_inline(requestedSize, pas_maybe_compact_allocation_mode);
+
+        if (BUNLIKELY(tzoneMallocFallback == TZoneMallocFallback::Undecided)) {
+            TZoneHeapManager::ensureSingleton();
+            return tzoneAllocateCompactWithFastFallbackSlow(requestedSize, spec);
+        }
 
         RELEASE_BASSERT(tzoneMallocFallback == TZoneMallocFallback::ForceDebugMalloc);
         IsoMallocFallback::MallocResult result = IsoMallocFallback::tryMalloc(requestedSize, CompactAllocationMode::Compact);
@@ -108,6 +118,11 @@ void* tzoneAllocateNonCompactWithIsoFallbackSlow(size_t requestedSize, const TZo
             return bmalloc_iso_allocate_inline(TO_PAS_HEAPREF(heapRef), pas_non_compact_allocation_mode);
         }
 
+        if (BUNLIKELY(tzoneMallocFallback == TZoneMallocFallback::Undecided)) {
+            TZoneHeapManager::ensureSingleton();
+            return tzoneAllocateNonCompactWithIsoFallbackSlow(requestedSize, spec);
+        }
+
         RELEASE_BASSERT(tzoneMallocFallback == TZoneMallocFallback::ForceDebugMalloc);
         IsoMallocFallback::MallocResult result = IsoMallocFallback::tryMalloc(requestedSize, CompactAllocationMode::NonCompact);
         BASSERT(result.didFallBack);
@@ -135,6 +150,11 @@ void* tzoneAllocateCompactWithIsoFallbackSlow(size_t requestedSize, const TZoneS
                 *spec.addressOfHeapRef = heapRef;
             }
             return bmalloc_iso_allocate_inline(TO_PAS_HEAPREF(heapRef), pas_maybe_compact_allocation_mode);
+        }
+
+        if (BUNLIKELY(tzoneMallocFallback == TZoneMallocFallback::Undecided)) {
+            TZoneHeapManager::ensureSingleton();
+            return tzoneAllocateCompactWithIsoFallbackSlow(requestedSize, spec);
         }
 
         RELEASE_BASSERT(tzoneMallocFallback == TZoneMallocFallback::ForceDebugMalloc);


### PR DESCRIPTION
#### ceec628d12b7ebd4c806b9b14172ff268b76c68b
<pre>
Need to automatically initialize TZoneHeapManager for non-WebKit processes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=285931">https://bugs.webkit.org/show_bug.cgi?id=285931</a>
<a href="https://rdar.apple.com/142764839">rdar://142764839</a>

Reviewed by Yusuke Suzuki.

* Source/bmalloc/bmalloc/TZoneHeap.cpp:
(bmalloc::api::tzoneAllocateNonCompactWithFastFallbackSlow):
(bmalloc::api::tzoneAllocateCompactWithFastFallbackSlow):
(bmalloc::api::tzoneAllocateNonCompactWithIsoFallbackSlow):
(bmalloc::api::tzoneAllocateCompactWithIsoFallbackSlow):

Canonical link: <a href="https://commits.webkit.org/288895@main">https://commits.webkit.org/288895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a674a28bff302e5509f8ebefe1a5d67178bb8fd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89834 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35746 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12395 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/65919 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/23749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87740 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3428 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76973 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46192 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31185 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34821 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77658 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91210 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83737 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12034 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74397 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72777 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73523 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17893 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16336 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/3482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13199 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11986 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106130 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11820 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25618 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15314 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13566 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->