### PR TITLE
9x fast/events/iOS/* are flaky timeouts on EWS

### DIFF
--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-control.html
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-control.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-option.html
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-option.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-shift.html
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-shift.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-option-shift.html
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-option-shift.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/events/ios/keyboard-scrolling-distance.html
+++ b/LayoutTests/fast/events/ios/keyboard-scrolling-distance.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true useHardwareKeyboardMode=true ] -->
 
 <html>
 

--- a/LayoutTests/fast/events/ios/keydown-keyup-arrow-keys-in-non-editable-element.html
+++ b/LayoutTests/fast/events/ios/keydown-keyup-arrow-keys-in-non-editable-element.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/events/ios/keydown-keyup-in-non-editable-content.html
+++ b/LayoutTests/fast/events/ios/keydown-keyup-in-non-editable-content.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/events/ios/keydown-keyup-special-keys-in-non-editable-element.html
+++ b/LayoutTests/fast/events/ios/keydown-keyup-special-keys-in-non-editable-element.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width">

--- a/LayoutTests/fast/events/ios/tab-cycle.html
+++ b/LayoutTests/fast/events/ios/tab-cycle.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../../resources/js-test.js"></script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7539,13 +7539,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-opacity-ze
 
 webkit.org/b/279295 fast/inline/list-marker-inside-container-with-margin.html [ ImageOnlyFailure ]
 
-# webkit.org/b/279704 [ iOS wk2 EWS ] 5x fast/events/iOS/* are false positive on EWS.
-fast/events/ios/keyboard-scrolling-distance.html [ Failure Timeout ]
-# [ Release ] fast/events/ios/keydown-keyup-arrow-keys-in-non-editable-element.html [ Pass Timeout ]
-# [ Release ] fast/events/ios/keydown-keyup-in-non-editable-content.html [ Pass Timeout ]
-# [ Release ] fast/events/ios/keydown-keyup-special-keys-in-non-editable-element.html [ Pass Timeout ]
-# [ Release ] fast/events/ios/tab-cycle.html [ Pass Timeout ]
-
 # webkit.org/b/279321 [Navigation] scroll API behaves differently on iOS
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-basic.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-change-history-scroll-restoration-during-promise.html [ Failure ]
@@ -7640,17 +7633,6 @@ webkit.org/b/284595 imported/w3c/web-platform-tests/css/css-grid/masonry/tentati
 # webkit.org/b/284096 (REGRESSION (286687@main): [ iOS ] 2 imported scroll-animations tests are consistently failing.)
 imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-responsiveness-from-endpoint.html [ Pass Failure ]
 imported/w3c/web-platform-tests/scroll-animations/view-timelines/fieldset-source.html [ Failure ]
-
-# webkit.org/b/284381 (REGRESSION (iOS 18): 8 fast/events/ios layout tests are constantly timing out.)
-# When resolved, uncomment expectations added in webkit.org/b/279704 above.
-fast/events/ios/key-events-comprehensive/key-events-meta-control.html [ Skip ]
-fast/events/ios/key-events-comprehensive/key-events-meta-option.html [ Skip ]
-fast/events/ios/key-events-comprehensive/key-events-meta-shift.html [ Skip ]
-fast/events/ios/key-events-comprehensive/key-events-option-shift.html [ Skip ]
-fast/events/ios/keydown-keyup-arrow-keys-in-non-editable-element.html [ Skip ]
-fast/events/ios/keydown-keyup-in-non-editable-content.html [ Skip ]
-fast/events/ios/keydown-keyup-special-keys-in-non-editable-element.html [ Skip ]
-fast/events/ios/tab-cycle.html [ Skip ]
 
 webkit.org/b/284419 imported/w3c/web-platform-tests/html/rendering/the-details-element/details-pseudo-elements-006.html [ Failure ]
 


### PR DESCRIPTION
#### 1c7bd44a4a92b266c8ae7f0c35bc33f9ab5862ba
<pre>
9x fast/events/iOS/* are flaky timeouts on EWS
<a href="https://bugs.webkit.org/show_bug.cgi?id=279704">https://bugs.webkit.org/show_bug.cgi?id=279704</a>
<a href="https://rdar.apple.com/136982012">rdar://136982012</a>

Reviewed by Abrar Rahman Protyasha and Tim Horton.

9 layout tests are currently failing on iOS since the tests rely on key events
being received without an editable-element focused. The failures were caused by
collisions with UIKit&apos;s usage of `+isInHardwareKeyboardMode` as discussed in
<a href="https://commits.webkit.org/283793@main">https://commits.webkit.org/283793@main</a>, which prevented the WebKit content view
from receiving key events. Each of these tests have been updated to set test
option &apos;useHardwareKeyboardMode&apos; to true so that `+isInHardwareKeyboardMode`
returns YES, allowing the content view to once again receive the key events for
these tests. The TestExpectations have been updated accordingly.

* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-control.html:
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-option.html:
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-shift.html:
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-option-shift.html:
* LayoutTests/fast/events/ios/keyboard-scrolling-distance.html:
* LayoutTests/fast/events/ios/keydown-keyup-arrow-keys-in-non-editable-element.html:
* LayoutTests/fast/events/ios/keydown-keyup-in-non-editable-content.html:
* LayoutTests/fast/events/ios/keydown-keyup-special-keys-in-non-editable-element.html:
* LayoutTests/fast/events/ios/tab-cycle.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/288917@main">https://commits.webkit.org/288917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/300198720c7c12e80afe180a83e75e41fe5a3e9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89928 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35841 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12489 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65977 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/23799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46251 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31270 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34915 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91304 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12128 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74455 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12355 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73580 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18200 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17962 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16405 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3576 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12080 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11914 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13660 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->