### PR TITLE
Add a runtime flag for mutation events

### DIFF
--- a/LayoutTests/fast/dom/mutation-events-disablement-expected.txt
+++ b/LayoutTests/fast/dom/mutation-events-disablement-expected.txt
@@ -1,0 +1,11 @@
+This tests disabling mutation events.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS mutationEvents is []
+PASS mutationEvents is []
+PASS successfullyParsed is true
+
+TEST COMPLETE
+world

--- a/LayoutTests/fast/dom/mutation-events-disablement.html
+++ b/LayoutTests/fast/dom/mutation-events-disablement.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html><!-- webkit-test-runner [ MutationEventsEnabled=false ] -->
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description('This tests disabling mutation events.');
+
+let mutationEvents = [];
+window.addEventListener('DOMCharacterDataModified', (event) => mutationEvents.push(event.type), {capture: true});
+window.addEventListener('DOMNodeInserted', (event) => mutationEvents.push(event.type), {capture: true});
+window.addEventListener('DOMNodeInsertedIntoDocument', (event) => mutationEvents.push(event.type), {capture: true});
+window.addEventListener('DOMNodeRemoved', (event) => mutationEvents.push(event.type), {capture: true});
+window.addEventListener('DOMNodeRemovedFromDocument', (event) => mutationEvents.push(event.type), {capture: true});
+window.addEventListener('DOMSubtreeModified', (event) => mutationEvents.push(event.type), {capture: true});
+
+const element = document.createElement('div');
+document.body.appendChild(element);
+document.body.removeChild(element);
+shouldBe('mutationEvents', '[]');
+
+const text = document.body.appendChild(document.createTextNode('hello'));
+mutationEvents = [];
+text.replaceData(0, 5, 'world');
+shouldBe('mutationEvents', '[]');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/mutation-events-enablement-expected.txt
+++ b/LayoutTests/fast/dom/mutation-events-enablement-expected.txt
@@ -1,0 +1,11 @@
+This tests disabling mutation events.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS mutationEvents is ["DOMNodeInserted", "DOMNodeInsertedIntoDocument", "DOMSubtreeModified", "DOMNodeRemoved", "DOMNodeRemovedFromDocument", "DOMSubtreeModified"]
+PASS mutationEvents is ["DOMCharacterDataModified", "DOMSubtreeModified"]
+PASS successfullyParsed is true
+
+TEST COMPLETE
+world

--- a/LayoutTests/fast/dom/mutation-events-enablement.html
+++ b/LayoutTests/fast/dom/mutation-events-enablement.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html><!-- webkit-test-runner [ MutationEventsEnabled=true ] -->
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description('This tests disabling mutation events.');
+
+let mutationEvents = [];
+window.addEventListener('DOMCharacterDataModified', (event) => mutationEvents.push(event.type), {capture: true});
+window.addEventListener('DOMNodeInserted', (event) => mutationEvents.push(event.type), {capture: true});
+window.addEventListener('DOMNodeInsertedIntoDocument', (event) => mutationEvents.push(event.type), {capture: true});
+window.addEventListener('DOMNodeRemoved', (event) => mutationEvents.push(event.type), {capture: true});
+window.addEventListener('DOMNodeRemovedFromDocument', (event) => mutationEvents.push(event.type), {capture: true});
+window.addEventListener('DOMSubtreeModified', (event) => mutationEvents.push(event.type), {capture: true});
+
+const element = document.createElement('div');
+document.body.appendChild(element);
+document.body.removeChild(element);
+//document.body.textContent = 'hello';
+shouldBe('mutationEvents', '["DOMNodeInserted", "DOMNodeInsertedIntoDocument", "DOMSubtreeModified", "DOMNodeRemoved", "DOMNodeRemovedFromDocument", "DOMSubtreeModified"]');
+
+const text = document.body.appendChild(document.createTextNode('hello'));
+mutationEvents = [];
+text.replaceData(0, 5, 'world');
+shouldBe('mutationEvents', '["DOMCharacterDataModified", "DOMSubtreeModified"]');
+
+</script>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5262,6 +5262,18 @@ MouseEventsSimulationEnabled:
     WebCore:
       default: false
 
+MutationEventsEnabled:
+  type: bool
+  status: mature
+  humanReadableName: "DOM mutation events"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
 MuteCameraOnMicrophoneInterruptionEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/dom/CharacterData.cpp
+++ b/Source/WebCore/dom/CharacterData.cpp
@@ -227,7 +227,7 @@ void CharacterData::dispatchModifiedEvent(const String& oldData)
     if (auto mutationRecipients = MutationObserverInterestGroup::createForCharacterDataMutation(*this))
         mutationRecipients->enqueueMutationRecord(MutationRecord::createCharacterData(*this, oldData));
 
-    if (!isInShadowTree()) {
+    if (!isInShadowTree() && !document().shouldNotFireMutationEvents()) {
         if (document().hasListenerType(Document::ListenerType::DOMCharacterDataModified))
             dispatchScopedEvent(MutationEvent::create(eventNames().DOMCharacterDataModifiedEvent, Event::CanBubble::Yes, nullptr, oldData, m_data));
         dispatchSubtreeModifiedEvent();

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -1070,14 +1070,13 @@ Node* ContainerNode::traverseToChildAt(unsigned index) const
 
 static void dispatchChildInsertionEvents(Node& child)
 {
-    if (child.isInShadowTree())
+    Ref document = child.document();
+    if (child.isInShadowTree() || document->shouldNotFireMutationEvents())
         return;
 
     ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isEventDispatchAllowedInSubtree(child));
 
     RefPtr c = &child;
-    Ref document = child.document();
-
     if (c->parentNode() && document->hasListenerType(Document::ListenerType::DOMNodeInserted))
         c->dispatchScopedEvent(MutationEvent::create(eventNames().DOMNodeInsertedEvent, Event::CanBubble::Yes, c->protectedParentNode().get()));
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -688,6 +688,9 @@ Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, 
     // that an engineer writes the relevant manual code whenever a new generated type is added.
     for (const ProcessSyncDataType dataType : allDocumentSyncDataTypes)
         populateDocumentSyncDataForNewlyConstructedDocument(dataType);
+
+    if (!settings.mutationEventsEnabled())
+        m_shouldNotFireMutationEvents = true;
 }
 
 void Document::populateDocumentSyncDataForNewlyConstructedDocument(ProcessSyncDataType dataType)

--- a/Source/WebCore/dom/ShouldNotFireMutationEventsScope.h
+++ b/Source/WebCore/dom/ShouldNotFireMutationEventsScope.h
@@ -31,18 +31,19 @@ class ShouldNotFireMutationEventsScope {
 public:
     ShouldNotFireMutationEventsScope(Document& document)
         : m_document(document)
+        , m_previousValue(document.shouldNotFireMutationEvents())
     {
-        ASSERT(!document.shouldNotFireMutationEvents());
         document.setShouldNotFireMutationEvents(true);
     }
+
     ~ShouldNotFireMutationEventsScope()
     {
-        ASSERT(m_document->shouldNotFireMutationEvents());
-        m_document->setShouldNotFireMutationEvents(false);
+        m_document->setShouldNotFireMutationEvents(m_previousValue);
     }
 
 private:
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
+    bool m_previousValue;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 88b128b0813256ca283a50e2b8718030fa456a2e
<pre>
Add a runtime flag for mutation events
<a href="https://bugs.webkit.org/show_bug.cgi?id=286050">https://bugs.webkit.org/show_bug.cgi?id=286050</a>

Reviewed by Anne van Kesteren.

Added a runtime flag for DOM mutation events so that they can be disabled at runtime.

* LayoutTests/fast/dom/mutation-events-disablement-expected.txt: Added.
* LayoutTests/fast/dom/mutation-events-disablement.html: Added.
* LayoutTests/fast/dom/mutation-events-enablement-expected.txt: Added.
* LayoutTests/fast/dom/mutation-events-enablement.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/CharacterData.cpp:
(WebCore::CharacterData::dispatchModifiedEvent):
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::dispatchChildInsertionEvents):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::Document):
* Source/WebCore/dom/ShouldNotFireMutationEventsScope.h:
(WebCore::ShouldNotFireMutationEventsScope::ShouldNotFireMutationEventsScope):
(WebCore::ShouldNotFireMutationEventsScope::~ShouldNotFireMutationEventsScope):

Canonical link: <a href="https://commits.webkit.org/288994@main">https://commits.webkit.org/288994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/898b83ab3861fe00ab3145c95b83cf50a6be714c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/84971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90120 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36027 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12676 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66123 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23942 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77219 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46390 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31446 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35100 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/77939 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91493 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84016 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12315 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/8999 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12544 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73730 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18117 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16568 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13247 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12263 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106406 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12099 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25685 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15595 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->