### PR TITLE
element-render-blocking-039 fails WPT lint.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-039.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-039.html
@@ -7,12 +7,11 @@
 
 <link rel=expect href="#invalid" blocking="render">
 <script>
-var timeoutHit = false;
-setTimeout(() => { timeoutHit = true; }, 3000);
+const startTime = performance.now();
 
 async_test((t) => {
   requestAnimationFrame(() => {
-    t.step(() => assert_false(timeoutHit, "requestAnimationFrame should not have been delayed by the link that didn't find its target"));
+    t.step(() => assert_less_than(performance.now() - startTime, 3000, "requestAnimationFrame should not have been delayed by the link that didn't find its target after load completes"));
     t.done();
   });
 }, "");


### PR DESCRIPTION
#### f1e621e35e01132c9a082d0d66a4bbb5c20c6837
<pre>
element-render-blocking-039 fails WPT lint.
<a href="https://bugs.webkit.org/show_bug.cgi?id=285936">https://bugs.webkit.org/show_bug.cgi?id=285936</a>

Reviewed by Tim Nguyen.

setTimeout is a lint failure, but we want to compare against the &apos;UA defined timeout&apos; (from the spec), so we really do need some sort of time tracking.

* LayoutTests/imported/w3c/web-platform-tests/html/dom/render-blocking/element-render-blocking-039.html:

Canonical link: <a href="https://commits.webkit.org/288913@main">https://commits.webkit.org/288913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55675c6d124dea73d038163829736b90bfeff033

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89837 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35749 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65920 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23750 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46193 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3310 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31188 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34824 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74172 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91213 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74408 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12264 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73534 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18198 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17897 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16339 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3485 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11989 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11823 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15317 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->