### PR TITLE
URLPattern canonicalisation of hostname should check for forbidden host code points

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -222,7 +222,7 @@ PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
 PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
 PASS Pattern: ["data\\:foobar"] Inputs: ["data:foobar"]
 PASS Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
@@ -261,9 +261,9 @@ PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
 PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
-FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 PASS Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
-FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]
 FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] assert_equals: compiled pattern property 'pathname' expected "text/javascript,let x = 100/:tens?5;" but got "text/javascript,let%20x%20=%20100/:tens?5;"
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
@@ -276,22 +276,22 @@ PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: [{}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -222,7 +222,7 @@ PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
 PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
 PASS Pattern: ["data\\:foobar"] Inputs: ["data:foobar"]
 PASS Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
@@ -261,9 +261,9 @@ PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
 PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
-FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 PASS Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
-FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]
 FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] assert_equals: compiled pattern property 'pathname' expected "text/javascript,let x = 100/:tens?5;" but got "text/javascript,let%20x%20=%20100/:tens?5;"
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
@@ -276,22 +276,22 @@ PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: [{}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -222,7 +222,7 @@ PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
 PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
 PASS Pattern: ["data\\:foobar"] Inputs: ["data:foobar"]
 PASS Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
@@ -261,9 +261,9 @@ PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
 PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
-FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 PASS Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
-FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]
 FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] assert_equals: compiled pattern property 'pathname' expected "text/javascript,let x = 100/:tens?5;" but got "text/javascript,let%20x%20=%20100/:tens?5;"
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
@@ -276,22 +276,22 @@ PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: [{}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -222,7 +222,7 @@ PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
 PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
 PASS Pattern: ["data\\:foobar"] Inputs: ["data:foobar"]
 PASS Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
@@ -261,9 +261,9 @@ PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
 PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
-FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 PASS Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
-FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]
 FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] assert_equals: compiled pattern property 'pathname' expected "text/javascript,let x = 100/:tens?5;" but got "text/javascript,let%20x%20=%20100/:tens?5;"
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
@@ -276,22 +276,22 @@ PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: [{}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -222,7 +222,7 @@ PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
 PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
 PASS Pattern: ["data\\:foobar"] Inputs: ["data:foobar"]
 PASS Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
@@ -261,9 +261,9 @@ PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
 PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
-FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 PASS Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
-FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]
 FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] assert_equals: compiled pattern property 'pathname' expected "text/javascript,let x = 100/:tens?5;" but got "text/javascript,let%20x%20=%20100/:tens?5;"
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
@@ -276,22 +276,22 @@ PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: [{}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -222,7 +222,7 @@ PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
 PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
 PASS Pattern: ["data\\:foobar"] Inputs: ["data:foobar"]
 PASS Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
@@ -261,9 +261,9 @@ PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
 PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
-FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 PASS Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
-FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]
 FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] assert_equals: compiled pattern property 'pathname' expected "text/javascript,let x = 100/:tens?5;" but got "text/javascript,let%20x%20=%20100/:tens?5;"
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
@@ -276,22 +276,22 @@ PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: [{}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -222,7 +222,7 @@ PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
 PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
 PASS Pattern: ["data\\:foobar"] Inputs: ["data:foobar"]
 PASS Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
@@ -261,9 +261,9 @@ PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
 PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
-FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 PASS Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
-FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]
 FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] assert_equals: compiled pattern property 'pathname' expected "text/javascript,let x = 100/:tens?5;" but got "text/javascript,let%20x%20=%20100/:tens?5;"
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
@@ -276,22 +276,22 @@ PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: [{}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -222,7 +222,7 @@ PASS Pattern: ["https://example.com/"] Inputs: ["https://example.com:8080/"]
 PASS Pattern: ["data:foobar"] Inputs: ["data:foobar"]
 PASS Pattern: ["data\\:foobar"] Inputs: ["data:foobar"]
 PASS Pattern: ["https://{sub.}?example.com/foo"] Inputs: ["https://example.com/foo"]
-FAIL Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["https://{sub.}?example{.com/}foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["{https://}example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example.com/foo"] Inputs: ["https://example.com/foo"]
 PASS Pattern: ["https://(sub.)?example(.com/)foo"] Inputs: ["https://example.com/foo"]
@@ -261,9 +261,9 @@ PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
 PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
 FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
-FAIL Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 PASS Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
-FAIL Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"] assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]
 FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"] assert_equals: compiled pattern property 'pathname' expected "text/javascript,let x = 100/:tens?5;" but got "text/javascript,let%20x%20=%20100/:tens?5;"
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
@@ -276,22 +276,22 @@ PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
-FAIL Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: [{}]

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -320,6 +320,11 @@ static constexpr std::array<uint8_t, 256> characterClassTable {
     QueryEncode, // 0xFF
 };
 
+bool isForbiddenHostCodePoint(UChar character)
+{
+    return character <= 0x7F && characterClassTable[character] & ForbiddenHost;
+}
+
 template<typename CharacterType> ALWAYS_INLINE static bool isC0Control(CharacterType character) { return character <= 0x1F; }
 template<typename CharacterType> ALWAYS_INLINE static bool isC0ControlOrSpace(CharacterType character) { return character <= 0x20; }
 template<typename CharacterType> ALWAYS_INLINE static bool isTabOrNewline(CharacterType character) { return character <= 0xD && character >= 0x9 && character != 0xB && character != 0xC; }
@@ -336,7 +341,7 @@ template<typename CharacterType>
 ALWAYS_INLINE bool URLParser::isForbiddenHostCodePoint(CharacterType character)
 {
     ASSERT(!m_urlIsSpecial);
-    return character <= 0x7F && characterClassTable[character] & ForbiddenHost;
+    return WTF::isForbiddenHostCodePoint(character);
 }
 
 template<typename CharacterType>

--- a/Source/WTF/wtf/URLParser.h
+++ b/Source/WTF/wtf/URLParser.h
@@ -158,4 +158,6 @@ private:
     bool shouldPopPath(unsigned);
 };
 
+WTF_EXPORT_PRIVATE bool isForbiddenHostCodePoint(UChar);
+
 }

--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
@@ -124,6 +124,10 @@ ExceptionOr<String> canonicalizeHostname(StringView value, BaseURLStringType val
     if (valueType == BaseURLStringType::Pattern)
         return value.toString();
 
+    // URL::setHost is not fully validating forbidden host code points, so we do it before, except for IPv6 addresses.
+    if (value[0] != '[' && value.find(WTF::isForbiddenHostCodePoint) != notFound)
+        return Exception { ExceptionCode::TypeError, "Invalid input to canonicalize a URL host string - forbidden code point."_s };
+
     URL dummyURL(dummyURLCharacters);
     dummyURL.setHost(value);
 


### PR DESCRIPTION
#### 048ca0693a470cccab74bd26636b43ff3fa07332
<pre>
URLPattern canonicalisation of hostname should check for forbidden host code points
<a href="https://rdar.apple.com/142950591">rdar://142950591</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=285976">https://bugs.webkit.org/show_bug.cgi?id=285976</a>

Reviewed by Anne van Kesteren.

URLPattern is relying on URL.setHost to validate the hostname.
This is not exactly matching the basic URL parser with hostname state as state override.
In particular, setHost will split based on some forbidden code points like /, # or ?.
To fix this, we add a specific forbidden host code point check in canonicalizeHostname.
We skip these checks for IPv6 hostnames that will need further validation in a follow-up.

Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* Source/WTF/wtf/URLParser.cpp:
(WTF::isForbiddenHostCodePoint):
(WTF::URLParser::isForbiddenHostCodePoint):
* Source/WTF/wtf/URLParser.h:
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp:
(WebCore::canonicalizeHostname):

Canonical link: <a href="https://commits.webkit.org/288927@main">https://commits.webkit.org/288927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e623f8643c48fb6a299ceb661b3dd63ae2e6ca4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89952 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35865 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86898 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12513 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/65997 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23815 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46271 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31288 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34939 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77776 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32097 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91328 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/83855 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12152 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73602 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18206 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17981 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16423 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3600 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12104 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106248 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11938 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25645 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15432 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->