### PR TITLE
[CoordinatedGraphics] Simplify surface resize

### DIFF
--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
@@ -175,9 +175,11 @@ void DrawingAreaProxyCoordinatedGraphics::sizeDidChange()
 
 void DrawingAreaProxyCoordinatedGraphics::deviceScaleFactorDidChange(CompletionHandler<void()>&& completionHandler)
 {
-    if (m_webPageProxy)
-        send(Messages::DrawingArea::SetDeviceScaleFactor(m_webPageProxy->deviceScaleFactor()));
-    completionHandler();
+    if (!m_webPageProxy) {
+        completionHandler();
+        return;
+    }
+    sendWithAsyncReply(Messages::DrawingArea::SetDeviceScaleFactor(m_webPageProxy->deviceScaleFactor()), WTFMove(completionHandler));
 }
 
 void DrawingAreaProxyCoordinatedGraphics::setBackingStoreIsDiscardable(bool isBackingStoreDiscardable)

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp
@@ -70,20 +70,16 @@ std::unique_ptr<AcceleratedSurface> AcceleratedSurface::create(ThreadedComposito
 AcceleratedSurface::AcceleratedSurface(WebPage& webPage, Function<void()>&& frameCompleteHandler)
     : m_webPage(webPage)
     , m_frameCompleteHandler(WTFMove(frameCompleteHandler))
-    , m_size(webPage.size())
     , m_isOpaque(!webPage.backgroundColor().has_value() || webPage.backgroundColor()->isOpaque())
 {
-    m_size.scale(m_webPage->deviceScaleFactor());
 }
 
-bool AcceleratedSurface::hostResize(const IntSize& size)
+bool AcceleratedSurface::resize(const IntSize& size)
 {
-    IntSize scaledSize(size);
-    scaledSize.scale(m_webPage->deviceScaleFactor());
-    if (scaledSize == m_size)
+    if (m_size == size)
         return false;
 
-    m_size = scaledSize;
+    m_size = size;
     return true;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
@@ -53,8 +53,7 @@ public:
 
     virtual uint64_t window() const { ASSERT_NOT_REACHED(); return 0; }
     virtual uint64_t surfaceID() const { ASSERT_NOT_REACHED(); return 0; }
-    virtual bool hostResize(const WebCore::IntSize&);
-    virtual void clientResize(const WebCore::IntSize&) { };
+    virtual bool resize(const WebCore::IntSize&);
     virtual bool shouldPaintMirrored() const { return false; }
 
     virtual void didCreateGLContext() { }
@@ -77,7 +76,6 @@ public:
     virtual void visibilityDidChange(bool) { }
     virtual bool backgroundColorDidChange();
 
-    const WebCore::IntSize& size() const { return m_size; }
     void clearIfNeeded();
 
 protected:

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -230,12 +230,6 @@ void DrawingAreaCoordinatedGraphics::updatePreferences(const WebPreferencesStore
 }
 
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
-void DrawingAreaCoordinatedGraphics::deviceOrPageScaleFactorChanged()
-{
-    if (m_layerTreeHost)
-        m_layerTreeHost->deviceOrPageScaleFactorChanged();
-}
-
 bool DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingModeIfNeeded()
 {
     ASSERT(!m_layerTreeHost);
@@ -253,9 +247,10 @@ void DrawingAreaCoordinatedGraphics::backgroundColorDidChange()
 }
 #endif
 
-void DrawingAreaCoordinatedGraphics::setDeviceScaleFactor(float deviceScaleFactor)
+void DrawingAreaCoordinatedGraphics::setDeviceScaleFactor(float deviceScaleFactor, CompletionHandler<void()>&& completionHandler)
 {
     Ref { m_webPage.get() }->setDeviceScaleFactor(deviceScaleFactor);
+    completionHandler();
 }
 
 bool DrawingAreaCoordinatedGraphics::supportsAsyncScrolling() const

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
@@ -65,7 +65,6 @@ private:
     void sendEnterAcceleratedCompositingModeIfNeeded() override;
 
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
-    void deviceOrPageScaleFactorChanged() override;
     bool enterAcceleratedCompositingModeIfNeeded() override;
     void backgroundColorDidChange() override;
 #endif
@@ -90,7 +89,7 @@ private:
     // IPC message handlers.
     void updateGeometry(const WebCore::IntSize&, CompletionHandler<void()>&&) override;
     void displayDidRefresh() override;
-    void setDeviceScaleFactor(float) override;
+    void setDeviceScaleFactor(float, CompletionHandler<void()>&&) override;
     void forceUpdate() override;
     void didDiscardBackingStore() override;
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -102,14 +102,13 @@ public:
 
     void forceRepaint();
     void forceRepaintAsync(CompletionHandler<void()>&&);
-    void sizeDidChange(const WebCore::IntSize& newSize);
+    void sizeDidChange(const WebCore::IntSize&);
 
     void pauseRendering();
     void resumeRendering();
 
     WebCore::GraphicsLayerFactory* graphicsLayerFactory();
 
-    void deviceOrPageScaleFactorChanged();
     void backgroundColorDidChange();
 
     void willRenderFrame();
@@ -183,6 +182,7 @@ private:
     bool m_didInitializeRootCompositingLayer { false };
     bool m_layerTreeStateIsFrozen { false };
     bool m_isPurgingBackingStores { false };
+    bool m_pendingResize { false };
     bool m_isSuspended { false };
     bool m_isWaitingForRenderer { false };
     bool m_scheduledWhileWaitingForRenderer { false };

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
@@ -257,10 +257,6 @@ void LayerTreeHost::setIsDiscardable(bool)
 {
 }
 
-void LayerTreeHost::deviceOrPageScaleFactorChanged()
-{
-}
-
 void LayerTreeHost::backgroundColorDidChange()
 {
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h
@@ -83,7 +83,6 @@ public:
     WebCore::GraphicsLayerFactory* graphicsLayerFactory();
     void contentsSizeChanged(const WebCore::IntSize&);
     void setIsDiscardable(bool);
-    void deviceOrPageScaleFactorChanged();
     void backgroundColorDidChange();
     RefPtr<WebCore::DisplayRefreshMonitor> createDisplayRefreshMonitor(WebCore::PlatformDisplayID);
     WebCore::PlatformDisplayID displayID() const { return m_displayID; }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -61,15 +61,14 @@ public:
     };
 
 #if HAVE(DISPLAY_LINK)
-    static Ref<ThreadedCompositor> create(LayerTreeHost&, float scaleFactor);
+    static Ref<ThreadedCompositor> create(LayerTreeHost&);
 #else
-    static Ref<ThreadedCompositor> create(LayerTreeHost&, ThreadedDisplayRefreshMonitor::Client&, float scaleFactor, WebCore::PlatformDisplayID);
+    static Ref<ThreadedCompositor> create(LayerTreeHost&, ThreadedDisplayRefreshMonitor::Client&, WebCore::PlatformDisplayID);
 #endif
     virtual ~ThreadedCompositor();
 
     uint64_t surfaceID() const;
 
-    void setViewportSize(const WebCore::IntSize&, float scale);
     void backgroundColorDidChange();
 #if PLATFORM(WPE) && USE(GBM) && ENABLE(WPE_PLATFORM)
     void preferredBufferFormatsDidChange();
@@ -96,9 +95,9 @@ public:
 
 private:
 #if HAVE(DISPLAY_LINK)
-    ThreadedCompositor(LayerTreeHost&, float scaleFactor);
+    explicit ThreadedCompositor(LayerTreeHost&);
 #else
-    ThreadedCompositor(LayerTreeHost&, ThreadedDisplayRefreshMonitor::Client&, float scaleFactor, WebCore::PlatformDisplayID);
+    ThreadedCompositor(LayerTreeHost&, ThreadedDisplayRefreshMonitor::Client&, WebCore::PlatformDisplayID);
 #endif
 
     // CoordinatedGraphicsSceneClient
@@ -130,11 +129,12 @@ private:
     struct {
         Lock lock;
         WebCore::IntSize viewportSize;
-        float scaleFactor { 1 };
-        bool needsResize { false };
-
-        bool clientRendersNextFrame { false };
+        float deviceScaleFactor { 1 };
         uint32_t compositionRequestID { 0 };
+
+#if !HAVE(DISPLAY_LINK)
+        bool clientRendersNextFrame { false };
+#endif
     } m_attributes;
 
 #if HAVE(DISPLAY_LINK)

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -162,7 +162,6 @@ public:
 
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
     virtual void updateGeometry(const WebCore::IntSize&, CompletionHandler<void()>&&) = 0;
-    virtual void deviceOrPageScaleFactorChanged() = 0;
     virtual bool enterAcceleratedCompositingModeIfNeeded() = 0;
     virtual void backgroundColorDidChange() { };
 #endif
@@ -215,17 +214,17 @@ private:
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
     virtual void updateBackingStoreState(uint64_t /*backingStoreStateID*/, bool /*respondImmediately*/, float /*deviceScaleFactor*/, const WebCore::IntSize& /*size*/,
                                          const WebCore::IntSize& /*scrollOffset*/) { }
-    virtual void setDeviceScaleFactor(float) { }
     virtual void forceUpdate() { }
     virtual void didDiscardBackingStore() { }
 #endif
+
+    virtual void setDeviceScaleFactor(float, CompletionHandler<void()>&& completionHandler) { completionHandler(); }
     virtual void displayDidRefresh() { }
 
     // DisplayRefreshMonitorFactory.
     RefPtr<WebCore::DisplayRefreshMonitor> createDisplayRefreshMonitor(WebCore::PlatformDisplayID) override;
 
 #if PLATFORM(COCOA)
-    virtual void setDeviceScaleFactor(float, CompletionHandler<void()>&&) { }
     virtual void setColorSpace(std::optional<WebCore::DestinationColorSpace>) { }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
@@ -27,16 +27,15 @@
 messages -> DrawingArea {
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
     UpdateGeometry(WebCore::IntSize size) -> ()
-    SetDeviceScaleFactor(float deviceScaleFactor)
     ForceUpdate()
     DidDiscardBackingStore()
 #endif
 
+    SetDeviceScaleFactor(float deviceScaleFactor) -> ()
     DisplayDidRefresh()
 
 #if PLATFORM(COCOA)
     UpdateGeometry(WebCore::IntSize viewSize, bool flushSynchronously, MachSendRight fencePort) -> ()
-    SetDeviceScaleFactor(float deviceScaleFactor) -> ()
     SetColorSpace(struct std::optional<WebCore::DestinationColorSpace> colorSpace)
     SetViewExposedRect(std::optional<WebCore::FloatRect> viewExposedRect)
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2598,10 +2598,6 @@ void WebPage::didScalePage(double scale, const IntPoint& origin)
     }
 #endif
 
-#if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
-    protectedDrawingArea()->deviceOrPageScaleFactorChanged();
-#endif
-
     platformDidScalePage();
 }
 
@@ -2727,10 +2723,6 @@ void WebPage::setDeviceScaleFactor(float scaleFactor)
         layoutIfNeeded();
         findController().deviceScaleFactorDidChange();
     }
-
-#if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
-    protectedDrawingArea()->deviceOrPageScaleFactorChanged();
-#endif
 }
 
 float WebPage::deviceScaleFactor() const

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -649,9 +649,13 @@ uint64_t AcceleratedSurfaceDMABuf::surfaceID() const
     return m_id;
 }
 
-void AcceleratedSurfaceDMABuf::clientResize(const WebCore::IntSize& size)
+bool AcceleratedSurfaceDMABuf::resize(const WebCore::IntSize& size)
 {
-    m_swapChain.resize(size);
+    if (!AcceleratedSurface::resize(size))
+        return false;
+
+    m_swapChain.resize(m_size);
+    return true;
 }
 
 void AcceleratedSurfaceDMABuf::willRenderFrame()

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
@@ -77,7 +77,7 @@ public:
 private:
     uint64_t window() const override { return 0; }
     uint64_t surfaceID() const override;
-    void clientResize(const WebCore::IntSize&) override;
+    bool resize(const WebCore::IntSize&) override;
     bool shouldPaintMirrored() const override
     {
 #if PLATFORM(WPE) || (PLATFORM(GTK) && USE(GTK4))

--- a/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h
+++ b/Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h
@@ -46,7 +46,7 @@ public:
 
     uint64_t window() const override;
     uint64_t surfaceID() const override;
-    void clientResize(const WebCore::IntSize&) override;
+    bool resize(const WebCore::IntSize&) override;
     void finalize() override;
     void willRenderFrame() override;
     void didRenderFrame() override;
@@ -57,6 +57,7 @@ private:
     void initialize();
 
     UnixFileDescriptor m_hostFD;
+    WebCore::IntSize m_initialSize;
     struct wpe_renderer_backend_egl_target* m_backend { nullptr };
 };
 

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
@@ -57,7 +57,6 @@ private:
     void scroll(const WebCore::IntRect& scrollRect, const WebCore::IntSize& scrollDelta) override;
     void updateRenderingWithForcedRepaintAsync(WebPage&, CompletionHandler<void()>&&) override;
     void triggerRenderingUpdate() override;
-    void deviceOrPageScaleFactorChanged() override { }
     bool enterAcceleratedCompositingModeIfNeeded() override { return false; }
     void setLayerTreeStateIsFrozen(bool) override;
     bool layerTreeStateIsFrozen() const override { return m_isRenderingSuspended; }


### PR DESCRIPTION
#### e7294cc235c64cdbd1ce2a7cb692d8ef480dbeeb
<pre>
[CoordinatedGraphics] Simplify surface resize
<a href="https://bugs.webkit.org/show_bug.cgi?id=285991">https://bugs.webkit.org/show_bug.cgi?id=285991</a>

Reviewed by Adrian Perez de Castro.

We currently have a method in the threaded compositor to set the new
size, which schedules an update without waiting for the layer flush. We
can pass the size and device scale factor as part of the composition
request, which always happens after the layer flush. Then the compositor
always tries to resize the surface to the requested size, and only when
it changed it calls glViewport with the new size.
This patch also handles the completion handler of
DrawingAreaProxyCoordinatedGraphics::deviceScaleFactorDidChange()
correctly making SetDeviceScaleFactor async like in apple ports and
waiting for the response to call the completion handler.

* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp:
(WebKit::DrawingAreaProxyCoordinatedGraphics::deviceScaleFactorDidChange):
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::AcceleratedSurface):
(WebKit::AcceleratedSurface::resize):
(WebKit::AcceleratedSurface::hostResize): Deleted.
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h:
(WebKit::AcceleratedSurface::clientResize): Deleted.
(WebKit::AcceleratedSurface::size const): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::setDeviceScaleFactor):
(WebKit::DrawingAreaCoordinatedGraphics::deviceOrPageScaleFactorChanged): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
(WebKit::LayerTreeHost::flushLayers):
(WebKit::LayerTreeHost::sizeDidChange):
(WebKit::LayerTreeHost::deviceOrPageScaleFactorChanged): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp:
(WebKit::LayerTreeHost::deviceOrPageScaleFactorChanged): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::create):
(WebKit::ThreadedCompositor::ThreadedCompositor):
(WebKit::ThreadedCompositor::renderLayerTree):
(WebKit::ThreadedCompositor::requestComposition):
(WebKit::ThreadedCompositor::setViewportSize): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::updateBackingStoreState):
(WebKit::DrawingArea::setDeviceScaleFactor):
* Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didScalePage):
(WebKit::WebPage::setDeviceScaleFactor):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::resize):
(WebKit::AcceleratedSurfaceDMABuf::clientResize): Deleted.
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h:
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp:
(WebKit::AcceleratedSurfaceLibWPE::AcceleratedSurfaceLibWPE):
(WebKit::AcceleratedSurfaceLibWPE::initialize):
(WebKit::AcceleratedSurfaceLibWPE::resize):
(WebKit::AcceleratedSurfaceLibWPE::clientResize): Deleted.
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h:
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h:

Canonical link: <a href="https://commits.webkit.org/288997@main">https://commits.webkit.org/288997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c98e9d762f570436e1763939ef720f2d1b82df9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89981 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35891 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12541 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66028 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23843 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46298 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3432 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34965 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74267 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91356 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74511 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72914 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73634 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18007 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16461 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/3628 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13249 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12130 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17576 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11964 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15458 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13710 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->