### PR TITLE
Test description

### DIFF
--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -1647,6 +1647,7 @@
 		45830D4E1679B4F800ACF8C3 /* AutoscrollController.h in Headers */ = {isa = PBXBuildFile; fileRef = 45830D4C1679B4F800ACF8C3 /* AutoscrollController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		458FE40A1589DF0B005609E6 /* RenderSearchField.h in Headers */ = {isa = PBXBuildFile; fileRef = 458FE4081589DF0B005609E6 /* RenderSearchField.h */; };
 		45B5D8612A968620004C85A0 /* LoaderMalloc.h in Headers */ = {isa = PBXBuildFile; fileRef = 45B5D85F2A968620004C85A0 /* LoaderMalloc.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		45EA87922D35D30400DD0194 /* CSSParserFastPaths.h in Headers */ = {isa = PBXBuildFile; fileRef = BC7C5E522BE2A8FB00AE645C /* CSSParserFastPaths.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		45FEA5D0156DDE8C00654101 /* Decimal.h in Headers */ = {isa = PBXBuildFile; fileRef = 45FEA5CE156DDE8C00654101 /* Decimal.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46014ACC28333F65004C0B84 /* FrameDestructionObserverInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 46014ACB28333F52004C0B84 /* FrameDestructionObserverInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		460357FD2B9A3E8D00010695 /* IDBDatabaseConnectionIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 460357FC2B9A3E8C00010695 /* IDBDatabaseConnectionIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -40384,6 +40385,7 @@
 				BCFE79AD2BE3082000114272 /* CSSParser.h in Headers */,
 				BCFE79AA2BE307C900114272 /* CSSParserContext.h in Headers */,
 				BCFE79B32BE308D000114272 /* CSSParserEnum.h in Headers */,
+				45EA87922D35D30400DD0194 /* CSSParserFastPaths.h in Headers */,
 				BCFE79B02BE308AD00114272 /* CSSParserIdioms.h in Headers */,
 				BCFE79AC2BE3081700114272 /* CSSParserMode.h in Headers */,
 				BCFE79AF2BE308A200114272 /* CSSParserToken.h in Headers */,

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -616,13 +616,13 @@ static std::optional<SRGBA<uint8_t>> parseNumericColor(std::span<const Character
         auto expectedUnitType = CSSUnitType::CSS_UNKNOWN;
 
         auto current = characters.subspan(5);
-        auto red = parseColorIntOrPercentage(current, ',', expectedUnitType);
+        auto red = parseColorIntOrPercentage(current, '?', expectedUnitType);
         if (!red)
             return std::nullopt;
-        auto green = parseColorIntOrPercentage(current, ',', expectedUnitType);
+        auto green = parseColorIntOrPercentage(current, '?', expectedUnitType);
         if (!green)
             return std::nullopt;
-        auto blue = parseColorIntOrPercentage(current, ',', expectedUnitType);
+        auto blue = parseColorIntOrPercentage(current, '?', expectedUnitType);
         if (!blue)
             return std::nullopt;
         auto alpha = parseRGBAlphaValue(current, ')');
@@ -637,13 +637,13 @@ static std::optional<SRGBA<uint8_t>> parseNumericColor(std::span<const Character
         auto expectedUnitType = CSSUnitType::CSS_UNKNOWN;
 
         auto current = characters.subspan(4);
-        auto red = parseColorIntOrPercentage(current, ',', expectedUnitType);
+        auto red = parseColorIntOrPercentage(current, '?', expectedUnitType);
         if (!red)
             return std::nullopt;
-        auto green = parseColorIntOrPercentage(current, ',', expectedUnitType);
+        auto green = parseColorIntOrPercentage(current, '?', expectedUnitType);
         if (!green)
             return std::nullopt;
-        auto blue = parseColorIntOrPercentage(current, ')', expectedUnitType);
+        auto blue = parseColorIntOrPercentage(current, '?', expectedUnitType);
         if (!blue)
             return std::nullopt;
         if (!current.empty())

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -368,7 +368,6 @@
 		7AC7B57120D9BA5B002C09A0 /* CustomBundleObject.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7AC7B56F20D9BA5B002C09A0 /* CustomBundleObject.mm */; };
 		7AEAD47F1E20116C00416EFE /* CrossPartitionFileSchemeAccess.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7AEAD47C1E20113800416EFE /* CrossPartitionFileSchemeAccess.mm */; };
 		7AFEA3172CB83910007EFE75 /* element-targeting-11.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7AFEA30F2CB838FF007EFE75 /* element-targeting-11.html */; };
-		7AEAD4811E20122700416EFE /* CrossPartitionFileSchemeAccess.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7AEAD47D1E20114E00416EFE /* CrossPartitionFileSchemeAccess.html */; };
 		7B0594792CB44CF600B571AC /* RegionTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B0594782CB44CF600B571AC /* RegionTests.cpp */; };
 		7B06F95F2A377E23000DFC95 /* SequenceLockedTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B06F95E2A377E23000DFC95 /* SequenceLockedTest.cpp */; };
 		7B18417C2673860200ED4F8D /* ImageBufferTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B18417B2673860200ED4F8D /* ImageBufferTests.cpp */; };

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPI.xcscheme
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPI.xcscheme
@@ -66,10 +66,22 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "--gtest_filter=ContentRuleList.ResourceTypes"
+            argument = "--gtest_filter=CSSParser.ParseNumericColor"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "DYLD_LIBRARY_PATH"
+            value = "$(pwd)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DYLD_FRAMEWORK_PATH"
+            value = "$(pwd)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp
@@ -25,11 +25,13 @@
  */
 
 #include "config.h"
+#include "wtf/text/ASCIILiteral.h"
 
 #include <WebCore/CSSColorValue.h>
 #include <WebCore/CSSCustomPropertyValue.h>
 #include <WebCore/CSSGridIntegerRepeatValue.h>
 #include <WebCore/CSSParser.h>
+#include <WebCore/CSSParserFastPaths.h>
 #include <WebCore/CSSValueList.h>
 #include <WebCore/Color.h>
 #include <WebCore/MutableStyleProperties.h>
@@ -38,6 +40,48 @@
 namespace TestWebKitAPI {
 
 using namespace WebCore;
+
+TEST(CSSParser, ParseNumericColor)
+{
+    // auto res = CSSParserFastPaths::parseSimpleColor("rgb(255,0,0)"_s);
+    // EXPECT_TRUE(res);
+    auto res = CSSParserFastPaths::parseSimpleColor("rgb(0% 50% 0%)"_s);
+    EXPECT_TRUE(res);
+    res = CSSParserFastPaths::parseSimpleColor("rgb(255,0,0)"_s);
+    EXPECT_TRUE(res);
+    res = CSSParserFastPaths::parseSimpleColor("rgb(0 128.0 0)"_s);
+    EXPECT_TRUE(res);
+    res = CSSParserFastPaths::parseSimpleColor("rgb(0% 50% 0% / 1.0)"_s);
+    EXPECT_TRUE(res);
+    res = CSSParserFastPaths::parseSimpleColor("rgb(0 128.0 0 / 1)"_s);
+    EXPECT_TRUE(res);
+    res = CSSParserFastPaths::parseSimpleColor("rgb(0% 50% 0% / 100%)"_s);
+    EXPECT_TRUE(res);
+    res = CSSParserFastPaths::parseSimpleColor("rgb(0 128.0 0 / 100%)"_s);
+    EXPECT_TRUE(res);
+    res = CSSParserFastPaths::parseSimpleColor("rgb(0%, 50%, 0%, 100%)"_s);
+    EXPECT_TRUE(res);
+    res = CSSParserFastPaths::parseSimpleColor("rgb(0, 128.0, 0, 100%)"_s);
+    EXPECT_TRUE(res);
+    res = CSSParserFastPaths::parseSimpleColor("rgba(0% 50% 0%)"_s);
+    EXPECT_TRUE(res);
+    res = CSSParserFastPaths::parseSimpleColor("rgba(0 128.0 0)"_s);
+    EXPECT_TRUE(res);
+    res = CSSParserFastPaths::parseSimpleColor("rgba(0% 50% 0% / 1.0)"_s);
+    EXPECT_TRUE(res);
+    res = CSSParserFastPaths::parseSimpleColor("rgba(0 128.0 0 / 1)"_s);
+    EXPECT_TRUE(res);
+    res = CSSParserFastPaths::parseSimpleColor("rgba(0% 50% 0% / 100%)"_s);
+    EXPECT_TRUE(res);
+    res = CSSParserFastPaths::parseSimpleColor("rgba(0 128.0 0 / 100%)"_s);
+    EXPECT_TRUE(res);
+    res = CSSParserFastPaths::parseSimpleColor("rgba(0%, 50%, 0%, 100%)"_s);
+    EXPECT_TRUE(res);
+    res = CSSParserFastPaths::parseSimpleColor("rgba(0, 128.0, 0, 100%)"_s);
+    EXPECT_TRUE(res);
+    printf("HERE!\n");
+    // printf("HERE2!\n");
+}
 
 TEST(CSSParser, ParseColorInput)
 {

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/xcshareddata/xcschemes/WebKitTestRunner.xcscheme
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/xcshareddata/xcschemes/WebKitTestRunner.xcscheme
@@ -71,7 +71,23 @@
             argument = "--no-timeout"
             isEnabled = "YES">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/Users/robertorodriguez/workspace/safari/OpenSource/LayoutTests/fast/css/hex-colors.html"
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "DYLD_FRAMEWORK_PATH"
+            value = "$(pwd)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DYLD_LIBRARY_PATH"
+            value = "$(pwd)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
#### fd5905b5dd6af103485d3e37e7030ab2f36c76ba
<pre>
Test description
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::parseNumericColor):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/xcshareddata/xcschemes/TestWebKitAPI.xcscheme:
* Tools/TestWebKitAPI/Tests/WebCore/CSSParser.cpp:
(TestWebKitAPI::TEST(CSSParser, ParseNumericColor)):
* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/xcshareddata/xcschemes/WebKitTestRunner.xcscheme:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd5905b5dd6af103485d3e37e7030ab2f36c76ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84702 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39090 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89841 "Hash fd5905b5 for PR 39017 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35753 "Hash fd5905b5 for PR 39017 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86787 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12402 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/89841 "Hash fd5905b5 for PR 39017 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/35753 "Hash fd5905b5 for PR 39017 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87747 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3434 "Found 1 new test failure: fast/canvas/canvas-color-clamping.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76978 "Found 1 new API test failure: TestWebKitAPI.CSSParser.ParseNumericColor (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/89841 "Hash fd5905b5 for PR 39017 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3312 "Found 4 new test failures: imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.html imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.html imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.worker.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-root-scroller.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31190 "Found 4 new test failures: fast/canvas/canvas-color-clamping.html imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.html imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.html imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.worker.html (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34828 "Hash fd5905b5 for PR 39017 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74173 "Found 1 new API test failure: TestWebKitAPI.CSSParser.ParseNumericColor (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/31995 "Found 4 new test failures: fast/canvas/canvas-color-clamping.html imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.html imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.html imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.worker.html (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91217 "Hash fd5905b5 for PR 39017 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12041 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8801 "Found 4 new test failures: fast/canvas/canvas-color-clamping.html imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.html imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.html imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.worker.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/91217 "Hash fd5905b5 for PR 39017 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12268 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72782 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/91217 "Hash fd5905b5 for PR 39017 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17900 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16341 "Found 4 new test failures: fast/canvas/canvas-color-clamping.html imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.html imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.html imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.fillStyle.parse.rgb-clamp-5.worker.html (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/3489 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11993 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17433 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11827 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15321 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13573 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->