### PR TITLE
Eliminate unsafe buffer usage in GraphicsContextGLCVCocoa and GraphicsContextCG

### DIFF
--- a/Source/WTF/wtf/IndexedRange.h
+++ b/Source/WTF/wtf/IndexedRange.h
@@ -35,13 +35,13 @@ public:
     template<typename Collection>
     static BoundsCheckedIterator begin(Collection&& collection)
     {
-        return BoundsCheckedIterator(std::forward<Collection>(collection), collection.begin());
+        return BoundsCheckedIterator(std::forward<Collection>(collection), std::begin(collection));
     }
 
     template<typename Collection>
     static BoundsCheckedIterator end(Collection&& collection)
     {
-        return BoundsCheckedIterator(std::forward<Collection>(collection), collection.end());
+        return BoundsCheckedIterator(std::forward<Collection>(collection), std::end(collection));
     }
 
     BoundsCheckedIterator& operator++()
@@ -69,7 +69,7 @@ private:
     template<typename Collection>
     BoundsCheckedIterator(Collection&& collection, Iterator&& iterator)
         : m_iterator(WTFMove(iterator))
-        , m_end(collection.end())
+        , m_end(std::end(collection))
     {
     }
 
@@ -79,12 +79,12 @@ private:
 
 template<typename Collection> auto boundsCheckedBegin(Collection&& collection)
 {
-    return BoundsCheckedIterator<decltype(collection.begin())>::begin(std::forward<Collection>(collection));
+    return BoundsCheckedIterator<decltype(std::begin(collection))>::begin(std::forward<Collection>(collection));
 }
 
 template<typename Collection> auto boundsCheckedEnd(Collection&& collection)
 {
-    return BoundsCheckedIterator<decltype(collection.end())>::end(std::forward<Collection>(collection));
+    return BoundsCheckedIterator<decltype(std::end(collection))>::end(std::forward<Collection>(collection));
 }
 
 template<typename Iterator> class IndexedRangeIterator {

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1140,12 +1140,10 @@ void GraphicsContextCG::setCGStyle(const std::optional<GraphicsStyle>& style, bo
         },
         [&] (const GraphicsColorMatrix& colorMatrix) {
 #if HAVE(CGSTYLE_COLORMATRIX_BLUR)
-            CGColorMatrixStyle colorMatrixStyle = { 1, { 0 } };
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-            for (size_t i = 0; i < colorMatrix.values.size(); ++i)
-                colorMatrixStyle.matrix[i] = colorMatrix.values[i];
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-            auto style = adoptCF(CGStyleCreateColorMatrix(&colorMatrixStyle));
+            CGColorMatrixStyle cgColorMatrix = { 1, { 0 } };
+            for (auto [dst, src] : zippedRange(cgColorMatrix.matrix, colorMatrix.values))
+                dst = src;
+            auto style = adoptCF(CGStyleCreateColorMatrix(&cgColorMatrix));
             CGContextSetStyle(context, style.get());
 #else
             ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.mm
+++ b/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.mm
@@ -46,8 +46,6 @@
 
 #include "CoreVideoSoftLink.h"
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GraphicsContextGLCVCocoa);
@@ -248,7 +246,7 @@ struct GLfloatColors {
 };
 
 struct YCbCrMatrix {
-    GLfloat rows[4][4];
+    std::array<std::array<GLfloat, 4>, 4> rows;
 
     constexpr YCbCrMatrix(PixelRange, GLfloat cbCoefficient, GLfloat crCoefficient);
 
@@ -771,7 +769,5 @@ RetainPtr<CVPixelBufferRef> GraphicsContextGLCVCocoa::convertPixelBuffer(CVPixel
 }
 
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif


### PR DESCRIPTION
#### da8462128955b0a095f803704003b777f12582da
<pre>
Eliminate unsafe buffer usage in GraphicsContextGLCVCocoa and GraphicsContextCG
<a href="https://bugs.webkit.org/show_bug.cgi?id=286100">https://bugs.webkit.org/show_bug.cgi?id=286100</a>
<a href="https://rdar.apple.com/143082904">rdar://143082904</a>

Reviewed by Chris Dumez.

I pre-merged a little code from <a href="https://github.com/WebKit/WebKit/pull/39148">https://github.com/WebKit/WebKit/pull/39148</a> so
we don&apos;t end up conflicting.

* Source/WTF/wtf/IndexedRange.h:
(WTF::BoundsCheckedIterator::begin):
(WTF::BoundsCheckedIterator::end):
(WTF::BoundsCheckedIterator::BoundsCheckedIterator):
(WTF::boundsCheckedBegin):
(WTF::boundsCheckedEnd): use std::begin / std::end so we can do indexed and
zipped ranged for loops on C arrays.

* Source/WTF/wtf/TrailingArray.h: Paragraph separate first from last. (I came
here to try to add data(), but it&apos;s there already.)

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageImpl): Updated for span.

* Source/WebCore/platform/graphics/GraphicsContextGLImageExtractor.h:
(WebCore::GraphicsContextGLImageExtractor::imagePixelData): Use span and
MallocSpan because UniqueArray doesn&apos;t know its length.

* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::setCGStyle): Use zippedRange instead of raw
indexing into a C array.

* Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp:
(WebCore::getSourceDataFormat): Use std::array and std::span.

(WebCore::GraphicsContextGLImageExtractor::extractImage):
* Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.mm: Use std::array.

Canonical link: <a href="https://commits.webkit.org/289065@main">https://commits.webkit.org/289065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d0b7b42f4e413e0e6d6a5030937869578759b2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90319 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36232 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87281 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66241 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24049 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77377 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46510 "Found 2 new API test failures: /WPE/TestSSL:/webkit/WebKitWebView/web-socket-client-side-certificate, /WPE/TestSSL:/webkit/WebKitWebView/web-socket-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3683 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31637 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35300 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/78160 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/74449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91726 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/84233 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12539 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/9126 "Found 1 new test failure: http/tests/navigation/page-cache-requestAnimationFrame.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74746 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73864 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18286 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16712 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4526 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13283 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12482 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/17931 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/106623 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12312 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25710 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15805 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->