### PR TITLE
element.children index getter returns a wrong element when traversing backwards

### DIFF
--- a/LayoutTests/fast/dom/collection-children-backwards-expected.txt
+++ b/LayoutTests/fast/dom/collection-children-backwards-expected.txt
@@ -1,0 +1,10 @@
+This tests iterating element.children backwarwds. The collection index getter should return the last element when indexed for the last item.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS container.children[3]; container.children[2] is child2
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/collection-children-backwards.html
+++ b/LayoutTests/fast/dom/collection-children-backwards.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="container">
+    <div id="child0"></div>
+    <div id="child1"></div>
+    <div id="child2"></div>
+</div>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description('This tests iterating element.children backwarwds. The collection index getter should return the last element when indexed for the last item.');
+shouldBe('container.children[3]; container.children[2]', 'child2');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/CollectionTraversalInlines.h
+++ b/Source/WebCore/html/CollectionTraversalInlines.h
@@ -98,7 +98,10 @@ inline auto CollectionTraversal<CollectionTraversalType::ChildrenOnly>::begin(co
 template <typename CollectionClass>
 inline auto CollectionTraversal<CollectionTraversalType::ChildrenOnly>::last(const CollectionClass& collection, ContainerNode& rootNode) -> Iterator
 {
-    auto it = childrenOfType<Element>(rootNode).begin();
+    auto* lastElement = childrenOfType<Element>(rootNode).last();
+    if (!lastElement)
+        return childrenOfType<Element>(rootNode).begin();
+    auto it = childrenOfType<Element>(rootNode).beginAt(*lastElement);
     while (it && !collection.elementMatches(*it))
         --it;
     // Drop iterator assertions because HTMLCollections / NodeList use a fine-grained invalidation scheme.


### PR DESCRIPTION
#### 5b32e928bc978e067a412a2edb71e6da194acc6a
<pre>
element.children index getter returns a wrong element when traversing backwards
<a href="https://bugs.webkit.org/show_bug.cgi?id=285705">https://bugs.webkit.org/show_bug.cgi?id=285705</a>
<a href="https://rdar.apple.com/142838915">rdar://142838915</a>

Reviewed by Simon Fraser.

The bug was caused by CollectionTraversal&lt;CollectionTraversalType::ChildrenOnly&gt;::last
traversing from the beginning instead of the end. The PR fixes the bug accordingly.

* LayoutTests/fast/dom/collection-children-backwards-expected.txt: Added.
* LayoutTests/fast/dom/collection-children-backwards.html: Added.
* Source/WebCore/html/CollectionTraversalInlines.h:
(WebCore::CollectionTraversal&lt;CollectionTraversalType::ChildrenOnly&gt;::last):

Canonical link: <a href="https://commits.webkit.org/288969@main">https://commits.webkit.org/288969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5855ac08dbc84baaf4815fe6b186894d7d94a617

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90039 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35947 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86979 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12596 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/66068 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23883 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87939 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77149 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/46338 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31376 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35020 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91411 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12233 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8937 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74551 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12463 "Failed to checkout and rebase branch from PR 39090") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73675 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16506 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13229 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12185 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12020 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15514 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13765 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->