### PR TITLE
AX: Ensure Nodes are cleaned up from AXObjectCache::m_nodeObjectMapping when they are destroyed

### DIFF
--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -446,6 +446,13 @@ Node::~Node()
         // Not refing document because it may be in the middle of destruction.
         auto& document = this->document(); // Store document before clearing out m_treeScope.
 
+        // FIXME: We also cleanup nodes in the AXObjectCache via Node::willBeDeletedFrom(Document&), and we should really
+        // only have to do this cleanup in one spot. However, only cleaning up in Node::willBeDeletedFrom(Document&) causes
+        // WeakRef crashes, as willBeDeletedFrom seems to miss some Nodes, thus "poisoning" AXObjectCache::m_nodeObjectMapping
+        // with a nullified WeakRef, causing any subsequent operation (e.g. a lookup) to crash.
+        if (CheckedPtr cache = document.existingAXObjectCache())
+            cache->remove(*this);
+
         // The call to decrementReferencingNodeCount() below may destroy the document so we need to clear our
         // m_treeScope CheckedPtr beforehand.
         m_treeScope = nullptr;


### PR DESCRIPTION
#### 13e383f65077cfd61c0763208830dd2a12a2ae67
<pre>
AX: Ensure Nodes are cleaned up from AXObjectCache::m_nodeObjectMapping when they are destroyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=285962">https://bugs.webkit.org/show_bug.cgi?id=285962</a>
<a href="https://rdar.apple.com/142764858">rdar://142764858</a>

Reviewed by Chris Fleizach.

With this commit, we add a call to AXObjectCache::remove(Node&amp;) as a speculative fix for a crash. This crash happens
because AXObjectCache::m_nodeObjectMapping is an UncheckedKeyHashMap&lt;WeakRef&lt;Node, WeakPtrImplWithEventTargetData&gt;, AXID&gt;,
and in seemingly rare edgecases, we fail to remove `Node`s from this map before they are destroyed, causing the WeakRef
to become null, in turn causing a crash next time any operation (e.g. a lookup) compares with this nullified WeakRef.

Prior to this commit, we relied on Node::willBeDeletedFrom(Document&amp;) to perform AXObjectCache::remove(Node&amp;). And the
vast majority of the time, this works perfectly. Some theories I considered and ruled out:

  - Every Node subclass ends up calling into willBeDeletedFrom, except for DocumentType. But we never create an accessibility
    object for this type of Node, so it could not get into m_nodeObjectMapping in the first place.

  - ~ContainerNode only conditionally calls willBeDeletedFrom, specifically only when !isDocumentNode(). But again, we
    will not create an accessibility object for a Document Node, so it could not ever enter the map.

* Source/WebCore/dom/Node.cpp:
(WebCore::Node::~Node):

Canonical link: <a href="https://commits.webkit.org/289060@main">https://commits.webkit.org/289060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da6526778b80dc9941518ff85a7ff66931263d85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90153 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36059 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87090 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66160 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23970 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3691 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77251 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46425 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3570 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31480 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35132 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74365 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91771 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74775 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73893 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18288 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18147 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16601 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4364 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12295 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17769 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12131 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15626 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13877 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->