### PR TITLE
AX: content-visibility: hidden does not remove elements from the accessibility tree

### DIFF
--- a/LayoutTests/accessibility/details-summary-content-hidden-expected.txt
+++ b/LayoutTests/accessibility/details-summary-content-hidden-expected.txt
@@ -1,0 +1,16 @@
+This tests that the summary content is inaccessible when a details element is collapsed.
+PASS: details.isExpanded === false
+PASS: summary.isExpanded === false
+PASS: !accessibilityController.accessibleElementById('content') === true
+PASS: details.isExpanded === true
+PASS: summary.isExpanded === true
+PASS: !!accessibilityController.accessibleElementById('content') === true
+PASS: details.isExpanded === false
+PASS: summary.isExpanded === false
+PASS: !accessibilityController.accessibleElementById('content') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Some open info
+

--- a/LayoutTests/accessibility/details-summary-content-hidden.html
+++ b/LayoutTests/accessibility/details-summary-content-hidden.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<details id="details">
+    <summary id="summary">Some open info</summary>
+    <p id="content">Details about the open topic.</p>
+</details>
+
+<script>
+var output = "This tests that the summary content is inaccessible when a details element is collapsed.\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var details = accessibilityController.accessibleElementById("details");
+    var summary = accessibilityController.accessibleElementById("summary");
+
+    output += expect("details.isExpanded", "false");
+    output += expect("summary.isExpanded", "false");
+    output += expect("!accessibilityController.accessibleElementById('content')", "true")
+    
+    document.getElementById("details").setAttribute("open", "true");
+    setTimeout(async function() {
+        output += await expectAsync("details.isExpanded", "true");
+        output += await expectAsync("summary.isExpanded", "true");
+        output += expect("!!accessibilityController.accessibleElementById('content')", "true");
+
+        document.getElementById("details").removeAttribute("open");
+        output += await expectAsync("details.isExpanded", "false");
+        output += await expectAsync("summary.isExpanded", "false");
+        output += expect("!accessibilityController.accessibleElementById('content')", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/accessibility/mac/details-summary-expected.txt
+++ b/LayoutTests/accessibility/mac/details-summary-expected.txt
@@ -6,12 +6,12 @@ PASS: summary1.role === 'AXRole: AXDisclosureTriangle'
 PASS: summary1.subrole === 'AXSubrole: AXSummary'
 PASS: summary1.title === 'AXTitle: Some open info'
 PASS: details1.isAttributeSettable('AXExpanded') === true
-Got AXExpandedChanged notification for details1
+Got AXExpandedChanged notification for details1 (count 1)
 PASS: details1.isExpanded === false
 PASS: summary1.isExpanded === false
 PASS: details1.isExpanded === false
 PASS: summary1.isExpanded === false
-Got AXExpandedChanged notification for details1
+Got AXExpandedChanged notification for details1 (count 2)
 PASS: details1.isExpanded === true
 PASS: summary1.isExpanded === true
 PASS: details1.isExpanded === true

--- a/LayoutTests/accessibility/mac/details-summary.html
+++ b/LayoutTests/accessibility/mac/details-summary.html
@@ -24,88 +24,72 @@
 </div>
 
 <script>
-    var output = "This tests some basic attributes about the details element.\n";
+var output = "This tests some basic attributes about the details element.\n";
 
-    if (window.accessibilityController) {
-        window.jsTestIsAsync = true;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
 
-        var body = accessibilityController.rootElement.childAtIndex(0);
-        accessibilityController.addNotificationListener(function(element, notification) {
-            if (notification != "AXExpandedChanged")
-                return;
-            output += `Got AXExpandedChanged notification for ${element.domIdentifier}\n`;
+    var expandedChangedCount = 0;
+    var body = accessibilityController.rootElement.childAtIndex(0);
+    accessibilityController.addNotificationListener(function(element, notification) {
+        if (notification != "AXExpandedChanged")
+            return;
+        expandedChangedCount++;
+        output += `Got AXExpandedChanged notification for ${element.domIdentifier} (count ${expandedChangedCount})\n`;
+    });
+
+    var details1 = accessibilityController.accessibleElementById("details1");
+    var summary1 = accessibilityController.accessibleElementById("summary1");
+    output += expect("details1.role", "'AXRole: AXGroup'");
+    output += expect("details1.subrole", "'AXSubrole: AXDetails'");
+    output += expect("details1.isExpanded", "true");
+    output += expect("summary1.role", "'AXRole: AXDisclosureTriangle'");
+    output += expect("summary1.subrole", "'AXSubrole: AXSummary'");
+    output += expect("summary1.title", "'AXTitle: Some open info'");
+    output += expect("details1.isAttributeSettable('AXExpanded')", "true");
+
+    // Toggle the expanded state.
+    details1.setBoolAttributeValue("AXExpanded", false);
+    setTimeout(async function() {
+        await waitFor(() => {
+            details1 = accessibilityController.accessibleElementById("details1");
+            return details1 && !details1.isExpanded;
         });
+        summary1 = accessibilityController.accessibleElementById("summary1");
+        output += await expectAsync("details1.isExpanded", "false");
+        output += await expectAsync("summary1.isExpanded", "false");
 
-        var details1 = accessibilityController.accessibleElementById("details1");
-        var summary1 = accessibilityController.accessibleElementById("summary1");
-        output += expect("details1.role", "'AXRole: AXGroup'");
-        output += expect("details1.subrole", "'AXSubrole: AXDetails'");
-        output += expect("details1.isExpanded", "true");
-        output += expect("summary1.role", "'AXRole: AXDisclosureTriangle'");
-        output += expect("summary1.subrole", "'AXSubrole: AXSummary'");
-        output += expect("summary1.title", "'AXTitle: Some open info'");
-        output += expect("details1.isAttributeSettable('AXExpanded')", "true");
-
-        // Toggle the expanded state.
+        // Give it the same value to make sure we don't expand.
         details1.setBoolAttributeValue("AXExpanded", false);
+        output += await expectAsync("details1.isExpanded", "false");
+        output += await expectAsync("summary1.isExpanded", "false");
 
-        // After toggling the expanded state on a <details> element, the underlying HTMLDetailsElement goes away and it is replaced by a new object.
-        // Thus, we need to retrieve the corresponding accessible object again since the current one becomes defunct.
-        // See HTMLDetailsElement::toggleOpen().
-        setTimeout(async function() {
-            await waitFor(() => {
-                details1 = accessibilityController.accessibleElementById("details1");
-                return details1 && !details1.isExpanded;
-            });
-            summary1 = accessibilityController.accessibleElementById("summary1");
-            output += expect("details1.isExpanded", "false");
-            output += expect("summary1.isExpanded", "false");
+        // Set to expand again.
+        details1.setBoolAttributeValue("AXExpanded", true);
+        await waitFor(() => expandedChangedCount == 2);
+        output += await expectAsync("details1.isExpanded", "true");
+        output += await expectAsync("summary1.isExpanded", "true");
 
-            // Give it the same value to make sure we don't expand.
-            details1.setBoolAttributeValue("AXExpanded", false);
-            await waitFor(() => {
-                details1 = accessibilityController.accessibleElementById("details1");
-                return details1 && !details1.isExpanded;
-            });
-            summary1 = accessibilityController.accessibleElementById("summary1");
-            output += expect("details1.isExpanded", "false");
-            output += expect("summary1.isExpanded", "false");
+        // And duplicate the true state to make sure it doesn't toggle off.
+        details1.setBoolAttributeValue("AXExpanded", true);
+        output += await expectAsync("details1.isExpanded", "true");
+        output += await expectAsync("summary1.isExpanded", "true");
 
-            // Set to expand again.
-            details1.setBoolAttributeValue("AXExpanded", true);
-            await waitFor(() => {
-                details1 = accessibilityController.accessibleElementById("details1");
-                return details1 && details1.isExpanded;
-            });
-            summary1 = accessibilityController.accessibleElementById("summary1");
-            output += expect("details1.isExpanded", "true");
-            output += expect("summary1.isExpanded", "true");
+        details2 = accessibilityController.accessibleElementById("details2");
+        output += expect("details2.subrole", "'AXSubrole: AXDetails'");
+        output += expect("details2.isExpanded", "false");
 
-            // And duplicate the true state to make sure it doesn't toggle off.
-            details1.setBoolAttributeValue("AXExpanded", true);
-            await waitFor(() => {
-                details1 = accessibilityController.accessibleElementById("details1");
-                return details1 && details1.isExpanded;
-            });
-            summary1 = accessibilityController.accessibleElementById("summary1");
-            output += expect("details1.isExpanded", "true");
-            output += expect("summary1.isExpanded", "true");
+        // Expanded status should be correct when detail has group role
+        details3 = accessibilityController.accessibleElementById("details3");
+        output += expect("details3.subrole", "'AXSubrole: AXApplicationGroup'");
+        output += expect("details3.isExpanded", "true");
 
-            details2 = accessibilityController.accessibleElementById("details2");
-            output += expect("details2.subrole", "'AXSubrole: AXDetails'");
-            output += expect("details2.isExpanded", "false");
-
-            // Expanded status should be correct when detail has group role
-            details3 = accessibilityController.accessibleElementById("details3");
-            output += expect("details3.subrole", "'AXSubrole: AXApplicationGroup'");
-            output += expect("details3.isExpanded", "true");
-
-            debug(output);
-            accessibilityController.removeNotificationListener();
-            document.getElementById("content").style.visibility = "hidden";
-            finishJSTest();
-        }, 0);
-    }
+        debug(output);
+        accessibilityController.removeNotificationListener();
+        document.getElementById("content").style.visibility = "hidden";
+        finishJSTest();
+    }, 0);
+}
 </script>
 </body>
 </html>

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -358,7 +358,6 @@ public:
     void onDragElementChanged(Element* oldElement, Element* newElement);
     void onEventListenerAdded(Node&, const AtomString& eventType);
     void onEventListenerRemoved(Node&, const AtomString& eventType);
-    void onExpandedChanged(HTMLDetailsElement&);
     void onFocusChange(Element* oldElement, Element* newElement);
     void onInertOrVisibilityChange(RenderElement&);
     void onPopoverToggle(const HTMLElement&);
@@ -944,7 +943,10 @@ bool hasAccNameAttribute(Element&);
 bool isNodeFocused(Node&);
 
 bool isRenderHidden(const RenderStyle*);
+// Checks both CSS display properties, and CSS visibility properties.
 bool isRenderHidden(const RenderStyle&);
+// Only checks CSS visibility properties.
+bool isVisibilityHidden(const RenderStyle&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, AXNotification);
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -3938,7 +3938,7 @@ AccessibilityObjectInclusion AccessibilityObject::defaultObjectInclusion() const
     if (auto* style = this->style()) {
         if (style->effectiveInert())
             return AccessibilityObjectInclusion::IgnoreObject;
-        if (style->usedVisibility() != Visibility::Visible)
+        if (isVisibilityHidden(*style))
             return AccessibilityObjectInclusion::IgnoreObject;
     }
 
@@ -3972,7 +3972,8 @@ bool AccessibilityObject::isWithinHiddenWebArea() const
     CheckedPtr renderView = webArea ? dynamicDowncast<RenderView>(webArea->renderer()) : nullptr;
     CheckedPtr frameRenderer = renderView ? renderView->frameView().frame().ownerRenderer() : nullptr;
     while (frameRenderer) {
-        if (frameRenderer->style().usedVisibility() != Visibility::Visible || frameRenderer->style().effectiveInert())
+        const auto& style = frameRenderer->style();
+        if (isVisibilityHidden(style) || style.effectiveInert())
             return true;
 
         renderView = frameRenderer->document().renderView();

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -210,12 +210,4 @@ void HTMLDetailsElement::ensureDetailsExclusivityAfterMutation()
     }
 }
 
-void HTMLDetailsElement::toggleOpen()
-{
-    setBooleanAttribute(openAttr, !hasAttribute(openAttr));
-
-    if (CheckedPtr cache = document().existingAXObjectCache())
-        cache->onExpandedChanged(*this);
-}
-
-}
+} // namespace WebCore

--- a/Source/WebCore/html/HTMLDetailsElement.h
+++ b/Source/WebCore/html/HTMLDetailsElement.h
@@ -35,7 +35,7 @@ public:
     static Ref<HTMLDetailsElement> create(const QualifiedName& tagName, Document&);
     ~HTMLDetailsElement();
 
-    void toggleOpen();
+    void toggleOpen() { setBooleanAttribute(HTMLNames::openAttr, !hasAttribute(HTMLNames::openAttr)); }
 
     bool isActiveSummary(const HTMLSummaryElement&) const;
 


### PR DESCRIPTION
#### 3727ac7f682278095aecd5714957126d38d72b13
<pre>
AX: content-visibility: hidden does not remove elements from the accessibility tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=285955">https://bugs.webkit.org/show_bug.cgi?id=285955</a>
<a href="https://rdar.apple.com/142915090">rdar://142915090</a>

Reviewed by Chris Fleizach.

When an element has content-visibility:hidden, it should not be exposed in the accessibility tree. This commit fixes that.

This bug caused us to expose collapsed content in details elements, which is hidden with content-visibility:hidden after
<a href="https://github.com/WebKit/WebKit/commit/cd2f382c7dc0e50ae049f7e2420377e944ba60a8.">https://github.com/WebKit/WebKit/commit/cd2f382c7dc0e50ae049f7e2420377e944ba60a8.</a>

This patch was co-authored with Josh Hoffman (<a href="https://github.com/hoffmanjoshua).">https://github.com/hoffmanjoshua).</a>

* LayoutTests/accessibility/details-summary-content-hidden-expected.txt: Added.
* LayoutTests/accessibility/details-summary-content-hidden.html: Added.
* LayoutTests/accessibility/mac/details-summary-expected.txt:
* LayoutTests/accessibility/mac/details-summary.html:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::isNodeVisible const):
(WebCore::AXObjectCache::onStyleChange):
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::isVisibilityHidden):
(WebCore::isRenderHidden):
(WebCore::AXObjectCache::onExpandedChanged): Deleted.
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::defaultObjectInclusion const):
(WebCore::AccessibilityObject::isWithinHiddenWebArea const):
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::toggleOpen): Deleted.
* Source/WebCore/html/HTMLDetailsElement.h:

Canonical link: <a href="https://commits.webkit.org/288940@main">https://commits.webkit.org/288940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ac1069356276f9a48b3e131084420514d999456

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89884 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35797 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86830 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65946 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23776 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77008 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46220 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3337 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31227 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34871 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91260 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12084 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8823 "Found 2 new test failures: http/wpt/webrtc/third-party-frame-ice-candidate-filtering.html swipe/navigate-event-back-swipe-verify-ua-transition.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74423 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12311 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72819 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73549 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18216 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17923 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16366 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3532 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12036 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17476 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11870 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15364 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->