### PR TITLE
[GLib] Remove all GLIB_CHECK_VERSION conditionals

### DIFF
--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -27,7 +27,7 @@
 
 #include <wtf/text/WTFString.h>
 
-#if USE(GLIB) && HAVE(GURI)
+#if USE(GLIB)
 #include <wtf/glib/GRefPtr.h>
 #endif
 
@@ -237,7 +237,7 @@ public:
     WTF_EXPORT_PRIVATE operator NSURL *() const;
 #endif
 
-#if USE(GLIB) && HAVE(GURI)
+#if USE(GLIB)
     WTF_EXPORT_PRIVATE URL(GUri*);
     WTF_EXPORT_PRIVATE GRefPtr<GUri> createGUri() const;
 #endif

--- a/Source/WTF/wtf/glib/GRefPtr.cpp
+++ b/Source/WTF/wtf/glib/GRefPtr.cpp
@@ -207,7 +207,6 @@ template <> void derefGPtr(GDBusNodeInfo* ptr)
         g_dbus_node_info_unref(ptr);
 }
 
-#if HAVE(GURI)
 template <> GUri* refGPtr(GUri* ptr)
 {
     if (ptr)
@@ -220,7 +219,6 @@ template <> void derefGPtr(GUri* ptr)
     if (ptr)
         g_uri_unref(ptr);
 }
-#endif
 
 template <>
 GArray* refGPtr(GArray* ptr)

--- a/Source/WTF/wtf/glib/GRefPtr.h
+++ b/Source/WTF/wtf/glib/GRefPtr.h
@@ -264,11 +264,8 @@ template <> WTF_EXPORT_PRIVATE GArray* refGPtr(GArray*);
 template <> WTF_EXPORT_PRIVATE void derefGPtr(GArray*);
 template <> WTF_EXPORT_PRIVATE GResource* refGPtr(GResource*);
 template <> WTF_EXPORT_PRIVATE void derefGPtr(GResource*);
-
-#if HAVE(GURI)
 template <> WTF_EXPORT_PRIVATE GUri* refGPtr(GUri*);
 template <> WTF_EXPORT_PRIVATE void derefGPtr(GUri*);
-#endif
 
 template <typename T> inline T* refGPtr(T* ptr)
 {

--- a/Source/WTF/wtf/glib/URLGLib.cpp
+++ b/Source/WTF/wtf/glib/URLGLib.cpp
@@ -35,7 +35,6 @@
 
 namespace WTF {
 
-#if HAVE(GURI)
 URL::URL(GUri* uri)
 {
     if (!uri) {
@@ -57,7 +56,6 @@ GRefPtr<GUri> URL::createGUri() const
         static_cast<GUriFlags>(G_URI_FLAGS_HAS_PASSWORD | G_URI_FLAGS_ENCODED_PATH | G_URI_FLAGS_ENCODED_QUERY | G_URI_FLAGS_ENCODED_FRAGMENT | G_URI_FLAGS_SCHEME_NORMALIZE | G_URI_FLAGS_PARSE_RELAXED),
         nullptr));
 }
-#endif
 
 bool URL::hostIsIPAddress(StringView host)
 {

--- a/Source/WebCore/platform/LowPowerModeNotifier.h
+++ b/Source/WebCore/platform/LowPowerModeNotifier.h
@@ -61,10 +61,8 @@ private:
     RetainPtr<WebLowPowerModeObserver> m_observer;
     LowPowerModeChangeCallback m_callback;
 #elif USE(GLIB)
-#if GLIB_CHECK_VERSION(2, 69, 1)
     LowPowerModeChangeCallback m_callback;
     GRefPtr<GPowerProfileMonitor> m_powerProfileMonitor;
-#endif
     bool m_lowPowerModeEnabled { false };
 #endif
 };

--- a/Source/WebCore/platform/glib/LowPowerModeNotifierGLib.cpp
+++ b/Source/WebCore/platform/glib/LowPowerModeNotifierGLib.cpp
@@ -28,13 +28,10 @@ namespace WebCore {
 
 
 LowPowerModeNotifier::LowPowerModeNotifier(LowPowerModeChangeCallback&& callback)
-#if GLIB_CHECK_VERSION(2, 69, 1)
     : m_callback(WTFMove(callback))
     , m_powerProfileMonitor(adoptGRef(g_power_profile_monitor_dup_default()))
     , m_lowPowerModeEnabled(g_power_profile_monitor_get_power_saver_enabled(m_powerProfileMonitor.get()))
-#endif
 {
-#if GLIB_CHECK_VERSION(2, 69, 1)
     g_signal_connect_swapped(m_powerProfileMonitor.get(), "notify::power-saver-enabled", G_CALLBACK(+[] (LowPowerModeNotifier* self, GParamSpec*, GPowerProfileMonitor* monitor) {
         bool powerSaverEnabled = g_power_profile_monitor_get_power_saver_enabled(monitor);
         if (self->m_lowPowerModeEnabled != powerSaverEnabled) {
@@ -42,16 +39,11 @@ LowPowerModeNotifier::LowPowerModeNotifier(LowPowerModeChangeCallback&& callback
             self->m_callback(self->m_lowPowerModeEnabled);
         }
     }), this);
-#else
-    UNUSED_PARAM(callback);
-#endif
 }
 
 LowPowerModeNotifier::~LowPowerModeNotifier()
 {
-#if GLIB_CHECK_VERSION(2, 69, 1)
     g_signal_handlers_disconnect_by_data(m_powerProfileMonitor.get(), this);
-#endif
 }
 
 bool LowPowerModeNotifier::isLowPowerModeEnabled() const

--- a/Source/WebCore/platform/network/soup/CertificateInfoSoup.cpp
+++ b/Source/WebCore/platform/network/soup/CertificateInfoSoup.cpp
@@ -73,11 +73,9 @@ CertificateInfo CertificateInfo::isolatedCopy() const
         certificatesDataList.append(certificateData.release());
     }
 
-#if GLIB_CHECK_VERSION(2, 69, 0)
     GUniqueOutPtr<char> privateKey;
     GUniqueOutPtr<char> privateKeyPKCS11Uri;
     g_object_get(m_certificate.get(), "private-key-pem", &privateKey.outPtr(), "private-key-pkcs11-uri", &privateKeyPKCS11Uri.outPtr(), nullptr);
-#endif
 
     GType certificateType = g_tls_backend_get_certificate_type(g_tls_backend_get_default());
     GRefPtr<GTlsCertificate> certificate;
@@ -88,10 +86,8 @@ CertificateInfo CertificateInfo::isolatedCopy() const
             certificateType, nullptr, nullptr,
             "certificate-pem", certificateData.get(),
             "issuer", issuer,
-#if GLIB_CHECK_VERSION(2, 69, 0)
             "private-key-pem", certificatesDataList.isEmpty() ? privateKey.get() : nullptr,
             "private-key-pkcs11-uri", certificatesDataList.isEmpty() ? privateKeyPKCS11Uri.get() : nullptr,
-#endif
             nullptr)));
         RELEASE_ASSERT(certificate);
         issuer = certificate.get();
@@ -105,7 +101,6 @@ std::optional<CertificateSummary> CertificateInfo::summary() const
     if (!m_certificate)
         return std::nullopt;
 
-#if GLIB_CHECK_VERSION(2, 69, 0)
     CertificateSummary summaryInfo;
 
     GRefPtr<GDateTime> validNotBefore;
@@ -130,9 +125,6 @@ std::optional<CertificateSummary> CertificateInfo::summary() const
     }
 
     return summaryInfo;
-#else
-    return std::nullopt;
-#endif
 }
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/glib/DNSCache.cpp
+++ b/Source/WebKit/NetworkProcess/glib/DNSCache.cpp
@@ -50,17 +50,9 @@ DNSCache::DNSCacheMap& DNSCache::mapForType(Type type)
     case Type::Default:
         return m_dnsMap;
     case Type::IPv4Only:
-#if GLIB_CHECK_VERSION(2, 59, 0)
         return m_ipv4Map;
-#else
-        return m_dnsMap;
-#endif
     case Type::IPv6Only:
-#if GLIB_CHECK_VERSION(2, 59, 0)
         return m_ipv6Map;
-#else
-        return m_dnsMap;
-#endif
     }
 
     RELEASE_ASSERT_NOT_REACHED();
@@ -126,20 +118,16 @@ void DNSCache::removeExpiredResponsesFired()
 {
     Locker locker { m_lock };
     removeExpiredResponsesInMap(m_dnsMap);
-#if GLIB_CHECK_VERSION(2, 59, 0)
     removeExpiredResponsesInMap(m_ipv4Map);
     removeExpiredResponsesInMap(m_ipv6Map);
-#endif
 }
 
 void DNSCache::clear()
 {
     Locker locker { m_lock };
     m_dnsMap.clear();
-#if GLIB_CHECK_VERSION(2, 59, 0)
     m_ipv4Map.clear();
     m_ipv6Map.clear();
-#endif
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/glib/DNSCache.h
+++ b/Source/WebKit/NetworkProcess/glib/DNSCache.h
@@ -65,10 +65,8 @@ private:
 
     Lock m_lock;
     DNSCacheMap m_dnsMap WTF_GUARDED_BY_LOCK(m_lock);
-#if GLIB_CHECK_VERSION(2, 59, 0)
     DNSCacheMap m_ipv4Map;
     DNSCacheMap m_ipv6Map;
-#endif
     RunLoop::Timer m_expiredTimer;
 };
 

--- a/Source/WebKit/NetworkProcess/glib/WebKitCachedResolver.cpp
+++ b/Source/WebKit/NetworkProcess/glib/WebKitCachedResolver.cpp
@@ -67,9 +67,7 @@ static Vector<GRefPtr<GInetAddress>> addressListGListToVector(GList* addressList
 
 struct LookupAsyncData {
     CString hostname;
-#if GLIB_CHECK_VERSION(2, 59, 0)
     DNSCache::Type dnsCacheType { DNSCache::Type::Default };
-#endif
 };
 WEBKIT_DEFINE_ASYNC_DATA_STRUCT(LookupAsyncData)
 
@@ -119,7 +117,6 @@ static GList* webkitCachedResolverLookupByNameFinish(GResolver* resolver, GAsync
     return static_cast<GList*>(g_task_propagate_pointer(G_TASK(result), error));
 }
 
-#if GLIB_CHECK_VERSION(2, 59, 0)
 static inline DNSCache::Type dnsCacheType(GResolverNameLookupFlags flags)
 {
     // A cache is kept for each type of response to avoid the overcomplication of combining or filtering results.
@@ -180,7 +177,6 @@ static GList* webkitCachedResolverLookupByNameWithFlagsFinish(GResolver* resolve
 
     return static_cast<GList*>(g_task_propagate_pointer(G_TASK(result), error));
 }
-#endif // GLIB_CHECK_VERSION(2, 59, 0)
 
 static char* webkitCachedResolverLookupByAddress(GResolver* resolver, GInetAddress* address, GCancellable* cancellable, GError** error)
 {
@@ -223,11 +219,9 @@ static void webkit_cached_resolver_class_init(WebKitCachedResolverClass* klass)
     resolverClass->lookup_by_name = webkitCachedResolverLookupByName;
     resolverClass->lookup_by_name_async = webkitCachedResolverLookupByNameAsync;
     resolverClass->lookup_by_name_finish = webkitCachedResolverLookupByNameFinish;
-#if GLIB_CHECK_VERSION(2, 59, 0)
     resolverClass->lookup_by_name_with_flags = webkitCachedResolverLookupByNameWithFlags;
     resolverClass->lookup_by_name_with_flags_async = webkitCachedResolverLookupByNameWithFlagsAsync;
     resolverClass->lookup_by_name_with_flags_finish = webkitCachedResolverLookupByNameWithFlagsFinish;
-#endif
     resolverClass->lookup_by_address = webkitCachedResolverLookupByAddress;
     resolverClass->lookup_by_address_async = webkitCachedResolverLookupByAddressAsync;
     resolverClass->lookup_by_address_finish = webkitCachedResolverLookupByAddressFinish;

--- a/Source/WebKit/NetworkProcess/glib/WebKitOverridingResolver.cpp
+++ b/Source/WebKit/NetworkProcess/glib/WebKitOverridingResolver.cpp
@@ -90,7 +90,6 @@ static GList* webkitOverridingResolverLookupByNameFinish(GResolver* resolver, GA
     return static_cast<GList*>(g_task_propagate_pointer(G_TASK(result), error));
 }
 
-#if GLIB_CHECK_VERSION(2, 59, 0)
 static GList* createLoobackAddressList(WebKitOverridingResolver* resolver, GResolverNameLookupFlags flags)
 {
     GList* list = nullptr;
@@ -130,7 +129,6 @@ static GList* webkitOverridingResolverLookupByNameWithFlagsFinish(GResolver* res
 
     return static_cast<GList*>(g_task_propagate_pointer(G_TASK(result), error));
 }
-#endif // GLIB_CHECK_VERSION(2, 59, 0)
 
 static char* webkitOverridingResolverLookupByAddress(GResolver* resolver, GInetAddress* address, GCancellable* cancellable, GError** error)
 {
@@ -168,11 +166,9 @@ static void webkit_overriding_resolver_class_init(WebKitOverridingResolverClass*
     resolverClass->lookup_by_name = webkitOverridingResolverLookupByName;
     resolverClass->lookup_by_name_async = webkitOverridingResolverLookupByNameAsync;
     resolverClass->lookup_by_name_finish = webkitOverridingResolverLookupByNameFinish;
-#if GLIB_CHECK_VERSION(2, 59, 0)
     resolverClass->lookup_by_name_with_flags = webkitOverridingResolverLookupByNameWithFlags;
     resolverClass->lookup_by_name_with_flags_async = webkitOverridingResolverLookupByNameWithFlagsAsync;
     resolverClass->lookup_by_name_with_flags_finish = webkitOverridingResolverLookupByNameWithFlagsFinish;
-#endif
     resolverClass->lookup_by_address = webkitOverridingResolverLookupByAddress;
     resolverClass->lookup_by_address_async = webkitOverridingResolverLookupByAddressAsync;
     resolverClass->lookup_by_address_finish = webkitOverridingResolverLookupByAddressFinish;

--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
@@ -121,13 +121,11 @@ void ArgumentCoder<GRefPtr<GTlsCertificate>>::encode(Encoder& encoder, const GRe
 
     encoder << certificatesData;
 
-#if GLIB_CHECK_VERSION(2, 69, 0)
     GRefPtr<GByteArray> privateKey;
     GUniqueOutPtr<char> privateKeyPKCS11Uri;
     g_object_get(certificate.get(), "private-key", &privateKey.outPtr(), "private-key-pkcs11-uri", &privateKeyPKCS11Uri.outPtr(), nullptr);
     encoder << privateKey;
     encoder << CString(privateKeyPKCS11Uri.get());
-#endif
 }
 
 std::optional<GRefPtr<GTlsCertificate>> ArgumentCoder<GRefPtr<GTlsCertificate>>::decode(Decoder& decoder)
@@ -140,7 +138,6 @@ std::optional<GRefPtr<GTlsCertificate>> ArgumentCoder<GRefPtr<GTlsCertificate>>:
     if (!certificatesData->size())
         return GRefPtr<GTlsCertificate>();
 
-#if GLIB_CHECK_VERSION(2, 69, 0)
     std::optional<GRefPtr<GByteArray>> privateKey;
     decoder >> privateKey;
     if (UNLIKELY(!privateKey))
@@ -150,7 +147,6 @@ std::optional<GRefPtr<GTlsCertificate>> ArgumentCoder<GRefPtr<GTlsCertificate>>:
     decoder >> privateKeyPKCS11Uri;
     if (UNLIKELY(!privateKeyPKCS11Uri))
         return std::nullopt;
-#endif
 
     GType certificateType = g_tls_backend_get_certificate_type(g_tls_backend_get_default());
     GRefPtr<GTlsCertificate> certificate;
@@ -160,10 +156,8 @@ std::optional<GRefPtr<GTlsCertificate>> ArgumentCoder<GRefPtr<GTlsCertificate>>:
             certificateType, nullptr, nullptr,
             "certificate", certificateData.get(),
             "issuer", issuer,
-#if GLIB_CHECK_VERSION(2, 69, 0)
             "private-key", i == certificatesData->size() - 1 ? privateKey->get() : nullptr,
             "private-key-pkcs11-uri", i == certificatesData->size() - 1 ? privateKeyPKCS11Uri->data() : nullptr,
-#endif
             nullptr)));
         issuer = certificate.get();
     }

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -7,6 +7,7 @@ SET_PROJECT_VERSION(2 47 3)
 
 set(USER_AGENT_BRANDING "" CACHE STRING "Branding to add to user agent string")
 
+find_package(GLIB 2.70.0 REQUIRED COMPONENTS gio gio-unix gobject gthread gmodule)
 find_package(Cairo 1.16.0 REQUIRED)
 find_package(LibGcrypt 1.7.0 REQUIRED)
 find_package(Libtasn1 REQUIRED)
@@ -209,13 +210,6 @@ else ()
     SET_AND_EXPOSE_TO_BUILD(ENABLE_2022_GLIB_API OFF)
 endif ()
 
-if (ENABLE_2022_GLIB_API)
-    set(GLIB_MINIMUM_VERSION 2.70.0)
-else ()
-    set(GLIB_MINIMUM_VERSION 2.56.4)
-endif ()
-find_package(GLIB ${GLIB_MINIMUM_VERSION} REQUIRED COMPONENTS gio gio-unix gobject gthread gmodule)
-
 EXPOSE_STRING_VARIABLE_TO_BUILD(WEBKITGTK_API_INFIX)
 EXPOSE_STRING_VARIABLE_TO_BUILD(WEBKITGTK_API_VERSION)
 
@@ -286,11 +280,6 @@ endif ()
 if (ENABLED_COMPILER_SANITIZERS)
     set(ENABLE_INTROSPECTION OFF)
     set(ENABLE_DOCUMENTATION OFF)
-endif ()
-
-# GUri is available in GLib since version 2.66, but we only want to use it if version is >= 2.67.1.
-if (PC_GLIB_VERSION VERSION_GREATER "2.67.1" OR PC_GLIB_VERSION STREQUAL "2.67.1")
-    SET_AND_EXPOSE_TO_BUILD(HAVE_GURI 1)
 endif ()
 
 if (ENABLE_GAMEPAD)

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -5,6 +5,7 @@ SET_PROJECT_VERSION(2 47 3)
 
 set(USER_AGENT_BRANDING "" CACHE STRING "Branding to add to user agent string")
 
+find_package(GLIB 2.70.0 REQUIRED COMPONENTS gio gio-unix gobject gthread gmodule)
 find_package(HarfBuzz 2.7.4 REQUIRED COMPONENTS ICU)
 find_package(ICU 70.1 REQUIRED COMPONENTS data i18n uc)
 find_package(JPEG REQUIRED)
@@ -177,13 +178,6 @@ if (NOT LibSoup_FOUND)
 endif ()
 
 EXPOSE_STRING_VARIABLE_TO_BUILD(WPE_API_VERSION)
-
-if (ENABLE_2022_GLIB_API)
-    set(GLIB_MINIMUM_VERSION 2.70.0)
-else ()
-    set(GLIB_MINIMUM_VERSION 2.56.4)
-endif ()
-find_package(GLIB ${GLIB_MINIMUM_VERSION} REQUIRED COMPONENTS gio gio-unix gobject gthread gmodule)
 
 if (WPE_API_VERSION VERSION_EQUAL "1.1")
     CALCULATE_LIBRARY_VERSIONS_FROM_LIBTOOL_TRIPLE(WEBKIT 9 2 9)
@@ -428,11 +422,6 @@ if (USE_LIBBACKTRACE)
     if (NOT LIBBACKTRACE_FOUND)
         message(FATAL_ERROR "libbacktrace is required for USE_LIBBACKTRACE")
     endif ()
-endif ()
-
-# GUri is available in GLib since version 2.66, but we only want to use it if version is >= 2.67.1.
-if (PC_GLIB_VERSION VERSION_GREATER "2.67.1" OR PC_GLIB_VERSION STREQUAL "2.67.1")
-    SET_AND_EXPOSE_TO_BUILD(HAVE_GURI 1)
 endif ()
 
 # Using DERIVED_SOURCES_DIR is deprecated


### PR DESCRIPTION
#### 85b637b69f1c3a6242420b198d1c173477ce0f22
<pre>
[GLib] Remove all GLIB_CHECK_VERSION conditionals
<a href="https://bugs.webkit.org/show_bug.cgi?id=286061">https://bugs.webkit.org/show_bug.cgi?id=286061</a>

Reviewed by Miguel Gomez.

Among the Linux distributions that will be supported in 2025 the oldest
version of GLib in use is 2.72 (packaged in Ubuntu 22.04). This means it
is now possible to remove all the existing GLib version checks and
increase the minimum GLib version required by CMake to 2.70 instead.

While at it, remove the HAVE(GURI) conditionals: GUri was introduced in
GLib 2.66, and has had all the functionality required for WebKit usage
since version 2.68.

* Source/WTF/wtf/URL.h:
* Source/WTF/wtf/glib/GRefPtr.cpp:
(WTF::derefGPtr):
* Source/WTF/wtf/glib/GRefPtr.h:
* Source/WTF/wtf/glib/SocketConnection.cpp:
(WTF::SocketConnection::readMessage):
* Source/WTF/wtf/glib/URLGLib.cpp:
(WTF::URL::createGUri const):
* Source/WebCore/platform/LowPowerModeNotifier.h:
* Source/WebCore/platform/glib/LowPowerModeNotifierGLib.cpp:
(WebCore::LowPowerModeNotifier::LowPowerModeNotifier):
(WebCore::LowPowerModeNotifier::~LowPowerModeNotifier):
* Source/WebCore/platform/network/soup/CertificateInfoSoup.cpp:
(WebCore::CertificateInfo::isolatedCopy const):
(WebCore::CertificateInfo::summary const):
* Source/WebKit/NetworkProcess/glib/DNSCache.cpp:
(WebKit::DNSCache::mapForType):
(WebKit::DNSCache::removeExpiredResponsesFired):
(WebKit::DNSCache::clear):
* Source/WebKit/NetworkProcess/glib/DNSCache.h:
* Source/WebKit/NetworkProcess/glib/WebKitCachedResolver.cpp:
(webkitCachedResolverLookupByNameWithFlagsFinish):
(webkit_cached_resolver_class_init):
* Source/WebKit/NetworkProcess/glib/WebKitOverridingResolver.cpp:
(webkitOverridingResolverLookupByNameWithFlagsFinish):
(webkit_overriding_resolver_class_init):
* Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp:
(IPC::ArgumentCoder&lt;GRefPtr&lt;GTlsCertificate&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GTlsCertificate&gt;&gt;::decode):
* Source/cmake/OptionsGTK.cmake:
* Source/cmake/OptionsWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/289318@main">https://commits.webkit.org/289318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8d2df3324fe9ee4df8a4b933922b9ee86ac6412

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/40710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91286 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37176 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66884 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24675 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4693 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78237 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47205 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32554 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36293 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/79223 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93162 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/85211 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13577 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9854 "Found 1 new test failure: fast/mediastream/get-user-media-on-loadedmetadata.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75694 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/13785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/74876 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19116 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17507 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13445 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13601 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18888 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/107677 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13354 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25915 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/16797 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15138 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->