### PR TITLE
REGRESSION (285237@main): khanacademy.org: Live Text selection is misplaced in fullscreen video on iPad

### DIFF
--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -192,6 +192,17 @@ IntRect RenderVideo::videoBox() const
     return snappedIntRect(replacedContentRect(intrinsicSize));
 }
 
+IntRect RenderVideo::videoBoxInRootView() const
+{
+    RefPtr view = document().view();
+    if (!view)
+        return { };
+
+    auto videoBox = this->videoBox();
+    videoBox.moveBy(absoluteBoundingBoxRect().location());
+    return view->contentsToRootView(videoBox);
+}
+
 bool RenderVideo::shouldDisplayVideo() const
 {
     return !videoElement().shouldDisplayPosterImage();

--- a/Source/WebCore/rendering/RenderVideo.h
+++ b/Source/WebCore/rendering/RenderVideo.h
@@ -41,7 +41,8 @@ public:
 
     WEBCORE_EXPORT HTMLVideoElement& videoElement() const;
 
-    WEBCORE_EXPORT IntRect videoBox() const;
+    IntRect videoBox() const;
+    WEBCORE_EXPORT IntRect videoBoxInRootView() const;
 
     static IntSize defaultSize();
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12865,8 +12865,6 @@ static BOOL shouldUseMachineReadableCodeMenuFromImageAnalysisResult(CocoaImageAn
 {
     auto unitInteractionRect = _imageAnalysisInteractionBounds;
     WebCore::FloatRect contentViewBounds = self.bounds;
-    auto obscuredInset = self.webView._computedObscuredInset;
-    unitInteractionRect.move(obscuredInset.left, obscuredInset.top);
     unitInteractionRect.moveBy(-contentViewBounds.location());
     unitInteractionRect.scale(1 / contentViewBounds.size());
     return unitInteractionRect;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9484,19 +9484,15 @@ void WebPage::scrollToRect(const WebCore::FloatRect& targetRect, const WebCore::
 #if ENABLE(IMAGE_ANALYSIS) && ENABLE(VIDEO)
 void WebPage::beginTextRecognitionForVideoInElementFullScreen(const HTMLVideoElement& element)
 {
-    RefPtr view = element.document().view();
-    if (!view)
-        return;
-
     auto mediaPlayerIdentifier = element.playerIdentifier();
     if (!mediaPlayerIdentifier)
         return;
 
-    auto* renderer = element.renderer();
+    CheckedPtr renderer = element.renderer();
     if (!renderer)
         return;
 
-    auto rectInRootView = view->contentsToRootView(renderer->videoBox());
+    auto rectInRootView = renderer->videoBoxInRootView();
     if (rectInRootView.isEmpty())
         return;
 

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -71,7 +71,7 @@ static FloatRect inlineVideoFrame(HTMLVideoElement& element)
         return { };
 
     document->updateLayout(LayoutOptions::IgnorePendingStylesheets);
-    auto* renderer = element.renderer();
+    CheckedPtr renderer = element.renderer();
     if (!renderer)
         return { };
 
@@ -81,9 +81,7 @@ static FloatRect inlineVideoFrame(HTMLVideoElement& element)
         return document->view()->contentsToRootView(contentsBox.boundingBox());
     }
 
-    auto rect = renderer->videoBox();
-    rect.moveBy(renderer->absoluteBoundingBoxRect().location());
-    return document->view()->contentsToRootView(rect);
+    return renderer->videoBoxInRootView();
 }
 
 #pragma mark - VideoPresentationInterfaceContext


### PR DESCRIPTION
#### d7b5c032766f7771a5fa80cdca4966c3d4b56539
<pre>
REGRESSION (285237@main): khanacademy.org: Live Text selection is misplaced in fullscreen video on iPad
<a href="https://bugs.webkit.org/show_bug.cgi?id=286007">https://bugs.webkit.org/show_bug.cgi?id=286007</a>
<a href="https://rdar.apple.com/142822957">rdar://142822957</a>

Reviewed by Abrar Rahman Protyasha and Megan Gardner.

The prior fix in 285237@main is incorrect, since the video on New York Times wasn&apos;t actually offset
by the top obscured inset. Rather, the root cause is that the interaction bounds we&apos;re using to
position the `VKCImageAnalysisInteraction` simply uses `RenderVideo::videoBox()`, which doesn&apos;t
include the absolute left/top offset of the renderer itself. As a result, some videos just happen to
be positioned more accurately after the changes in 285237@main, while others (for which the renderer
is already at the origin) become offset.

`VideoPresentationManager` already has a helper, `inlineVideoFrame`, which handles this computation
correctly — to fix this, we simply pull that logic out into a separate `RenderVideo` helper method,
and use it in both places.

This isn&apos;t currently testable in API or layout tests — I manually verified that Live Text selections
are positioned correctly across various video players (youtube.com, YouTube embeds, websites from
previous bug reports like New York Times, and simple test cases).

* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::videoBoxInRootView const):

Pull logic to compute the video box in root view coordinates into a separate helper method, which we
can use in both `VideoPresentationManager` and `WebPage` (when computing bounds for Live Text).

* Source/WebCore/rendering/RenderVideo.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView contentsRectForImageAnalysisInteraction:]):

Revert the previous (incorrect) attempt to fix this bug.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::beginTextRecognitionForVideoInElementFullScreen):

Use `videoBoxInRootView()` (see above).

* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::inlineVideoFrame):

Move some of this logic into the new `videoBoxInRootView()` method above.

Canonical link: <a href="https://commits.webkit.org/288963@main">https://commits.webkit.org/288963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57e9cacfffe2415500299bc71c36c6636f2a1260

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90011 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35920 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86952 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12569 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/66056 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23863 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3572 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77125 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIMenus.MacAudioContextMenuItems (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46326 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3450 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31350 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/34993 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91384 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74532 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73657 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18233 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18030 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16482 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/3877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12158 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/11993 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15487 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13738 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->