### PR TITLE
[scroll-animations] WPT test scroll-animations/css/view-timeline-with-transform-on-subject.html is a failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-transform-on-subject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-with-transform-on-subject-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL ViewTimeline use untransformed box for range calculations assert_approx_equals: progress at contain 100% expected 1 +/- 0.000001 but got 0
+PASS ViewTimeline use untransformed box for range calculations
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/intermediate-transform.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/intermediate-transform.html
@@ -49,7 +49,7 @@
     const anim = target.animate({ backgroundColor: ['green', 'red' ] },
                                 { timeline: timeline });
     await new Promise(requestAnimationFrame);
-    assert_px_equals(timeline.startOffset, 654, 'startOffset');
-    assert_px_equals(timeline.endOffset, 954, 'endOffset');
+    assert_px_equals(timeline.startOffset, 604, 'startOffset');
+    assert_px_equals(timeline.endOffset, 904, 'endOffset');
   });
 </script>

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -215,7 +215,11 @@ void ViewTimeline::cacheCurrentTime()
 
         float scrollOffset = scrollDirection->isVertical ? sourceScrollableArea->scrollOffset().y() : sourceScrollableArea->scrollOffset().x();
         float scrollContainerSize = scrollDirection->isVertical ? sourceScrollableArea->visibleHeight() : sourceScrollableArea->visibleWidth();
-        auto subjectOffsetFromSource = subjectRenderer->localToContainerPoint(pointForLocalToContainer(*sourceScrollableArea), sourceRenderer.get());
+
+        // https://drafts.csswg.org/scroll-animations-1/#view-timelines-ranges
+        // Transforms are ignored, but relative and absolute positioning are accounted for.
+        OptionSet<MapCoordinatesMode> excludeTransforms { };
+        auto subjectOffsetFromSource = subjectRenderer->localToContainerPoint(pointForLocalToContainer(*sourceScrollableArea), sourceRenderer.get(), excludeTransforms);
         float subjectOffset = scrollDirection->isVertical ? subjectOffsetFromSource.y() : subjectOffsetFromSource.x();
 
         // Ensure borders are subtracted.


### PR DESCRIPTION
#### b2bd6a9053f4bafdeacb4641efae3077cc1a435e
<pre>
[scroll-animations] WPT test scroll-animations/css/view-timeline-with-transform-on-subject.html is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=285990">https://bugs.webkit.org/show_bug.cgi?id=285990</a>
<a href="https://rdar.apple.com/142961850">rdar://142961850</a>

Reviewed by Simon Fraser.

We must make sure we do not account for CSS Transforms applied on the subject when computing a view timeline&apos;s
current time as specified by <a href="https://drafts.csswg.org/scroll-animations-1/#view-timelines-ranges.">https://drafts.csswg.org/scroll-animations-1/#view-timelines-ranges.</a>

Canonical link: <a href="https://commits.webkit.org/288970@main">https://commits.webkit.org/288970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb06c4d3be01832eefcbafa8da70166101cc18bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39273 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90027 "Hash eb06c4d3 for PR 39077 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35936 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12585 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/90027 "Hash eb06c4d3 for PR 39077 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23872 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77136 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/90027 "Hash eb06c4d3 for PR 39077 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3463 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31362 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35009 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91400 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8930 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74535 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12452 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72947 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73660 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18045 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16493 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13230 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12174 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12009 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15503 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13754 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->