### PR TITLE
Disable IsoHeap code when TZoneHeap is enabled.

### DIFF
--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -25,6 +25,10 @@
 #include <wtf/DebugHeap.h>
 #include <wtf/StdLibExtras.h>
 
+#if !USE(SYSTEM_MALLOC)
+#include <bmalloc/BPlatform.h>
+#endif
+
 namespace WTF {
 
 // There are several malloc-related macros to annotate class / struct. If these annotations are attached,

--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -301,16 +301,17 @@
 #define USE_SANDBOX_EXTENSIONS_FOR_CACHE_AND_TEMP_DIRECTORY_ACCESS 1
 #endif
 
-#if !defined(USE_ISO_MALLOC)
-#define USE_ISO_MALLOC 1
-#endif
-
 #if !defined(USE_TZONE_MALLOC)
 #if (CPU(ARM64) || CPU(X86_64)) && OS(DARWIN) && (__SIZEOF_POINTER__ == 8)
 #define USE_TZONE_MALLOC 1
+#define USE_ISO_MALLOC 0
 #else
 #define USE_TZONE_MALLOC 0
 #endif
+#endif
+
+#if !defined(USE_ISO_MALLOC)
+#define USE_ISO_MALLOC 1
 #endif
 
 #if !PLATFORM(WATCHOS)

--- a/Source/bmalloc/bmalloc/AllIsoHeaps.cpp
+++ b/Source/bmalloc/bmalloc/AllIsoHeaps.cpp
@@ -23,8 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+#include "BPlatform.h"
 #include "AllIsoHeaps.h"
 
+#if !BUSE(TZONE)
 #if !BUSE(LIBPAS)
 
 namespace bmalloc {
@@ -51,3 +53,4 @@ IsoHeapImplBase* AllIsoHeaps::head()
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/AllIsoHeaps.h
+++ b/Source/bmalloc/bmalloc/AllIsoHeaps.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include "BPlatform.h"
+
+#if !BUSE(TZONE)
+
 #include "IsoHeapImpl.h"
 #include "StaticPerProcess.h"
 #include "Vector.h"
@@ -54,3 +58,4 @@ BALLOW_DEPRECATED_DECLARATIONS_END
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/AllIsoHeapsInlines.h
+++ b/Source/bmalloc/bmalloc/AllIsoHeapsInlines.h
@@ -25,6 +25,10 @@
 
 #pragma once
 
+#include "BPlatform.h"
+
+#if !BUSE(TZONE)
+
 #include "AllIsoHeaps.h"
 #include "IsoHeapImpl.h"
 
@@ -42,3 +46,4 @@ void AllIsoHeaps::forEach(const Func& func)
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/DeferredDecommit.h
+++ b/Source/bmalloc/bmalloc/DeferredDecommit.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
 #if !BUSE(LIBPAS)
 
 namespace bmalloc {
@@ -44,3 +45,4 @@ struct DeferredDecommit {
 } // namespace bmalloc
     
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/DeferredDecommitInlines.h
+++ b/Source/bmalloc/bmalloc/DeferredDecommitInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "DeferredDecommit.h"
 
 #if !BUSE(LIBPAS)
@@ -45,3 +47,4 @@ inline DeferredDecommit::DeferredDecommit(IsoDirectoryBaseBase* directory, IsoPa
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/DeferredTrigger.h
+++ b/Source/bmalloc/bmalloc/DeferredTrigger.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "IsoPageTrigger.h"
 #include "Mutex.h"
 #include <mutex>
@@ -53,3 +55,4 @@ private:
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/DeferredTriggerInlines.h
+++ b/Source/bmalloc/bmalloc/DeferredTriggerInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "BAssert.h"
 #include "DeferredTrigger.h"
 
@@ -57,3 +59,4 @@ void DeferredTrigger<trigger>::handleDeferral(const LockHolder& locker, IsoPage<
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/EligibilityResult.h
+++ b/Source/bmalloc/bmalloc/EligibilityResult.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "IsoPage.h"
 
 #if !BUSE(LIBPAS)
@@ -56,3 +58,4 @@ struct EligibilityResult {
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/EligibilityResultInlines.h
+++ b/Source/bmalloc/bmalloc/EligibilityResultInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "EligibilityResult.h"
 
 #if !BUSE(LIBPAS)
@@ -47,3 +49,4 @@ EligibilityResult<Config>::EligibilityResult(IsoPage<Config>* page)
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/FreeList.cpp
+++ b/Source/bmalloc/bmalloc/FreeList.cpp
@@ -23,7 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+#include "BPlatform.h"
 #include "FreeList.h"
+
+#if !BUSE(TZONE)
 
 #include "FreeListInlines.h"
 
@@ -80,3 +83,4 @@ bool FreeList::contains(void* target) const
 } // namespace JSC
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/FreeList.h
+++ b/Source/bmalloc/bmalloc/FreeList.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "BExport.h"
 #include <cstddef>
 #include <cstdint>
@@ -97,3 +99,4 @@ private:
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/FreeListInlines.h
+++ b/Source/bmalloc/bmalloc/FreeListInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "FreeList.h"
 
 #if !BUSE(LIBPAS)
@@ -69,3 +71,4 @@ void FreeList::forEach(const Func& func) const
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoAllocator.h
+++ b/Source/bmalloc/bmalloc/IsoAllocator.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "FreeList.h"
 
 #if !BUSE(LIBPAS)
@@ -55,3 +57,4 @@ private:
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoAllocatorInlines.h
+++ b/Source/bmalloc/bmalloc/IsoAllocatorInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "BInline.h"
 #include "EligibilityResult.h"
 #include "IsoAllocator.h"
@@ -105,3 +107,4 @@ void IsoAllocator<Config>::scavenge(IsoHeapImpl<Config>& heap)
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoConfig.h
+++ b/Source/bmalloc/bmalloc/IsoConfig.h
@@ -25,8 +25,7 @@
 
 #pragma once
 
-#include "BPlatform.h"
-
+#if !BUSE(TZONE)
 #if !BUSE(LIBPAS)
 
 namespace bmalloc {
@@ -39,3 +38,4 @@ struct IsoConfig {
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoDeallocator.h
+++ b/Source/bmalloc/bmalloc/IsoDeallocator.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "FixedVector.h"
 #include "IsoPage.h"
 #include "Mutex.h"
@@ -55,3 +57,4 @@ private:
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoDeallocatorInlines.h
+++ b/Source/bmalloc/bmalloc/IsoDeallocatorInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "BInline.h"
 #include "IsoDeallocator.h"
 #include "IsoPage.h"
@@ -85,3 +87,4 @@ BNO_INLINE void IsoDeallocator<Config>::scavenge()
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoDirectory.h
+++ b/Source/bmalloc/bmalloc/IsoDirectory.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "Bits.h"
 #include "EligibilityResult.h"
 #include "IsoPage.h"
@@ -97,3 +99,4 @@ private:
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoDirectoryInlines.h
+++ b/Source/bmalloc/bmalloc/IsoDirectoryInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "IsoDirectory.h"
 
 #if !BUSE(LIBPAS)
@@ -158,3 +160,4 @@ void IsoDirectory<Config, passedNumPages>::forEachCommittedPage(const LockHolder
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoDirectoryPage.h
+++ b/Source/bmalloc/bmalloc/IsoDirectoryPage.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "BMalloced.h"
 #include "IsoDirectory.h"
 
@@ -61,3 +63,4 @@ private:
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoDirectoryPageInlines.h
+++ b/Source/bmalloc/bmalloc/IsoDirectoryPageInlines.h
@@ -25,7 +25,9 @@
 
 #pragma once
 
-#include "IsoDirectoryPageInlines.h"
+#if !BUSE(TZONE)
+
+#include "IsoDirectoryPage.h"
 
 #if !BUSE(LIBPAS)
 
@@ -48,3 +50,4 @@ IsoDirectoryPage<Config>* IsoDirectoryPage<Config>::pageFor(IsoDirectory<Config,
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoHeap.cpp
+++ b/Source/bmalloc/bmalloc/IsoHeap.cpp
@@ -23,8 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+#include "BPlatform.h"
 #include "IsoHeap.h"
 
+#if !BUSE(TZONE)
 #include "AllocationCounts.h"
 
 #if BUSE(LIBPAS)
@@ -121,4 +123,4 @@ void isoDeallocate(void* ptr)
 } } // namespace bmalloc::api
 
 #endif // BUSE(LIBPAS)
-
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoHeap.h
+++ b/Source/bmalloc/bmalloc/IsoHeap.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "CompactAllocationMode.h"
 #include "IsoConfig.h"
 #include "Mutex.h"
@@ -253,3 +255,5 @@ void isoType::freeAfterDestruction(void* p) \
 using __makeBisoMallocedMacroSemicolonifier BUNUSED_TYPE_ALIAS = int
 
 } } // namespace bmalloc::api
+
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoHeapImpl.cpp
+++ b/Source/bmalloc/bmalloc/IsoHeapImpl.cpp
@@ -23,7 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+#include "BPlatform.h"
 #include "IsoHeapImpl.h"
+
+#if !BUSE(TZONE)
 
 #include "AllIsoHeaps.h"
 #include "PerProcess.h"
@@ -98,3 +101,4 @@ void IsoHeapImplBase::finishScavenging(Vector<DeferredDecommit>& deferredDecommi
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoHeapImpl.h
+++ b/Source/bmalloc/bmalloc/IsoHeapImpl.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "BMalloced.h"
 #include "IsoAllocator.h"
 #include "IsoDirectoryPage.h"
@@ -55,14 +57,14 @@ public:
     void scavengeNow();
     static void finishScavenging(Vector<DeferredDecommit>&);
 
-    void didCommit(void* ptr, size_t bytes);
-    void didDecommit(void* ptr, size_t bytes);
+    inline void didCommit(void* ptr, size_t bytes);
+    inline void didDecommit(void* ptr, size_t bytes);
 
-    void isNowFreeable(void* ptr, size_t bytes);
-    void isNoLongerFreeable(void* ptr, size_t bytes);
+    inline void isNowFreeable(void* ptr, size_t bytes);
+    inline void isNoLongerFreeable(void* ptr, size_t bytes);
 
-    size_t freeableMemory();
-    size_t footprint();
+    inline size_t freeableMemory();
+    inline size_t footprint();
 
     void addToAllIsoHeaps();
 
@@ -145,3 +147,4 @@ private:
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoHeapImplInlines.h
+++ b/Source/bmalloc/bmalloc/IsoHeapImplInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "IsoHeapImpl.h"
 #include "IsoTLSDeallocatorEntry.h"
 #include "IsoSharedHeapInlines.h"
@@ -329,3 +331,4 @@ void* IsoHeapImpl<Config>::allocateFromShared(const LockHolder&, bool abortOnFai
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoHeapInlines.h
+++ b/Source/bmalloc/bmalloc/IsoHeapInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "BPlatform.h"
 #include "DeferredDecommitInlines.h"
 #include "DeferredTriggerInlines.h"
@@ -176,3 +178,4 @@ using __makeBisoMallocedInlineMacroSemicolonifier BUNUSED_TYPE_ALIAS = int
 
 } } // namespace bmalloc::api
 
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoMallocFallback.cpp
+++ b/Source/bmalloc/bmalloc/IsoMallocFallback.cpp
@@ -23,7 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+#include "BPlatform.h"
 #include "IsoMallocFallback.h"
+
+#if !BUSE(TZONE)
 
 #include "DebugHeap.h"
 #include "Environment.h"
@@ -112,3 +115,5 @@ bool tryFree(
 }
 
 } } // namespace bmalloc::IsoMallocFallback
+
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoMallocFallback.h
+++ b/Source/bmalloc/bmalloc/IsoMallocFallback.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "BExport.h"
 #include "BInline.h"
 #include "BPlatform.h"
@@ -84,3 +86,5 @@ BEXPORT bool tryFree(
     );
     
 } } // namespace bmalloc::IsoMallocFallback
+
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoPage.cpp
+++ b/Source/bmalloc/bmalloc/IsoPage.cpp
@@ -23,7 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+#include "BPlatform.h"
 #include "IsoPage.h"
+
+#if !BUSE(TZONE)
 
 #include "PerProcess.h"
 #include "VMAllocate.h"
@@ -40,3 +43,4 @@ void* IsoPageBase::allocatePageMemory()
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoPage.h
+++ b/Source/bmalloc/bmalloc/IsoPage.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "Bits.h"
 #include "DeferredTrigger.h"
 #include "FreeList.h"
@@ -131,3 +133,4 @@ private:
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoPageInlines.h
+++ b/Source/bmalloc/bmalloc/IsoPageInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "CryptoRandom.h"
 #include "IsoDirectory.h"
 #include "IsoHeapImpl.h"
@@ -257,3 +259,4 @@ IsoHeapImpl<Config>& IsoPage<Config>::heap()
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoPageTrigger.h
+++ b/Source/bmalloc/bmalloc/IsoPageTrigger.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
 #if !BUSE(LIBPAS)
 
 namespace bmalloc {
@@ -37,3 +38,4 @@ enum class IsoPageTrigger {
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoSharedConfig.h
+++ b/Source/bmalloc/bmalloc/IsoSharedConfig.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
+#include "BPlatform.h"
 #include "IsoConfig.h"
 
 #if !BUSE(LIBPAS)
@@ -36,3 +39,4 @@ static constexpr unsigned alignmentForIsoSharedAllocation = 16;
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoSharedHeap.cpp
+++ b/Source/bmalloc/bmalloc/IsoSharedHeap.cpp
@@ -23,8 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "BPlatform.h"
 #include "IsoSharedHeap.h"
 
+#if !BUSE(TZONE)
 #if !BUSE(LIBPAS)
 
 namespace bmalloc {
@@ -34,3 +36,4 @@ DEFINE_STATIC_PER_PROCESS_STORAGE(IsoSharedHeap);
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoSharedHeap.h
+++ b/Source/bmalloc/bmalloc/IsoSharedHeap.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "IsoSharedConfig.h"
 #include "IsoSharedPage.h"
 #include "StaticPerProcess.h"
@@ -76,3 +78,4 @@ BALLOW_DEPRECATED_DECLARATIONS_END
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoSharedHeapInlines.h
+++ b/Source/bmalloc/bmalloc/IsoSharedHeapInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "IsoSharedHeap.h"
 
 #include "IsoSharedPage.h"
@@ -86,3 +88,4 @@ BNO_INLINE void* IsoSharedHeap::allocateSlow(const LockHolder& locker, bool abor
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoSharedPage.cpp
+++ b/Source/bmalloc/bmalloc/IsoSharedPage.cpp
@@ -23,7 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "BPlatform.h"
 #include "IsoSharedPage.h"
+
+#if !BUSE(TZONE)
 
 #include "VMAllocate.h"
 #include <bit>
@@ -45,3 +48,4 @@ IsoSharedPage* IsoSharedPage::tryCreate()
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoSharedPage.h
+++ b/Source/bmalloc/bmalloc/IsoSharedPage.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "IsoHeap.h"
 #include "IsoPage.h"
 #include "IsoSharedConfig.h"
@@ -61,3 +63,4 @@ uint8_t* indexSlotFor(void* ptr)
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoSharedPageInlines.h
+++ b/Source/bmalloc/bmalloc/IsoSharedPageInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "IsoPage.h"
 #include "VMAllocate.h"
 #include <bit>
@@ -74,3 +76,4 @@ inline void IsoSharedPage::stopAllocating(const LockHolder&)
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoTLS.cpp
+++ b/Source/bmalloc/bmalloc/IsoTLS.cpp
@@ -23,7 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+#include "BPlatform.h"
 #include "IsoTLS.h"
+
+#if !BUSE(TZONE)
 
 #include "Environment.h"
 #include "IsoTLSEntryInlines.h"
@@ -177,3 +180,4 @@ void IsoTLS::forEachEntry(const Func& func)
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoTLS.h
+++ b/Source/bmalloc/bmalloc/IsoTLS.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "PerThread.h"
 #include <cstddef>
 
@@ -111,3 +113,4 @@ private:
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoTLSAllocatorEntry.h
+++ b/Source/bmalloc/bmalloc/IsoTLSAllocatorEntry.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "IsoAllocator.h"
 #include "IsoTLSEntry.h"
 
@@ -53,3 +55,4 @@ private:
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoTLSAllocatorEntryInlines.h
+++ b/Source/bmalloc/bmalloc/IsoTLSAllocatorEntryInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "IsoHeapImpl.h"
 
 #if !BUSE(LIBPAS)
@@ -57,3 +59,4 @@ void IsoTLSAllocatorEntry<Config>::scavenge(void* entry)
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoTLSDeallocatorEntry.h
+++ b/Source/bmalloc/bmalloc/IsoTLSDeallocatorEntry.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "IsoDeallocator.h"
 #include "IsoTLSEntry.h"
 #include "Mutex.h"
@@ -54,3 +56,4 @@ private:
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoTLSDeallocatorEntryInlines.h
+++ b/Source/bmalloc/bmalloc/IsoTLSDeallocatorEntryInlines.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
 #if !BUSE(LIBPAS)
 
 namespace bmalloc {
@@ -54,3 +55,4 @@ void IsoTLSDeallocatorEntry<Config>::scavenge(void* entry)
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoTLSEntryInlines.h
+++ b/Source/bmalloc/bmalloc/IsoTLSEntryInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "IsoTLSEntry.h"
 
 #if !BUSE(LIBPAS)
@@ -69,3 +71,4 @@ void DefaultIsoTLSEntry<EntryType>::destruct(void* passedEntry)
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoTLSInlines.h
+++ b/Source/bmalloc/bmalloc/IsoTLSInlines.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "Environment.h"
 #include "IsoHeapImpl.h"
 #include "IsoMallocFallback.h"
@@ -192,3 +194,4 @@ BNO_INLINE IsoTLS* IsoTLS::ensureHeapAndEntries(api::IsoHeapBase<Type>& handle)
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoTLSLayout.cpp
+++ b/Source/bmalloc/bmalloc/IsoTLSLayout.cpp
@@ -23,7 +23,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+#include "BPlatform.h"
 #include "IsoTLSLayout.h"
+
+#if !BUSE(TZONE)
 
 #include "IsoTLSEntry.h"
 
@@ -64,3 +67,4 @@ void IsoTLSLayout::add(IsoTLSEntry* entry)
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/IsoTLSLayout.h
+++ b/Source/bmalloc/bmalloc/IsoTLSLayout.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if !BUSE(TZONE)
+
 #include "Mutex.h"
 #include "StaticPerProcess.h"
 #include <mutex>
@@ -54,3 +56,5 @@ BALLOW_DEPRECATED_DECLARATIONS_END
 } // namespace bmalloc
 
 #endif
+#endif // !BUSE(TZONE)
+

--- a/Source/bmalloc/bmalloc/TZoneHeap.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeap.cpp
@@ -23,6 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+#include "BPlatform.h"
 #include "TZoneHeap.h"
 
 #if BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/TZoneHeapInlines.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapInlines.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include "BPlatform.h"
-
 #if BUSE(TZONE)
 
 #include "TZoneHeap.h"

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "BExport.h"
-#include "BPlatform.h"
 
 #if BUSE(TZONE)
 

--- a/Source/bmalloc/bmalloc/TZoneLog.cpp
+++ b/Source/bmalloc/bmalloc/TZoneLog.cpp
@@ -23,6 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+#include "BPlatform.h"
 #include "TZoneLog.h"
 
 #if BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/TZoneLog.h
+++ b/Source/bmalloc/bmalloc/TZoneLog.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
+#if BUSE(TZONE)
+
 #include "BExport.h"
 #include "BInline.h"
 #include "BPlatform.h"
-
-#if BUSE(TZONE)
 
 #include <os/log.h>
 #include <stdarg.h>


### PR DESCRIPTION
#### 81b85b9b573f56941699ce4c7867d47a2b4fc0df
<pre>
Disable IsoHeap code when TZoneHeap is enabled.
<a href="https://bugs.webkit.org/show_bug.cgi?id=286048">https://bugs.webkit.org/show_bug.cgi?id=286048</a>
<a href="https://rdar.apple.com/143020852">rdar://143020852</a>

Reviewed by Yusuke Suzuki.

The IsoHeap code is unused and just taking up space.  We can #if them out.  This also helps to
clearly delineate the IsoHeap code from the TZoneHeap code making the code boundary clearer.
It also reduces the reduces code size by just under 4K.

For this patch, I also built with TZoneHeap disabled, and then, libpas and TZoneHeap disabled to
verify that my changes didn&apos;t break those builds.  The non-libpas IsoHeap build seems to have a
pre-existing build issue with fields in malloc_introspection_t.  I worked around that for my test
build, but will not attempt to fix it here because it is a pre-existing condition and independent
to this change.

In general, I follow the common convention of #include &quot;BPlatform.h&quot; in .c/cpp files, and not
include it in header files.  However, there are a few bmalloc header files that are #included by
external files (like tests) that did not #include &quot;BPlatform.h&quot; already.  In those few cases, I
made an exception and just #include &quot;BPlatform.h&quot; there.

I also #include &quot;BPlatform.h&quot; in FastMalloc.h if !USE(SYSTEM_MALLOC).  This ensures that all WTF
and higher layers will build with the correct configuration of bmalloc i.e. use libpas or not,
use TZoneHeap or not, etc.

* Source/WTF/wtf/FastMalloc.h:
* Source/WTF/wtf/PlatformUse.h:
* Source/bmalloc/bmalloc/AllIsoHeaps.cpp:
* Source/bmalloc/bmalloc/AllIsoHeaps.h:
* Source/bmalloc/bmalloc/AllIsoHeapsInlines.h:
* Source/bmalloc/bmalloc/DeferredDecommit.h:
* Source/bmalloc/bmalloc/DeferredDecommitInlines.h:
* Source/bmalloc/bmalloc/DeferredTrigger.h:
* Source/bmalloc/bmalloc/DeferredTriggerInlines.h:
* Source/bmalloc/bmalloc/EligibilityResult.h:
* Source/bmalloc/bmalloc/EligibilityResultInlines.h:
* Source/bmalloc/bmalloc/FreeList.cpp:
* Source/bmalloc/bmalloc/FreeList.h:
* Source/bmalloc/bmalloc/FreeListInlines.h:
* Source/bmalloc/bmalloc/IsoAllocator.h:
* Source/bmalloc/bmalloc/IsoAllocatorInlines.h:
* Source/bmalloc/bmalloc/IsoConfig.h:
* Source/bmalloc/bmalloc/IsoDeallocator.h:
* Source/bmalloc/bmalloc/IsoDeallocatorInlines.h:
* Source/bmalloc/bmalloc/IsoDirectory.h:
* Source/bmalloc/bmalloc/IsoDirectoryInlines.h:
* Source/bmalloc/bmalloc/IsoDirectoryPage.h:
* Source/bmalloc/bmalloc/IsoDirectoryPageInlines.h:
* Source/bmalloc/bmalloc/IsoHeap.cpp:
* Source/bmalloc/bmalloc/IsoHeap.h:
* Source/bmalloc/bmalloc/IsoHeapImpl.cpp:
* Source/bmalloc/bmalloc/IsoHeapImpl.h:
* Source/bmalloc/bmalloc/IsoHeapImplInlines.h:
* Source/bmalloc/bmalloc/IsoHeapInlines.h:
* Source/bmalloc/bmalloc/IsoMallocFallback.cpp:
* Source/bmalloc/bmalloc/IsoMallocFallback.h:
* Source/bmalloc/bmalloc/IsoPage.cpp:
* Source/bmalloc/bmalloc/IsoPage.h:
* Source/bmalloc/bmalloc/IsoPageInlines.h:
* Source/bmalloc/bmalloc/IsoPageTrigger.h:
* Source/bmalloc/bmalloc/IsoSharedConfig.h:
* Source/bmalloc/bmalloc/IsoSharedHeap.cpp:
* Source/bmalloc/bmalloc/IsoSharedHeap.h:
* Source/bmalloc/bmalloc/IsoSharedHeapInlines.h:
* Source/bmalloc/bmalloc/IsoSharedPage.cpp:
* Source/bmalloc/bmalloc/IsoSharedPage.h:
* Source/bmalloc/bmalloc/IsoSharedPageInlines.h:
* Source/bmalloc/bmalloc/IsoTLS.cpp:
* Source/bmalloc/bmalloc/IsoTLS.h:
* Source/bmalloc/bmalloc/IsoTLSAllocatorEntry.h:
* Source/bmalloc/bmalloc/IsoTLSAllocatorEntryInlines.h:
* Source/bmalloc/bmalloc/IsoTLSDeallocatorEntry.h:
* Source/bmalloc/bmalloc/IsoTLSDeallocatorEntryInlines.h:
* Source/bmalloc/bmalloc/IsoTLSEntryInlines.h:
* Source/bmalloc/bmalloc/IsoTLSInlines.h:
* Source/bmalloc/bmalloc/IsoTLSLayout.cpp:
* Source/bmalloc/bmalloc/IsoTLSLayout.h:
* Source/bmalloc/bmalloc/TZoneHeap.cpp:
* Source/bmalloc/bmalloc/TZoneHeapInlines.h:
* Source/bmalloc/bmalloc/TZoneHeapManager.h:
* Source/bmalloc/bmalloc/TZoneLog.cpp:
* Source/bmalloc/bmalloc/TZoneLog.h:

Canonical link: <a href="https://commits.webkit.org/289011@main">https://commits.webkit.org/289011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a841ea4aa61275fda7f1bf58fde2fb3be1f0353

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84964 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36020 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66121 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23936 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46388 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3532 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31442 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35093 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77932 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91486 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84009 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12308 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74602 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12537 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73722 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18112 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16564 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4334 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/13256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17709 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106400 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12092 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25683 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15588 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13837 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->