### PR TITLE
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in CSSParserObserverWrapper.cpp

### DIFF
--- a/Source/WebCore/css/parser/CSSParserObserverWrapper.cpp
+++ b/Source/WebCore/css/parser/CSSParserObserverWrapper.cpp
@@ -51,24 +51,24 @@ unsigned CSSParserObserverWrapper::endOffset(const CSSParserTokenRange& range)
     return m_tokenOffsets[range.end() - m_firstParserToken];
 }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 void CSSParserObserverWrapper::skipCommentsBefore(const CSSParserTokenRange& range, bool leaveDirectlyBefore)
 {
     unsigned startIndex = range.begin() - m_firstParserToken;
     if (!leaveDirectlyBefore)
         ++startIndex;
-    while (m_commentIterator < m_commentOffsets.end() && m_commentIterator->tokensBefore < startIndex)
-        ++m_commentIterator;
+    while (m_commentIndex < m_commentOffsets.size() && m_commentOffsets[m_commentIndex].tokensBefore < startIndex)
+        ++m_commentIndex;
 }
 
 void CSSParserObserverWrapper::yieldCommentsBefore(const CSSParserTokenRange& range)
 {
     unsigned startIndex = range.begin() - m_firstParserToken;
-    while (m_commentIterator < m_commentOffsets.end() && m_commentIterator->tokensBefore <= startIndex) {
-        m_observer.observeComment(m_commentIterator->startOffset, m_commentIterator->endOffset);
-        ++m_commentIterator;
+    for (; m_commentIndex < m_commentOffsets.size(); ++m_commentIndex) {
+        auto& commentOffset = m_commentOffsets[m_commentIndex];
+        if (commentOffset.tokensBefore > startIndex)
+            break;
+        m_observer.observeComment(commentOffset.startOffset, commentOffset.endOffset);
     }
 }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSParserObserverWrapper.h
+++ b/Source/WebCore/css/parser/CSSParserObserverWrapper.h
@@ -67,7 +67,7 @@ public:
     void finalizeConstruction(CSSParserToken* firstParserToken)
     {
         m_firstParserToken = firstParserToken;
-        m_commentIterator = m_commentOffsets.begin();
+        ASSERT(!m_commentIndex);
     }
 
 private:
@@ -82,7 +82,7 @@ private:
     };
 
     Vector<CommentPosition> m_commentOffsets;
-    Vector<CommentPosition>::iterator m_commentIterator;
+    size_t m_commentIndex { 0 };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### c8a416ce162ea34279ab4a166ea870fc4352b9f0
<pre>
Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE usage in CSSParserObserverWrapper.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=286113">https://bugs.webkit.org/show_bug.cgi?id=286113</a>

Reviewed by Darin Adler.

* Source/WebCore/css/parser/CSSParserObserverWrapper.cpp:
(WebCore::CSSParserObserverWrapper::skipCommentsBefore):
(WebCore::CSSParserObserverWrapper::yieldCommentsBefore):
* Source/WebCore/css/parser/CSSParserObserverWrapper.h:
(WebCore::CSSParserObserverWrapper::finalizeConstruction):

Canonical link: <a href="https://commits.webkit.org/289062@main">https://commits.webkit.org/289062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14ac118505646caa88c8bacea8349c148a1997ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90377 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36291 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66281 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24098 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88296 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3865 "Found 1 new test failure: fast/forms/switch/click-animation-twice-fast.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77433 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46559 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3750 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31694 "Found 1 new test failure: editing/undo/redo-reapply-edit-command-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35359 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91826 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12597 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73270 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18339 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16768 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4611 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13281 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12540 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12370 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15863 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14121 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->