### PR TITLE
Fix ObjC memory leaks

### DIFF
--- a/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
+++ b/Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm
@@ -208,12 +208,12 @@ void AXRemoteFrame::initializePlatformElementWithRemoteToken(std::span<const uin
         return;
 
     NSString *uuid = [tokenDictionary objectForKey:@"ax-uuid"];
-    AXRemoteElement *remoteElement = [allocAXRemoteElementInstance() initWithUUID:uuid andRemotePid:processIdentifier andContextId:0];
-    remoteElement.onClientSide = YES;
+    RetainPtr remoteElement = adoptNS([allocAXRemoteElementInstance() initWithUUID:uuid andRemotePid:processIdentifier andContextId:0]);
+    remoteElement.get().onClientSide = YES;
     RefPtr parent = parentObjectUnignored();
-    remoteElement.accessibilityContainer = parent ?  parent->wrapper() : nil;
+    remoteElement.get().accessibilityContainer = parent ?  parent->wrapper() : nil;
 
-    m_remoteFramePlatformElement = adoptNS(remoteElement);
+    m_remoteFramePlatformElement = WTFMove(remoteElement);
 
     if (CheckedPtr cache = axObjectCache())
         cache->onRemoteFrameInitialized(*this);

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -370,7 +370,7 @@ void PlaybackSessionInterfaceLMK::spatialVideoMetadataChanged(const std::optiona
 {
     RetainPtr<WKSLinearMediaSpatialVideoMetadata> spatialVideoMetadata;
     if (metadata && spatialVideoEnabled())
-        spatialVideoMetadata = [allocWKSLinearMediaSpatialVideoMetadataInstance() initWithWidth:metadata->size.width() height:metadata->size.height() horizontalFOVDegrees:metadata->horizontalFOVDegrees baseline:metadata->baseline disparityAdjustment:metadata->disparityAdjustment];
+        spatialVideoMetadata = adoptNS([allocWKSLinearMediaSpatialVideoMetadataInstance() initWithWidth:metadata->size.width() height:metadata->size.height() horizontalFOVDegrees:metadata->horizontalFOVDegrees baseline:metadata->baseline disparityAdjustment:metadata->disparityAdjustment]);
     [m_player setSpatialVideoMetadata:spatialVideoMetadata.get()];
 }
 
@@ -409,7 +409,7 @@ static RetainPtr<NSData> artworkData(const WebCore::NowPlayingMetadata& metadata
 
 void PlaybackSessionInterfaceLMK::nowPlayingMetadataChanged(const WebCore::NowPlayingMetadata& metadata)
 {
-    RetainPtr contentMetadata = [allocWKSLinearMediaContentMetadataInstance() initWithTitle:metadata.title subtitle:metadata.artist];
+    RetainPtr contentMetadata = adoptNS([allocWKSLinearMediaContentMetadataInstance() initWithTitle:metadata.title subtitle:metadata.artist]);
     [m_player setContentMetadata:contentMetadata.get()];
     [m_player setArtwork:artworkData(metadata).get()];
 }

--- a/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
@@ -229,7 +229,7 @@ void ModelElementController::modelElementLoadRemotePreview(String uuid, URL file
     });
 
     RELEASE_ASSERT(isMainRunLoop());
-    [preview preparePreviewOfFileAtURL:[[NSURL alloc] initFileURLWithPath:fileURL.fileSystemPath()] completionHandler:makeBlockPtr([weakThis = WeakPtr { *this }, uuid = WTFMove(uuid), handler = WTFMove(handler)] (NSError *loadError) mutable {
+    [preview preparePreviewOfFileAtURL:adoptNS([[NSURL alloc] initFileURLWithPath:fileURL.fileSystemPath()]).get() completionHandler:makeBlockPtr([weakThis = WeakPtr { *this }, uuid = WTFMove(uuid), handler = WTFMove(handler)] (NSError *loadError) mutable {
         if (loadError) {
             LOG(ModelElement, "Unable to load file for uuid %s: %@.", uuid.utf8().data(), loadError.localizedDescription);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
@@ -85,7 +85,7 @@ void LocalConnection::verifyUser(const String& rpId, ClientDataType type, SecAcc
     }
 #endif
 
-    m_context = [allocLAContextInstance() init];
+    m_context = adoptNS([allocLAContextInstance() init]);
 
     auto options = adoptNS([[NSMutableDictionary alloc] init]);
 #if HAVE(UNIFIED_ASC_AUTH_UI)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -772,7 +772,7 @@ static inline RetainPtr<ASCPublicKeyCredentialDescriptor> toASCDescriptor(Public
 
 static inline RetainPtr<ASCWebAuthenticationExtensionsClientInputs> toASCExtensions(const AuthenticationExtensionsClientInputs& extensions)
 {
-    if ([allocASCWebAuthenticationExtensionsClientInputsInstance() respondsToSelector:@selector(initWithAppID:)])
+    if ([getASCWebAuthenticationExtensionsClientInputsClass() instancesRespondToSelector:@selector(initWithAppID:)])
         return adoptNS([allocASCWebAuthenticationExtensionsClientInputsInstance() initWithAppID:extensions.appid]);
 
     return nil;

--- a/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
@@ -130,10 +130,10 @@ static WebAVPlayerView *allocWebAVPlayerViewInstance()
     RefPtr<WebCore::PlaybackSessionModelMediaElement> _playbackModel;
     RefPtr<WebCore::PlaybackSessionInterfaceIOS> _playbackInterface;
     RetainPtr<NSView> _contentOverlay;
+    RetainPtr<WebAVPlayerView> _playerView;
     BOOL _isFullScreen;
 }
 @property (readonly) WebCoreFullScreenWindow* fullscreenWindow;
-@property (readonly) WebAVPlayerView* playerView;
 @end
 
 @implementation WebVideoFullscreenController
@@ -162,9 +162,14 @@ static WebAVPlayerView *allocWebAVPlayerViewInstance()
 {
     ASSERT(!_backgroundFullscreenWindow);
     ASSERT(!_fadeAnimation);
-    _playerView.webDelegate = nil;
+    _playerView.get().webDelegate = nil;
     _playbackModel = nil;
     [super dealloc];
+}
+
+- (WebAVPlayerView *)playerView
+{
+    return _playerView.get();
 }
 
 - (WebCoreFullScreenWindow *)fullscreenWindow
@@ -179,14 +184,14 @@ static WebAVPlayerView *allocWebAVPlayerViewInstance()
     [window setHasShadow:YES]; // This is nicer with a shadow.
     [window setLevel:NSPopUpMenuWindowLevel-1];
 
-    _playerView = [allocWebAVPlayerViewInstance() initWithFrame:window.contentLayoutRect];
-    _playerView.controlsStyle = AVPlayerViewControlsStyleNone;
-    _playerView.showsFullScreenToggleButton = YES;
-    _playerView.showsAudioOnlyIndicatorView = NO;
-    _playerView.webDelegate = self;
-    window.contentView = _playerView;
-    [_contentOverlay setFrame:_playerView.contentOverlayView.bounds];
-    [_playerView.contentOverlayView addSubview:_contentOverlay.get()];
+    _playerView = adoptNS([allocWebAVPlayerViewInstance() initWithFrame:window.contentLayoutRect]);
+    _playerView.get().controlsStyle = AVPlayerViewControlsStyleNone;
+    _playerView.get().showsFullScreenToggleButton = YES;
+    _playerView.get().showsAudioOnlyIndicatorView = NO;
+    _playerView.get().webDelegate = self;
+    window.contentView = _playerView.get();
+    [_contentOverlay setFrame:_playerView.get().contentOverlayView.bounds];
+    [_playerView.get().contentOverlayView addSubview:_contentOverlay.get()];
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidResignActive:) name:NSApplicationDidResignActiveNotification object:NSApp];
 }
@@ -307,7 +312,7 @@ static WebAVPlayerView *allocWebAVPlayerViewInstance()
 
 - (void)windowDidEnterFullScreen:(NSNotification *)notification
 {
-    _playerView.controlsStyle = AVPlayerViewControlsStyleFloating;
+    _playerView.get().controlsStyle = AVPlayerViewControlsStyleFloating;
     [_playerView willChangeValueForKey:@"isFullScreen"];
     _isFullScreen = YES;
     [_playerView didChangeValueForKey:@"isFullScreen"];
@@ -317,7 +322,7 @@ static WebAVPlayerView *allocWebAVPlayerViewInstance()
 
 - (void)windowWillExitFullScreen:(NSNotification *)notification
 {
-    _playerView.controlsStyle = AVPlayerViewControlsStyleNone;
+    _playerView.get().controlsStyle = AVPlayerViewControlsStyleNone;
 }
 
 - (void)windowDidExitFullScreen:(NSNotification *)notification


### PR DESCRIPTION
#### 130169a292024b9bfca8225def5a68c1866733ce
<pre>
Fix ObjC memory leaks
<a href="https://bugs.webkit.org/show_bug.cgi?id=286027">https://bugs.webkit.org/show_bug.cgi?id=286027</a>
<a href="https://rdar.apple.com/142998270">rdar://142998270</a>

Reviewed by Abrar Rahman Protyasha and Geoffrey Garen.

grep -r &apos;\[alloc&apos; Source | grep -v adopt

The change in AccessibilityObjectIOS.mm wasn&apos;t a memory leak, but I
think it&apos;s good to adopt in the same statement as the allocation.

* Source/WebCore/accessibility/ios/AccessibilityObjectIOS.mm:
(WebCore::AXRemoteFrame::initializePlatformElementWithRemoteToken):
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
(WebKit::PlaybackSessionInterfaceLMK::spatialVideoMetadataChanged):
(WebKit::PlaybackSessionInterfaceLMK::nowPlayingMetadataChanged):
* Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm:
(WebKit::ModelElementController::modelElementLoadRemotePreview):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm:
(WebKit::LocalConnection::verifyUser):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::toASCExtensions):
* Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm:
(-[WebVideoFullscreenController dealloc]):
(-[WebVideoFullscreenController playerView]):
(-[WebVideoFullscreenController windowDidLoad]):
(-[WebVideoFullscreenController windowDidEnterFullScreen:]):
(-[WebVideoFullscreenController windowWillExitFullScreen:]):

Canonical link: <a href="https://commits.webkit.org/289029@main">https://commits.webkit.org/289029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a4e2bffa8d2ee0ab81ee1c28c9a3eccd4d41f6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90059 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/35967 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/86999 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66089 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23899 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/87959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3612 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46349 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3488 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31393 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35040 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74304 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91432 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12253 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/8952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74574 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12483 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/72978 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73689 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18077 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16520 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4288 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13265 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12205 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17657 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12040 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15534 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->