### PR TITLE
Fixed an unsafe buffer usage in WebKit::NetworkCacheKeyHash

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
@@ -135,10 +135,7 @@ namespace WTF {
 struct NetworkCacheKeyHash {
     static unsigned hash(const WebKit::NetworkCache::Key& key)
     {
-        static_assert(SHA1::hashSize >= sizeof(unsigned), "Hash size must be greater than sizeof(unsigned)");
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        return *reinterpret_cast<const unsigned*>(key.hash().data());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        return spanReinterpretCast<const unsigned>(std::span { key.hash() })[0];
     }
 
     static bool equal(const WebKit::NetworkCache::Key& a, const WebKit::NetworkCache::Key& b)


### PR DESCRIPTION
#### f49760aa666119db1c73254b0bf13d2a55e77106
<pre>
Fixed an unsafe buffer usage in WebKit::NetworkCacheKeyHash
<a href="https://bugs.webkit.org/show_bug.cgi?id=285961">https://bugs.webkit.org/show_bug.cgi?id=285961</a>
<a href="https://rdar.apple.com/142920104">rdar://142920104</a>

Reviewed by NOBODY (OOPS!).

This gets WebKit back to a 100% pass rate on C++ Safe Buffers.

* Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h:
(WTF::NetworkCacheKeyHash::hash): Use spanReinterpretCast instead of
reinterpret_cast, to verify bounds when converting between types.

No need for a separate static_assert anymore, since the static_assert inside
spanReinterpretCast covers the same issue and is more precise.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f49760aa666119db1c73254b0bf13d2a55e77106

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84754 "Failed to checkout and rebase branch from PR 39040") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4479 "Failed to checkout and rebase branch from PR 39040") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39142 "Failed to checkout and rebase branch from PR 39040") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/35806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/4568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12454 "Failed to checkout and rebase branch from PR 39040") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/89893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/35806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87799 "Failed to checkout and rebase branch from PR 39040") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/4568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/39142 "Failed to checkout and rebase branch from PR 39040") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/89893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/4568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/39142 "Failed to checkout and rebase branch from PR 39040") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34880 "Failed to checkout and rebase branch from PR 39040") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/4568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/39142 "Failed to checkout and rebase branch from PR 39040") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/91269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/12093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/12454 "Failed to checkout and rebase branch from PR 39040") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/91269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/12320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/39142 "Failed to checkout and rebase branch from PR 39040") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/91269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/39142 "Failed to checkout and rebase branch from PR 39040") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/3541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/12045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/11879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/15373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/13625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->