### PR TITLE
Remove duplicated data by moving category/range out of CSSCalc::Tree/Calculation::Tree

### DIFF
--- a/Source/WebCore/css/calc/CSSCalcTree+Copy.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Copy.cpp
@@ -137,9 +137,7 @@ Tree copy(const Tree& tree)
     return Tree {
         .root = copy(tree.root),
         .type = tree.type,
-        .category = tree.category,
         .stage = tree.stage,
-        .range = tree.range,
         .requiresConversionData = tree.requiresConversionData
     };
 }

--- a/Source/WebCore/css/calc/CSSCalcTree+Evaluation.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Evaluation.h
@@ -37,6 +37,12 @@ struct Anchor;
 struct Tree;
 
 struct EvaluationOptions {
+    // `category` represents the context in which the evaluation is taking place.
+    Calculation::Category category;
+
+    // `range` represents the allowed numeric range for the calculated result.
+    CSS::Range range;
+
     // `conversionData` contains information needed to convert units into their canonical forms.
     std::optional<CSSToLengthConversionData> conversionData;
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -149,14 +149,12 @@ std::optional<Tree> parseAndSimplify(CSSParserTokenRange& range, const CSSParser
     auto result = Tree {
         .root = WTFMove(root->child),
         .type = root->type,
-        .category = parserOptions.category,
         .stage = CSSCalc::Stage::Specified,
-        .range = parserOptions.range,
         .requiresConversionData = state.requiresConversionData,
         .unique = state.unique,
     };
 
-    LOG_WITH_STREAM(Calc, stream << "Completed top level parse/simplification for function '" << nameLiteralForSerialization(function) << "': " << serializationForCSS(result) << ", type: " << getType(result.root) << ", category=" << result.category << ", requires-conversion-data: " << result.requiresConversionData << ", unique: " << result.unique);
+    LOG_WITH_STREAM(Calc, stream << "Completed top level parse/simplification for function '" << nameLiteralForSerialization(function) << "': " << serializationForCSS(result, { parserOptions.range }) << ", type: " << getType(result.root) << ", category=" << parserOptions.category << ", requires-conversion-data: " << result.requiresConversionData << ", unique: " << result.unique);
 
     return result;
 }
@@ -932,20 +930,17 @@ static std::optional<TypedChild> consumeMediaProgress(CSSParserTokenRange& token
         },
         .simplificationOptions = nullptr
     };
-
-    SimplificationOptions nestedSimplificationOptions;
-    if (state.simplificationOptions) {
-        nestedSimplificationOptions = {
-            .category = schemaCategory,
-            .conversionData = state.simplificationOptions->conversionData,
-            .symbolTable = state.simplificationOptions->symbolTable,
-            .allowZeroValueLengthRemovalFromSum = state.simplificationOptions->allowZeroValueLengthRemovalFromSum,
-            .allowUnresolvedUnits = state.simplificationOptions->allowUnresolvedUnits,
-            .allowNonMatchingUnits = state.simplificationOptions->allowNonMatchingUnits,
-
-        };
+    SimplificationOptions nestedSimplificationOptions = {
+        .category = schemaCategory,
+        .range = CSS::All,
+        .conversionData = state.simplificationOptions->conversionData,
+        .symbolTable = state.simplificationOptions->symbolTable,
+        .allowZeroValueLengthRemovalFromSum = state.simplificationOptions->allowZeroValueLengthRemovalFromSum,
+        .allowUnresolvedUnits = state.simplificationOptions->allowUnresolvedUnits,
+        .allowNonMatchingUnits = state.simplificationOptions->allowNonMatchingUnits,
+    };
+    if (state.simplificationOptions)
         nestedState.simplificationOptions = &nestedSimplificationOptions;
-    }
 
     auto start = parseCalcSum(tokens, depth, nestedState);
     if (!start) {
@@ -1040,20 +1035,17 @@ static std::optional<TypedChild> consumeContainerProgress(CSSParserTokenRange& t
         },
         .simplificationOptions = nullptr
     };
-
-    SimplificationOptions nestedSimplificationOptions;
-    if (state.simplificationOptions) {
-        nestedSimplificationOptions = {
-            .category = schemaCategory,
-            .conversionData = state.simplificationOptions->conversionData,
-            .symbolTable = state.simplificationOptions->symbolTable,
-            .allowZeroValueLengthRemovalFromSum = state.simplificationOptions->allowZeroValueLengthRemovalFromSum,
-            .allowUnresolvedUnits = state.simplificationOptions->allowUnresolvedUnits,
-            .allowNonMatchingUnits = state.simplificationOptions->allowNonMatchingUnits,
-
-        };
+    SimplificationOptions nestedSimplificationOptions = {
+        .category = schemaCategory,
+        .range = CSS::All,
+        .conversionData = state.simplificationOptions->conversionData,
+        .symbolTable = state.simplificationOptions->symbolTable,
+        .allowZeroValueLengthRemovalFromSum = state.simplificationOptions->allowZeroValueLengthRemovalFromSum,
+        .allowUnresolvedUnits = state.simplificationOptions->allowUnresolvedUnits,
+        .allowNonMatchingUnits = state.simplificationOptions->allowNonMatchingUnits,
+    };
+    if (state.simplificationOptions)
         nestedState.simplificationOptions = &nestedSimplificationOptions;
-    }
 
     auto start = parseCalcSum(tokens, depth, nestedState);
     if (!start) {

--- a/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
@@ -690,32 +690,34 @@ template<typename Op> void serializeCalculationTree(StringBuilder& builder, cons
 
 // MARK: Exposed interface
 
-void serializationForCSS(StringBuilder& builder, const Tree& tree)
+void serializationForCSS(StringBuilder& builder, const Tree& tree, const SerializationOptions& options)
 {
     SerializationState state {
         .stage = tree.stage,
-        .range = tree.range
+        .range = options.range
     };
     serializeMathFunction(builder, tree.root, state);
 }
 
-String serializationForCSS(const Tree& tree)
+String serializationForCSS(const Tree& tree, const SerializationOptions& options)
 {
     StringBuilder builder;
-    serializationForCSS(builder, tree);
+    serializationForCSS(builder, tree, options);
     return builder.toString();
 }
 
-void serializationForCSS(StringBuilder& builder, const Child& child)
+void serializationForCSS(StringBuilder& builder, const Child& child, const SerializationOptions& options)
 {
-    SerializationState state { };
+    SerializationState state {
+        .range = options.range
+    };
     serializeCalculationTree(builder, child, state);
 }
 
-String serializationForCSS(const Child& child)
+String serializationForCSS(const Child& child, const SerializationOptions& options)
 {
     StringBuilder builder;
-    serializationForCSS(builder, child);
+    serializationForCSS(builder, child, options);
     return builder.toString();
 }
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Serialization.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Serialization.h
@@ -30,12 +30,17 @@
 namespace WebCore {
 namespace CSSCalc {
 
-// https://drafts.csswg.org/css-values-4/#serialize-a-math-function
-void serializationForCSS(StringBuilder&, const Tree&);
-String serializationForCSS(const Tree&);
+struct SerializationOptions {
+    // `range` represents the allowed numeric range for the calculated result.
+    CSS::Range range;
+};
 
-void serializationForCSS(StringBuilder&, const Child&);
-String serializationForCSS(const Child&);
+// https://drafts.csswg.org/css-values-4/#serialize-a-math-function
+void serializationForCSS(StringBuilder&, const Tree&, const SerializationOptions&);
+String serializationForCSS(const Tree&, const SerializationOptions&);
+
+void serializationForCSS(StringBuilder&, const Child&, const SerializationOptions&);
+String serializationForCSS(const Child&, const SerializationOptions&);
 
 } // namespace CSSCalc
 } // namespace WebCore

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -1430,7 +1430,12 @@ std::optional<Child> simplify(Anchor& anchor, const SimplificationOptions& optio
     if (!options.conversionData || !options.conversionData->styleBuilderState())
         return { };
 
-    auto evaluationOptions = EvaluationOptions { .conversionData = options.conversionData, .symbolTable = options.symbolTable };
+    auto evaluationOptions = EvaluationOptions {
+        .category = options.category,
+        .range = CSS::All,
+        .conversionData = options.conversionData,
+        .symbolTable = options.symbolTable
+    };
 
     auto result = evaluateWithoutFallback(anchor, evaluationOptions);
     if (!result) {
@@ -1583,10 +1588,9 @@ Tree copyAndSimplify(const Tree& tree, const SimplificationOptions& options)
     return Tree {
         .root = copyAndSimplify(tree.root, options),
         .type = tree.type,
-        .category = tree.category,
         .stage = tree.stage,
-        .range = tree.range,
-        .requiresConversionData = tree.requiresConversionData
+        .requiresConversionData = tree.requiresConversionData,
+        .unique = tree.unique,
     };
 }
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.h
@@ -42,6 +42,9 @@ struct SimplificationOptions {
     // `category` represents the context in which the simplification is taking place.
     Calculation::Category category;
 
+    // `range` represents the allowed numeric range for the calculated result.
+    CSS::Range range;
+
     // `conversionData` contains information needed to convert length units into their canonical forms.
     std::optional<CSSToLengthConversionData> conversionData;
 

--- a/Source/WebCore/css/calc/CSSCalcTree.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree.cpp
@@ -447,7 +447,7 @@ std::optional<Type> toType(const ContainerProgress&)
 
 TextStream& operator<<(TextStream& ts, Tree tree)
 {
-    return ts << "CSSCalc::Tree [ " << serializationForCSS(tree) << " ]";
+    return ts << "CSSCalc::Tree [ " << serializationForCSS(tree, { .range = CSS::All }) << " ]";
 }
 
 } // namespace CSSCalc

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -226,9 +226,7 @@ enum class Stage : bool { Specified, Computed };
 struct Tree {
     Child root;
     Type type;
-    Calculation::Category category;
     Stage stage;
-    CSS::Range range;
 
     // `requiresConversionData` is used both to both indicate whether eager evaluation of the tree (at parse time) is possible or not and to trigger a warning in `CSSCalcValue::doubleValueDeprecated` that the evaluation results will be incorrect.
     bool requiresConversionData = false;

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -65,6 +65,7 @@ RefPtr<CSSCalcValue> CSSCalcValue::parse(CSSParserTokenRange& tokens, const CSSP
     };
     auto simplificationOptions = CSSCalc::SimplificationOptions {
         .category = category,
+        .range = range,
         .conversionData = std::nullopt,
         .symbolTable = { },
         .allowZeroValueLengthRemovalFromSum = false,
@@ -76,7 +77,7 @@ RefPtr<CSSCalcValue> CSSCalcValue::parse(CSSParserTokenRange& tokens, const CSSP
     if (!tree)
         return nullptr;
 
-    RefPtr result = adoptRef(new CSSCalcValue(WTFMove(*tree)));
+    RefPtr result = adoptRef(new CSSCalcValue(category, range, WTFMove(*tree)));
     LOG_WITH_STREAM(Calc, stream << "CSSCalcValue::create " << *result);
     return result;
 }
@@ -84,14 +85,14 @@ RefPtr<CSSCalcValue> CSSCalcValue::parse(CSSParserTokenRange& tokens, const CSSP
 Ref<CSSCalcValue> CSSCalcValue::create(const CalculationValue& value, const RenderStyle& style)
 {
     auto tree = CSSCalc::fromCalculationValue(value, style);
-    Ref result = adoptRef(*new CSSCalcValue(WTFMove(tree)));
+    Ref result = adoptRef(*new CSSCalcValue(value.category(), { value.range().min, value.range().max }, WTFMove(tree)));
     LOG_WITH_STREAM(Calc, stream << "CSSCalcValue::create from CalculationValue: " << result);
     return result;
 }
 
-Ref<CSSCalcValue> CSSCalcValue::create(CSSCalc::Tree&& tree)
+Ref<CSSCalcValue> CSSCalcValue::create(Calculation::Category category, CSS::Range range, CSSCalc::Tree&& tree)
 {
-    return adoptRef(*new CSSCalcValue(WTFMove(tree)));
+    return adoptRef(*new CSSCalcValue(category, range, WTFMove(tree)));
 }
 
 Ref<CSSCalcValue> CSSCalcValue::copySimplified(const CSSToLengthConversionData& conversionData) const
@@ -102,7 +103,8 @@ Ref<CSSCalcValue> CSSCalcValue::copySimplified(const CSSToLengthConversionData& 
 Ref<CSSCalcValue> CSSCalcValue::copySimplified(const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) const
 {
     auto simplificationOptions = CSSCalc::SimplificationOptions {
-        .category = m_tree.category,
+        .category = m_category,
+        .range = m_range,
         .conversionData = conversionData,
         .symbolTable = symbolTable,
         .allowZeroValueLengthRemovalFromSum = true,
@@ -113,7 +115,7 @@ Ref<CSSCalcValue> CSSCalcValue::copySimplified(const CSSToLengthConversionData& 
     if (!canSimplify(m_tree, simplificationOptions))
         return const_cast<CSSCalcValue&>(*this);
 
-    return create(copyAndSimplify(m_tree, simplificationOptions));
+    return create(m_category, m_range, copyAndSimplify(m_tree, simplificationOptions));
 }
 
 Ref<CSSCalcValue> CSSCalcValue::copySimplified(NoConversionDataRequiredToken token) const
@@ -124,7 +126,8 @@ Ref<CSSCalcValue> CSSCalcValue::copySimplified(NoConversionDataRequiredToken tok
 Ref<CSSCalcValue> CSSCalcValue::copySimplified(NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable) const
 {
     auto simplificationOptions = CSSCalc::SimplificationOptions {
-        .category = m_tree.category,
+        .category = m_category,
+        .range = m_range,
         .conversionData = std::nullopt,
         .symbolTable = symbolTable,
         .allowZeroValueLengthRemovalFromSum = true,
@@ -135,11 +138,13 @@ Ref<CSSCalcValue> CSSCalcValue::copySimplified(NoConversionDataRequiredToken, co
     if (!canSimplify(m_tree, simplificationOptions))
         return const_cast<CSSCalcValue&>(*this);
 
-    return create(copyAndSimplify(m_tree, simplificationOptions));
+    return create(m_category, m_range, copyAndSimplify(m_tree, simplificationOptions));
 }
 
-CSSCalcValue::CSSCalcValue(CSSCalc::Tree&& tree)
+CSSCalcValue::CSSCalcValue(Calculation::Category category, CSS::Range range, CSSCalc::Tree&& tree)
     : CSSValue(ClassType::Calculation)
+    , m_category(category)
+    , m_range(range)
     , m_tree(WTFMove(tree))
 {
 }
@@ -150,7 +155,7 @@ CSSUnitType CSSCalcValue::primitiveType() const
 {
     // This returns the CSSUnitType associated with the value returned by doubleValue, or, if CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH, that a call to createCalculationValue() is needed.
 
-    switch (m_tree.category) {
+    switch (m_category) {
     case Calculation::Category::Integer:
         return CSSUnitType::CSS_INTEGER;
     case Calculation::Category::Number:
@@ -199,7 +204,10 @@ void CSSCalcValue::collectComputedStyleDependencies(ComputedStyleDependencies& d
 
 String CSSCalcValue::customCSSText() const
 {
-    return CSSCalc::serializationForCSS(m_tree);
+    auto options = CSSCalc::SerializationOptions {
+        .range = m_range,
+    };
+    return CSSCalc::serializationForCSS(m_tree, options);
 }
 
 bool CSSCalcValue::equals(const CSSCalcValue& other) const
@@ -215,13 +223,13 @@ inline double CSSCalcValue::clampToPermittedRange(double value) const
 
     // If an <angle> must be converted due to exceeding the implementation-defined range of supported values,
     // it must be clamped to the nearest supported multiple of 360deg.
-    if (m_tree.category == Calculation::Category::Angle && std::isinf(value))
+    if (m_category == Calculation::Category::Angle && std::isinf(value))
         return 0;
 
-    if (m_tree.category == Calculation::Category::Integer)
+    if (m_category == Calculation::Category::Integer)
         value = std::floor(value + 0.5);
 
-    return std::clamp(value, m_tree.range.min, m_tree.range.max);
+    return std::clamp(value, m_range.min, m_range.max);
 }
 
 double CSSCalcValue::doubleValue(const CSSToLengthConversionData& conversionData) const
@@ -232,6 +240,8 @@ double CSSCalcValue::doubleValue(const CSSToLengthConversionData& conversionData
 double CSSCalcValue::doubleValue(const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) const
 {
     auto options = CSSCalc::EvaluationOptions {
+        .category = m_category,
+        .range = m_range,
         .conversionData = conversionData,
         .symbolTable = symbolTable
     };
@@ -246,6 +256,8 @@ double CSSCalcValue::doubleValue(NoConversionDataRequiredToken token) const
 double CSSCalcValue::doubleValue(NoConversionDataRequiredToken, const CSSCalcSymbolTable& symbolTable) const
 {
     auto options = CSSCalc::EvaluationOptions {
+        .category = m_category,
+        .range = m_range,
         .conversionData = std::nullopt,
         .symbolTable = symbolTable,
         .allowUnresolvedUnits = true,
@@ -270,6 +282,8 @@ double CSSCalcValue::computeLengthPx(const CSSToLengthConversionData& conversion
 double CSSCalcValue::computeLengthPx(const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) const
 {
     auto options = CSSCalc::EvaluationOptions {
+        .category = m_category,
+        .range = m_range,
         .conversionData = conversionData,
         .symbolTable = symbolTable
     };
@@ -284,6 +298,8 @@ Ref<CalculationValue> CSSCalcValue::createCalculationValue(const CSSToLengthConv
 Ref<CalculationValue> CSSCalcValue::createCalculationValue(const CSSToLengthConversionData& conversionData, const CSSCalcSymbolTable& symbolTable) const
 {
     auto options = CSSCalc::EvaluationOptions {
+        .category = m_category,
+        .range = m_range,
         .conversionData = conversionData,
         .symbolTable = symbolTable
     };
@@ -300,6 +316,8 @@ Ref<CalculationValue> CSSCalcValue::createCalculationValue(NoConversionDataRequi
     ASSERT(!m_tree.requiresConversionData);
 
     auto options = CSSCalc::EvaluationOptions {
+        .category = m_category,
+        .range = m_range,
         .conversionData = std::nullopt,
         .symbolTable = symbolTable
     };
@@ -313,9 +331,9 @@ void CSSCalcValue::dump(TextStream& ts) const
     TextStream multilineStream;
     multilineStream.setIndent(ts.indent() + 2);
 
-    multilineStream.dumpProperty("minimum value", m_tree.range.min);
-    multilineStream.dumpProperty("maximum value", m_tree.range.max);
-    multilineStream.dumpProperty("expression", CSSCalc::serializationForCSS(m_tree));
+    multilineStream.dumpProperty("minimum value", m_range.min);
+    multilineStream.dumpProperty("maximum value", m_range.max);
+    multilineStream.dumpProperty("expression", customCSSText());
 
     ts << multilineStream.release();
     ts << ")\n";

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -67,7 +67,7 @@ public:
     static RefPtr<CSSCalcValue> parse(CSSParserTokenRange&, const CSSParserContext&, Calculation::Category, CSS::Range, CSSCalcSymbolsAllowed, CSSPropertyParserOptions);
 
     static Ref<CSSCalcValue> create(const CalculationValue&, const RenderStyle&);
-    static Ref<CSSCalcValue> create(CSSCalc::Tree&&);
+    static Ref<CSSCalcValue> create(Calculation::Category, CSS::Range, CSSCalc::Tree&&);
 
     ~CSSCalcValue();
 
@@ -77,7 +77,9 @@ public:
     Ref<CSSCalcValue> copySimplified(NoConversionDataRequiredToken) const;
     Ref<CSSCalcValue> copySimplified(NoConversionDataRequiredToken, const CSSCalcSymbolTable&) const;
 
-    Calculation::Category category() const { return m_tree.category; }
+    Calculation::Category category() const { return m_category; }
+    CSS::Range range() const { return m_range; }
+
     CSSUnitType primitiveType() const;
 
     // Returns whether the CSSCalc::Tree requires `CSSToLengthConversionData` to fully resolve.
@@ -107,10 +109,12 @@ public:
     const CSSCalc::Tree& tree() const { return m_tree; }
 
 private:
-    explicit CSSCalcValue(CSSCalc::Tree&&);
+    explicit CSSCalcValue(Calculation::Category, CSS::Range, CSSCalc::Tree&&);
 
     double clampToPermittedRange(double) const;
 
+    Calculation::Category m_category;
+    CSS::Range m_range;
     CSSCalc::Tree m_tree;
 };
 

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -469,6 +469,7 @@ ExceptionOr<Ref<CSSNumericValue>> CSSNumericValue::parse(Document& document, Str
             };
             auto simplificationOptions = CSSCalc::SimplificationOptions {
                 .category = Calculation::Category::LengthPercentage,
+                .range = CSS::All,
                 .conversionData = std::nullopt,
                 .symbolTable = { },
                 .allowZeroValueLengthRemovalFromSum = false,

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -404,12 +404,10 @@ RefPtr<CSSValue> CSSUnitValue::toCSSValueWithProperty(CSSPropertyID propertyID) 
         sumChildren.append(WTFMove(*node));
         auto sum = CSSCalc::makeChild(CSSCalc::Sum { .children = WTFMove(sumChildren) }, type);
 
-        return CSSPrimitiveValue::create(CSSCalcValue::create(CSSCalc::Tree {
+        return CSSPrimitiveValue::create(CSSCalcValue::create(category, range, CSSCalc::Tree {
             .root = WTFMove(sum),
             .type = type,
-            .category = category,
             .stage = CSSCalc::Stage::Specified,
-            .range = range
         }));
     }
     return toCSSValue();

--- a/Source/WebCore/css/typedom/numeric/CSSMathValue.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathValue.cpp
@@ -43,12 +43,10 @@ RefPtr<CSSValue> CSSMathValue::toCSSValue() const
     if (!category)
         return nullptr;
 
-    return CSSPrimitiveValue::create(CSSCalcValue::create(CSSCalc::Tree {
+    return CSSPrimitiveValue::create(CSSCalcValue::create(*category, CSS::All, CSSCalc::Tree {
         .root = WTFMove(*node),
         .type = type,
-        .category = *category,
         .stage = CSSCalc::Stage::Specified,
-        .range = CSS::All
     }));
 }
 

--- a/Source/WebCore/platform/Length.cpp
+++ b/Source/WebCore/platform/Length.cpp
@@ -365,7 +365,7 @@ static Length makeLength(Calculation::Child&& root)
     // FIXME: Value range should be passed in.
 
     // NOTE: category is always `LengthPercentage` as late resolved `Length` values defined by percentages is the only reason calculation value is needed by `Length`.
-    return Length(CalculationValue::create(Calculation::Tree { .root = WTFMove(root), .category = Calculation::Category::LengthPercentage, .range = Calculation::All }));
+    return Length(CalculationValue::create(Calculation::Category::LengthPercentage, Calculation::All, Calculation::Tree { WTFMove(root) }));
 }
 
 Length convertTo100PercentMinusLength(const Length& length)

--- a/Source/WebCore/platform/calc/CalculationTree+Copy.cpp
+++ b/Source/WebCore/platform/calc/CalculationTree+Copy.cpp
@@ -47,7 +47,7 @@ static auto copy(const IndirectNode<Op>&) -> Child;
 
 Tree copy(const Tree& tree)
 {
-    return Tree { .root = copy(tree.root), .category = tree.category, .range = tree.range };
+    return Tree { .root = copy(tree.root) };
 }
 
 double copy(double value)

--- a/Source/WebCore/platform/calc/CalculationTree.h
+++ b/Source/WebCore/platform/calc/CalculationTree.h
@@ -191,8 +191,6 @@ using Children = Vector<Child>;
 
 struct Tree {
     Child root;
-    Category category;
-    Range range;
 
     bool operator==(const Tree&) const = default;
 };

--- a/Source/WebCore/platform/calc/CalculationValue.cpp
+++ b/Source/WebCore/platform/calc/CalculationValue.cpp
@@ -39,13 +39,15 @@
 
 namespace WebCore {
 
-Ref<CalculationValue> CalculationValue::create(Calculation::Tree&& tree)
+Ref<CalculationValue> CalculationValue::create(Calculation::Category category, Calculation::Range range, Calculation::Tree&& tree)
 {
-    return adoptRef(*new CalculationValue(WTFMove(tree)));
+    return adoptRef(*new CalculationValue(category, range, WTFMove(tree)));
 }
 
-CalculationValue::CalculationValue(Calculation::Tree&& tree)
-    : m_tree(WTFMove(tree))
+CalculationValue::CalculationValue(Calculation::Category category, Calculation::Range range, Calculation::Tree&& tree)
+    : m_category(category)
+    , m_range(range)
+    , m_tree(WTFMove(tree))
 {
 }
 
@@ -56,7 +58,7 @@ Calculation::NumericValue CalculationValue::evaluate(Calculation::NumericValue p
     auto result = Calculation::evaluate(m_tree, percentResolutionLength);
     if (std::isnan(result))
         return 0;
-    return std::clamp(result, m_tree.range.min, m_tree.range.max);
+    return std::clamp(result, m_range.min, m_range.max);
 }
 
 Calculation::Tree CalculationValue::copyTree() const

--- a/Source/WebCore/platform/calc/CalculationValue.h
+++ b/Source/WebCore/platform/calc/CalculationValue.h
@@ -41,10 +41,13 @@ namespace WebCore {
 class CalculationValue : public RefCounted<CalculationValue> {
     WTF_MAKE_FAST_COMPACT_ALLOCATED;
 public:
-    WEBCORE_EXPORT static Ref<CalculationValue> create(Calculation::Tree&&);
+    WEBCORE_EXPORT static Ref<CalculationValue> create(Calculation::Category, Calculation::Range, Calculation::Tree&&);
     WEBCORE_EXPORT ~CalculationValue();
 
     Calculation::NumericValue evaluate(Calculation::NumericValue percentResolutionLength) const;
+
+    Calculation::Category category() const { return m_category; }
+    Calculation::Range range() const { return m_range; }
 
     const Calculation::Tree& tree() const { return m_tree; }
     Calculation::Tree copyTree() const;
@@ -53,8 +56,10 @@ public:
     WEBCORE_EXPORT bool operator==(const CalculationValue&) const;
 
 private:
-    CalculationValue(Calculation::Tree&&);
+    CalculationValue(Calculation::Category, Calculation::Range, Calculation::Tree&&);
 
+    Calculation::Category m_category;
+    Calculation::Range m_range;
     Calculation::Tree m_tree;
 };
 

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -336,12 +336,12 @@ template<auto R> struct ToStyle<CSS::UnevaluatedCalc<CSS::AnglePercentageRaw<R>>
         // should go away once the typed CSSOM learns to set the correct category when creating internal
         // representations of CSSMath* types.
 
-        ASSERT(simplifiedCalc->tree().category == Calculation::Category::AnglePercentage || simplifiedCalc->tree().category == Calculation::Category::Angle || simplifiedCalc->tree().category == Calculation::Category::Percentage);
+        ASSERT(simplifiedCalc->category() == Calculation::Category::AnglePercentage || simplifiedCalc->category() == Calculation::Category::Angle || simplifiedCalc->category() == Calculation::Category::Percentage);
 
-        if (simplifiedCalc->tree().category == Calculation::Category::Angle)
+        if (simplifiedCalc->category() == Calculation::Category::Angle)
             return { Style::Angle<R> { simplifiedCalc->doubleValue(std::forward<Rest>(rest)...) } };
 
-        if (simplifiedCalc->tree().category == Calculation::Category::Percentage) {
+        if (simplifiedCalc->category() == Calculation::Category::Percentage) {
             if (std::holds_alternative<CSSCalc::Percentage>(simplifiedCalc->tree().root))
                 return { Style::Percentage<R> { simplifiedCalc->doubleValue(std::forward<Rest>(rest)...) } };
             return { simplifiedCalc->createCalculationValue(std::forward<Rest>(rest)...) };
@@ -370,12 +370,12 @@ template<auto R> struct ToStyle<CSS::UnevaluatedCalc<CSS::LengthPercentageRaw<R>
         // should go away once the typed CSSOM learns to set the correct category when creating internal
         // representations of CSSMath* types.
 
-        ASSERT(simplifiedCalc->tree().category == Calculation::Category::LengthPercentage || simplifiedCalc->tree().category == Calculation::Category::Length || simplifiedCalc->tree().category == Calculation::Category::Percentage);
+        ASSERT(simplifiedCalc->category() == Calculation::Category::LengthPercentage || simplifiedCalc->category() == Calculation::Category::Length || simplifiedCalc->category() == Calculation::Category::Percentage);
 
-        if (simplifiedCalc->tree().category == Calculation::Category::Length)
+        if (simplifiedCalc->category() == Calculation::Category::Length)
             return { Style::Length<R> { clampLengthToAllowedLimits(simplifiedCalc->doubleValue(std::forward<Rest>(rest)...)) } };
 
-        if (simplifiedCalc->tree().category == Calculation::Category::Percentage) {
+        if (simplifiedCalc->category() == Calculation::Category::Percentage) {
             if (std::holds_alternative<CSSCalc::Percentage>(simplifiedCalc->tree().root))
                 return { Style::Percentage<R> { simplifiedCalc->doubleValue(std::forward<Rest>(rest)...) } };
             return { simplifiedCalc->createCalculationValue(std::forward<Rest>(rest)...) };

--- a/Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.h
+++ b/Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.h
@@ -45,11 +45,9 @@ template<CSS::Numeric CSSType> struct UnevaluatedCalculation {
     explicit UnevaluatedCalculation(Calculation::Child root)
         : UnevaluatedCalculation {
             CalculationValue::create(
-                Calculation::Tree {
-                    .root = WTFMove(root),
-                    .category = category,
-                    .range = { range.min, range.max },
-                }
+                category,
+                Calculation::Range { range.min, range.max },
+                Calculation::Tree { WTFMove(root) }
             )
         }
     {


### PR DESCRIPTION
#### 3556d19ffd1927968c65a7213ef38f1d00744ebe
<pre>
Remove duplicated data by moving category/range out of CSSCalc::Tree/Calculation::Tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=285943">https://bugs.webkit.org/show_bug.cgi?id=285943</a>

Reviewed by Darin Adler.

UnevaluatedCalc already has the category/range embedded in its type so CSSCalc::Tree
really doesn&apos;t need it. For now, move it to CSSCalcValue/CalculationValue to keep the
CSSValue path working.

* Source/WebCore/css/calc/CSSCalcTree+CalculationValue.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Copy.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Evaluation.h:
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Serialization.h:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
* Source/WebCore/css/calc/CSSCalcTree+Simplification.h:
* Source/WebCore/css/calc/CSSCalcTree.cpp:
* Source/WebCore/css/calc/CSSCalcTree.h:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
* Source/WebCore/css/calc/CSSCalcValue.h:
* Source/WebCore/css/typedom/CSSNumericValue.cpp:
* Source/WebCore/css/typedom/CSSUnitValue.cpp:
* Source/WebCore/css/typedom/numeric/CSSMathValue.cpp:
* Source/WebCore/platform/Length.cpp:
* Source/WebCore/platform/calc/CalculationTree+Copy.cpp:
* Source/WebCore/platform/calc/CalculationTree.h:
* Source/WebCore/platform/calc/CalculationValue.cpp:
* Source/WebCore/platform/calc/CalculationValue.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.h:

Canonical link: <a href="https://commits.webkit.org/288936@main">https://commits.webkit.org/288936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62d2c2a1ceab4bd7acc31338f914ce39dca1d3b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89846 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35758 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65932 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23764 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/76990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46205 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3319 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31204 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34833 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91222 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12046 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8808 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74409 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72795 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73535 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18215 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17906 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16351 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3494 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/11998 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17438 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11832 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15326 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13578 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->