### PR TITLE
[TexMap] Correctly gather damage information for 3D-transformed layers

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -500,8 +500,6 @@ public:
 
     virtual void setContentsNeedsDisplay() { };
 
-    virtual void markDamageRectsUnreliable() { };
-
     // The tile phase is relative to the GraphicsLayer bounds.
     virtual void setContentsTilePhase(const FloatSize& p) { m_contentsTilePhase = p; }
     FloatSize contentsTilePhase() const { return m_contentsTilePhase; }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -287,7 +287,8 @@ private:
 
 #if ENABLE(DAMAGE_TRACKING)
     bool m_damagePropagation { false };
-    Damage m_damage;
+    Damage m_damage; // In layer coordinate space.
+    Damage m_inferredDamage; // In global coordinate space.
     FloatRect m_accumulatedOverlapRegionDamage;
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -865,14 +865,8 @@ void CoordinatedPlatformLayer::flushCompositingState(TextureMapper& textureMappe
         layer.setSolidColor(m_contentsColor);
 
 #if ENABLE(DAMAGE_TRACKING)
-    if (m_pendingChanges.contains(Change::Damage)) {
-        if (m_committedContentsBuffer || (m_imageBackingStore && m_imageBackingStoreVisible)) {
-            // Layers with content layer should have no explicit damage other than inferred one (e.g. due to transform changes).
-            // FIXME: Remove special handling of content layers.
-            layer.setDamage({ });
-        } else
-            layer.setDamage(m_damage);
-    }
+    if (m_pendingChanges.contains(Change::Damage))
+        layer.setDamage(m_damage);
 #endif
 
     if (m_pendingChanges.contains(Change::Filters))

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -111,17 +111,6 @@ void GraphicsLayerCoordinated::setNeedsDisplayInRect(const FloatRect& initialRec
     addRepaintRect(rect);
 }
 
-#if ENABLE(DAMAGE_TRACKING)
-void GraphicsLayerCoordinated::markDamageRectsUnreliable()
-{
-    if (m_damagedRectsAreUnreliable)
-        return;
-
-    m_damagedRectsAreUnreliable = true;
-    noteLayerPropertyChanged(Change::DirtyRegion, ScheduleFlush::No);
-}
-#endif
-
 void GraphicsLayerCoordinated::setPosition(const FloatPoint& position)
 {
     if (m_position == position)
@@ -850,9 +839,7 @@ void GraphicsLayerCoordinated::updateDamage()
         return;
 
     Damage damage;
-    if (m_damagedRectsAreUnreliable)
-        damage.invalidate();
-    else if (m_dirtyRegion.fullRepaint)
+    if (m_dirtyRegion.fullRepaint)
         damage.add(FloatRect({ }, m_size));
     else {
         for (const auto& rect : m_dirtyRegion.rects)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h
@@ -111,9 +111,6 @@ private:
 
     void setNeedsDisplay() override;
     void setNeedsDisplayInRect(const FloatRect&, ShouldClipToLayer = ClipToLayer) override;
-#if ENABLE(DAMAGE_TRACKING)
-    void markDamageRectsUnreliable() override;
-#endif
 
     FloatSize pixelAlignmentOffset() const override { return m_pixelAlignmentOffset; }
 
@@ -217,9 +214,6 @@ private:
     Color m_contentsColor;
     RefPtr<CoordinatedPlatformLayer> m_backdropLayer;
     TextureMapperAnimations m_animations;
-#if ENABLE(DAMAGE_TRACKING)
-    bool m_damagedRectsAreUnreliable { false };
-#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1721,18 +1721,6 @@ void RenderLayerBacking::updateScrollOffset(ScrollOffset scrollOffset)
     ASSERT(m_scrolledContentsLayer->position().isZero());
 }
 
-static bool layerRendererStyleHas3DTransformOperation(RenderLayer& layer)
-{
-    auto* renderer = &layer.renderer();
-    if (layer.isReflection())
-        renderer = downcast<RenderLayerModelObject>(renderer->parent());
-    const RenderStyle& style = renderer->style();
-    return style.transform().has3DOperation()
-        || (style.translate() && style.translate()->is3DOperation())
-        || (style.scale() && style.scale()->is3DOperation())
-        || (style.rotate() && style.rotate()->is3DOperation());
-}
-
 void RenderLayerBacking::updateAfterDescendants()
 {
     // FIXME: this potentially duplicates work we did in updateConfiguration().
@@ -1752,10 +1740,6 @@ void RenderLayerBacking::updateAfterDescendants()
         ASSERT(!m_backgroundLayer);
         m_graphicsLayer->setContentsOpaque(!m_hasSubpixelRounding && m_owningLayer.backgroundIsKnownToBeOpaqueInRect(compositedBounds()));
     }
-
-    if (layerRendererStyleHas3DTransformOperation(m_owningLayer)
-        || m_owningLayer.hasCompositedScrollableOverflow())
-        m_graphicsLayer->markDamageRectsUnreliable();
 
     m_graphicsLayer->setContentsVisible(m_owningLayer.hasVisibleContent() || hasVisibleNonCompositedDescendants());
     if (m_scrollContainerLayer) {


### PR DESCRIPTION
#### d2869dc073cdd0dcd3a90ffd0d8d6913f7a010c6
<pre>
[TexMap] Correctly gather damage information for 3D-transformed layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=275803">https://bugs.webkit.org/show_bug.cgi?id=275803</a>

Reviewed by Nikolas Zimmermann.

This change:
- changes the machanism that damages the whole layer on transform change. From now on,
  the damage is computed and stored in the global coordinate space as with the usage
  of local coordinate space (as before) it was impossible to get back the correct damage
  for 3D transforms as the operation was lossy
- separates the damage inferred during layer updates processing from the damage received
  from the main thread
- removes the workarounds necessary for 3D transform handling
thus effectively fixing the support for collecting damage from 3D-transformed layers.

* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::markDamageRectsUnreliable): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::collectDamageSelf):
(WebCore::TextureMapperLayer::damageWholeLayerDueToTransformChange):
(WebCore::TextureMapperLayer::transformRectForDamage):
(WebCore::TextureMapperLayer::setSize):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::flushCompositingState):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::updateDamage):
(WebCore::GraphicsLayerCoordinated::markDamageRectsUnreliable): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAfterDescendants):
(WebCore::layerRendererStyleHas3DTransformOperation): Deleted.

Canonical link: <a href="https://commits.webkit.org/289232@main">https://commits.webkit.org/289232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10752cab8bce7d506f728f39fee64c7ba596b5c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90745 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36656 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87706 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66565 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24374 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32041 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35731 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74794 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/92444 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9573 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75314 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74452 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18387 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18662 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17107 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/5090 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13001 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18375 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12796 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16226 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14581 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->