### PR TITLE
[cocoa] Cache opt-in partitioned cookie enablement in Web Process and use it when creating cookie cache

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm
@@ -43,6 +43,9 @@ NetworkStorageSession& WebCookieCache::inMemoryStorageSession()
         auto storageSession = WebCore::createPrivateStorageSession(sessionName.createCFString().get(), cookieAcceptPolicy);
         auto cookieStorage = adoptCF(_CFURLStorageSessionCopyCookieStorage(kCFAllocatorDefault, storageSession.get()));
         m_inMemoryStorageSession = makeUnique<NetworkStorageSession>(WebProcess::singleton().sessionID(), WTFMove(storageSession), WTFMove(cookieStorage), NetworkStorageSession::IsInMemoryCookieStore::Yes);
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+        setOptInCookiePartitioningEnabled(WebProcess::singleton().isOptInCookiePartitioningEnabled());
+#endif
     }
     return *m_inMemoryStorageSession;
 }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1996,6 +1996,7 @@ void WebProcess::setEnabledServices(bool hasImageServices, bool hasSelectionServ
 #if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
 void WebProcess::setOptInCookiePartitioningEnabled(bool enabled)
 {
+    m_isOptInCookiePartitioningEnabled = enabled;
     m_cookieJar->setOptInCookiePartitioningEnabled(enabled);
 }
 #endif

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -491,6 +491,10 @@ public:
     void registerAdditionalFonts(AdditionalFonts&&);
 #endif
 
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+    bool isOptInCookiePartitioningEnabled() { return m_isOptInCookiePartitioningEnabled; }
+#endif
+
 private:
     WebProcess();
     ~WebProcess();
@@ -893,6 +897,9 @@ private:
     bool m_isWebTransportEnabled { false };
 #if ENABLE(ACCESSIBILITY_NON_BLINKING_CURSOR)
     bool m_prefersNonBlinkingCursor { false };
+#endif
+#if HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+    bool m_isOptInCookiePartitioningEnabled { false };
 #endif
 
     String m_mediaKeysStorageDirectory;


### PR DESCRIPTION
#### 6dcc241d7bdc59bf02745294d8e2819c1f998917
<pre>
[cocoa] Cache opt-in partitioned cookie enablement in Web Process and use it when creating cookie cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=286016">https://bugs.webkit.org/show_bug.cgi?id=286016</a>
<a href="https://rdar.apple.com/142985374">rdar://142985374</a>

Reviewed by Alex Christensen.

On some platforms where the WebCookieCache is supported, the cache can be
destroyed at any time, such as when the process is suspended. We need to
remember if opt-in cookie partitioning was enabled so we can enable it in the
cache when that is recreated. This patch caches the state in the WebProcess and
uses the singleton when instantiating a new in-memory cache on Cocoa platforms.

* Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm:
(WebKit::WebCookieCache::inMemoryStorageSession):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::setOptInCookiePartitioningEnabled):
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/288981@main">https://commits.webkit.org/288981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94ac6c3284640dbf2b90a1969eceb31d9e43089f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90074 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35982 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12631 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/66095 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23914 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77172 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46357 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/3503 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35055 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74309 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91447 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12268 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8967 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74579 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12498 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73695 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18081 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16526 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13237 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12220 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12055 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15549 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13800 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->