### PR TITLE
Fix some more ObjC memory leaks

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCLocale.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCLocale.mm
@@ -57,7 +57,7 @@ CoreIPCLocale::CoreIPCLocale(String&& identifier)
 
 RetainPtr<id> CoreIPCLocale::toID() const
 {
-    return [[NSLocale alloc] initWithLocaleIdentifier:(NSString *)m_identifier];
+    return adoptNS([[NSLocale alloc] initWithLocaleIdentifier:(NSString *)m_identifier]);
 }
 
 std::optional<String> CoreIPCLocale::canonicalLocaleStringReplacement(const String& identifier)

--- a/Source/WebKit/UIProcess/QuickLookThumbnailLoader.h
+++ b/Source/WebKit/UIProcess/QuickLookThumbnailLoader.h
@@ -33,7 +33,7 @@ class Attachment;
 
 @interface WKQLThumbnailQueueManager : NSObject
 
-@property (nonatomic, readonly, retain) NSOperationQueue *queue;
+@property (nonatomic, readonly) NSOperationQueue *queue;
 
 - (instancetype)init;
 + (WKQLThumbnailQueueManager *)sharedInstance;

--- a/Source/WebKit/UIProcess/QuickLookThumbnailLoader.mm
+++ b/Source/WebKit/UIProcess/QuickLookThumbnailLoader.mm
@@ -32,20 +32,26 @@
 #import <wtf/FileSystem.h>
 #import "QuickLookThumbnailingSoftLink.h"
 
-@implementation WKQLThumbnailQueueManager 
+@implementation WKQLThumbnailQueueManager {
+    RetainPtr<NSOperationQueue> _queue;
+}
 
 - (instancetype)init
 {
     self = [super init];
     if (self)
-        _queue = [[NSOperationQueue alloc] init];
+        _queue = adoptNS([[NSOperationQueue alloc] init]);
     return self;
 }
 
 - (void)dealloc
 {
-    [_queue release];
     [super dealloc];
+}
+
+- (NSOperationQueue *)queue
+{
+    return _queue.get();
 }
 
 + (WKQLThumbnailQueueManager *)sharedInstance

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -226,7 +226,7 @@
 
 + (instancetype)selectionRectWithCGRect:(CGRect)rect
 {
-    return [[[WKUITextSelectionRect alloc] initWithCGRect:rect] autorelease];
+    return adoptNS([[WKUITextSelectionRect alloc] initWithCGRect:rect]).autorelease();
 }
 
 - (instancetype)initWithCGRect:(CGRect)rect

--- a/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
+++ b/Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm
@@ -40,7 +40,7 @@ static _WKMockUserNotificationCenter *centersByBundleIdentifier(NSString *bundle
     static NeverDestroyed<RetainPtr<NSMutableDictionary>> centers = adoptNS([NSMutableDictionary new]);
 
     if (!centers->get()[bundleIdentifier])
-        centers->get()[bundleIdentifier] = [[_WKMockUserNotificationCenter alloc] _internalInitWithBundleIdentifier:bundleIdentifier];
+        centers->get()[bundleIdentifier] = adoptNS([[_WKMockUserNotificationCenter alloc] _internalInitWithBundleIdentifier:bundleIdentifier]).autorelease();
 
     return centers->get()[bundleIdentifier];
 }


### PR DESCRIPTION
#### 01562ca5be8e86b4676bdfa8d18de5615323a778
<pre>
Fix some more ObjC memory leaks
<a href="https://bugs.webkit.org/show_bug.cgi?id=286098">https://bugs.webkit.org/show_bug.cgi?id=286098</a>
<a href="https://rdar.apple.com/143081413">rdar://143081413</a>

Reviewed by Wenson Hsieh.

WKQLThumbnailQueueManager isn&apos;t a memory leak, but using smart pointers
makes that more clear.

* Source/WebKit/Shared/Cocoa/CoreIPCLocale.mm:
(WebKit::CoreIPCLocale::toID const):
* Source/WebKit/UIProcess/QuickLookThumbnailLoader.h:
* Source/WebKit/UIProcess/QuickLookThumbnailLoader.mm:
(-[WKQLThumbnailQueueManager init]):
(-[WKQLThumbnailQueueManager queue]):
(+[WKQLThumbnailQueueManager sharedInstance]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(+[WKUITextSelectionRect selectionRectWithCGRect:]):
* Source/WebKit/webpushd/_WKMockUserNotificationCenter.mm:
(centersByBundleIdentifier):

Canonical link: <a href="https://commits.webkit.org/289078@main">https://commits.webkit.org/289078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/403ffa941505e9e51095769da7dc7edcb3f12e33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4846 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36172 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/4936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66204 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24031 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77328 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46474 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3649 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35245 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74425 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91795 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9129 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74796 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73914 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18239 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16667 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4474 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13290 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12408 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17879 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12244 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15740 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/13990 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->