### PR TITLE
[Tools][CISupport] start-local-buildbot-server fails to import modules from 'Shared' directory

### DIFF
--- a/Tools/CISupport/start-local-buildbot-server
+++ b/Tools/CISupport/start-local-buildbot-server
@@ -108,8 +108,10 @@ def cmd_exists(cmd):
 
 class BuildbotTestRunner(object):
 
-    def __init__(self, configdir):
-        self._configdir = os.path.abspath(os.path.realpath(configdir))
+    def __init__(self, dir_to_copy, subdir_with_configuration):
+        self._dir_to_copy = os.path.abspath(os.path.realpath(dir_to_copy))
+        self._subdir_with_configuration = subdir_with_configuration
+        self._configdir = os.path.join(self._dir_to_copy, self._subdir_with_configuration)
         if not os.path.isdir(self._configdir):
             raise RuntimeError('The configdir {} is not a directory'.format(self._configdir))
         if not os.path.isfile(os.path.join(self._configdir, 'config.json')):
@@ -240,12 +242,14 @@ class BuildbotTestRunner(object):
         return result
 
     def _setup_server_workdir(self):
-        self._server_wordir = os.path.join(self._base_workdir_temp, os.path.basename(self._configdir))
+        self._server_wordir = os.path.join(self._base_workdir_temp, os.path.basename(self._dir_to_copy))
         assert(not os.path.exists(self._server_wordir))
+        print('Copying files from {} to {} ...'.format(self._dir_to_copy, self._server_wordir))
+        shutil.copytree(self._dir_to_copy, self._server_wordir)
+        self._server_wordir = os.path.join(self._server_wordir, self._subdir_with_configuration)
+        assert(os.path.isdir(self._server_wordir))
         self._server_log = os.path.join(self._server_wordir, 'server.log')
         self._server_ready_fd = os.path.join(self._server_wordir, '.server-is-ready')
-        print('Copying files from {} to {} ...'.format(self._configdir, self._server_wordir))
-        shutil.copytree(self._configdir, self._server_wordir)
         print('Generating buildbot files at {} ...'.format(self._server_wordir))
         with open(os.path.join(self._server_wordir, 'buildbot.tac'), 'w') as f:
             f.write(buildbot_server_tac % {'config_file': self._server_config_file_name})
@@ -406,14 +410,17 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.configuration == "ews":
-        configdir = os.path.join(os.path.dirname(__file__), 'ews-build')
+        dir_to_copy = os.path.dirname(__file__)
+        subdir_with_configuration = "ews-build"
     elif args.configuration == "post_commit":
-        configdir = os.path.join(os.path.dirname(__file__), 'build-webkit-org')
+        dir_to_copy = os.path.dirname(__file__)
+        subdir_with_configuration = "build-webkit-org"
     else:
-        configdir = args.configdir
+        dir_to_copy = args.configdir
+        subdir_with_configuration = ""
 
     if args.number_workers is None:
         args.number_workers = 1
 
-    buildbot_test_runner = BuildbotTestRunner(configdir)
+    buildbot_test_runner = BuildbotTestRunner(dir_to_copy, subdir_with_configuration)
     buildbot_test_runner.start(args.basetempdir, args.no_clean, args.number_workers, args.use_system_version)


### PR DESCRIPTION
#### 966ff65d47269e86fa9c3eb918eaa3ce8993bc05
<pre>
[Tools][CISupport] start-local-buildbot-server fails to import modules from &apos;Shared&apos; directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=286087">https://bugs.webkit.org/show_bug.cgi?id=286087</a>

Reviewed by Ryan Haddad.

Since 286664@main on the factories.py buildbot code there is an import
from the &apos;Shared&apos; directory which is located one directory above, and
the script start-local-buildbot-server is not copying that to the
temporal runtime workdir.

Fix that by copying everything inside the directory above,
that is, by copying everything from directory &apos;CISupport&apos;.

* Tools/CISupport/start-local-buildbot-server:
(BuildbotTestRunner):
(BuildbotTestRunner.__init__):
(BuildbotTestRunner._setup_server_workdir):

Canonical link: <a href="https://commits.webkit.org/289345@main">https://commits.webkit.org/289345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9306f31b581aca5adbc46d8451e84a92098baaac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36124 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87157 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66184 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24008 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3729 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77306 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46451 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31538 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35197 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74412 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91605 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9066 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74684 "Found 67 new test failures: compositing/blend-mode/non-separable-blend-modes.html compositing/layer-creation/will-change-layer-creation.html css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute.html editing/inserting/insert-list-user-select-none-crash.html editing/pasteboard/copy-paste-across-shadow-boundaries-with-style-2.html editing/spelling/grammar-and-spelling-error-styling.html fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html fast/css/focus-ring-exists-for-search-field.html fast/hidpi/filters-drop-shadow.html fast/inline/list-marker-inside-container-with-margin.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12641 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73122 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73803 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18196 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16649 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4426 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13459 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12360 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12196 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15691 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13942 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->