### PR TITLE
URLPattern should validate IPv6 hostnames correctly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -249,18 +249,18 @@ PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 PASS Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"]
 PASS Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"]
-FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"]
+PASS Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"]
+PASS Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"]
+PASS Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"]
+PASS Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"]
+PASS Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 PASS Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
 PASS Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -249,18 +249,18 @@ PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 PASS Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"]
 PASS Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"]
-FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"]
+PASS Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"]
+PASS Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"]
+PASS Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"]
+PASS Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"]
+PASS Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 PASS Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
 PASS Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -249,18 +249,18 @@ PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 PASS Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"]
 PASS Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"]
-FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"]
+PASS Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"]
+PASS Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"]
+PASS Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"]
+PASS Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"]
+PASS Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 PASS Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
 PASS Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -249,18 +249,18 @@ PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 PASS Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"]
 PASS Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"]
-FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"]
+PASS Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"]
+PASS Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"]
+PASS Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"]
+PASS Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"]
+PASS Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 PASS Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
 PASS Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -249,18 +249,18 @@ PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 PASS Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"]
 PASS Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"]
-FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"]
+PASS Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"]
+PASS Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"]
+PASS Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"]
+PASS Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"]
+PASS Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 PASS Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
 PASS Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -249,18 +249,18 @@ PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 PASS Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"]
 PASS Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"]
-FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"]
+PASS Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"]
+PASS Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"]
+PASS Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"]
+PASS Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"]
+PASS Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 PASS Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
 PASS Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -249,18 +249,18 @@ PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 PASS Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"]
 PASS Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"]
-FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"]
+PASS Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"]
+PASS Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"]
+PASS Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"]
+PASS Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"]
+PASS Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 PASS Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
 PASS Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -249,18 +249,18 @@ PASS Pattern: ["https\\:foo\\:bar@example.com"] Inputs: ["https:foo:bar@example.
 PASS Pattern: ["data\\:foo\\:bar@example.com"] Inputs: ["data:foo:bar@example.com"]
 PASS Pattern: ["https://foo{\\:}bar@example.com"] Inputs: ["https://foo:bar@example.com"]
 PASS Pattern: ["data{\\:}channel.html","https://example.com"] Inputs: ["https://example.com/data:channel.html"]
-FAIL Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"] Invalid input to canonicalize a URL host string.
-FAIL Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: ["http://[\\:\\:1]/"] Inputs: ["http://[::1]/"]
+PASS Pattern: ["http://[\\:\\:1]:8080/"] Inputs: ["http://[::1]:8080/"]
+PASS Pattern: ["http://[\\:\\:a]/"] Inputs: ["http://[::a]/"]
+PASS Pattern: ["http://[:address]/"] Inputs: ["http://[::1]/"]
+PASS Pattern: ["http://[\\:\\:AB\\::num]/"] Inputs: ["http://[::ab:1]/"]
+PASS Pattern: [{"hostname":"[\\:\\:AB\\::num]"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"[\\:\\:xY\\::num]"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\:ab\\::num]}"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"{[\\:\\:fé\\::num]}"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"{[\\:\\::num\\:1]}"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"{[\\:\\::num\\:fé]}"}] Inputs: undefined
-FAIL Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}] Invalid input to canonicalize a URL host string.
+PASS Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}]
 PASS Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 PASS Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
 PASS Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]

--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -55,6 +55,20 @@ static String processBaseURLString(StringView input, BaseURLStringType type)
     return URLPatternUtilities::escapePatternString(input);
 }
 
+// https://urlpattern.spec.whatwg.org/#hostname-pattern-is-an-ipv6-address
+static bool isHostnamePatternIPv6(StringView hostname)
+{
+    if (hostname.length() < 2)
+        return false;
+    if (hostname[0] == '[')
+        return true;
+    if (hostname[0] == '{' && hostname[1] == '[')
+        return true;
+    if (hostname[0] == '\\' && hostname[1] == '[')
+        return true;
+    return false;
+}
+
 URLPattern::URLPattern() = default;
 
 // https://urlpattern.spec.whatwg.org/#process-a-urlpatterninit
@@ -309,7 +323,7 @@ ExceptionOr<void> URLPattern::compileAllComponents(ScriptExecutionContext& conte
         return maybePasswordComponent.releaseException();
     m_passwordComponent = maybePasswordComponent.releaseReturnValue();
 
-    auto hostnameEncodingCallbackType = URL::isIPv6Address(processedInit.hostname) ? EncodingCallbackType::IPv6Host : EncodingCallbackType::Host;
+    auto hostnameEncodingCallbackType = isHostnamePatternIPv6(processedInit.hostname) ? EncodingCallbackType::IPv6Host : EncodingCallbackType::Host;
     auto maybeHostnameComponent = URLPatternUtilities::URLPatternComponent::compile(vm, processedInit.hostname, hostnameEncodingCallbackType, URLPatternUtilities::URLPatternStringOptions { .delimiterCodepoint = "."_s });
     if (maybeHostnameComponent.hasException())
         return maybeHostnameComponent.releaseException();

--- a/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.cpp
@@ -256,7 +256,7 @@ void URLPatternConstructorStringParser::updateState(ScriptExecutionContext& cont
         else if (isNonSpecialPatternChararacter(m_tokenIndex, ']'))
             --m_hostnameIPv6BracketDepth;
         // Look for port prefix.
-        else if (isNonSpecialPatternChararacter(m_tokenIndex, ':'))
+        else if (isNonSpecialPatternChararacter(m_tokenIndex, ':') && !m_hostnameIPv6BracketDepth)
             changeState(URLPatternConstructorStringParserState::Port, 1);
         // Look for pathname start.
         else if (isNonSpecialPatternChararacter(m_tokenIndex, '/'))


### PR DESCRIPTION
#### 452e3815223fdac36e001b2721112dc539b4a00d
<pre>
URLPattern should validate IPv6 hostnames correctly
<a href="https://rdar.apple.com/142950979">rdar://142950979</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=285979">https://bugs.webkit.org/show_bug.cgi?id=285979</a>

Reviewed by Anne van Kesteren.

Fix bug in isInvalidIPv6HostCodePoint (check of valid special code points).
To make it clearer we rename isInvalidIPv6HostCodePoint to isValidIPv6HostCodePoint.

We also remove the use of URL::isIPv6Address in lieu of a routine isHostnamePatternIPv6 that implements <a href="https://urlpattern.spec.whatwg.org/#hostname-pattern-is-an-ipv6-address">https://urlpattern.spec.whatwg.org/#hostname-pattern-is-an-ipv6-address</a> to follow the spec.

We update hostname canonicalization to add a check that the last character of an IPv6 hostname is &apos;]&apos; as per <a href="https://url.spec.whatwg.org/#concept-host-parser.">https://url.spec.whatwg.org/#concept-host-parser.</a>

We update URLPatternConstructorStringParser so that it only checks for non special pattern character outside of IPv6 hostnames.

Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::isHostnamePatternIPv6):
(WebCore::URLPattern::compileAllComponents):
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp:
(WebCore::isValidIPv6HostCodePoint):
(WebCore::canonicalizeHostname):
(WebCore::canonicalizeIPv6Hostname):
(WebCore::isInvalidIPv6HostCodePoint): Deleted.
* Source/WebCore/Modules/url-pattern/URLPatternConstructorStringParser.cpp:
(WebCore::URLPatternConstructorStringParser::updateState):

Canonical link: <a href="https://commits.webkit.org/288931@main">https://commits.webkit.org/288931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb2f71621d5331adc87180c8f2c69d3ece1ed11f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89967 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35880 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86913 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12530 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66012 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23831 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46287 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3409 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31306 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34954 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91343 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12167 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74495 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73621 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18211 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17998 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16440 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3616 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12119 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11953 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15447 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->