### PR TITLE
Add support for extraInfoSpec to webRequest event listeners.

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
@@ -45,17 +45,22 @@ class WebExtensionAPIWebRequestEvent : public WebExtensionAPIObject, public JSWe
 
 public:
 #if PLATFORM(COCOA)
-    using FilterAndCallbackPair = std::pair<RefPtr<WebExtensionCallbackHandler>, RetainPtr<_WKWebExtensionWebRequestFilter>>;
-    using ListenerVector = Vector<FilterAndCallbackPair>;
+    struct Listener {
+        RefPtr<WebExtensionCallbackHandler> callback;
+        RetainPtr<_WKWebExtensionWebRequestFilter> filter;
+        Vector<String> extraInfo;
+    };
+
+    using ListenerVector = Vector<Listener>;
 
     const ListenerVector& listeners() const { return m_listeners; }
 
-    void addListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, id extraInfoSpec, NSString **outExceptionString);
+    void addListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, NSArray *extraInfo, NSString **outExceptionString);
     void removeListener(WebCore::FrameIdentifier, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 #endif
 
-    void enumerateListeners(WebExtensionTabIdentifier, WebExtensionWindowIdentifier, const ResourceLoadInfo&, const Function<void(WebExtensionCallbackHandler&)>&);
+    void enumerateListeners(WebExtensionTabIdentifier, WebExtensionWindowIdentifier, const ResourceLoadInfo&, const Function<void(WebExtensionCallbackHandler&, const Vector<String>&)>&);
     void invokeListenersWithArgument(NSDictionary *argument, WebExtensionTabIdentifier, WebExtensionWindowIdentifier, const ResourceLoadInfo&);
 
     void removeAllListeners();

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
@@ -368,7 +368,7 @@ JSValueRef toJSValueRefOrJSNull(JSContextRef context, id object)
 NSArray *toNSArray(JSContextRef context, JSValueRef value, Class containingObjectsOfClass)
 {
     ASSERT(containingObjectsOfClass);
-    return toNSObject(context, value, containingObjectsOfClass);
+    return dynamic_objc_cast<NSArray>(toNSObject(context, value, containingObjectsOfClass));
 }
 
 JSContext *toJSContext(JSContextRef context)


### PR DESCRIPTION
#### dcd3996be0e78cf7e553c70b8e83c9f4399602e3
<pre>
Add support for extraInfoSpec to webRequest event listeners.
<a href="https://webkit.org/b/285940">https://webkit.org/b/285940</a>
<a href="https://rdar.apple.com/problem/142907168">rdar://problem/142907168</a>

Reviewed by Brian Weinstein.

Add support for the extraInfoSpec array on webRequest event listeners for requestBody, requestHeaders
and responseHeaders. This allows us to avoid some extra work per-request if the extension does not
require these extra fields, which can be large and expensive to create.

Also use string constants for the webRequest properties.

Updated tests and added new ones to verify the info is and is not there when expected.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm:
(WebKit::toWebAPI):
(WebKit::webRequestDetailsForResourceLoad):
(WebKit::convertHeaderFieldsToWebExtensionFormat):
(WebKit::headersReceivedDetails):
(WebKit::WebExtensionContextProxy::resourceLoadDidSendRequest):
(WebKit::WebExtensionContextProxy::resourceLoadDidPerformHTTPRedirection):
(WebKit::WebExtensionContextProxy::resourceLoadDidReceiveChallenge):
(WebKit::WebExtensionContextProxy::resourceLoadDidReceiveResponse):
(WebKit::WebExtensionContextProxy::resourceLoadDidCompleteWithError):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm:
(WebKit::WebExtensionAPIWebRequestEvent::enumerateListeners):
(WebKit::WebExtensionAPIWebRequestEvent::invokeListenersWithArgument):
(WebKit::WebExtensionAPIWebRequestEvent::addListener):
(WebKit::WebExtensionAPIWebRequestEvent::removeListener):
(WebKit::WebExtensionAPIWebRequestEvent::hasListener):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h:
* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
(WebKit::toNSArray): Cast to NSArray, since the result of toNSObject can be any object.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, BeforeRequestEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventForSubresource)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, BeforeRequestEventWithRequestBodyAndFormData)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, BeforeSendHeadersEvent)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, BeforeSendHeadersEventWithRequestHeaders)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, BeforeSendHeadersEventForSubresource)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, SendHeadersEvent)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, SendHeadersEventWithRequestHeaders)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, SendHeadersEventForSubresource)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, HeadersReceivedEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, HeadersReceivedEventWithResponseHeaders)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, HeadersReceivedEventForSubresource)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, ErrorOccurredEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, RedirectOccurredEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, RedirectOccurredEventForSubresource)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, ResponseStartedEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, ResponseStartedEventWithResponseHeaders)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, ResponseStartedEventForSubresource)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, CompletedEvent)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, CompletedEventWithResponseHeaders)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, CompletedEventForSubresource)):

Canonical link: <a href="https://commits.webkit.org/288938@main">https://commits.webkit.org/288938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffe6ec6f28516db1a17a8946df37f42ed36007e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89855 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35767 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12416 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65930 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23762 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3442 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46203 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31206 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34842 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74179 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91231 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12055 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74406 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73532 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17905 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3503 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13219 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12007 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17447 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11841 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->