### PR TITLE
Clarify Inline Box Traversal Methods

### DIFF
--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -1249,7 +1249,7 @@ static std::optional<unsigned> visualDistanceOnSameLine(const RenderedPosition& 
     unsigned distance = 0;
     bool foundFirst = false;
     bool foundSecond = false;
-    for (auto box = first.lineBox()->firstLeafBox(); box; box = box->nextOnLine()) {
+    for (auto box = first.lineBox()->lineLeftmostLeafBox(); box; box = box->nextLineRightwardOnLine()) {
         if (box == first.box()) {
             distance += distanceFromOffsetToVisualBoundary(first, foundSecond ? VisualBoundary::Left : VisualBoundary::Right);
             foundFirst = true;
@@ -1292,7 +1292,7 @@ static std::optional<BoundaryPoint> findBidiBoundary(const RenderedPosition& pos
 
 static InlineIterator::LeafBoxIterator advanceInDirection(InlineIterator::LeafBoxIterator box, TextDirection direction, bool iterateInSameDirection)
 {
-    return iterateInSameDirection == (direction == TextDirection::LTR) ? box->nextOnLine() : box->previousOnLine();
+    return iterateInSameDirection == (direction == TextDirection::LTR) ? box->nextLineRightwardOnLine() : box->nextLineLeftwardOnLine();
 }
 
 static void forEachRenderedBoxBetween(const RenderedPosition& first, const RenderedPosition& second, const Function<void(InlineIterator::LeafBoxIterator)>& callback)
@@ -1318,7 +1318,7 @@ static void forEachRenderedBoxBetween(const RenderedPosition& first, const Rende
     }
 
     bool foundEndpoint = false;
-    for (auto box = first.lineBox()->firstLeafBox(); box; box = box->nextOnLine()) {
+    for (auto box = first.lineBox()->lineLeftmostLeafBox(); box; box = box->nextLineRightwardOnLine()) {
         bool atEndpoint = box == first.box() || box == second.box();
         if (!atEndpoint && !foundEndpoint)
             continue;

--- a/Source/WebCore/editing/RenderedPosition.cpp
+++ b/Source/WebCore/editing/RenderedPosition.cpp
@@ -97,14 +97,14 @@ RenderedPosition::RenderedPosition(const Position& position, Affinity affinity)
 InlineIterator::LeafBoxIterator RenderedPosition::previousLeafOnLine() const
 {
     if (!m_previousLeafOnLine)
-        m_previousLeafOnLine = m_box->previousOnLineIgnoringLineBreak();
+        m_previousLeafOnLine = m_box->nextLineLeftwardOnLineIgnoringLineBreak();
     return *m_previousLeafOnLine;
 }
 
 InlineIterator::LeafBoxIterator RenderedPosition::nextLeafOnLine() const
 {
     if (!m_nextLeafOnLine)
-        m_nextLeafOnLine = m_box->nextOnLineIgnoringLineBreak();
+        m_nextLeafOnLine = m_box->nextLineRightwardOnLineIgnoringLineBreak();
     return *m_nextLeafOnLine;
 }
 
@@ -134,7 +134,7 @@ RenderedPosition RenderedPosition::leftBoundaryOfBidiRun(unsigned char bidiLevel
 
     auto box = m_box;
     do {
-        auto prev = box->previousOnLineIgnoringLineBreak();
+        auto prev = box->nextLineLeftwardOnLineIgnoringLineBreak();
         if (!prev || prev->bidiLevel() < bidiLevelOfRun)
             return RenderedPosition(&box->renderer(), box, box->leftmostCaretOffset());
         box = prev;
@@ -151,7 +151,7 @@ RenderedPosition RenderedPosition::rightBoundaryOfBidiRun(unsigned char bidiLeve
 
     auto box = m_box;
     do {
-        auto next = box->nextOnLineIgnoringLineBreak();
+        auto next = box->nextLineRightwardOnLineIgnoringLineBreak();
         if (!next || next->bidiLevel() < bidiLevelOfRun)
             return RenderedPosition(&box->renderer(), box, box->rightmostCaretOffset());
         box = next;

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -139,7 +139,7 @@ Position VisiblePosition::leftVisuallyDistinctCandidate() const
                 return box->isLeftToRightDirection() ? previousVisuallyDistinctCandidate(m_deepPosition) : nextVisuallyDistinctCandidate(m_deepPosition);
 
             if (!renderer->node()) {
-                box.traversePreviousOnLine();
+                box.traverseLineLeftwardOnLine();
                 if (!box)
                     return primaryDirection == TextDirection::LTR ? previousVisuallyDistinctCandidate(m_deepPosition) : nextVisuallyDistinctCandidate(m_deepPosition);
                 renderer = &box->renderer();
@@ -158,7 +158,7 @@ Position VisiblePosition::leftVisuallyDistinctCandidate() const
 
             if (offset != box->leftmostCaretOffset()) {
                 // Overshot to the left.
-                auto previousBox = box->previousOnLineIgnoringLineBreak();
+                auto previousBox = box->nextLineLeftwardOnLineIgnoringLineBreak();
                 if (!previousBox) {
                     Position positionOnLeft = primaryDirection == TextDirection::LTR ? previousVisuallyDistinctCandidate(m_deepPosition) : nextVisuallyDistinctCandidate(m_deepPosition);
                     auto boxOnLeft = positionOnLeft.inlineBoxAndOffset(m_affinity, primaryDirection).box;
@@ -175,7 +175,7 @@ Position VisiblePosition::leftVisuallyDistinctCandidate() const
             }
 
             unsigned char level = box->bidiLevel();
-            auto previousBox = box->previousOnLine();
+            auto previousBox = box->nextLineLeftwardOnLine();
 
             if (box->direction() == primaryDirection) {
                 if (!previousBox) {
@@ -196,7 +196,7 @@ Position VisiblePosition::leftVisuallyDistinctCandidate() const
 
                 auto nextBox = box;
                 do {
-                    nextBox.traverseNextOnLine();
+                    nextBox.traverseLineRightwardOnLine();
                 } while (nextBox && nextBox->bidiLevel() > level);
 
                 if (nextBox && nextBox->bidiLevel() == level)
@@ -211,7 +211,7 @@ Position VisiblePosition::leftVisuallyDistinctCandidate() const
             }
 
             while (previousBox && !previousBox->renderer().node())
-                previousBox.traversePreviousOnLine();
+                previousBox.traverseLineLeftwardOnLine();
 
             if (previousBox) {
                 box = previousBox;
@@ -219,7 +219,7 @@ Position VisiblePosition::leftVisuallyDistinctCandidate() const
                 offset = box->rightmostCaretOffset();
                 if (box->bidiLevel() > level) {
                     do {
-                        previousBox = previousBox.traversePreviousOnLine();
+                        previousBox = previousBox.traverseLineLeftwardOnLine();
                     } while (previousBox && previousBox->bidiLevel() > level);
 
                     if (!previousBox || previousBox->bidiLevel() < level)
@@ -228,7 +228,7 @@ Position VisiblePosition::leftVisuallyDistinctCandidate() const
             } else {
                 // Trailing edge of a secondary box. Set to the leading edge of the entire box.
                 while (true) {
-                    while (auto nextBox = box->nextOnLine()) {
+                    while (auto nextBox = box->nextLineRightwardOnLine()) {
                         if (nextBox->bidiLevel() < level)
                             break;
                         box = nextBox;
@@ -236,7 +236,7 @@ Position VisiblePosition::leftVisuallyDistinctCandidate() const
                     if (box->bidiLevel() == level)
                         break;
                     level = box->bidiLevel();
-                    while (auto previousBox = box->previousOnLine()) {
+                    while (auto previousBox = box->nextLineLeftwardOnLine()) {
                         if (previousBox->bidiLevel() < level)
                             break;
                         box = previousBox;
@@ -304,7 +304,7 @@ Position VisiblePosition::rightVisuallyDistinctCandidate() const
                 return box->isLeftToRightDirection() ? nextVisuallyDistinctCandidate(m_deepPosition) : previousVisuallyDistinctCandidate(m_deepPosition);
 
             if (!renderer->node()) {
-                box.traverseNextOnLine();
+                box.traverseLineRightwardOnLine();
                 if (!box)
                     return primaryDirection == TextDirection::LTR ? nextVisuallyDistinctCandidate(m_deepPosition) : previousVisuallyDistinctCandidate(m_deepPosition);
                 renderer = &box->renderer();
@@ -323,7 +323,7 @@ Position VisiblePosition::rightVisuallyDistinctCandidate() const
 
             if (offset != box->rightmostCaretOffset()) {
                 // Overshot to the right.
-                auto nextBox = box->nextOnLineIgnoringLineBreak();
+                auto nextBox = box->nextLineRightwardOnLineIgnoringLineBreak();
                 if (!nextBox) {
                     Position positionOnRight = primaryDirection == TextDirection::LTR ? nextVisuallyDistinctCandidate(m_deepPosition) : previousVisuallyDistinctCandidate(m_deepPosition);
                     auto boxOnRight = positionOnRight.inlineBoxAndOffset(m_affinity, primaryDirection).box;
@@ -340,7 +340,7 @@ Position VisiblePosition::rightVisuallyDistinctCandidate() const
             }
 
             unsigned char level = box->bidiLevel();
-            auto nextBox = box->nextOnLine();
+            auto nextBox = box->nextLineRightwardOnLine();
 
             if (box->direction() == primaryDirection) {
                 if (!nextBox) {
@@ -363,7 +363,7 @@ Position VisiblePosition::rightVisuallyDistinctCandidate() const
 
                 auto previousBox = box;
                 do {
-                    previousBox.traversePreviousOnLine();
+                    previousBox.traverseLineLeftwardOnLine();
                 } while (previousBox && previousBox->bidiLevel() > level);
 
                 if (previousBox && previousBox->bidiLevel() == level) // For example, abc FED 123 ^ CBA
@@ -379,7 +379,7 @@ Position VisiblePosition::rightVisuallyDistinctCandidate() const
             }
 
             while (nextBox && !nextBox->renderer().node())
-                nextBox.traverseNextOnLine();
+                nextBox.traverseLineRightwardOnLine();
 
             if (nextBox) {
                 box = nextBox;
@@ -388,7 +388,7 @@ Position VisiblePosition::rightVisuallyDistinctCandidate() const
 
                 if (box->bidiLevel() > level) {
                     do {
-                        nextBox.traverseNextOnLine();
+                        nextBox.traverseLineRightwardOnLine();
                     } while (nextBox && nextBox->bidiLevel() > level);
 
                     if (!nextBox || nextBox->bidiLevel() < level)
@@ -397,7 +397,7 @@ Position VisiblePosition::rightVisuallyDistinctCandidate() const
             } else {
                 // Trailing edge of a secondary box. Set to the leading edge of the entire box.
                 while (true) {
-                    while (auto previousBox = box->previousOnLine()) {
+                    while (auto previousBox = box->nextLineLeftwardOnLine()) {
                         if (previousBox->bidiLevel() < level)
                             break;
                         box = previousBox;
@@ -405,7 +405,7 @@ Position VisiblePosition::rightVisuallyDistinctCandidate() const
                     if (box->bidiLevel() == level)
                         break;
                     level = box->bidiLevel();
-                    while (auto nextBox = box->nextOnLine()) {
+                    while (auto nextBox = box->nextLineRightwardOnLine()) {
                         if (nextBox->bidiLevel() < level)
                             break;
                         box = nextBox;

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -755,7 +755,7 @@ static VisiblePosition startPositionForLine(const VisiblePosition& c, LineEndpoi
     InlineIterator::LineLogicalOrderCache orderCache;
 
     RefPtr<Node> startNode;
-    auto startBox = mode == UseLogicalOrdering ? InlineIterator::firstLeafOnLineInLogicalOrderWithNode(lineBox, orderCache) : lineBox->firstLeafBox();
+    auto startBox = mode == UseLogicalOrdering ? InlineIterator::firstLeafOnLineInLogicalOrderWithNode(lineBox, orderCache) : lineBox->lineLeftmostLeafBox();
     // Generated content (e.g. list markers and CSS :before and :after pseudoelements) have no corresponding DOM element,
     // and so cannot be represented by a VisiblePosition. Use whatever follows instead.
     while (true) {
@@ -769,7 +769,7 @@ static VisiblePosition startPositionForLine(const VisiblePosition& c, LineEndpoi
         if (mode == UseLogicalOrdering)
             startBox = InlineIterator::nextLeafOnLineInLogicalOrder(startBox, orderCache);
         else
-            startBox.traverseNextOnLine();
+            startBox.traverseLineRightwardOnLine();
     }
 
     RefPtr startTextNode = dynamicDowncast<Text>(*startNode);
@@ -828,7 +828,7 @@ static VisiblePosition endPositionForLine(const VisiblePosition& c, LineEndpoint
     InlineIterator::LineLogicalOrderCache orderCache;
 
     RefPtr<Node> endNode;
-    auto endBox = mode == UseLogicalOrdering ? InlineIterator::lastLeafOnLineInLogicalOrder(lineBox, orderCache) : lineBox->lastLeafBox();
+    auto endBox = mode == UseLogicalOrdering ? InlineIterator::lastLeafOnLineInLogicalOrder(lineBox, orderCache) : lineBox->lineRightmostLeafBox();
     // Generated content (e.g. list markers and CSS :before and :after pseudoelements) have no corresponding DOM element,
     // and so cannot be represented by a VisiblePosition. Use whatever precedes instead.
     while (true) {
@@ -842,7 +842,7 @@ static VisiblePosition endPositionForLine(const VisiblePosition& c, LineEndpoint
         if (mode == UseLogicalOrdering)
             endBox = InlineIterator::previousLeafOnLineInLogicalOrder(endBox, orderCache);
         else
-            endBox.traversePreviousOnLine();
+            endBox.traverseLineLeftwardOnLine();
     }
 
     Position pos;
@@ -977,7 +977,7 @@ VisiblePosition previousLinePosition(const VisiblePosition& visiblePosition, Lay
         lineBox = box->lineBox()->previous();
         // We want to skip zero height boxes.
         // This could happen in case it is a LegacyRootInlineBox with trailing floats.
-        if (!lineBox || !lineBox->logicalHeight() || !lineBox->firstLeafBox())
+        if (!lineBox || !lineBox->logicalHeight() || !lineBox->lineLeftmostLeafBox())
             lineBox = { };
     }
 
@@ -1032,7 +1032,7 @@ VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutU
         lineBox = box->lineBox()->next();
         // We want to skip zero height boxes.
         // This could happen in case it is a LegacyRootInlineBox with trailing floats.
-        if (!lineBox || !lineBox->logicalHeight() || !lineBox->firstLeafBox())
+        if (!lineBox || !lineBox->logicalHeight() || !lineBox->lineLeftmostLeafBox())
             lineBox = { };
     }
 

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -812,7 +812,7 @@ String HTMLTextFormControlElement::valueWithHardLineBreaks() const
 
     auto skipToNextSoftLineBreakPosition = [&] {
         while (currentLineBox) {
-            auto lastRun = currentLineBox->lastLeafBox();
+            auto lastRun = currentLineBox->lineRightmostLeafBox();
             ASSERT(lastRun);
             // Skip last line.
             currentLineBox.traverseNext();

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp
@@ -62,7 +62,7 @@ bool BoxIterator::atEnd() const
     });
 }
 
-BoxIterator& BoxIterator::traverseNextOnLine()
+BoxIterator& BoxIterator::traverseLineRightwardOnLine()
 {
     WTF::switchOn(m_box.m_pathVariant, [](auto& path) {
         path.traverseNextBoxOnLine();
@@ -70,7 +70,7 @@ BoxIterator& BoxIterator::traverseNextOnLine()
     return *this;
 }
 
-BoxIterator& BoxIterator::traverseNextOnLineSkippingChildren()
+BoxIterator& BoxIterator::traverseLineRightwardOnLineSkippingChildren()
 {
     WTF::switchOn(m_box.m_pathVariant, [](auto& path) {
         path.traverseNextBoxOnLineSkippingChildren();
@@ -83,24 +83,24 @@ bool Box::isSVGText() const
     return isText() && renderer().isRenderSVGInlineText();
 }
 
-LeafBoxIterator Box::nextOnLine() const
+LeafBoxIterator Box::nextLineRightwardOnLine() const
 {
-    return LeafBoxIterator(*this).traverseNextOnLine();
+    return LeafBoxIterator(*this).traverseLineRightwardOnLine();
 }
 
-LeafBoxIterator Box::previousOnLine() const
+LeafBoxIterator Box::nextLineLeftwardOnLine() const
 {
-    return LeafBoxIterator(*this).traversePreviousOnLine();
+    return LeafBoxIterator(*this).traverseLineLeftwardOnLine();
 }
 
-LeafBoxIterator Box::nextOnLineIgnoringLineBreak() const
+LeafBoxIterator Box::nextLineRightwardOnLineIgnoringLineBreak() const
 {
-    return LeafBoxIterator(*this).traverseNextOnLineIgnoringLineBreak();
+    return LeafBoxIterator(*this).traverseLineRightwardOnLineIgnoringLineBreak();
 }
 
-LeafBoxIterator Box::previousOnLineIgnoringLineBreak() const
+LeafBoxIterator Box::nextLineLeftwardOnLineIgnoringLineBreak() const
 {
-    return LeafBoxIterator(*this).traversePreviousOnLineIgnoringLineBreak();
+    return LeafBoxIterator(*this).traverseLineLeftwardOnLineIgnoringLineBreak();
 }
 
 InlineBoxIterator Box::parentInlineBox() const
@@ -150,7 +150,7 @@ LeafBoxIterator::LeafBoxIterator(const Box& run)
 {
 }
 
-LeafBoxIterator& LeafBoxIterator::traverseNextOnLine()
+LeafBoxIterator& LeafBoxIterator::traverseLineRightwardOnLine()
 {
     WTF::switchOn(m_box.m_pathVariant, [](auto& path) {
         path.traverseNextLeafOnLine();
@@ -158,7 +158,7 @@ LeafBoxIterator& LeafBoxIterator::traverseNextOnLine()
     return *this;
 }
 
-LeafBoxIterator& LeafBoxIterator::traversePreviousOnLine()
+LeafBoxIterator& LeafBoxIterator::traverseLineLeftwardOnLine()
 {
     WTF::switchOn(m_box.m_pathVariant, [](auto& path) {
         path.traversePreviousLeafOnLine();
@@ -166,18 +166,18 @@ LeafBoxIterator& LeafBoxIterator::traversePreviousOnLine()
     return *this;
 }
 
-LeafBoxIterator& LeafBoxIterator::traverseNextOnLineIgnoringLineBreak()
+LeafBoxIterator& LeafBoxIterator::traverseLineRightwardOnLineIgnoringLineBreak()
 {
     do {
-        traverseNextOnLine();
+        traverseLineRightwardOnLine();
     } while (!atEnd() && m_box.isLineBreak());
     return *this;
 }
 
-LeafBoxIterator& LeafBoxIterator::traversePreviousOnLineIgnoringLineBreak()
+LeafBoxIterator& LeafBoxIterator::traverseLineLeftwardOnLineIgnoringLineBreak()
 {
     do {
-        traversePreviousOnLine();
+        traverseLineLeftwardOnLine();
     } while (!atEnd() && m_box.isLineBreak());
     return *this;
 }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
@@ -96,10 +96,17 @@ public:
     const LegacyInlineBox* legacyInlineBox() const;
     const InlineDisplay::Box* inlineBox() const;
 
-    LeafBoxIterator nextOnLine() const;
-    LeafBoxIterator previousOnLine() const;
-    LeafBoxIterator nextOnLineIgnoringLineBreak() const;
-    LeafBoxIterator previousOnLineIgnoringLineBreak() const;
+    // Text-relative left/right
+    LeafBoxIterator nextLineRightwardOnLine() const;
+    LeafBoxIterator nextLineLeftwardOnLine() const;
+    LeafBoxIterator nextLineRightwardOnLineIgnoringLineBreak() const;
+    LeafBoxIterator nextLineLeftwardOnLineIgnoringLineBreak() const;
+
+    // Coordinate-relative left/right
+    inline LeafBoxIterator nextLogicalRightwardOnLine() const;
+    inline LeafBoxIterator nextLogicalLeftwardOnLine() const;
+    inline LeafBoxIterator nextLogicalRightwardOnLineIgnoringLineBreak() const;
+    inline LeafBoxIterator nextLogicalLeftwardOnLineIgnoringLineBreak() const;
 
     InlineBoxIterator parentInlineBox() const;
 
@@ -135,10 +142,10 @@ public:
     const Box& operator*() const { return m_box; }
     const Box* operator->() const { return &m_box; }
 
-    BoxIterator& traverseNextOnLine();
-    BoxIterator& traverseNextOnLineSkippingChildren();
+    BoxIterator& traverseLineRightwardOnLine();
+    BoxIterator& traverseLineRightwardOnLineSkippingChildren();
 
-    BoxIterator& operator++() { return traverseNextOnLine(); }
+    BoxIterator& operator++() { return traverseLineRightwardOnLine(); }
 
     bool atEnd() const;
 
@@ -152,12 +159,19 @@ public:
     LeafBoxIterator(Box::PathVariant&&);
     LeafBoxIterator(const Box&);
 
-    LeafBoxIterator& traverseNextOnLine();
-    LeafBoxIterator& traversePreviousOnLine();
-    LeafBoxIterator& traverseNextOnLineIgnoringLineBreak();
-    LeafBoxIterator& traversePreviousOnLineIgnoringLineBreak();
+    // Text-relative left/right
+    LeafBoxIterator& traverseLineRightwardOnLine();
+    LeafBoxIterator& traverseLineLeftwardOnLine();
+    LeafBoxIterator& traverseLineRightwardOnLineIgnoringLineBreak();
+    LeafBoxIterator& traverseLineLeftwardOnLineIgnoringLineBreak();
 
-    LeafBoxIterator& operator++() { return traverseNextOnLine(); }
+    // Coordinate-relative left/right
+    inline LeafBoxIterator& traverseLogicalRightwardOnLine();
+    inline LeafBoxIterator& traverseLogicalLeftwardOnLine();
+    inline LeafBoxIterator& traverseLogicalRightwardOnLineIgnoringLineBreak();
+    inline LeafBoxIterator& traverseLogicalLeftwardOnLineIgnoringLineBreak();
+
+    LeafBoxIterator& operator++() { return traverseLineRightwardOnLine(); }
 };
 
 template<class IteratorType>

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxInlines.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxInlines.h
@@ -51,5 +51,30 @@ inline FloatRect Box::logicalRectIgnoringInlineDirection() const
     return isHorizontal() ? rect : rect.transposedRect();
 }
 
+// Coordinate-relative left/right
+inline LeafBoxIterator Box::nextLogicalRightwardOnLine() const
+{
+    return writingMode().isLogicalLeftLineLeft()
+        ? nextLineRightwardOnLine() : nextLineLeftwardOnLine();
+}
+
+inline LeafBoxIterator Box::nextLogicalLeftwardOnLine() const
+{
+    return writingMode().isLogicalLeftLineLeft()
+        ? nextLineLeftwardOnLine() : nextLineRightwardOnLine();
+}
+
+inline LeafBoxIterator Box::nextLogicalRightwardOnLineIgnoringLineBreak() const
+{
+    return writingMode().isLogicalLeftLineLeft()
+        ? nextLineRightwardOnLineIgnoringLineBreak() : nextLineLeftwardOnLineIgnoringLineBreak();
+}
+
+inline LeafBoxIterator Box::nextLogicalLeftwardOnLineIgnoringLineBreak() const
+{
+    return writingMode().isLogicalLeftLineLeft()
+        ? nextLineLeftwardOnLineIgnoringLineBreak() : nextLineRightwardOnLineIgnoringLineBreak();
+}
+
 }
 }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.cpp
@@ -46,21 +46,21 @@ RectEdges<bool> InlineBox::closedEdges() const
     if (style().boxDecorationBreak() == BoxDecorationBreak::Clone)
         return closedEdges;
     auto writingMode = style().writingMode();
-    bool isFirst = !previousInlineBox() && !renderer().isContinuation();
-    bool isLast = !nextInlineBox() && !renderer().continuation();
+    bool isFirst = !nextInlineBoxLineLeftward() && !renderer().isContinuation();
+    bool isLast = !nextInlineBoxLineRightward() && !renderer().continuation();
     closedEdges.setStart(isFirst, writingMode);
     closedEdges.setEnd(isLast, writingMode);
     return closedEdges;
 };
 
-InlineBoxIterator InlineBox::nextInlineBox() const
+InlineBoxIterator InlineBox::nextInlineBoxLineRightward() const
 {
-    return InlineBoxIterator(*this).traverseNextInlineBox();
+    return InlineBoxIterator(*this).traverseInlineBoxLineRightward();
 }
 
-InlineBoxIterator InlineBox::previousInlineBox() const
+InlineBoxIterator InlineBox::nextInlineBoxLineLeftward() const
 {
-    return InlineBoxIterator(*this).traversePreviousInlineBox();
+    return InlineBoxIterator(*this).traverseInlineBoxLineLeftward();
 }
 
 LeafBoxIterator InlineBox::firstLeafBox() const
@@ -80,17 +80,17 @@ LeafBoxIterator InlineBox::lastLeafBox() const
 LeafBoxIterator InlineBox::endLeafBox() const
 {
     if (auto last = lastLeafBox())
-        return last->nextOnLine();
+        return last->nextLineRightwardOnLine();
     return { };
 }
 
 IteratorRange<BoxIterator> InlineBox::descendants() const
 {
     BoxIterator begin(*this);
-    begin.traverseNextOnLine();
+    begin.traverseLineRightwardOnLine();
 
     BoxIterator end(*this);
-    end.traverseNextOnLineSkippingChildren();
+    end.traverseLineRightwardOnLineSkippingChildren();
 
     return { begin, end };
 }
@@ -105,7 +105,7 @@ InlineBoxIterator::InlineBoxIterator(const Box& box)
 {
 }
 
-InlineBoxIterator& InlineBoxIterator::traverseNextInlineBox()
+InlineBoxIterator& InlineBoxIterator::traverseInlineBoxLineRightward()
 {
     WTF::switchOn(m_box.m_pathVariant, [](auto& path) {
         path.traverseNextInlineBox();
@@ -113,7 +113,7 @@ InlineBoxIterator& InlineBoxIterator::traverseNextInlineBox()
     return *this;
 }
 
-InlineBoxIterator& InlineBoxIterator::traversePreviousInlineBox()
+InlineBoxIterator& InlineBoxIterator::traverseInlineBoxLineLeftward()
 {
     WTF::switchOn(m_box.m_pathVariant, [](auto& path) {
         path.traversePreviousInlineBox();
@@ -121,7 +121,7 @@ InlineBoxIterator& InlineBoxIterator::traversePreviousInlineBox()
     return *this;
 }
 
-InlineBoxIterator firstInlineBoxFor(const RenderInline& renderInline)
+InlineBoxIterator lineLeftmostInlineBoxFor(const RenderInline& renderInline)
 {
     if (auto* lineLayout = LayoutIntegration::LineLayout::containing(renderInline))
         return lineLayout->firstInlineBoxFor(renderInline);

--- a/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.h
@@ -44,8 +44,8 @@ public:
     // FIXME: Remove. For intermediate porting steps only.
     const LegacyInlineFlowBox* legacyInlineBox() const { return downcast<LegacyInlineFlowBox>(Box::legacyInlineBox()); }
 
-    InlineBoxIterator nextInlineBox() const;
-    InlineBoxIterator previousInlineBox() const;
+    InlineBoxIterator nextInlineBoxLineRightward() const;
+    InlineBoxIterator nextInlineBoxLineLeftward() const;
     InlineBoxIterator iterator() const;
 
     LeafBoxIterator firstLeafBox() const;
@@ -64,14 +64,14 @@ public:
     const InlineBox& operator*() const { return get(); }
     const InlineBox* operator->() const { return &get(); }
 
-    InlineBoxIterator& traverseNextInlineBox();
-    InlineBoxIterator& traversePreviousInlineBox();
+    InlineBoxIterator& traverseInlineBoxLineRightward();
+    InlineBoxIterator& traverseInlineBoxLineLeftward();
 
 private:
     const InlineBox& get() const { return downcast<InlineBox>(m_box); }
 };
 
-InlineBoxIterator firstInlineBoxFor(const RenderInline&);
+InlineBoxIterator lineLeftmostInlineBoxFor(const RenderInline&);
 InlineBoxIterator firstRootInlineBoxFor(const RenderBlockFlow&);
 
 InlineBoxIterator inlineBoxFor(const LegacyInlineFlowBox&);

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp
@@ -110,14 +110,14 @@ LineBoxIterator LineBox::previous() const
     return LineBoxIterator(*this).traversePrevious();
 }
 
-LeafBoxIterator LineBox::firstLeafBox() const
+LeafBoxIterator LineBox::lineLeftmostLeafBox() const
 {
     return WTF::switchOn(m_pathVariant, [](auto& path) -> LeafBoxIterator {
         return { path.firstLeafBox() };
     });
 }
 
-LeafBoxIterator LineBox::lastLeafBox() const
+LeafBoxIterator LineBox::lineRightmostLeafBox() const
 {
     return WTF::switchOn(m_pathVariant, [](auto& path) -> LeafBoxIterator {
         return { path.lastLeafBox() };
@@ -130,14 +130,14 @@ LeafBoxIterator closestBoxForHorizontalPosition(const LineBox& lineBox, float ho
         return box && box->renderer().node() && box->renderer().node()->hasEditableStyle();
     };
 
-    auto firstBox = lineBox.firstLeafBox();
-    auto lastBox = lineBox.lastLeafBox();
+    auto firstBox = lineBox.lineLeftmostLeafBox();
+    auto lastBox = lineBox.lineRightmostLeafBox();
 
     if (firstBox != lastBox) {
         if (firstBox->isLineBreak())
-            firstBox = firstBox->nextOnLineIgnoringLineBreak();
+            firstBox = firstBox->nextLineRightwardOnLineIgnoringLineBreak();
         else if (lastBox->isLineBreak())
-            lastBox = lastBox->previousOnLineIgnoringLineBreak();
+            lastBox = lastBox->nextLineLeftwardOnLineIgnoringLineBreak();
     }
 
     if (firstBox == lastBox && (!editableOnly || isEditable(firstBox)))
@@ -150,7 +150,7 @@ LeafBoxIterator closestBoxForHorizontalPosition(const LineBox& lineBox, float ho
         return lastBox;
 
     auto closestBox = lastBox;
-    for (auto box = firstBox; box; box = box.traverseNextOnLineIgnoringLineBreak()) {
+    for (auto box = firstBox; box; box = box.traverseLineRightwardOnLineIgnoringLineBreak()) {
         if (!box->renderer().isRenderListMarker() && (!editableOnly || isEditable(box))) {
             if (horizontalPosition < box->logicalRightIgnoringInlineDirection())
                 return box;
@@ -163,7 +163,7 @@ LeafBoxIterator closestBoxForHorizontalPosition(const LineBox& lineBox, float ho
 
 RenderObject::HighlightState LineBox::ellipsisSelectionState() const
 {
-    auto lastLeafBox = this->lastLeafBox();
+    auto lastLeafBox = this->lineRightmostLeafBox();
     if (!lastLeafBox)
         return RenderObject::HighlightState::None;
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
@@ -88,8 +88,8 @@ public:
     bool isFirst() const;
     bool isFirstAfterPageBreak() const;
 
-    LeafBoxIterator firstLeafBox() const;
-    LeafBoxIterator lastLeafBox() const;
+    LeafBoxIterator lineLeftmostLeafBox() const;
+    LeafBoxIterator lineRightmostLeafBox() const;
 
     LineBoxIterator next() const;
     LineBoxIterator previous() const;

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLogicalOrderTraversal.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLogicalOrderTraversal.cpp
@@ -72,7 +72,7 @@ std::pair<TextBoxIterator, TextLogicalOrderCache> firstTextBoxInLogicalOrderFor(
     if (auto cache = makeTextLogicalOrderCacheIfNeeded(text))
         return { cache->boxes.first(), WTFMove(cache) };
 
-    return { firstTextBoxFor(text), nullptr };
+    return { lineLeftmostTextBoxFor(text), nullptr };
 }
 
 TextBoxIterator nextTextBoxInLogicalOrder(const TextBoxIterator& textBox, TextLogicalOrderCache& cache)

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLogicalOrderTraversal.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLogicalOrderTraversal.h
@@ -68,7 +68,7 @@ Vector<LeafBoxIterator> leafBoxesInLogicalOrder(const LineBoxIterator& lineBox, 
     unsigned char minLevel = 128;
     unsigned char maxLevel = 0;
 
-    for (auto box = lineBox->firstLeafBox(); box; box = box.traverseNextOnLine()) {
+    for (auto box = lineBox->lineLeftmostLeafBox(); box; box = box.traverseLineRightwardOnLine()) {
         minLevel = std::min(minLevel, box->bidiLevel());
         maxLevel = std::max(maxLevel, box->bidiLevel());
         boxes.append(box);

--- a/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp
@@ -68,7 +68,7 @@ TextBoxIterator& TextBoxIterator::traverseNextTextBox()
     return *this;
 }
 
-TextBoxIterator firstTextBoxFor(const RenderText& text)
+TextBoxIterator lineLeftmostTextBoxFor(const RenderText& text)
 {
     if (auto* lineLayout = LayoutIntegration::LineLayout::containing(text))
         return lineLayout->textBoxesFor(text);
@@ -94,7 +94,7 @@ TextBoxIterator textBoxFor(const LayoutIntegration::InlineContent& content, size
 
 BoxRange<TextBoxIterator> textBoxesFor(const RenderText& text)
 {
-    return { firstTextBoxFor(text) };
+    return { lineLeftmostTextBoxFor(text) };
 }
 
 }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h
@@ -73,15 +73,15 @@ public:
     TextBoxIterator& traverseNextTextBox();
 
 private:
-    BoxIterator& traverseNextOnLine() = delete;
-    BoxIterator& traversePreviousOnLine() = delete;
-    BoxIterator& traverseNextOnLineIgnoringLineBreak() = delete;
-    BoxIterator& traversePreviousOnLineIgnoringLineBreak() = delete;
+    BoxIterator& traverseLineRightwardOnLine() = delete;
+    BoxIterator& traverseLineLeftwardOnLine() = delete;
+    BoxIterator& traverseLineRightwardOnLineIgnoringLineBreak() = delete;
+    BoxIterator& traverseLineLeftwardOnLineIgnoringLineBreak() = delete;
 
     const TextBox& get() const { return downcast<TextBox>(m_box); }
 };
 
-TextBoxIterator firstTextBoxFor(const RenderText&);
+TextBoxIterator lineLeftmostTextBoxFor(const RenderText&);
 TextBoxIterator textBoxFor(const LegacyInlineTextBox*);
 TextBoxIterator textBoxFor(const LayoutIntegration::InlineContent&, const InlineDisplay::Box&);
 TextBoxIterator textBoxFor(const LayoutIntegration::InlineContent&, size_t boxIndex);

--- a/Source/WebCore/layout/integration/inline/LineSelection.h
+++ b/Source/WebCore/layout/integration/inline/LineSelection.h
@@ -63,7 +63,7 @@ public:
             return RenderObject::HighlightState::None;
 
         auto lineState = RenderObject::HighlightState::None;
-        for (auto box = lineBox.firstLeafBox(); box; box.traverseNextOnLine()) {
+        for (auto box = lineBox.lineLeftmostLeafBox(); box; box.traverseLineRightwardOnLine()) {
             auto boxState = box->selectionState();
             if (lineState == RenderObject::HighlightState::None)
                 lineState = boxState;

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -1022,7 +1022,7 @@ bool BackgroundPainter::boxShadowShouldBeAppliedToBackground(const RenderBoxMode
         // would be clipped out, so it has to be drawn separately).
         if (inlineBox->isRootInlineBox())
             return true;
-        if (!inlineBox->previousInlineBox() && !inlineBox->nextInlineBox())
+        if (!inlineBox->nextInlineBoxLineLeftward() && !inlineBox->nextInlineBoxLineRightward())
             return true;
         auto* image = lastBackgroundLayer->image();
         auto& renderer = inlineBox->renderer();

--- a/Source/WebCore/rendering/CaretRectComputation.cpp
+++ b/Source/WebCore/rendering/CaretRectComputation.cpp
@@ -321,7 +321,7 @@ static LayoutRect computeCaretRectForInline(const RenderInline& renderer)
 
     LayoutRect caretRect = computeCaretRectForEmptyElement(renderer, renderer.borderAndPaddingLogicalWidth(), 0, CaretRectMode::Normal);
 
-    if (auto firstInlineBox = InlineIterator::firstInlineBoxFor(renderer))
+    if (auto firstInlineBox = InlineIterator::lineLeftmostInlineBoxFor(renderer))
         caretRect.moveBy(LayoutPoint { firstInlineBox->visualRectIgnoringBlockDirection().location() });
 
     return caretRect;

--- a/Source/WebCore/rendering/InlineBoxPainter.cpp
+++ b/Source/WebCore/rendering/InlineBoxPainter.cpp
@@ -185,7 +185,7 @@ void InlineBoxPainter::paintMask()
         return; // Don't paint anything while we wait for the image to load.
     }
 
-    bool hasSingleLine = !m_inlineBox.previousInlineBox() && !m_inlineBox.nextInlineBox();
+    bool hasSingleLine = !m_inlineBox.nextInlineBoxLineLeftward() && !m_inlineBox.nextInlineBoxLineRightward();
 
     BorderPainter borderPainter { renderer(), m_paintInfo };
 
@@ -195,10 +195,10 @@ void InlineBoxPainter::paintMask()
         // We have a mask image that spans multiple lines.
         // We need to adjust _tx and _ty by the width of all previous lines.
         LayoutUnit logicalOffsetOnLine;
-        for (auto box = m_inlineBox.previousInlineBox(); box; box.traversePreviousInlineBox())
+        for (auto box = m_inlineBox.nextInlineBoxLineLeftward(); box; box.traverseInlineBoxLineLeftward())
             logicalOffsetOnLine += box->logicalWidth();
         LayoutUnit totalLogicalWidth = logicalOffsetOnLine;
-        for (auto box = m_inlineBox.iterator(); box; box.traverseNextInlineBox())
+        for (auto box = m_inlineBox.iterator(); box; box.traverseInlineBoxLineRightward())
             totalLogicalWidth += box->logicalWidth();
         LayoutUnit stripX = adjustedPaintOffset.x() - (isHorizontal() ? logicalOffsetOnLine : 0_lu);
         LayoutUnit stripY = adjustedPaintOffset.y() - (isHorizontal() ? 0_lu : logicalOffsetOnLine);
@@ -259,7 +259,7 @@ void InlineBoxPainter::paintDecorations()
 
     BorderPainter borderPainter { renderer(), m_paintInfo };
 
-    bool hasSingleLine = !m_inlineBox.previousInlineBox() && !m_inlineBox.nextInlineBox();
+    bool hasSingleLine = !m_inlineBox.nextInlineBoxLineLeftward() && !m_inlineBox.nextInlineBoxLineRightward();
     if (!hasBorderImage || hasSingleLine) {
         auto closedEdges = m_inlineBox.closedEdges();
         borderPainter.paintBorder(paintRect, style, BleedAvoidance::None, closedEdges);
@@ -275,10 +275,10 @@ void InlineBoxPainter::paintDecorations()
     // FIXME: What the heck do we do with RTL here? The math we're using is obviously not right,
     // but it isn't even clear how this should work at all.
     LayoutUnit logicalOffsetOnLine;
-    for (auto box = m_inlineBox.previousInlineBox(); box; box.traversePreviousInlineBox())
+    for (auto box = m_inlineBox.nextInlineBoxLineLeftward(); box; box.traverseInlineBoxLineLeftward())
         logicalOffsetOnLine += box->logicalWidth();
     LayoutUnit totalLogicalWidth = logicalOffsetOnLine;
-    for (auto box = m_inlineBox.iterator(); box; box.traverseNextInlineBox())
+    for (auto box = m_inlineBox.iterator(); box; box.traverseInlineBoxLineRightward())
         totalLogicalWidth += box->logicalWidth();
 
     LayoutUnit stripX = adjustedPaintoffset.x() - (isHorizontal() ? logicalOffsetOnLine : 0_lu);
@@ -307,7 +307,7 @@ void InlineBoxPainter::paintFillLayer(const Color& color, const FillLayer& fillL
     auto* image = fillLayer.image();
     bool hasFillImage = image && image->canRender(&renderer(), renderer().style().usedZoom());
     bool hasFillImageOrBorderRadious = hasFillImage || renderer().style().hasBorderRadius();
-    bool hasSingleLine = !m_inlineBox.previousInlineBox() && !m_inlineBox.nextInlineBox();
+    bool hasSingleLine = !m_inlineBox.nextInlineBoxLineLeftward() && !m_inlineBox.nextInlineBoxLineRightward();
 
     BackgroundPainter backgroundPainter { renderer(), m_paintInfo };
 
@@ -332,16 +332,16 @@ void InlineBoxPainter::paintFillLayer(const Color& color, const FillLayer& fillL
     LayoutUnit logicalOffsetOnLine;
     LayoutUnit totalLogicalWidth;
     if (renderer().writingMode().isBidiLTR()) {
-        for (auto box = m_inlineBox.previousInlineBox(); box; box.traversePreviousInlineBox())
+        for (auto box = m_inlineBox.nextInlineBoxLineLeftward(); box; box.traverseInlineBoxLineLeftward())
             logicalOffsetOnLine += box->logicalWidth();
         totalLogicalWidth = logicalOffsetOnLine;
-        for (auto box = m_inlineBox.iterator(); box; box.traverseNextInlineBox())
+        for (auto box = m_inlineBox.iterator(); box; box.traverseInlineBoxLineRightward())
             totalLogicalWidth += box->logicalWidth();
     } else {
-        for (auto box = m_inlineBox.nextInlineBox(); box; box.traverseNextInlineBox())
+        for (auto box = m_inlineBox.nextInlineBoxLineRightward(); box; box.traverseInlineBoxLineRightward())
             logicalOffsetOnLine += box->logicalWidth();
         totalLogicalWidth = logicalOffsetOnLine;
-        for (auto box = m_inlineBox.iterator(); box; box.traversePreviousInlineBox())
+        for (auto box = m_inlineBox.iterator(); box; box.traverseInlineBoxLineLeftward())
             totalLogicalWidth += box->logicalWidth();
     }
     LayoutRect backgroundImageStrip {
@@ -360,7 +360,7 @@ void InlineBoxPainter::paintBoxShadow(ShadowStyle shadowStyle, const LayoutRect&
 {
     BackgroundPainter backgroundPainter { renderer(), m_paintInfo };
 
-    bool hasSingleLine = !m_inlineBox.previousInlineBox() && !m_inlineBox.nextInlineBox();
+    bool hasSingleLine = !m_inlineBox.nextInlineBoxLineLeftward() && !m_inlineBox.nextInlineBoxLineRightward();
     if (hasSingleLine || m_isRootInlineBox) {
         backgroundPainter.paintBoxShadow(paintRect, style(), shadowStyle);
         return;

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1311,7 +1311,7 @@ void RenderBlock::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffs
             // in the same layer. 
             if (!inlineEnclosedInSelfPaintingLayer && !hasLayer())
                 containingBlock->addContinuationWithOutline(inlineRenderer);
-            else if (!InlineIterator::firstInlineBoxFor(*inlineRenderer) || (!inlineEnclosedInSelfPaintingLayer && hasLayer()))
+            else if (!InlineIterator::lineLeftmostInlineBoxFor(*inlineRenderer) || (!inlineEnclosedInSelfPaintingLayer && hasLayer()))
                 inlineRenderer->paintOutline(paintInfo, paintOffset - locationOffset() + inlineRenderer->containingBlock()->location());
         }
         paintContinuationOutlines(paintInfo, paintOffset);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4173,13 +4173,13 @@ static std::optional<float> positionWithRTLInlineBoxContainingBlock(const Render
     if (!renderInline || containingBlock.writingMode().isLogicalLeftInlineStart())
         return { };
 
-    auto firstInlineBox = InlineIterator::firstInlineBoxFor(*renderInline);
+    auto firstInlineBox = InlineIterator::lineLeftmostInlineBoxFor(*renderInline);
     if (!firstInlineBox)
         return { };
 
     auto lastInlineBox = [&] {
         auto inlineBox = firstInlineBox;
-        for (; inlineBox->nextInlineBox(); inlineBox.traverseNextInlineBox()) { }
+        for (; inlineBox->nextInlineBoxLineRightward(); inlineBox.traverseInlineBoxLineRightward()) { }
         return inlineBox;
     }();
     if (firstInlineBox == lastInlineBox)

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -684,7 +684,7 @@ void RenderBoxModelObject::paintMaskForTextFillBox(GraphicsContext& context, con
     if (inlineBox) {
         auto paintOffset = scrolledPaintRect.location() - toLayoutSize(LayoutPoint(inlineBox->visualRectIgnoringBlockDirection().location()));
 
-        for (auto box = inlineBox->firstLeafBox(), end = inlineBox->endLeafBox(); box != end; box.traverseNextOnLine()) {
+        for (auto box = inlineBox->firstLeafBox(), end = inlineBox->endLeafBox(); box != end; box.traverseLineRightwardOnLine()) {
             if (!box->isText())
                 continue;
             TextBoxPainter { box->modernPath().inlineContent(), box->modernPath().box(), box->modernPath().box().style(), maskInfo, paintOffset }.paint();

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1923,12 +1923,12 @@ bool RenderElement::getLeadingCorner(FloatPoint& point, bool& insideFixed) const
             return true;
         }
 
-        if (p->node() && p->node() == element() && is<RenderText>(*o) && !InlineIterator::firstTextBoxFor(downcast<RenderText>(*o))) {
+        if (p->node() && p->node() == element() && is<RenderText>(*o) && !InlineIterator::lineLeftmostTextBoxFor(downcast<RenderText>(*o))) {
             // do nothing - skip unrendered whitespace that is a child or next sibling of the anchor
         } else if (is<RenderText>(*o) || o->isReplacedOrAtomicInline()) {
             point = FloatPoint();
             if (CheckedPtr textRenderer = dynamicDowncast<RenderText>(*o)) {
-                if (auto run = InlineIterator::firstTextBoxFor(*textRenderer))
+                if (auto run = InlineIterator::lineLeftmostTextBoxFor(*textRenderer))
                     point.move(textRenderer->linesBoundingBox().x(), run->lineBox()->contentLogicalTop());
             } else if (auto* box = dynamicDowncast<RenderBox>(*o))
                 point.moveBy(box->location());

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -185,7 +185,7 @@ void RenderFileUploadControl::paintControl(PaintInfo& paintInfo, const LayoutPoi
         auto textLogicalTop = [&]() -> float {
             if (auto* buttonRenderer = downcast<RenderButton>(button->renderer())) {
                 if (auto* buttonTextRenderer = buttonRenderer->textRenderer()) {
-                    if (auto textBox = InlineIterator::firstTextBoxFor(*buttonTextRenderer)) {
+                    if (auto textBox = InlineIterator::lineLeftmostTextBoxFor(*buttonTextRenderer)) {
                         auto textVisualRect = textBox->visualRectIgnoringBlockDirection();
                         textVisualRect.setLocation(buttonTextRenderer->localToContainerPoint(textVisualRect.location(), this));
                         textVisualRect.moveBy(roundPointToDevicePixels(paintOffset, document().deviceScaleFactor()));

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -127,8 +127,8 @@ void RenderImage::collectSelectionGeometries(Vector<SelectionGeometry>& geometri
         int selectionTop = !containingBlock->writingMode().isBlockFlipped() ? selectionLogicalRect.y() - logicalTop() : logicalBottom() - selectionLogicalRect.maxY();
         int selectionHeight = selectionLogicalRect.height();
         imageRect = IntRect { 0,  selectionTop, logicalWidth(), selectionHeight };
-        isFirstOnLine = !run->previousOnLine();
-        isLastOnLine = !run->nextOnLine();
+        isFirstOnLine = !run->nextLineLeftwardOnLine();
+        isLastOnLine = !run->nextLineRightwardOnLine();
         LogicalSelectionOffsetCaches cache(*containingBlock);
         LayoutUnit leftOffset = containingBlock->logicalLeftSelectionOffset(*containingBlock, LayoutUnit(run->logicalTop()), cache);
         LayoutUnit rightOffset = containingBlock->logicalRightSelectionOffset(*containingBlock, LayoutUnit(run->logicalTop()), cache);

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -453,15 +453,15 @@ LayoutUnit RenderInline::innerPaddingBoxWidth() const
     auto lastInlineBoxPaddingBoxRight = LayoutUnit { };
 
     if (LayoutIntegration::LineLayout::containing(*this)) {
-        if (auto inlineBox = InlineIterator::firstInlineBoxFor(*this)) {
+        if (auto inlineBox = InlineIterator::lineLeftmostInlineBoxFor(*this)) {
             if (writingMode().isBidiLTR()) {
                 firstInlineBoxPaddingBoxLeft = inlineBox->logicalLeftIgnoringInlineDirection() + borderStart();
-                for (; inlineBox->nextInlineBox(); inlineBox.traverseNextInlineBox()) { }
+                for (; inlineBox->nextInlineBoxLineRightward(); inlineBox.traverseInlineBoxLineRightward()) { }
                 ASSERT(inlineBox);
                 lastInlineBoxPaddingBoxRight = inlineBox->logicalRightIgnoringInlineDirection() - borderEnd();
             } else {
                 lastInlineBoxPaddingBoxRight = inlineBox->logicalRightIgnoringInlineDirection() - borderStart();
-                for (; inlineBox->nextInlineBox(); inlineBox.traverseNextInlineBox()) { }
+                for (; inlineBox->nextInlineBoxLineRightward(); inlineBox.traverseInlineBoxLineRightward()) { }
                 ASSERT(inlineBox);
                 firstInlineBoxPaddingBoxLeft = inlineBox->logicalLeftIgnoringInlineDirection() + borderEnd();
             }
@@ -505,7 +505,7 @@ IntRect RenderInline::linesBoundingBox() const
             // FIXME: Always build the bounding box like this. LineLayouyt::enclosingBorderBoxRectFor does not include
             // any post-layout box adjustments.
             FloatRect result;
-            for (auto box = InlineIterator::firstInlineBoxFor(*this); box; box.traverseNextInlineBox()) {
+            for (auto box = InlineIterator::lineLeftmostInlineBoxFor(*this); box; box.traverseInlineBoxLineRightward()) {
                 auto rect = box->visualRectIgnoringBlockDirection();
                 result.unite(rect);
             }
@@ -876,7 +876,7 @@ LayoutSize RenderInline::offsetForInFlowPositionedInline(const RenderBox* child)
             ASSERT(needsLayout());
             return LayoutSize();
         }
-        if (auto inlineBox = InlineIterator::firstInlineBoxFor(*this)) {
+        if (auto inlineBox = InlineIterator::lineLeftmostInlineBoxFor(*this)) {
             inlinePosition = LayoutUnit::fromFloatRound(inlineBox->logicalLeftIgnoringInlineDirection());
             blockPosition = inlineBox->logicalTop();
         }
@@ -974,7 +974,7 @@ void RenderInline::paintOutline(PaintInfo& paintInfo, const LayoutPoint& paintOf
     auto& containingBlock = *this->containingBlock();
     auto isFlipped = containingBlock.writingMode().isBlockFlipped();
     Vector<LayoutRect> rects;
-    for (auto box = InlineIterator::firstInlineBoxFor(*this); box; box.traverseNextInlineBox()) {
+    for (auto box = InlineIterator::lineLeftmostInlineBoxFor(*this); box; box.traverseInlineBoxLineRightward()) {
         auto lineBox = box->lineBox();
         auto logicalTop = std::max(lineBox->contentLogicalTop(), box->logicalTop());
         auto logicalBottom = std::min(lineBox->contentLogicalBottom(), box->logicalBottom());

--- a/Source/WebCore/rendering/RenderLineBreak.cpp
+++ b/Source/WebCore/rendering/RenderLineBreak.cpp
@@ -172,8 +172,8 @@ void RenderLineBreak::collectSelectionGeometries(Vector<SelectionGeometry>& rect
     extentsRect = localToAbsoluteQuad(FloatRect(extentsRect)).enclosingBoundingBox();
     if (!run->isHorizontal())
         extentsRect = extentsRect.transposedRect();
-    bool isFirstOnLine = !run->previousOnLine();
-    bool isLastOnLine = !run->nextOnLine();
+    bool isFirstOnLine = !run->nextLineLeftwardOnLine();
+    bool isLastOnLine = !run->nextLineRightwardOnLine();
 
     bool isFixed = false;
     auto absoluteQuad = localToAbsoluteQuad(FloatRect(rect), UseTransforms, &isFixed);

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -515,7 +515,7 @@ Vector<IntRect> RenderText::absoluteRectsForRange(unsigned start, unsigned end, 
 // Full annotations are added in this class.
 void RenderText::collectSelectionGeometries(Vector<SelectionGeometry>& rects, unsigned start, unsigned end)
 {
-    for (auto textBox = InlineIterator::firstTextBoxFor(*this); textBox; textBox = textBox.traverseNextTextBox()) {
+    for (auto textBox = InlineIterator::lineLeftmostTextBoxFor(*this); textBox; textBox = textBox.traverseNextTextBox()) {
         LayoutRect rect;
         if (start <= textBox->start() && textBox->end() <= end)
             rect = selectionRectForTextBox(*textBox, start, end);
@@ -549,8 +549,8 @@ void RenderText::collectSelectionGeometries(Vector<SelectionGeometry>& rects, un
         extentsRect = localToAbsoluteQuad(FloatRect(extentsRect)).enclosingBoundingBox();
         if (!textBox->isHorizontal())
             extentsRect = extentsRect.transposedRect();
-        bool isFirstOnLine = !textBox->previousOnLine();
-        bool isLastOnLine = !textBox->nextOnLine();
+        bool isFirstOnLine = !textBox->nextLineLeftwardOnLine();
+        bool isLastOnLine = !textBox->nextLineRightwardOnLine();
 
         bool containsStart = textBox->start() <= start && textBox->end() >= start;
         bool containsEnd = textBox->start() <= end && textBox->end() >= end;
@@ -752,7 +752,7 @@ static bool lineDirectionPointFitsInBox(int pointLineDirection, const InlineIter
     // the affinity must be downstream so the position doesn't jump back to the previous line
     // except when box is the first box in the line
     if (pointLineDirection <= textRun->logicalLeftIgnoringInlineDirection()) {
-        shouldAffinityBeDownstream = !textRun->previousOnLine() ? UpstreamIfPositionIsNotAtStart : AlwaysDownstream;
+        shouldAffinityBeDownstream = !textRun->nextLineLeftwardOnLine() ? UpstreamIfPositionIsNotAtStart : AlwaysDownstream;
         return true;
     }
 
@@ -767,10 +767,10 @@ static bool lineDirectionPointFitsInBox(int pointLineDirection, const InlineIter
 
     // box is first on line
     // and the x coordinate is to the left of the first text box left edge
-    if (!textRun->previousOnLineIgnoringLineBreak() && pointLineDirection < textRun->logicalLeftIgnoringInlineDirection())
+    if (!textRun->nextLineLeftwardOnLineIgnoringLineBreak() && pointLineDirection < textRun->logicalLeftIgnoringInlineDirection())
         return true;
 
-    if (!textRun->nextOnLineIgnoringLineBreak()) {
+    if (!textRun->nextLineRightwardOnLineIgnoringLineBreak()) {
         // box is last on line
         // and the x coordinate is to the right of the last text box right edge
         // generate VisiblePosition, use Affinity::Upstream affinity if possible
@@ -807,7 +807,7 @@ static VisiblePosition createVisiblePositionAfterAdjustingOffsetForBiDi(const In
     if (positionIsAtStartOfBox == run->isLeftToRightDirection()) {
         // offset is on the left edge
 
-        auto previousRun = run->previousOnLineIgnoringLineBreak();
+        auto previousRun = run->nextLineLeftwardOnLineIgnoringLineBreak();
         if ((previousRun && previousRun->bidiLevel() == run->bidiLevel())
             || run->renderer().containingBlock()->writingMode().bidiDirection() == run->direction()) // FIXME: left on 12CBA
             return createVisiblePositionForBox(run, run->leftmostCaretOffset(), shouldAffinityBeDownstream);
@@ -815,7 +815,7 @@ static VisiblePosition createVisiblePositionAfterAdjustingOffsetForBiDi(const In
         if (previousRun && previousRun->bidiLevel() > run->bidiLevel()) {
             // e.g. left of B in aDC12BAb
             auto leftmostRun = previousRun;
-            for (; previousRun; previousRun.traversePreviousOnLineIgnoringLineBreak()) {
+            for (; previousRun; previousRun.traverseLineLeftwardOnLineIgnoringLineBreak()) {
                 if (previousRun->bidiLevel() <= run->bidiLevel())
                     break;
                 leftmostRun = previousRun;
@@ -826,7 +826,7 @@ static VisiblePosition createVisiblePositionAfterAdjustingOffsetForBiDi(const In
         if (!previousRun || previousRun->bidiLevel() < run->bidiLevel()) {
             // e.g. left of D in aDC12BAb
             InlineIterator::BoxIterator rightmostRun = run;
-            for (auto nextRun = run->nextOnLineIgnoringLineBreak(); nextRun; nextRun.traverseNextOnLineIgnoringLineBreak()) {
+            for (auto nextRun = run->nextLineRightwardOnLineIgnoringLineBreak(); nextRun; nextRun.traverseLineRightwardOnLineIgnoringLineBreak()) {
                 if (nextRun->bidiLevel() < run->bidiLevel())
                     break;
                 rightmostRun = nextRun;
@@ -838,7 +838,7 @@ static VisiblePosition createVisiblePositionAfterAdjustingOffsetForBiDi(const In
         return createVisiblePositionForBox(run, run->rightmostCaretOffset(), shouldAffinityBeDownstream);
     }
 
-    auto nextRun = run->nextOnLineIgnoringLineBreak();
+    auto nextRun = run->nextLineRightwardOnLineIgnoringLineBreak();
     if ((nextRun && nextRun->bidiLevel() == run->bidiLevel())
         || run->renderer().containingBlock()->writingMode().bidiDirection() == run->direction())
         return createVisiblePositionForBox(run, run->rightmostCaretOffset(), shouldAffinityBeDownstream);
@@ -847,7 +847,7 @@ static VisiblePosition createVisiblePositionAfterAdjustingOffsetForBiDi(const In
     if (nextRun && nextRun->bidiLevel() > run->bidiLevel()) {
         // e.g. right of C in aDC12BAb
         auto rightmostRun = nextRun;
-        for (; nextRun; nextRun.traverseNextOnLineIgnoringLineBreak()) {
+        for (; nextRun; nextRun.traverseLineRightwardOnLineIgnoringLineBreak()) {
             if (nextRun->bidiLevel() <= run->bidiLevel())
                 break;
             rightmostRun = nextRun;
@@ -859,7 +859,7 @@ static VisiblePosition createVisiblePositionAfterAdjustingOffsetForBiDi(const In
     if (!nextRun || nextRun->bidiLevel() < run->bidiLevel()) {
         // e.g. right of A in aDC12BAb
         InlineIterator::BoxIterator leftmostRun = run;
-        for (auto previousRun = run->previousOnLineIgnoringLineBreak(); previousRun; previousRun.traversePreviousOnLineIgnoringLineBreak()) {
+        for (auto previousRun = run->nextLineLeftwardOnLineIgnoringLineBreak(); previousRun; previousRun.traverseLineLeftwardOnLineIgnoringLineBreak()) {
             if (previousRun->bidiLevel() < run->bidiLevel())
                 break;
             leftmostRun = previousRun;
@@ -875,7 +875,7 @@ static VisiblePosition createVisiblePositionAfterAdjustingOffsetForBiDi(const In
 
 VisiblePosition RenderText::positionForPoint(const LayoutPoint& point, HitTestSource, const RenderFragmentContainer*)
 {
-    auto firstRun = InlineIterator::firstTextBoxFor(*this);
+    auto firstRun = InlineIterator::lineLeftmostTextBoxFor(*this);
 
     if (!firstRun || !text().length())
         return createVisiblePosition(0, Affinity::Downstream);
@@ -886,7 +886,7 @@ VisiblePosition RenderText::positionForPoint(const LayoutPoint& point, HitTestSo
 
     InlineIterator::TextBoxIterator lastRun;
     for (auto run = firstRun; run; run.traverseNextTextBox()) {
-        if (run->isLineBreak() && !run->previousOnLine() && run->nextOnLine() && !run->nextOnLine()->isLineBreak())
+        if (run->isLineBreak() && !run->nextLineLeftwardOnLine() && run->nextLineRightwardOnLine() && !run->nextLineRightwardOnLine()->isLineBreak())
             run.traverseNextTextBox();
 
         auto lineBox = run->lineBox();
@@ -1516,7 +1516,7 @@ Vector<std::pair<unsigned, unsigned>> RenderText::contentRangesBetweenOffsetsFor
 
 IntPoint RenderText::firstRunLocation() const
 {
-    auto first = InlineIterator::firstTextBoxFor(*this);
+    auto first = InlineIterator::lineLeftmostTextBoxFor(*this);
     if (!first)
         return { };
     return IntPoint(first->visualRectIgnoringBlockDirection().location());
@@ -1942,7 +1942,7 @@ float RenderText::width(unsigned from, unsigned length, const FontCascade& fontC
 
 IntRect RenderText::linesBoundingBox() const
 {
-    auto firstTextBox = InlineIterator::firstTextBoxFor(*this);
+    auto firstTextBox = InlineIterator::lineLeftmostTextBoxFor(*this);
     if (!firstTextBox)
         return { };
 
@@ -2035,7 +2035,7 @@ LayoutRect RenderText::selectionRectForRepaint(const RenderLayerModelObject* rep
 
 int RenderText::caretMinOffset() const
 {
-    auto first = InlineIterator::firstTextBoxFor(*this);
+    auto first = InlineIterator::lineLeftmostTextBoxFor(*this);
     if (!first)
         return 0;
 
@@ -2048,7 +2048,7 @@ int RenderText::caretMinOffset() const
 
 int RenderText::caretMaxOffset() const
 {
-    auto first = InlineIterator::firstTextBoxFor(*this);
+    auto first = InlineIterator::lineLeftmostTextBoxFor(*this);
     if (!first)
         return text().length();
 

--- a/Source/WebCore/rendering/RenderVTTCue.cpp
+++ b/Source/WebCore/rendering/RenderVTTCue.cpp
@@ -87,7 +87,7 @@ bool RenderVTTCue::initializeLayoutParameters(LayoutUnit& step, LayoutUnit& posi
     if (!box)
         return false;
 
-    auto firstInlineBox = InlineIterator::firstInlineBoxFor(*box) ? InlineIterator::firstInlineBoxFor(*box) : InlineIterator::firstRootInlineBoxFor(*this);
+    auto firstInlineBox = InlineIterator::lineLeftmostInlineBoxFor(*box) ? : InlineIterator::firstRootInlineBoxFor(*this);
     if (!firstInlineBox)
         return false;
 
@@ -105,7 +105,7 @@ bool RenderVTTCue::initializeLayoutParameters(LayoutUnit& step, LayoutUnit& posi
     // position the difference between the the logicalHeight of the cue and its
     // first line box.
     auto inlineBoxHeights = LayoutUnit { };
-    for (auto inlineBox = firstInlineBox; inlineBox; inlineBox = inlineBox->nextInlineBox())
+    for (auto inlineBox = firstInlineBox; inlineBox; inlineBox = inlineBox->nextInlineBoxLineRightward())
         inlineBoxHeights += inlineBox->logicalHeight();
     auto logicalHeightDelta = backdropBox().logicalHeight() - inlineBoxHeights;
     if (logicalHeightDelta > 0)
@@ -364,7 +364,7 @@ void RenderVTTCue::repositionCueSnapToLinesSet()
     if (!box)
         return;
 
-    auto firstInlineBox = InlineIterator::firstInlineBoxFor(*box) ? InlineIterator::firstInlineBoxFor(*box) : InlineIterator::firstRootInlineBoxFor(*this);
+    auto firstInlineBox = InlineIterator::lineLeftmostInlineBoxFor(*box) ? : InlineIterator::firstRootInlineBoxFor(*this);
     ASSERT(firstInlineBox);
     // 11. Step loop: If none of the boxes in boxes would overlap any of the boxes
     // in output and all the boxes in output are within the video's rendering area
@@ -395,7 +395,7 @@ void RenderVTTCue::repositionGenericCue()
     if (!box)
         return;
 
-    auto firstInlineBox = InlineIterator::firstInlineBoxFor(*box);
+    auto firstInlineBox = InlineIterator::lineLeftmostInlineBoxFor(*box);
     if (downcast<TextTrackCueGeneric>(*m_cue).useDefaultPosition() && firstInlineBox) {
         LayoutUnit parentWidth = containingBlock()->logicalWidth();
         LayoutUnit width { firstInlineBox->visualRectIgnoringBlockDirection().width() };

--- a/Source/WebCore/rendering/TextBoxTrimmer.cpp
+++ b/Source/WebCore/rendering/TextBoxTrimmer.cpp
@@ -58,7 +58,7 @@ static bool shouldIgnoreAsFirstLastFormattedLineContainer(const RenderBlockFlow&
     // Empty continuation pre/post blocks should be ignored as they are implementation detail.
     if (container.isAnonymousBlock()) {
         if (auto firstLineBox = InlineIterator::firstLineBoxFor(container))
-            return !firstLineBox->firstLeafBox();
+            return !firstLineBox->lineLeftmostLeafBox();
         return true;
     }
     return false;

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -179,7 +179,7 @@ static int offsetForPositionInFragment(const InlineIterator::SVGTextBox& textBox
 
 VisiblePosition RenderSVGInlineText::positionForPoint(const LayoutPoint& point, HitTestSource, const RenderFragmentContainer*)
 {
-    if (!InlineIterator::firstTextBoxFor(*this) || text().isEmpty())
+    if (!InlineIterator::lineLeftmostTextBoxFor(*this) || text().isEmpty())
         return createVisiblePosition(0, Affinity::Downstream);
 
     float baseline = m_scaledFont.metricsOfPrimaryFont().ascent();

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -481,7 +481,7 @@ void RenderSVGText::layoutCharactersInTextBoxes(const InlineIterator::InlineBoxI
 {
     auto descendants = parent->descendants();
 
-    for (auto child = descendants.begin(), end = descendants.end(); child != end; child.traverseNextOnLineSkippingChildren()) {
+    for (auto child = descendants.begin(), end = descendants.end(); child != end; child.traverseLineRightwardOnLineSkippingChildren()) {
         if (auto* textBox = dynamicDowncast<InlineIterator::SVGTextBox>(*child)) {
             characterLayout.layoutInlineTextBox(*textBox);
             continue;
@@ -910,12 +910,12 @@ void RenderSVGText::paintInlineChildren(PaintInfo& paintInfo, const LayoutPoint&
             contextStack.append({ const_cast<RenderElement&>(*renderer), paintInfo, SVGRenderingContext::SaveGraphicsContext });
 
             if (!contextStack.last().isRenderingPrepared() || renderer->hasSelfPaintingLayer()) {
-                box.traverseNextOnLineSkippingChildren();
+                box.traverseLineRightwardOnLineSkippingChildren();
                 continue;
             }
         }
 
-        box.traverseNextOnLine();
+        box.traverseLineRightwardOnLine();
     }
 
     while (!contextStack.isEmpty())

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
@@ -460,7 +460,7 @@ void SVGTextLayoutEngine::layoutTextOnLineOrPath(InlineIterator::SVGTextBoxItera
 
         float x = data.x;
         float y = data.y;
-        auto previousBoxOnLine = textBox->previousOnLine();
+        auto previousBoxOnLine = textBox->nextLineLeftwardOnLine();
 
         bool hasXOrY = !SVGTextLayoutAttributes::isEmptyValue(x) || !SVGTextLayoutAttributes::isEmptyValue(y);
 

--- a/Source/WebCore/rendering/svg/SVGTextQuery.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextQuery.cpp
@@ -56,7 +56,7 @@ static inline InlineIterator::InlineBoxIterator inlineBoxForRenderer(RenderObjec
     }
 
     if (CheckedPtr renderInline = dynamicDowncast<RenderInline>(*renderer))
-        return InlineIterator::firstInlineBoxFor(*renderInline);
+        return InlineIterator::lineLeftmostInlineBoxFor(*renderInline);
 
     ASSERT_NOT_REACHED();
     return { };
@@ -77,16 +77,16 @@ void SVGTextQuery::collectTextBoxesInInlineBox(InlineIterator::InlineBoxIterator
         if (auto* flowBox = dynamicDowncast<InlineIterator::InlineBox>(*box)) {
             // Skip generated content.
             if (!flowBox->renderer().element())
-                box.traverseNextOnLineSkippingChildren();
+                box.traverseLineRightwardOnLineSkippingChildren();
             else
-                box.traverseNextOnLine();
+                box.traverseLineRightwardOnLine();
             continue;
         }
 
         if (auto* inlineTextBox = dynamicDowncast<InlineIterator::SVGTextBoxIterator>(box))
             m_textBoxes.append(*inlineTextBox);
 
-        box.traverseNextOnLine();
+        box.traverseLineRightwardOnLine();
     }
 }
 

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -56,7 +56,7 @@ static bool isAncestorAndWithinBlock(const RenderInline& ancestor, const RenderO
 static float minLogicalTopForTextDecorationLineUnder(const InlineIterator::LineBoxIterator& lineBox, float textRunLogicalTop, const RenderElement& decoratingBoxRendererForUnderline)
 {
     auto minLogicalTop = textRunLogicalTop;
-    for (auto run = lineBox->firstLeafBox(); run; run.traverseNextOnLine()) {
+    for (auto run = lineBox->lineLeftmostLeafBox(); run; run.traverseLineRightwardOnLine()) {
         if (run->renderer().isOutOfFlowPositioned())
             continue; // Positioned placeholders don't affect calculations.
 
@@ -75,7 +75,7 @@ static float minLogicalTopForTextDecorationLineUnder(const InlineIterator::LineB
 static float maxLogicalBottomForTextDecorationLineUnder(const InlineIterator::LineBoxIterator& lineBox, float textRunLogicalBottom, const RenderElement& decoratingBoxRendererForUnderline)
 {
     auto maxLogicalBottom = textRunLogicalBottom;
-    for (auto run = lineBox->firstLeafBox(); run; run.traverseNextOnLine()) {
+    for (auto run = lineBox->lineLeftmostLeafBox(); run; run.traverseLineRightwardOnLine()) {
         if (run->renderer().isOutOfFlowPositioned())
             continue; // Positioned placeholders don't affect calculations.
 


### PR DESCRIPTION
#### d0bccb1198a21b4353be52a27f83e95dbbda45f5
<pre>
Clarify Inline Box Traversal Methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=286207">https://bugs.webkit.org/show_bug.cgi?id=286207</a>
<a href="https://rdar.apple.com/problem/143182898">rdar://problem/143182898</a>

Reviewed by Alan Baradlay.

Our inline box traversal methods go in LTR order, not tree order
or coordinate order. Rename them to clarify this, and add methods
for coordinate order traversal.

This is a cosmetic change, setting us up to switch to coordinate
order traversal or source order traversal methods where needed.

* Source/WebCore/dom/Position.cpp:
(WebCore::hasInlineRun):
(WebCore::Position::inlineBoxAndOffset const):
* Source/WebCore/editing/Editing.cpp:
(WebCore::visualDistanceOnSameLine):
(WebCore::advanceInDirection):
(WebCore::forEachRenderedBoxBetween):
* Source/WebCore/editing/RenderedPosition.cpp:
(WebCore::RenderedPosition::previousLeafOnLine const):
(WebCore::RenderedPosition::nextLeafOnLine const):
(WebCore::RenderedPosition::leftBoundaryOfBidiRun const):
(WebCore::RenderedPosition::rightBoundaryOfBidiRun const):
* Source/WebCore/editing/VisiblePosition.cpp:
(WebCore::VisiblePosition::leftVisuallyDistinctCandidate const):
(WebCore::VisiblePosition::rightVisuallyDistinctCandidate const):
* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::startPositionForLine):
(WebCore::endPositionForLine):
(WebCore::previousLinePosition):
(WebCore::nextLinePosition):
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::valueWithHardLineBreaks const):
* Source/WebCore/layout/integration/inline/InlineIteratorBox.cpp:
(WebCore::InlineIterator::BoxIterator::traverseLineRightwardOnLine):
(WebCore::InlineIterator::BoxIterator::traverseLineRightwardOnLineSkippingChildren):
(WebCore::InlineIterator::Box::nextLineRightwardOnLine const):
(WebCore::InlineIterator::Box::nextLineLeftwardOnLine const):
(WebCore::InlineIterator::Box::nextLineRightwardOnLineIgnoringLineBreak const):
(WebCore::InlineIterator::Box::nextLineLeftwardOnLineIgnoringLineBreak const):
(WebCore::InlineIterator::LeafBoxIterator::traverseLineRightwardOnLine):
(WebCore::InlineIterator::LeafBoxIterator::traverseLineLeftwardOnLine):
(WebCore::InlineIterator::LeafBoxIterator::traverseLineRightwardOnLineIgnoringLineBreak):
(WebCore::InlineIterator::LeafBoxIterator::traverseLineLeftwardOnLineIgnoringLineBreak):
(WebCore::InlineIterator::BoxIterator::traverseNextOnLine): Deleted.
(WebCore::InlineIterator::BoxIterator::traverseNextOnLineSkippingChildren): Deleted.
(WebCore::InlineIterator::Box::nextOnLine const): Deleted.
(WebCore::InlineIterator::Box::previousOnLine const): Deleted.
(WebCore::InlineIterator::Box::nextOnLineIgnoringLineBreak const): Deleted.
(WebCore::InlineIterator::Box::previousOnLineIgnoringLineBreak const): Deleted.
(WebCore::InlineIterator::LeafBoxIterator::traverseNextOnLine): Deleted.
(WebCore::InlineIterator::LeafBoxIterator::traversePreviousOnLine): Deleted.
(WebCore::InlineIterator::LeafBoxIterator::traverseNextOnLineIgnoringLineBreak): Deleted.
(WebCore::InlineIterator::LeafBoxIterator::traversePreviousOnLineIgnoringLineBreak): Deleted.
* Source/WebCore/layout/integration/inline/InlineIteratorBox.h:
(WebCore::InlineIterator::BoxIterator::operator++):
(WebCore::InlineIterator::LeafBoxIterator::operator++):
* Source/WebCore/layout/integration/inline/InlineIteratorBoxInlines.h:
(WebCore::InlineIterator::Box::nextLogicalRightwardOnLine const):
(WebCore::InlineIterator::Box::nextLogicalLeftwardOnLine const):
(WebCore::InlineIterator::Box::nextLogicalRightwardOnLineIgnoringLineBreak const):
(WebCore::InlineIterator::Box::nextLogicalLeftwardOnLineIgnoringLineBreak const):
* Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.cpp:
(WebCore::InlineIterator::InlineBox::closedEdges const):
(WebCore::InlineIterator::InlineBox::nextInlineBoxLineRightward const):
(WebCore::InlineIterator::InlineBox::nextInlineBoxLineLeftward const):
(WebCore::InlineIterator::InlineBox::endLeafBox const):
(WebCore::InlineIterator::InlineBox::descendants const):
(WebCore::InlineIterator::InlineBoxIterator::traverseInlineBoxLineRightward):
(WebCore::InlineIterator::InlineBoxIterator::traverseInlineBoxLineLeftward):
(WebCore::InlineIterator::lineLeftmostInlineBoxFor):
(WebCore::InlineIterator::InlineBox::nextInlineBox const): Deleted.
(WebCore::InlineIterator::InlineBox::previousInlineBox const): Deleted.
(WebCore::InlineIterator::InlineBoxIterator::traverseNextInlineBox): Deleted.
(WebCore::InlineIterator::InlineBoxIterator::traversePreviousInlineBox): Deleted.
(WebCore::InlineIterator::firstInlineBoxFor): Deleted.
* Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.h:
* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp:
(WebCore::InlineIterator::LineBox::lineLeftmostLeafBox const):
(WebCore::InlineIterator::LineBox::lineRightmostLeafBox const):
(WebCore::InlineIterator::closestBoxForHorizontalPosition):
(WebCore::InlineIterator::LineBox::ellipsisSelectionState const):
(WebCore::InlineIterator::LineBox::firstLeafBox const): Deleted.
(WebCore::InlineIterator::LineBox::lastLeafBox const): Deleted.
* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h:
* Source/WebCore/layout/integration/inline/InlineIteratorLogicalOrderTraversal.cpp:
(WebCore::InlineIterator::firstTextBoxInLogicalOrderFor):
* Source/WebCore/layout/integration/inline/InlineIteratorLogicalOrderTraversal.h:
(WebCore::InlineIterator::leafBoxesInLogicalOrder):
* Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp:
(WebCore::InlineIterator::lineLeftmostTextBoxFor):
(WebCore::InlineIterator::textBoxesFor):
(WebCore::InlineIterator::firstTextBoxFor): Deleted.
* Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h:
* Source/WebCore/layout/integration/inline/LineSelection.h:
(WebCore::LineSelection::selectionState):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::boxShadowShouldBeAppliedToBackground):
* Source/WebCore/rendering/CaretRectComputation.cpp:
(WebCore::computeCaretRectForInline):
* Source/WebCore/rendering/InlineBoxPainter.cpp:
(WebCore::InlineBoxPainter::paintMask):
(WebCore::InlineBoxPainter::paintDecorations):
(WebCore::InlineBoxPainter::paintFillLayer):
(WebCore::InlineBoxPainter::paintBoxShadow):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::paintObject):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::computeLineAdjustmentForPagination):
(WebCore::RenderBlockFlow::inlineSelectionGaps):
(WebCore::RenderBlockFlow::containsNonZeroBidiLevel const):
(WebCore::RenderBlockFlow::findClosestTextAtAbsolutePoint):
(WebCore::RenderBlockFlow::positionForPointWithInlineChildren):
(WebCore::RenderBlockFlow::addFocusRingRectsForInlineChildren const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::positionWithRTLInlineBoxContainingBlock):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::paintMaskForTextFillBox):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::getLeadingCorner const):
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::RenderFileUploadControl::paintControl):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::collectSelectionGeometries):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::innerPaddingBoxWidth const):
(WebCore::RenderInline::linesBoundingBox const):
(WebCore::RenderInline::offsetForInFlowPositionedInline const):
(WebCore::RenderInline::paintOutline const):
* Source/WebCore/rendering/RenderLineBreak.cpp:
(WebCore::RenderLineBreak::collectSelectionGeometries):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::collectSelectionGeometries):
(WebCore::lineDirectionPointFitsInBox):
(WebCore::createVisiblePositionAfterAdjustingOffsetForBiDi):
(WebCore::RenderText::positionForPoint):
(WebCore::RenderText::firstRunLocation const):
(WebCore::RenderText::linesBoundingBox const):
(WebCore::RenderText::caretMinOffset const):
(WebCore::RenderText::caretMaxOffset const):
* Source/WebCore/rendering/RenderVTTCue.cpp:
(WebCore::RenderVTTCue::initializeLayoutParameters):
(WebCore::RenderVTTCue::repositionCueSnapToLinesSet):
(WebCore::RenderVTTCue::repositionGenericCue):
* Source/WebCore/rendering/TextBoxTrimmer.cpp:
(WebCore::shouldIgnoreAsFirstLastFormattedLineContainer):
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(WebCore::RenderSVGInlineText::positionForPoint):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::layoutCharactersInTextBoxes):
(WebCore::RenderSVGText::paintInlineChildren):
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath):
* Source/WebCore/rendering/svg/SVGTextQuery.cpp:
(WebCore::inlineBoxForRenderer):
(WebCore::SVGTextQuery::collectTextBoxesInInlineBox):
* Source/WebCore/style/InlineTextBoxStyle.cpp:
(WebCore::minLogicalTopForTextDecorationLineUnder):
(WebCore::maxLogicalBottomForTextDecorationLineUnder):

Canonical link: <a href="https://commits.webkit.org/289159@main">https://commits.webkit.org/289159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/842d7bcc4784761d3740c6b85893a6ea67620926

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36414 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87461 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13084 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66370 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24184 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46652 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3856 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31805 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35482 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74564 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91999 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12719 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74962 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74082 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18353 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18448 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16879 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4753 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12669 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18131 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12498 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14250 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->