### PR TITLE
[Site Isolation] Avoid reusing the main frame after cross-site navigation

### DIFF
--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -158,10 +158,14 @@ Ref<FrameState> WebBackForwardListFrameItem::copyFrameStateWithChildren()
     return frameState;
 }
 
-bool WebBackForwardListFrameItem::hasAncestorFrame(FrameIdentifier frameID)
+bool WebBackForwardListFrameItem::sharesAncestor(WebBackForwardListFrameItem& frameItem) const
 {
-    for (RefPtr ancestor = m_parent.get(); ancestor; ancestor = ancestor->m_parent.get()) {
-        if (ancestor->frameID() == frameID)
+    HashSet<WebCore::BackForwardFrameItemIdentifier> currentAncestors;
+    for (RefPtr currentAncestor = m_parent.get(); currentAncestor; currentAncestor = currentAncestor->m_parent.get())
+        currentAncestors.add(currentAncestor->m_identifier);
+
+    for (RefPtr frameItemAncestor = frameItem.m_parent.get(); frameItemAncestor; frameItemAncestor = frameItemAncestor->m_parent.get()) {
+        if (currentAncestors.contains(frameItemAncestor->m_identifier))
             return true;
     }
     return false;

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -55,7 +55,7 @@ public:
     WebBackForwardListFrameItem* parent() const { return m_parent.get(); }
     RefPtr<WebBackForwardListFrameItem> protectedParent() const { return m_parent.get(); }
     void setParent(WebBackForwardListFrameItem* parent) { m_parent = parent; }
-    bool hasAncestorFrame(WebCore::FrameIdentifier);
+    bool sharesAncestor(WebBackForwardListFrameItem&) const;
 
     WebBackForwardListFrameItem& rootFrame();
     WebBackForwardListFrameItem& mainFrame();

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -153,6 +153,8 @@ public:
 
     WebPageProxyMessageReceiverRegistration& messageReceiverRegistration() { return m_messageReceiverRegistration; }
 
+    bool didCreateMainFrame() const { return m_didCreateMainFrame; }
+
 private:
     ProvisionalPageProxy(WebPageProxy&, Ref<FrameProcess>&&, BrowsingContextGroup&, RefPtr<SuspendedPageProxy>&&, API::Navigation&, bool isServerRedirect, const WebCore::ResourceRequest&, ProcessSwapRequestedByClient, bool isProcessSwappingOnNavigationResponse, API::WebsitePolicies*, WebsiteDataStore* replacedDataStoreForWebArchiveLoad = nullptr);
 
@@ -225,6 +227,7 @@ private:
     bool m_needsCookieAccessAddedInNetworkProcess { false };
     bool m_needsDidStartProvisionalLoad { true };
     bool m_shouldClosePage { true };
+    bool m_didCreateMainFrame { false };
     URL m_provisionalLoadURL;
     WebPageProxyMessageReceiverRegistration m_messageReceiverRegistration;
     std::unique_ptr<WebsitePoliciesData> m_mainFrameWebsitePoliciesData;

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -117,21 +117,19 @@ void WebBackForwardList::addItem(Ref<WebBackForwardListItem>&& newItem)
             m_entries.removeLast();
         }
 
-        if (auto frameID = newItem->navigatedFrameItem().frameID()) {
-            while (m_entries.size()) {
-                Ref lastEntry = m_entries.last();
-                if (!lastEntry->isRemoteFrameNavigation() || !lastEntry->navigatedFrameItem().hasAncestorFrame(*frameID))
-                    break;
-                didRemoveItem(lastEntry);
-                removedItems.append(WTFMove(lastEntry));
-                m_entries.removeLast();
+        while (m_entries.size()) {
+            Ref lastEntry = m_entries.last();
+            if (!lastEntry->isRemoteFrameNavigation() || lastEntry->navigatedFrameItem().sharesAncestor(newItem->navigatedFrameItem()))
+                break;
+            didRemoveItem(lastEntry);
+            removedItems.append(WTFMove(lastEntry));
+            m_entries.removeLast();
 
-                if (m_entries.isEmpty()) {
-                    m_currentIndex = std::nullopt;
-                    m_provisionalIndex = std::nullopt;
-                } else
-                    setProvisionalOrCurrentIndex(*provisionalOrCurrentIndex() - 1);
-            }
+            if (m_entries.isEmpty()) {
+                m_currentIndex = std::nullopt;
+                m_provisionalIndex = std::nullopt;
+            } else
+                setProvisionalOrCurrentIndex(*provisionalOrCurrentIndex() - 1);
         }
 
         // Toss the first item if the list is getting too big, as long as we're not using it

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1453,8 +1453,7 @@ void WebPageProxy::swapToProvisionalPage(Ref<ProvisionalPageProxy>&& provisional
     setDrawingArea(provisionalPage->takeDrawingArea());
     ASSERT(!m_mainFrame);
     m_mainFrame = provisionalPage->mainFrame();
-
-    if (!protectedPreferences()->siteIsolationEnabled())
+    if (provisionalPage->didCreateMainFrame())
         m_mainFrame->frameLoadState().addObserver(internals().protectedPageLoadTimingFrameLoadStateObserver());
 
     // FIXME: Think about what to do if the provisional page didn't get its browsing context group from the SuspendedPageProxy.
@@ -4941,7 +4940,7 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
     if (mainFrameInPreviousProcess && preferences->siteIsolationEnabled())
         mainFrameInPreviousProcess->removeChildFrames();
 
-    ASSERT(m_legacyMainFrameProcess.ptr() != &provisionalPage->process());
+    ASSERT(m_legacyMainFrameProcess.ptr() != &provisionalPage->process() || preferences->siteIsolationEnabled());
 
     auto shouldDelayClosingUntilFirstLayerFlush = ShouldDelayClosingUntilFirstLayerFlush::No;
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 693d7534811e6525561c884b48539ff5454ed010
<pre>
[Site Isolation] Avoid reusing the main frame after cross-site navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=286095">https://bugs.webkit.org/show_bug.cgi?id=286095</a>
<a href="https://rdar.apple.com/143077012">rdar://143077012</a>

Reviewed by Pascoe.

This relands 288547@main without breaking an internal page loading benchmark. I need to remove a
siteIsolationEnabled check before calling FrameLoadState::addObserver in
WebPageProxy::swapToProvisionalPage, since we now switch main frames when navigating in the benchmark.

* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::sharesAncestor const):
(WebKit::WebBackForwardListFrameItem::hasAncestorFrame): Deleted.
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::addItem):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::swapToProvisionalPage):
(WebKit::WebPageProxy::commitProvisionalPage):

Canonical link: <a href="https://commits.webkit.org/289034@main">https://commits.webkit.org/289034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/524a7a57aa77a705627cafc41647993b3e8945b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39572 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/90296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/36209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/4989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12871 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/90296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/36209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88212 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/77358 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/90296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/3660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/35277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32440 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/91700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/12512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/91700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73197 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/91700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18268 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/16692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13268 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12463 "Build is in progress. Recent messages:") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/12287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/15775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->