### PR TITLE
Prepare AXObjectCache to be moved to be owned by Page instead of Document

### DIFF
--- a/Source/WebCore/accessibility/AXGeometryManager.cpp
+++ b/Source/WebCore/accessibility/AXGeometryManager.cpp
@@ -122,10 +122,10 @@ void AXGeometryManager::willUpdateObjectRegions()
 
 void AXGeometryManager::scheduleRenderingUpdate()
 {
-    if (!m_cache)
+    if (!m_cache || !m_cache->document())
         return;
 
-    if (RefPtr page = m_cache->document().page())
+    if (RefPtr page = m_cache->document()->page())
         page->scheduleRenderingUpdate(RenderingUpdateStep::AccessibilityRegionUpdate);
 }
 

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -1259,7 +1259,10 @@ TextStream& operator<<(TextStream& stream, AXObjectCache& axObjectCache)
     TextStream::GroupScope groupScope(stream);
     stream << "AXObjectCache " << &axObjectCache;
 
-    if (RefPtr root = axObjectCache.get(axObjectCache.document().view())) {
+    RefPtr document = axObjectCache.document();
+    if (!document)
+        stream << "No document!";
+    else if (RefPtr root = axObjectCache.get(document->view())) {
         constexpr OptionSet<AXStreamOptions> options = { AXStreamOptions::ObjectID, AXStreamOptions::Role, AXStreamOptions::ParentID, AXStreamOptions::IdentifierAttribute, AXStreamOptions::OuterHTML, AXStreamOptions::DisplayContents, AXStreamOptions::Address };
         streamSubtree(stream, root.releaseNonNull(), options);
     } else

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -554,8 +554,8 @@ public:
 
     AXComputedObjectAttributeCache* computedObjectAttributeCache() { return m_computedObjectAttributeCache.get(); }
 
-    Document& document() const { return const_cast<Document&>(m_document.get()); }
-    Ref<Document> protectedDocument() const;
+    Document* document() const { return m_document.get(); }
+    RefPtr<Document> protectedDocument() const;
     constexpr const std::optional<PageIdentifier>& pageID() const { return m_pageID; }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -775,7 +775,7 @@ private:
     Ref<AccessibilityRenderObject> createObjectFromRenderer(RenderObject&);
     Ref<AccessibilityNodeObject> createFromNode(Node&);
 
-    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     const std::optional<PageIdentifier> m_pageID; // constant for object's lifetime.
     OptionSet<ActivityState> m_pageActivityState;
     UncheckedKeyHashMap<AXID, Ref<AccessibilityObject>> m_objects;

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -165,7 +165,7 @@ void AccessibilityObject::detachRemoteParts(AccessibilityDetachmentType detachme
     // Menu close events need to notify the platform. No element is used in the notification because it's a destruction event.
     if (detachmentType == AccessibilityDetachmentType::ElementDestroyed && roleValue() == AccessibilityRole::Menu) {
         if (auto* cache = axObjectCache())
-            cache->postNotification(nullptr, &cache->document(), AXNotification::MenuClosed);
+            cache->postNotification(nullptr, cache->document(), AXNotification::MenuClosed);
     }
 
     // Clear any children and call detachFromParent on them so that

--- a/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 
 void AXObjectCache::attachWrapper(AccessibilityObject& axObject)
 {
-    auto wrapper = AccessibilityObjectAtspi::create(&axObject, document().page()->accessibilityRootObject());
+    auto wrapper = AccessibilityObjectAtspi::create(&axObject, document()->page()->accessibilityRootObject());
     axObject.setWrapper(wrapper.ptr());
 
     m_deferredParentChangedList.add(&axObject);
@@ -51,7 +51,7 @@ void AXObjectCache::platformPerformDeferredCacheUpdate()
 
         auto* axParent = axObject.parentObjectUnignored();
         if (!axParent) {
-            if (axObject.isScrollView() && axObject.scrollView() == document().view())
+            if (axObject.isScrollView() && document() && axObject.scrollView() == document()->view())
                 wrapper->setParent(nullptr); // nullptr means root.
             return;
         }

--- a/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
+++ b/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
@@ -95,7 +95,7 @@ ASCIILiteral AXObjectCache::notificationPlatformName(AXNotification notification
 
 void AXObjectCache::relayNotification(const String& notificationName, RetainPtr<NSData> notificationData)
 {
-    if (auto* page = document().page())
+    if (RefPtr page = document() ? document()->page() : nullptr)
         page->chrome().relayAccessibilityNotification(notificationName, notificationData);
 }
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -350,7 +350,7 @@ class AXIsolatedTree : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AX
     friend WTF::TextStream& operator<<(WTF::TextStream&, AXIsolatedTree&);
     friend void streamIsolatedSubtreeOnMainThread(TextStream&, const AXIsolatedTree&, AXID, const OptionSet<AXStreamOptions>&);
 public:
-    static Ref<AXIsolatedTree> create(AXObjectCache&);
+    static RefPtr<AXIsolatedTree> create(AXObjectCache&);
     // Creates a tree consisting of only the Scrollview and the WebArea objects. This tree is used as a temporary placeholder while the whole tree is being built.
     static Ref<AXIsolatedTree> createEmpty(AXObjectCache&);
     constexpr bool isEmptyContentTree() const { return m_isEmptyContentTree; }

--- a/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
+++ b/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
@@ -79,7 +79,8 @@ static AXNotification checkInteractableObjects(AXCoreObject* object)
 
 void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNotification notification)
 {
-    if (!!object.document()
+    if (!document()
+        || !!object.document()
         || !object.document()->view()
         || object.document()->view()->layoutContext().layoutState()
         || object.document()->childNeedsStyleRecalc())
@@ -97,31 +98,33 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
         break;
     }
 
-    ChromeClient& client = document().frame()->page()->chrome().client();
+    ChromeClient& client = document()->frame()->page()->chrome().client();
     client.postAccessibilityNotification(*protectedObject, notification);
 }
 
 void AXObjectCache::nodeTextChangePlatformNotification(AccessibilityObject* object, AXTextChange textChange, unsigned offset, const String& text)
 {
-    if (!object
+    if (!document()
+        || !object
         || !object->document()
         || !object->document()->view()
         || object->document()->view()->layoutContext().layoutState()
         || object->document()->childNeedsStyleRecalc())
         return;
-    ChromeClient& client = document().frame()->page()->chrome().client();
+    ChromeClient& client = document()->frame()->page()->chrome().client();
     client.postAccessibilityNodeTextChangeNotification(object, textChange, offset, text);
 }
 
 void AXObjectCache::frameLoadingEventPlatformNotification(AccessibilityObject* object, AXLoadingEvent loadingEvent)
 {
-    if (!object
+    if (!document()
+        || !object
         || !object->document()
         || !object->document()->view()
         || object->document()->view()->layoutContext().layoutState()
         || object->document()->childNeedsStyleRecalc())
         return;
-    ChromeClient& client = document().frame()->page()->chrome().client();
+    ChromeClient& client = document()->frame()->page()->chrome().client();
     client.postAccessibilityFrameLoadingEventNotification(object, loadingEvent);
 }
 


### PR DESCRIPTION
#### f1ec9aeef00eb1bcfd4242fba8e749903c6a1076
<pre>
Prepare AXObjectCache to be moved to be owned by Page instead of Document
<a href="https://bugs.webkit.org/show_bug.cgi?id=286118">https://bugs.webkit.org/show_bug.cgi?id=286118</a>
<a href="https://rdar.apple.com/143103591">rdar://143103591</a>

Reviewed by Brady Eidson.

The AXObjectCache is currently owned by the main frame&apos;s Document,
but it is desired that there be one per Page even in iframe processes
with site isolation enabled.  That means that we will need to make
an AXObjectCache when there is no main frame Document in the current
process.  To prepare for that, make the Document pointer a WeakPtr
instead of a WeakRef.

* Source/WebCore/accessibility/AXGeometryManager.cpp:
(WebCore::AXGeometryManager::scheduleRenderingUpdate):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::AXObjectCache):
(WebCore::AXObjectCache::findModalNodes):
(WebCore::AXObjectCache::updateCurrentModalNode):
(WebCore::AXObjectCache::rootObject):
(WebCore::AXObjectCache::setIsolatedTreeRoot):
(WebCore::AXObjectCache::handleMenuOpened):
(WebCore::AXObjectCache::handleLiveRegionCreated):
(WebCore::AXObjectCache::notificationPostTimerFired):
(WebCore::AXObjectCache::handleMenuItemSelected):
(WebCore::AXObjectCache::onPopoverToggle):
(WebCore::AXObjectCache::handleAriaExpandedChange):
(WebCore::AXObjectCache::handleLabelChanged):
(WebCore::AXObjectCache::protectedDocument const):
(WebCore::AXObjectCache::characterOffsetForPoint):
(WebCore::AXObjectCache::performDeferredCacheUpdate):
(WebCore::AXObjectCache::rootWebArea):
(WebCore::AXObjectCache::treeData):
(WebCore::AXObjectCache::updateRelationsIfNeeded):
(WebCore::AXObjectCache::addRelation):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::detachRemoteParts):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::createEmpty):
(WebCore::AXIsolatedTree::create):
(WebCore::AXIsolatedTree::updateRootScreenRelativePosition):

Canonical link: <a href="https://commits.webkit.org/289089@main">https://commits.webkit.org/289089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6590e704c1f54545fe35ac8b908bce48e3fc7ed7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/85297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/5032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/39728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/90424 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/36339 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/87386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/5121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/13008 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/66304 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/24123 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/88343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/3899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/77478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/46586 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/3787 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/31739 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/35407 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/74511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/32577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/91875 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/12644 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/9241 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/74855 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/12873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/73315 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/73970 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/18387 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/16813 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/4663 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13299 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/12587 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/18048 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/12417 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/15910 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/14168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->