### PR TITLE
[scroll-animations] Animation-range values provided by JS bindings should be resolved when needed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Scroll timeline with percentage range [JavaScript API]
 PASS Scroll timeline with px range [JavaScript API]
-FAIL Scroll timeline with calculated range [JavaScript API] assert_approx_equals: expected a number but got a "object"
-FAIL Scroll timeline with EM range [JavaScript API] assert_approx_equals: expected a number but got a "object"
+PASS Scroll timeline with calculated range [JavaScript API]
+PASS Scroll timeline with EM range [JavaScript API]
 PASS Scroll timeline with percentage range [CSS]
 PASS Scroll timeline with px range [CSS]
 PASS Scroll timeline with calculated range [CSS]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Getting and setting the animation range assert_approx_equals: expected 100 +/- 0.000001 but got 0
+PASS Getting and setting the animation range
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt
@@ -2,6 +2,6 @@
 PASS View timeline with range as <name> <percent> pair.
 PASS View timeline with range and inferred name or offset.
 PASS View timeline with range as <name> <px> pair.
-FAIL View timeline with range as <name> <percent+px> pair. assert_equals: Effect at the start of the active phase: contain undefined% to contain undefined% expected "0.3" but got "0.7"
-FAIL View timeline with range as strings. assert_equals: Effect at the start of the active phase:  to  expected "0.3" but got "0.7"
+PASS View timeline with range as <name> <percent+px> pair.
+PASS View timeline with range as strings.
 

--- a/Source/WebCore/animation/TimelineRange.cpp
+++ b/Source/WebCore/animation/TimelineRange.cpp
@@ -88,7 +88,7 @@ static const std::optional<CSSToLengthConversionData> cssToLengthConversionData(
 
 Length SingleTimelineRange::lengthForCSSValue(RefPtr<const CSSPrimitiveValue> value, RefPtr<Element> element)
 {
-    if (!value || value->isCalculated() || !element)
+    if (!value || !element)
         return { };
     if (value->valueID() == CSSValueAuto)
         return { };
@@ -137,7 +137,7 @@ SingleTimelineRange SingleTimelineRange::range(const CSSValue& value, Type type,
     return { SingleTimelineRange::timelineName(pair->first().valueID()), state ? Style::BuilderConverter::convertLength(*state, primitiveValue) : lengthForCSSValue(RefPtr { primitiveValue.ptr() }, element) };
 }
 
-SingleTimelineRange SingleTimelineRange::parse(TimelineRangeValue&& value, RefPtr<Element> element, Type type)
+RefPtr<CSSValue> SingleTimelineRange::parse(TimelineRangeValue&& value, RefPtr<Element> element, Type type)
 {
     if (!element)
         return { };
@@ -146,32 +146,30 @@ SingleTimelineRange SingleTimelineRange::parse(TimelineRangeValue&& value, RefPt
         return { };
     const auto& parserContext = document->cssParserContext();
     return WTF::switchOn(value,
-    [&](String& rangeString) {
+    [&](String& rangeString) -> RefPtr<CSSValue> {
         CSSTokenizer tokenizer(rangeString);
         auto tokenRange = tokenizer.tokenRange();
         tokenRange.consumeWhitespace();
-        if (auto consumedRange = CSSPropertyParserHelpers::consumeAnimationRange(tokenRange, parserContext, type))
-            return range(*consumedRange, type, nullptr, element);
-        return SingleTimelineRange { };
+        return CSSPropertyParserHelpers::consumeAnimationRange(tokenRange, parserContext, type);
     },
-    [&](TimelineRangeOffset& rangeOffset) {
+    [&](TimelineRangeOffset& rangeOffset) -> RefPtr<CSSValue> {
         CSSTokenizer tokenizer(rangeOffset.rangeName);
         auto tokenRange = tokenizer.tokenRange();
         tokenRange.consumeWhitespace();
         if (auto consumedRangeName = CSSPropertyParserHelpers::consumeAnimationRange(tokenRange, parserContext, type)) {
             if (rangeOffset.offset)
-                return range(CSSValuePair::createNoncoalescing(*consumedRangeName, *rangeOffset.offset->toCSSValue()), type, nullptr, element);
-            return range(*consumedRangeName, type, nullptr, element);
+                return CSSValuePair::createNoncoalescing(*consumedRangeName, *rangeOffset.offset->toCSSValue());
+            return consumedRangeName;
         }
         if (RefPtr offset = rangeOffset.offset)
-            return range(*offset->toCSSValue(), type, nullptr, element);
-        return SingleTimelineRange { };
+            return offset->toCSSValue();
+        return nullptr;
     },
     [&](RefPtr<CSSKeywordValue> rangeKeyword) {
-        return range(*rangeKeyword->toCSSValue(), type, nullptr, element);
+        return rangeKeyword->toCSSValue();
     },
     [&](RefPtr<CSSNumericValue> rangeValue) {
-        return range(*rangeValue->toCSSValue(), type, nullptr, element);
+        return rangeValue->toCSSValue();
     });
 }
 

--- a/Source/WebCore/animation/TimelineRange.h
+++ b/Source/WebCore/animation/TimelineRange.h
@@ -56,7 +56,7 @@ struct SingleTimelineRange {
     static CSSValueID valueID(Name);
 
     static SingleTimelineRange range(const CSSValue&, Type, const Style::BuilderState* = nullptr, RefPtr<Element> = nullptr);
-    static SingleTimelineRange parse(TimelineRangeValue&&, RefPtr<Element>, Type);
+    static RefPtr<CSSValue> parse(TimelineRangeValue&&, RefPtr<Element>, Type);
     TimelineRangeValue serialize() const;
 };
 

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -146,7 +146,7 @@ public:
     virtual void setBindingsRangeEnd(TimelineRangeValue&&);
     void setRangeStart(SingleTimelineRange);
     void setRangeEnd(SingleTimelineRange);
-    const TimelineRange& range() const { return m_timelineRange; }
+    const TimelineRange& range();
 
     bool needsTick() const;
     virtual void tick();
@@ -233,6 +233,8 @@ private:
 
     RefPtr<AnimationEffect> m_effect;
     RefPtr<AnimationTimeline> m_timeline;
+    RefPtr<CSSValue> m_specifiedRangeStart;
+    RefPtr<CSSValue> m_specifiedRangeEnd;
     UniqueRef<ReadyPromise> m_readyPromise;
     UniqueRef<FinishedPromise> m_finishedPromise;
     std::optional<WebAnimationTime> m_previousCurrentTime;


### PR DESCRIPTION
#### 406f6c335d9f223f5c6f081a787311ee33e1f426
<pre>
[scroll-animations] Animation-range values provided by JS bindings should be resolved when needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=285946">https://bugs.webkit.org/show_bug.cgi?id=285946</a>
<a href="https://rdar.apple.com/142910399">rdar://142910399</a>

Reviewed by Antoine Quint.

We should resolve animation-range values provided through the JS API when needed to take into account changes
to scroll container size, font size, etc. This is a similar fix to the one made for ViewTimeline insets.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-range-animation.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-timeline-range-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-range-expected.txt:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::registerNamedScrollTimeline):
(WebCore::AnimationTimelinesController::setTimelineForName):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::intervalForAttachmentRange const):
* Source/WebCore/animation/TimelineRange.cpp:
(WebCore::SingleTimelineRange::lengthForCSSValue):
(WebCore::SingleTimelineRange::parse):
* Source/WebCore/animation/TimelineRange.h:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::intervalForAttachmentRange const):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::autoAlignStartTime):
(WebCore::WebAnimation::setBindingsRangeStart):
(WebCore::WebAnimation::setBindingsRangeEnd):
(WebCore::WebAnimation::range):
(WebCore::WebAnimation::progressBasedTimelineSourceDidChangeMetrics):
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::range const): Deleted.

Canonical link: <a href="https://commits.webkit.org/288986@main">https://commits.webkit.org/288986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/848318c7f240cc42f151d320dd56168f53e6b68e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90087 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35992 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12637 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/66101 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23920 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77182 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/46368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3505 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31412 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35065 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32220 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91453 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12274 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8970 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74582 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73701 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18085 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16533 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13241 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12226 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12061 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15555 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->