### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in GraphicsContextGL.cpp

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -283,15 +283,34 @@ ALWAYS_INLINE static unsigned texelBytesForFormat(GraphicsContextGL::DataFormat 
     }
 }
 
+static std::span<const uint8_t> clampedSubspan(std::span<const uint8_t> span, size_t offset, size_t length)
+{
+    size_t clampedOffset = std::min(offset, span.size());
+    size_t clampedLength = std::min(span.size() - clampedOffset, length);
+    return span.subspan(clampedOffset, clampedLength);
+}
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+template<typename T>
+static void clampedSkip(std::span<T>& span, size_t offset)
+{
+    skip(span, std::min(offset, span.size()));
+}
+
+static void clampedMoveCursor(std::span<uint8_t>& cursor, std::span<uint8_t> container, ptrdiff_t delta)
+{
+    ASSERT(cursor.data() >= container.data());
+    ASSERT(std::to_address(cursor.end()) == std::to_address(container.end()));
+
+    auto clampedNewIndex = std::clamp<ptrdiff_t>(cursor.data() - container.data() + delta, 0, container.size());
+    cursor = container.subspan(clampedNewIndex);
+}
 
 // Helper for packImageData/extractImageData/extractTextureData which implement packing of pixel
 // data into the specified OpenGL destination format and type.
 // A sourceUnpackAlignment of zero indicates that the source
 // data is tightly packed. Non-zero values may take a slow path.
 // Destination data will have no gaps between rows.
-static bool packPixels(const uint8_t* sourceData, GraphicsContextGL::DataFormat sourceDataFormat, unsigned sourceDataWidth, unsigned sourceDataHeight, const IntRect& sourceDataSubRectangle, int depth, unsigned sourceUnpackAlignment, int unpackImageHeight, unsigned destinationFormat, unsigned destinationType, GraphicsContextGL::AlphaOp alphaOp, uint8_t* destinationData, bool flipY)
+static bool packPixels(std::span<const uint8_t> sourceData, GraphicsContextGL::DataFormat sourceDataFormat, unsigned sourceDataWidth, unsigned sourceDataHeight, const IntRect& sourceDataSubRectangle, int depth, unsigned sourceUnpackAlignment, int unpackImageHeight, unsigned destinationFormat, unsigned destinationType, GraphicsContextGL::AlphaOp alphaOp, std::span<uint8_t> destinationData, bool flipY)
 {
     ASSERT(depth >= 1);
     UNUSED_PARAM(sourceDataHeight); // Derived from sourceDataSubRectangle.height().
@@ -306,16 +325,17 @@ static bool packPixels(const uint8_t* sourceData, GraphicsContextGL::DataFormat 
     if (dstDataFormat == GraphicsContextGL::DataFormat::Invalid)
         return false;
     int dstStride = sourceDataSubRectangle.width() * texelBytesForFormat(dstDataFormat);
+    auto destinationCursor = destinationData;
     if (flipY) {
-        destinationData = destinationData + dstStride * ((depth * sourceDataSubRectangle.height()) - 1);
+        clampedMoveCursor(destinationCursor, destinationData, dstStride * ((depth * sourceDataSubRectangle.height()) - 1));
         dstStride = -dstStride;
     }
     if (!GraphicsContextGL::hasAlpha(sourceDataFormat) || !GraphicsContextGL::hasColor(sourceDataFormat) || !GraphicsContextGL::hasColor(dstDataFormat))
         alphaOp = GraphicsContextGL::AlphaOp::DoNothing;
 
     if (sourceDataFormat == dstDataFormat && alphaOp == GraphicsContextGL::AlphaOp::DoNothing) {
-        const uint8_t* basePtr = sourceData + srcStride * sourceDataSubRectangle.y();
-        const uint8_t* baseEnd = sourceData + srcStride * sourceDataSubRectangle.maxY();
+        ASSERT(srcStride >= 0);
+        size_t baseSpanOffset = srcStride * sourceDataSubRectangle.y();
 
         // If packing multiple images into a 3D texture, and flipY is true,
         // then the sub-rectangle is pointing at the start of the
@@ -324,38 +344,27 @@ static bool packPixels(const uint8_t* sourceData, GraphicsContextGL::DataFormat 
         // last, or "topmost", of these images.
         if (flipY && depth > 1) {
             const ptrdiff_t distanceToTopImage = (depth - 1) * srcStride * unpackImageHeight;
-            basePtr -= distanceToTopImage;
-            baseEnd -= distanceToTopImage;
+            baseSpanOffset -= distanceToTopImage;
         }
 
-        unsigned rowSize = (dstStride > 0) ? dstStride: -dstStride;
-        uint8_t* dst = static_cast<uint8_t*>(destinationData);
-
+        auto baseSpan = clampedSubspan(sourceData, baseSpanOffset, srcStride * sourceDataSubRectangle.maxY() - srcStride * sourceDataSubRectangle.y());
+        unsigned rowSize = dstStride > 0 ? dstStride: -dstStride;
         for (int i = 0; i < depth; ++i) {
-            const uint8_t* ptr = basePtr;
-            const uint8_t* ptrEnd = baseEnd;
-            while (ptr < ptrEnd) {
-                memcpy(dst, ptr + srcRowOffset, rowSize);
-                ptr += srcStride;
-                dst += dstStride;
+            auto sourceCursor = baseSpan;
+            while (!sourceCursor.empty()) {
+                memcpySpan(destinationCursor, sourceCursor.subspan(srcRowOffset, rowSize));
+                clampedSkip(sourceCursor, srcStride);
+                clampedMoveCursor(destinationCursor, destinationData, dstStride);
             }
-            basePtr += unpackImageHeight * srcStride;
-            baseEnd += unpackImageHeight * srcStride;
+            baseSpan = clampedSubspan(sourceData, baseSpan.data() - sourceData.data() + unpackImageHeight * srcStride, baseSpan.size());
         }
         return true;
     }
 
-    FormatConverter converter(
-        sourceDataSubRectangle, depth,
-        unpackImageHeight, sourceData, destinationData,
-        srcStride, srcRowOffset, dstStride);
+    FormatConverter converter(sourceDataSubRectangle, depth, unpackImageHeight, sourceData.data(), destinationCursor.data(), srcStride, srcRowOffset, dstStride);
     converter.convert(sourceDataFormat, dstDataFormat, alphaOp);
-    if (!converter.success())
-        return false;
-    return true;
+    return converter.success();
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 GraphicsContextGL::Client::Client() = default;
 
@@ -491,7 +500,7 @@ bool GraphicsContextGL::packImageData(Image* image, std::span<const uint8_t> pix
         return false;
     data.resize(packSizes->imageBytes);
 
-    if (!packPixels(pixels.data(), sourceFormat, sourceImageWidth, sourceImageHeight, sourceImageSubRectangle, depth, sourceUnpackAlignment, unpackImageHeight, format, type, alphaOp, data.data(), flipY))
+    if (!packPixels(pixels, sourceFormat, sourceImageWidth, sourceImageHeight, sourceImageSubRectangle, depth, sourceUnpackAlignment, unpackImageHeight, format, type, alphaOp, data.mutableSpan(), flipY))
         return false;
     if (auto observer = image->imageObserver())
         observer->didDraw(*image);
@@ -511,7 +520,7 @@ bool GraphicsContextGL::extractPixelBuffer(const PixelBuffer& pixelBuffer, DataF
         return false;
     data.resize(packSizes->imageBytes);
 
-    if (!packPixels(pixelBuffer.bytes().data(), sourceDataFormat, width, height, sourceImageSubRectangle, depth, 0, unpackImageHeight, format, type, premultiplyAlpha ? AlphaOp::DoPremultiply : AlphaOp::DoNothing, data.data(), flipY))
+    if (!packPixels(pixelBuffer.bytes(), sourceDataFormat, width, height, sourceImageSubRectangle, depth, 0, unpackImageHeight, format, type, premultiplyAlpha ? AlphaOp::DoPremultiply : AlphaOp::DoNothing, data.mutableSpan(), flipY))
         return false;
 
     return true;
@@ -531,7 +540,7 @@ bool GraphicsContextGL::extractTextureData(unsigned width, unsigned height, GCGL
         return false;
     data.resize(width * height * bytesPerPixel);
     skip(pixels, packSizes->initialSkipBytes);
-    if (!packPixels(pixels.data(), sourceDataFormat, unpackParams.rowLength ? unpackParams.rowLength : width, height, IntRect(0, 0, width, height), 1, unpackParams.alignment, 0, format, type, (premultiplyAlpha ? AlphaOp::DoPremultiply : AlphaOp::DoNothing), data.data(), flipY))
+    if (!packPixels(pixels, sourceDataFormat, unpackParams.rowLength ? unpackParams.rowLength : width, height, IntRect(0, 0, width, height), 1, unpackParams.alignment, 0, format, type, (premultiplyAlpha ? AlphaOp::DoPremultiply : AlphaOp::DoNothing), data.mutableSpan(), flipY))
         return false;
     return true;
 }


### PR DESCRIPTION
#### a04f1185dd058327d242534b5d704f94c3d7957c
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in GraphicsContextGL.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=285944">https://bugs.webkit.org/show_bug.cgi?id=285944</a>
<a href="https://rdar.apple.com/142982532">rdar://142982532</a>

Reviewed by Geoff Garen.

* Source/WebCore/platform/graphics/GraphicsContextGL.cpp:
(WebCore::clampedSubspan):
(WebCore::clampedSkip):
(WebCore::clampedMoveCursor):
(WebCore::packPixels):
(WebCore::GraphicsContextGL::packImageData):
(WebCore::GraphicsContextGL::extractPixelBuffer):
(WebCore::GraphicsContextGL::extractTextureData):

Canonical link: <a href="https://commits.webkit.org/289041@main">https://commits.webkit.org/289041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8de1b06aa652e384c0f68e7a00520567e3b48c52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90323 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36236 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87285 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12906 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66234 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24052 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3797 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77383 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46503 "Found 2 new API test failures: /WPE/TestSSL:/webkit/WebKitWebView/web-socket-client-side-certificate, /WPE/TestSSL:/webkit/WebKitWebView/web-socket-tls-errors (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/3672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31643 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35304 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91734 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12543 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12772 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73220 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73863 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18278 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/18294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16718 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4530 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12486 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12316 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/15809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14066 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->