### PR TITLE
9 iOS layout tests are failing due to hardware keyboard mode not being used

### DIFF
--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-control.html
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-control.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-option.html
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-option.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-shift.html
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-shift.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-option-shift.html
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-option-shift.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/events/ios/keyboard-scrolling-distance.html
+++ b/LayoutTests/fast/events/ios/keyboard-scrolling-distance.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true useHardwareKeyboardMode=true ] -->
 
 <html>
 

--- a/LayoutTests/fast/events/ios/keydown-keyup-arrow-keys-in-non-editable-element.html
+++ b/LayoutTests/fast/events/ios/keydown-keyup-arrow-keys-in-non-editable-element.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/events/ios/keydown-keyup-in-non-editable-content.html
+++ b/LayoutTests/fast/events/ios/keydown-keyup-in-non-editable-content.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/events/ios/keydown-keyup-special-keys-in-non-editable-element.html
+++ b/LayoutTests/fast/events/ios/keydown-keyup-special-keys-in-non-editable-element.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/events/ios/tab-cycle.html
+++ b/LayoutTests/fast/events/ios/tab-cycle.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/js-test.js"></script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7542,13 +7542,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-opacity-ze
 
 webkit.org/b/279295 fast/inline/list-marker-inside-container-with-margin.html [ ImageOnlyFailure ]
 
-# webkit.org/b/279704 [ iOS wk2 EWS ] 5x fast/events/iOS/* are false positive on EWS.
-fast/events/ios/keyboard-scrolling-distance.html [ Failure Timeout ]
-# [ Release ] fast/events/ios/keydown-keyup-arrow-keys-in-non-editable-element.html [ Pass Timeout ]
-# [ Release ] fast/events/ios/keydown-keyup-in-non-editable-content.html [ Pass Timeout ]
-# [ Release ] fast/events/ios/keydown-keyup-special-keys-in-non-editable-element.html [ Pass Timeout ]
-# [ Release ] fast/events/ios/tab-cycle.html [ Pass Timeout ]
-
 # webkit.org/b/279321 [Navigation] scroll API behaves differently on iOS
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-basic.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-change-history-scroll-restoration-during-promise.html [ Failure ]
@@ -7643,17 +7636,6 @@ webkit.org/b/284595 imported/w3c/web-platform-tests/css/css-grid/masonry/tentati
 # webkit.org/b/284096 (REGRESSION (286687@main): [ iOS ] 2 imported scroll-animations tests are consistently failing.)
 imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-responsiveness-from-endpoint.html [ Pass Failure ]
 imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source.html [ Failure ]
-
-# webkit.org/b/284381 (REGRESSION (iOS 18): 8 fast/events/ios layout tests are constantly timing out.)
-# When resolved, uncomment expectations added in webkit.org/b/279704 above.
-fast/events/ios/key-events-comprehensive/key-events-meta-control.html [ Skip ]
-fast/events/ios/key-events-comprehensive/key-events-meta-option.html [ Skip ]
-fast/events/ios/key-events-comprehensive/key-events-meta-shift.html [ Skip ]
-fast/events/ios/key-events-comprehensive/key-events-option-shift.html [ Skip ]
-fast/events/ios/keydown-keyup-arrow-keys-in-non-editable-element.html [ Skip ]
-fast/events/ios/keydown-keyup-in-non-editable-content.html [ Skip ]
-fast/events/ios/keydown-keyup-special-keys-in-non-editable-element.html [ Skip ]
-fast/events/ios/tab-cycle.html [ Skip ]
 
 webkit.org/b/284419 imported/w3c/web-platform-tests/html/rendering/the-details-element/details-pseudo-elements-006.html [ Failure ]
 


### PR DESCRIPTION
#### 48a35119e65b6b195ffb5e7834dba68b1a6b5bec
<pre>
9 iOS layout tests are failing due to hardware keyboard mode not being used
<a href="https://bugs.webkit.org/show_bug.cgi?id=285964">https://bugs.webkit.org/show_bug.cgi?id=285964</a>
<a href="https://rdar.apple.com/142933719">rdar://142933719</a>

Reviewed by NOBODY (OOPS!).

Nine layout tests failed on iOS since the tests rely on key events
being received without an editable-element focused. Each test
was updated to set test option &apos;useHardwareKeyboardMode&apos; to true,
and the TestExpectations have been updated accordingly.

* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-control.html:
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-option.html:
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-shift.html:
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-option-shift.html:
* LayoutTests/fast/events/ios/keyboard-scrolling-distance.html:
* LayoutTests/fast/events/ios/keydown-keyup-arrow-keys-in-non-editable-element.html:
* LayoutTests/fast/events/ios/keydown-keyup-in-non-editable-content.html:
* LayoutTests/fast/events/ios/keydown-keyup-special-keys-in-non-editable-element.html:
* LayoutTests/fast/events/ios/tab-cycle.html:
* LayoutTests/platform/ios/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48a35119e65b6b195ffb5e7834dba68b1a6b5bec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89918 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/35831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12479 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65968 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/35831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3487 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/77041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46242 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3366 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31260 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34905 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91294 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12118 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73573 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17952 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16395 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/3566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12070 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11904 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15398 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13650 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->