### PR TITLE
Update UTF-16 handling of URLPatternUtilities::Tokenizer::getNextCodePoint()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/urlpatterntestdata.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/urlpatterntestdata.json
@@ -1122,6 +1122,63 @@
     }
   },
   {
+    "pattern": ["http://\uD83D\uDEB2.com/"],
+    "inputs": ["http://\uD83D\uDEB2.com/"],
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "http",
+      "hostname": "xn--h78h.com",
+      "pathname": "/"
+    },
+    "expected_match": {
+      "protocol": { "input": "http", "groups": {}},
+      "hostname": { "input": "xn--h78h.com", "groups": {}},
+      "pathname": { "input": "/", "groups": {}}
+    }
+  },
+  {
+    "pattern": ["http://\uD83D \uDEB2"],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{"hostname":"\uD83D \uDEB2"}],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{"pathname":"\uD83D \uDEB2"}],
+    "inputs": [],
+    "expected_obj": {
+      "pathname": "%EF%BF%BD%20%EF%BF%BD"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{"pathname":":\uD83D \uDEB2"}],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{"pathname":":a\uDB40\uDD00b"}],
+    "inputs": [],
+    "expected_obj": {
+      "pathname": ":a\uDB40\uDD00b"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{"pathname":"test/:a\uD801\uDC50b"}],
+    "inputs": [{"pathname":"test/foo"}],
+    "expected_obj": {
+      "pathname": "test/:a\uD801\uDC50b"
+    },
+    "expected_match": {
+      "pathname": { "input": "test/foo", "groups": { "a\uD801\uDC50b": "foo" }}
+    }
+  },
+  {
+    "pattern": [{"pathname":":\uD83D\uDEB2"}],
+    "expected_obj": "error"
+  },
+  {
     "pattern": [{ "port": "" }],
     "inputs": [{ "protocol": "http", "port": "80" }],
     "exactly_empty_components": [ "port" ],

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -154,6 +154,14 @@ PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}]
 PASS Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}]
+PASS Pattern: ["http://🚲.com/"] Inputs: ["http://🚲.com/"]
+PASS Pattern: ["http://\ud83d \udeb2"] Inputs: undefined
+PASS Pattern: [{"hostname":"\ud83d \udeb2"}] Inputs: undefined
+PASS Pattern: [{"pathname":"\ud83d \udeb2"}] Inputs: []
+PASS Pattern: [{"pathname":":\ud83d \udeb2"}] Inputs: undefined
+PASS Pattern: [{"pathname":":a󠄀b"}] Inputs: []
+PASS Pattern: [{"pathname":"test/:a𐑐b"}] Inputs: [{"pathname":"test/foo"}]
+PASS Pattern: [{"pathname":":🚲"}] Inputs: undefined
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -154,6 +154,14 @@ PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}]
 PASS Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}]
+PASS Pattern: ["http://🚲.com/"] Inputs: ["http://🚲.com/"]
+PASS Pattern: ["http://\ud83d \udeb2"] Inputs: undefined
+PASS Pattern: [{"hostname":"\ud83d \udeb2"}] Inputs: undefined
+PASS Pattern: [{"pathname":"\ud83d \udeb2"}] Inputs: []
+PASS Pattern: [{"pathname":":\ud83d \udeb2"}] Inputs: undefined
+PASS Pattern: [{"pathname":":a󠄀b"}] Inputs: []
+PASS Pattern: [{"pathname":"test/:a𐑐b"}] Inputs: [{"pathname":"test/foo"}]
+PASS Pattern: [{"pathname":":🚲"}] Inputs: undefined
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -154,6 +154,14 @@ PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}]
 PASS Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}]
+PASS Pattern: ["http://🚲.com/"] Inputs: ["http://🚲.com/"]
+PASS Pattern: ["http://\ud83d \udeb2"] Inputs: undefined
+PASS Pattern: [{"hostname":"\ud83d \udeb2"}] Inputs: undefined
+PASS Pattern: [{"pathname":"\ud83d \udeb2"}] Inputs: []
+PASS Pattern: [{"pathname":":\ud83d \udeb2"}] Inputs: undefined
+PASS Pattern: [{"pathname":":a󠄀b"}] Inputs: []
+PASS Pattern: [{"pathname":"test/:a𐑐b"}] Inputs: [{"pathname":"test/foo"}]
+PASS Pattern: [{"pathname":":🚲"}] Inputs: undefined
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -154,6 +154,14 @@ PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}]
 PASS Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}]
+PASS Pattern: ["http://🚲.com/"] Inputs: ["http://🚲.com/"]
+PASS Pattern: ["http://\ud83d \udeb2"] Inputs: undefined
+PASS Pattern: [{"hostname":"\ud83d \udeb2"}] Inputs: undefined
+PASS Pattern: [{"pathname":"\ud83d \udeb2"}] Inputs: []
+PASS Pattern: [{"pathname":":\ud83d \udeb2"}] Inputs: undefined
+PASS Pattern: [{"pathname":":a󠄀b"}] Inputs: []
+PASS Pattern: [{"pathname":"test/:a𐑐b"}] Inputs: [{"pathname":"test/foo"}]
+PASS Pattern: [{"pathname":":🚲"}] Inputs: undefined
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -154,6 +154,14 @@ PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}]
 PASS Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}]
+PASS Pattern: ["http://🚲.com/"] Inputs: ["http://🚲.com/"]
+PASS Pattern: ["http://\ud83d \udeb2"] Inputs: undefined
+PASS Pattern: [{"hostname":"\ud83d \udeb2"}] Inputs: undefined
+PASS Pattern: [{"pathname":"\ud83d \udeb2"}] Inputs: []
+PASS Pattern: [{"pathname":":\ud83d \udeb2"}] Inputs: undefined
+PASS Pattern: [{"pathname":":a󠄀b"}] Inputs: []
+PASS Pattern: [{"pathname":"test/:a𐑐b"}] Inputs: [{"pathname":"test/foo"}]
+PASS Pattern: [{"pathname":":🚲"}] Inputs: undefined
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -154,6 +154,14 @@ PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}]
 PASS Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}]
+PASS Pattern: ["http://🚲.com/"] Inputs: ["http://🚲.com/"]
+PASS Pattern: ["http://\ud83d \udeb2"] Inputs: undefined
+PASS Pattern: [{"hostname":"\ud83d \udeb2"}] Inputs: undefined
+PASS Pattern: [{"pathname":"\ud83d \udeb2"}] Inputs: []
+PASS Pattern: [{"pathname":":\ud83d \udeb2"}] Inputs: undefined
+PASS Pattern: [{"pathname":":a󠄀b"}] Inputs: []
+PASS Pattern: [{"pathname":"test/:a𐑐b"}] Inputs: [{"pathname":"test/foo"}]
+PASS Pattern: [{"pathname":":🚲"}] Inputs: undefined
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -154,6 +154,14 @@ PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}]
 PASS Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}]
+PASS Pattern: ["http://🚲.com/"] Inputs: ["http://🚲.com/"]
+PASS Pattern: ["http://\ud83d \udeb2"] Inputs: undefined
+PASS Pattern: [{"hostname":"\ud83d \udeb2"}] Inputs: undefined
+PASS Pattern: [{"pathname":"\ud83d \udeb2"}] Inputs: []
+PASS Pattern: [{"pathname":":\ud83d \udeb2"}] Inputs: undefined
+PASS Pattern: [{"pathname":":a󠄀b"}] Inputs: []
+PASS Pattern: [{"pathname":"test/:a𐑐b"}] Inputs: [{"pathname":"test/foo"}]
+PASS Pattern: [{"pathname":":🚲"}] Inputs: undefined
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -154,6 +154,14 @@ PASS Pattern: [{"password":"café"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"password":"caf%c3%a9"}] Inputs: [{"password":"café"}]
 PASS Pattern: [{"hostname":"xn--caf-dma.com"}] Inputs: [{"hostname":"café.com"}]
 PASS Pattern: [{"hostname":"café.com"}] Inputs: [{"hostname":"café.com"}]
+PASS Pattern: ["http://🚲.com/"] Inputs: ["http://🚲.com/"]
+PASS Pattern: ["http://\ud83d \udeb2"] Inputs: undefined
+PASS Pattern: [{"hostname":"\ud83d \udeb2"}] Inputs: undefined
+PASS Pattern: [{"pathname":"\ud83d \udeb2"}] Inputs: []
+PASS Pattern: [{"pathname":":\ud83d \udeb2"}] Inputs: undefined
+PASS Pattern: [{"pathname":":a󠄀b"}] Inputs: []
+PASS Pattern: [{"pathname":"test/:a𐑐b"}] Inputs: [{"pathname":"test/foo"}]
+PASS Pattern: [{"pathname":":🚲"}] Inputs: undefined
 PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]

--- a/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp
@@ -28,7 +28,6 @@
 
 #include "URLPatternParser.h"
 #include <unicode/utf16.h>
-#include <unicode/utf8.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -46,15 +45,17 @@ bool Token::isNull() const
 // https://urlpattern.spec.whatwg.org/#get-the-next-code-point
 void Tokenizer::getNextCodePoint()
 {
-    if (m_input.is8Bit())
-        m_codepoint = m_input[m_nextIndex++];
-    else {
-        // FIXME: We should handle surrogates if any.
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        auto characters = m_input.span16();
-        U16_NEXT_OR_FFFD(characters, m_nextIndex, m_input.length(), m_codepoint);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-    }
+    m_codepoint = m_input[m_nextIndex++];
+
+    if (m_input.is8Bit() || !U16_IS_LEAD(m_codepoint) || m_nextIndex >= m_input.length())
+        return;
+
+    auto next = m_input[m_nextIndex];
+    if (!U16_IS_TRAIL(next))
+        return;
+
+    m_nextIndex++;
+    m_codepoint = U16_GET_SUPPLEMENTARY(m_codepoint, next);
 }
 
 // https://urlpattern.spec.whatwg.org/#seek-and-get-the-next-code-point

--- a/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h
@@ -54,7 +54,7 @@ private:
     Vector<Token> m_tokenList;
     size_t m_index { 0 };
     size_t m_nextIndex { 0 };
-    UChar m_codepoint;
+    char32_t m_codepoint;
 
     void getNextCodePoint();
     void seekNextCodePoint(size_t index);


### PR DESCRIPTION
#### 6d61bd1c4f0ae6b6da4dcfd6a748bd848fcc7b56
<pre>
Update UTF-16 handling of URLPatternUtilities::Tokenizer::getNextCodePoint()
<a href="https://rdar.apple.com/143033714">rdar://143033714</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=286058">https://bugs.webkit.org/show_bug.cgi?id=286058</a>

Reviewed by Anne van Kesteren.

Tokenizer is expected to process code points.
We should treat surrogate pairs as a single code point.
Dangling surrogates should also be handled as a single code point.

We update URLPatternUtilities::Tokenizer::getNextCodePoint accordingly and add some tests that cover UTF-16 surrogates.

We add some WPT tests to cover the changes.

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/urlpatterntestdata.json:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* Source/WebCore/Modules/url-pattern/URLPatternTokenizer.cpp:
(WebCore::URLPatternUtilities::Tokenizer::getNextCodePoint):
* Source/WebCore/Modules/url-pattern/URLPatternTokenizer.h:

Canonical link: <a href="https://commits.webkit.org/289045@main">https://commits.webkit.org/289045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fa95fbc6d5bdc9e26d8bd4d8521e0bee0970cc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90201 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36109 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66182 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24001 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46448 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31523 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35182 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91588 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9063 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74685 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12626 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73804 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18280 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18193 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16637 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4411 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12345 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17806 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12181 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13927 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->