### PR TITLE
Simplify Element attributes iteration logic by leveraging std::span

### DIFF
--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -622,7 +622,7 @@ static bool anyAttributeMatches(const Element& element, const CSSSelector& selec
 {
     ASSERT(element.hasAttributesWithoutUpdate());
     bool isHTML = element.isHTMLElement() && element.document().isHTMLDocument();
-    for (const Attribute& attribute : element.attributesIterator()) {
+    for (auto& attribute : element.attributes()) {
         if (!attribute.matches(selectorAttr.prefix(), isHTML ? selectorAttr.localNameLowercase() : selectorAttr.localName(), selectorAttr.namespaceURI()))
             continue;
 

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -61,7 +61,7 @@ void SelectorFilter::collectElementIdentifierHashes(const Element& element, Vect
     }
     
     if (element.hasAttributesWithoutUpdate()) {
-        for (auto& attribute : element.attributesIterator()) {
+        for (auto& attribute : element.attributes()) {
             auto attributeName = element.isHTMLElement() ? attribute.localName() : attribute.localNameLowercase();
             if (isExcludedAttribute(attributeName))
                 continue;

--- a/Source/WebCore/dom/CustomElementReactionQueue.cpp
+++ b/Source/WebCore/dom/CustomElementReactionQueue.cpp
@@ -271,7 +271,7 @@ void CustomElementReactionQueue::enqueuePostUpgradeReactions(Element& element)
     auto& queue = *element.reactionQueue();
 
     if (element.hasAttributes()) {
-        for (auto& attribute : element.attributesIterator()) {
+        for (auto& attribute : element.attributes()) {
             if (queue.m_interface->observesAttribute(attribute.localName()))
                 queue.m_items.append({ Item::Type::AttributeChanged, std::make_tuple(attribute.name(), nullAtom(), attribute.value()) });
         }

--- a/Source/WebCore/dom/DatasetDOMStringMap.cpp
+++ b/Source/WebCore/dom/DatasetDOMStringMap.cpp
@@ -131,15 +131,15 @@ bool DatasetDOMStringMap::isSupportedPropertyName(const String& propertyName) co
     if (!element->hasAttributes())
         return false;
 
-    auto attributeIteratorAccessor = element->attributesIterator();
-    if (attributeIteratorAccessor.attributeCount() == 1) {
+    auto attributes = element->attributes();
+    if (attributes.size() == 1) {
         // Avoid creating AtomString when there is only one attribute.
-        const auto& attribute = *attributeIteratorAccessor.begin();
+        auto& attribute = attributes[0];
         if (convertAttributeNameToPropertyName(attribute.localName()) == propertyName)
             return true;
     } else {
         auto attributeName = convertPropertyNameToAttributeName(propertyName);
-        for (const Attribute& attribute : attributeIteratorAccessor) {
+        for (auto& attribute : attributes) {
             if (attribute.localName() == attributeName)
                 return true;
         }
@@ -156,7 +156,7 @@ Vector<String> DatasetDOMStringMap::supportedPropertyNames() const
     if (!element->hasAttributes())
         return names;
 
-    for (auto& attribute : element->attributesIterator()) {
+    for (auto& attribute : element->attributes()) {
         if (isValidAttributeName(attribute.localName()))
             names.append(convertAttributeNameToPropertyName(attribute.localName()));
     }
@@ -168,16 +168,16 @@ const AtomString* DatasetDOMStringMap::item(const String& propertyName) const
 {
     Ref element = m_element.get();
     if (element->hasAttributes()) {
-        AttributeIteratorAccessor attributeIteratorAccessor = element->attributesIterator();
+        auto attributes = element->attributes();
 
-        if (attributeIteratorAccessor.attributeCount() == 1) {
+        if (attributes.size() == 1) {
             // Avoid creating AtomString when there is only one attribute.
-            const Attribute& attribute = *attributeIteratorAccessor.begin();
+            auto& attribute = attributes[0];
             if (convertAttributeNameToPropertyName(attribute.localName()) == propertyName)
                 return &attribute.value();
         } else {
             AtomString attributeName = convertPropertyNameToAttributeName(propertyName);
-            for (const Attribute& attribute : attributeIteratorAccessor) {
+            for (auto& attribute : attributes) {
                 if (attribute.localName() == attributeName)
                     return &attribute.value();
             }

--- a/Source/WebCore/dom/DocumentSharedObjectPool.cpp
+++ b/Source/WebCore/dom/DocumentSharedObjectPool.cpp
@@ -39,14 +39,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(DocumentSharedObjectPool);
 struct DocumentSharedObjectPool::ShareableElementDataHash {
     static unsigned hash(const Ref<ShareableElementData>& data)
     {
-        return computeHash(data->span());
+        return computeHash(data->attributes());
     }
     static bool equal(const Ref<ShareableElementData>& a, const Ref<ShareableElementData>& b)
     {
         // We need to disable type checking because std::has_unique_object_representations_v<Attribute>
         // return false. Attribute contains pointers but memcmp() is safe because those pointers were
         // atomized.
-        return equalSpans<WTF::IgnoreTypeChecks::Yes>(a->span(), b->span());
+        return equalSpans<WTF::IgnoreTypeChecks::Yes>(a->attributes(), b->attributes());
     }
     static constexpr bool safeToCompareToEmptyOrDeleted = false;
 };
@@ -62,7 +62,7 @@ struct AttributeSpanTranslator {
         // We need to disable type checking because std::has_unique_object_representations_v<Attribute>
         // return false. Attribute contains pointers but memcmp() is safe because those pointers were
         // atomized.
-        return equalSpans<WTF::IgnoreTypeChecks::Yes>(a->span(), b);
+        return equalSpans<WTF::IgnoreTypeChecks::Yes>(a->attributes(), b);
     }
 
     static void translate(Ref<ShareableElementData>& location, std::span<const Attribute> attributes, unsigned /*hash*/)

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -360,7 +360,7 @@ bool Element::isNonceable() const
         static constexpr auto scriptString = "<script"_s;
         static constexpr auto styleString = "<style"_s;
 
-        for (const auto& attribute : attributesIterator()) {
+        for (auto& attribute : attributes()) {
             auto name = attribute.localNameLowercase();
             auto value = attribute.value().convertToASCIILowercase();
             if (name.contains(scriptString)
@@ -703,7 +703,7 @@ void Element::setBooleanAttribute(const QualifiedName& name, bool value)
         removeAttribute(name);
 }
 
-NamedNodeMap& Element::attributes() const
+NamedNodeMap& Element::attributesMap() const
 {
     ElementRareData& rareData = const_cast<Element*>(this)->ensureElementRareData();
     if (NamedNodeMap* attributeMap = rareData.attributeMap())
@@ -805,7 +805,7 @@ Vector<String> Element::getAttributeNames() const
     if (!hasAttributes())
         return { };
 
-    auto attributes = attributesIterator();
+    auto attributes = this->attributes();
     return WTF::map(attributes, [](auto& attribute) {
         return attribute.name().toString();
     });
@@ -5343,7 +5343,7 @@ void Element::detachAllAttrNodesFromElement()
     auto* attrNodeList = attrNodeListForElement(*this);
     ASSERT(attrNodeList);
 
-    for (const Attribute& attribute : attributesIterator()) {
+    for (auto& attribute : attributes()) {
         if (RefPtr<Attr> attrNode = findAttrNodeInList(*attrNodeList, attribute.name()))
             attrNode->detachFromElementWithValue(attribute.value());
     }
@@ -5500,7 +5500,7 @@ void Element::cloneAttributesFromElement(const Element& other)
         inputElement->initializeInputTypeAfterParsingOrCloning();
     }
 
-    for (const Attribute& attribute : attributesIterator())
+    for (auto& attribute : attributes())
         notifyAttributeChanged(attribute.name(), nullAtom(), attribute.value(), AttributeModificationReason::ByCloning);
 
     setNonce(other.nonce());

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -243,7 +243,7 @@ public:
 
     // Internal methods that assume the existence of attribute storage, one should use hasAttributes()
     // before calling them.
-    inline AttributeIteratorAccessor attributesIterator() const;
+    inline std::span<const Attribute> attributes() const;
     inline unsigned attributeCount() const;
     inline const Attribute& attributeAt(unsigned index) const;
     inline const Attribute* findAttributeByName(const QualifiedName&) const;
@@ -356,7 +356,7 @@ public:
     WEBCORE_EXPORT void setBooleanAttribute(const QualifiedName& name, bool);
 
     // For exposing to DOM only.
-    WEBCORE_EXPORT NamedNodeMap& attributes() const;
+    WEBCORE_EXPORT NamedNodeMap& attributesMap() const;
 
     enum class AttributeModificationReason : uint8_t { Directly, ByCloning, Parser };
     // This function is called whenever an attribute is added, changed or removed.

--- a/Source/WebCore/dom/Element.idl
+++ b/Source/WebCore/dom/Element.idl
@@ -38,7 +38,7 @@
     [SameObject, PutForwards=value] readonly attribute DOMTokenList part;
 
     [DOMJIT=ReadDOM] boolean hasAttributes();
-    [SameObject] readonly attribute NamedNodeMap attributes;
+    [SameObject, ImplementedAs=attributesMap] readonly attribute NamedNodeMap attributes;
     sequence<DOMString> getAttributeNames();
     [DOMJIT=ReadDOM, ImplementedAs=getAttributeForBindings] DOMString? getAttribute([AtomString] DOMString qualifiedName);
     [ImplementedAs=getAttributeNSForBindings] DOMString? getAttributeNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString localName);

--- a/Source/WebCore/dom/ElementData.cpp
+++ b/Source/WebCore/dom/ElementData.cpp
@@ -85,13 +85,13 @@ Ref<UniqueElementData> UniqueElementData::create()
 ShareableElementData::ShareableElementData(std::span<const Attribute> attributes)
     : ElementData(attributes.size())
 {
-    for (auto [sourceAttribute, destinationAttribute] : zippedRange(attributes, span()))
+    for (auto [sourceAttribute, destinationAttribute] : zippedRange(attributes, this->attributes()))
         new (NotNull, &destinationAttribute) Attribute(sourceAttribute);
 }
 
 ShareableElementData::~ShareableElementData()
 {
-    for (auto& attribute : span())
+    for (auto& attribute : attributes())
         attribute.~Attribute();
 }
 
@@ -105,7 +105,7 @@ ShareableElementData::ShareableElementData(const UniqueElementData& other)
         m_inlineStyle = other.m_inlineStyle->immutableCopyIfNeeded();
     }
 
-    for (auto [sourceAttribute, destinationAttribute] : zippedRange(other.m_attributeVector.span(), span()))
+    for (auto [sourceAttribute, destinationAttribute] : zippedRange(other.m_attributeVector.span(), attributes()))
         new (NotNull, &destinationAttribute) Attribute(sourceAttribute);
 }
 
@@ -170,8 +170,8 @@ bool ElementData::isEquivalent(const ElementData* other) const
     if (length() != other->length())
         return false;
 
-    for (const Attribute& attribute : attributesIterator()) {
-        const Attribute* otherAttr = other->findAttributeByName(attribute.name());
+    for (auto& attribute : attributes()) {
+        auto* otherAttr = other->findAttributeByName(attribute.name());
         if (!otherAttr || attribute.value() != otherAttr->value())
             return false;
     }

--- a/Source/WebCore/dom/ElementInlines.h
+++ b/Source/WebCore/dom/ElementInlines.h
@@ -35,9 +35,9 @@
 
 namespace WebCore {
 
-inline AttributeIteratorAccessor Element::attributesIterator() const
+inline std::span<const Attribute> Element::attributes() const
 {
-    return elementData()->attributesIterator();
+    return elementData()->attributes();
 }
 
 inline unsigned Element::findAttributeIndexByName(const QualifiedName& name) const
@@ -56,10 +56,10 @@ inline bool Node::hasAttributes() const
     return element && element->hasAttributes();
 }
 
-inline NamedNodeMap* Node::attributes() const
+inline NamedNodeMap* Node::attributesMap() const
 {
     if (auto* element = dynamicDowncast<Element>(*this))
-        return &element->attributes();
+        return &element->attributesMap();
     return nullptr;
 }
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1650,7 +1650,7 @@ static const AtomString& locateDefaultNamespace(const Node& node, const AtomStri
             return namespaceURI;
 
         if (element.hasAttributes()) {
-            for (auto& attribute : element.attributesIterator()) {
+            for (auto& attribute : element.attributes()) {
                 if (attribute.namespaceURI() != XMLNSNames::xmlnsNamespaceURI)
                     continue;
 
@@ -1702,7 +1702,7 @@ static const AtomString& locateNamespacePrefix(const Element& element, const Ato
         return element.prefix();
 
     if (element.hasAttributes()) {
-        for (auto& attribute : element.attributesIterator()) {
+        for (auto& attribute : element.attributes()) {
             if (attribute.prefix() == xmlnsAtom() && attribute.value() == namespaceURI)
                 return attribute.localName();
         }
@@ -1870,7 +1870,7 @@ unsigned short Node::compareDocumentPosition(Node& otherNode)
         // We are comparing two attributes on the same node. Crawl our attribute map and see which one we hit first.
         Element* owner1 = attr1->ownerElement();
         owner1->synchronizeAllAttributes();
-        for (const Attribute& attribute : owner1->attributesIterator()) {
+        for (auto& attribute : owner1->attributes()) {
             // If neither of the two determining nodes is a child node and nodeType is the same for both determining nodes, then an
             // implementation-dependent order between the determining nodes is returned. This order is stable as long as no nodes of
             // the same nodeType are inserted into or removed from the direct container. This would be the case, for example, 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -162,7 +162,7 @@ public:
     inline Node* lastChild() const; // Defined in ContainerNode.h
     inline RefPtr<Node> protectedLastChild() const; // Defined in ContainerNode.h
     inline bool hasAttributes() const;
-    inline NamedNodeMap* attributes() const;
+    inline NamedNodeMap* attributesMap() const;
     Node* pseudoAwareNextSibling() const;
     Node* pseudoAwarePreviousSibling() const;
     Node* pseudoAwareFirstChild() const;

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -444,7 +444,7 @@ ALWAYS_INLINE void SelectorDataList::executeSingleAttributeExactSelectorData(con
 
         bool isHTML = documentIsHTML && element->isHTMLElement();
         const auto& localNameToMatch = isHTML ? localNameLowercase : localName;
-        for (const Attribute& attribute : element->attributesIterator()) {
+        for (auto& attribute : element->attributes()) {
             if (!attribute.matches(prefix, localNameToMatch, namespaceURI))
                 continue;
 

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -335,7 +335,7 @@ void StyledElement::rebuildPresentationalHintStyle()
 {
     bool isSVG = isSVGElement();
     auto style = MutableStyleProperties::create(isSVG ? SVGAttributeMode : HTMLQuirksMode);
-    for (auto& attribute : attributesIterator())
+    for (auto& attribute : attributes())
         collectPresentationalHintsForAttribute(attribute.name(), attribute.value(), style);
     collectExtraStyleForPresentationalHints(style);
 

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -592,7 +592,7 @@ void MarkupAccumulator::appendStartTagWithURLReplacement(StringBuilder& result, 
     Vector<Attribute> attributesToAppendIfURLNotReplaced;
 
     if (element.hasAttributes()) {
-        for (const Attribute& attribute : element.attributesIterator()) {
+        for (auto& attribute : element.attributes()) {
             if (attribute.name() == crossoriginAttr || attribute.name() == integrityAttr) {
                 attributesToAppendIfURLNotReplaced.append(attribute);
                 continue;
@@ -626,7 +626,7 @@ void MarkupAccumulator::appendStartTag(StringBuilder& result, const Element& ele
         appendStartTagWithURLReplacement(result, element, namespaces);
     } else {
         if (element.hasAttributes()) {
-            for (const Attribute& attribute : element.attributesIterator())
+            for (auto& attribute : element.attributes())
                 appendAttribute(result, element, attribute, namespaces);
         }
     }
@@ -861,7 +861,7 @@ static bool isElementExcludedByRule(const MarkupExclusionRule& rule, const Eleme
             }
 
             // FIXME: We might optimize this by using a UncheckedKeyHashMap when there are too many attributes.
-            for (const Attribute& attribute : element.attributesIterator()) {
+            for (auto& attribute : element.attributes()) {
                 if (!equalIgnoringASCIICase(attribute.localName(), attributeLocalName))
                     continue;
                 if (attributeValue.isNull() || equalIgnoringASCIICase(attribute.value(), attributeValue)) {

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -253,7 +253,7 @@ void ReplacementFragment::removeContentsWithSideEffects()
             continue;
         }
         if (element->hasAttributes()) {
-            for (auto& attribute : element->attributesIterator()) {
+            for (auto& attribute : element->attributes()) {
                 if (element->isEventHandlerAttribute(attribute) || element->attributeContainsJavaScriptURL(attribute))
                     attributesToRemove.append({ element.copyRef(), attribute.name() });
             }

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -516,7 +516,7 @@ void TextManipulationController::observeParagraphs(const Position& start, const 
                 addItem(ManipulationItemData { Position(), Position(), *currentElement, nullQName(), { TextManipulationToken { TextManipulationTokenIdentifier::generate(), currentElement->textContent(), tokenInfo(currentElement.get()) } } });
 
             if (currentElement->hasAttributes()) {
-                for (auto& attribute : currentElement->attributesIterator()) {
+                for (auto& attribute : currentElement->attributes()) {
                     if (isAttributeForTextManipulation(attribute.name()))
                         addItem(ManipulationItemData { Position(), Position(), *currentElement, attribute.name(), { TextManipulationToken { TextManipulationTokenIdentifier::generate(), attribute.value(), tokenInfo(currentElement.get()) } } });
                 }

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -357,7 +357,7 @@ static void maybeCopyNodeAttributesToFragment(const Node& node, DocumentFragment
     if (oldElement->localName() != newElement->localName())
         return;
 
-    for (auto& attribute : oldElement->attributesIterator()) {
+    for (auto& attribute : oldElement->attributes()) {
         if (newElement->hasAttribute(attribute.name()))
             continue;
         newElement->setAttribute(attribute.name(), attribute.value());

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -139,7 +139,7 @@ static void completeURLs(DocumentFragment* fragment, const String& baseURL)
     for (Ref element : descendantsOfType<Element>(*fragment)) {
         if (!element->hasAttributes())
             continue;
-        for (const Attribute& attribute : element->attributesIterator()) {
+        for (auto& attribute : element->attributes()) {
             if (element->attributeContainsURL(attribute) && !attribute.value().isEmpty())
                 changes.append(AttributeChange(element.copyRef(), QualifiedName { attribute.name() }, AtomString { element->completeURLsInAttributeValue(parsedBaseURL, attribute) }));
         }
@@ -155,7 +155,7 @@ void replaceSubresourceURLs(Ref<DocumentFragment>&& fragment, UncheckedKeyHashMa
     for (Ref element : descendantsOfType<Element>(fragment)) {
         if (!element->hasAttributes())
             continue;
-        for (const Attribute& attribute : element->attributesIterator()) {
+        for (auto& attribute : element->attributes()) {
             // FIXME: This won't work for srcset.
             if (element->attributeContainsURL(attribute) && !attribute.value().isEmpty()) {
                 auto replacement = replacementMap.get(attribute.value());
@@ -179,7 +179,7 @@ void removeSubresourceURLAttributes(Ref<DocumentFragment>&& fragment, Function<b
     for (Ref element : descendantsOfType<Element>(fragment)) {
         if (!element->hasAttributes())
             continue;
-        for (const Attribute& attribute : element->attributesIterator()) {
+        for (auto& attribute : element->attributes()) {
             // FIXME: This won't work for srcset.
             if (element->attributeContainsURL(attribute) && !attribute.value().isEmpty()) {
                 if (shouldRemoveURL(URL { attribute.value() }))
@@ -663,7 +663,7 @@ void StyledMarkupAccumulator::appendStartTag(StringBuilder& out, const Element& 
     const bool shouldAnnotateOrForceInline = element.isHTMLElement() && (shouldAnnotate() || addDisplayInline);
     bool shouldOverrideStyleAttr = (shouldAnnotateOrForceInline || shouldApplyWrappingStyle(element) || replacementType != SpanReplacementType::None) && !shouldPreserveMSOListStyleForElement(element);
     if (element.hasAttributes()) {
-        for (const Attribute& attribute : element.attributesIterator()) {
+        for (auto& attribute : element.attributes()) {
             // We'll handle the style attribute separately, below.
             if (attribute.name() == styleAttr && shouldOverrideStyleAttr)
                 continue;

--- a/Source/WebCore/html/HTMLEmbedElement.cpp
+++ b/Source/WebCore/html/HTMLEmbedElement.cpp
@@ -130,7 +130,7 @@ void HTMLEmbedElement::parametersForPlugin(Vector<AtomString>& paramNames, Vecto
     if (!hasAttributes())
         return;
 
-    for (const Attribute& attribute : attributesIterator()) {
+    for (auto& attribute : attributes()) {
         paramNames.append(attribute.localName());
         paramValues.append(attribute.value());
     }

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -159,7 +159,7 @@ static void mapDataParamToSrc(Vector<AtomString>& paramNames, Vector<AtomString>
 void HTMLObjectElement::parametersForPlugin(Vector<AtomString>& paramNames, Vector<AtomString>& paramValues)
 {
     if (hasAttributes()) {
-        for (const Attribute& attribute : attributesIterator()) {
+        for (auto& attribute : attributes()) {
             paramNames.append(attribute.name().localName());
             paramValues.append(attribute.value());
         }

--- a/Source/WebCore/html/LinkIconCollector.cpp
+++ b/Source/WebCore/html/LinkIconCollector.cpp
@@ -102,8 +102,8 @@ auto LinkIconCollector::iconsOfTypes(OptionSet<LinkIconType> iconTypes) -> Vecto
 
         Vector<std::pair<String, String>> attributes;
         if (linkElement.hasAttributes()) {
-            auto attributesAccessor = linkElement.attributesIterator();
-            attributes = WTF::map(attributesAccessor, [](auto& attribute) -> std::pair<String, String> {
+            auto linkAttributes = linkElement.attributes();
+            attributes = WTF::map(linkAttributes, [](auto& attribute) -> std::pair<String, String> {
                 return { attribute.localName(), attribute.value() };
             });
         }

--- a/Source/WebCore/inspector/DOMPatchSupport.cpp
+++ b/Source/WebCore/inspector/DOMPatchSupport.cpp
@@ -190,7 +190,7 @@ ExceptionOr<void> DOMPatchSupport::innerPatchNode(Digest& oldDigest, Digest& new
 
         // FIXME: Create a function in Element for copying properties. cloneDataFromElement() is close but not enough for this case.
         if (newElement.hasAttributesWithoutUpdate()) {
-            for (auto& attribute : newElement.attributesIterator()) {
+            for (auto& attribute : newElement.attributes()) {
                 auto result = m_domEditor.setAttribute(oldElement, attribute.name().localName(), attribute.value());
                 if (result.hasException())
                     return result.releaseException();
@@ -424,7 +424,7 @@ std::unique_ptr<DOMPatchSupport::Digest> DOMPatchSupport::createDigest(Node& nod
 
         if (element.hasAttributesWithoutUpdate()) {
             SHA1 attrsSHA1;
-            for (auto& attribute : element.attributesIterator()) {
+            for (auto& attribute : element.attributes()) {
                 addStringToSHA1(attrsSHA1, attribute.name().toString());
                 addStringToSHA1(attrsSHA1, attribute.value());
             }

--- a/Source/WebCore/inspector/InspectorNodeFinder.cpp
+++ b/Source/WebCore/inspector/InspectorNodeFinder.cpp
@@ -149,7 +149,7 @@ bool InspectorNodeFinder::matchesElement(const Element& element)
     if (!element.hasAttributes())
         return false;
 
-    for (const Attribute& attribute : element.attributesIterator()) {
+    for (auto& attribute : element.attributes()) {
         if (matchesAttribute(attribute))
             return true;
     }

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -813,7 +813,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setAttributesAsText(
     }
 
     bool foundOriginalAttribute = false;
-    for (const Attribute& attribute : childElement->attributesIterator()) {
+    for (auto& attribute : childElement->attributes()) {
         // Add attribute pair
         auto attributeName = attribute.name().toAtomString();
         foundOriginalAttribute = foundOriginalAttribute || attributeName == name;
@@ -2032,7 +2032,7 @@ Ref<JSON::ArrayOf<String>> InspectorDOMAgent::buildArrayForElementAttributes(Ele
     // Go through all attributes and serialize them.
     if (!element->hasAttributes())
         return attributesValue;
-    for (const Attribute& attribute : element->attributesIterator()) {
+    for (auto& attribute : element->attributes()) {
         // Add attribute pair
         attributesValue->addItem(attribute.name().toString());
         attributesValue->addItem(attribute.value());

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -261,7 +261,7 @@ static inline String computeTagAndAttributeSelector(const Element& element, cons
     static constexpr auto maximumValueLengthForExactMatch = 60;
 
     Vector<std::pair<String, String>> attributesToCheck;
-    auto& attributes = element.attributes();
+    auto& attributes = element.attributesMap();
     attributesToCheck.reserveInitialCapacity(attributes.length());
     for (unsigned i = 0; i < attributes.length(); ++i) {
         RefPtr attribute = attributes.item(i);

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -74,7 +74,7 @@ static bool isCharsetSpecifyingNode(const HTMLMetaElement& element)
     if (!element.hasAttributes())
         return false;
     Vector<std::pair<StringView, StringView>> attributes;
-    for (auto& attribute : element.attributesIterator()) {
+    for (auto& attribute : element.attributes()) {
         if (attribute.name().hasPrefix())
             continue;
         attributes.append({ StringView { attribute.name().localName() }, StringView { attribute.value() } });

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -904,7 +904,7 @@ static bool isKinjaLoginAvatarElement(const Element& element)
         svgElement = element.parentElement();
 
     if (svgElement && svgElement->hasAttributes()) {
-        auto ariaLabelAttr = svgElement->attributes().getNamedItem("aria-label"_s);
+        auto ariaLabelAttr = svgElement->attributesMap().getNamedItem("aria-label"_s);
         if (ariaLabelAttr && ariaLabelAttr->value() == "UserFilled icon"_s)
             return true;
     }

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -213,7 +213,7 @@ void ElementRuleCollector::collectMatchingRules(const MatchRequest& matchRequest
     }
     if (element.hasAttributesWithoutUpdate() && matchRequest.ruleSet.hasAttributeRules()) {
         Vector<const RuleSet::RuleDataVector*, 4> ruleVectors;
-        for (auto& attribute : element.attributesIterator()) {
+        for (auto& attribute : element.attributes()) {
             if (auto* rules = matchRequest.ruleSet.attributeRules(attribute.localName(), isHTML))
                 ruleVectors.append(rules);
         }

--- a/Source/WebCore/xml/XPathNodeSet.cpp
+++ b/Source/WebCore/xml/XPathNodeSet.cpp
@@ -219,7 +219,7 @@ void NodeSet::traversalSort() const
         if (!element || !element->hasAttributes())
             continue;
 
-        for (const Attribute& attribute : element->attributesIterator()) {
+        for (auto& attribute : element->attributes()) {
             RefPtr attr = element->attrIfExists(attribute.name());
             if (attr && nodes.contains(attr.get()))
                 sortedNodes.append(attr);

--- a/Source/WebCore/xml/XPathStep.cpp
+++ b/Source/WebCore/xml/XPathStep.cpp
@@ -375,7 +375,7 @@ void Step::nodesInAxis(Node& context, NodeSet& nodes) const
             if (!contextElement->hasAttributes())
                 return;
 
-            for (const Attribute& attribute : contextElement->attributesIterator()) {
+            for (auto& attribute : contextElement->attributes()) {
                 auto attr = contextElement->ensureAttr(attribute.name());
                 if (nodeMatches(attr.get(), AttributeAxis, m_nodeTest))
                     nodes.append(WTFMove(attr));

--- a/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -276,7 +276,7 @@ static XMLParsingNamespaces findXMLParsingNamespaces(Element* contextElement)
     for (auto& element : lineageOfType<Element>(*contextElement)) {
         if (!element.hasAttributes())
             continue;
-        for (auto& attribute : element.attributesIterator()) {
+        for (auto& attribute : element.attributes()) {
             if (attribute.prefix() == xmlnsAtom())
                 result.prefixNamespaces.set(attribute.localName(), attribute.value());
         }

--- a/Source/WebKitLegacy/mac/DOM/DOMNode.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMNode.mm
@@ -176,7 +176,7 @@ DOMNode *kit(Node* value)
 - (DOMNamedNodeMap *)attributes
 {
     JSMainThreadNullState state;
-    return kit(unwrap(*self).attributes());
+    return kit(unwrap(*self).attributesMap());
 }
 
 - (NSString *)baseURI


### PR DESCRIPTION
#### a7dabfb4de43edd4cbaec8092ed5db4147a78aef
<pre>
Simplify Element attributes iteration logic by leveraging std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=285970">https://bugs.webkit.org/show_bug.cgi?id=285970</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::anyAttributeMatches):
* Source/WebCore/css/SelectorFilter.cpp:
(WebCore::SelectorFilter::collectElementIdentifierHashes):
* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementReactionQueue::enqueuePostUpgradeReactions):
* Source/WebCore/dom/DatasetDOMStringMap.cpp:
(WebCore::DatasetDOMStringMap::isSupportedPropertyName const):
(WebCore::DatasetDOMStringMap::supportedPropertyNames const):
(WebCore::DatasetDOMStringMap::item const):
* Source/WebCore/dom/DocumentSharedObjectPool.cpp:
(WebCore::DocumentSharedObjectPool::ShareableElementDataHash::hash):
(WebCore::DocumentSharedObjectPool::ShareableElementDataHash::equal):
(WebCore::AttributeSpanTranslator::equal):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isNonceable const):
(WebCore::Element::attributesMap const):
(WebCore::Element::getAttributeNames const):
(WebCore::Element::detachAllAttrNodesFromElement):
(WebCore::Element::cloneAttributesFromElement):
(WebCore::Element::attributes const): Deleted.
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Element.idl:
* Source/WebCore/dom/ElementData.cpp:
(WebCore::ShareableElementData::ShareableElementData):
(WebCore::ShareableElementData::~ShareableElementData):
(WebCore::ElementData::isEquivalent const):
* Source/WebCore/dom/ElementData.h:
(WebCore::ShareableElementData::attributes):
(WebCore::ShareableElementData::attributes const):
(WebCore::UniqueElementData::attributes const):
(WebCore::ElementData::attributes const):
(WebCore::AttributeConstIterator::AttributeConstIterator): Deleted.
(WebCore::AttributeConstIterator::operator* const): Deleted.
(WebCore::AttributeConstIterator::operator-&gt; const): Deleted.
(WebCore::AttributeConstIterator::operator++): Deleted.
(WebCore::AttributeConstIterator::operator--): Deleted.
(WebCore::AttributeConstIterator::operator== const): Deleted.
(WebCore::AttributeIteratorAccessor::AttributeIteratorAccessor): Deleted.
(WebCore::AttributeIteratorAccessor::begin const): Deleted.
(WebCore::AttributeIteratorAccessor::end const): Deleted.
(WebCore::AttributeIteratorAccessor::size const): Deleted.
(WebCore::AttributeIteratorAccessor::attributeCount const): Deleted.
(WebCore::ShareableElementData::span): Deleted.
(WebCore::ShareableElementData::span const): Deleted.
(WebCore::ElementData::attributesIterator const): Deleted.
* Source/WebCore/dom/ElementInlines.h:
(WebCore::Element::attributes const):
(WebCore::Node::attributesMap const):
(WebCore::Element::attributesIterator const): Deleted.
(WebCore::Node::attributes const): Deleted.
* Source/WebCore/dom/Node.cpp:
(WebCore::locateDefaultNamespace):
(WebCore::locateNamespacePrefix):
(WebCore::Node::compareDocumentPosition):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorDataList::executeSingleAttributeExactSelectorData const):
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::rebuildPresentationalHintStyle):
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::appendStartTagWithURLReplacement):
(WebCore::MarkupAccumulator::appendStartTag):
(WebCore::isElementExcludedByRule):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplacementFragment::removeContentsWithSideEffects):
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::TextManipulationController::observeParagraphs):
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::maybeCopyNodeAttributesToFragment):
* Source/WebCore/editing/markup.cpp:
(WebCore::completeURLs):
(WebCore::replaceSubresourceURLs):
(WebCore::removeSubresourceURLAttributes):
(WebCore::StyledMarkupAccumulator::appendStartTag):
* Source/WebCore/html/HTMLEmbedElement.cpp:
(WebCore::HTMLEmbedElement::parametersForPlugin):
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::parametersForPlugin):
* Source/WebCore/html/LinkIconCollector.cpp:
(WebCore::LinkIconCollector::iconsOfTypes):
* Source/WebCore/inspector/DOMPatchSupport.cpp:
(WebCore::DOMPatchSupport::innerPatchNode):
(WebCore::DOMPatchSupport::createDigest):
* Source/WebCore/inspector/InspectorNodeFinder.cpp:
(WebCore::InspectorNodeFinder::matchesElement):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::setAttributesAsText):
(WebCore::InspectorDOMAgent::buildArrayForElementAttributes):
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::computeTagAndAttributeSelector):
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::isCharsetSpecifyingNode):
* Source/WebCore/page/Quirks.cpp:
(WebCore::isKinjaLoginAvatarElement):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRules):
* Source/WebCore/xml/XPathNodeSet.cpp:
(WebCore::XPath::NodeSet::traversalSort const):
* Source/WebCore/xml/XPathStep.cpp:
(WebCore::XPath::Step::nodesInAxis const):
* Source/WebCore/xml/parser/XMLDocumentParser.cpp:
(WebCore::findXMLParsingNamespaces):
* Source/WebKitLegacy/mac/DOM/DOMNode.mm:
(-[DOMNode attributes]):

Canonical link: <a href="https://commits.webkit.org/288961@main">https://commits.webkit.org/288961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8396024e51fb5e0184b2bf24f1333d925f4afb5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89930 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35843 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65979 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23803 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3497 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77050 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46254 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3376 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31272 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34917 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74228 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91306 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8853 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74462 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12357 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73587 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17964 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16407 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3578 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13227 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12082 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17522 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11916 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15410 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13662 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->