### PR TITLE
Context menu images for internal clients need to be updated to improve clarity

### DIFF
--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -172,6 +172,7 @@ NSString *symbolNameForAction(const WebCore::ContextMenuAction action, bool useA
     case WebCore::ContextMenuItemTagDictationAlternative:
     case WebCore::ContextMenuItemTagFontMenu:
     case WebCore::ContextMenuItemTagNoAction:
+    case WebCore::ContextMenuItemTagNoGuessesFound:
     case WebCore::ContextMenuItemTagOther:
     case WebCore::ContextMenuItemTagSpellingGuess:
     case WebCore::ContextMenuItemTagSpeechMenu:
@@ -270,16 +271,14 @@ NSString *symbolNameForAction(const WebCore::ContextMenuAction action, bool useA
     case WebCore::ContextMenuItemTagMediaMute:
         return @"speaker.slash";
     case WebCore::ContextMenuItemTagMediaPlayPause:
-        return useAlternateImage ? @"pause" : @"play";
-    case WebCore::ContextMenuItemTagNoGuessesFound:
-        return @"x.circle";
+        return useAlternateImage ? @"pause.fill" : @"play.fill";
     case WebCore::ContextMenuItemTagOpenFrameInNewWindow:
     case WebCore::ContextMenuItemTagOpenImageInNewWindow:
     case WebCore::ContextMenuItemTagOpenLinkInNewWindow:
     case WebCore::ContextMenuItemTagOpenMediaInNewWindow:
         return @"macwindow.badge.plus";
     case WebCore::ContextMenuItemTagOpenLink:
-        return @"arrow.up.to.line";
+        return @"safari";
     case WebCore::ContextMenuItemTagOpenWithDefaultApplication:
         return @"arrow.up.forward.app";
     case WebCore::ContextMenuItemTagOutline:
@@ -295,7 +294,7 @@ NSString *symbolNameForAction(const WebCore::ContextMenuAction action, bool useA
     case WebCore::ContextMenuItemTagPlayAnimation:
         return @"play.rectangle";
     case WebCore::ContextMenuItemTagReload:
-        return @"arrow.clockwise.circle";
+        return @"arrow.clockwise";
     case WebCore::ContextMenuItemTagRightToLeft:
         return [NSMenuItem _systemImageNameForAction:@selector(makeTextWritingDirectionRightToLeft:)];
     case WebCore::ContextMenuItemTagShareMenu:
@@ -318,10 +317,10 @@ NSString *symbolNameForAction(const WebCore::ContextMenuAction action, bool useA
     case WebCore::ContextMenuItemTagSmartQuotes:
         return @"quote.closing";
     case WebCore::ContextMenuItemTagStartSpeaking:
-        return @"play";
+        return @"play.fill";
     case WebCore::ContextMenuItemTagStop:
     case WebCore::ContextMenuItemTagStopSpeaking:
-        return @"stop";
+        return @"stop.fill";
     case WebCore::ContextMenuItemTagStyles:
         return @"bold.italic.underline";
     case WebCore::ContextMenuItemTagTextDirectionLeftToRight:


### PR DESCRIPTION
#### 701bca1a2a2809ac421c5d4cb2dccd5e3ef66ce8
<pre>
Context menu images for internal clients need to be updated to improve clarity
<a href="https://bugs.webkit.org/show_bug.cgi?id=286115">https://bugs.webkit.org/show_bug.cgi?id=286115</a>
<a href="https://rdar.apple.com/143100423">rdar://143100423</a>

Reviewed by Aditya Keerthi.

The images for certain context menu items for internal clients have
been updated to improve clarity, including “Play,” “Pause,” “Stop,”
“Reload,” “Open Link,&quot; and &quot;No Guesses Found.&quot;

* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::symbolNameForAction):

Canonical link: <a href="https://commits.webkit.org/289040@main">https://commits.webkit.org/289040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36e31007a5fbe211876b02d2c9bed24467538548

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/4935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90328 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36241 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/12911 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/66240 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24057 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88247 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/3803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77386 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46508 "Found 2 new API test failures: /WPE/TestSSL:/webkit/WebKitWebView/web-socket-client-side-certificate, /WPE/TestSSL:/webkit/WebKitWebView/web-socket-tls-errors (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/3680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35309 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32478 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91741 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12548 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/74750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12777 "Failed to checkout and rebase branch from PR 39171") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73223 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/73868 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18277 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/16721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/4535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12491 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/17941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/12321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/15814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14071 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->