### PR TITLE
REGRESSION(288829@main) [CMake] Build failure with clang-18 crashing on Vector::map and complex LengthPercentage templates

### DIFF
--- a/Source/WebCore/rendering/shapes/LayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/LayoutShape.cpp
@@ -151,7 +151,7 @@ Ref<const LayoutShape> LayoutShape::createShape(const Style::BasicShape& basicSh
         [&](const Style::PolygonFunction& polygon) -> Ref<LayoutShape> {
             auto boxSize = FloatSize { boxWidth, boxHeight };
 
-            auto vertices = polygon->vertices.value.map([&](const auto& vertex) -> FloatPoint {
+            auto vertices = polygon->vertices.value.map([&](const auto& vertex) {
                 return physicalPointToLogical(Style::evaluate(vertex, boxSize) + borderBoxOffset, logicalBoxSize.height(), writingMode);
             });
 

--- a/Source/WebCore/style/values/shapes/StylePolygonFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StylePolygonFunction.cpp
@@ -62,7 +62,7 @@ WebCore::Path PathComputation<Polygon>::operator()(const Polygon& value, const F
 {
     auto boundingLocation = boundingBox.location();
     auto boundingSize = boundingBox.size();
-    auto points = value.vertices.value.map([&](const auto& vertex) -> FloatPoint {
+    auto points = value.vertices.value.map([&](const auto& vertex) {
         return evaluate(vertex, boundingSize) + boundingLocation;
     });
     return cachedPolygonPath(points);


### PR DESCRIPTION
#### fa7b6d6d744766a6847a4fd493c27393daf1fc9b
<pre>
REGRESSION(288829@main) [CMake] Build failure with clang-18 crashing on Vector::map and complex LengthPercentage templates
<a href="https://bugs.webkit.org/show_bug.cgi?id=286004">https://bugs.webkit.org/show_bug.cgi?id=286004</a>

Reviewed by Fujii Hironori.

Related to llvm&apos;s <a href="https://github.com/llvm/llvm-project/pull/93206">https://github.com/llvm/llvm-project/pull/93206</a>, a fix
that&apos;s part of clang-19. As clang-18 is still quite new and the version
in distros like Ubuntu 24.04 LTS, we are adding a workaround on this
commit.

Thanks to Fujii Hironori for the suggested simpler fix of removing the
lambda return type instead of replacing the map with a for loop.

* Source/WebCore/rendering/shapes/LayoutShape.cpp:
(WebCore::LayoutShape::createShape):
* Source/WebCore/style/values/shapes/StylePolygonFunction.cpp:
(WebCore::Style::PathComputation&lt;Polygon&gt;::operator):

Canonical link: <a href="https://commits.webkit.org/289103@main">https://commits.webkit.org/289103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d4d3b8f61516d2928c7adfc10f9ab4d6048d035

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36285 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87333 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66274 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24091 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3859 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77429 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46551 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31690 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35353 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74479 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91811 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12591 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74810 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73931 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18325 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18334 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16764 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4600 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12534 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17991 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12364 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15857 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14115 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->