### PR TITLE
matchHelperAssignInputsFromInit does not need to process again its URLPatternInit

### DIFF
--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -368,91 +368,16 @@ static inline void matchHelperAssignInputsFromURL(const URL& input, String& prot
     hash = input.fragmentIdentifier().toString();
 }
 
-// https://urlpattern.spec.whatwg.org/#process-protocol-for-init
-static ExceptionOr<String> processProtocolForInit(const String& protocol)
+static inline void matchHelperAssignInputsFromInit(const URLPatternInit& input, String& protocol, String& username, String& password, String& hostname, String& port, String& pathname, String& search, String& hash)
 {
-    // canonicalizeProtocol does both steps.
-    return canonicalizeProtocol(protocol, BaseURLStringType::URL);
-}
-
-// https://urlpattern.spec.whatwg.org/#process-username-for-init
-static ExceptionOr<String> processUsernameForInit(const String& username)
-{
-    return canonicalizeUsername(username, BaseURLStringType::URL);
-}
-
-// https://urlpattern.spec.whatwg.org/#process-password-for-init
-static ExceptionOr<String> processPasswordForInit(const String& password)
-{
-    return canonicalizePassword(password, BaseURLStringType::URL);
-}
-
-// https://urlpattern.spec.whatwg.org/#process-hostname-for-init
-static ExceptionOr<String> processHostnameForInit(const String& hostname)
-{
-    return canonicalizeHostname(hostname, BaseURLStringType::URL);
-}
-
-// https://urlpattern.spec.whatwg.org/#process-port-for-init
-static ExceptionOr<String> processPortForInit(const String& port, const String& protocol)
-{
-    std::optional<StringView> protocolValue;
-    if (!protocol.isNull())
-        protocolValue = StringView { protocol };
-    return canonicalizePort(port, protocolValue, BaseURLStringType::URL);
-}
-
-// https://urlpattern.spec.whatwg.org/#process-search-for-init
-static ExceptionOr<String> processSearchForInit(const String& search)
-{
-    // canonicalizeSearch does both steps.
-    return canonicalizeSearch(search, BaseURLStringType::URL);
-}
-
-// https://urlpattern.spec.whatwg.org/#process-hash-for-init
-static ExceptionOr<String> processHashForInit(const String& hash)
-{
-    // canonicalizeHash does both steps.
-    return canonicalizeHash(hash, BaseURLStringType::URL);
-}
-
-static inline ExceptionOr<void> matchHelperAssignInputsFromInit(const URLPatternInit& input, String& protocol, String& username, String& password, String& hostname, String& port, String& pathname, String& search, String& hash)
-{
-    auto canonicalizedProtocol = processProtocolForInit(input.protocol);
-    if (canonicalizedProtocol.hasException())
-        return canonicalizedProtocol.releaseException();
-    auto canonicalizedUsername = processUsernameForInit(input.username);
-    if (canonicalizedUsername.hasException())
-        return canonicalizedUsername.releaseException();
-    auto canonicalizedPassword = processPasswordForInit(input.password);
-    if (canonicalizedPassword.hasException())
-        return canonicalizedPassword.releaseException();
-    auto canonicalizedHostname = processHostnameForInit(input.hostname);
-    if (canonicalizedHostname.hasException())
-        return canonicalizedHostname.releaseException();
-    auto canonicalizedPort = processPortForInit(input.port, canonicalizedProtocol.returnValue());
-    if (canonicalizedPort.hasException())
-        return canonicalizedPort.releaseException();
-    auto canonicalizedPathname = processPathname(input.pathname, canonicalizedProtocol.returnValue(), BaseURLStringType::URL);
-    if (canonicalizedPathname.hasException())
-        return canonicalizedPathname.releaseException();
-    auto canonicalizedSearch = processSearchForInit(input.search);
-    if (canonicalizedSearch.hasException())
-        return canonicalizedSearch.releaseException();
-    auto canonicalizedHash = processHashForInit(input.hash);
-    if (canonicalizedHash.hasException())
-        return canonicalizedHash.releaseException();
-
-    protocol = canonicalizedProtocol.releaseReturnValue();
-    username = canonicalizedUsername.releaseReturnValue();
-    password = canonicalizedPassword.releaseReturnValue();
-    hostname = canonicalizedHostname.releaseReturnValue();
-    port = canonicalizedPort.releaseReturnValue();
-    pathname = canonicalizedPathname.releaseReturnValue();
-    search = canonicalizedSearch.releaseReturnValue();
-    hash = canonicalizedHash.releaseReturnValue();
-
-    return { };
+    protocol = input.protocol;
+    username = input.username;
+    password = input.password;
+    hostname = input.hostname;
+    port = input.port;
+    pathname = input.pathname;
+    search = input.search;
+    hash = input.hash;
 }
 
 // https://urlpattern.spec.whatwg.org/#url-pattern-match
@@ -478,10 +403,7 @@ ExceptionOr<std::optional<URLPatternResult>> URLPattern::match(ScriptExecutionCo
             if (maybeResult.hasException())
                 return true;
 
-            URLPatternInit processedInit = maybeResult.releaseReturnValue();
-            auto parsingResult = matchHelperAssignInputsFromInit(processedInit, protocol, username, password, hostname, port, pathname, search, hash);
-            if (parsingResult.hasException())
-                return parsingResult.releaseException();
+            matchHelperAssignInputsFromInit(maybeResult.releaseReturnValue(), protocol, username, password, hostname, port, pathname, search, hash);
             return false;
         }, [&](const String& value) -> ExceptionOr<bool> {
             URL baseURL;


### PR DESCRIPTION
#### 880264ba2e4b1e667d6dff4d2d09bb3a4b54ecbc
<pre>
matchHelperAssignInputsFromInit does not need to process again its URLPatternInit
<a href="https://rdar.apple.com/142967409">rdar://142967409</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=285996">https://bugs.webkit.org/show_bug.cgi?id=285996</a>

Reviewed by Anne van Kesteren.

Removing redundant and no longer needed code.

* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
(WebCore::matchHelperAssignInputsFromInit):
(WebCore::URLPattern::match const):
(WebCore::processProtocolForInit): Deleted.
(WebCore::processUsernameForInit): Deleted.
(WebCore::processPasswordForInit): Deleted.
(WebCore::processHostnameForInit): Deleted.
(WebCore::processPortForInit): Deleted.
(WebCore::processSearchForInit): Deleted.
(WebCore::processHashForInit): Deleted.

Canonical link: <a href="https://commits.webkit.org/288941@main">https://commits.webkit.org/288941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f7033ddd2eef3e8dc7c39d5e939ad61d0dfc779

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/89990 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35901 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86933 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12550 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/66035 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/23855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77106 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/46305 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3437 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31330 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34974 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32138 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91365 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12187 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73637 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18217 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18016 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16463 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/3637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12139 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11974 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15468 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13719 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->