### PR TITLE
[WTF] ThreadSafeWeakOrStrongPtr should appropriately reset payload

### DIFF
--- a/JSTests/wasm/stress/thread-safe-weak-or-strong-ptr-validate.js
+++ b/JSTests/wasm/stress/thread-safe-weak-or-strong-ptr-validate.js
@@ -1,0 +1,170 @@
+function instantiate(moduleBase64, importObject) {
+    let bytes = Uint8Array.fromBase64(moduleBase64);
+    return WebAssembly.instantiate(bytes, importObject);
+  }
+  const log = function () { };
+  const report = $.agent.report;
+  const isJIT = callerIsBBQOrOMGCompiled;
+const extra = {isJIT};
+(async function () {
+/**
+@param {I32} a0
+@param {ExternRef} a1
+@param {FuncRef} a2
+@returns {[I32, ExternRef, FuncRef]}
+ */
+let fn0 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return [30, a1, a2];
+};
+/**
+@returns {I32}
+ */
+let fn1 = function () {
+
+return 26;
+};
+/**
+@param {I32} a0
+@param {ExternRef} a1
+@param {FuncRef} a2
+@returns {[I32, ExternRef, FuncRef]}
+ */
+let fn2 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return [64, a1, a2];
+};
+/**
+@param {I32} a0
+@param {ExternRef} a1
+@param {FuncRef} a2
+@returns {[I32, ExternRef, FuncRef]}
+ */
+let fn3 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+return [38, a1, a2];
+};
+/**
+@param {I32} a0
+@param {ExternRef} a1
+@param {FuncRef} a2
+@returns {void}
+ */
+let fn4 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+};
+/**
+@param {I32} a0
+@param {ExternRef} a1
+@param {FuncRef} a2
+@returns {void}
+ */
+let fn5 = function (a0, a1, a2) {
+a0?.toString(); a1?.toString(); a2?.toString();
+};
+let tag3 = new WebAssembly.Tag({parameters: ['i32', 'externref', 'anyfunc']});
+let global0 = new WebAssembly.Global({value: 'externref', mutable: true}, {});
+let global1 = new WebAssembly.Global({value: 'i32', mutable: true}, 1020505450);
+let table0 = new WebAssembly.Table({initial: 51, element: 'externref', maximum: 506});
+let table2 = new WebAssembly.Table({initial: 45, element: 'anyfunc', maximum: 45});
+let m2 = {fn0, fn1, global0, table1: table0};
+let m1 = {fn2, fn3, global1, tag3};
+let m0 = {fn4, fn5, table0, table2};
+let importObject0 = /** @type {Imports2} */ ({extra, m0, m1, m2});
+let i0 = await instantiate('AGFzbQEAAAABLwdgAAF/YAJ7cAF9YAJ7cAJ7cGACe3AAYAN/b3ADfXtwYAN/b3ADf29wYAN/b3AAApkBDQJtMgNmbjAABQJtMgNmbjEAAAJtMQNmbjIABQJtMQNmbjMABQJtMANmbjQABgJtMANmbjUABgVleHRyYQVpc0pJVAAAAm0xBHRhZzMEAAYCbTIHZ2xvYmFsMANvAQJtMQdnbG9iYWwxA38BAm0wBnRhYmxlMAFvATP6AwJtMgZ0YWJsZTEBbwAEAm0wBnRhYmxlMgFwAS0tAwMCAAUEDQRwAB9vACpvAB9wADMFBgEDzQ/3HQ0LBQAGAAYAAwAGAAYGEQJ+AUKq97gDC30BQx3pG9sLB2QMBnRhYmxlNgEGA2ZuNwAHBnRhYmxlMwEDBnRhYmxlNAEEB2dsb2JhbDIDAgR0YWcyBAQEdGFnMAQBBHRhZzEEAwZ0YWJsZTUBBQNmbjYAAgdtZW1vcnkwAgAHZ2xvYmFsMwMDCUsEAQAfBwAHCAgBAwgICAQEAQUFBwMFBAgHBQMBAAgEAwgABwIGQRcLAAQAAgMIBgNBCAtwA9IBC9IGC9IHCwYDQRALcALSBAvSBQsMAQEKvxQCwggJAHABfgJwAHAAfwN/AX4BfQF8RDlYHQIIIqT0Q3rLu9gkAyACIQIGfwYABgBB0CoEfwIABgAGAEG57cgAQf//A3EtAERBCyUFQRclBhAIBn4CAAZ9Am8GAAYAAgACAAYAAgA/AEECcARvIwD8EAJBAnAOAgcABwUCANIF/gMAIwD8EARBAnAOAggBCAtBAnAEb0PpJuWdu0RHNTKV0qL+fyAAJAIgAiACIwNBAQwNAAUGAAZ/A3AgBEEBaiIEQS5JBEAMAQsGACMADAwLQgt5p0ECcARwAgAgANIBROcXiLprf88M/BAADAoACwAFQ+0UrVJDVH/iMwwNAAtDVtD49QwMAAsgAEQAAAAAAAAAgL0MDQsMCwsMEgALDAALQm+5IwAgAiAB0gYgAAJ+BgAGAENf1Buj0gBEAAAAAAAAAABChdXGzHoMDAtBAnAEfAIAQ42mcfAjAgwNAAsABQN/0gMjAgwDAAsACyACQQxBEkED/AwAAyICIgEjA0E1DA8BAAsgASMADAcLDAkAC0ECcARA0gAjAgZ9DAEL/AR9IwIMCQsCQEQvc6uK1yEaciMAQgEMCQALAnwCAERypwosms/LmAwBAAsAC50gASACIgICfyABIwEGcAJ8AgADACAAPwBBAXAOAQ0NC0P8VIp/JAMPAAsACwN/EAZFDQBCcwwLAAsMBAELQ++ISXAkAyEB/BAGcCABJgYhASMADAYACz8APwAMAAtp/BAGDAMAC0ECcARABgAMAQsMCwsGf/wQAAwJCwZvIwAgAEGrCQwCCwwDC0ECcARACyMCRHLePWi1QyBOGgJvIwBCon0MBgALJAAMBQtB//8Dcf4UAAAMBAtBAnAEfgZACwYAQT4MBgsMBgAFAgACfwJ/IAEjAgwDAAsACwALAAshAAYAQQMLDAkBCyQAAwAQBkUNACAIRAAAAAAAAPA/oCIIRAAAAAAAAPA/YwRADAELAwAgBUEBaiIFQS5JDQAgBUEBaiIFQRRJBEAMAQsCAEG8AgsLC0ECcAR8BgAjAQv8EANBCXAOCQUCBAsJBgcKCAoF0gYaQQgRAAMMBwAL0gL8EAEDfQYAIwEYCQwJAAsMAAsgAiECkdIIGtIGIwMkAxrSBUMXS/Z/GtIAIwIMAQsgAAwACyQC/BADAn5C8gEL0gQaQrsBIQAhAPwQBnATAAYLCwsMAAUGACMBC9IIGkECcAR9IwEMAQAFIAAhAAJvRCwJY1XHvnV20gAaGkECJQEMAAALJAAjAyQDQwAAAAALGgJwQRglAgsjAyQDIQECAEEhQQ1BAfwMAAJBvRUkAUGlAQJvBn9E64rzmjI+yBsGfgIAIwFBAnAEAAIAAgAgAAwEAAsACwAFBgDSAUOd2nirJAMaQyKNneAaIwEMCAELCwsMBAt6JAKcIAIjA/wBDAMLDAIACwALDAEBCwsZQYi3iQELCw8L+AsMAH4AbwBwAHACfAJvAHABfgN/AX4BfQF8RDx/VVOOOUEfQqemvQcgBCMA0gI/ACIAIgAGcEQlIyDxlCV2ISMCIQdDgTUYryQDRDG+3GGBLyAIIwAkAD8AQQJwBAADcEGt8QMhAAIAAgAGAAJwEAZFBEAMBQsjAiIHBn0QBkECcARAIwEMAwAF0gBCFiQCQ/GJbKr8EAYMAwALBkDSBiABBn1EsKH0ak9DWzScQ5U5zafSAkI8JAJC4eXR37vLxnJDjWDz/wJvAgACAAIAQugA0gZDgo4NJkMt6F5WDAQACwALAAsAC9IIIwMkA0Q0uX/vDP6XPiID/ANBAXAOAQEBAAvSBSMC0gXQcCICRFxShS/wvpoCQcEAQQJwBHxD/ke8oUS7am0sb+VWWdIFBm8MAgsCfD8AQQFwDgECAgALQoX9sMfMpQPEwiEHIAQgBfwQA0EBcA4BAQEFQwnmif8MAgALBn4QBkUNBwwBAAsjACQAIgfCAkACAEGZgukHDAAAC0ECcA4CAAEAAAALIgckAtIBAn4MAQAL0gBBBkEUQQP8DAADQyu9IMIMAQsGACAIQQFqIghBJ0kNBiAJQQFqIglBHEkEQAwHCyAIQQFqIghBEkkNBkND/DsADAELIAMGbyAIQQFqIghBL0kEQAwHCyMB/BAEPwAMAwsGcAIAIA1EAAAAAAAA8D+gIg1EAAAAAACAREBjDQcGf9IIQozbrIp/IAFCxQEkAiQAesQGfgYABgD8EAYMCAsMAwsMAgv8EAAkAUEGQRNBAvwMAAP8EAIMAQELBn8GAAIAQy5JokJCurNFRImofjX4cWpvIQO0IwIgAtICIwA/AAwDAAsMAQsMCQsMBgsMBwsMBwuORMBvl1iUPrVKQ4ZgSom7PwBBAnAEfSMDDAAABQIAIwIiB8MhB9IGA33SBRojAPwQBQwFAAsACwALIAdBrwFBAnAEcCAKQQFqIgpBB0kNBfwQBEECcAR/IApBAWoiCkEMSQ0GIwFBAnAEfyMBAnACAEQpUgqaUvbHywZvQRolBBkgCEEBaiIIQSRJBEAMCwv8EAMMAQshBUGOAQwIC6wCQAwAAAs/AAwGAAsABQYARB1A4yteRbHWIQRB4DgLCwUGACAAGANEkOL1stO1YzEaQQJwBEAgASEBBQsgCUEBaiIJQS1JBEAMBwsjAQwAAAv8EABwJQAhAUElJQIMAAAFBgACABAGDAAAC0ECcARw0gZDhYP4FNIEGvwBDAUABSMBDAUAC0KOASQCQv/8jGkhB0PUcQ+B/BACDAcL/BACcCUCCwwAAAsgASEGDAUL/BAFAnxEWeDGMxOytPcMAAAL0gEa/BAEDAELCwwBAAsMAQAFIwELJAHSB/wQAsEkASMCIQcaIQM/ACQB0gca/BAAQRNBBEEF/AwABgN8BgAjAQsiACEAIAchB0SVUtU7Fv8P7SEDRO2/ipDu/APDnfwDIwMkAyQBBgACcNIIGgMAEAEL/BAEDAEACwwCC7cLGkECcARvAgD8EAYMAAALwT8AJAFBAnAEfAMAQQMgB0PmwaolQbecnc0AaCQBJANC+ftetJAjASQBjPwFJAIkAgtB//8DcSoCtwIkA0TO0ILlxnw0jwwAAAUQBkECcARwIwNDK2D2fyQD0gEaQtej1fqOyXYkAhogAgwDAAUgAyEEQSElAgsMAgALIwMgAgwBAAVBByUFCyQA/BAFBH8jAQwAAAUjAQJ+IwILJAIMAAALQfuAECEAPwAkASQB/AkAQRpB/v8Dcf4TAQA/AEECcARvQQAlAAwAAAUjAAv8EAEiACQBJAD8EARwIwAmBAZ+QtCB4KK/ueEBC7ohAz8AQZgBQQJwBH0jAwwAAAVDWqwGgAskAyQBIQQCfUPu4u//C/wQBqwkAvwFIwAkACQCQRolAwshAvwQBnAgAiYGPwAjAiQCuCEEGiQAIAUhBbY/ACQBJAN7IQcaQcb6ktUDrXtB39MOIwIkAkH//wNxKQGfBD8AHAF+JAIjAbhCLiQCIQMgAGkjAEEaJQYLCwUBAQKFtQ==', importObject0);
+let {fn6, fn7, global2, global3, memory0, table3, table4, table5, table6, tag0, tag1, tag2} = /**
+  @type {{
+fn6: (a0: I32, a1: ExternRef, a2: FuncRef) => [I32, ExternRef, FuncRef],
+fn7: () => I32,
+global2: WebAssembly.Global,
+global3: WebAssembly.Global,
+memory0: WebAssembly.Memory,
+table3: WebAssembly.Table,
+table4: WebAssembly.Table,
+table5: WebAssembly.Table,
+table6: WebAssembly.Table,
+tag0: WebAssembly.Tag,
+tag1: WebAssembly.Tag,
+tag2: WebAssembly.Tag
+  }} */ (i0.instance.exports);
+table0.set(30, table0);
+table5.set(9, table4);
+table5.set(4, table0);
+table5.set(3, table0);
+global1.value = 0;
+global2.value = 0n;
+global3.value = 0;
+log('calling fn6');
+report('progress');
+try {
+  for (let k=0; k<5; k++) {
+  let zzz = fn6(global1.value, global0.value, null);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn7');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn7();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn7');
+report('progress');
+try {
+  for (let k=0; k<17; k++) {
+  let zzz = fn7();
+  zzz?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+log('calling fn6');
+report('progress');
+try {
+  for (let k=0; k<11; k++) {
+  let zzz = fn6(global1.value, global0.value, null);
+  if (!(zzz instanceof Array)) { throw new Error('expected array but return value is '+zzz); }
+if (zzz.length != 3) { throw new Error('expected array of length 3 but return value is '+zzz); }
+let [r0, r1, r2] = zzz;
+r0?.toString(); r1?.toString(); r2?.toString();
+  }
+} catch (e) {
+  if (e instanceof WebAssembly.Exception) {
+  log(e); if (e.stack) { log(e.stack); }
+  } else if (e instanceof TypeError) {
+  if (e.message === 'an exported wasm function cannot contain a v128 parameter or return value') { log(e); } else { throw e; }
+  } else if (e instanceof WebAssembly.RuntimeError || e instanceof RangeError) { log(e); } else { throw e; }
+}
+let tables = [table0, table4, table5, table2, table6, table3];
+for (let table of tables) {
+for (let k=0; k < table.length; k++) { table.get(k)?.toString(); }
+}
+})().then(() => {
+  log('after')
+  report('after');
+}).catch(e => {
+  log(e)
+  log('error')
+  report('error');
+})

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -486,94 +486,124 @@ public:
 
     ThreadSafeWeakOrStrongPtr& operator=(const ThreadSafeWeakOrStrongPtr& other)
     {
-        *this = nullptr;
-        if (other.isWeak())
-            m_weak = other.m_weak;
-        else
-            m_strong = other.m_strong;
-        ASSERT(status() == other.status());
+        ThreadSafeWeakOrStrongPtr copied(other);
+        swap(copied);
         return *this;
     }
 
     ThreadSafeWeakOrStrongPtr& operator=(ThreadSafeWeakOrStrongPtr&& other)
     {
-        *this = nullptr;
-        Status status = other.status();
-        if (status == Status::Weak)
-            m_weak = std::exchange(other.m_weak, nullptr);
-        else
-            m_strong = std::exchange(other.m_strong, nullptr);
-        ASSERT(status == this->status());
-        ASSERT(!other.ptr());
+        ThreadSafeWeakOrStrongPtr moved(WTFMove(other));
+        swap(moved);
         return *this;
     }
 
     ThreadSafeWeakOrStrongPtr& operator=(std::nullptr_t)
     {
-        if (isWeak())
-            m_weak = nullptr;
-        else
-            m_strong = nullptr;
+        ThreadSafeWeakOrStrongPtr zeroed;
+        swap(zeroed);
         return *this;
     }
 
     template<typename U>
     ThreadSafeWeakOrStrongPtr& operator=(const RefPtr<U>& strongReference)
     {
-        if (isWeak())
-            m_weak = nullptr;
-        m_strong = strongReference;
-        ASSERT(isStrong());
+        ThreadSafeWeakOrStrongPtr copied(strongReference);
+        swap(copied);
         return *this;
     }
 
     template<typename U>
     ThreadSafeWeakOrStrongPtr& operator=(RefPtr<U>&& strongReference)
     {
-        if (isWeak())
-            m_weak = nullptr;
-        m_strong = WTFMove(strongReference);
-        ASSERT(isStrong());
+        ThreadSafeWeakOrStrongPtr moved(WTFMove(strongReference));
+        swap(moved);
         return *this;
     }
 
     template<typename U>
     ThreadSafeWeakOrStrongPtr& operator=(const Ref<U>& strongReference)
     {
-        if (isWeak())
-            m_weak = nullptr;
-        m_strong = strongReference;
-        ASSERT(isStrong());
+        ThreadSafeWeakOrStrongPtr copied(strongReference);
+        swap(copied);
         return *this;
     }
 
     template<typename U>
     ThreadSafeWeakOrStrongPtr& operator=(Ref<U>&& strongReference)
     {
-        if (isWeak())
-            m_weak = nullptr;
-        m_strong = WTFMove(strongReference);
-        ASSERT(isStrong());
+        ThreadSafeWeakOrStrongPtr moved(WTFMove(strongReference));
+        swap(moved);
         return *this;
     }
 
     ThreadSafeWeakOrStrongPtr()
-        : m_weak(nullptr)
     {
         ASSERT(isStrong());
     }
 
-    template<typename U>
-    ThreadSafeWeakOrStrongPtr(const Ref<U>& strongReference) { *this = strongReference; }
+    ThreadSafeWeakOrStrongPtr(std::nullptr_t)
+    {
+        ASSERT(isStrong());
+    }
+
+    ThreadSafeWeakOrStrongPtr(const ThreadSafeWeakOrStrongPtr& other)
+    {
+        ASSERT(isStrong());
+        copyConstructFrom(other);
+    }
 
     template<typename U>
-    ThreadSafeWeakOrStrongPtr(const RefPtr<U>& strongReference) { *this = strongReference; }
+    ThreadSafeWeakOrStrongPtr(const ThreadSafeWeakOrStrongPtr<U>& other)
+    {
+        ASSERT(isStrong());
+        copyConstructFrom(other);
+    }
+
+    ThreadSafeWeakOrStrongPtr(ThreadSafeWeakOrStrongPtr&& other)
+    {
+        ASSERT(isStrong());
+        moveConstructFrom(WTFMove(other));
+    }
 
     template<typename U>
-    ThreadSafeWeakOrStrongPtr(Ref<U>&& strongReference) { *this = WTFMove(strongReference); }
+    ThreadSafeWeakOrStrongPtr(ThreadSafeWeakOrStrongPtr<U>&& other)
+    {
+        ASSERT(isStrong());
+        moveConstructFrom(WTFMove(other));
+    }
 
     template<typename U>
-    ThreadSafeWeakOrStrongPtr(RefPtr<U>&& strongReference) { *this = WTFMove(strongReference); }
+    ThreadSafeWeakOrStrongPtr(const Ref<U>& strongReference)
+    {
+        ASSERT(isStrong());
+        m_strong = strongReference;
+        ASSERT(isStrong());
+    }
+
+    template<typename U>
+    ThreadSafeWeakOrStrongPtr(const RefPtr<U>& strongReference)
+    {
+        ASSERT(isStrong());
+        m_strong = strongReference;
+        ASSERT(isStrong());
+    }
+
+    template<typename U>
+    ThreadSafeWeakOrStrongPtr(Ref<U>&& strongReference)
+    {
+        ASSERT(isStrong());
+        m_strong = WTFMove(strongReference);
+        ASSERT(isStrong());
+    }
+
+    template<typename U>
+    ThreadSafeWeakOrStrongPtr(RefPtr<U>&& strongReference)
+    {
+        ASSERT(isStrong());
+        m_strong = WTFMove(strongReference);
+        ASSERT(isStrong());
+    }
 
     ~ThreadSafeWeakOrStrongPtr()
     {
@@ -583,9 +613,65 @@ public:
             m_weak.~ThreadSafeWeakPtr<T, EnumTaggingTraits<T, Status>>();
     }
 
+    template<typename U>
+    void swap(ThreadSafeWeakOrStrongPtr<U>& other)
+    {
+        if (isStrong()) {
+            if (other.isStrong()) {
+                std::swap(m_strong, other.m_strong);
+                return;
+            }
+            auto weak = std::exchange(other.m_weak, ThreadSafeWeakPtr<U, EnumTaggingTraits<U, Status>> { });
+            ASSERT(other.isStrong());
+            other.m_strong = std::exchange(m_strong, nullptr);
+            m_weak = WTFMove(weak);
+            ASSERT(isWeak());
+            return;
+        }
+
+        if (other.isWeak()) {
+            std::swap(m_weak, other.m_weak);
+            return;
+        }
+
+        auto strong = std::exchange(other.m_strong, nullptr);
+        other.m_weak = std::exchange(m_weak, ThreadSafeWeakPtr<T, EnumTaggingTraits<T, Status>> { });
+        ASSERT(other.isWeak());
+        ASSERT(isStrong());
+        m_strong = WTFMove(strong);
+    }
+
 private:
+    template<typename U>
+    void copyConstructFrom(const ThreadSafeWeakOrStrongPtr<U>& other)
+    {
+        ASSERT(isStrong());
+        if (other.isWeak()) {
+            m_weak = other.m_weak;
+            ASSERT(isWeak());
+        } else {
+            m_strong = other.m_strong;
+            ASSERT(isStrong());
+        }
+    }
+
+    template<typename U>
+    void moveConstructFrom(ThreadSafeWeakOrStrongPtr<U>&& other)
+    {
+        ASSERT(isStrong());
+        if (other.isWeak()) {
+            m_weak = std::exchange(other.m_weak, ThreadSafeWeakPtr<U, EnumTaggingTraits<U, Status>> { });
+            ASSERT(isWeak());
+            ASSERT(other.isStrong());
+        } else {
+            m_strong = std::exchange(other.m_strong, nullptr);
+            ASSERT(isStrong());
+            ASSERT(other.isStrong());
+        }
+    }
+
     union {
-        ThreadSafeWeakPtr<T, EnumTaggingTraits<T, Status>> m_weak;
+        ThreadSafeWeakPtr<T, EnumTaggingTraits<T, Status>> m_weak { };
         RefPtr<T> m_strong;
     };
 };


### PR DESCRIPTION
#### 3985cfe856ce74f978ce7d1a85408d3a5864a9bf
<pre>
[WTF] ThreadSafeWeakOrStrongPtr should appropriately reset payload
<a href="https://bugs.webkit.org/show_bug.cgi?id=286042">https://bugs.webkit.org/show_bug.cgi?id=286042</a>
<a href="https://rdar.apple.com/142973371">rdar://142973371</a>

Reviewed by Keith Miller.

The code like this is not correct.

    if (isWeak())
        m_weak = nullptr;
    m_strong = ...

The reason is that m_weak does not change the enum. As a result,
m_strong contains Weak enum in the pointer, causing the crash due to
destroying invalid pointer. This patch refactors ThreadSafeWeakOrStrongPtr
so that we can clearly track the underlying payload state.

* JSTests/wasm/stress/thread-safe-weak-or-strong-ptr-validate.js: Added.
(instantiate):
(const.log):
(async let.fn0):
(let.fn1):
(let.fn2):
(let.fn3):
(let.fn4):
(let.fn5):
(async let):
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeWeakOrStrongPtr::operator=):
(WTF::ThreadSafeWeakOrStrongPtr::ThreadSafeWeakOrStrongPtr):
(WTF::ThreadSafeWeakOrStrongPtr::swap):
(WTF::ThreadSafeWeakOrStrongPtr::copyConstructFrom):
(WTF::ThreadSafeWeakOrStrongPtr::moveConstructFrom):

Canonical link: <a href="https://commits.webkit.org/288991@main">https://commits.webkit.org/288991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2d63aaebd3adb6042570d499e1b259a3deb41ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90107 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36014 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12663 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/66113 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/23934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77210 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/46380 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3527 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31437 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35087 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77926 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91480 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84003 "Found 1 new JSC stress test failure: stress/scoped-arguments-table-should-be-tolerant-for-oom.js.bytecode-cache (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12302 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74599 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73719 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18108 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16559 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13244 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12250 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106394 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12086 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25682 "Found 11 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-many-args.js.layout-no-llint, stress/json-stringify-inspector-check.js.no-llint, stress/regexp-escape-oom.js.default, wasm.yaml/wasm/stress/cc-int-to-int-cross-module-with-exception.js.default-wasm, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.default-wasm, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.wasm-bbq, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.wasm-collect-continuously, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.wasm-eager, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.wasm-eager-jettison, wasm.yaml/wasm/stress/wasm-bbq-catch-unbind.js.wasm-no-cjit ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15582 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13830 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->