### PR TITLE
Reland 288650@main: [Site Isolation] Client initiated cross-site navigations should create a new browsing context

### DIFF
--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -441,7 +441,7 @@ void ProvisionalPageProxy::didCommitLoadForFrame(IPC::Connection& connection, Fr
         if (RefPtr openerPage = openerFrame ? openerFrame->page() : nullptr) {
             Site openerSite(openerFrame->url());
             Site openedSite(request.url());
-            if (openerSite != openedSite) {
+            if (openerSite != openedSite && m_browsingContextGroup.ptr() == &page->browsingContextGroup()) {
                 page->legacyMainFrameProcess().send(Messages::WebPage::LoadDidCommitInAnotherProcess(page->mainFrame()->frameID(), std::nullopt), page->webPageIDInMainFrameProcess());
                 m_browsingContextGroup->transitionPageToRemotePage(*page, openerSite);
             }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5043,7 +5043,7 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
         return;
     }
 
-    Ref browsingContextGroup = newProcess->websiteDataStore() == &websiteDataStore() ? m_browsingContextGroup : BrowsingContextGroup::create();
+    Ref browsingContextGroup = newProcess->websiteDataStore() == &websiteDataStore() && !navigation.isRequestFromClientOrUserInput() ? m_browsingContextGroup : BrowsingContextGroup::create();
     Ref frameProcess = browsingContextGroup->ensureProcessForSite(navigationSite, newProcess, preferences);
     // Make sure we destroy any existing ProvisionalPageProxy object *before* we construct a new one.
     // It is important from the previous provisional page to unregister itself before we register a
@@ -8362,6 +8362,7 @@ void WebPageProxy::createNewPage(IPC::Connection& connection, WindowFeatures&& w
             *originatingFrameInfoData.frameID
         } });
         configuration->setOpenedSite(openerFrame->frameProcess().site());
+        configuration->setBrowsingContextGroup(m_browsingContextGroup.copyRef());
     } else {
         configuration->setOpenerInfo(std::nullopt);
         configuration->setBrowsingContextGroup(BrowsingContextGroup::create());

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -7544,11 +7544,11 @@ TEST(ProcessSwap, SameSiteWindowWithOpenerNavigateToFile)
 
     using namespace TestWebKitAPI;
     checkFrameTreesInProcesses(webView.get(), {
-        { "pson://www.webkit.org"_s }, { RemoteFrame }
+        { "pson://www.webkit.org"_s }
     });
 
     checkFrameTreesInProcesses(createdWebView.get(), {
-        { RemoteFrame }, { "file://"_s }
+        { "file://"_s }
     });
 
     [createdWebView goBack];


### PR DESCRIPTION
#### d2f6b0a1f35d0895b1e1bd25f7d63706996fa5ad
<pre>
Reland 288650@main: [Site Isolation] Client initiated cross-site navigations should create a new browsing context
<a href="https://bugs.webkit.org/show_bug.cgi?id=286110">https://bugs.webkit.org/show_bug.cgi?id=286110</a>
<a href="https://rdar.apple.com/143091422">rdar://143091422</a>

Reviewed by Alex Christensen.

An opened window should not have access to its opener after the opener has begun a client-initiated
cross-site navigation. This matches behavior with site isolation disabled.

* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::didCommitLoadForFrame):
If we are navigating away from a page with an opener and about to switch browsing contexts we do not want
to add the previous page.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::createNewPage):
If a new window is opened with an opener, explicitly share the browsing context to the new page. This was
revealed by this change because we now switch browsing contexts between each layout test.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
((ProcessSwap, SameSiteWindowWithOpenerNavigateToFile)):
Expecting the opener to be preserved after loading a file URL in the opened webView with loadRequest was
incorrect.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, LoadRequestOnOpenerWebView)):
(TestWebKitAPI::TEST(SiteIsolation, LoadRequestOnOpenedWebView)):

Canonical link: <a href="https://commits.webkit.org/289035@main">https://commits.webkit.org/289035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfa409ece6b4a150e73e18f7b8b47517720c4c1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85177 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4912 "Build is in progress. Recent messages:") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39583 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/90309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/36222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87267 "Passed tests") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12880 "Failed to checkout and rebase branch from PR 39164") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/90309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/36222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88223 "Passed tests") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/39583 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/90309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/39583 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/35290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/39583 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/91715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/12519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/12880 "Failed to checkout and rebase branch from PR 39164") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/91715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/12747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/39583 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/91715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/39583 "Build is in progress. Recent messages:OS: Ventura (13.6.7), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13269 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/12460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/12302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/15795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/14043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->