### PR TITLE
[CISupport][build.webkit.org][GTK][WPE] Add new MVT testers

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -110,6 +110,7 @@
                   { "name": "gtk-linux-bot-22", "platform": "gtk" },
                   { "name": "gtk-linux-bot-23", "platform": "gtk" },
                   { "name": "gtk-linux-bot-24", "platform": "gtk" },
+                  { "name": "gtk-linux-bot-25", "platform": "gtk" },
 
                   { "name": "jsconly-linux-igalia-bot-1", "platform": "jsc-only" },
                   { "name": "jsconly-linux-igalia-bot-2", "platform": "jsc-only" },
@@ -151,6 +152,7 @@
                   { "name": "wpe-linux-bot-33", "platform": "wpe" },
                   { "name": "wpe-linux-bot-34", "platform": "wpe" },
                   { "name": "wpe-linux-bot-35", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-36", "platform": "wpe" },
 
                   { "name": "wpe-linux-queue-1-bot-1", "platform": "wpe" },
                   { "name": "wpe-linux-queue-1-bot-2", "platform": "wpe" },
@@ -475,7 +477,7 @@
                     "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
                     "triggers": ["gtk-linux-64-release-tests", "gtk-linux-64-release-tests-js", "gtk-linux-64-release-tests-webdriver",
                                  "gtk-linux-64-release-wayland-tests", "gtk-linux-64-release-perf-tests",
-                                 "gtk-linux-64-release-skip-failing-tests"],
+                                 "gtk-linux-64-release-skip-failing-tests", "gtk-linux-64-release-tests-mvt"],
                     "workernames": ["gtk-linux-bot-2"]
                   },
                   {
@@ -578,6 +580,11 @@
                     "workernames": ["gtk-linux-bot-24"]
                   },
                   {
+                    "name": "GTK-Linux-64-bit-Release-MVT-Tests", "factory": "TestMVTFactory",
+                    "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
+                    "workernames": ["gtk-linux-bot-25"]
+                  },
+                  {
                     "name": "Windows-64-bit-Release-Build", "factory": "BuildFactory",
                     "platform": "win", "configuration": "release", "architectures": ["x86_64"],
                     "triggers": ["win-release-tests"],
@@ -622,7 +629,7 @@
                   {
                     "name": "WPE-Linux-64-bit-Release-Build", "factory": "BuildFactory",
                     "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
-                    "triggers": ["wpe-linux-64-release-tests", "wpe-linux-64-release-tests-js", "wpe-linux-64-release-tests-webdriver"],
+                    "triggers": ["wpe-linux-64-release-tests", "wpe-linux-64-release-tests-js", "wpe-linux-64-release-tests-webdriver", "wpe-linux-64-release-tests-mvt"],
                     "workernames": ["wpe-linux-bot-1"]
                   },
                   {
@@ -736,6 +743,11 @@
                     "name": "WPE-Linux-64-bit-Release-SDK-Container", "factory": "BuildAndTestAndArchiveAllButJSCFactory",
                     "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
                     "workernames": ["wpe-linux-queue-1-bot-1", "wpe-linux-queue-1-bot-2", "wpe-linux-queue-1-bot-3", "wpe-linux-queue-1-bot-4", "wpe-linux-queue-1-bot-5"]
+                  },
+                  {
+                    "name": "WPE-Linux-64-bit-Release-MVT-Tests", "factory": "TestMVTFactory",
+                    "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
+                    "workernames": ["wpe-linux-bot-36"]
                   }
                 ],
 
@@ -942,6 +954,9 @@
                   { "type": "Triggerable", "name": "gtk-linux-64-release-skip-failing-tests",
                     "builderNames": ["GTK-Linux-64-bit-Release-Skip-Failing-Tests"]
                   },
+                  { "type": "Triggerable", "name": "gtk-linux-64-release-tests-mvt",
+                    "builderNames": ["GTK-Linux-64-bit-Release-MVT-Tests"]
+                  },
                   { "type": "Triggerable", "name": "win-release-tests",
                     "builderNames": ["Windows-64-bit-Release-Tests"]
                   },
@@ -971,6 +986,9 @@
                   },
                   { "type": "Triggerable", "name": "wpe-linux-rpi4-64-mesa-release-perf-tests",
                     "builderNames": ["WPE-Linux-RPi4-64bits-Mesa-Release-Perf-Tests"]
+                  },
+                  { "type": "Triggerable", "name": "wpe-linux-64-release-tests-mvt",
+                    "builderNames": ["WPE-Linux-64-bit-Release-MVT-Tests"]
                   },
                   { "type": "Nightly", "name": "NightlyScheduler", "change_filter": "main_filter",
                     "branch": "main", "hour": 22, "minute": 0,

--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -259,6 +259,13 @@ class TestWebDriverFactory(Factory):
         self.addStep(RunWebDriverTests())
 
 
+class TestMVTFactory(Factory):
+    def __init__(self, platform, configuration, architectures, additionalArguments=None, device_model=None):
+        Factory.__init__(self, platform, configuration, architectures, False, additionalArguments, device_model)
+        self.addStep(DownloadBuiltProduct())
+        self.addStep(ExtractBuiltProduct())
+        self.addStep(RunMVTTests())
+
 class TestWebKit1Factory(TestFactory):
     LayoutTestClass = RunWebKit1Tests
 

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -1509,6 +1509,20 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'archive-built-product',
             'upload-built-product-via-sftp'
         ],
+        'GTK-Linux-64-bit-Release-MVT-Tests': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'jhbuild',
+            'download-built-product',
+            'extract-built-product',
+            'MVT-tests'
+        ],
         'Windows-64-bit-Release-Build': [
             'configure-build',
             'configuration',
@@ -1926,6 +1940,20 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'API-tests',
             'archive-built-product',
             'upload-built-product'
+        ],
+        'WPE-Linux-64-bit-Release-MVT-Tests': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'jhbuild',
+            'download-built-product',
+            'extract-built-product',
+            'MVT-tests'
         ],
     }
 

--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1255,6 +1255,27 @@ class RunBuiltinsTests(shell.TestNewStyle):
     command = ["python3", "Tools/Scripts/run-builtins-generator-tests"]
 
 
+class RunMVTTests(shell.TestNewStyle):
+    command = ["Tools/Scripts/run-mvt-tests", WithProperties("--%(configuration)s"),
+               WithProperties("--%(fullPlatform)s"), "--headless"]
+    name = "MVT-tests"
+    description = ["MVT tests running"]
+    descriptionDone = ["MVT tests"]
+
+    def evaluateCommand(self, cmd):
+        self.totalUnexpectedFailures = cmd.rc
+        if self.totalUnexpectedFailures != 0:
+            self.commandFailed = True
+            return FAILURE
+        return SUCCESS
+
+    def getResultSummary(self):
+        if self.results != SUCCESS and self.totalUnexpectedFailures > 0:
+            s = "s" if self.totalUnexpectedFailures > 1 else ""
+            return {'step': f"MVT Tests: {self.totalUnexpectedFailures} unexpected failure{s}"}
+        return super().getResultSummary()
+
+
 class RunGLibAPITests(shell.TestNewStyle):
     name = "API-tests"
     description = ["API tests running"]


### PR DESCRIPTION
#### 5bb4535614eb3a9be508c74f49de52fd7721d81a
<pre>
[CISupport][build.webkit.org][GTK][WPE] Add new MVT testers
<a href="https://bugs.webkit.org/show_bug.cgi?id=286089">https://bugs.webkit.org/show_bug.cgi?id=286089</a>

Reviewed by Philippe Normand.

The MVT test suite is a test suite for Multimedia capabilities
in the Web Browser.

On the GTK and WPE ports we want to run this test suite
continously to make easier to detect regressions.

Since this test step takes 30-40 minutes to run, we will add
dedicate testers for it to not slow down the layout/api ones.

* Tools/CISupport/build-webkit-org/factories.py:
(TestFactory.__init__):
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/CISupport/build-webkit-org/steps.py:
(RunMVTTests):
(RunMVTTests.evaluateCommand):
(RunMVTTests.getResultSummary):

Canonical link: <a href="https://commits.webkit.org/289576@main">https://commits.webkit.org/289576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36c5f44ad283f570e64e9da13627d783b3249ba1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/6572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/41419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/91920 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/37801 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/6848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/14640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67294 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25048 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/78805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/47616 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5018 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33180 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/36918 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75509 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/93808 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14224 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10354 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76093 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/86648 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/14428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/74660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75293 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/19636 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18067 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7141 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13613 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14243 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/13987 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/17430 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/15768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->