### PR TITLE
Regression (288954@main) [Intelligence Effects] Clicking outside the selection after a Proofreading animation has begun but before the animation completed causes the text to disappear

### DIFF
--- a/Source/WebKit/WebKitSwift/WritingTools/IntelligenceTextEffectViewManager.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/IntelligenceTextEffectViewManager.swift
@@ -29,7 +29,12 @@ import WebKitSwift
 @_spi(Private) import WebKit
 
 @MainActor
-class IntelligenceTextEffectViewManager<Source> where Source: PlatformIntelligenceTextEffectViewSource, Source.Chunk == IntelligenceTextEffectChunk {
+protocol IntelligenceTextEffectViewManagerDelegate  {
+    func updateTextChunkVisibility(_ chunk: IntelligenceTextEffectChunk, visible: Bool, force: Bool) async
+}
+
+@MainActor
+class IntelligenceTextEffectViewManager<Source> where Source: IntelligenceTextEffectViewManagerDelegate, Source: PlatformIntelligenceTextEffectViewSource, Source.Chunk == IntelligenceTextEffectChunk {
     init(source: Source? = nil, contentView: PlatformView) {
         self.source = source
         self.contentView = contentView
@@ -103,7 +108,7 @@ class IntelligenceTextEffectViewManager<Source> where Source: PlatformIntelligen
             //
             // Therefore, the delegate method itself must avoid any work so that it can be synchronous, which is what the platform
             // interfaces expect.
-            await self.source?.updateTextChunkVisibility(oldEffect!.chunk, visible: true)
+            await self.source?.updateTextChunkVisibility(oldEffect!.chunk, visible: true, force: true)
 
             await self.effectView?.removeEffect(oldEffect!.id)
 

--- a/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift
+++ b/Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift
@@ -194,15 +194,10 @@ import WebKitSwift
     }
 }
 
-// MARK: WKIntelligenceReplacementTextEffectCoordinator + PlatformIntelligenceTextEffectViewSource conformance
+// MARK: WKIntelligenceReplacementTextEffectCoordinator + IntelligenceTextEffectViewManager.Delegate conformance
 
-extension WKIntelligenceReplacementTextEffectCoordinator: PlatformIntelligenceTextEffectViewSource {
-    func textPreview(for chunk: IntelligenceTextEffectChunk) async -> PlatformTextPreview? {
-        let previews = await self.delegate.intelligenceTextEffectCoordinator(self, textPreviewsFor: NSRange(chunk.range))
-        return platformTextPreview(from: previews)
-    }
-
-    private func updateTextChunkVisibility(_ chunk: IntelligenceTextEffectChunk, visible: Bool, force: Bool) async {
+extension WKIntelligenceReplacementTextEffectCoordinator: IntelligenceTextEffectViewManagerDelegate {
+    func updateTextChunkVisibility(_ chunk: IntelligenceTextEffectChunk, visible: Bool, force: Bool) async {
         if chunk is IntelligenceTextEffectChunk.Pondering && visible && !force {
             // Typically, if `chunk` is part of a pondering effect, this delegate method will get called with `visible == true`
             // once the pondering effect is removed. However, instead of performing that logic here, it is done in `setActivePonderingEffect`
@@ -219,6 +214,15 @@ extension WKIntelligenceReplacementTextEffectCoordinator: PlatformIntelligenceTe
         }
 
         await self.delegate.intelligenceTextEffectCoordinator(self, updateTextVisibilityFor: NSRange(chunk.range), visible: visible, identifier: chunk.id)
+    }
+}
+
+// MARK: WKIntelligenceReplacementTextEffectCoordinator + PlatformIntelligenceTextEffectViewSource conformance
+
+extension WKIntelligenceReplacementTextEffectCoordinator: PlatformIntelligenceTextEffectViewSource {
+    func textPreview(for chunk: IntelligenceTextEffectChunk) async -> PlatformTextPreview? {
+        let previews = await self.delegate.intelligenceTextEffectCoordinator(self, textPreviewsFor: NSRange(chunk.range))
+        return platformTextPreview(from: previews)
     }
 
     func updateTextChunkVisibility(_ chunk: Chunk, visible: Bool) async {


### PR DESCRIPTION
#### 833171523e242785e47554ece9be8abdad3fafc8
<pre>
Regression (288954@main) [Intelligence Effects] Clicking outside the selection after a Proofreading animation has begun but before the animation completed causes the text to disappear
<a href="https://bugs.webkit.org/show_bug.cgi?id=286090">https://bugs.webkit.org/show_bug.cgi?id=286090</a>
<a href="https://rdar.apple.com/143074196">rdar://143074196</a>

Reviewed by Abrar Rahman Protyasha.

288954@main accidentally incorrectly changed a line when moving it between the coordinator and manager types, and this restores the original logic.

* Source/WebKit/WebKitSwift/WritingTools/IntelligenceTextEffectViewManager.swift:
(IntelligenceTextEffectViewManagerDelegate.updateTextChunkVisibility(_:visible:force:)):
(IntelligenceTextEffectViewManager.setActivePonderingEffect(_:)):
* Source/WebKit/WebKitSwift/WritingTools/WKIntelligenceReplacementTextEffectCoordinator.swift:
(WKIntelligenceReplacementTextEffectCoordinator.updateTextChunkVisibility(_:visible:force:)):
(WKIntelligenceReplacementTextEffectCoordinator.textPreview(for:)):

Canonical link: <a href="https://commits.webkit.org/289026@main">https://commits.webkit.org/289026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3364d3b8b4dcef95988b2de6b93edf4e5b4c8dfa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39485 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/90232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/36140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4904 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12791 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/90232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/36140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88132 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/77310 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/90232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/3609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31542 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/35213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32362 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/91625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12428 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/91625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73127 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/91625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18206 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16653 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13262 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12376 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12212 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/15707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->