### PR TITLE
URLPattern hostname canonicalisation should properly handle non ASCII characters

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -152,8 +152,8 @@ PASS Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}]
 PASS Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
+PASS Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}]
+PASS Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}]
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -152,8 +152,8 @@ PASS Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}]
 PASS Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
+PASS Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}]
+PASS Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}]
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -152,8 +152,8 @@ PASS Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}]
 PASS Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
+PASS Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}]
+PASS Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}]
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -152,8 +152,8 @@ PASS Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}]
 PASS Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
+PASS Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}]
+PASS Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}]
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -152,8 +152,8 @@ PASS Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}]
 PASS Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
+PASS Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}]
+PASS Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}]
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -152,8 +152,8 @@ PASS Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}]
 PASS Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
+PASS Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}]
+PASS Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}]
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -152,8 +152,8 @@ PASS Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}]
 PASS Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
+PASS Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}]
+PASS Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}]
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -152,8 +152,8 @@ PASS Pattern: [{"username":"caf%c3%a9"}] Inputs: [{"username":"café"}]
 PASS Pattern: [{"password":"caf%C3%A9"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
-FAIL Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: test() result expected true but got false
-FAIL Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}] assert_equals: compiled pattern property 'hostname' expected "xn--caf-dma.com" but got "café.com"
+PASS Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}]
+PASS Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}]
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]

--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp
@@ -134,7 +134,7 @@ ExceptionOr<String> canonicalizeHostname(StringView value, BaseURLStringType val
     if (!dummyURL.isValid())
         return Exception { ExceptionCode::TypeError, "Invalid input to canonicalize a URL host string."_s };
 
-    return value.toString();
+    return dummyURL.host().toString();
 }
 
 // https://urlpattern.spec.whatwg.org/#canonicalize-an-ipv6-hostname


### PR DESCRIPTION
#### 8d10e51f3cfaccc8698d74788c31d7930723477d
<pre>
URLPattern hostname canonicalisation should properly handle non ASCII characters
<a href="https://rdar.apple.com/142951274">rdar://142951274</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=285980">https://bugs.webkit.org/show_bug.cgi?id=285980</a>

Reviewed by Anne van Kesteren.

Use the host canonicalized by URL parser instead of the initial given host.

Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp:
(WebCore::canonicalizeHostname):

Canonical link: <a href="https://commits.webkit.org/288929@main">https://commits.webkit.org/288929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81f2575ec814f48eddbdfcde6b51caf299a81286

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89968 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35881 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86914 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12531 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66010 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-ident.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/23833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46285 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/3410 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31308 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34955 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32116 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91344 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12168 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74494 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73620 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18210 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17999 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16442 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3617 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12120 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11954 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15448 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13700 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->