### PR TITLE
URLPattern constructor should check whether baseURL is null

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -268,7 +268,7 @@ FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:tex
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined
 PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -268,7 +268,7 @@ FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:tex
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined
 PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -268,7 +268,7 @@ FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:tex
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined
 PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -268,7 +268,7 @@ FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:tex
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined
 PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -268,7 +268,7 @@ FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:tex
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined
 PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -268,7 +268,7 @@ FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:tex
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined
 PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -268,7 +268,7 @@ FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:tex
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined
 PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -268,7 +268,7 @@ FAIL Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:tex
 PASS Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 PASS Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 PASS Pattern: ["/foo",""] Inputs: undefined
-FAIL Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined assert_throws_js: URLPattern() constructor function "_ => new URLPattern(...entry.pattern)" did not throw
+PASS Pattern: [{"pathname":"/foo"},"https://example.com"] Inputs: undefined
 PASS Pattern: [{"pathname":":name*"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name+"}] Inputs: [{"pathname":"foobar"}]
 PASS Pattern: [{"pathname":":name"}] Inputs: [{"pathname":"foobar"}]

--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -213,8 +213,11 @@ ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context,
         if (baseURL.isNull() && init.protocol.isEmpty())
             return Exception { ExceptionCode::TypeError, "Relative constructor string must have additional baseURL argument."_s };
         init.baseURL = WTFMove(baseURL);
-    } else if (std::holds_alternative<URLPatternInit>(input))
+    } else if (std::holds_alternative<URLPatternInit>(input)) {
+        if (!baseURL.isNull())
+            return Exception { ExceptionCode::TypeError, "Constructor with a URLPatternInit should have a null baseURL argument."_s };
         init = std::get<URLPatternInit>(input);
+    }
 
     auto maybeProcessedInit = processInit(WTFMove(init), BaseURLStringType::Pattern);
 


### PR DESCRIPTION
#### e5d805f75a49444d7b830c6a55b22b3bb7dfacd5
<pre>
URLPattern constructor should check whether baseURL is null
<a href="https://rdar.apple.com/142952397">rdar://142952397</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=285981">https://bugs.webkit.org/show_bug.cgi?id=285981</a>

Reviewed by Anne van Kesteren.

Update implementation to align with <a href="https://urlpattern.spec.whatwg.org/#url-pattern-create">https://urlpattern.spec.whatwg.org/#url-pattern-create</a> step 3.2.

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::URLPattern::create):

Canonical link: <a href="https://commits.webkit.org/288930@main">https://commits.webkit.org/288930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4aa50f327a804adf1f0ef7f9538bd120b09c6e22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89965 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35878 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12528 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66009 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23830 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77084 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46284 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3407 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31307 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34952 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91341 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12165 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74492 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73618 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18209 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/17996 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16441 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3614 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12117 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11951 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15445 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13697 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->