### PR TITLE
REGRESSION (282580@main): font-size: calc(). using rem and em prevents text from scaling up or down

### DIFF
--- a/LayoutTests/fast/css/font-size-calc-with-em-zoom-expected.txt
+++ b/LayoutTests/fast/css/font-size-calc-with-em-zoom-expected.txt
@@ -1,0 +1,8 @@
+
+PASS 'font-size: calc(16px)' at zoom level 1
+PASS 'font-size: calc(1em)' at zoom level 1
+PASS 'font-size: calc(1rem)' at zoom level 1
+PASS 'font-size: calc(16px)' at zoom level 2
+PASS 'font-size: calc(1em)' at zoom level 2
+PASS 'font-size: calc(1rem)' at zoom level 2
+

--- a/LayoutTests/fast/css/font-size-calc-with-em-zoom.html
+++ b/LayoutTests/fast/css/font-size-calc-with-em-zoom.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<div id="container">
+</div>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+  let container = document.getElementById('container')
+  const test_font_size = (specified_font_size, zoom, expected_font_size) => {
+      test(() => {
+        try {
+          document.body.style.zoom = zoom;
+
+          let target = document.createElement("div");
+          target.className = 'target';
+          target.appendChild(new Text("test"));
+          container.appendChild(target)
+
+          target.style['font-size'] = specified_font_size;
+          const computed_font_size = window.getComputedStyle(target)['font-size']
+          assert_equals(computed_font_size, expected_font_size);
+        } finally {
+          document.body.style.zoom = 1;
+        }
+      }, `'font-size: ${specified_font_size}' at zoom level ${zoom}`)
+  }
+
+  test_font_size("calc(16px)", 1, '16px');
+  test_font_size("calc(1em)", 1, '16px');
+  test_font_size("calc(1rem)", 1, '16px');
+
+  test_font_size("calc(16px)", 2, '16px');
+  test_font_size("calc(1em)", 2, '16px');
+  test_font_size("calc(1rem)", 2, '16px');
+
+  container.remove();
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -178,7 +178,9 @@ std::optional<CanonicalDimension> canonicalize(NonCanonicalDimension root, const
 
     auto tryMakeCanonical = [&](double value, CSS::LengthUnit lengthUnit) -> std::optional<CanonicalDimension> {
         if (conversionData) {
-            // We are only interested in canonicalizing to `px`, not adjusting for zoom, which will be handled later.
+            // We are only interested in canonicalizing to `px`, not adjusting for zoom, which will be handled later. When computing font-size, zoom is not applied in the same way, so must be special cased here.
+            if (conversionData->computingFontSize())
+                return CanonicalDimension { .value = Style::computeNonCalcLengthDouble(value, lengthUnit, *conversionData), .dimension = CanonicalDimension::Dimension::Length };
             return CanonicalDimension { .value = Style::computeNonCalcLengthDouble(value, lengthUnit, *conversionData) / conversionData->style()->usedZoom(), .dimension = CanonicalDimension::Dimension::Length };
         }
         return std::nullopt;


### PR DESCRIPTION
#### 5a1ed2afa80c4acc4434c81badc2d86b54c30f20
<pre>
REGRESSION (282580@main): font-size: calc(). using rem and em prevents text from scaling up or down
<a href="https://bugs.webkit.org/show_bug.cgi?id=285914">https://bugs.webkit.org/show_bug.cgi?id=285914</a>

Reviewed by Simon Fraser.

Style::computeNonCalcLengthDouble doesn&apos;t apply zoom when processing the font-size
property, so unconditionally trying to remove zoom in the calc code path is incorrect.

This adds a special case for font-size, which fixes the issue, but a better fix would
be to refactor Style::computeNonCalcLengthDouble to explicitly track when zoom is applied.

* LayoutTests/fast/css/font-size-calc-with-em-zoom-expected.txt: Added.
* LayoutTests/fast/css/font-size-calc-with-em-zoom.html: Added.
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
* Source/WebCore/style/values/primitives/StyleLengthResolution.h:

Canonical link: <a href="https://commits.webkit.org/289030@main">https://commits.webkit.org/289030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa757496fca600f20788cd08cf05a20a73ef0913

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90164 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36070 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87101 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66162 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23985 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77262 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46453 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3578 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31492 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35143 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91545 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12358 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9043 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74659 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12587 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73773 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18270 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18157 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16611 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4375 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12306 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17765 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12142 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15637 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13888 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->