### PR TITLE
[Grid] RELEASE_ASSERT when subgrid is modified to establish an independent formatting context.

### DIFF
--- a/LayoutTests/fast/css-grid-layout/subgrid-establishes-independent-formatting-context-crash-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/subgrid-establishes-independent-formatting-context-crash-expected.txt
@@ -1,0 +1,1 @@
+PASSES if no crash

--- a/LayoutTests/fast/css-grid-layout/subgrid-establishes-independent-formatting-context-crash.html
+++ b/LayoutTests/fast/css-grid-layout/subgrid-establishes-independent-formatting-context-crash.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<style>
+.grid {
+  display: grid;
+}
+.subgrid-rows {
+  grid-template-rows: subgrid [b] [a] [c];
+}
+</style>
+</head>
+<body>
+<div class="grid">
+  <div id="outer-subgrid" class="grid subgrid-rows">
+    <div></div>
+    <div id="inner-subgrid" class="grid subgrid-rows">PASSES if no crash</div>
+  </div>
+</div>
+</body>
+
+<script>
+  document.body.offsetHeight;
+  document.getElementById("outer-subgrid").style.contain = "layout";
+  document.getElementById("inner-subgrid").style.border = "1px solid black";
+  document.body.offsetHeight;
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-layout-dynamic-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-layout-dynamic-001-expected.txt
@@ -1,8 +1,8 @@
 
 PASS contain: none
 PASS contain: layout
-FAIL switching contain from none to layout assert_equals: vertical baseline suppressed expected true but got false
-FAIL switching contain from layout to none assert_equals: vertical baseline suppressed expected false but got true
+PASS switching contain from none to layout
+PASS switching contain from layout to none
 X
 X
 X

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5162,7 +5162,7 @@ bool RenderBox::shrinkToAvoidFloats() const
     return style().width().isAuto();
 }
 
-bool RenderBox::establishesIndependentFormattingContext() const
+bool RenderBox::establishesIndependentFormattingContext(const RenderStyle*) const
 {
     return isGridItem() || RenderElement::establishesIndependentFormattingContext();
 }

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -619,7 +619,7 @@ public:
     inline std::optional<LayoutUnit> explicitIntrinsicInnerLogicalWidth() const;
     inline std::optional<LayoutUnit> explicitIntrinsicInnerLogicalHeight() const;
 
-    bool establishesIndependentFormattingContext() const override;
+    bool establishesIndependentFormattingContext(const RenderStyle* overridingStyle = nullptr) const override;
 
     void updateFloatPainterAfterSelfPaintingLayerChange();
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2485,14 +2485,33 @@ bool RenderElement::createsNewFormattingContext() const
         || establishesIndependentFormattingContext();
 }
 
-bool RenderElement::establishesIndependentFormattingContext() const
+bool RenderElement::establishesIndependentFormattingContext(const RenderStyle* overridingStyle) const
 {
-    auto& style = this->style();
-    return isFloatingOrOutOfFlowPositioned()
-        || (isBlockBox() && hasPotentiallyScrollableOverflow())
+    auto& style = overridingStyle ? *overridingStyle : this->style();
+    auto hasPaintContainment = [&] {
+        if (auto* element = this->element())
+            return WebCore::shouldApplyPaintContainment(style, *element);
+        return false;
+    };
+
+    auto isBlockBoxWithPotentiallyScrollableOverflow = [&] {
+        if (auto* element = this->element()) {
+            return style.isDisplayBlockLevel()
+                && style.doesDisplayGenerateBlockContainer()
+                && !element->isReplaced(style)
+                && hasNonVisibleOverflow()
+                && style.overflowX() != Overflow::Clip
+                && style.overflowX() != Overflow::Visible;
+        }
+        return false;
+    };
+
+    return style.isFloating()
+        || style.hasOutOfFlowPosition()
+        || isBlockBoxWithPotentiallyScrollableOverflow()
         || style.containsLayout()
         || style.containerType() != ContainerType::Normal
-        || paintContainmentApplies()
+        || hasPaintContainment()
         || (style.isDisplayBlockLevel() && style.blockStepSize());
 }
 

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -291,7 +291,7 @@ public:
     virtual LayoutRect paintRectToClipOutFromBorder(const LayoutRect&) { return { }; }
     void paintFocusRing(const PaintInfo&, const RenderStyle&, const Vector<LayoutRect>& focusRingRects) const;
 
-    virtual bool establishesIndependentFormattingContext() const;
+    virtual bool establishesIndependentFormattingContext(const RenderStyle* overridingStyle = nullptr) const;
     bool createsNewFormattingContext() const;
 
     static void markRendererDirtyAfterTopLayerChange(RenderElement* renderer, RenderBlock* containingBlockBeforeStyleResolution);

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -119,8 +119,19 @@ void RenderGrid::styleDidChange(StyleDifference diff, const RenderStyle* oldStyl
     }
 
     auto subgridDidChange = this->subgridDidChange(*oldStyle);
-    if (explicitGridDidResize(*oldStyle) || namedGridLinesDefinitionDidChange(*oldStyle) || implicitGridLinesDefinitionDidChange(*oldStyle) || oldStyle->gridAutoFlow() != style().gridAutoFlow()
-        || (style().gridAutoRepeatColumns().size() || style().gridAutoRepeatRows().size()) || subgridDidChange == SubgridDidChange::Yes)
+    auto isSubgridWithIndependentFormattingContextChange = [&] {
+        if (newStyle.gridSubgridRows() || newStyle.gridSubgridColumns())
+            return RenderElement::establishesIndependentFormattingContext(oldStyle) != RenderElement::establishesIndependentFormattingContext();
+        return false;
+    };
+    if (explicitGridDidResize(*oldStyle)
+        || namedGridLinesDefinitionDidChange(*oldStyle)
+        || implicitGridLinesDefinitionDidChange(*oldStyle)
+        || oldStyle->gridAutoFlow() != style().gridAutoFlow()
+        || style().gridAutoRepeatColumns().size()
+        || style().gridAutoRepeatRows().size()
+        || subgridDidChange == SubgridDidChange::Yes
+        || isSubgridWithIndependentFormattingContextChange())
         dirtyGrid(subgridDidChange);
 }
 
@@ -2583,7 +2594,7 @@ GridSpan RenderGrid::gridSpanForGridItem(const RenderBox& gridItem, GridTrackSiz
     return span;
 }
 
-bool RenderGrid::establishesIndependentFormattingContext() const
+bool RenderGrid::establishesIndependentFormattingContext(const RenderStyle*) const
 {
     // Grid items establish a new independent formatting context, unless
     // they're a subgrid

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -268,7 +268,7 @@ private:
     LayoutUnit translateRTLCoordinate(LayoutUnit) const;
 
     bool shouldResetLogicalHeightBeforeLayout() const override { return true; }
-    bool establishesIndependentFormattingContext() const override;
+    bool establishesIndependentFormattingContext(const RenderStyle* overridingStyle = nullptr) const override;
 
     bool aspectRatioPrefersInline(const RenderBox& gridItem, bool blockFlowIsColumnAxis);
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -852,7 +852,8 @@ static bool rareDataChangeRequiresLayout(const StyleRareNonInheritedData& first,
         return true;
 
     if (first.usedContain().contains(Containment::Size) != second.usedContain().contains(Containment::Size)
-        || first.usedContain().contains(Containment::InlineSize) != second.usedContain().contains(Containment::InlineSize))
+        || first.usedContain().contains(Containment::InlineSize) != second.usedContain().contains(Containment::InlineSize)
+        || first.usedContain().contains(Containment::Layout) != second.usedContain().contains(Containment::Layout))
         return true;
 
     // content-visibiliy:hidden turns on contain:size which requires relayout.

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1853,6 +1853,7 @@ public:
     constexpr bool isDisplayFlexibleBoxIncludingDeprecatedOrGridBox() const;
     constexpr bool isDisplayRegionType() const;
     constexpr bool isDisplayBlockLevel() const;
+    constexpr bool doesDisplayGenerateBlockContainer() const;
     constexpr bool isOriginalDisplayBlockType() const;
     constexpr bool isDisplayTableOrTablePart() const;
     constexpr bool isInternalTableBox() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -1004,6 +1004,17 @@ constexpr bool RenderStyle::isRubyContainerOrInternalRubyBox(DisplayType display
         || display == DisplayType::RubyBase;
 }
 
+constexpr bool RenderStyle::doesDisplayGenerateBlockContainer() const
+{
+    auto display = this->display();
+    return (display == DisplayType::Block
+        || display == DisplayType::InlineBlock
+        || display == DisplayType::FlowRoot
+        || display == DisplayType::ListItem
+        || display == DisplayType::TableCell
+        || display == DisplayType::TableCaption);
+}
+
 inline double RenderStyle::logicalAspectRatio() const
 {
     ASSERT(aspectRatioType() != AspectRatioType::Auto);


### PR DESCRIPTION
#### 225e7c33ad4957c20efeb74e0a3c05f909fd8d5f
<pre>
[Grid] RELEASE_ASSERT when subgrid is modified to establish an independent formatting context.
<a href="https://bugs.webkit.org/show_bug.cgi?id=284862">https://bugs.webkit.org/show_bug.cgi?id=284862</a>
<a href="https://rdar.apple.com/problem/137177436">rdar://problem/137177436</a>

Reviewed by Alan Baradlay.

According to the grid spec, a grid which has grid-template-rows/column: subgrid is not supposed
to behave as a subgrid if it establishes an independent formatting context.
<a href="https://drafts.csswg.org/css-grid-2/#track-sizing">https://drafts.csswg.org/css-grid-2/#track-sizing</a>

Currently, this can lead to a RELEASE_ASSERT in copyUsedTrackSizesForSubgrid in certain types of content, such as
nested subgrids. This is because we fail to perform item placement again in the parent (of the
subgrid that established an independent formatting context) grid and end up with stale information
in copyUsedTrackSizesForSubgrid.

This patch fixes the RELEASE_ASSERT from the testcase by:
1.) Making sure a change so that a layout containment style mutation requires layout
2.) Allowing callers to pass in an overriding RenderStyle to establishesIndependentFormattingContext
to use instead of the one on the renderer.
3.) Changing RenderElement::establishesIndependentFormattingContext to make its decisions
based purely off the passed in style.

By allowing establishesIndependentFormattingContext to take in an overriding RenderStyle,
we can use this to compare the old and new styles that are used in styleDidChange.
RenderGrid::styleDidChange is able to learn when a style mutation causes a change that
results in the box establishing an independent formatting context or not and call dirtyGrid()
as a result.

In order for this overriding style to have any practical effect in RenderElement::establishesIndependentFormattingContext,
We need to change its logic slightly so that it only checks the used RenderStyle to make
its decision. Otherwise, it may return an incorrect result from the perspective of the caller who
wanted information based upon the passed-in style. This should be no
functional change as these helpers were indirectly referencing the RenderStyle on the
renderer anyway in some form. This also required a new helper on RenderStyle which determines
whether the display type &quot;generates a block container&quot; according to:
<a href="https://drafts.csswg.org/css-display/#the-display-properties">https://drafts.csswg.org/css-display/#the-display-properties</a>

There is also an unforunate side effect of having slight code
duplication,  but we should be able to clean this up in a future patch by refactoring the
helper functions that were previously being used.

* LayoutTests/fast/css-grid-layout/subgrid-establishes-independent-formatting-context-crash-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/subgrid-establishes-independent-formatting-context-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-layout-dynamic-001-expected.txt:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::establishesIndependentFormattingContext const):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::establishesIndependentFormattingContext const):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::styleDidChange):
(WebCore::RenderGrid::establishesIndependentFormattingContext const):
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::rareDataChangeRequiresLayout):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::doesDisplayGenerateBlockContainer const):

Canonical link: <a href="https://commits.webkit.org/289038@main">https://commits.webkit.org/289038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bcb05a690e848b33253b90465a1aa27241f8cb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90234 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36142 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12793 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66197 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24028 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77314 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46465 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3619 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31549 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35215 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32367 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91733 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9079 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12659 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73134 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18275 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18212 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16656 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4444 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12378 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12214 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15709 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->