### PR TITLE
[iPadOS] Swiping between articles in Feedly using a trackpad sometimes fails, or the transition animation sometimes stutters

### DIFF
--- a/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.h
+++ b/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.h
@@ -71,7 +71,6 @@ private:
     WebCore::FloatPoint locationInScreen() const;
 
     const WeakObjCPtr<WKWebView> m_view;
-    RunLoop::Timer m_stateResetWatchdogTimer;
     WebCore::FloatPoint m_centroid;
     WebCore::FloatSize m_touchDelta;
     WebCore::FloatSize m_initialDelta;

--- a/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.mm
+++ b/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.mm
@@ -42,7 +42,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(PointerTouchCompatibilitySimulator);
 
 PointerTouchCompatibilitySimulator::PointerTouchCompatibilitySimulator(WKWebView *view)
     : m_view { view }
-    , m_stateResetWatchdogTimer { RunLoop::main(), this, &PointerTouchCompatibilitySimulator::resetState }
 {
 }
 
@@ -50,7 +49,6 @@ PointerTouchCompatibilitySimulator::PointerTouchCompatibilitySimulator(WKWebView
 
 static constexpr auto predominantAxisDeltaRatio = 5;
 static constexpr auto minimumPredominantAxisDelta = 15;
-static constexpr auto stateResetTimerDelay = 250_ms;
 
 static bool hasPredominantHorizontalAxis(WebCore::FloatSize delta)
 {
@@ -97,7 +95,6 @@ bool PointerTouchCompatibilitySimulator::handleScrollUpdate(WKBaseScrollView *sc
         return false;
 
     m_centroid = [update locationInView:view.get()];
-    m_stateResetWatchdogTimer.startOneShot(stateResetTimerDelay);
 
     if (!isSimulatingTouches()) {
         [[_WKTouchEventGenerator sharedTouchEventGenerator] touchDown:locationInScreen() window:window.get()];
@@ -119,7 +116,6 @@ void PointerTouchCompatibilitySimulator::resetState()
     m_centroid = { };
     m_touchDelta = { };
     m_initialDelta = { };
-    m_stateResetWatchdogTimer.stop();
 }
 
 WebCore::FloatPoint PointerTouchCompatibilitySimulator::locationInScreen() const


### PR DESCRIPTION
#### 901227a198cab34e4ed87062ae9e1784bc10fd8a
<pre>
[iPadOS] Swiping between articles in Feedly using a trackpad sometimes fails, or the transition animation sometimes stutters
<a href="https://bugs.webkit.org/show_bug.cgi?id=286025">https://bugs.webkit.org/show_bug.cgi?id=286025</a>

Reviewed by Abrar Rahman Protyasha.

Remove the watchdog timer from `PointerTouchCompatibilitySimulator` — this was only used to work
around the underlying bug in <a href="https://rdar.apple.com/142995637">rdar://142995637</a>. Once a fix for <a href="https://rdar.apple.com/142995637">rdar://142995637</a> is in place, we no
longer need this watchdog timer to guard against the case where the trackpad wheel event stream
abruptly stops before it&apos;s ended or cancelled.

* Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.h:
* Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.mm:
(WebKit::PointerTouchCompatibilitySimulator::PointerTouchCompatibilitySimulator):
(WebKit::PointerTouchCompatibilitySimulator::handleScrollUpdate):
(WebKit::PointerTouchCompatibilitySimulator::resetState):
(): Deleted.

Canonical link: <a href="https://commits.webkit.org/289690@main">https://commits.webkit.org/289690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf2516a69d5c90ece07c4808d585caaa3fde0c6b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90053 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35961 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12610 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66091 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23895 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77158 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46353 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3483 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35034 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74300 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91426 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8959 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74563 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72970 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73687 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18637 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18070 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16514 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4282 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12199 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17650 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12034 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15528 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->