### PR TITLE
[iOS] Base writing direction should update to reflect active input mode after inserting a newline

### DIFF
--- a/LayoutTests/editing/input/ios/update-writing-direction-after-inserting-newline-expected.txt
+++ b/LayoutTests/editing/input/ios/update-writing-direction-after-inserting-newline-expected.txt
@@ -1,0 +1,16 @@
+Verifies that switching to a RTL input mode and then pressing Return automatically sets the base writing direction to RTL
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS caretRectUsingArabic.top is caretRectUsingEnglish.top
+PASS caretRectUsingArabic.width is caretRectUsingEnglish.width
+PASS caretRectUsingArabic.height is caretRectUsingEnglish.height
+PASS caretRectUsingArabic.left is > caretRectUsingEnglish.left
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello world
+
+
+

--- a/LayoutTests/editing/input/ios/update-writing-direction-after-inserting-newline.html
+++ b/LayoutTests/editing/input/ios/update-writing-direction-after-inserting-newline.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    font-family: system-ui;
+}
+
+.editor {
+    width: 300px;
+    height: 300px;
+    border: 1px solid lightgray;
+}
+</style>
+</head>
+<body>
+    <div contenteditable class="editor">
+        <p>Hello world</p>
+    </div>
+</body>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that switching to a RTL input mode and then pressing Return automatically sets the base writing direction to RTL");
+
+    const editor = document.querySelector(".editor");
+
+    async function doAfterInputEvent(callback) {
+        await UIHelper.callFunctionAndWaitForEvent(callback, editor, "input");
+    }
+
+    await UIHelper.activateElementAndWaitForInputSession(editor);
+    await UIHelper.setKeyboardInputModeIdentifier("ar");
+    await doAfterInputEvent(async () => await UIHelper.enterText("\n"));
+    await UIHelper.ensurePresentationUpdate();
+    caretRectUsingArabic = await UIHelper.getUICaretViewRect();
+
+    await UIHelper.setKeyboardInputModeIdentifier("en_US");
+    await doAfterInputEvent(async () => await UIHelper.keyDown("delete"));
+    await UIHelper.ensurePresentationUpdate();
+
+    await doAfterInputEvent(async () => await UIHelper.enterText("\n"));
+    await UIHelper.ensurePresentationUpdate();
+    caretRectUsingEnglish = await UIHelper.getUICaretViewRect();
+
+    shouldBe("caretRectUsingArabic.top", "caretRectUsingEnglish.top");
+    shouldBe("caretRectUsingArabic.width", "caretRectUsingEnglish.width");
+    shouldBe("caretRectUsingArabic.height", "caretRectUsingEnglish.height");
+    shouldBeGreaterThan("caretRectUsingArabic.left", "caretRectUsingEnglish.left");
+
+    editor.blur();
+    await UIHelper.waitForKeyboardToHide();
+
+    finishJSTest();
+});
+</script>
+</html>

--- a/Source/WebKit/Shared/Cocoa/InsertTextOptions.h
+++ b/Source/WebKit/Shared/Cocoa/InsertTextOptions.h
@@ -28,6 +28,10 @@
 #include "ArgumentCoders.h"
 #include "EditingRange.h"
 
+namespace WebCore {
+enum class TextDirection : bool;
+}
+
 namespace WebKit {
 
 struct InsertTextOptions {
@@ -36,6 +40,7 @@ struct InsertTextOptions {
     bool processingUserGesture { false };
     bool shouldSimulateKeyboardInput { false };
     EditingRangeIsRelativeTo editingRangeIsRelativeTo { EditingRangeIsRelativeTo::EditableRoot };
+    std::optional<WebCore::TextDirection> directionFromCurrentInputMode;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/InsertTextOptions.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/InsertTextOptions.serialization.in
@@ -26,4 +26,5 @@ struct WebKit::InsertTextOptions {
     bool processingUserGesture;
     bool shouldSimulateKeyboardInput;
     WebKit::EditingRangeIsRelativeTo editingRangeIsRelativeTo;
+    std::optional<WebCore::TextDirection> directionFromCurrentInputMode;
 };


### PR DESCRIPTION
#### ff24546a6c0762f37c9d67c10f91aee76a868b99
<pre>
[iOS] Base writing direction should update to reflect active input mode after inserting a newline
<a href="https://bugs.webkit.org/show_bug.cgi?id=285960">https://bugs.webkit.org/show_bug.cgi?id=285960</a>
<a href="https://rdar.apple.com/142411271">rdar://142411271</a>

Reviewed by Abrar Rahman Protyasha.

Add a heuristic to automatically set the base writing direction to match the character direction of
the user&apos;s active input mode on iOS, after inserting a new paragraph. To achieve this, we use the
content view&apos;s `textInputMode.primaryLanguage` to compute `directionFromCurrentInputMode`, and send
it through `InsertTextOptions` to the web process. If we&apos;re inserting only a newline and the
selection is a caret, then we adjust the base writing direction to match the incoming
`directionFromCurrentInputMode`.

* LayoutTests/editing/input/ios/update-writing-direction-after-inserting-newline-expected.txt: Added.
* LayoutTests/editing/input/ios/update-writing-direction-after-inserting-newline.html: Added.

Add a layout test to exercise this change.

* Source/WebKit/Shared/Cocoa/InsertTextOptions.h:
* Source/WebKit/Shared/Cocoa/InsertTextOptions.serialization.in:

Add an optional `directionFromCurrentInputMode` member to `InsertTextOptions`.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView insertText:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::insertTextAsync):

See description above for more details.

Canonical link: <a href="https://commits.webkit.org/288911@main">https://commits.webkit.org/288911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f48bd749850398e795d362ca80f8fae0b160e04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4477 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89891 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35804 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4566 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12452 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65950 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/23777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3462 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77016 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46224 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31235 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34878 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91267 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12091 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74427 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 53 flakes 87 failures; Uploaded test results; 19 flakes 66 failures; Compiled WebKit; 3 flakes 62 failures; Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73553 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18197 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17931 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16374 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3539 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12043 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11877 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15371 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->