### PR TITLE
Missing Trailing Code Validation in end Instruction

### DIFF
--- a/JSTests/wasm/stress/unexpected-function-body-size.js
+++ b/JSTests/wasm/stress/unexpected-function-body-size.js
@@ -1,0 +1,65 @@
+
+var wasm_code = new Uint8Array([
+  0, 97, 115, 109,    // Magic number indicating this is a WebAssembly binary.
+  1, 0, 0, 0,         // Version 1 of the WebAssembly specification.
+
+  // Type Section
+  1,   // Section ID.
+  6,   // Section size (6 bytes) for the payload excluding the Section ID and size bytes.
+  1,   // Number of types defined.
+  96,  // Function type.
+  1,   // One parameter.
+  127, // Parameter is an i32.
+  1,   // One return value.
+  127, // Return type is an i32.
+
+  // Function Section
+  3, // Section ID.
+  2, // Section size.
+  1, // Number of functions.
+  0, // Type index: Function uses type[0]
+
+  // Export Section
+  7,  // Section ID.
+  8,  // Section size.
+  1,  // Number of exports.
+  4,  // String length of the export name.
+  109, 97, 105, 110, // Export name is `main`.
+  0,  // The export is a function.
+  0,  // Index of the exported function (first).
+
+  // Code Section
+  10, // Section ID for the Code section.
+  18, // Section size (18 bytes).
+  1,  // One function body.
+  16, // Size of the function body (16 bytes).
+
+  0,      // Local count (no additional locals).
+  32, 0,  // local.get 0 <num> (retrieve the first parameter)
+  65, 10, // i32.const 10
+  74,     // i32.gt_s
+  4, 127, // if i32 
+  65, 1,  //     i32.const 1
+  5,      // else
+  65, 0,  //     i32.const 0
+  11,     // end (if block)
+  11,     // end (function)
+  11,     // <-- Not expected!
+
+  // Custom Section ...
+  0, 24, 4, 110, 97, 109, 101, 1, 7, 1, 0, 4, 109, 97, 105, 110, 2, 8, 1, 0, 1, 0, 3, 110, 117, 109,
+]);
+
+let shouldThrow = false;
+
+try {
+  var wasm_module = new WebAssembly.Module(wasm_code);
+  var wasm_instance = new WebAssembly.Instance(wasm_module);
+  const { 'main': func } = wasm_instance.exports;
+  var a = func(1);
+} catch (e) {
+  shouldThrow = true;
+}
+
+if (!shouldThrow)
+  throw new Error("bad")

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -865,6 +865,7 @@ public:
     static constexpr bool shouldFuseBranchCompare = is64Bit();
 
     static constexpr bool tierSupportsSIMD = true;
+    static constexpr bool validateFunctionBodySize = true;
 
     BBQJIT(CCallHelpers& jit, const TypeDefinition& signature, BBQCallee& callee, const FunctionData& function, FunctionCodeIndex functionIndex, const ModuleInformation& info, Vector<UnlinkedWasmToWasmCall>& unlinkedWasmToWasmCalls, MemoryMode mode, InternalFunction* compilation, std::optional<bool> hasExceptionHandlers, unsigned loopIndexForOSREntry);
 

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -180,6 +180,7 @@ public:
 
     static constexpr bool shouldFuseBranchCompare = false;
     static constexpr bool tierSupportsSIMD = true;
+    static constexpr bool validateFunctionBodySize = false;
     static ExpressionType emptyExpression() { return 0; };
 
 protected:

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -537,6 +537,8 @@ auto FunctionParser<Context>::parseBody() -> PartialResult
         m_context.didParseOpcode();
     }
     WASM_FAIL_IF_HELPER_FAILS(m_context.endTopLevel({ m_signature.as<FunctionSignature>(), nullptr }, m_expressionStack));
+    if (Context::validateFunctionBodySize)
+        WASM_PARSER_FAIL_IF(m_offset != source().size(), "function body size doesn't match the expected size");
 
     ASSERT(op == OpType::End);
     return { };

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -589,6 +589,7 @@ public:
     }
 
     static constexpr bool tierSupportsSIMD = false;
+    static constexpr bool validateFunctionBodySize = true;
 private:
     Checked<uint32_t> m_stackSize { 0 };
     uint32_t m_maxStackSize { 0 };

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -52,6 +52,7 @@ public:
 
     static constexpr bool shouldFuseBranchCompare = false;
     static constexpr bool tierSupportsSIMD = false;
+    static constexpr bool validateFunctionBodySize = true;
 
     struct ControlLoop  {
         Ref<Label> m_body;

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -130,6 +130,7 @@ public:
 
     static constexpr bool shouldFuseBranchCompare = false;
     static constexpr bool tierSupportsSIMD = true;
+    static constexpr bool validateFunctionBodySize = true;
 
     struct ControlData {
         ControlData(Procedure& proc, Origin origin, BlockSignature signature, BlockType type, unsigned stackSize, BasicBlock* continuation, BasicBlock* special = nullptr)

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -130,6 +130,7 @@ public:
 
     static constexpr bool shouldFuseBranchCompare = false;
     static constexpr bool tierSupportsSIMD = true;
+    static constexpr bool validateFunctionBodySize = true;
 
     struct ControlData {
         ControlData(Procedure& proc, Origin origin, BlockSignature signature, BlockType type, unsigned stackSize, BasicBlock* continuation, BasicBlock* special = nullptr)


### PR DESCRIPTION
#### 5c94b688c7a1fd50b27a4a6e9edce80eef46cffa
<pre>
Missing Trailing Code Validation in end Instruction
<a href="https://bugs.webkit.org/show_bug.cgi?id=285496">https://bugs.webkit.org/show_bug.cgi?id=285496</a>
<a href="https://rdar.apple.com/142866140">rdar://142866140</a>

Reviewed by Yusuke Suzuki.

WASM parser should throw an error when parsing a function with a expected body size[1].

[1] <a href="https://webassembly.github.io/spec/core/binary/modules.html#code-section">https://webassembly.github.io/spec/core/binary/modules.html#code-section</a>

* JSTests/wasm/stress/unexpected-function-body-size.js: Added.
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseBody):

Canonical link: <a href="https://commits.webkit.org/288996@main">https://commits.webkit.org/288996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68c983ccf41453851c7faf1540cf016cd9a857f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90019 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35928 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12577 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66050 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23868 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3578 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77132 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46320 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31357 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35001 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77840 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91392 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83918 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12214 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74529 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12444 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73653 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18249 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18035 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16489 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4260 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12166 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17625 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106310 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12001 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25659 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13746 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->