### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in PlatformXRPose

### DIFF
--- a/Source/WebCore/platform/xr/cocoa/PlatformXRPose.cpp
+++ b/Source/WebCore/platform/xr/cocoa/PlatformXRPose.cpp
@@ -8,8 +8,6 @@
 
 #if ENABLE(WEBXR) && PLATFORM(COCOA)
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PlatformXRPose);
 
 WebCore::FloatPoint3D PlatformXRPose::position() const
@@ -32,6 +30,7 @@ PlatformXR::FrameData::Pose PlatformXRPose::pose() const
     return pose;
 }
 
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 PlatformXRPose::FloatMatrix4 PlatformXRPose::toColumnMajorFloatArray() const
 {
     const simd_float4 (&columns)[4] = m_simdTransform.columns;
@@ -42,6 +41,7 @@ PlatformXRPose::FloatMatrix4 PlatformXRPose::toColumnMajorFloatArray() const
         columns[3][0], columns[3][1], columns[3][2], columns[3][3],
     } };
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 float PlatformXRPose::distanceToPose(const PlatformXRPose& otherPose) const
 {
@@ -54,7 +54,9 @@ PlatformXRPose PlatformXRPose::verticalTransformPose() const
 {
     simd_float3 position = simdPosition();
     simd_float4x4 transform = matrix_identity_float4x4;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     transform.columns[3].y  = position.y;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return PlatformXRPose(transform);
 }
 
@@ -67,7 +69,5 @@ PlatformXRPose::PlatformXRPose(const simd_float4x4& transform, const simd_float4
 {
     m_simdTransform = simd_mul(parentTransform, transform);
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEBXR) && PLATFORM(COCOA)

--- a/Source/WebCore/platform/xr/cocoa/PlatformXRPose.h
+++ b/Source/WebCore/platform/xr/cocoa/PlatformXRPose.h
@@ -10,14 +10,14 @@
 #include <simd/simd.h>
 #include <wtf/TZoneMalloc.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 class PlatformXRPose {
     WTF_MAKE_TZONE_ALLOCATED(PlatformXRPose);
 
 public:
     simd_float4x4 simdTransform() const { return m_simdTransform; }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     simd_float3 simdPosition() const { return m_simdTransform.columns[3].xyz; }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     simd_quatf simdOrientation() const { return simd_quaternion(m_simdTransform); }
     WEBCORE_EXPORT WebCore::FloatPoint3D position() const;
     WEBCORE_EXPORT PlatformXR::FrameData::FloatQuaternion orientation() const;
@@ -35,7 +35,5 @@ public:
 private:
     simd_float4x4 m_simdTransform;
 };
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(WEBXR) && PLATFORM(COCOA)


### PR DESCRIPTION
#### d027841002b64bbcc19318a02a926dd026d2fb5e
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in PlatformXRPose
<a href="https://bugs.webkit.org/show_bug.cgi?id=286000">https://bugs.webkit.org/show_bug.cgi?id=286000</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/xr/cocoa/PlatformXRPose.cpp:
(PlatformXRPose::verticalTransformPose const):
* Source/WebCore/platform/xr/cocoa/PlatformXRPose.h:

Canonical link: <a href="https://commits.webkit.org/288977@main">https://commits.webkit.org/288977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bc6ed8cbe3e8bd88b5ae724241e72980a259562

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90038 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35923 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86955 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66064 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23865 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87915 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46334 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31355 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34996 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91387 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8922 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74545 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12439 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73650 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18036 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16487 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/3966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13235 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12161 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17607 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11996 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15490 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->