### PR TITLE
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in CSS code

### DIFF
--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -5045,11 +5045,10 @@ Ref<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesForShorthandProper
 
 RefPtr<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesFor2SidesShorthand(const StylePropertyShorthand& shorthand) const
 {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // Assume the properties are in the usual order start, end.
-    auto startValue = propertyValue(shorthand.properties()[0], UpdateLayout::No);
-    auto endValue = propertyValue(shorthand.properties()[1], UpdateLayout::No);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    auto longhands = shorthand.properties();
+    auto startValue = propertyValue(longhands[0], UpdateLayout::No);
+    auto endValue = propertyValue(longhands[1], UpdateLayout::No);
 
     // All 2 properties must be specified.
     if (!startValue || !endValue)
@@ -5062,13 +5061,12 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 RefPtr<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesFor4SidesShorthand(const StylePropertyShorthand& shorthand) const
 {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     // Assume the properties are in the usual order top, right, bottom, left.
-    auto topValue = propertyValue(shorthand.properties()[0], UpdateLayout::No);
-    auto rightValue = propertyValue(shorthand.properties()[1], UpdateLayout::No);
-    auto bottomValue = propertyValue(shorthand.properties()[2], UpdateLayout::No);
-    auto leftValue = propertyValue(shorthand.properties()[3], UpdateLayout::No);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    auto longhands = shorthand.properties();
+    auto topValue = propertyValue(longhands[0], UpdateLayout::No);
+    auto rightValue = propertyValue(longhands[1], UpdateLayout::No);
+    auto bottomValue = propertyValue(longhands[2], UpdateLayout::No);
+    auto leftValue = propertyValue(longhands[3], UpdateLayout::No);
 
     // All 4 properties must be specified.
     if (!topValue || !rightValue || !bottomValue || !leftValue)
@@ -5180,18 +5178,18 @@ Ref<CSSValue> ComputedStyleExtractor::getFillLayerPropertyShorthandValue(CSSProp
 
 Ref<CSSValue> ComputedStyleExtractor::getBackgroundShorthandValue() const
 {
-    static const CSSPropertyID propertiesBeforeSlashSeparator[] = { CSSPropertyBackgroundImage, CSSPropertyBackgroundRepeat, CSSPropertyBackgroundAttachment, CSSPropertyBackgroundPosition };
-    static const CSSPropertyID propertiesAfterSlashSeparator[] = { CSSPropertyBackgroundSize, CSSPropertyBackgroundOrigin, CSSPropertyBackgroundClip };
+    static constexpr std::array propertiesBeforeSlashSeparator { CSSPropertyBackgroundImage, CSSPropertyBackgroundRepeat, CSSPropertyBackgroundAttachment, CSSPropertyBackgroundPosition };
+    static constexpr std::array propertiesAfterSlashSeparator { CSSPropertyBackgroundSize, CSSPropertyBackgroundOrigin, CSSPropertyBackgroundClip };
 
-    return getFillLayerPropertyShorthandValue(CSSPropertyBackground, StylePropertyShorthand(CSSPropertyBackground, propertiesBeforeSlashSeparator), StylePropertyShorthand(CSSPropertyBackground, propertiesAfterSlashSeparator), CSSPropertyBackgroundColor);
+    return getFillLayerPropertyShorthandValue(CSSPropertyBackground, StylePropertyShorthand(CSSPropertyBackground, std::span { propertiesBeforeSlashSeparator }), StylePropertyShorthand(CSSPropertyBackground, std::span { propertiesAfterSlashSeparator }), CSSPropertyBackgroundColor);
 }
 
 Ref<CSSValue> ComputedStyleExtractor::getMaskShorthandValue() const
 {
-    static const CSSPropertyID propertiesBeforeSlashSeparator[2] = { CSSPropertyMaskImage, CSSPropertyMaskPosition };
-    static const CSSPropertyID propertiesAfterSlashSeparator[6] = { CSSPropertyMaskSize, CSSPropertyMaskRepeat, CSSPropertyMaskOrigin, CSSPropertyMaskClip, CSSPropertyMaskComposite, CSSPropertyMaskMode };
+    static constexpr std::array propertiesBeforeSlashSeparator { CSSPropertyMaskImage, CSSPropertyMaskPosition };
+    static constexpr std::array propertiesAfterSlashSeparator { CSSPropertyMaskSize, CSSPropertyMaskRepeat, CSSPropertyMaskOrigin, CSSPropertyMaskClip, CSSPropertyMaskComposite, CSSPropertyMaskMode };
 
-    return getFillLayerPropertyShorthandValue(CSSPropertyMask, StylePropertyShorthand(CSSPropertyMask, propertiesBeforeSlashSeparator), StylePropertyShorthand(CSSPropertyMask, propertiesAfterSlashSeparator), CSSPropertyInvalid);
+    return getFillLayerPropertyShorthandValue(CSSPropertyMask, StylePropertyShorthand(CSSPropertyMask, std::span { propertiesBeforeSlashSeparator }), StylePropertyShorthand(CSSPropertyMask, std::span { propertiesAfterSlashSeparator }), CSSPropertyInvalid);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/MutableStyleProperties.cpp
+++ b/Source/WebCore/css/MutableStyleProperties.cpp
@@ -98,7 +98,7 @@ inline bool MutableStyleProperties::removeShorthandProperty(CSSPropertyID proper
     // FIXME: Use serializeShorthandValue here to return the value of the removed shorthand as we do when removing a longhand.
     if (returnText)
         *returnText = String();
-    return removeProperties(shorthandForProperty(propertyID).propertiesSpan());
+    return removeProperties(shorthandForProperty(propertyID).properties());
 }
 
 bool MutableStyleProperties::removePropertyAtIndex(int index, String* returnText)
@@ -183,7 +183,7 @@ void MutableStyleProperties::setProperty(CSSPropertyID propertyID, RefPtr<CSSVal
         return;
     }
     auto shorthand = shorthandForProperty(propertyID);
-    removeProperties(shorthand.propertiesSpan());
+    removeProperties(shorthand.properties());
     for (auto longhand : shorthand)
         m_propertyVector.append(CSSProperty(longhand, value.copyRef(), important));
 }

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -44,6 +44,8 @@
 #include "StylePropertiesInlines.h"
 #include "StylePropertyShorthand.h"
 #include "TimelineRange.h"
+#include <algorithm>
+#include <wtf/IndexedRange.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -152,15 +154,11 @@ inline ShorthandSerializer::ShorthandSerializer(const PropertiesType& properties
 
 inline CSSPropertyID ShorthandSerializer::longhandProperty(unsigned index) const
 {
-    ASSERT(index < length());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     return m_shorthand.properties()[index];
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 inline CSSValue& ShorthandSerializer::longhandValue(unsigned index) const
 {
-    ASSERT(index < length());
     return *m_longhandValues[index];
 }
 
@@ -521,10 +519,8 @@ public:
     void set(unsigned index, const CSSValue* value, bool skipSerializing = false)
     {
         ASSERT(index < m_shorthand.length());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         m_skipSerializing[index] = skipSerializing
             || !value || isInitialValueForLonghand(m_shorthand.properties()[index], *value);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         m_values[index] = value;
     }
 
@@ -534,13 +530,10 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return m_skipSerializing[index];
     }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     std::optional<CSSValueID> valueID(unsigned index) const
     {
-        ASSERT(index < m_shorthand.length());
         return longhandValueID(m_shorthand.properties()[index], m_values[index].get());
     }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     CSSValueID valueIDIncludingCustomIdent(unsigned index) const
     {

--- a/Source/WebCore/css/StylePropertyShorthand.cpp
+++ b/Source/WebCore/css/StylePropertyShorthand.cpp
@@ -29,10 +29,10 @@ StylePropertyShorthand transitionShorthandForParsing()
 {
     // Similar to animations, we have property after timing-function and delay after
     // duration.
-    static const CSSPropertyID transitionProperties[] = {
+    static constexpr std::array transitionProperties = {
         CSSPropertyTransitionDuration, CSSPropertyTransitionTimingFunction,
         CSSPropertyTransitionDelay, CSSPropertyTransitionBehavior, CSSPropertyTransitionProperty };
-    return StylePropertyShorthand(CSSPropertyTransition, transitionProperties);
+    return StylePropertyShorthand(CSSPropertyTransition, std::span { transitionProperties });
 }
 
 unsigned indexOfShorthandForLonghand(CSSPropertyID shorthandID, const StylePropertyShorthandVector& shorthands)

--- a/Source/WebCore/css/StylePropertyShorthand.h
+++ b/Source/WebCore/css/StylePropertyShorthand.h
@@ -31,23 +31,21 @@ class StylePropertyShorthand {
 public:
     StylePropertyShorthand() = default;
 
-    template<unsigned numProperties> StylePropertyShorthand(CSSPropertyID id, const CSSPropertyID (&properties)[numProperties])
-        : m_properties(properties)
-        , m_length(numProperties)
+    template<std::size_t numProperties> StylePropertyShorthand(CSSPropertyID id, std::span<const CSSPropertyID, numProperties> properties)
+        : m_properties(properties.data())
+        , m_length(properties.size())
         , m_shorthandID(id)
     {
+        static_assert(numProperties != std::dynamic_extent);
     }
 
-    const CSSPropertyID* begin() const { return properties(); }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    const CSSPropertyID* end() const { return properties() + length(); }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    const CSSPropertyID* begin() const { return std::to_address(properties().begin()); }
+    const CSSPropertyID* end() const { return std::to_address(properties().end()); }
 
-    const CSSPropertyID* properties() const { return m_properties; }
-    unsigned length() const { return m_length; }
+    size_t length() const { return m_length; }
     CSSPropertyID id() const { return m_shorthandID; }
 
-    std::span<const CSSPropertyID> propertiesSpan() const { return unsafeMakeSpan(m_properties, m_length); }
+    std::span<const CSSPropertyID> properties() const { return unsafeMakeSpan(m_properties, m_length); }
 
 private:
     const CSSPropertyID* m_properties { nullptr };

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -770,7 +770,7 @@ bool CSSPropertyParser::consumeFont(bool important)
 
     m_range = range;
     auto shorthand = fontShorthand();
-    for (auto [i, longhand] : indexedRange(shorthand.propertiesSpan()))
+    for (auto [i, longhand] : indexedRange(shorthand.properties()))
         addProperty(longhand, CSSPropertyFont, i < values.size() ? WTFMove(values[i]) : nullptr, important, true);
 
     return true;
@@ -1524,7 +1524,7 @@ bool CSSPropertyParser::consumeShorthandGreedily(const StylePropertyShorthand& s
 {
     ASSERT(shorthand.length() <= 6); // Existing shorthands have at most 6 longhands.
     std::array<RefPtr<CSSValue>, 6> longhands;
-    auto shorthandProperties = shorthand.propertiesSpan();
+    auto shorthandProperties = shorthand.properties();
     do {
         bool foundLonghand = false;
         for (size_t i = 0; !foundLonghand && i < shorthand.length(); ++i) {
@@ -1666,7 +1666,7 @@ bool CSSPropertyParser::consumeBorderShorthand(CSSPropertyID widthProperty, CSSP
 bool CSSPropertyParser::consume2ValueShorthand(const StylePropertyShorthand& shorthand, bool important)
 {
     ASSERT(shorthand.length() == 2);
-    auto longhands = shorthand.propertiesSpan();
+    auto longhands = shorthand.properties();
     RefPtr start = parseSingleValue(longhands[0], shorthand.id());
     if (!start)
         return false;
@@ -1684,7 +1684,7 @@ bool CSSPropertyParser::consume2ValueShorthand(const StylePropertyShorthand& sho
 bool CSSPropertyParser::consume4ValueShorthand(const StylePropertyShorthand& shorthand, bool important)
 {
     ASSERT(shorthand.length() == 4);
-    auto longhands = shorthand.propertiesSpan();
+    auto longhands = shorthand.properties();
     RefPtr top = parseSingleValue(longhands[0], shorthand.id());
     if (!top)
         return false;
@@ -1896,7 +1896,7 @@ static RefPtr<CSSValue> consumeAnimationValueForShorthand(CSSPropertyID property
 
 bool CSSPropertyParser::consumeAnimationShorthand(const StylePropertyShorthand& shorthand, bool important)
 {
-    auto shorthandProperties = shorthand.propertiesSpan();
+    auto shorthandProperties = shorthand.properties();
     const unsigned longhandCount = shorthand.length();
     std::array<CSSValueListBuilder, 8> longhands;
     ASSERT(longhandCount <= 8);
@@ -2029,7 +2029,7 @@ static RefPtr<CSSValue> consumeBackgroundComponent(CSSPropertyID property, CSSPa
 // the x properties in the shorthand array.
 bool CSSPropertyParser::consumeBackgroundShorthand(const StylePropertyShorthand& shorthand, bool important)
 {
-    auto shorthandProperties = shorthand.propertiesSpan();
+    auto shorthandProperties = shorthand.properties();
     unsigned longhandCount = shorthand.length();
 
     // mask resets mask-border properties outside of this method.
@@ -2186,7 +2186,7 @@ bool CSSPropertyParser::consumeGridItemPositionShorthand(CSSPropertyID shorthand
     }
     if (!m_range.atEnd())
         return false;
-    auto longhands = shorthand.propertiesSpan();
+    auto longhands = shorthand.properties();
     addProperty(longhands[0], shorthandId, startValue.releaseNonNull(), important);
     addProperty(longhands[1], shorthandId, endValue.releaseNonNull(), important);
     return true;
@@ -2431,7 +2431,7 @@ bool CSSPropertyParser::consumeAlignShorthand(const StylePropertyShorthand& shor
     //   <'gap'>           https://drafts.csswg.org/css-align/#propdef-gap
 
     ASSERT(shorthand.length() == 2);
-    auto longhands = shorthand.propertiesSpan();
+    auto longhands = shorthand.properties();
 
     auto rangeCopy = m_range;
 

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -3759,7 +3759,7 @@ class GenerateStylePropertyShorthandFunctions:
                             to.write(f"{longhand.id},")
 
                 to.write(f"}};")
-                to.write(f"return StylePropertyShorthand({property.id}, {property.id_without_prefix_with_lowercase_first_letter}Properties);")
+                to.write(f"return StylePropertyShorthand({property.id}, std::span {{ {property.id_without_prefix_with_lowercase_first_letter}Properties }});")
             to.write(f"}}")
             to.newline()
 


### PR DESCRIPTION
#### e9aef032fc07b35f8ea8a5324102111c3b99b6ed
<pre>
Reduce use of WTF_ALLOW_UNSAFE_BUFFER_USAGE in CSS code
<a href="https://bugs.webkit.org/show_bug.cgi?id=286066">https://bugs.webkit.org/show_bug.cgi?id=286066</a>
<a href="https://rdar.apple.com/143488112">rdar://143488112</a>

Reviewed by Sam Weinig.

This tested as performance neutral on Speedometer and MemBuster.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesFor2SidesShorthand const):
(WebCore::ComputedStyleExtractor::getCSSPropertyValuesFor4SidesShorthand const):
(WebCore::ComputedStyleExtractor::getBackgroundShorthandValue const):
(WebCore::ComputedStyleExtractor::getMaskShorthandValue const):
* Source/WebCore/css/MutableStyleProperties.cpp:
(WebCore::MutableStyleProperties::removeShorthandProperty):
(WebCore::MutableStyleProperties::setProperty):
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::longhandProperty const):
(WebCore::ShorthandSerializer::longhandValue const):
(WebCore::LayerValues::set):
(WebCore::LayerValues::valueID const):
* Source/WebCore/css/StylePropertyShorthand.cpp:
(WebCore::transitionShorthandForParsing):
* Source/WebCore/css/StylePropertyShorthand.h:
(WebCore::StylePropertyShorthand::StylePropertyShorthand):
(WebCore::StylePropertyShorthand::begin const):
(WebCore::StylePropertyShorthand::end const):
(WebCore::StylePropertyShorthand::length const):
(WebCore::StylePropertyShorthand::properties const):
(WebCore::StylePropertyShorthand::propertiesSpan const): Deleted.
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumeFont):
(WebCore::CSSPropertyParser::consumeShorthandGreedily):
(WebCore::CSSPropertyParser::consume2ValueShorthand):
(WebCore::CSSPropertyParser::consume4ValueShorthand):
(WebCore::CSSPropertyParser::consumeAnimationShorthand):
(WebCore::CSSPropertyParser::consumeBackgroundShorthand):
(WebCore::CSSPropertyParser::consumeGridItemPositionShorthand):
(WebCore::CSSPropertyParser::consumeAlignShorthand):
* Source/WebCore/css/process-css-properties.py:

Canonical link: <a href="https://commits.webkit.org/289376@main">https://commits.webkit.org/289376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b43f3f7d24097f3af01406b4801eb1cb764e8a83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/86746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91591 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37478 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/88795 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14312 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/67066 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/24839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/89749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/4961 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/78528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47387 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/4753 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/32872 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36596 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/75264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/33758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93486 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/13899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/75861 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14100 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75056 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18458 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19370 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/17776 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/6684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/13922 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/19182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13660 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17105 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->