### PR TITLE
[libpas] Add PAS_ALLOW_UNSAFE_BUFFER_USAGE macro to fix build

### DIFF
--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -136,6 +136,8 @@
 		3044790B2B992F5500043E8E /* CompactAllocationMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 3044790A2B992F4A00043E8E /* CompactAllocationMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		304B034B2B18FBE00063B1B5 /* AllocationCounts.h in Headers */ = {isa = PBXBuildFile; fileRef = 306D49052ACCA01400CCFEE5 /* AllocationCounts.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		304B03532B1901730063B1B5 /* libWebKitAdditions.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 304B03502B19014B0063B1B5 /* libWebKitAdditions.a */; };
+		314164E62D38446D006B8C0D /* pas_compiler_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 314164E52D38445C006B8C0D /* pas_compiler_utils.h */; };
+		314164E82D38449E006B8C0D /* pas_promote_intrinsic_heap.h in Headers */ = {isa = PBXBuildFile; fileRef = 314164E72D38449E006B8C0D /* pas_promote_intrinsic_heap.h */; };
 		4426E2801C838EE0008EB042 /* Logging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4426E27E1C838EE0008EB042 /* Logging.cpp */; };
 		4426E2811C838EE0008EB042 /* Logging.h in Headers */ = {isa = PBXBuildFile; fileRef = 4426E27F1C838EE0008EB042 /* Logging.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		52F47249210BA30200B730BB /* MemoryStatusSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 52F47248210BA2F500B730BB /* MemoryStatusSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1365,6 +1367,8 @@
 		3044790A2B992F4A00043E8E /* CompactAllocationMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CompactAllocationMode.h; path = bmalloc/CompactAllocationMode.h; sourceTree = "<group>"; };
 		304B03502B19014B0063B1B5 /* libWebKitAdditions.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libWebKitAdditions.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		306D49052ACCA01400CCFEE5 /* AllocationCounts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AllocationCounts.h; path = bmalloc/AllocationCounts.h; sourceTree = "<group>"; };
+		314164E52D38445C006B8C0D /* pas_compiler_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pas_compiler_utils.h; sourceTree = "<group>"; };
+		314164E72D38449E006B8C0D /* pas_promote_intrinsic_heap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pas_promote_intrinsic_heap.h; path = libpas/src/libpas/pas_promote_intrinsic_heap.h; sourceTree = "<group>"; };
 		4426E27E1C838EE0008EB042 /* Logging.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Logging.cpp; path = bmalloc/Logging.cpp; sourceTree = "<group>"; };
 		4426E27F1C838EE0008EB042 /* Logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Logging.h; path = bmalloc/Logging.h; sourceTree = "<group>"; };
 		52F47248210BA2F500B730BB /* MemoryStatusSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MemoryStatusSPI.h; path = bmalloc/darwin/MemoryStatusSPI.h; sourceTree = "<group>"; };
@@ -1680,6 +1684,7 @@
 				2CE2AE512769928200D02BBC /* pas_compact_tagged_void_ptr.h */,
 				2C09D8C02797C6EA005AA15C /* pas_compact_thread_local_cache_layout_node.h */,
 				0FC4099A2451496100876DA0 /* pas_compact_unsigned_ptr.h */,
+				314164E52D38445C006B8C0D /* pas_compiler_utils.h */,
 				0FC409792451495F00876DA0 /* pas_compute_summary_object_callbacks.c */,
 				0FC409B32451496200876DA0 /* pas_compute_summary_object_callbacks.h */,
 				0FC409B82451496300876DA0 /* pas_config.h */,
@@ -1896,6 +1901,7 @@
 				0FC40AF82451499400876DA0 /* pas_primitive_heap_ref.h */,
 				2CE2AE572769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.c */,
 				2CE2AE582769928300D02BBC /* pas_probabilistic_guard_malloc_allocator.h */,
+				314164E72D38449E006B8C0D /* pas_promote_intrinsic_heap.h */,
 				0F87004625AF8A18000E1ABF /* pas_ptr_hash_map.h */,
 				0FC40AC32451499000876DA0 /* pas_ptr_hash_set.h */,
 				0F87004725AF8A18000E1ABF /* pas_ptr_min_heap.h */,
@@ -2471,6 +2477,7 @@
 				DD4BEC2A29CBA49700398E35 /* pas_compact_tagged_void_ptr.h in Headers */,
 				DD4BEC3529CBA49700398E35 /* pas_compact_thread_local_cache_layout_node.h in Headers */,
 				DD4BEDA929CBA49700398E35 /* pas_compact_unsigned_ptr.h in Headers */,
+				314164E62D38446D006B8C0D /* pas_compiler_utils.h in Headers */,
 				DD4BEE0929CBA49700398E35 /* pas_compute_summary_object_callbacks.h in Headers */,
 				DD4BEDDC29CBA49700398E35 /* pas_config.h in Headers */,
 				DD4BEE1A29CBA49700398E35 /* pas_config_prefix.h in Headers */,
@@ -2619,6 +2626,7 @@
 				DD4BEC6029CBA49700398E35 /* pas_platform.h in Headers */,
 				DD4BED1029CBA49700398E35 /* pas_primitive_heap_ref.h in Headers */,
 				DD4BED8B29CBA49700398E35 /* pas_probabilistic_guard_malloc_allocator.h in Headers */,
+				314164E82D38449E006B8C0D /* pas_promote_intrinsic_heap.h in Headers */,
 				DD4BED6229CBA49700398E35 /* pas_ptr_hash_map.h in Headers */,
 				DD4BEDBB29CBA49700398E35 /* pas_ptr_hash_set.h in Headers */,
 				DD4BEC9C29CBA49700398E35 /* pas_ptr_min_heap.h in Headers */,
@@ -3043,7 +3051,6 @@
 				DD4BEC9929CBA49700398E35 /* pas_simple_large_free_heap.c in Sources */,
 				DD4BEDC529CBA49700398E35 /* pas_simple_type.c in Sources */,
 				7234F6B82D01112E000B645D /* pas_small_medium_bootstrap_free_heap.c in Sources */,
-				7234F6C72D011EF3000B645D /* pas_small_medium_bootstrap_free_heap.h in Sources */,
 				7234F6B92D01112E000B645D /* pas_small_medium_bootstrap_heap_page_provider.c in Sources */,
 				DD4BEC7A29CBA49700398E35 /* pas_status_reporter.c in Sources */,
 				DD4BED2329CBA49700398E35 /* pas_stream.c in Sources */,

--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -594,6 +594,7 @@
 		2CB9B15B278F85EE003A8C1B /* pas_lenient_compact_ptr_inlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CB9B157278F85EE003A8C1B /* pas_lenient_compact_ptr_inlines.h */; };
 		2CB9B15D278F861B003A8C1B /* LotsOfHeapsAndThreads.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2CB9B15C278F861B003A8C1B /* LotsOfHeapsAndThreads.cpp */; };
 		2CE2AE35275A953E00D02BBC /* BitfitTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2CE2AE34275A953E00D02BBC /* BitfitTests.cpp */; };
+		31AEEEDB2D385BF40079F562 /* pas_compiler_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 31AEEEDA2D385BF40079F562 /* pas_compiler_utils.h */; };
 		E3096D4C2A82357800BC4CA0 /* pas_allocation_result.c in Sources */ = {isa = PBXBuildFile; fileRef = E3096D4B2A82357800BC4CA0 /* pas_allocation_result.c */; };
 		E3AA9B8328C724D8005DF9D6 /* pas_darwin_spi.h in Headers */ = {isa = PBXBuildFile; fileRef = E3AA9B8228C724D8005DF9D6 /* pas_darwin_spi.h */; };
 /* End PBXBuildFile section */
@@ -1311,6 +1312,7 @@
 		2CB9B157278F85EE003A8C1B /* pas_lenient_compact_ptr_inlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_lenient_compact_ptr_inlines.h; sourceTree = "<group>"; };
 		2CB9B15C278F861B003A8C1B /* LotsOfHeapsAndThreads.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LotsOfHeapsAndThreads.cpp; sourceTree = "<group>"; };
 		2CE2AE34275A953E00D02BBC /* BitfitTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BitfitTests.cpp; sourceTree = "<group>"; };
+		31AEEEDA2D385BF40079F562 /* pas_compiler_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pas_compiler_utils.h; sourceTree = "<group>"; };
 		E3096D4B2A82357800BC4CA0 /* pas_allocation_result.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_allocation_result.c; sourceTree = "<group>"; };
 		E3AA9B8228C724D8005DF9D6 /* pas_darwin_spi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_darwin_spi.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1604,6 +1606,7 @@
 				0F6D567823CD705900F40DBB /* pas_compact_tagged_unsigned_ptr.h */,
 				2C473168277D4CCC00B62C49 /* pas_compact_thread_local_cache_layout_node.h */,
 				0F6D564F23CBD19B00F40DBB /* pas_compact_unsigned_ptr.h */,
+				31AEEEDA2D385BF40079F562 /* pas_compiler_utils.h */,
 				0FC4EC35234A91E300B710A3 /* pas_compute_summary_object_callbacks.c */,
 				0FC4EC30234A91E200B710A3 /* pas_compute_summary_object_callbacks.h */,
 				0FC681A22103917B003C6A13 /* pas_config.h */,
@@ -2174,6 +2177,7 @@
 				0F6D564B23CAA1BA00F40DBB /* pas_compact_tagged_ptr.h in Headers */,
 				0F6D567923CD705900F40DBB /* pas_compact_tagged_unsigned_ptr.h in Headers */,
 				0F6D566223CBD19D00F40DBB /* pas_compact_unsigned_ptr.h in Headers */,
+				31AEEEDB2D385BF40079F562 /* pas_compiler_utils.h in Headers */,
 				0FC4EC39234A91E300B710A3 /* pas_compute_summary_object_callbacks.h in Headers */,
 				0FE7EE0A22960142004F4166 /* pas_config.h in Headers */,
 				0F85EFDA22E2BEC7003A362B /* pas_config_prefix.h in Headers */,

--- a/Source/bmalloc/libpas/src/libpas/pas_allocation_result.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_allocation_result.h
@@ -93,7 +93,10 @@ pas_allocation_result_zero(pas_allocation_result result,
     if (size >= (1ULL << PAS_VA_BASED_ZERO_MEMORY_SHIFT))
         return pas_allocation_result_zero_large_slow(result, size);
 
+    PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     PAS_PROFILE(ZERO_ALLOCATION_RESULT, result.begin);
+    PAS_ALLOW_UNSAFE_BUFFER_USAGE_END
+
     void* memory = (void*)result.begin;
     pas_zero_memory(memory, size);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_compiler_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_compiler_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Apple Inc. All rights reserved.
+ * Copyright (c) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,24 +20,44 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#pragma once
 
-#ifndef PAS_COMPACT_CARTESIAN_TREE_NODE_PTR_H
-#define PAS_COMPACT_CARTESIAN_TREE_NODE_PTR_H
+#if defined(__clang__)
+#define PAS_COMPILER_CLANG 1
+#endif
 
-#include "pas_compact_ptr.h"
+/* PAS_ALLOW_UNSAFE_BUFFER_USAGE */
+#if PAS_COMPILER_CLANG
+#define PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN \
+    _Pragma("clang diagnostic push") \
+    _Pragma("clang diagnostic ignored \"-Wunsafe-buffer-usage\"")
 
-PAS_BEGIN_EXTERN_C;
+#define PAS_ALLOW_UNSAFE_BUFFER_USAGE_END \
+    _Pragma("clang diagnostic pop")
+#else
+#define PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#define PAS_ALLOW_UNSAFE_BUFFER_USAGE_END
+#endif
 
-struct pas_cartesian_tree_node;
-typedef struct pas_cartesian_tree_node pas_cartesian_tree_node;
+/* PAS_UNSAFE_BUFFER_USAGE */
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
 
-PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-PAS_DEFINE_COMPACT_PTR(pas_cartesian_tree_node, pas_compact_cartesian_tree_node_ptr);
-PAS_ALLOW_UNSAFE_BUFFER_USAGE_END
+#ifndef __has_cpp_attribute
+#define __has_cpp_attribute(x) 0
+#endif
 
-PAS_END_EXTERN_C;
-
-#endif /* PAS_COMPACT_CARTESIAN_TREE_NODE_PTR_H */
-
+#if PAS_COMPILER_CLANG
+#if __has_cpp_attribute(clang::unsafe_buffer_usage)
+#define PAS_UNSAFE_BUFFER_USAGE [[clang::unsafe_buffer_usage]]
+#elif __has_attribute(unsafe_buffer_usage)
+#define PAS_UNSAFE_BUFFER_USAGE __attribute__((__unsafe_buffer_usage__))
+#else
+#define PAS_UNSAFE_BUFFER_USAGE
+#endif
+#else
+#define PAS_UNSAFE_BUFFER_USAGE
+#endif

--- a/Source/bmalloc/libpas/src/libpas/pas_ptr_hash_map.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_ptr_hash_map.h
@@ -93,11 +93,12 @@ static inline bool pas_ptr_hash_map_key_is_equal(pas_ptr_hash_map_key a,
     return a == b;
 }
 
+PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 PAS_CREATE_HASHTABLE(pas_ptr_hash_map,
                      pas_ptr_hash_map_entry,
                      pas_ptr_hash_map_key);
+PAS_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 PAS_END_EXTERN_C;
 
 #endif /* PAS_PTR_HASH_MAP_H */
-


### PR DESCRIPTION
#### 2cb447a130b9b26fd5800e940b311feb6613bc5b
<pre>
[libpas] Add PAS_ALLOW_UNSAFE_BUFFER_USAGE macro to fix build
<a href="https://bugs.webkit.org/show_bug.cgi?id=285937">https://bugs.webkit.org/show_bug.cgi?id=285937</a>
<a href="https://rdar.apple.com/142905646">rdar://142905646</a>

Reviewed by Geoffrey Garen.

After recent changes, the compiler is more aggressive
about `unsafe pointer arithmetic [-Werror,-Wunsafe-buffer-usage]`.

We should a macro similar to `WTF_ALLOW_UNSAFE_BUFFER_USAGE` to allow
libpas builds to continue for now, with a followup patch fixing these after.

* Source/bmalloc/bmalloc.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/src/libpas/pas_allocation_result.h:
(pas_allocation_result_zero):
* Source/bmalloc/libpas/src/libpas/pas_compact_cartesian_tree_node_ptr.h:
* Source/bmalloc/libpas/src/libpas/pas_compiler_utils.h: Copied from Source/bmalloc/libpas/src/libpas/pas_compact_cartesian_tree_node_ptr.h.
* Source/bmalloc/libpas/src/libpas/pas_ptr_hash_map.h:

Canonical link: <a href="https://commits.webkit.org/288968@main">https://commits.webkit.org/288968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eed78a46c2d992b3da167c080da71ce281218ea8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84898 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90043 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35951 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12600 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/66073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23887 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77151 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/46343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/3476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31378 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35024 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77863 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91416 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83941 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12237 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12467 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73679 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18238 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18060 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16508 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12189 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106333 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12024 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25665 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->