### PR TITLE
Videos using `transform-style: separated` loose their controls

### DIFF
--- a/LayoutTests/platform/visionos/transforms/separated-video-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-video-expected.txt
@@ -1,0 +1,92 @@
+
+(CALayer tree root
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer anchorPoint [x: 0 y: 0])
+  (sublayers
+    (
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer anchorPoint [x: 0 y: 0])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+          (layer position [x: 400 y: 400])
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer position [x: 400 y: 400])
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                  (layer anchorPoint [x: 0 y: 0])
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                      (layer anchorPoint [x: 0 y: 0])
+                      (sublayers
+                        (
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                              (layer anchorPoint [x: 0 y: 0]))))
+                        (
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 352 height: 288])
+                              (layer position [x: 176 y: 176])
+                              (separated 1)
+                              (layer cornerRadius 24)
+                              (sublayers
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (sublayers
+                                    (
+                                      (type 0)
+                                      (layer bounds [x: 0 y: 0 width: 352 height: 288])
+                                      (layer position [x: 176 y: 176])
+                                      (layer cornerRadius 24))))
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 352 height: 288])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (sublayers
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 352 height: 288])
+                                      (layer anchorPoint [x: 0 y: 0])
+                                      (sublayers
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 352 height: 288])
+                                          (layer position [x: 176 y: 176])
+                                          (sublayers
+                                            (
+                                              (layer bounds [x: 0 y: 0 width: 300 height: 150])
+                                              (layer position [x: 176 y: 176]))))))
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 352 height: 288])
+                                      (layer position [x: 176 y: 176])
+                                      (sublayers
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 51 height: 51])
+                                          (layer position [x: 201.5 y: 201.5])
+                                          (sublayers
+                                            (
+                                              (layer bounds [x: 0 y: 0 width: 31 height: 31])
+                                              (layer position [x: 25.5 y: 25.5])
+                                              (sublayers
+                                                (
+                                                  (layer bounds [x: 0 y: 0 width: 31 height: 31])
+                                                  (layer anchorPoint [x: 0 y: 0]))))
+                                            (
+                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                              (sublayers
+                                                (
+                                                  (type 0)
+                                                  (layer bounds [x: 0 y: 0 width: 51 height: 51])
+                                                  (layer position [x: 25.5 y: 25.5])
+                                                  (layer cornerRadius 25.5))))))))))))))))))))))))
+    (
+      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+      (layer position [x: 400 y: 400]))
+    (
+      (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/platform/visionos/transforms/separated-video.html
+++ b/LayoutTests/platform/visionos/transforms/separated-video.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ CSSTransformStyleSeparatedEnabled=true useFlexibleViewport=false ] -->
+<html>
+<style>
+    body { margin: 0; }
+
+    .transformed {
+      background: purple;
+      translate: 0 0 20px;
+      border-radius: 24px;
+    }
+    .separated {
+      transform-style: separated;
+    }
+    .offscreen {
+        margin-top: 2000px;
+    }
+</style>
+<script src="../../../resources/ui-helper.js"></script>
+<body>
+<section id="test">
+    <video class="transformed separated" src="../../../media/content/counting.mp4" controls></video>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    const video = document.querySelector("video");
+    if (video.readyState < HTMLMediaElement.HAVE_ENOUGH_DATA)
+        await new Promise(r => video.addEventListener("canplay", r));
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getCALayerTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -2376,9 +2376,9 @@ void GraphicsLayerCA::updateSublayerList(bool maxLayerDepthReached)
     bool structuralLayerHostsChildren = !clippingLayerHostsChildren && m_structuralLayer && structuralLayerPurpose() != StructuralLayerPurpose::StructuralLayerForBackdrop;
     if (m_contentsClippingLayer) {
         PlatformCALayerList clippingChildren;
+        appendContentsLayer(clippingChildren);
         if (clippingLayerHostsChildren)
             buildChildLayerList(clippingChildren);
-        appendContentsLayer(clippingChildren);
         m_contentsClippingLayer->setSublayers(clippingChildren);
     }
 


### PR DESCRIPTION
#### 661da23a2ffacb724e573950eade16beefb1b160
<pre>
Videos using `transform-style: separated` loose their controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=286070">https://bugs.webkit.org/show_bug.cgi?id=286070</a>
&lt;<a href="https://rdar.apple.com/140916909">rdar://140916909</a>&gt;

Reviewed by Simon Fraser.

Separated layers have the `contentsRectClipsDescendants` flag on.
This caused the controls to be rendered behind the video because of a
small ordering issue, originally from 236998@main.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::updateSublayerList):
Append the contents layer _before_ the child layers in the
`clippingLayerHostsChildren` case.

* LayoutTests/platform/visionos/transforms/separated-video-expected.txt: Added.
* LayoutTests/platform/visionos/transforms/separated-video.html: Added.
Add a test, the tests from 236998@main remain unchanged.

Canonical link: <a href="https://commits.webkit.org/289046@main">https://commits.webkit.org/289046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae5b5c8d8c6269399403250d1f6a0618771acf9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90172 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36078 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87109 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66172 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/23982 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46438 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31500 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35151 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74376 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91707 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74730 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73082 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73849 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18281 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18164 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16618 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4382 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12314 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17773 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12150 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15645 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13896 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->