### PR TITLE
REGRESSION: "tabs" field missing from windows.create returned windows.Window.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -65,7 +65,7 @@ void WebExtensionContext::runtimeOpenOptionsPage(CompletionHandler<void(Expected
 
     RefPtr extensionController = this->extensionController();
     if (!extensionController) {
-        completionHandler(toWebExtensionError(apiName, nullString(), @"No extensionController"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"the extension is not loaded"));
         return;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -65,7 +65,7 @@ void WebExtensionContext::tabsCreate(std::optional<WebPageProxyIdentifier> webPa
 
     RefPtr extensionController = this->extensionController();
     if (!extensionController) {
-        completionHandler(toWebExtensionError(apiName, nullString(), @"No extensionController"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"the extension is not loaded"));
         return;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm
@@ -102,9 +102,10 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
 
     RefPtr extensionController = this->extensionController();
     if (!extensionController) {
-        completionHandler(toWebExtensionError(apiName, nullString(), @"No extensionController"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"the extension is not loaded"));
         return;
     }
+
     [extensionController->delegate() webExtensionController:extensionController->wrapper() openNewWindowUsingConfiguration:configuration forExtensionContext:wrapper() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](id<WKWebExtensionWindow> newWindow, NSError *error) mutable {
         if (error) {
             RELEASE_LOG_ERROR(Extensions, "Error for open new window: %{public}@", privacyPreservingDescription(error));
@@ -118,7 +119,7 @@ void WebExtensionContext::windowsCreate(const WebExtensionWindowParameters& crea
         }
 
         RefPtr window = getOrCreateWindow(newWindow);
-        completionHandler(window->extensionHasAccess() ? std::optional(window->parameters()) : std::nullopt);
+        completionHandler(window->extensionHasAccess() ? std::optional(window->parameters(WebExtensionWindow::PopulateTabs::Yes)) : std::nullopt);
     }).get()];
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -785,7 +785,7 @@ void WebExtensionTab::duplicate(const WebExtensionTabParameters& parameters, Com
 
     RefPtr extensionContext = m_extensionContext.get();
     if (!extensionContext) {
-        completionHandler(toWebExtensionError(apiName, nullString(), @"No extensionContext"));
+        completionHandler(toWebExtensionError(apiName, nullString(), @"the extension is not loaded"));
         return;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm
@@ -517,20 +517,28 @@ TEST(WKWebExtensionAPIWindows, Create)
         @"  state: 'normal',",
         @"  type: 'popup',",
         @"  url: 'http://example.com/',",
-        @"};",
+        @"}",
 
-        @"const window = await browser.windows.create(windowOptions);",
-        @"browser.test.assertEq(typeof window, 'object', 'The window should be an object');",
-        @"browser.test.assertEq(window.top, 50, 'The window should have the specified top');",
-        @"browser.test.assertEq(window.left, 300, 'The window should have the specified left');",
-        @"browser.test.assertEq(window.width, 800, 'The window should have the specified width');",
-        @"browser.test.assertEq(window.height, 400, 'The window should have the specified height');",
-        @"browser.test.assertFalse(window.incognito, 'The window should not be in incognito mode');",
-        @"browser.test.assertEq(window.type, 'popup', 'The window should be of type popup');",
-        @"browser.test.assertEq(window.state, 'normal', 'The window state should be normal');",
-        @"browser.test.assertTrue(window.focused, 'The window should be focused');",
+        @"const window = await browser.windows.create(windowOptions)",
+        @"browser.test.assertEq(typeof window, 'object', 'The window should be an object')",
+        @"browser.test.assertEq(window?.top, 50, 'The window should have the specified top')",
+        @"browser.test.assertEq(window?.left, 300, 'The window should have the specified left')",
+        @"browser.test.assertEq(window?.width, 800, 'The window should have the specified width')",
+        @"browser.test.assertEq(window?.height, 400, 'The window should have the specified height')",
+        @"browser.test.assertFalse(window?.incognito, 'The window should not be in incognito mode')",
+        @"browser.test.assertEq(window?.type, 'popup', 'The window should be of type popup')",
+        @"browser.test.assertEq(window?.state, 'normal', 'The window state should be normal')",
+        @"browser.test.assertTrue(window?.focused, 'The window should be focused')",
 
-        @"browser.test.notifyPass();"
+        @"browser.test.assertEq(typeof window?.tabs, 'object', 'The window should have a tabs array')",
+        @"browser.test.assertEq(window?.tabs?.length, 1, 'The tabs array should contain one tab')",
+
+        @"const tab = window?.tabs?.[0]",
+        @"browser.test.assertEq(typeof tab, 'object', 'The tab should be an object')",
+        @"browser.test.assertEq(tab?.active, true, 'The tab should be active')",
+        @"browser.test.assertEq(tab?.incognito, false, 'The tab should not be in incognito mode')",
+
+        @"browser.test.notifyPass()"
     ]);
 
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:windowsManifest resources:@{ @"background.js": backgroundScript }]);
@@ -575,6 +583,16 @@ TEST(WKWebExtensionAPIWindows, CreateWithRelativeURL)
 
         @"const window = await browser.windows.create(windowOptions)",
 
+        @"browser.test.assertEq(typeof window, 'object', 'The window should be an object')",
+        @"browser.test.assertEq(typeof window?.tabs, 'object', 'The window should have a tabs array')",
+        @"browser.test.assertEq(window?.tabs?.length, 1, 'The tabs array should contain one tab')",
+
+        @"const tab = window?.tabs?.[0]",
+        @"browser.test.assertEq(typeof tab, 'object', 'The tab should be an object')",
+        @"browser.test.assertEq(tab?.url, browser.runtime.getURL('/test.html'), 'The tab URL should match the runtime-generated test.html URL')",
+        @"browser.test.assertEq(tab?.active, true, 'The tab should be active')",
+        @"browser.test.assertEq(tab?.incognito, false, 'The tab should not be in incognito mode')",
+
         @"browser.test.notifyPass()"
     ]);
 
@@ -605,6 +623,22 @@ TEST(WKWebExtensionAPIWindows, CreateWithRelativeURLs)
         @"}",
 
         @"const window = await browser.windows.create(windowOptions)",
+
+        @"browser.test.assertEq(typeof window, 'object', 'The window should be an object')",
+        @"browser.test.assertEq(typeof window?.tabs, 'object', 'The window should have a tabs array')",
+        @"browser.test.assertEq(window?.tabs?.length, 2, 'The tabs array should contain two tabs')",
+
+        @"const firstTab = window?.tabs?.[0]",
+        @"browser.test.assertEq(typeof firstTab, 'object', 'The first tab should be an object')",
+        @"browser.test.assertEq(firstTab?.url, browser.runtime.getURL('/one.html'), 'The first tab URL should match the runtime-generated one.html URL')",
+        @"browser.test.assertEq(firstTab?.active, true, 'The first tab should be active')",
+        @"browser.test.assertEq(firstTab?.incognito, false, 'The first tab should not be in incognito mode')",
+
+        @"const secondTab = window?.tabs?.[1]",
+        @"browser.test.assertEq(typeof secondTab, 'object', 'The second tab should be an object')",
+        @"browser.test.assertEq(secondTab?.url, browser.runtime.getURL('/two.html'), 'The second tab URL should match the runtime-generated two.html URL')",
+        @"browser.test.assertEq(secondTab?.active, false, 'The second tab should not be active')",
+        @"browser.test.assertEq(secondTab?.incognito, false, 'The second tab should not be in incognito mode')",
 
         @"browser.test.notifyPass()"
     ]);
@@ -668,20 +702,28 @@ TEST(WKWebExtensionAPIWindows, CreateIncognitoWithPrivateAccess)
         @"  incognito: true,",
         @"  state: 'normal',",
         @"  type: 'popup',",
-        @"};",
+        @"}",
 
-        @"const window = await browser.windows.create(windowOptions);",
-        @"browser.test.assertEq(typeof window, 'object', 'The window should be an object');",
-        @"browser.test.assertEq(window.top, 50, 'The window should have the specified top');",
-        @"browser.test.assertEq(window.left, 300, 'The window should have the specified left');",
-        @"browser.test.assertEq(window.width, 800, 'The window should have the specified width');",
-        @"browser.test.assertEq(window.height, 400, 'The window should have the specified height');",
-        @"browser.test.assertTrue(window.incognito, 'The window should be in incognito mode');",
-        @"browser.test.assertEq(window.type, 'popup', 'The window should be of type popup');",
-        @"browser.test.assertEq(window.state, 'normal', 'The window state should be normal');",
-        @"browser.test.assertTrue(window.focused, 'The window should be focused');",
+        @"const window = await browser.windows.create(windowOptions)",
+        @"browser.test.assertEq(typeof window, 'object', 'The window should be an object')",
+        @"browser.test.assertEq(window?.top, 50, 'The window should have the specified top')",
+        @"browser.test.assertEq(window?.left, 300, 'The window should have the specified left')",
+        @"browser.test.assertEq(window?.width, 800, 'The window should have the specified width')",
+        @"browser.test.assertEq(window?.height, 400, 'The window should have the specified height')",
+        @"browser.test.assertTrue(window?.incognito, 'The window should be in incognito mode')",
+        @"browser.test.assertEq(window?.type, 'popup', 'The window should be of type popup')",
+        @"browser.test.assertEq(window?.state, 'normal', 'The window state should be normal')",
+        @"browser.test.assertTrue(window?.focused, 'The window should be focused')",
 
-        @"browser.test.notifyPass();"
+        @"browser.test.assertEq(typeof window?.tabs, 'object', 'The window should have a tabs array')",
+        @"browser.test.assertEq(window?.tabs?.length, 1, 'The tabs array should contain one tab')",
+
+        @"const tab = window?.tabs?.[0]",
+        @"browser.test.assertEq(typeof tab, 'object', 'The tab should be an object')",
+        @"browser.test.assertEq(tab?.active, true, 'The tab should be active')",
+        @"browser.test.assertTrue(tab?.incognito, 'The tab should be in incognito mode')",
+
+        @"browser.test.notifyPass()"
     ]);
 
     auto extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:windowsManifest resources:@{ @"background.js": backgroundScript }]);

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -91,7 +91,7 @@
 #if PLATFORM(MAC)
     __weak TestWebExtensionManager *weakSelf = self;
 
-    _internalDelegate.openNewWindow = ^(WKWebExtensionWindowConfiguration *configuration, WKWebExtensionContext *, void (^completionHandler)(id<WKWebExtensionWindow>, NSError *)) {
+    _internalDelegate.openNewWindow = ^(WKWebExtensionWindowConfiguration *configuration, WKWebExtensionContext *context, void (^completionHandler)(id<WKWebExtensionWindow>, NSError *)) {
         auto *newWindow = [weakSelf openNewWindowUsingPrivateBrowsing:configuration.shouldBePrivate];
 
         newWindow.windowType = configuration.windowType;
@@ -118,6 +118,14 @@
         }
 
         newWindow.frame = desiredFrame;
+
+        bool isFirstURL = true;
+        for (NSURL *url in configuration.tabURLs) {
+            auto *targetTab = isFirstURL ? newWindow.tabs.firstObject : [newWindow openNewTab];
+            [targetTab changeWebViewIfNeededForURL:url forExtensionContext:context];
+            [targetTab.webView loadRequest:[NSURLRequest requestWithURL:url]];
+            isFirstURL = false;
+        }
 
         completionHandler(newWindow, nil);
     };


### PR DESCRIPTION
#### 8e0fc5af568b513af2ee869301ba2be6237cc8df
<pre>
REGRESSION: &quot;tabs&quot; field missing from windows.create returned windows.Window.
<a href="https://webkit.org/b/282025">https://webkit.org/b/282025</a>
<a href="https://rdar.apple.com/problem/138529797">rdar://problem/138529797</a>

Reviewed by Brian Weinstein.

Make sure to pass PopulateTabs::Yes when returning the new window parameters.

Added tests and test harness support for creating windows with URLs.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeOpenOptionsPage): Drive-by error string fix.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsCreate): Drive-by error string fix.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm:
(WebKit::WebExtensionContext::windowsCreate): Pass PopulateTabs::Yes
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::duplicate): Drive-by error string fix.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIWindows, Create)): Test window.tabs result.
(TestWebKitAPI::TEST(WKWebExtensionAPIWindows, CreateWithRelativeURL)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIWindows, CreateWithRelativeURLs)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIWindows, CreateIncognitoWithPrivateAccess)): Ditto.
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initForExtension:extensionControllerConfiguration:]): Support tabURLs.

Canonical link: <a href="https://commits.webkit.org/288949@main">https://commits.webkit.org/288949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0920746c47ea63224c239ea8100a68e79c0a2f75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89916 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35829 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12477 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65963 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23796 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77035 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46237 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31254 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34903 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74218 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91292 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8842 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74442 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12343 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73567 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17948 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16389 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3564 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13221 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12068 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17508 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11902 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15396 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13648 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->