### PR TITLE
Have GraphicsContextGLImageExtractor::imagePixelData() return a span

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -3516,16 +3516,13 @@ void WebGLRenderingContextBase::texImageImpl(TexImageFunctionID functionID, GCGL
 
     GraphicsContextGL::DataFormat sourceDataFormat = imageExtractor.imageSourceFormat();
     GraphicsContextGL::AlphaOp alphaOp = imageExtractor.imageAlphaOp();
-    const uint8_t* imagePixelData = static_cast<const uint8_t*>(imageExtractor.imagePixelData());
-    CheckedSize imagePixelByteLength(imageExtractor.imageWidth());
-    imagePixelByteLength *= imageExtractor.imageHeight();
-    imagePixelByteLength *= 4u;
-    if (imagePixelByteLength.hasOverflowed()) {
+    auto imagePixelData = imageExtractor.imagePixelData();
+    if (!imagePixelData.data()) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "image too large"_s);
         return;
     }
 
-    std::span pixels { imagePixelData, imagePixelByteLength };
+    auto pixels = imagePixelData;
     if (type != GraphicsContextGL::UNSIGNED_BYTE || sourceDataFormat != GraphicsContextGL::DataFormat::RGBA8 || format != GraphicsContextGL::RGBA || alphaOp != GraphicsContextGL::AlphaOp::DoNothing || flipY || selectingSubRectangle || depth != 1) {
         if (!m_context->packImageData(&image, pixels, format, type, flipY, alphaOp, sourceDataFormat, imageExtractor.imageWidth(), imageExtractor.imageHeight(), adjustedSourceImageRect, depth, imageExtractor.imageSourceUnpackAlignment(), unpackImageHeight, data)) {
             synthesizeGLError(GraphicsContextGL::INVALID_VALUE, functionName, "packImage error"_s);

--- a/Source/WebCore/platform/graphics/GraphicsContextGLImageExtractor.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGLImageExtractor.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEBGL)
 
 #include "GraphicsContextGL.h"
+#include <wtf/MallocSpan.h>
 
 namespace WebCore {
 
@@ -43,7 +44,7 @@ public:
     ~GraphicsContextGLImageExtractor();
 
     bool extractSucceeded() { return m_extractSucceeded; }
-    const void* imagePixelData() { return m_imagePixelData; }
+    std::span<const uint8_t> imagePixelData() { return m_imagePixelData; }
     unsigned imageWidth() { return m_imageWidth; }
     unsigned imageHeight() { return m_imageHeight; }
     DataFormat imageSourceFormat() { return m_imageSourceFormat; }
@@ -60,7 +61,7 @@ private:
     RefPtr<cairo_surface_t> m_imageSurface;
 #elif USE(CG)
     RetainPtr<CFDataRef> m_pixelData;
-    UniqueArray<uint8_t> m_formalizedRGBA8Data;
+    MallocSpan<uint8_t> m_formalizedRGBA8Data;
 #elif USE(SKIA)
     sk_sp<SkData> m_pixelData;
     sk_sp<SkImage> m_skImage;
@@ -68,7 +69,7 @@ private:
     Ref<Image> m_image;
     DOMSource m_imageHtmlDomSource;
     bool m_extractSucceeded;
-    const void* m_imagePixelData;
+    std::span<const uint8_t> m_imagePixelData;
     unsigned m_imageWidth;
     unsigned m_imageHeight;
     DataFormat m_imageSourceFormat;

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp
@@ -40,6 +40,13 @@
 
 namespace WebCore {
 
+static std::span<const uint8_t> span(cairo_surface_t* surface)
+{
+    size_t stride = cairo_image_surface_get_stride(surface);
+    size_t height = cairo_image_surface_get_height(surface);
+    return unsafeMakeSpan(cairo_image_surface_get_data(surface), stride * height);
+}
+
 GraphicsContextGLImageExtractor::~GraphicsContextGLImageExtractor() = default;
 
 bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool ignoreGammaAndColorProfile, bool)
@@ -97,7 +104,7 @@ bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool i
             ++srcUnpackAlignment;
     }
 
-    m_imagePixelData = cairo_image_surface_get_data(m_imageSurface.get());
+    m_imagePixelData = span(m_imageSurface.get());
     m_imageSourceFormat = DataFormat::BGRA8;
     m_imageSourceUnpackAlignment = srcUnpackAlignment;
     return true;

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
@@ -34,6 +34,7 @@
 #include "PixelBuffer.h"
 #include "PlatformDisplay.h"
 #include "SharedBuffer.h"
+#include "SkiaSpanExtras.h"
 #include <skia/core/SkData.h>
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -105,7 +106,7 @@ bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool i
             return false;
 
         m_pixelData = WTFMove(data);
-        m_imagePixelData = m_pixelData->data();
+        m_imagePixelData = span(m_pixelData.get());
 
         // SkSurfaces backed by textures have RGBA format.
         m_imageSourceFormat = DataFormat::RGBA8;
@@ -115,7 +116,7 @@ bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool i
             return false;
 
         m_skImage = WTFMove(platformImage);
-        m_imagePixelData = pixmap.addr();
+        m_imagePixelData = span(pixmap);
 
         // Raster SkSurfaces have BGRA format.
         m_imageSourceFormat = DataFormat::BGRA8;

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
@@ -30,6 +30,7 @@
 #include "FontRenderOptions.h"
 #include "IntRect.h"
 #include "PixelBuffer.h"
+#include "SkiaSpanExtras.h"
 #include <skia/core/SkPixmap.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -76,16 +77,6 @@ RefPtr<NativeImage> ImageBufferSkiaUnacceleratedBackend::createNativeImageRefere
         }, SkSafeRef(m_surface.get())));
     }
     return nullptr;
-}
-
-static std::span<const uint8_t> span(const SkPixmap& pixmap)
-{
-    return unsafeMakeSpan(static_cast<const uint8_t*>(pixmap.addr()), pixmap.computeByteSize());
-}
-
-static std::span<uint8_t> mutableSpan(SkPixmap& pixmap)
-{
-    return unsafeMakeSpan(static_cast<uint8_t*>(pixmap.writable_addr()), pixmap.computeByteSize());
 }
 
 void ImageBufferSkiaUnacceleratedBackend::getPixelBuffer(const IntRect& srcRect, PixelBuffer& destination)

--- a/Source/WebCore/platform/graphics/skia/SkiaSpanExtras.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaSpanExtras.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <skia/core/SkPixmap.h>
 #include <wtf/StdLibExtras.h>
 
 #if USE(SKIA)
@@ -39,6 +40,16 @@ inline std::span<const uint8_t> span(SkData* data)
 inline std::span<const uint8_t> span(const sk_sp<SkData>& data)
 {
     return span(data.get());
+}
+
+inline std::span<const uint8_t> span(const SkPixmap& pixmap)
+{
+    return unsafeMakeSpan(static_cast<const uint8_t*>(pixmap.addr()), pixmap.computeByteSize());
+}
+
+inline std::span<uint8_t> mutableSpan(SkPixmap& pixmap)
+{
+    return unsafeMakeSpan(static_cast<uint8_t*>(pixmap.writable_addr()), pixmap.computeByteSize());
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 6b85e2966feb4124d40326b2f227102ff954e088
<pre>
Have GraphicsContextGLImageExtractor::imagePixelData() return a span
<a href="https://bugs.webkit.org/show_bug.cgi?id=286096">https://bugs.webkit.org/show_bug.cgi?id=286096</a>

Reviewed by Geoffrey Garen.

This also addresses the issue where the data size is not always correctly
calculated in WebGLRenderingContextBase::texImageImpl(), which was preventing
me from doing further bounds checking (since the span has the wrong size).

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageImpl):
* Source/WebCore/platform/graphics/GraphicsContextGLImageExtractor.h:
(WebCore::GraphicsContextGLImageExtractor::imagePixelData):
* Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp:
(WebCore::span):
(WebCore::GraphicsContextGLImageExtractor::extractImage):
* Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp:
(WebCore::GraphicsContextGLImageExtractor::extractImage):
* Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp:
(WebCore::GraphicsContextGLImageExtractor::extractImage):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp:
(WebCore::span): Deleted.
(WebCore::mutableSpan): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaSpanExtras.h:
(WebCore::span):
(WebCore::mutableSpan):

Canonical link: <a href="https://commits.webkit.org/289032@main">https://commits.webkit.org/289032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3865cd97ee408ec5610624c3fd90d10451c96002

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90272 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36180 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12837 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/66208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/24025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77339 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/46479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/3648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31581 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35253 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91672 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12473 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12702 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73168 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18249 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16675 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13267 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12421 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12257 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15751 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14002 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->