### PR TITLE
[ARMv7] Reduce usage of dataTempRegister

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -218,8 +218,9 @@ public:
     
     void add32(AbsoluteAddress src, RegisterID dest)
     {
-        load32(setupArmAddress(src), dataTempRegister);
-        add32(dataTempRegister, dest);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        load32(setupArmAddress(src), scratch);
+        add32(scratch, dest);
     }
 
     void add32(TrustedImm32 imm, RegisterID src, RegisterID dest)
@@ -244,8 +245,9 @@ public:
             return;
         }
 
-        move(imm, dataTempRegister);
-        m_assembler.add(dest, src, dataTempRegister);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        move(imm, scratch);
+        m_assembler.add(dest, src, scratch);
     }
 
     void add32(TrustedImm32 imm, Address address)
@@ -256,9 +258,9 @@ public:
 
     void add32(Address src, RegisterID dest)
     {
-        // load32 will invalidate the cachedDataTempRegister() for us
-        load32(src, dataTempRegister);
-        add32(dataTempRegister, dest);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        load32(src, scratch);
+        add32(scratch, dest);
     }
 
     void add32(TrustedImm32 imm, AbsoluteAddress address)
@@ -269,9 +271,10 @@ public:
 
     void add8(TrustedImm32 imm, Address address)
     {
-        load8(address, dataTempRegister);
-        add32(imm, dataTempRegister, dataTempRegister);
-        store8(dataTempRegister, address);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        load8(address, scratch);
+        add32(imm, scratch, scratch);
+        store8(scratch, address);
     }
 
     void getEffectiveAddress(BaseIndex address, RegisterID dest)
@@ -318,8 +321,9 @@ public:
 
     void and16(Address src, RegisterID dest)
     {
-        load16(src, dataTempRegister);
-        and32(dataTempRegister, dest);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        load16(src, scratch);
+        and32(scratch, dest);
     }
 
     void and32(RegisterID op1, RegisterID op2, RegisterID dest)
@@ -344,8 +348,9 @@ public:
             return;
         }
 
-        move(imm, dataTempRegister);
-        m_assembler.ARM_and(dest, src, dataTempRegister);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        move(imm, scratch);
+        m_assembler.ARM_and(dest, src, scratch);
     }
 
     void and32(RegisterID src, RegisterID dest)
@@ -360,8 +365,9 @@ public:
 
     void and32(Address src, RegisterID dest)
     {
-        load32(src, dataTempRegister);
-        and32(dataTempRegister, dest);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        load32(src, scratch);
+        and32(scratch, dest);
     }
 
     void countLeadingZeros32(RegisterID src, RegisterID dest)
@@ -378,6 +384,7 @@ public:
     void lshift32(RegisterID src, RegisterID shiftAmount, RegisterID dest)
     {
         RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
+        ASSERT(dest != scratch);
         // Clamp the shift to the range 0..31
         ARMThumbImmediate armImm = ARMThumbImmediate::makeEncodedImm(0x1f);
         ASSERT(armImm.isValid());
@@ -395,8 +402,10 @@ public:
     {
         // Clamp the shift to the range 0..31
         m_assembler.ARM_and(dest, shiftAmount, ARMThumbImmediate::makeEncodedImm(0x1f));
-        move(imm, getCachedDataTempRegisterIDAndInvalidate());
-        m_assembler.lsl(dest, dataTempRegister, dest);
+        ASSERT(dest != scratch);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        move(imm, scratch);
+        m_assembler.lsl(dest, scratch, dest);
     }
 
     void lshift32(RegisterID shiftAmount, RegisterID dest)
@@ -423,9 +432,10 @@ public:
 
     void mul32(TrustedImm32 imm, RegisterID src, RegisterID dest)
     {
-        move(imm, dataTempRegister);
-        cachedDataTempRegister().invalidate();
-        m_assembler.smull(dest, dataTempRegister, src, dataTempRegister);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        ASSERT(dest != scratch);
+        move(imm, scratch);
+        m_assembler.smull(dest, scratch, src, scratch);
     }
 
     void uMull32(RegisterID left, RegisterID right, RegisterID destHi, RegisterID destLo)
@@ -446,38 +456,41 @@ public:
     void or8(TrustedImm32 imm, AbsoluteAddress address)
     {
         ARMThumbImmediate armImm = ARMThumbImmediate::makeEncodedImm(imm.m_value);
-        load8(setupArmAddress(address), dataTempRegister);
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
+        load8(setupArmAddress(address), scratch);
         if (armImm.isValid()) {
-            m_assembler.orr(dataTempRegister, dataTempRegister, armImm);
-            store8(dataTempRegister, Address(addressTempRegister));
+            m_assembler.orr(scratch, scratch, armImm);
+            store8(scratch, Address(addressTempRegister));
         } else {
             move(imm, addressTempRegister);
-            m_assembler.orr(dataTempRegister, dataTempRegister, addressTempRegister);
+            m_assembler.orr(scratch, scratch, addressTempRegister);
             move(TrustedImmPtr(address.m_ptr), addressTempRegister);
-            store8(dataTempRegister, Address(addressTempRegister));
+            store8(scratch, Address(addressTempRegister));
         }
     }
 
     void or16(TrustedImm32 imm, AbsoluteAddress dest)
     {
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
         ARMThumbImmediate armImm = ARMThumbImmediate::makeEncodedImm(imm.m_value);
-        load16(setupArmAddress(dest), dataTempRegister);
+        load16(setupArmAddress(dest), scratch);
         if (armImm.isValid()) {
-            m_assembler.orr(dataTempRegister, dataTempRegister, armImm);
-            store16(dataTempRegister, Address(addressTempRegister));
+            m_assembler.orr(scratch, scratch, armImm);
+            store16(scratch, Address(addressTempRegister));
         } else {
             move(imm, addressTempRegister);
-            m_assembler.orr(dataTempRegister, dataTempRegister, addressTempRegister);
+            m_assembler.orr(scratch, scratch, addressTempRegister);
             move(TrustedImmPtr(dest.m_ptr), addressTempRegister);
-            store16(dataTempRegister, Address(addressTempRegister));
+            store16(scratch, Address(addressTempRegister));
         }
     }
 
     void or16(RegisterID mask, AbsoluteAddress dest)
     {
-        load16(setupArmAddress(dest), dataTempRegister);
-        m_assembler.orr(dataTempRegister, dataTempRegister, mask);
-        store16(dataTempRegister, Address(addressTempRegister));
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
+        load16(setupArmAddress(dest), scratch);
+        m_assembler.orr(scratch, scratch, mask);
+        store16(scratch, Address(addressTempRegister));
     }
 
     void or32(RegisterID src, RegisterID dest)
@@ -487,38 +500,43 @@ public:
 
     void or32(RegisterID src, AbsoluteAddress dest)
     {
-        load32(setupArmAddress(dest), dataTempRegister);
-        or32(src, dataTempRegister);
-        store32(dataTempRegister, Address(addressTempRegister));
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
+        load32(setupArmAddress(dest), scratch);
+        or32(src, scratch);
+        store32(scratch, Address(addressTempRegister));
     }
 
     void or32(RegisterID src, Address dest)
     {
-        load32(dest, dataTempRegister);
-        or32(src, dataTempRegister);
-        store32(dataTempRegister, dest);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        ASSERT(dest != scratch);
+        load32(dest, scratch);
+        or32(src, scratch);
+        store32(scratch, dest);
     }
 
     void or32(TrustedImm32 imm, AbsoluteAddress address)
     {
         ARMThumbImmediate armImm = ARMThumbImmediate::makeEncodedImm(imm.m_value);
-        load32(setupArmAddress(address), dataTempRegister);
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
+        load32(setupArmAddress(address), scratch);
         if (armImm.isValid()) {
-            m_assembler.orr(dataTempRegister, dataTempRegister, armImm);
-            store32(dataTempRegister, Address(addressTempRegister));
+            m_assembler.orr(scratch, scratch, armImm);
+            store32(scratch, Address(addressTempRegister));
         } else {
             move(imm, addressTempRegister);
-            m_assembler.orr(dataTempRegister, dataTempRegister, addressTempRegister);
+            m_assembler.orr(scratch, scratch, addressTempRegister);
             move(TrustedImmPtr(address.m_ptr), addressTempRegister);
-            store32(dataTempRegister, Address(addressTempRegister));
+            store32(scratch, Address(addressTempRegister));
         }
     }
 
     void or32(TrustedImm32 imm, Address address)
     {
-        load32(address, dataTempRegister);
-        or32(imm, dataTempRegister, dataTempRegister);
-        store32(dataTempRegister, address);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        load32(address, scratch);
+        or32(imm, scratch, scratch);
+        store32(scratch, address);
     }
 
     void or32(TrustedImm32 imm, RegisterID dest)
@@ -537,9 +555,11 @@ public:
         if (armImm.isValid())
             m_assembler.orr(dest, src, armImm);
         else {
-            ASSERT(src != dataTempRegister);
-            move(imm, dataTempRegister);
-            m_assembler.orr(dest, src, dataTempRegister);
+            RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+            ASSERT(src != scratch);
+            ASSERT(dest != scratch);
+            move(imm, scratch);
+            m_assembler.orr(dest, src, scratch);
         }
     }
 
@@ -638,8 +658,10 @@ public:
     void addUnsignedRightShift32(RegisterID src1, RegisterID src2, TrustedImm32 amount, RegisterID dest)
     {
         // dest = src1 + (src2 >> amount)
-        urshift32(src2, amount, dataTempRegister);
-        add32(src1, dataTempRegister, dest);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        ASSERT(dest != scratch);
+        urshift32(src2, amount, scratch);
+        add32(src1, scratch, dest);
     }
 
     void sub32(RegisterID src, RegisterID dest)
@@ -658,8 +680,11 @@ public:
         if (armImm.isValid())
             m_assembler.sub(dest, left, armImm);
         else {
-            move(right, dataTempRegister);
-            m_assembler.sub(dest, left, dataTempRegister);
+            RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+            ASSERT(dest != scratch);
+            ASSERT(left != scratch);
+            move(right, scratch);
+            m_assembler.sub(dest, left, scratch);
         }
     }
 
@@ -669,49 +694,56 @@ public:
         if (armImm.isValid())
             m_assembler.sub(dest, dest, armImm);
         else {
-            move(imm, dataTempRegister);
-            m_assembler.sub(dest, dest, dataTempRegister);
+            RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+            ASSERT(dest != scratch);
+            ASSERT(left != scratch);
+            move(imm, scratch);
+            m_assembler.sub(dest, dest, scratch);
         }
     }
 
     void sub32(TrustedImm32 imm, Address address)
     {
-        load32(address, dataTempRegister);
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
+        load32(address, scratch);
 
         ARMThumbImmediate armImm = ARMThumbImmediate::makeUInt12OrEncodedImm(imm.m_value);
         if (armImm.isValid())
-            m_assembler.sub(dataTempRegister, dataTempRegister, armImm);
+            m_assembler.sub(scratch, scratch, armImm);
         else {
-            // Hrrrm, since dataTempRegister holds the data loaded,
+            // Hrrrm, since scratch holds the data loaded,
             // use addressTempRegister to hold the immediate.
             move(imm, addressTempRegister);
-            m_assembler.sub(dataTempRegister, dataTempRegister, addressTempRegister);
+            m_assembler.sub(scratch, scratch, addressTempRegister);
         }
 
-        store32(dataTempRegister, address);
+        store32(scratch, address);
     }
 
     void sub32(Address src, RegisterID dest)
     {
-        load32(src, dataTempRegister);
-        sub32(dataTempRegister, dest);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        ASSERT(dest != scratch);
+        load32(src, scratch);
+        sub32(scratch, dest);
     }
 
     void sub32(TrustedImm32 imm, AbsoluteAddress address)
     {
-        load32(setupArmAddress(address), dataTempRegister);
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
+        load32(setupArmAddress(address), scratch);
 
         ARMThumbImmediate armImm = ARMThumbImmediate::makeUInt12OrEncodedImm(imm.m_value);
         if (armImm.isValid())
-            m_assembler.sub(dataTempRegister, dataTempRegister, armImm);
+            m_assembler.sub(scratch, scratch, armImm);
         else {
-            // Hrrrm, since dataTempRegister holds the data loaded,
+            // Hrrrm, since scratch holds the data loaded,
             // use addressTempRegister to hold the immediate.
             move(imm, addressTempRegister);
-            m_assembler.sub(dataTempRegister, dataTempRegister, addressTempRegister);
+            m_assembler.sub(scratch, scratch, addressTempRegister);
         }
 
-        store32(dataTempRegister, address.m_ptr);
+        store32(scratch, address.m_ptr);
     }
 
     void sub64(RegisterID leftHi, RegisterID leftLo, RegisterID rightHi, RegisterID rightLo, RegisterID destHi, RegisterID destLo)
@@ -738,8 +770,11 @@ public:
         if (armImm.isValid())
             m_assembler.eor(dest, src, armImm);
         else {
-            move(imm, dataTempRegister);
-            m_assembler.eor(dest, src, dataTempRegister);
+            RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+            ASSERT(dest != scratch);
+            ASSERT(src != scratch);
+            move(imm, scratch);
+            m_assembler.eor(dest, src, scratch);
         }
     }
 
@@ -750,8 +785,10 @@ public:
 
     void xor32(Address src, RegisterID dest)
     {
-        load32(src, dataTempRegister);
-        xor32(dataTempRegister, dest);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        ASSERT(dest != scratch);
+        load32(src, scratch);
+        xor32(scratch, dest);
     }
 
     void xor32(TrustedImm32 imm, RegisterID dest)
@@ -958,7 +995,8 @@ public:
 
     void abortWithReason(AbortReason reason)
     {
-        move(TrustedImm32(reason), dataTempRegister);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        move(TrustedImm32(reason), scratch);
         breakpoint();
     }
 
@@ -1034,8 +1072,9 @@ public:
         if (armImm.isValid())
             m_assembler.ldrh(dest, address.base, armImm);
         else {
-            move(TrustedImm32(address.offset), dataTempRegister);
-            m_assembler.ldrh(dest, address.base, dataTempRegister);
+            RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+            move(TrustedImm32(address.offset), scratch);
+            m_assembler.ldrh(dest, address.base, scratch);
         }
     }
 
@@ -1196,15 +1235,16 @@ public:
         ArmAddress armAddress = setupArmAddress(address);
         RegisterID scratch = addressTempRegister;
         if (armAddress.type == ArmAddress::HasIndex)
-            scratch = dataTempRegister;
+            scratch = getCachedDataTempRegisterIDAndInvalidate();
         move(imm, scratch);
         store32(scratch, armAddress);
     }
 
     void store32(TrustedImm32 imm, BaseIndex address)
     {
-        move(imm, dataTempRegister);
-        store32(dataTempRegister, setupArmAddress(address));
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
+        move(imm, scratch);
+        store32(scratch, setupArmAddress(address));
     }
 
     void store32(RegisterID src, const void* address)
@@ -1215,8 +1255,9 @@ public:
     void store32(TrustedImm32 imm, const void* address)
     {
         RELEASE_ASSERT(m_allowScratchRegister);
-        move(imm, dataTempRegister);
-        store32(dataTempRegister, address);
+        RegisterID scratch = getCachedDataTempRegisterIDAndInvalidate();
+        move(imm, scratch);
+        store32(scratch, address);
     }
 
     void storeRel32(RegisterID src, Address address)
@@ -1243,15 +1284,17 @@ public:
     void store8(TrustedImm32 imm, const void* address)
     {
         TrustedImm32 imm8(static_cast<int8_t>(imm.m_value));
-        move(imm8, dataTempRegister);
-        store8(dataTempRegister, address);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        move(imm8, scratch);
+        store8(scratch, address);
     }
     
     void store8(TrustedImm32 imm, Address address)
     {
         TrustedImm32 imm8(static_cast<int8_t>(imm.m_value));
-        move(imm8, dataTempRegister);
-        store8(dataTempRegister, address);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        move(imm8, scratch);
+        store8(scratch, address);
     }
 
     void store8(RegisterID src, RegisterID addrreg)
@@ -1282,8 +1325,9 @@ public:
 
     void store16(TrustedImm32 imm, const void* address)
     {
-        move(imm, dataTempRegister);
-        store16(dataTempRegister, address);
+        RegisterID scratch = getCachedAddressTempRegisterIDAndInvalidate();
+        move(imm, scratch);
+        store16(scratch, address);
     }
 
     void storeRel16(RegisterID src, Address address)


### PR DESCRIPTION
#### 14ab921ce1691aeead22764c04bce00c5f29eb40
<pre>
[ARMv7] Reduce usage of dataTempRegister
<a href="https://bugs.webkit.org/show_bug.cgi?id=286014">https://bugs.webkit.org/show_bug.cgi?id=286014</a>

Reviewed by NOBODY (OOPS!).

We would like to free up dataTempRegister for use in other places, so this
patch starts by slowly moving away from using it.

* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h:
(JSC::MacroAssemblerARMv7::add32):
(JSC::MacroAssemblerARMv7::add8):
(JSC::MacroAssemblerARMv7::and16):
(JSC::MacroAssemblerARMv7::and32):
(JSC::MacroAssemblerARMv7::lshift32):
(JSC::MacroAssemblerARMv7::mul32):
(JSC::MacroAssemblerARMv7::or8):
(JSC::MacroAssemblerARMv7::or16):
(JSC::MacroAssemblerARMv7::or32):
(JSC::MacroAssemblerARMv7::addUnsignedRightShift32):
(JSC::MacroAssemblerARMv7::sub32):
(JSC::MacroAssemblerARMv7::xor32):
(JSC::MacroAssemblerARMv7::abortWithReason):
(JSC::MacroAssemblerARMv7::load16):
(JSC::MacroAssemblerARMv7::store32):
(JSC::MacroAssemblerARMv7::store8):
(JSC::MacroAssemblerARMv7::store16):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73c85ef7818bf5f6ee9fe2351c8e8827988bc117

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45170 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22687 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72219 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29522 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52554 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10513 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3166 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44510 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87344 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80731 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101740 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93299 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21706 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15833 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81214 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21954 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80597 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25150 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2543 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14923 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26802 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115992 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21351 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33515 "Found 1 new JSC binary failure: testb3, Found 250 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.default, microbenchmarks/memcpy-wasm-small.js.dfg-eager, stress/call-apply-exponential-bytecode-size.js.dfg-eager-no-cjit-validate, stress/call-apply-exponential-bytecode-size.js.no-llint, stress/loop-unrolling-branch.js.default, stress/missing-clobber-top-validation.js.default, wasm.yaml/wasm/gc/any.js.default-wasm, wasm.yaml/wasm/gc/any.js.wasm-bbq, wasm.yaml/wasm/gc/any.js.wasm-collect-continuously, wasm.yaml/wasm/gc/any.js.wasm-eager ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->